### PR TITLE
[Issue 770] percent of issues pointed

### DIFF
--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -48,6 +48,7 @@ disable = [
   "R0801", # duplicate-code
   "W0511", # fix-me
   "R0913", # too-many-arguments
+  "R0902", # too-many-instance-attributes
 ]
 
 [tool.ruff]

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -85,6 +85,8 @@ def calculate_sprint_burndown(
     # optionally display the burndown chart in the browser
     if show_results:
         burndown.show_chart()
+        print("Slack message:\n")
+        print(burndown.format_slack_message())
     # optionally post the results to slack
     if post_results:
         slackbot = slack.SlackBot(client=WebClient(token=settings.slack_bot_token))
@@ -120,6 +122,8 @@ def calculate_deliverable_percent_complete(
     # optionally display the burndown chart in the browser
     if show_results:
         pct_complete.show_chart()
+        print("Slack message:\n")
+        print(pct_complete.format_slack_message())
     if post_results:
         slackbot = slack.SlackBot(client=WebClient(token=settings.slack_bot_token))
         pct_complete.post_results_to_slack(

--- a/analytics/src/analytics/metrics/base.py
+++ b/analytics/src/analytics/metrics/base.py
@@ -1,6 +1,8 @@
 """Base class for all metrics."""
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 from plotly.graph_objects import Figure
@@ -15,6 +17,14 @@ class Unit(Enum):
     points = "points"  # pylint: disable=C0103
 
 
+@dataclass
+class Statistic:
+    """Store a single value that represents a summary statistic about a dataset."""
+
+    value: Any
+    suffix: str | None = None
+
+
 class BaseMetric:
     """Base class for all metrics."""
 
@@ -25,10 +35,15 @@ class BaseMetric:
     def __init__(self) -> None:
         """Initialize and calculate the metric from the input dataset."""
         self.results = self.calculate()
+        self.stats = self.get_stats()
         self._chart: Figure | None = None
 
     def calculate(self) -> pd.DataFrame:
         """Calculate the metric and return the resulting dataset."""
+        raise NotImplementedError
+
+    def get_stats(self) -> dict[str, Statistic]:
+        """Get the list of stats associated with this metric to include in reporting."""
         raise NotImplementedError
 
     @property

--- a/analytics/src/analytics/metrics/base.py
+++ b/analytics/src/analytics/metrics/base.py
@@ -22,7 +22,7 @@ class Statistic:
     """Store a single value that represents a summary statistic about a dataset."""
 
     value: Any
-    suffix: str | None = None
+    suffix: str = ""
 
 
 class BaseMetric:

--- a/analytics/src/analytics/metrics/burndown.py
+++ b/analytics/src/analytics/metrics/burndown.py
@@ -161,16 +161,21 @@ class SprintBurndown(BaseMetric):
         Notes
         -----
         It does this by:
-        - Finding the earliest date a ticket was created
         - Finding the date when the sprint ends
-        - Creating a row for each day between the earliest date a ticket was closed
-
+        - Finding the earliest date a issue was created
+        - Finding the latest date a issue was closed
+        - Creating a row for each day between the earliest date a ticket was opened
+          and either the sprint end _or_ the latest date an issue was closed,
+          whichever is the later date.
         """
-        opened_min = df[self.opened_col].min()  # earliest date a tix was created
+        # get earliest date an issue was opened and latest date one was closed
         sprint_end = self.dataset.sprint_end(self.sprint)
+        opened_min = df[self.opened_col].min()
+        closed_max = df[self.closed_col].max()
+        closed_max = sprint_end if closed_max is nan else max(sprint_end, closed_max)
         # creates a dataframe with one row for each day between min and max date
         return pd.DataFrame(
-            pd.date_range(opened_min, sprint_end),
+            pd.date_range(opened_min, closed_max),
             columns=[self.date_col],
         )
 

--- a/analytics/src/analytics/metrics/burndown.py
+++ b/analytics/src/analytics/metrics/burndown.py
@@ -117,7 +117,9 @@ class SprintBurndown(BaseMetric):
 
     def format_slack_message(self) -> str:
         """Format the message that will be included with the charts posted to slack."""
-        message = f"*:github: Burndown summary for {self.sprint} by {self.unit.value}*"
+        message = (
+            f"*:github: Burndown summary for {self.sprint} by {self.unit.value}*\n"
+        )
         for label, stat in self.stats.items():
             message += f"• *{label}:* {stat.value}{stat.suffix}\n"
         return message

--- a/analytics/src/analytics/metrics/percent_complete.py
+++ b/analytics/src/analytics/metrics/percent_complete.py
@@ -7,7 +7,7 @@ from plotly.graph_objects import Figure
 
 from analytics.datasets.deliverable_tasks import DeliverableTasks
 from analytics.etl.slack import SlackBot
-from analytics.metrics.base import BaseMetric, Unit
+from analytics.metrics.base import BaseMetric, Statistic, Unit
 
 
 class DeliverablePercentComplete(BaseMetric):
@@ -104,6 +104,10 @@ class DeliverablePercentComplete(BaseMetric):
         # to prevent duplicate col names when open and closed counts are joined
         df_agg = df.groupby(self.deliverable_col, as_index=False).agg({unit_col: "sum"})
         return df_agg.rename(columns={unit_col: status})
+
+    def get_stats(self) -> dict[str, Statistic]:
+        """Calculate stats for this metric."""
+        return {}
 
     def _prepare_result_dataframe_for_plotly(self) -> pd.DataFrame:
         """Stack the open and closed counts self.results for plotly charts."""

--- a/analytics/tests/metrics/test_burndown.py
+++ b/analytics/tests/metrics/test_burndown.py
@@ -362,3 +362,51 @@ class TestGetStats:
         assert output.stats.get(self.PCT_POINTED).value == 50
         # validation - check that stat contains '%' suffix
         assert f"% of {Unit.issues.value}" in output.stats.get(self.PCT_POINTED).suffix
+
+
+class TestFormatSlackMessage:
+    """Test the DeliverablePercentComplete.format_slack_message()."""
+
+    def test_slack_message_contains_right_number_of_lines(self):
+        """Message should contain one line for the title and one for each stat."""
+        # setup - create test data
+        sprint_data = [
+            sprint_row(issue=1, sprint_start=DAY_1, created=DAY_0, points=2),
+            sprint_row(issue=1, sprint_start=DAY_1, created=DAY_2, points=3),
+        ]
+        test_data = SprintBoard.from_dict(sprint_data)
+        # execution
+        output = SprintBurndown(test_data, sprint="Sprint 1", unit=Unit.points)
+        lines = output.format_slack_message().splitlines()
+        for line in lines:
+            print(line)
+        # validation
+        assert len(lines) == len(list(output.stats)) + 1
+
+    def test_title_includes_issues_when_unit_is_issue(self):
+        """Test that the title is formatted correctly when unit is issues."""
+        # setup - create test data
+        sprint_data = [
+            sprint_row(issue=1, sprint_start=DAY_1, created=DAY_0, points=2),
+            sprint_row(issue=1, sprint_start=DAY_1, created=DAY_2, points=3),
+        ]
+        test_data = SprintBoard.from_dict(sprint_data)
+        # execution
+        output = SprintBurndown(test_data, sprint="Sprint 1", unit=Unit.issues)
+        title = output.format_slack_message().splitlines()[0]
+        # validation
+        assert Unit.issues.value in title
+
+    def test_title_includes_points_when_unit_is_points(self):
+        """Test that the title is formatted correctly when unit is points."""
+        # setup - create test data
+        sprint_data = [
+            sprint_row(issue=1, sprint_start=DAY_1, created=DAY_0, points=2),
+            sprint_row(issue=1, sprint_start=DAY_1, created=DAY_2, points=3),
+        ]
+        test_data = SprintBoard.from_dict(sprint_data)
+        # execution
+        output = SprintBurndown(test_data, sprint="Sprint 1", unit=Unit.points)
+        title = output.format_slack_message().splitlines()[0]
+        # validation
+        assert Unit.points.value in title

--- a/analytics/tests/metrics/test_percent_complete.py
+++ b/analytics/tests/metrics/test_percent_complete.py
@@ -129,3 +129,107 @@ class TestDeliverablePercentComplete:
         # validation - check percent complete
         assert df.loc["Deliverable 1", "percent_complete"] == 1.0
         assert df.loc["Deliverable 2", "percent_complete"] == 0.0
+
+
+class TestGetStats:
+    """Test the DeliverablePercentComplete.get_stats() method."""
+
+    def test_all_issues_are_pointed(self):
+        """Test that stats show 100% of issues are pointed if all have points."""
+        # setup - create test dataset
+        test_rows = [
+            task_row(deliverable=1, task=1, points=2, status="open"),
+            task_row(deliverable=1, task=2, points=1, status="closed"),
+            task_row(deliverable=2, task=3, points=3, status="open"),
+            task_row(deliverable=2, task=3, points=1, status="open"),
+        ]
+        test_data = DeliverableTasks.from_dict(test_rows)
+        # execution
+        output = DeliverablePercentComplete(test_data, unit=Unit.issues)
+        # validation
+        assert len(output.stats) == 2
+        for deliverable in ["Deliverable 1", "Deliverable 2"]:
+            stat = output.stats.get(deliverable)
+            assert stat.value == 100
+            assert stat.suffix == f"% of {Unit.issues.value} pointed"
+
+    def test_some_issues_are_not_pointed(self):
+        """Test that stats are calculated correctly if not all issues are pointed."""
+        # setup - create test dataset
+        test_rows = [
+            task_row(deliverable=1, task=1, points=2, status="open"),
+            task_row(deliverable=1, task=2, points=0, status="closed"),
+            task_row(deliverable=2, task=3, points=3, status="open"),
+            task_row(deliverable=2, task=3, points=None, status="open"),
+        ]
+        test_data = DeliverableTasks.from_dict(test_rows)
+        # execution
+        output = DeliverablePercentComplete(test_data, unit=Unit.issues)
+        # validation
+        assert len(output.stats) == 2
+        for deliverable in ["Deliverable 1", "Deliverable 2"]:
+            stat = output.stats.get(deliverable)
+            assert stat.value == 50
+            assert stat.suffix == f"% of {Unit.issues.value} pointed"
+
+    def test_deliverables_without_tasks_have_0_pct_pointed(self):
+        """Deliverables without tasks should have 0% pointed in stats."""
+        # setup - create test dataset
+        test_rows = [
+            task_row(deliverable=1, task=1, points=2, status="open"),
+            task_row(deliverable=1, task=2, points=1, status="closed"),
+            task_row(deliverable=2, task=None, points=None, status=None),
+        ]
+        test_data = DeliverableTasks.from_dict(test_rows)
+        # execution
+        output = DeliverablePercentComplete(test_data, unit=Unit.issues)
+        # validation
+        assert len(output.stats) == 2
+        assert output.stats.get("Deliverable 1").value == 100
+        assert output.stats.get("Deliverable 2").value == 0
+
+
+class TestFormatSlackMessage:
+    """Test the DeliverablePercentComplete.format_slack_message()."""
+
+    def test_slack_message_contains_right_number_of_lines(self):
+        """Message should contain one line for the title and one for each deliverable."""
+        # setup - create test dataset
+        test_rows = [
+            task_row(deliverable=1, task=1, points=2, status="open"),
+            task_row(deliverable=2, task=2, points=1, status=None),
+        ]
+        test_data = DeliverableTasks.from_dict(test_rows)
+        # execution
+        output = DeliverablePercentComplete(test_data, unit=Unit.issues)
+        lines = output.format_slack_message().partition("\n")
+        # validation
+        assert len(lines) == 3
+
+    def test_title_includes_issues_when_unit_is_issue(self):
+        """Test that the title is formatted correctly when unit is issues."""
+        # setup - create test dataset
+        test_rows = [
+            task_row(deliverable=1, task=1, points=2, status="open"),
+            task_row(deliverable=2, task=2, points=1, status=None),
+        ]
+        test_data = DeliverableTasks.from_dict(test_rows)
+        # execution
+        output = DeliverablePercentComplete(test_data, unit=Unit.issues)
+        title = output.format_slack_message().partition("\n")[0]
+        # validation
+        assert Unit.issues.value in title
+
+    def test_title_includes_points_when_unit_is_points(self):
+        """Test that the title is formatted correctly when unit is points."""
+        # setup - create test dataset
+        test_rows = [
+            task_row(deliverable=1, task=1, points=2, status="open"),
+            task_row(deliverable=2, task=2, points=1, status=None),
+        ]
+        test_data = DeliverableTasks.from_dict(test_rows)
+        # execution
+        output = DeliverablePercentComplete(test_data, unit=Unit.points)
+        title = output.format_slack_message().partition("\n")[0]
+        # validation
+        assert Unit.points.value in title

--- a/analytics/tests/metrics/test_percent_complete.py
+++ b/analytics/tests/metrics/test_percent_complete.py
@@ -197,14 +197,15 @@ class TestFormatSlackMessage:
         # setup - create test dataset
         test_rows = [
             task_row(deliverable=1, task=1, points=2, status="open"),
-            task_row(deliverable=2, task=2, points=1, status=None),
+            task_row(deliverable=2, task=2, points=1, status="closed"),
+            task_row(deliverable=3, task=3, points=3, status="open"),
         ]
         test_data = DeliverableTasks.from_dict(test_rows)
         # execution
         output = DeliverablePercentComplete(test_data, unit=Unit.issues)
-        lines = output.format_slack_message().partition("\n")
+        lines = output.format_slack_message().splitlines()
         # validation
-        assert len(lines) == 3
+        assert len(lines) == 4
 
     def test_title_includes_issues_when_unit_is_issue(self):
         """Test that the title is formatted correctly when unit is issues."""
@@ -216,7 +217,7 @@ class TestFormatSlackMessage:
         test_data = DeliverableTasks.from_dict(test_rows)
         # execution
         output = DeliverablePercentComplete(test_data, unit=Unit.issues)
-        title = output.format_slack_message().partition("\n")[0]
+        title = output.format_slack_message().splitlines()[0]
         # validation
         assert Unit.issues.value in title
 
@@ -230,6 +231,6 @@ class TestFormatSlackMessage:
         test_data = DeliverableTasks.from_dict(test_rows)
         # execution
         output = DeliverablePercentComplete(test_data, unit=Unit.points)
-        title = output.format_slack_message().partition("\n")[0]
+        title = output.format_slack_message().splitlines()[0]
         # validation
         assert Unit.points.value in title


### PR DESCRIPTION
## Summary

Refactors how statistics about a metric are calculated and formatted for slack and adds a percent of issues pointed as a statistic to both `SprintBurndown` and `DeliverablePercentComplete`

Fixes #770 

### Time to review: __10 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

To test this yourself:

1. Checkout the PR locally: 

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1096" alt="Screenshot 2023-12-04 at 5 00 24 PM" src="https://github.com/HHS/simpler-grants-gov/assets/21350331/a61c3f71-b39b-43c6-a354-5e1e92f21105">

