### PR TITLE
[Issue 1037] Allow choosing between multiple VPCs

### DIFF
--- a/infra/api/database/main.tf
+++ b/infra/api/database/main.tf
@@ -1,17 +1,20 @@
-# TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
-data "aws_vpc" "default" {
-  default = true
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc
+data "aws_vpc" "network" {
+  filter {
+    name   = "tag:Name"
+    values = module.project_config.network_configs[var.environment_name].vpc_name
+  }
 }
 
-# TODO(https://github.com/navapbc/template-infra/issues/152) use private subnets
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "default" {
   filter {
     name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
+    values = [data.aws_vpc.network.id]
   }
   filter {
-    name   = "default-for-az"
-    values = [true]
+    name   = "tag:subnet_type"
+    values = ["database"]
   }
 }
 

--- a/infra/api/database/main.tf
+++ b/infra/api/database/main.tf
@@ -2,7 +2,7 @@
 data "aws_vpc" "network" {
   filter {
     name   = "tag:Name"
-    values = module.project_config.network_configs[var.environment_name].vpc_name
+    values = [module.project_config.network_configs[var.environment_name].vpc_name]
   }
 }
 

--- a/infra/api/database/main.tf
+++ b/infra/api/database/main.tf
@@ -7,7 +7,7 @@ data "aws_vpc" "network" {
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
-data "aws_subnets" "default" {
+data "aws_subnets" "database" {
   filter {
     name   = "vpc-id"
     values = [data.aws_vpc.network.id]
@@ -73,7 +73,7 @@ data "aws_security_groups" "aws_services" {
 
   filter {
     name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
+    values = [data.aws_vpc.network.id]
   }
 }
 
@@ -91,7 +91,7 @@ module "database" {
   migrator_username = local.database_config.migrator_username
   schema_name       = local.database_config.schema_name
 
-  vpc_id                         = data.aws_vpc.default.id
-  private_subnet_ids             = data.aws_subnets.default.ids
+  vpc_id                         = data.aws_vpc.network.id
+  private_subnet_ids             = data.aws_subnets.database.ids
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
 }

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -115,7 +115,7 @@ module "service" {
   is_temporary          = local.is_temporary
   image_repository_name = module.app_config.image_repository_name
   image_tag             = local.image_tag
-  vpc_id                = data.aws_vpc.default.id
+  vpc_id                = data.aws_vpc.network.id
   public_subnet_ids     = data.aws_subnets.public.ids
   private_subnet_ids    = data.aws_subnets.private.ids
   cpu                   = 1024

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -1,14 +1,16 @@
-# TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc
-data "aws_vpc" "default" {
-  default = true
+data "aws_vpc" "network" {
+  filter {
+    name   = "tag:Name"
+    values = module.project_config.network_configs[var.environment_name].vpc_name
+  }
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "private" {
   filter {
     name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
+    values = [data.aws_vpc.network.id]
   }
   filter {
     name   = "tag:subnet_type"

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -2,7 +2,7 @@
 data "aws_vpc" "network" {
   filter {
     name   = "tag:Name"
-    values = module.project_config.network_configs[var.environment_name].vpc_name
+    values = [module.project_config.network_configs[var.environment_name].vpc_name]
   }
 }
 

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -22,7 +22,7 @@ data "aws_subnets" "private" {
 data "aws_subnets" "public" {
   filter {
     name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
+    values = [data.aws_vpc.network.id]
   }
   filter {
     name   = "tag:subnet_type"

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -1,14 +1,16 @@
-# TODO(https://github.com/navapbc/template-infra/issues/152) use non-default VPC
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc
-data "aws_vpc" "default" {
-  default = true
+data "aws_vpc" "network" {
+  filter {
+    name   = "tag:Name"
+    values = module.project_config.network_configs[var.environment_name].vpc_name
+  }
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet
 data "aws_subnets" "private" {
   filter {
     name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
+    values = [data.aws_vpc.network.id]
   }
   filter {
     name   = "tag:subnet_type"

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -2,7 +2,7 @@
 data "aws_vpc" "network" {
   filter {
     name   = "tag:Name"
-    values = module.project_config.network_configs[var.environment_name].vpc_name
+    values = [module.project_config.network_configs[var.environment_name].vpc_name]
   }
 }
 

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -131,7 +131,7 @@ module "service" {
   is_temporary          = local.is_temporary
   image_repository_name = module.app_config.image_repository_name
   image_tag             = local.image_tag
-  vpc_id                = data.aws_vpc.default.id
+  vpc_id                = data.aws_vpc.network.id
   public_subnet_ids     = data.aws_subnets.public.ids
   private_subnet_ids    = data.aws_subnets.private.ids
   enable_autoscaling    = module.app_config.enable_autoscaling

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -22,7 +22,7 @@ data "aws_subnets" "private" {
 data "aws_subnets" "public" {
   filter {
     name   = "vpc-id"
-    values = [data.aws_vpc.default.id]
+    values = [data.aws_vpc.network.id]
   }
   filter {
     name   = "tag:subnet_type"

--- a/infra/networks/subnet-backfill.tf
+++ b/infra/networks/subnet-backfill.tf
@@ -27,7 +27,7 @@ resource "aws_subnet" "backfill_private" {
   cidr_block              = each.value
   map_public_ip_on_launch = false
   tags = {
-    Name        = "backfill-private-${each.key}"
+    Name        = "default-private-${each.key}"
     subnet_type = "private"
   }
 }
@@ -45,7 +45,7 @@ resource "aws_eip" "backfill_private" {
   for_each = local.backfill_subnet_cidrs
   domain   = "vpc"
   tags = {
-    Name = "backfill-private-${each.key}"
+    Name = "default-private-${each.key}"
   }
 }
 
@@ -55,7 +55,7 @@ resource "aws_nat_gateway" "backfill_private" {
   allocation_id = aws_eip.backfill_private[each.key].allocation_id
   subnet_id     = aws_subnet.backfill_private[each.key].id
   tags = {
-    Name = "backfill-private-${each.key}"
+    Name = "default-private-${each.key}"
   }
 }
 
@@ -68,7 +68,7 @@ resource "aws_route_table" "backfill_private" {
   for_each = local.backfill_subnet_cidrs
   vpc_id   = data.aws_vpc.default.id
   tags = {
-    Name = "backfill-private-${each.key}"
+    Name = "default-private-${each.key}"
   }
 }
 

--- a/infra/project-config/main.tf
+++ b/infra/project-config/main.tf
@@ -16,4 +16,11 @@ locals {
 
   github_actions_role_name                = "${local.project_name}-github-actions"
   aws_services_security_group_name_prefix = "aws-service-vpc-endpoints"
+
+  network_configs = {
+    # TODO(https://github.com/HHS/simpler-grants-gov/issues/1051) deploy to a non-default VPC in every environment
+    dev     = { vpc_name = "default" }
+    staging = { vpc_name = "staging" }
+    prod    = { vpc_name = "default" }
+  }
 }

--- a/infra/project-config/outputs.tf
+++ b/infra/project-config/outputs.tf
@@ -38,3 +38,7 @@ output "github_actions_role_name" {
 output "aws_services_security_group_name_prefix" {
   value = local.aws_services_security_group_name_prefix
 }
+
+output "network_configs" {
+  value = local.network_configs
+}


### PR DESCRIPTION
## Summary

In service of, but does not resolve, https://github.com/HHS/simpler-grants-gov/issues/1037

### Time to review: __5 mins__

## Changes proposed

- Changes all 3 terraform apps (frontend, backend, database) to allow them to be deployed from a non-default VPC
- Deploys the database into the "database" subnets, which have been backfilled into the default VPC

## Context for reviewers

The Nava template has been updated to use non-default VPCs as our core networking layer. Migrating to that infrastructure will take quite some time, so I'm doing it piece by piece. The center of this piece is this code:

```hcl
  network_configs = {
    # TODO(https://github.com/HHS/simpler-grants-gov/issues/1051) deploy to a non-default VPC in every environment
    dev     = { vpc_name = "default" }
    staging = { vpc_name = "staging" }
    prod    = { vpc_name = "default" }
  }
```

Which maps `environment` to `vpc name`. Currently, only `staging` is using a non-default VPC. I plan on having a long running branch (here: https://github.com/HHS/simpler-grants-gov/pull/1044) where I thoroughly test the staging VPC before merging it. This PR allows me to merge code that uses the non-default VPC, exclusively in our staging configuration.

## Additional information

Here is the proposed network design that I am working towards:

```mermaid
graph RL;

  subgraph accounts
    shared_account[shared]
  end

  subgraph networks
    dev_network[dev]
    staging_network[staging]
    prod_network[prod]
  end

  subgraph environments
    dev_environment[dev]
    staging_environment[staging]
    prod_environment[prod]
  end

  dev_network --> shared_account
  staging_network --> shared_account
  prod_network --> shared_account

  dev_environment --> dev_network
  staging_environment --> staging_network
  prod_environment --> prod_network
```

Here is the _**temporary**_ network design as of this PR

```mermaid
graph RL;

  subgraph accounts
    shared_account[shared]
  end

  subgraph networks
    staging_network[staging]
    default_network[default]
  end

  subgraph environments
    dev_environment[dev]
    staging_environment[staging]
    prod_environment[prod]
  end

  default_network --> shared_account
  staging_network --> shared_account

  dev_environment --> default_network
  staging_environment --> staging_network
  prod_environment --> default_network
```
