### PR TITLE
[Issue 496] make FullWidthAlert sticky

### DIFF
--- a/frontend/src/components/FullWidthAlert.tsx
+++ b/frontend/src/components/FullWidthAlert.tsx
@@ -25,7 +25,7 @@ const getBGColor = (type: Props["type"]) => {
 
 const FullWidthAlert = ({ type, heading, children }: Props) => {
   return (
-    <div className={`${getBGColor(type)}`}>
+    <div className={`${getBGColor(type)} tablet:position-sticky top-0 z-top`}>
       <GridContainer className="padding-y-1 tablet-lg:padding-y-2">
         <Grid>
           <USWDSAlert


### PR DESCRIPTION
## Summary
Fixes #496

### Time to review: __1 mins__

## Changes proposed
Add `tablet:position-sticky top-0 z-top` to `FullWidthAlert` component. 

## Additional information

![image](https://github.com/HHS/grants-equity/assets/409279/92bba5f1-819d-4dde-b85d-98a50192db80)


