### PR TITLE
Fixing feature flag headers to not start with X-

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -54,7 +54,7 @@ paths:
     post:
       parameters:
       - in: header
-        name: X-FF-Enable-Opportunity-Log-Msg
+        name: FF-Enable-Opportunity-Log-Msg
         description: Whether to log a message in the opportunity endpoint
         schema:
           type: boolean

--- a/api/src/api/feature_flags/feature_flag.py
+++ b/api/src/api/feature_flags/feature_flag.py
@@ -9,20 +9,20 @@ class FeatureFlag(StrEnum):
         EXAMPLE_FLAG_A = "example_flag_a"
 
     Would be able to have its default value set by setting the "EXAMPLE_FLAG_A" environment
-    variable, and be overrideable in an endpoint by supplying it as "X-FF-Example-Flag-A" in a header.
+    variable, and be overrideable in an endpoint by supplying it as "FF-Example-Flag-A" in a header.
 
     """
 
     ### NOTE: This is a placeholder for future work, and only serves as a proof of concept of the idea.
     #
-    # Header: X-FF-Enable-Opportunity-Log-Msg
+    # Header: FF-Enable-Opportunity-Log-Msg
     # EnvVar: ENABLE_OPPORTUNITY_LOG_MSG
     ENABLE_OPPORTUNITY_LOG_MSG = "enable_opportunity_log_msg"
 
     def get_header_name(self) -> str:
         value = "-".join([v.capitalize() for v in self.value.lower().split("_")])
 
-        return f"X-FF-{value}"
+        return f"FF-{value}"
 
     def get_env_var_name(self) -> str:
         return self.value.upper()

--- a/api/src/api/feature_flags/feature_flag_config.py
+++ b/api/src/api/feature_flags/feature_flag_config.py
@@ -23,6 +23,18 @@ class FeatureFlagConfig(PydanticBaseEnvConfig):
 
 
 # Global, loaded once at startup by calling initialize
+"""
+NOTE: This structure of requiring you to initialize the config
+is to allow us to expand the feature flag implementation in the future
+to allow for updating feature flags while the application is still running.
+
+What we would need to add is a background thread that periodically
+checks some external system (the database, S3, AWS app config, etc.)
+for the current feature flag value, and load that into this configuration.
+
+By having this structure of initialize() + get_feature_flag_config() - we don't
+need to later modify the usage of the feature flag config, just this underlying implementation.
+"""
 _config: FeatureFlagConfig | None = None
 
 

--- a/api/src/api/opportunities/opportunity_schemas.py
+++ b/api/src/api/opportunities/opportunity_schemas.py
@@ -82,7 +82,7 @@ class OpportunitySearchSchema(request_schema.OrderedSchema):
 
 
 class OpportunitySearchHeaderSchema(request_schema.OrderedSchema):
-    # Header field: X-FF-Enable-Opportunity-Log-Msg
+    # Header field: FF-Enable-Opportunity-Log-Msg
     enable_opportunity_log_msg = fields.Boolean(
         data_key=FeatureFlag.ENABLE_OPPORTUNITY_LOG_MSG.get_header_name(),
         metadata={"description": "Whether to log a message in the opportunity endpoint"},

--- a/api/tests/src/route/test_opportunity_route.py
+++ b/api/tests/src/route/test_opportunity_route.py
@@ -321,7 +321,7 @@ def test_opportunity_search_feature_flag_200(
     headers = {"X-Auth": api_auth_token}
 
     if enable_opportunity_log_msg is not None:
-        headers["X-FF-Enable-Opportunity-Log-Msg"] = enable_opportunity_log_msg
+        headers["FF-Enable-Opportunity-Log-Msg"] = enable_opportunity_log_msg
 
     client.post("/v1/opportunities/search", json=get_search_request(), headers=headers)
 
@@ -338,11 +338,11 @@ def test_opportunity_search_feature_flag_invalid_value_422(
 ):
     headers = {
         "X-Auth": api_auth_token,
-        "X-FF-Enable-Opportunity-Log-Msg": enable_opportunity_log_msg,
+        "FF-Enable-Opportunity-Log-Msg": enable_opportunity_log_msg,
     }
 
     resp = client.post("/v1/opportunities/search", json=get_search_request(), headers=headers)
     assert resp.status_code == 422
 
     response_data = resp.get_json()["detail"]["headers"]
-    assert response_data == {"X-FF-Enable-Opportunity-Log-Msg": ["Not a valid boolean."]}
+    assert response_data == {"FF-Enable-Opportunity-Log-Msg": ["Not a valid boolean."]}


### PR DESCRIPTION
## Summary
Fixes #626

### Time to review: __1 mins__

## Changes proposed
Making the feature flags not start with `X-`

## Context for reviewers
This was supposed to be on PR https://github.com/HHS/simpler-grants-gov/pull/640 but I forgot to merge the change to that branch before merging the PR. Whoops.

## Additional information
![Screenshot 2023-11-06 at 3 57 50 PM](https://github.com/HHS/simpler-grants-gov/assets/46358556/6051c5c4-a98e-43ee-85a0-0361777f0802)

