### PR TITLE
[Issue 1041] Update infra service tf version

### DIFF
--- a/.github/workflows/infra-service.yml
+++ b/.github/workflows/infra-service.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.2.1
+          terraform_version: 1.4.6
           terraform_wrapper: false
 
       - uses: actions/setup-go@v3


### PR DESCRIPTION
## Summary
Fixes #1041 

### Time to review: __1 mins__

## Changes proposed
Update the terraform version used in infra service checks to be the same as the terraform version for the rest of the project (1.2.1 to 1.4.6)

