### PR TITLE
[Issue 888] Tweak responsive spacing of Hero

### DIFF
--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -12,10 +12,10 @@ const Hero = () => {
   return (
     <div data-testid="hero" className="usa-dark-background bg-primary">
       <GridContainer className="padding-y-1 tablet:padding-y-3 tablet-lg:padding-y-10 desktop-lg:padding-y-15 position-relative">
-        <h1 className="tablet:font-sans-2xl desktop-lg:font-sans-3xl text-ls-neg-2">
+        <h1 className="text-ls-neg-2 tablet:font-sans-2xl desktop-lg:font-sans-3xl desktop-lg:margin-top-2">
           <span>{t("title")}</span>
         </h1>
-        <p className="usa-intro line-height-sans- font-sans-md tablet:font-sans-lg desktop-lg:font-sans-xl">
+        <p className="usa-intro line-height-sans-3 font-sans-md tablet:font-sans-lg desktop-lg:font-sans-xl desktop-lg:margin-bottom-0">
           {t("content")}
         </p>
         <Link


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __2 mins__

## Changes proposed
- Add `desktop-lg:margin-top-2` to the Hero's heading to decrease the space between it and the button
- Decrease the `line-height` of the intro paragraph
- Add `desktop-lg:margin-bottom-0` to the intro paragraph to nix the extra space at bottom of Hero


## Context for reviewers
This change updates the site to better match the Figma. 