### PR TITLE
[Issue 1056] Fix release run names

### DIFF
--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -1,7 +1,7 @@
 name: Deploy API
 # Need to set a default value for when the workflow is triggered from a git push
 # which bypasses the default configuration for inputs
-run-name: Deploy ${{ github.ref_name }} to API ${{ inputs.environment || 'dev' }}
+run-name: Deploy ${{ github.ref_name }} to API ${{ inputs.environment || (github.event_name == 'release' && 'prod') || 'dev' }}
 
 on:
   push:

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -1,7 +1,7 @@
 name: Deploy Frontend
 # Need to set a default value for when the workflow is triggered from a git push
 # which bypasses the default configuration for inputs
-run-name: Deploy ${{ github.ref_name }} to Frontend ${{ inputs.environment || 'dev' }}
+run-name: Deploy ${{ github.ref_name }} to Frontend ${{ inputs.environment || (github.event_name == 'release' && 'prod') || 'dev' }}
 
 on:
   push:


### PR DESCRIPTION
## Summary

Related to release documentation, eg. https://github.com/HHS/simpler-grants-gov/pull/1057, https://github.com/HHS/simpler-grants-gov/issues/1056

### Time to review: __1 mins__

## Context

https://betagrantsgov.slack.com/archives/C05TSL64VUH/p1705952749866289

^ Currently `prod` releases are mislabeled, and say they are `dev`

## Risk Analysis

I haven't tested this, so its possible this syntax doesn't work inside of the `run-name:` key. We wouldn't find that out until our next release, unfortunately!