### PR TITLE
[Issue 888] Simplify the grid on "The goal" section

### DIFF
--- a/frontend/src/pages/content/IndexGoalContent.tsx
+++ b/frontend/src/pages/content/IndexGoalContent.tsx
@@ -13,7 +13,7 @@ const IndexGoalContent = () => {
       data-testid="goal-content"
       bottomBorder="light"
     >
-      <Grid tabletLg={{ col: 6 }} desktop={{ col: 5 }} desktopLg={{ col: 6 }}>
+      <Grid tabletLg={{ col: 6 }}>
         <p className="usa-intro padding-bottom-2">{t("goal.paragraph_1")}</p>
         <Link href="/newsletter" passHref>
           <Button className="margin-bottom-4" type="button" size="big">
@@ -26,7 +26,7 @@ const IndexGoalContent = () => {
           </Button>
         </Link>
       </Grid>
-      <Grid tabletLg={{ col: 6 }} desktop={{ col: 7 }} desktopLg={{ col: 6 }}>
+      <Grid tabletLg={{ col: 6 }}>
         <h3 className="tablet-lg:font-sans-lg tablet-lg:margin-bottom-05">
           {t("goal.title_2")}
         </h3>


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __2 mins__

## Changes proposed
- Only use a single grid breakpoint (removed the `desktop:grid-col-5` and `desktop-lg:grid-col-6` classes) 

## Context for reviewers
The grid for "The goal" section went from 6/6 on tablet, to 5/7 on desktop, to 6/6 on large desktop. There was no reason for that middle size to have a narrower lefthand column. Now it's just 6/6 on tablet and above. 
