### PR TITLE
[Issue 888] Add max width to `ContentLayout` headers for legibility

### DIFF
--- a/frontend/src/components/ContentLayout.tsx
+++ b/frontend/src/components/ContentLayout.tsx
@@ -23,7 +23,7 @@ const ContentLayout = ({
         : "tablet-lg:font-sans-l desktop-lg:font-sans-xl";
     return (
       <h2
-        className={`margin-bottom-0 ${size} ${
+        className={`margin-bottom-0 maxw-tablet-lg ${size} ${
           !paddingTop ? "margin-top-0" : ""
         }`}
       >


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __1 min__

## Changes proposed
- Adds the `maxw-tablet-lg` to the headers in the `ContentLayout` component so that they are more legible 

## Context for reviewers
Very long line lengths are difficult to read. Having a max width improves legibility. 

This change updates the site to better match the Figma.