### PR TITLE
[Issue 888] Make CTAs bold on newsletter subpages

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -219,7 +219,7 @@
     "intro": "You are signed up to receive project updates from Simpler.Grants.gov.",
     "paragraph_1": "Thank you for subscribing. We’ll keep you informed of our progress and you’ll know about every opportunity to get involved.",
     "heading": "Learn more",
-    "paragraph_2": "You can read all about our <process-link>transparent process</process-link> and what we’re doing now, or explore <research-link>our existing user research</research-link> and the findings that are guiding our work.",
+    "paragraph_2": "You can read all about our <strong><process-link>transparent process</process-link></strong> and what we’re doing now, or explore <strong><research-link>our existing user research</research-link></strong> and the findings that are guiding our work.",
     "disclaimer": "The Simpler.Grants.gov newsletter is powered by the Sendy data service. Personal information is not stored within Simpler.Grants.gov. "
   },
   "Newsletter_unsubscribe": {
@@ -229,7 +229,7 @@
     "paragraph_1": "Did you unsubscribe by accident? Sign up again.",
     "button_resub": "Re-subscribe",
     "heading": "Learn more",
-    "paragraph_2": "You can read all about our <process-link>transparent process</process-link> and what we’re doing now, or explore <research-link>our existing user research</research-link> and the findings that are guiding our work.",
+    "paragraph_2": "You can read all about our <strong><process-link>transparent process</process-link></strong> and what we’re doing now, or explore <strong><research-link>our existing user research</research-link></strong> and the findings that are guiding our work.",
     "disclaimer": "The Simpler.Grants.gov newsletter is powered by the Sendy data service. Personal information is not stored within Simpler.Grants.gov. "
   },
   "ErrorPages": {


### PR DESCRIPTION
## Summary
Partially addresses #888 

### Time to review: __1 mins__

## Changes proposed
- Makes the CTA links bold in the paragraphs on the newsletter subpages (to match Figma)
