### PR TITLE
[Issue 547] Update docs for simpler move

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -2,7 +2,7 @@
 # Constants
 ##################################################
 
-APP_NAME := main-api
+APP_NAME := grants-api
 
 # Adding this to the end of a script that outputs JSON will convert
 # it to a readable format with timestamps and color-coding.
@@ -118,7 +118,7 @@ check: format-check lint test
 init-db: start-db db-migrate
 
 start-db:
-	docker-compose up --detach main-db
+	docker-compose up --detach grants-db
 	./bin/wait-for-local-db.sh
 
 ## Destroy current DB, setup new one

--- a/api/bin/wait-for-local-db.sh
+++ b/api/bin/wait-for-local-db.sh
@@ -13,7 +13,7 @@ WAIT_TIME=0
 # Use pg_isready to wait for the DB to be ready to accept connections
 # We check every 3 seconds and consider it failed if it gets to 30+
 # https://www.postgresql.org/docs/current/app-pg-isready.html
-until pg_isready -h localhost -d main-db -q;
+until pg_isready -h localhost -d grants-db -q;
 do
   echo "waiting on Postgres DB to initialize..."
   sleep 3
@@ -21,8 +21,8 @@ do
   WAIT_TIME=$(($WAIT_TIME+3))
   if [ $WAIT_TIME -gt $MAX_WAIT_TIME ]
   then
-    echo -e "${RED}ERROR: Database appears to not be starting up, running \"docker logs main-db\" to troubleshoot.${NO_COLOR}"
-    docker logs main-db
+    echo -e "${RED}ERROR: Database appears to not be starting up, running \"docker logs grants-db\" to troubleshoot.${NO_COLOR}"
+    docker logs grants-db
     exit 1
   fi
 done

--- a/api/local.env
+++ b/api/local.env
@@ -48,7 +48,7 @@ POSTGRES_USER=app
 POSTGRES_PASSWORD=secret123
 
 # Set DB_HOST to localhost if accessing a non-dockerized database
-DB_HOST=main-db
+DB_HOST=grants-db
 DB_NAME=app
 DB_USER=app
 DB_SCHEMA=public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,17 +2,17 @@ version: '3'
 
 services:
 
-  main-db:
+  grants-db:
     image: postgres:14-alpine
-    container_name: main-db
+    container_name: grants-db
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     env_file: ./api/local.env
     ports:
       - "5432:5432"
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - grantsdbdata:/var/lib/postgresql/data
 
-  main-api:
+  grants-api:
     build:
       context: ./api
       target: dev
@@ -20,14 +20,14 @@ services:
         - RUN_UID=${RUN_UID:-4000}
         - RUN_USER=${RUN_USER:-api}
     command: ["poetry", "run", "flask", "--app", "src.app", "run", "--host", "0.0.0.0", "--port", "8080", "--reload"]
-    container_name: main-api
+    container_name: grants-api
     env_file: ./api/local.env
     ports:
       - 8080:8080
     volumes:
       - ./api:/api
     depends_on:
-      - main-db
+      - grants-db
 
   nextjs:
     container_name: next-dev
@@ -62,4 +62,4 @@ services:
       - 6006:6006
 
 volumes:
-  dbdata:
+  grantsdbdata:

--- a/documentation/architecture/README.md
+++ b/documentation/architecture/README.md
@@ -1,12 +1,12 @@
 # Beta.Grants.Gov Architecture
 
-This document is meant to be a living record of the architecture for the beta.grants.gov system. This includes the application, network, and infrastructure architecture, as well as the CI/CD pipeline, and other services and integrations used to support the applications.
+This document is meant to be a living record of the architecture for the simpler.grants.gov system. This includes the application, network, and infrastructure architecture, as well as the CI/CD pipeline, and other services and integrations used to support the applications.
 
 At a high level, this system uses Github to maintain the codebase repository and run the CI/CD pipeline, and AWS to host the applications and its supporting services.
 
 ## Architecture
 
-This is a general architecture diagram of the beta.grants.gov system.
+This is a general architecture diagram of the simpler.grants.gov system.
 
 ```mermaid
 %%{init: {'theme': 'neutral' } }%%
@@ -152,7 +152,7 @@ flowchart TB
 
 ## AWS Hosted Infrastructure
 
-This is an architecture diagram focusing on the AWS shared infrastructure managed by beta.grants.gov
+This is an architecture diagram focusing on the AWS shared infrastructure managed by simpler.grants.gov
 
 ```mermaid
 %%{init: {'theme': 'neutral' } }%%
@@ -242,7 +242,7 @@ flowchart TD
 
 ## AWS Shared Services
 
