### PR TITLE
[Issue 873] Roadmap chevrons, ContentLayout GapSizes

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -173,11 +173,11 @@
       "icon_list": [
         {
           "title": "Find",
-          "content": "<p>Improve how applicants discover funding opportunities that they’re qualified for and that meet their needs.</p>"
+          "content": "<p>Improve how applicants discover funding opportunities that they’re qualified for and that meet their needs.</p><chevron/>"
         },
         {
           "title": "Advanced reporting",
-          "content": "<p>Improve stakeholders’ capacity to understand, analyze, and assess grants from application to acceptance.</p><p>Make non-confidential Grants.gov data open for public analysis.</p>"
+          "content": "<p>Improve stakeholders’ capacity to understand, analyze, and assess grants from application to acceptance.</p><p>Make non-confidential Grants.gov data open for public analysis.</p><chevron/>"
         },
         {
           "title": "Apply",

--- a/frontend/src/components/ContentLayout.tsx
+++ b/frontend/src/components/ContentLayout.tsx
@@ -1,19 +1,21 @@
 import { Grid, GridContainer } from "@trussworks/react-uswds";
 
 type Props = {
-  titleSize?: "l" | "m";
-  title?: string;
-  children: React.ReactNode;
   bottomBorder?: "light" | "dark" | "none";
+  children: React.ReactNode;
+  gridGap?: true | "sm" | "md" | "lg" | "2px" | "05" | 1 | 2 | 3 | 4 | 5 | 6;
   paddingTop?: boolean;
+  title?: string;
+  titleSize?: "l" | "m";
 };
 
 const ContentLayout = ({
-  children,
-  title,
-  paddingTop = true,
-  titleSize = "l",
   bottomBorder = "none",
+  children,
+  gridGap = true,
+  paddingTop = true,
+  title,
+  titleSize = "l",
 }: Props) => {
   const formattedTitle = () => {
     if (!title) return "";
@@ -48,7 +50,7 @@ const ContentLayout = ({
       } ${bborder}`}
     >
       {formattedTitle()}
-      <Grid row gap>
+      <Grid row gap={gridGap}>
         {children}
       </Grid>
     </GridContainer>

--- a/frontend/src/pages/content/ProcessMilestones.tsx
+++ b/frontend/src/pages/content/ProcessMilestones.tsx
@@ -44,7 +44,8 @@ const ProcessMilestones = () => {
         title={t("milestones.tag")}
         data-test-id="process-high-level-content"
         titleSize="m"
-        bottomBorder="none"
+        bottomBorder="dark"
+        gridGap={6}
       >
         {!Array.isArray(iconList)
           ? ""
@@ -54,7 +55,7 @@ const ProcessMilestones = () => {
                   <IconList className="usa-icon-list--size-lg">
                     <IconListItem className="margin-top-4">
                       <IconListIcon>{getIcon(index)}</IconListIcon>
-                      <IconListContent>
+                      <IconListContent className="tablet-lg:padding-right-3 desktop-lg:padding-right-105">
                         <IconListTitle className="margin-bottom-2" type="h3">
                           {box.title}
                         </IconListTitle>
@@ -65,6 +66,13 @@ const ProcessMilestones = () => {
                             p: (
                               <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6"></p>
                             ),
+                            chevron: (
+                              <Icon.NavigateNext
+                                className="display-none tablet-lg:display-block text-base-lighter position-absolute right-0 top-0 margin-right-neg-5"
+                                size={9}
+                                aria-label="launch"
+                              />
+                            ),
                           }}
                         />
                       </IconListContent>
@@ -74,13 +82,11 @@ const ProcessMilestones = () => {
               );
             })}
       </ContentLayout>
-      <div className="padding-2 tablet:padding-1" />
       <ContentLayout
         title={t("milestones.title_1")}
         data-testid="process-methodology-content"
         titleSize="m"
         bottomBorder="none"
-        paddingTop={false}
       >
         <Grid tabletLg={{ col: 6 }}>
           <p className="usa-intro">{t("milestones.paragraph_1")}</p>


### PR DESCRIPTION
## Summary
Partially addresses #873 

### Time to review: __15 mins__

## Changes proposed
- Add a border below the roadmap section 
- Add chevron icons to the end of the first two items in the roadmap
  - Positioning them between the columns to show direction
  - hiding them on small screens, when the columns are stacked
- Update the `ContentLayout` component so that it accepts `gridGap` sizes 
  - …because the roadmap grid needs to always have the widest gutter possible to acomodate the chevron icons 
  - Set this to `true` by default, which is the setting for auto-sized gutters when just passing `gap` w/o an argument
  - Reordered the props too (they were inconsistent, used alpha) 

**wide screen:** 

<img width="1286" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/409279/952fee00-d582-4d57-ac91-f24e7b3c5614">

**medium screen:** 

<img width="863" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/409279/df266ef0-a44c-4f26-a1b6-ee4e8855449e">

**small screen:** 

<img width="677" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/409279/e4b34740-e77b-4b04-9588-3028a2185a88">
