### PR TITLE
Create DMS IAM roles in Terraform

### DIFF
--- a/infra/modules/dms/main.tf
+++ b/infra/modules/dms/main.tf
@@ -1,0 +1,65 @@
+# Put IAM Roles here
+
+resource "aws_iam_role_policy" "dms_access" {
+  name   = "DMS Access"
+  policy = ""
+  role   = ""
+}
+
+# Rough draft of IAM policies
+data "aws_iam_policy_document" "dms_access" {
+  statement {
+    sid       = "AllowDMSAccess"
+    effect    = "Allow"
+    actions   = [] # try to narrow this down from dms:*
+    resources = [] # arn for the actual dms service goes here
+  }
+
+  statement {
+    # Allows DMS to create the roles it needs if not created beforehand 
+    sid    = "AllowCreateIAM"
+    effect = "Allow"
+    actions = [
+      "iam:GetRole",
+      "iam:PassRole",
+      "iam:CreateRole",
+      "iam:AttachRolePolicy"
+    ]
+    resources = [] # DMS arn here
+  }
+  statement {
+    # Allow DMS to configure the network it needs
+    sid    = "EC2Access"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeVpcs",
+      "ec2:DescribeInternetGateways",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeSecurityGroups",
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface"
+    ]
+    resources = [] # DMS or EC2 arn?
+  }
+  statement {
+    # View replication metrics
+    sid       = "AllowCloudwatchMetrics"
+    effect    = "Allow"
+    actions   = ["cloudwatch:Get*", "cloudwatch:List*"]
+    resources = []
+  }
+  statement {
+    # View replication logs
+    sid    = "AllowCloudwatchLogs"
+    effect = "Allow"
+    actions = [
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:ilterLogEvents",
+      "logs:GetLogEvents"
+    ]
+    resources = [] # DMS arn
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #500 

### Time to review: __x mins__

## Changes proposed
* Add IAM policy document for DMS 

## Context for reviewers

> Create necessary IAM roles for DMS in terraform.
> Reference: https://repost.aws/knowledge-center/dms-redshift-connectivity-failures or https://docs.aws.amazon.com/dms/latest/userguide/security-iam.html#CHAP_Security.IAMPermissions


## Additional information
There's a bit of an "order of operations" thing we need to work through in order for things in Terraform to be configured. For example, we can't list the DMS instance as a resource for permissions because it hasn't been created yet (minor block). This ticket is following potential approach 1 listed in the original issue.

