### PR TITLE
[Issue 617] Rename app and db in docker-compose

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -2,7 +2,7 @@
 # Constants
 ##################################################
 
-APP_NAME := main-api
+APP_NAME := grants-api
 
 # Adding this to the end of a script that outputs JSON will convert
 # it to a readable format with timestamps and color-coding.
@@ -118,7 +118,7 @@ check: format-check lint test
 init-db: start-db db-migrate
 
 start-db:
-	docker-compose up --detach main-db
+	docker-compose up --detach grants-db
 	./bin/wait-for-local-db.sh
 
 ## Destroy current DB, setup new one

--- a/api/bin/wait-for-local-db.sh
+++ b/api/bin/wait-for-local-db.sh
@@ -13,7 +13,7 @@ WAIT_TIME=0
 # Use pg_isready to wait for the DB to be ready to accept connections
 # We check every 3 seconds and consider it failed if it gets to 30+
 # https://www.postgresql.org/docs/current/app-pg-isready.html
-until pg_isready -h localhost -d main-db -q;
+until pg_isready -h localhost -d grants-db -q;
 do
   echo "waiting on Postgres DB to initialize..."
   sleep 3
@@ -21,8 +21,8 @@ do
   WAIT_TIME=$(($WAIT_TIME+3))
   if [ $WAIT_TIME -gt $MAX_WAIT_TIME ]
   then
-    echo -e "${RED}ERROR: Database appears to not be starting up, running \"docker logs main-db\" to troubleshoot.${NO_COLOR}"
-    docker logs main-db
+    echo -e "${RED}ERROR: Database appears to not be starting up, running \"docker logs grants-db\" to troubleshoot.${NO_COLOR}"
+    docker logs grants-db
     exit 1
   fi
 done

--- a/api/local.env
+++ b/api/local.env
@@ -48,7 +48,7 @@ POSTGRES_USER=app
 POSTGRES_PASSWORD=secret123
 
 # Set DB_HOST to localhost if accessing a non-dockerized database
-DB_HOST=main-db
+DB_HOST=grants-db
 DB_NAME=app
 DB_USER=app
 DB_SCHEMA=public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,17 @@ version: '3'
 
 services:
 
-  main-db:
-    image: postgres:14-alpine
-    container_name: main-db
+  grants-db:
+    image: postgres:16-alpine
+    container_name: grants-db
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     env_file: ./api/local.env
     ports:
       - "5432:5432"
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - grantsdbdata:/var/lib/postgresql/data
 
-  main-api:
+  grants-api:
     build:
       context: ./api
       target: dev
@@ -20,14 +20,14 @@ services:
         - RUN_UID=${RUN_UID:-4000}
         - RUN_USER=${RUN_USER:-api}
     command: ["poetry", "run", "flask", "--app", "src.app", "run", "--host", "0.0.0.0", "--port", "8080", "--reload"]
-    container_name: main-api
+    container_name: grants-api
     env_file: ./api/local.env
     ports:
       - 8080:8080
     volumes:
       - ./api:/api
     depends_on:
-      - main-db
+      - grants-db
 
   nextjs:
     container_name: next-dev
@@ -62,4 +62,4 @@ services:
       - 6006:6006
 
 volumes:
-  dbdata:
+  grantsdbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   grants-db:
-    image: postgres:16-alpine
+    image: postgres:14-alpine
     container_name: grants-db
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     env_file: ./api/local.env


### PR DESCRIPTION
## Summary
Fixes #617

### Time to review: __5 mins__

## Changes proposed
Renamed the docker container for the app and DB to make them less generic.

## Context for reviewers
Nothing too fancy, just updated the names and where we reference them.

Verified that everything works locally (`make init format lint test`) and the API comes up and is usable (`make run-logs` go to  http://localhost:8080/docs ).

If you check this out, I suggest you do `make clean-volumes` to delete any existing DB volume as it was renamed.