-The beta.grants.gov is using the following non infrastructure shared services in AWS:
+The simpler.grants.gov is using the following non infrastructure shared services in AWS:
 
 - [ECS: Elastic Container Service](https://aws.amazon.com/ecs/)
 - [ECR: Elastic Container Registry](https://aws.amazon.com/ecr/)

--- a/documentation/decisions/adr/2023-06-30-api-language.md
+++ b/documentation/decisions/adr/2023-06-30-api-language.md
@@ -7,7 +7,7 @@
 
 ## Context and Problem Statement
 
-This ADR is to decide what programming language the API server for beta.grants.gov will use. This API server will initially be responsible for responding to queries to search a replicated database, but will grow to encompass all the back-end responsibilities of grants.gov
+This ADR is to decide what programming language the API server for simpler.grants.gov will use. This API server will initially be responsible for responding to queries to search a replicated database, but will grow to encompass all the back-end responsibilities of grants.gov
 
 In addition to the Nava and HHS teams ability to develop and maintain an API in the chosen language, it is also important that this language lends itself to open source engagement.
 

--- a/documentation/decisions/adr/2023-07-10-front-end-language.md
+++ b/documentation/decisions/adr/2023-07-10-front-end-language.md
@@ -7,7 +7,7 @@
 
 ## Context and Problem Statement
 
-The goal of this ADR is to select a language that we'll use to implement the front end for beta.grants.gov. The front end will only support static content at first, but will grow to include the new search, supported by the API and eventually the entire grants.gov functionality. Therefore, while a simple solution might work in the short term, it will quickly become insufficient to meet our needs.
+The goal of this ADR is to select a language that we'll use to implement the front end for simpler.grants.gov. The front end will only support static content at first, but will grow to include the new search, supported by the API and eventually the entire grants.gov functionality. Therefore, while a simple solution might work in the short term, it will quickly become insufficient to meet our needs.
 
 ## Decision Drivers <!-- RECOMMENDED -->
 

--- a/documentation/decisions/adr/2023-08-01-analytics-platform.md
+++ b/documentation/decisions/adr/2023-08-01-analytics-platform.md
@@ -8,7 +8,7 @@
 
 ## Context and Problem Statement
 
-The [communications platform milestone](milestone) identifies a series of platforms through which the Grants API project needs to engage both internal and external stakeholders. One of these platforms is an analytics platform for tracking key metrics during the launch of the first version of beta.grants.gov and as the project continues to grow. We will evaluate top 3-5 analytics tools, including analytics.gov and Google Analytics, to identify the best fit for our specific needs and objectives. The selected tool should provide valuable insights and data to help us measure and optimize the platform's performance.
+The [communications platform milestone](milestone) identifies a series of platforms through which the Grants API project needs to engage both internal and external stakeholders. One of these platforms is an analytics platform for tracking key metrics during the launch of the first version of simpler.grants.gov and as the project continues to grow. We will evaluate top 3-5 analytics tools, including analytics.gov and Google Analytics, to identify the best fit for our specific needs and objectives. The selected tool should provide valuable insights and data to help us measure and optimize the platform's performance.
 
 ## Decision Drivers <!-- RECOMMENDED -->
 

--- a/documentation/decisions/adr/2023-09-07-data-replication-tool.md
+++ b/documentation/decisions/adr/2023-09-07-data-replication-tool.md
@@ -254,7 +254,7 @@ For this solution we will only replicate opportunities data at first to limit th
   - Negligible impact to source database, even with replicating ongoing changes
   - Replicating only public data reduces our security criticality
   - Ability to transform data is part of the DMS tool and well documented
-  - Ensures that beta.grants.gov service remains available even if grants.gov has unexpected or planned downtime
+  - Ensures that simpler.grants.gov service remains available even if grants.gov has unexpected or planned downtime
   - Limits the cross VPC traffic to just DMS
 - **Cons**
   - Additional Cost

--- a/documentation/milestones/individual_milestones/db_planning.md
+++ b/documentation/milestones/individual_milestones/db_planning.md
@@ -22,7 +22,7 @@ Formalize a series of architectural decisions about how data is stored, includin
 
 <!-- Required -->
 
-This milestone is critical because it serves as the initial planning for the beta.grants.gov database and ultimately future grants.gov database, and has large downstream impact for the APIs and development related to Grants.gov.
+This milestone is critical because it serves as the initial planning for the simpler.grants.gov database and ultimately future grants.gov database, and has large downstream impact for the APIs and development related to Grants.gov.
 
 ### User Stories
 

--- a/documentation/milestones/individual_milestones/get_opportunities.md
+++ b/documentation/milestones/individual_milestones/get_opportunities.md
@@ -39,7 +39,7 @@ By delivering this public endpoint and ensuring it remains available even when t
 
 - As an **HHS staff member**, I want:
   - the API to adopt the proper security practices, so that we have a strategy for preventing and responding to security vulnerabilities before the API is launched
-  - published data about opportunities to be consistent between legacy grants.gov and `beta.grants.gov`, so that users won't be confused by discrepancies between these sources
+  - published data about opportunities to be consistent between legacy grants.gov and `simpler.grants.gov`, so that users won't be confused by discrepancies between these sources
 - As a **consumer of the API**, I want:
   - clear documentation and a user guide for the API, so that I don't have to rely on reading the source code to learn how to interact with and consume from it
   - changes made to a given endpoint to be backward-compatible, so that I can start building against this API without worrying about breaking changes
@@ -139,7 +139,7 @@ _What capabilities / milestones do we expect to be in place by the completion of
 - [ ] **[API Planning](https://github.com/HHS/simpler-grants-gov/issues/):** Determines the language, framework, and deployment service used to build and host the API.
 - [ ] **[DB planning](https://github.com/HHS/simpler-grants-gov/issues/):** Determines the DMBS and hosting service used to store and manage the data serviced by the API.
 - [ ] **[Developer tools](https://github.com/HHS/simpler-grants-gov/issues/):** Establishes a suite of tools used to ensure the quality and security of the API codebase.
-- [ ] **[beta.grants.gov domain](https://github.com/HHS/simpler-grants-gov/issues/):** Secures access to the `beta.grants.gov` domain from which the API endpoints will be routed.
+- [ ] **[simpler.grants.gov domain](https://github.com/HHS/simpler-grants-gov/issues/):** Secures access to the `simpler.grants.gov` domain from which the API endpoints will be routed.
 - [ ] **[Back-end CI/CD](https://github.com/HHS/simpler-grants-gov/issues/):** Sets up a CI/CD pipeline that will be used to test and publish code changes to the API.
 - [ ] **[Data architecture](https://github.com/HHS/simpler-grants-gov/issues/):** Establishes the updated data model used to support the new GET Opportunities endpoint.
 - [ ] **[Test data and schema](https://github.com/HHS/simpler-grants-gov/issues/):** Enables both project maintainers and open source contributors to effectively mock the database when developing or testing locally.
@@ -191,10 +191,10 @@ Timeline and strategy for translation is still TBD.
 
 _This can include services going into PROD behind a feature flag that is not turned on._
 
-1. **API:** This milestone is the official release of the `beta.grants.gov/api`
+1. **API:** This milestone is the official release of the `simpler.grants.gov/api`
 2. **Replica Database:** A replica of relevant tables from the legacy database
 3. **Updated Data Model:** An updated data model that will provide the data for the GET Opportunities endpoint
-4. **ETL Pipeline:** An ETL pipeline that both replicates data from legacy grants.gov and then transforms that data into the new `beta.grants.gov` data model
+4. **ETL Pipeline:** An ETL pipeline that both replicates data from legacy grants.gov and then transforms that data into the new `simpler.grants.gov` data model
 
 ### Services being integrated in PROD for the first time
 

--- a/documentation/milestones/individual_milestones/static_site.md
+++ b/documentation/milestones/individual_milestones/static_site.md
@@ -12,7 +12,7 @@
 
 ## Short description
 
-Launch a simple site at beta.grants.gov that provides static, informational content about the Simpler Grants.gov initiative.
+Launch a simple site at simpler.grants.gov that provides static, informational content about the Simpler Grants.gov initiative.
 
 ## Goals
 
@@ -23,10 +23,10 @@ The launch of a static site for the Simpler Grants.gov project represents the cu
 By sharing this information in a publicly accessible format and investing early in the infrastructure used to host it, this milestone aims to demonstrate the following value propositions:
 
 - Raises awareness about the Simpler Grants.gov project, its priorities, and ongoing workstreams
-- Establishes beta.grants.gov as the primary location that stakeholders can visit for project updates and previews of deliverables for the Simpler Grants.gov project
+- Establishes simpler.grants.gov as the primary location that stakeholders can visit for project updates and previews of deliverables for the Simpler Grants.gov project
 - Proves the successful completion of technical milestones that enable faster development without sacrificing code quality or security
 - Delivers an early win that both internal and external stakeholders can rally around, which helps build momentum and enthusiam for the project
-- Facilitates a parallel approach to development, in which new features can be built and tested on `beta.grants.gov` without risking or disrupting the existing functionality of legacy grants.gov
+- Facilitates a parallel approach to development, in which new features can be built and tested on `simpler.grants.gov` without risking or disrupting the existing functionality of legacy grants.gov
 
 ### User stories
 
@@ -80,13 +80,13 @@ Process for drafting and updating the content of the site should balance:
   - [ ] The resources required to deploy and host the site are provisioned programmatically using the framework established in the [Infrastructure-as-Code milestone](https://github.com/HHS/simpler-grants-gov/issues/123)
   - [ ] Code changes are deployed using the CI/CD pipeline set up in [the Front-end CI/CD milestone](https://github.com/HHS/simpler-grants-gov/issues/58)
 - [ ] The following user experience (UX) requirements are satisfied:
-  - [ ] Anyone can access a live version of the site at beta.grants.gov
+  - [ ] Anyone can access a live version of the site at simpler.grants.gov
   - [ ] The site adopts the UI principles and framework established in the [Foundational UI milestone](https://github.com/HHS/simpler-grants-gov/issues/60)
   - [ ] The site is 508 compliant and satisfies the other guidelines outlined in the Accessibility Planning milestone
   - [ ] Web traffic data for the site is actively being collected by the framework implemented in the [Web Analytics milestone](https://github.com/HHS/simpler-grants-gov/issues/63)
   - [ ] Additional development tickets have been created for collecting other data needed to calculate the metrics below
 - [ ] The following content requirements are satisfied:
-  - [ ] All content is deployed to beta.grants.gov
+  - [ ] All content is deployed to simpler.grants.gov
   - [ ] The content on the site has been been reviewed and approved by the relevant stakeholders within each workstream
   - [ ] The site also links to external resources related to the project (if they are available), including:
     - [ ] The legacy grants.gov site
@@ -123,7 +123,7 @@ _What capabilities / milestones do we expect to be in place by the completion of
 
 - [ ] **[Front-end Planning](https://github.com/HHS/simpler-grants-gov/issues/49):** Determines the language, framework, and deployment service used to build and host the site.
 - [ ] **[Developer Tools](https://github.com/HHS/simpler-grants-gov/issues/50):** Establishes a suite of tools used to ensure the quality and security of the site codebase.
-- [ ] **[beta.grants.gov Domain](https://github.com/HHS/simpler-grants-gov/issues/51):** Secures access to the `beta.grants.gov` domain which is where the site will be hosted.
+- [ ] **[simpler.grants.gov Domain](https://github.com/HHS/simpler-grants-gov/issues/51):** Secures access to the `simpler.grants.gov` domain which is where the site will be hosted.
 - [ ] **[Security Approval](https://github.com/HHS/simpler-grants-gov/issues/53):** Ensures that the site and the infrastructure that hosts it are comply with HHS security standards and practices.
 - [ ] **[Infrastructure-as-Code](https://github.com/HHS/simpler-grants-gov/issues/123):** Programmatically provisions the resources needed to deploy and host this site.
 - [ ] **[Front-end CI/CD](https://github.com/orgs/HHS/projects/12/views/3?pane=issue&itemId=31950276):** Sets up a CI/CD pipeline that will be used to test and publish code changes to the site.
@@ -148,7 +148,7 @@ _Are there any notable capabilities / milestones do NOT we expect to be in place
 _The following work will_ not _be completed as part of this milestone:_
 
 1. **Translating site contents:** Translation of key documents will be covered in an upcoming milestone slotted for FY24 Q1 (Oct - Dec 2023)
-2. **Legacy web analytics:** Updating the existing analytics recorded on legacy grants.gov in order to establish a baseline for comparing the site traffic for `beta.grants.gov` will happen in a later milestone
+2. **Legacy web analytics:** Updating the existing analytics recorded on legacy grants.gov in order to establish a baseline for comparing the site traffic for `simpler.grants.gov` will happen in a later milestone
 
 ## Integrations
 
@@ -171,8 +171,8 @@ The initial process for translation is slotted for release sometime in FY24 Q1 (
 _This can include services going into PROD behind a feature flag that is not turned on._
 
 - **Static Site:** This milestone represents the official launch of the static site
-- **beta.grants.gov Domain:** The static site is the first service to officially use the `beta.grants.gov` domain
-- **Stakeholder Feedback Form:** This is the first time we're collecting feedback directly from stakeholders on `beta.grants.gov`
+- **simpler.grants.gov Domain:** The static site is the first service to officially use the `simpler.grants.gov` domain
+- **Stakeholder Feedback Form:** This is the first time we're collecting feedback directly from stakeholders on `simpler.grants.gov`
 - **Web Analytics:** This will most likely be the first service for which we are configuring web analytics
 
 ### Services being integrated in PROD for the first time
@@ -191,7 +191,7 @@ _Are there multiple services that are being connected for the first time in PROD
 
 _Are there any fields being shared publicly that have never been shared in PROD before?_
 
-- No, the content of the static site in this milestone will be limited to general information about the Simpler Grants.gov project. It does not include exposing any production data from the new beta.grants.gov data model.
+- No, the content of the static site in this milestone will be limited to general information about the Simpler Grants.gov project. It does not include exposing any production data from the new simpler.grants.gov data model.
 
 ### Security considerations
 


### PR DESCRIPTION
## Summary
Fixes #547

### Time to review: __5 mins__

## Changes proposed
This picks up the `beta.grants.gov` to `simpler.grants.gov` strings. The rest of the docs are updated in #608 . 

