### PR TITLE
[Issue 888] Use dot not space when referring to Simpler.Grants.gov

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -39,7 +39,7 @@
     "wtgi_paragraph_2": "<strong>Questions?</strong> Contact us at <email>{{email}}</email>."
   },
   "Research": {
-    "page_title": "Research | Simpler Grants.gov",
+    "page_title": "Research | Simpler.Grants.gov",
     "meta_description": "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     "intro": {
       "title": "Our existing research",
@@ -148,7 +148,7 @@
     }
   },
   "Process": {
-    "page_title": "Process | Simpler Grants.gov",
+    "page_title": "Process | Simpler.Grants.gov",
     "meta_description": "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     "intro": {
       "title": "Our open process",
@@ -206,7 +206,7 @@
     }
   },
   "Newsletter": {
-    "page_title": "Newsletter | Simpler Grants.gov",
+    "page_title": "Newsletter | Simpler.Grants.gov",
     "title": "Newsletter signup",
     "intro": "Subscribe to get Simpler.Grants.gov project updates in your inbox!",
     "paragraph_1": "If you sign up for the Simpler.Grants.gov newsletter, we’ll keep you informed of our progress and you’ll know about every opportunity to get involved.",
@@ -214,7 +214,7 @@
     "disclaimer": "The Simpler.Grants.gov newsletter is powered by the Sendy data service. Personal information is not stored within Simpler.Grants.gov. "
   },
   "Newsletter_confirmation": {
-    "page_title": "Newsletter Confirmation | Simpler Grants.gov",
+    "page_title": "Newsletter Confirmation | Simpler.Grants.gov",
     "title": "You’re subscribed",
     "intro": "You are signed up to receive project updates from Simpler.Grants.gov.",
     "paragraph_1": "Thank you for subscribing. We’ll keep you informed of our progress and you’ll know about every opportunity to get involved.",
@@ -223,7 +223,7 @@
     "disclaimer": "The Simpler.Grants.gov newsletter is powered by the Sendy data service. Personal information is not stored within Simpler.Grants.gov. "
   },
   "Newsletter_unsubscribe": {
-    "page_title": "Newsletter Unsubscribe | Simpler Grants.gov",
+    "page_title": "Newsletter Unsubscribe | Simpler.Grants.gov",
     "title": "You have unsubscribed",
     "intro": "You will no longer receive project updates from Simpler.Grants.gov. ",
     "paragraph_1": "Did you unsubscribe by accident? Sign up again.",
@@ -245,7 +245,7 @@
     "nav_link_research": "Research",
     "nav_link_newsletter": "Newsletter",
     "nav_menu_toggle": "Menu",
-    "title": "Simpler Grants.gov"
+    "title": "Simpler.Grants.gov"
   },
   "Hero": {
     "title": "We're building a simpler Grants.gov!",


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __<1min__

## Changes proposed
- Change the site title in the header from "Simpler Grants.gov" to "Simpler.Grants.gov"
- Do the same in the tab titles for each page

## Context for reviewers
This change updates the site to match the Figma. We use the full URL — Simpler.Grants.gov — when referring to this beta website. We only use "simpler Grants.gov" (with a space and a lowercase s) when referring to the ultimate goal of making Grants.gov simpler. 

