### PR TITLE
[Issue 1061] Revert private subnets change

### DIFF
--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -11,8 +11,9 @@ data "aws_subnets" "private" {
     values = [data.aws_vpc.default.id]
   }
   filter {
-    name   = "tag:subnet_type"
-    values = ["private"]
+    name = "tag:subnet_type"
+    # TODO: change back to "private" when the private subnets are actually working
+    values = ["public"]
   }
 }
 

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -11,8 +11,9 @@ data "aws_subnets" "private" {
     values = [data.aws_vpc.default.id]
   }
   filter {
-    name   = "tag:subnet_type"
-    values = ["private"]
+    name = "tag:subnet_type"
+    # TODO: change back to "private" when the private subnets are actually working
+    values = ["public"]
   }
 }
 

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -49,6 +49,7 @@ resource "aws_ecs_service" "app" {
   }
 
   network_configuration {
+    # checkov:skip=CKV_AWS_333:Switch to using private subnets
     assign_public_ip = true
     subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.app.id]

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -49,7 +49,7 @@ resource "aws_ecs_service" "app" {
   }
 
   network_configuration {
-    assign_public_ip = false
+    assign_public_ip = true
     subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.app.id]
   }


### PR DESCRIPTION
## Summary

Fixes #1061

### Time to review: __1 mins__

## Context for reviewers

Changing to private subnets accidentally broke all networking that goes outbound from AWS. Which means that it broke Sendy.

https://betagrantsgov.slack.com/archives/C05T74HRWRL/p1705963641294149
