### PR TITLE
[Issue 959] Enable deletion protection for DynamoDB table `terraform_lock`

### DIFF
--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -22,9 +22,10 @@ resource "aws_kms_key" "tf_backend" {
 }
 
 resource "aws_dynamodb_table" "terraform_lock" {
-  name         = local.tf_locks_table_name
-  hash_key     = "LockID"
-  billing_mode = "PAY_PER_REQUEST"
+  name                        = local.tf_locks_table_name
+  hash_key                    = "LockID"
+  billing_mode                = "PAY_PER_REQUEST"
+  deletion_protection_enabled = true
 
   attribute {
     name = "LockID"


### PR DESCRIPTION
## Summary
Fixes #959

### Time to review: __5 mins__

## Changes proposed
- Enable deletion protection for DynamoDB table `terraform_lock`.

## Context for reviewers
Deletion protection is recommended by Security Hub.

This DynamoDB table is only used for terraform atomic locking. It doesn't contain any valuable data.

## Additional information

Verified that terraform plan looks as expected:

```terraform
~/Grants/simpler-grants-gov/infra/accounts$ terraform plan
...
module.backend.aws_dynamodb_table.terraform_lock: Refreshing state... [id=simpler-grants-gov-315341936575-us-east-1-tf-state-locks]
...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.backend.aws_dynamodb_table.terraform_lock will be updated in-place
  ~ resource "aws_dynamodb_table" "terraform_lock" {
      ~ deletion_protection_enabled = false -> true
        id                          = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
        name                        = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
        tags                        = {}
        # (8 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
