### PR TITLE
Adjust DB migrations as deleted ones ran already and need to be referenced

### DIFF
--- a/api/src/db/migrations/versions/2023_08_01_base_migration.py
+++ b/api/src/db/migrations/versions/2023_08_01_base_migration.py
@@ -1,0 +1,21 @@
+"""base migration
+
+Revision ID: 9fe657340f70
+Revises:
+Create Date: 2023-08-01 12:00:00.0000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "9fe657340f70"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass

--- a/api/src/db/migrations/versions/2023_08_10_default_table_privileges.py
+++ b/api/src/db/migrations/versions/2023_08_10_default_table_privileges.py
@@ -1,7 +1,7 @@
 """default table privileges
 
 Revision ID: 3ed861176e3d
-Revises:
+Revises: 9fe657340f70
 Create Date: 2023-08-10 15:52:10.626153
 
 """
@@ -9,7 +9,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "3ed861176e3d"
-down_revision = None
+down_revision = "9fe657340f70"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
Fixes https://github.com/HHS/simpler-grants-gov/actions/runs/6736356093/job/18311731606

### Time to review: __3 mins__

## Changes proposed
Adjusted the alembic migrations to reference a `9fe657340f70` revision that was deleted in a prior PR. I had mistakenly assumed the migrations were not already running and it was safe to delete them. This adds a dummy migration so that we can safely run the migrations again as it will pick up from this dummy migration.


## Context for reviewers
Alembic migrations are pretty simple, a table exists in the DB called `alembic_version` which has a single column+row with the current migration ID. Alembic reads all the migration files in the migration folder and finds that ID, then runs all the migrations after it. Right now it is seeing `9fe657340f70` in the DB, but that doesn't exist, so by creating a migration file with that ID, Alembic will be able to pick up from there and run the other two files without issue. Alembic does not manage any sort of history, that's done purely by the files we have, so this should work around it.

Note that technically the old user + role table still exist in the DB, we'll need to manually delete those later.


