### PR TITLE
[Issue 819] update index README with site info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-# Simpler Grants.gov
+# [Simpler.Grants.gov](https://simpler.grants.gov/)
 
-A modernization effort for Grants.gov.
+A modernization effort for [Grants.gov](https://grants.gov/)
 
 ## About the Project
 
-Our vision is for the following to become true:
+We want Grants.gov to be an extremely simple, accessible, and easy-to-use tool for posting, finding, sharing, and applying for federal financial assistance. Our mission is to increase access to grants and improve the grants experience for everyone We’re improving the way applicants search for and discover funding opportunities, making it easier to find and apply. For federal grantmaking agencies, we’re making it easier for their communities to find the funding they need.
 
-_**Grants.gov is the simplest, most inclusive, and most gratifying way to find and apply for financial assistance ever built, inside or outside the federal government.**_
-
-Grants.gov helps ensure that no communities are underserved by the federal government.
+Fo to [Simpler.Grants.gov](https://simpler.grants.gov/) to learn about our transparent process and what we’re doing now, or explore our existing user research and the findings that are guiding our work.
 
 See [goals.md](./documentation/goals.md) for more information about the vision and goals for the project.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A modernization effort for [Grants.gov](https://grants.gov/)
 
 We want Grants.gov to be an extremely simple, accessible, and easy-to-use tool for posting, finding, sharing, and applying for federal financial assistance. Our mission is to increase access to grants and improve the grants experience for everyone We’re improving the way applicants search for and discover funding opportunities, making it easier to find and apply. For federal grantmaking agencies, we’re making it easier for their communities to find the funding they need.
 
-Fo to [Simpler.Grants.gov](https://simpler.grants.gov/) to learn about our transparent process and what we’re doing now, or explore our existing user research and the findings that are guiding our work.
+Go to [Simpler.Grants.gov](https://simpler.grants.gov/) to learn about our transparent process and what we’re doing now, or explore our existing user research and the findings that are guiding our work.
 
 See [goals.md](./documentation/goals.md) for more information about the vision and goals for the project.
 


### PR DESCRIPTION
## Summary
Fixes #819

### Time to review: __2 mins__

## Changes proposed
Update the index README with a bit more project context, the goal from the site, and a links back to the site (so that folx arriving on GitHub can easily navigate to or get back to Simpler.Grants.gov). 

