### PR TITLE
[Issue 1037] Harden subnet selection logic

### DIFF
--- a/infra/api/database/main.tf
+++ b/infra/api/database/main.tf
@@ -6,6 +6,10 @@ data "aws_vpc" "default" {
 # TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
 data "aws_subnets" "default" {
   filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+  filter {
     name   = "default-for-az"
     values = [true]
   }

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -7,6 +7,10 @@ data "aws_vpc" "default" {
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "private" {
   filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+  filter {
     name   = "tag:subnet_type"
     values = ["private"]
   }
@@ -14,6 +18,10 @@ data "aws_subnets" "private" {
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
   filter {
     name   = "tag:subnet_type"
     values = ["public"]

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -7,6 +7,10 @@ data "aws_vpc" "default" {
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "private" {
   filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+  filter {
     name   = "tag:subnet_type"
     values = ["private"]
   }
@@ -14,6 +18,10 @@ data "aws_subnets" "private" {
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
   filter {
     name   = "tag:subnet_type"
     values = ["public"]


### PR DESCRIPTION
## Summary

In service of, but does not fix, https://github.com/HHS/simpler-grants-gov/issues/1037

### Time to review: __2 mins__

## Context for reviewers

@SammySteiner found that the frontend tests started failing once I created the staging VPC via https://github.com/HHS/simpler-grants-gov/pull/1044. This happened because the subnet selection logic is trying to deploy to every subnet in the account, as opposed to just the subnets for the current VPC. So when you create a 2nd VPC, the subnet selection logic fails. The error looks like this:

> Error: creating ELBv2 application Load Balancer (t-agywei-frontend-dev): InvalidConfigurationRequest: All subnets must belong to the same VPC

## The Fix

1. I'm deleting all the resources I created for https://github.com/HHS/simpler-grants-gov/pull/1044
2. This PR, which changes the subnet filter to only look for subnets in the same VPC