### PR TITLE
[Issue 888] Prevent orphaned button icons

### DIFF
--- a/frontend/src/pages/content/IndexGoalContent.tsx
+++ b/frontend/src/pages/content/IndexGoalContent.tsx
@@ -17,9 +17,9 @@ const IndexGoalContent = () => {
         <p className="usa-intro padding-bottom-2">{t("goal.paragraph_1")}</p>
         <Link href="/newsletter" passHref>
           <Button className="margin-bottom-4" type="button" size="big">
-            {t("goal.cta")}{" "}
+            <span className="margin-right-5">{t("goal.cta")}</span>
             <Icon.ArrowForward
-              className="text-middle"
+              className="text-middle margin-left-neg-4"
               size={4}
               aria-label="arrow-forward"
             />

--- a/frontend/src/pages/content/ProcessAndResearchContent.tsx
+++ b/frontend/src/pages/content/ProcessAndResearchContent.tsx
@@ -21,9 +21,11 @@ const ProcessAndResearchContent = () => {
         </p>
         <Link href="/process" passHref>
           <Button className="margin-bottom-4" type="button" size="big">
-            {t("process_and_research.cta_1")}{" "}
+            <span className="margin-right-5">
+              {t("process_and_research.cta_1")}
+            </span>
             <Icon.ArrowForward
-              className="text-middle"
+              className="text-middle margin-left-neg-4"
               size={4}
               aria-label="arrow-forward"
             />
@@ -39,9 +41,11 @@ const ProcessAndResearchContent = () => {
         </p>
         <Link href="research" passHref>
           <Button className="margin-bottom-4" type="button" size="big">
-            {t("process_and_research.cta_2")}{" "}
+            <span className="margin-right-5">
+              {t("process_and_research.cta_2")}
+            </span>
             <Icon.ArrowForward
-              className="text-middle"
+              className="text-middle margin-left-neg-4"
               size={4}
               aria-label="arrow-forward"
             />

--- a/frontend/src/pages/content/ProcessMilestones.tsx
+++ b/frontend/src/pages/content/ProcessMilestones.tsx
@@ -100,9 +100,9 @@ const ProcessMilestones = () => {
           </p>
           <Link href={ExternalRoutes.MILESTONES} passHref>
             <Button className="margin-bottom-4" type="button" size="big">
-              {t("milestones.cta_1")}{" "}
+              <span className="margin-right-5">{t("milestones.cta_1")}</span>
               <Icon.Launch
-                className="text-middle"
+                className="text-middle margin-left-neg-4"
                 size={4}
                 aria-label="launch"
               />
@@ -150,9 +150,9 @@ const ProcessMilestones = () => {
           </p>
           <Link href={ExternalRoutes.MILESTONES} passHref>
             <Button className="margin-bottom-4" type="button" size="big">
-              {t("milestones.cta_2")}{" "}
+              <span className="margin-right-5">{t("milestones.cta_2")}</span>
               <Icon.Launch
-                className="text-middle"
+                className="text-middle margin-left-neg-4"
                 size={4}
                 aria-label="launch"
               />

--- a/frontend/src/pages/content/ResearchMethodology.tsx
+++ b/frontend/src/pages/content/ResearchMethodology.tsx
@@ -46,9 +46,10 @@ const ResearchMethodology = () => {
         </p>
         <Link href="/newsletter" passHref>
           <Button className="margin-bottom-4" type="button" outline>
-            {t("methodology.cta")}{" "}
+            <span className="margin-right-4">{t("methodology.cta")}</span>
             <Icon.ArrowForward
-              className="text-middle"
+              className="text-middle margin-left-neg-3"
+              size={3}
               aria-label="arror-forward"
             />
           </Button>


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __5 mins__

## Changes proposed
- Changes the method used for spacing icons within buttons so that they are not orphaned when the text wraps to multiple lines. 
  - `margin-right` on a span containing the text causes it to wrap to a 2nd line sooner that would
  - negative `margin-left` on the icon pulls it back closer to the text and makes sure it's always on the same line

## Context for reviewers
On smaller screens, or when the grid column is smaller than the width of the text, buttons can wrap to two lines. At the largest point at which this happens, only the icon was wrapping to the second line. This fix makes it so that the icon is always on the same line as the last word of the text. 

## Additional information

![image](https://github.com/HHS/simpler-grants-gov/assets/409279/c86cea2a-bf54-4625-a3d1-6595e585acde)
