### PR TITLE
[Issue 963] Moves ECS services into private subnets

### DIFF
--- a/infra/api/app-config/main.tf
+++ b/infra/api/app-config/main.tf
@@ -7,8 +7,9 @@ locals {
   has_incident_management_service = false
 
   environment_configs = {
-    dev  = module.dev_config
-    prod = module.prod_config
+    dev     = module.dev_config
+    staging = module.staging_config
+    prod    = module.prod_config
   }
 
   build_repository_config = {
@@ -44,9 +45,10 @@ locals {
   #     prod    = "prod"
   #   }
   account_names_by_environment = {
-    shared = "simpler-grants-gov"
-    dev    = "simpler-grants-gov"
-    prod   = "simpler-grants-gov"
+    shared  = "simpler-grants-gov"
+    dev     = "simpler-grants-gov"
+    staging = "simpler-grants-gov"
+    prod    = "simpler-grants-gov"
   }
 }
 

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -1,0 +1,8 @@
+module "staging_config" {
+  source                          = "./env-config"
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "staging"
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+}

--- a/infra/api/database/staging.s3.tfbackend
+++ b/infra/api/database/staging.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/api/database/staging.tfstate"
+dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
+region         = "us-east-1"

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -1,16 +1,24 @@
 # TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc
 data "aws_vpc" "default" {
   default = true
 }
 
-# TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
-data "aws_subnets" "default" {
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
+data "aws_subnets" "private" {
   filter {
-    name   = "default-for-az"
-    values = [true]
+    name   = "tag:subnet_type"
+    values = ["private"]
   }
 }
 
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
+data "aws_subnets" "public" {
+  filter {
+    name   = "tag:subnet_type"
+    values = ["public"]
+  }
+}
 
 locals {
   # The prefix key/value pair is used for Terraform Workspaces, which is useful for projects with multiple infrastructure developers.
@@ -95,7 +103,8 @@ module "service" {
   image_repository_name = module.app_config.image_repository_name
   image_tag             = local.image_tag
   vpc_id                = data.aws_vpc.default.id
-  subnet_ids            = data.aws_subnets.default.ids
+  public_subnet_ids     = data.aws_subnets.public.ids
+  private_subnet_ids    = data.aws_subnets.private.ids
   cpu                   = 1024
   memory                = 2048
 

--- a/infra/api/service/staging.s3.tfbackend
+++ b/infra/api/service/staging.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/api/service/staging.tfstate"
+dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
+region         = "us-east-1"

--- a/infra/frontend/app-config/main.tf
+++ b/infra/frontend/app-config/main.tf
@@ -1,6 +1,6 @@
 locals {
   app_name                        = "frontend"
-  environments                    = ["dev", "prod"]
+  environments                    = ["dev", "staging", "prod"]
   project_name                    = module.project_config.project_name
   image_repository_name           = "${local.project_name}-${local.app_name}"
   has_database                    = false
@@ -13,8 +13,9 @@ locals {
   }
 
   environment_configs = {
-    dev  = module.dev_config
-    prod = module.prod_config
+    dev     = module.dev_config
+    staging = module.staging_config
+    prod    = module.prod_config
   }
   # Map from environment name to the account name for the AWS account that
   # contains the resources for that environment. Resources that are shared
@@ -46,9 +47,10 @@ locals {
   #     prod    = "prod"
   #   }
   account_names_by_environment = {
-    shared = "simpler-grants-gov"
-    dev    = "simpler-grants-gov"
-    prod   = "simpler-grants-gov"
+    shared  = "simpler-grants-gov"
+    dev     = "simpler-grants-gov"
+    staging = "simpler-grants-gov"
+    prod    = "simpler-grants-gov"
   }
 }
 

--- a/infra/frontend/app-config/staging.tf
+++ b/infra/frontend/app-config/staging.tf
@@ -1,0 +1,12 @@
+module "staging_config" {
+  source                          = "./env-config"
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "staging"
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  domain                          = "beta.grants.gov"
+  sendy_api_key                   = "/${local.app_name}/dev/sendy-api-key"
+  sendy_api_url                   = "/${local.app_name}/dev/sendy-api-url"
+  sendy_list_id                   = "/${local.app_name}/dev/sendy-list-id"
+}

--- a/infra/frontend/app-config/staging.tf
+++ b/infra/frontend/app-config/staging.tf
@@ -6,7 +6,7 @@ module "staging_config" {
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
   domain                          = "beta.grants.gov"
-  sendy_api_key                   = "/${local.app_name}/dev/sendy-api-key"
-  sendy_api_url                   = "/${local.app_name}/dev/sendy-api-url"
-  sendy_list_id                   = "/${local.app_name}/dev/sendy-list-id"
+  sendy_api_key                   = "/${local.app_name}/staging/sendy-api-key"
+  sendy_api_url                   = "/${local.app_name}/staging/sendy-api-url"
+  sendy_list_id                   = "/${local.app_name}/staging/sendy-list-id"
 }

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -1,13 +1,15 @@
 # TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc
 data "aws_vpc" "default" {
   default = true
 }
 
 # TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "default" {
   filter {
-    name   = "default-for-az"
-    values = [true]
+    name   = "tag:subnet_type"
+    values = ["private"]
   }
 }
 

--- a/infra/frontend/service/staging.s3.tfbackend
+++ b/infra/frontend/service/staging.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/frontend/service/staging.tfstate"
+dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
+region         = "us-east-1"

--- a/infra/modules/database/role_manager/role_manager.py
+++ b/infra/modules/database/role_manager/role_manager.py
@@ -2,8 +2,13 @@ import boto3
 import itertools
 from operator import itemgetter
 import os
+import json
 import logging
 from pg8000.native import Connection, identifier
+
+logging.basicConfig()
+logging.getLogger('botocore').setLevel(logging.DEBUG)
+logging.getLogger('boto3').setLevel(logging.DEBUG)
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -115,9 +120,9 @@ def connect_using_iam(user: str) -> Connection:
     return Connection(user=user, host=host, port=port, database=database, password=token, ssl_context=True)
 
 def get_password() -> str:
-    ssm = boto3.client("ssm")
+    ssm = boto3.client("ssm",region_name=os.environ["AWS_REGION"])
     param_name = os.environ["DB_PASSWORD_PARAM_NAME"]
-    logger.info("Fetching password from parameter store")
+    logger.info("Fetching password from parameter store:\n%s"%param_name)
     result = json.loads(ssm.get_parameter(
         Name=param_name,
         WithDecryption=True,

--- a/infra/modules/service/access-control.tf
+++ b/infra/modules/service/access-control.tf
@@ -69,3 +69,11 @@ resource "aws_iam_role_policy" "task_executor" {
   role   = aws_iam_role.task_executor.id
   policy = data.aws_iam_policy_document.task_executor.json
 }
+
+
+resource "aws_iam_role_policy_attachment" "extra_policies" {
+  for_each = var.extra_policies
+
+  role       = aws_iam_role.app_service.name
+  policy_arn = each.value
+}

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -9,7 +9,7 @@ resource "aws_lb" "alb" {
   idle_timeout    = "120"
   internal        = false
   security_groups = [aws_security_group.alb.id]
-  subnets         = var.subnet_ids
+  subnets         = var.public_subnet_ids
 
   # TODO(https://github.com/navapbc/template-infra/issues/163) Implement HTTPS
   # checkov:skip=CKV2_AWS_20:Redirect HTTP to HTTPS as part of implementing HTTPS support

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -28,7 +28,7 @@ locals {
     { name : "DB_NAME", value : var.db_vars.connection_info.db_name },
     { name : "DB_SCHEMA", value : var.db_vars.connection_info.schema_name },
   ]
-  environment_variables = concat(local.base_environment_variables, local.db_environment_variables)
+  environment_variables = concat(local.base_environment_variables, local.db_environment_variables, var.extra_environment_variables)
 }
 
 #-------------------
@@ -50,7 +50,7 @@ resource "aws_ecs_service" "app" {
 
   network_configuration {
     assign_public_ip = false
-    subnets          = var.subnet_ids
+    subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.app.id]
   }
 

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -49,9 +49,7 @@ resource "aws_ecs_service" "app" {
   }
 
   network_configuration {
-    # TODO(https://github.com/navapbc/template-infra/issues/152) set assign_public_ip = false after using private subnets
-    # checkov:skip=CKV_AWS_333:Switch to using private subnets
-    assign_public_ip = true
+    assign_public_ip = false
     subnets          = var.subnet_ids
     security_groups  = [aws_security_group.app.id]
   }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -70,9 +70,20 @@ variable "vpc_id" {
   description = "Uniquely identifies the VPC."
 }
 
-variable "subnet_ids" {
+variable "public_subnet_ids" {
   type        = list(any)
-  description = "Private subnet id from vpc module"
+  description = "Public subnet ids in VPC"
+}
+
+variable "private_subnet_ids" {
+  type        = list(any)
+  description = "Private subnet ids in VPC"
+}
+
+variable "extra_environment_variables" {
+  type        = list(object({ name = string, value = string }))
+  description = "Additional environment variables to pass to the service container"
+  default     = []
 }
 
 variable "db_vars" {
@@ -90,6 +101,12 @@ variable "db_vars" {
     })
   })
   default = null
+}
+
+variable "extra_policies" {
+  description = "Map of extra IAM policies to attach to the service's task role. The map's keys define the resource name in terraform."
+  type        = map(string)
+  default     = {}
 }
 
 variable "cert_arn" {

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -104,6 +104,7 @@ resource "aws_vpc_security_group_ingress_rule" "aws_services" {
   cidr_ipv4         = data.aws_vpc.default.cidr_block
 }
 
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint
 resource "aws_vpc_endpoint" "aws_service" {
   for_each = local.aws_service_integrations
 
@@ -115,6 +116,7 @@ resource "aws_vpc_endpoint" "aws_service" {
   private_dns_enabled = true
 }
 
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint
 resource "aws_vpc_endpoint" "gateway" {
   for_each = local.gateway_vpc_endpoints
 

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -93,12 +93,11 @@ resource "aws_security_group" "aws_services" {
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule
-#
-# purpose: Allow all traffic from the VPC's CIDR block to the VPC endpoint security group
 resource "aws_vpc_security_group_ingress_rule" "aws_services" {
   count = length(local.aws_service_integrations) > 0 ? 1 : 0
 
   security_group_id = aws_security_group.aws_services[0].id
+  description       = "Allow all traffic from the VPC's CIDR block to the VPC endpoint security group"
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -98,7 +98,7 @@ resource "aws_vpc_endpoint" "aws_service" {
   service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.aws_services[0].id]
-  subnet_ids          = data.aws_subnets.default.ids
+  subnet_ids          = [for subnet in aws_subnet.backfill_private : subnet.id]
   private_dns_enabled = true
 }
 

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -97,7 +97,7 @@ resource "aws_vpc_security_group_ingress_rule" "aws_services" {
   count = length(local.aws_service_integrations) > 0 ? 1 : 0
 
   security_group_id = aws_security_group.aws_services[0].id
-  description       = "Allow all traffic from the VPC's CIDR block to the VPC endpoint security group"
+  description       = "Allow all traffic from the VPCs CIDR block to the VPC endpoint security group"
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -7,6 +7,8 @@ locals {
     #
     # You can can confirm the ranges with a tool like:
     # https://www.ipaddressguide.com/cidr
+    #
+    # The `/20` CIDR block was chosen because most of the existing subnets are `/20`.
     "us-east-1a" = "172.31.144.0/20", # /20 = 4096 IPs, last address is 172.31.159.255
     "us-east-1b" = "172.31.160.0/20", # /20 = 4096 IPs, last address is	172.31.175.255
     "us-east-1c" = "172.31.176.0/20", # /20 = 4096 IPs, last address is 172.31.191.255

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -51,11 +51,11 @@ resource "aws_eip" "backfill_private" {
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway
 resource "aws_nat_gateway" "backfill_private" {
-  count         = length(local.backfill_subnet_cidrs)
-  allocation_id = aws_eip.backfill_private[count.index].allocation_id
-  subnet_id     = aws_subnet.backfill_private[count.index].id
+  for_each      = local.backfill_subnet_cidrs
+  allocation_id = aws_eip.backfill_private[each.key].allocation_id
+  subnet_id     = aws_subnet.backfill_private[each.key].id
   tags = {
-    Name = "backfill-private-${count.index}"
+    Name = "backfill-private-${each.key}"
   }
 }
 

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -21,13 +21,13 @@ locals {
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet
 resource "aws_subnet" "backfill_private" {
-  count                   = length(local.backfill_subnet_cidrs)
+  for_each                = local.backfill_subnet_cidrs
   vpc_id                  = data.aws_vpc.default.id
-  availability_zone       = keys(local.backfill_subnet_cidrs)[count.index]
-  cidr_block              = values(local.backfill_subnet_cidrs)[count.index]
+  availability_zone       = each.key
+  cidr_block              = each.value
   map_public_ip_on_launch = false
   tags = {
-    Name        = "backfill-private-${count.index}"
+    Name        = "backfill-private-${each.key}"
     subnet_type = "private"
   }
 }

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -43,7 +43,7 @@ resource "aws_subnet" "backfill_private" {
 resource "aws_eip" "backfill_private" {
   # checkov:skip=CKV2_AWS_19: These EIPs are attached to NAT gateways
   for_each = local.backfill_subnet_cidrs
-  domain = "vpc"
+  domain   = "vpc"
   tags = {
     Name = "backfill-private-${each.key}"
   }
@@ -66,7 +66,7 @@ resource "aws_nat_gateway" "backfill_private" {
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table
 resource "aws_route_table" "backfill_private" {
   for_each = local.backfill_subnet_cidrs
-  vpc_id = data.aws_vpc.default.id
+  vpc_id   = data.aws_vpc.default.id
   tags = {
     Name = "backfill-private-${each.key}"
   }

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -1,0 +1,81 @@
+# The purpose of this file is to backfill the default VPC with 3 private subnets.
+
+locals {
+  backfill_subnet_cidrs = {
+    # The CIDRs were chosen to be within `172.31.0.0/16` but not overlap with the nearest
+    # CIDRs already being used in the VPC.
+    "us-east-1a" = "172.31.144.0/20",
+    "us-east-1b" = "172.31.160.0/20",
+    "us-east-1c" = "172.31.176.0/20",
+  }
+}
+
+# ------- #
+# SUBNETS #
+# ------- #
+
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet
+resource "aws_subnet" "backfill_private" {
+  count                   = length(local.backfill_subnet_cidrs)
+  vpc_id                  = data.aws_vpc.default.id
+  availability_zone       = keys(local.backfill_subnet_cidrs)[count.index]
+  cidr_block              = values(local.backfill_subnet_cidrs)[count.index]
+  map_public_ip_on_launch = false
+  tags = {
+    Name        = "backfill-private-${count.index}"
+    subnet_type = "private"
+  }
+}
+
+# ----------- #
+# NAT GATEWAY #
+# ----------- #
+
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip
+resource "aws_eip" "backfill_private" {
+  count  = length(local.backfill_subnet_cidrs)
+  domain = "vpc"
+  tags = {
+    Name = "backfill-private-${count.index}"
+  }
+}
+
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway
+resource "aws_nat_gateway" "backfill_private" {
+  count         = length(local.backfill_subnet_cidrs)
+  allocation_id = aws_eip.backfill_private[count.index].allocation_id
+  subnet_id     = aws_subnet.backfill_private[count.index].id
+  tags = {
+    Name = "backfill-private-${count.index}"
+  }
+}
+
+# ------------ #
+# ROUTE TABLES #
+# ------------ #
+
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table
+resource "aws_route_table" "backfill_private" {
+  count  = length(local.backfill_subnet_cidrs)
+  vpc_id = data.aws_vpc.default.id
+  tags = {
+    Name = "backfill-private-${count.index}"
+  }
+}
+
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association
+resource "aws_route_table_association" "backfill_private" {
+  count          = length(local.backfill_subnet_cidrs)
+  subnet_id      = aws_subnet.backfill_private[count.index].id
+  route_table_id = aws_route_table.backfill_private[count.index].id
+}
+
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route
+#
+# purpose: route external traffic to the NAT gateway
+resource "aws_route" "backfill_private" {
+  count                  = length(local.backfill_subnet_cidrs)
+  route_table_id         = aws_route_table.backfill_private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.backfill_private[count.index].id
+}

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -42,10 +42,10 @@ resource "aws_subnet" "backfill_private" {
 #          via means of a NAT gateway.
 resource "aws_eip" "backfill_private" {
   # checkov:skip=CKV2_AWS_19: These EIPs are attached to NAT gateways
-  count  = length(local.backfill_subnet_cidrs)
+  for_each = local.backfill_subnet_cidrs
   domain = "vpc"
   tags = {
-    Name = "backfill-private-${count.index}"
+    Name = "backfill-private-${each.key}"
   }
 }
 

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -33,6 +33,7 @@ resource "aws_subnet" "backfill_private" {
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip
 resource "aws_eip" "backfill_private" {
+  # checkov:skip=CKV2_AWS_19: These EIPs are attached to NAT gateways
   count  = length(local.backfill_subnet_cidrs)
   domain = "vpc"
   tags = {

--- a/infra/networks/variables.tf
+++ b/infra/networks/variables.tf
@@ -1,8 +1,3 @@
-variable "aws_services_security_group_name_prefix" {
-  type    = string
-  default = "simpler"
-}
-
 variable "has_database" {
   type        = bool
   description = "whether the application has a database"

--- a/infra/networks/variables.tf
+++ b/infra/networks/variables.tf
@@ -1,0 +1,10 @@
+variable "aws_services_security_group_name_prefix" {
+  type    = string
+  default = "simpler"
+}
+
+variable "has_database" {
+  type        = bool
+  description = "whether the application has a database"
+  default     = true
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/HHS/simpler-grants-gov/issues/963

This PR will be split into 3 major stages:

### Stage 1: Create private subnets

The existing networking infrastructure is in its "default" (AWS provided) state. This state does not meet the standards of our [ideal network layer design](https://github.com/navapbc/template-infra/blob/main/docs/decisions/infra/0011-network-layer-design.md) in a few ways. But the most notable one is: the default networking infrastructure lacks private subnets. You cannot remove the public IP addresses from the ECS instances without a first creating private subnets. So I'm requesting code review for Stage 1, backfilling the private subnets into the default VPC. This also includes attaching the VPC endpoints onto those private subnets.

Deploying this will require me to deploy the subnets from my branch, before I merge. I've talked about this with @aplybeah. Essentially, I need to (temporarily) ignore "only deploy from main" rule in order to resolve https://github.com/HHS/simpler-grants-gov/issues/963 in a timely manner. The alternative would be for me to take several days to deploy an entirely new networking layer from scratch, which feels like too much work for this task / our timeline.

Due to the above, there will be a long running (eg. for a few days) terraform state diff on the `infra/networks/` folder.

### Stage 2: Creating a "staging" site inside the private subnets

When I create the private subnets, I won't be able to be sure that they are totally working for the sake of deploying our application. There's a chance this could be a breaking change from the point of view of the application. So it requires testing, specifically testing in the form of creating a 3rd simpler ECS application. I'm calling this application "staging", since "dev" and "prod" are already in use. I'll deploy this application to the private subnets to confirm that the application is working. I'll then keep the application around so that we can use it for other purposes later.

### Stage 3: Move all sites into the private subnets

After confirming that staging works, I'll make sure the terraform configuration for dev and prod are using the new subnets as well. I'll deploy to dev and prod after I merge. This will not change the load balancer URL, but it might cause a few minutes of downtime. I expect that any potential downtime will be 5 minutes at most, enough time for the new app containers to start up.

### Testing

Deploy the networking layer changes:

```
$ cd infra/networks/
$ terraform apply
```

Deploy the frontend application (with the latest build as of Jan 16th)

```
$ cd infra/frontend/service
$ terraform init -backend-config=staging.s3.tfbackend -reconfigure
$ terraform apply \
    -var="environment_name=staging" \
    -var="image_tag=2698a01eca3a7373ae4ddeec78271108f50234fd"
```

Deploy the database

```
$ cd infra/api/database
$ terraform init -backend-config=staging.s3.tfbackend -reconfigure
$ terraform apply \
    -var="environment_name=staging"
```

Deploy the backend application (with the latest build as of Jan 16th)

```
$ cd infra/api/service
$ terraform init -backend-config=staging.s3.tfbackend -reconfigure
$ terraform apply \
    -var="environment_name=staging" \
    -var="image_tag=2698a01eca3a7373ae4ddeec78271108f50234fd"
```

### Future Work

In the future, I would like to move to the network architecture described [in the Nava infra template](https://github.com/navapbc/template-infra/blob/main/docs/decisions/infra/0011-network-layer-design.md). That design specifies a separate network for every environment. This would be an improvement over our current design, where there is one network for all environments. The fact that there's only 1 network is what makes testing stage 1 so complicated.

This PR includes a new `staging` app, but does not (yet) add that staging app to Github Actions. I intend to do that at a later date!