### PR TITLE
Add vulnerabilities to ignore file

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -19,6 +19,9 @@ ignore:
   # https://github.com/anchore/grype/issues/1172
   - vulnerability: GHSA-xqr8-7jwr-rhp7
   - vulnerability: GHSA-7fh5-64p2-3v2j
-    # pip vulnerability, need to wait for the Python image to update to 23.x
-    # https://github.com/docker-library/python/blob/402b993af9ca7a5ee22d8ecccaa6197bfb957bc5/3.12/slim-bookworm/Dockerfile#L137
-  - vulnerability: GHSA-mq26-g339-26xf
+    # 11/14/2023 - Postgres vulnerabilities in the Debian image
+  - vulnerability: CVE-2023-39417
+  - vulnerability: CVE-2023-5869
+  - vulnerability: CVE-2023-39418
+  - vulnerability: CVE-2023-5868
+  - vulnerability: CVE-2023-5870

--- a/.grype.yml
+++ b/.grype.yml
@@ -19,7 +19,10 @@ ignore:
   # https://github.com/anchore/grype/issues/1172
   - vulnerability: GHSA-xqr8-7jwr-rhp7
   - vulnerability: GHSA-7fh5-64p2-3v2j
-    # 11/14/2023 - Postgres vulnerabilities in the Debian image
+  # pip vulnerability, need to wait for the Python image to update to 23.x
+  # https://github.com/docker-library/python/blob/402b993af9ca7a5ee22d8ecccaa6197bfb957bc5/3.12/slim-bookworm/Dockerfile#L137
+  - vulnerability: GHSA-mq26-g339-26xf
+  # 11/14/2023 - Postgres vulnerabilities in the Debian image
   - vulnerability: CVE-2023-39417
   - vulnerability: CVE-2023-5869
   - vulnerability: CVE-2023-39418

--- a/.trivyignore
+++ b/.trivyignore
@@ -8,3 +8,9 @@
 #  Last checked:  Date last checked in scans
 #The-CVE-or-vuln-id # Remove comment at start of line
 CVE-2023-5363
+# 11/14/2023 - Postgres vulnerabilities in the Debian image
+CVE-2023-39417
+CVE-2023-5869
+CVE-2023-39418
+CVE-2023-5868
+CVE-2023-5870


### PR DESCRIPTION

### Time to review: __1 mins__

## Changes proposed
Adds vulnerabilities to ignore list

## Context for reviewers
Several Postgres vulnerabilities in our Debian image (which the Python image pulls from). I believe these are fixed in Debian, but we need to wait for the Debian Docker image to be rebuilt (last rebuild at end of October) and they avoid rebuilding frequently, likely will be fixed in a few weeks.

## Additional information
https://github.com/HHS/simpler-grants-gov/actions/runs/6861302163/job/18656801836?pr=688
https://github.com/HHS/simpler-grants-gov/actions/runs/6867481396/job/18675968227?pr=690
