### PR TITLE
[Issue 623] Update contact info on openapi

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -19,3 +19,6 @@ ignore:
   # https://github.com/anchore/grype/issues/1172
   - vulnerability: GHSA-xqr8-7jwr-rhp7
   - vulnerability: GHSA-7fh5-64p2-3v2j
+    # pip vulnerability, need to wait for the Python image to update to 23.x
+    # https://github.com/docker-library/python/blob/402b993af9ca7a5ee22d8ecccaa6197bfb957bc5/3.12/slim-bookworm/Dockerfile#L137
+  - vulnerability: GHSA-mq26-g339-26xf

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -2,9 +2,9 @@ info:
   title: Simpler Grants API
   description: Back end API for simpler.grants.gov
   contact:
-    name: Nava PBC Engineering
-    url: https://www.navapbc.com
-    email: engineering@navapbc.com
+    name: Simpler Grants.gov
+    url: https://simpler.grants.gov/
+    email: simplergrantsgov@hhs.gov
   version: 0.1.0
 tags:
 - name: Health
@@ -111,7 +111,7 @@ paths:
               $ref: '#/components/schemas/OpportunitySearch'
       security:
       - ApiKeyAuth: []
-openapi: 3.0.3
+openapi: 3.1.0
 components:
   schemas:
     ValidationError:

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -52,16 +52,18 @@ def configure_app(app: APIFlask) -> None:
     app.config["BASE_RESPONSE_SCHEMA"] = response_schema.ResponseSchema
 
     # Set a few values for the Swagger endpoint
-    app.config["OPENAPI_VERSION"] = "3.0.3"
+    app.config["OPENAPI_VERSION"] = "3.1.0"
+
+    app.json.compact = False  # type: ignore
 
     # Set various general OpenAPI config values
     app.info = {
         "title": "Simpler Grants API",
         "description": "Back end API for simpler.grants.gov",
         "contact": {
-            "name": "Nava PBC Engineering",
-            "url": "https://www.navapbc.com",
-            "email": "engineering@navapbc.com",
+            "name": "Simpler Grants.gov",
+            "url": "https://simpler.grants.gov/",
+            "email": "simplergrantsgov@hhs.gov",
         },
     }
 


### PR DESCRIPTION
## Summary
Fixes #623

### Time to review: __1 mins__

## Changes proposed
Updated the contact info on our openapi docs

Also a minor update for the openapi version + how the openapi json formats while we're modifying this

## Context for reviewers
Contact info just links to the simpler website

Updating the version of openapi adjusts how a few things generate in openapi, but nothing that we need to worry about with what we have at the moment (better to do before we start setting up more). And the `compact = False` option just makes it so if you click the openapi.json file it is nicely formatted.

## Additional information

What the contact info looks like
<img width="1426" alt="Screenshot 2023-11-06 at 12 22 10 PM" src="https://github.com/HHS/simpler-grants-gov/assets/46358556/13d7abb7-9064-4cc2-a3e3-aeca85cca712">

What the OpenAPI file looks like now:
<img width="651" alt="Screenshot 2023-11-06 at 12 22 20 PM" src="https://github.com/HHS/simpler-grants-gov/assets/46358556/600b3d6b-a095-4dd4-97d0-a4c3bd58ce16">


