### PR TITLE
[Issue 893] Make opportunity API model have more fields from the DB

### DIFF
--- a/api/src/api/opportunities/opportunity_schemas.py
+++ b/api/src/api/opportunities/opportunity_schemas.py
@@ -36,11 +36,24 @@ class OpportunitySchema(Schema):
         },
     )
     category_explanation = fields.String(
-        metadata={"description": "TODO", "example": "TODO as well"}
+        metadata={
+            "description": "Explanation of the category when the category is 'O' (other)",
+            "example": None,
+        }
     )
 
-    revision_number = fields.Integer()
-    modified_comments = fields.String()
+    revision_number = fields.Integer(
+        metadata={
+            "description": "The current revision number of the opportunity, counting starts at 0",
+            "example": 0,
+        }
+    )
+    modified_comments = fields.String(
+        metadata={
+            "description": "Details regarding what modification was last made",
+            "example": None,
+        }
+    )
 
     created_at = fields.DateTime(dump_only=True)
     updated_at = fields.DateTime(dump_only=True)

--- a/api/src/api/opportunities/opportunity_schemas.py
+++ b/api/src/api/opportunities/opportunity_schemas.py
@@ -35,6 +35,15 @@ class OpportunitySchema(Schema):
             "example": OpportunityCategory.DISCRETIONARY,
         },
     )
+    category_explanation = fields.String(
+        metadata={
+            "description": "TODO",
+            "example": "TODO as well"
+        }
+    )
+
+    revision_number = fields.Integer()
+    modified_comments = fields.String()
 
     created_at = fields.DateTime(dump_only=True)
     updated_at = fields.DateTime(dump_only=True)

--- a/api/src/api/opportunities/opportunity_schemas.py
+++ b/api/src/api/opportunities/opportunity_schemas.py
@@ -36,10 +36,7 @@ class OpportunitySchema(Schema):
         },
     )
     category_explanation = fields.String(
-        metadata={
-            "description": "TODO",
-            "example": "TODO as well"
-        }
+        metadata={"description": "TODO", "example": "TODO as well"}
     )
 
     revision_number = fields.Integer()

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -75,7 +75,12 @@ class OpportunityFactory(BaseFactory):
     agency = factory.Iterator(["US-ABC", "US-XYZ", "US-123"])
 
     category = factory.fuzzy.FuzzyChoice(OpportunityCategory)
-    category_explanation = factory.Sequence(lambda n: f"Category as chosen by order #{n * n - 1}")
+    # only set the category explanation if category is Other
+    category_explanation = factory.Maybe(
+        decider=factory.LazyAttribute(lambda o: o.category == OpportunityCategory.OTHER),
+        yes_declaration=factory.Sequence(lambda n: f"Category as chosen by order #{n * n - 1}"),
+        no_declaration=None,
+    )
 
     is_draft = False  # Because we filter out drafts, just default these to False
 

--- a/api/tests/src/route/test_opportunity_route.py
+++ b/api/tests/src/route/test_opportunity_route.py
@@ -373,15 +373,16 @@ def test_opportunity_search_feature_flag_invalid_value_422(
 # GET /opportunities/<opportunity_id>
 #####################################
 
-@pytest.mark.parametrize("opportunity_params", [
-    # Whatever defaults we have in the factory
-    {},
-    # Set several values that can be null
-    {
-        "revision_number": 5,
-        "modified_comments": "I changed it"
-    },
-])
+
+@pytest.mark.parametrize(
+    "opportunity_params",
+    [
+        # Whatever defaults we have in the factory
+        {},
+        # Set several values that can be null
+        {"revision_number": 5, "modified_comments": "I changed it"},
+    ],
+)
 def test_get_opportunity_200(client, api_auth_token, enable_factory_create, opportunity_params):
     opportunity = OpportunityFactory.create(**opportunity_params)
 

--- a/api/tests/src/route/test_opportunity_route.py
+++ b/api/tests/src/route/test_opportunity_route.py
@@ -373,9 +373,17 @@ def test_opportunity_search_feature_flag_invalid_value_422(
 # GET /opportunities/<opportunity_id>
 #####################################
 
-
-def test_get_opportunity_200(client, api_auth_token, enable_factory_create):
-    opportunity = OpportunityFactory.create()
+@pytest.mark.parametrize("opportunity_params", [
+    # Whatever defaults we have in the factory
+    {},
+    # Set several values that can be null
+    {
+        "revision_number": 5,
+        "modified_comments": "I changed it"
+    },
+])
+def test_get_opportunity_200(client, api_auth_token, enable_factory_create, opportunity_params):
+    opportunity = OpportunityFactory.create(**opportunity_params)
 
     resp = client.get(
         f"/v1/opportunities/{opportunity.opportunity_id}", headers={"X-Auth": api_auth_token}
@@ -388,6 +396,9 @@ def test_get_opportunity_200(client, api_auth_token, enable_factory_create):
     assert response_data["opportunity_title"] == opportunity.opportunity_title
     assert response_data["agency"] == opportunity.agency
     assert response_data["category"] == opportunity.category
+    assert response_data["category_explanation"] == opportunity.category_explanation
+    assert response_data["revision_number"] == opportunity.revision_number
+    assert response_data["modified_comments"] == opportunity.modified_comments
 
 
 def test_get_opportunity_not_found_404(client, api_auth_token, truncate_opportunities):


### PR DESCRIPTION
## Summary
Fixes #893

### Time to review: __5 mins__

## Changes proposed
Return a few additional fields from the opportunity table in the opportunity search + get endpoints.

Updated the DB factory to only add a category explanation if the category is `O` (other)

## Context for reviewers
As we currently have things setup the DB model is converted to JSON directly, so we just need to update the response model to have it get returned in response.

## Additional information
Some examples of responses from the API endpoints:

![Screenshot 2023-12-14 at 12 26 44 PM](https://github.com/HHS/simpler-grants-gov/assets/46358556/085e23bb-9063-4bdc-8005-00d5c196bd7e)
![Screenshot 2023-12-14 at 12 26 58 PM](https://github.com/HHS/simpler-grants-gov/assets/46358556/946b82b4-4845-4173-972b-6078727f3831)

