### PR TITLE
[Issue 888] Fix 'Grants gov' typo

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -19,7 +19,7 @@
       "title_1": "The process",
       "title_2": "The research",
       "paragraph_1": "This project is transparent, iterative, and agile. All of the code we’re writing is open source and our roadmap is public. As we release new versions, you can try out functional software and give us feedback on what works and what can be improved to inform what happens next.",
-      "paragraph_2": "We conducted extensive research in 2023 to gather insights from applicants, potential applicants, and grantmakers. We’re using these findings to guide our work. And your ongoing feedback will inform and inspire new features as we build a simpler Grants gov together.",
+      "paragraph_2": "We conducted extensive research in 2023 to gather insights from applicants, potential applicants, and grantmakers. We’re using these findings to guide our work. And your ongoing feedback will inform and inspire new features as we build a simpler Grants.gov together.",
       "cta_1": "Learn about what’s happening",
       "cta_2": "Read the research findings"
     },
@@ -43,7 +43,7 @@
     "meta_description": "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     "intro": {
       "title": "Our existing research",
-      "content": "We conducted extensive research in 2023 to gather insights from applicants, potential applicants, and grantmakers. We’re using these findings to guide our work. And your ongoing feedback will inform and inspire new features as we build a simpler Grants gov together."
+      "content": "We conducted extensive research in 2023 to gather insights from applicants, potential applicants, and grantmakers. We’re using these findings to guide our work. And your ongoing feedback will inform and inspire new features as we build a simpler Grants.gov together."
     },
     "methodology": {
       "title": "The methodology",


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __< 1 min__

## Changes proposed
- Changes 2 instances of "Grants gov" to "Grants.gov"

## Context for reviewers
This is just fixing a typo. 