### PR TITLE
[Issue 888] Fix typos in end paragraph on /research

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -94,7 +94,7 @@
       "paragraph_1": "The most burden is on the Novice to become an expert on the grants process and system. In order to execute our mission, there is a need to improve awareness, access, and choice. This requires reaching out to those who are unfamiliar with the grant application process.",
       "paragraph_2": "There are many common barriers that users face:",
       "title_2": "Are there challenges you’ve experienced that aren’t captured here?",
-      "paragraph_3": "If you would like to share your experiences and challenges as either an applicant or grantmaker, reach out to us at <email>simpler@grants.gov</email> or <newsletter>sign up for project updates <arrowUpRightFromSquare></arrowUpRightFromSquare></newsletter>. to be notified of upcoming user research efforts.",
+      "paragraph_3": "If you would like to share your experiences and challenges as either an applicant or grantmaker, reach out to us at <strong><email>simpler@grants.gov</email></strong> or <strong><newsletter>sign up for project updates <arrowUpRightFromSquare></arrowUpRightFromSquare></newsletter></strong> to be notified of upcoming user research efforts.",
       "boxes": [
         {
           "title": "Digital connectivity",


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __1 min__

## Changes proposed
-  Make links bold (to match Figma)
-  nix stray period after the link

