### PR TITLE
[ISSUE 484] Configure Alerts for Static Site Launch

### DIFF
--- a/documentation/infra/set-up-monitoring-alerts.md
+++ b/documentation/infra/set-up-monitoring-alerts.md
@@ -9,6 +9,7 @@ The monitoring module defines metric-based alerting policies that provides aware
 1. Add the `email_alerts_subscription_list` variable to the monitoring module call in the service layer
 
 For example:
+
 ```
 module "monitoring" {
   source = "../../modules/monitoring"
@@ -16,14 +17,17 @@ module "monitoring" {
   ...
 }
 ```
+
 2. Run `make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>` to apply the changes to each environment.
-When any of the alerts described by the module are triggered notification will be send to all email specified in the `email_alerts_subscription_list`
+   When any of the alerts described by the module are triggered notification will be send to all email specified in the `email_alerts_subscription_list`
 
 ### Set up External incident management service integration.
 
 1. Set setting `has_incident_management_service = true` in app-config/main.tf
 2. Get the integration URL for the incident management service and store it in AWS SSM Parameter Store by running the following command for each environment:
+
 ```
 make infra-configure-monitoring-secrets APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT> URL=<WEBHOOK_URL>
 ```
+
 3. Run `make infra-update-app-service APP_NAME=<APP_NAME> ENVIRONMENT=<ENVIRONMENT>` to apply the changes to each environment.

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -111,7 +111,7 @@ module "service" {
 module "monitoring" {
   source = "../../modules/monitoring"
   #Email subscription list:
-  #email_alerts_subscription_list = ["email1@email.com", "email2@email.com"]
+  email_alerts_subscription_list = ["grantsalerts@navapbc.com"]
 
   # Module takes service and ALB names to link all alerts with corresponding targets
   service_name                                = local.service_name

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -121,7 +121,7 @@ module "service" {
 module "monitoring" {
   source = "../../modules/monitoring"
   #Email subscription list:
-  #email_alerts_subscription_list = ["email1@email.com", "email2@email.com"]
+  email_alerts_subscription_list = ["grantsalerts@navapbc.com"]
 
   # Module takes service and ALB names to link all alerts with corresponding targets
   service_name                                = local.service_name


### PR DESCRIPTION
## Summary
Fixes #484

### Time to review: __3 mins__

## Changes proposed
- Add email monitoring alerts for api and frontend (both dev and prod)

## Context for reviewers
I don't see a way currently to add email alerts to a service and disable them by environment. I can add that if we want it without a lot of trouble? Let me know.

