### PR TITLE
[Issue 530] Move Next to SSG

### DIFF
--- a/frontend/src/pages/health.tsx
+++ b/frontend/src/pages/health.tsx
@@ -1,4 +1,4 @@
-import type { GetServerSideProps, NextPage } from "next";
+import type { GetStaticProps, NextPage } from "next";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import React from "react";
@@ -7,7 +7,7 @@ const Health: NextPage = () => {
   return <>healthy</>;
 };
 
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const translations = await serverSideTranslations(locale ?? "en");
   return { props: { ...translations } };
 };

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import type { GetServerSideProps, NextPage } from "next";
+import type { GetStaticProps, NextPage } from "next";
 import { ExternalRoutes } from "src/constants/routes";
 
 import { Trans, useTranslation } from "next-i18next";
@@ -38,8 +38,8 @@ const Home: NextPage = () => {
   );
 };
 
-// Change this to getStaticProps if you're not using server-side rendering
-export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+// Change this to GetServerSideProps if you're using server-side rendering
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const translations = await serverSideTranslations(locale ?? "en");
   return { props: { ...translations } };
 };


### PR DESCRIPTION
## Summary
Fixes #530

Depends on: #569, #583 

### Time to review: __15 mins__

## Changes proposed
1. Upgrade to latest version of next and i18next
2. Move to `getStaticProps` for SSG

## Context for reviewers
This PR updates the static site to be much more performant. The [most recent version of Next](https://nextjs.org/blog/next-13-5) includes a number of performance improvements.

Moving to [Static Site Generation](https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation) will also dramatically improve the number of requests the server can handle. It also provides the correct HTML headers for adding a CDN (#555).

When running `npm run build` you will now get the following:

```bash

λ  (Server)  server-side renders at runtime (uses getInitialProps or getServerSideProps)
○  (Static)  automatically rendered as static HTML (uses no initial props)
●  (SSG)     automatically generated as static HTML + JSON (uses getStaticProps)

```

I tested this locally using `ab -n 5000 -c 50 http://127.0.0.1:3000` and saw a dramatic improvement in page speed:

`main`:

```bash

Concurrency Level:      50
Time taken for tests:   25.548 seconds
Complete requests:      5000
Failed requests:        0
Total transferred:      137295000 bytes
HTML transferred:       136015000 bytes
Requests per second:    195.71 [#/sec] (mean)
Time per request:       255.484 [ms] (mean)
Time per request:       5.110 [ms] (mean, across all concurrent requests)
Transfer rate:          5247.96 [Kbytes/sec] received

```

vs this PR:

```bash

Concurrency Level:      50
Time taken for tests:   2.801 seconds
Complete requests:      5000
Failed requests:        0
Total transferred:      138265000 bytes
HTML transferred:       136835000 bytes
Requests per second:    1785.24 [#/sec] (mean)
Time per request:       28.007 [ms] (mean)
Time per request:       0.560 [ms] (mean, across all concurrent requests)
Transfer rate:          48210.23 [Kbytes/sec] received

```

The time per request is 10x improved.

This takes a much less drastic approach than the original PR that used `next export` to generate a static HTML file.
