### PR TITLE
[Issue 1051] Fix CIDR overlap

### DIFF
--- a/infra/modules/dms-networking/main.tf
+++ b/infra/modules/dms-networking/main.tf
@@ -1,6 +1,6 @@
 locals {
-  our_target_cidr_block   = "172.31.0.0/16" # our [Nava] cidr block, where the target database for the DMS is located
-  their_source_cidr_block = "10.220.0.0/16" # their [MicroHealth] cidr block, where the origin database for the DMS is located
+  our_target_cidr_block   = var.dms_target_cidr_block # our [Nava] cidr block, where the target database for the DMS is located
+  their_source_cidr_block = var.dms_source_cidr_block # their [MicroHealth] cidr block, where the origin database for the DMS is located
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter

--- a/infra/modules/dms-networking/variables.tf
+++ b/infra/modules/dms-networking/variables.tf
@@ -1,3 +1,11 @@
 variable "vpc_id" {
   type = string
 }
+
+variable "dms_target_cidr_block" {
+  type = string
+}
+
+variable "dms_source_cidr_block" {
+  type = string
+}

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,7 +1,7 @@
 data "aws_availability_zones" "available" {}
 
 locals {
-  vpc_cidr               = "10.0.0.0/20"
+  vpc_cidr               = "10.${var.second_octet}.0.0/20"
   num_availability_zones = 3
   availability_zones     = slice(data.aws_availability_zones.available.names, 0, local.num_availability_zones)
 }
@@ -14,9 +14,9 @@ module "aws_vpc" {
   azs  = local.availability_zones
   cidr = local.vpc_cidr
 
-  public_subnets             = ["10.0.10.0/24", "10.0.11.0/24", "10.0.12.0/24"]
-  private_subnets            = ["10.0.0.0/24", "10.0.1.0/24", "10.0.2.0/24"]
-  database_subnets           = ["10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24"]
+  public_subnets             = ["10.${var.second_octet}.10.0/24", "10.${var.second_octet}.11.0/24", "10.${var.second_octet}.12.0/24"]
+  private_subnets            = ["10.${var.second_octet}.0.0/24", "10.${var.second_octet}.1.0/24", "10.${var.second_octet}.2.0/24"]
+  database_subnets           = ["10.${var.second_octet}.5.0/24", "10.${var.second_octet}.6.0/24", "10.${var.second_octet}.7.0/24"]
   public_subnet_tags         = { subnet_type = "public" }
   private_subnet_tags        = { subnet_type = "private" }
   database_subnet_tags       = { subnet_type = "database" }

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -1,3 +1,7 @@
 output "vpc_id" {
   value = module.aws_vpc.vpc_id
 }
+
+output "vpc_cidr" {
+  value = local.vpc_cidr
+}

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   description = "Name to give the VPC. Will be added to the VPC under the 'network_name' tag."
 }
 
+variable "second_octet" {
+  type        = number
+  description = "Second octet of the VPC CIDR block. Must be between 0 and 255."
+}
+
 variable "aws_services_security_group_name_prefix" {
   type        = string
   description = "Prefix for the name of the security group attached to VPC endpoints"

--- a/infra/networks/.terraform.lock.hcl
+++ b/infra/networks/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fdbbf96948e96dfed614ea4daa4f1706859122a3f978c42c37db8727cb55c94f",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.0"
+  hashes = [
+    "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
+    "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
+    "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
+    "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
+    "zh:30ffb297ffd1633175d6545d37c2217e2cef9545a6e03946e514c59c0859b77d",
+    "zh:454ce4b3dbc73e6775f2f6605d45cee6e16c3872a2e66a2c97993d6e5cbd7055",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:91df0a9fab329aff2ff4cf26797592eb7a3a90b4a0c04d64ce186654e0cc6e17",
+    "zh:aa57384b85622a9f7bfb5d4512ca88e61f22a9cea9f30febaa4c98c68ff0dc21",
+    "zh:c4a3e329ba786ffb6f2b694e1fd41d413a7010f3a53c20b432325a94fa71e839",
+    "zh:e2699bc9116447f96c53d55f2a00570f982e6f9935038c3810603572693712d0",
+    "zh:e747c0fd5d7684e5bfad8aa0ca441903f15ae7a98a737ff6aca24ba223207e2c",
+    "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
+  ]
+}

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -37,11 +37,6 @@ module "app_config" {
   source = "../api/app-config"
 }
 
-module "dms_networking" {
-  source = "../modules/dms-networking"
-  vpc_id = module.network.vpc_id
-}
-
 data "aws_vpc" "default" {
   default = true
 }
@@ -58,4 +53,12 @@ module "network" {
   name                                    = var.environment_name
   database_subnet_group_name              = var.environment_name
   aws_services_security_group_name_prefix = var.environment_name
+  second_octet                            = module.project_config.network_configs[var.environment_name].second_octet
+}
+
+module "dms_networking" {
+  source                = "../modules/dms-networking"
+  vpc_id                = module.network.vpc_id
+  dms_target_cidr_block = module.network.vpc_cidr
+  dms_source_cidr_block = module.project_config.network_configs[var.environment_name].dms_source_cidr_block
 }

--- a/infra/project-config/main.tf
+++ b/infra/project-config/main.tf
@@ -19,8 +19,20 @@ locals {
 
   network_configs = {
     # TODO(https://github.com/HHS/simpler-grants-gov/issues/1051) deploy to a non-default VPC in every environment
-    dev     = { vpc_name = "default" }
-    staging = { vpc_name = "staging" }
-    prod    = { vpc_name = "default" }
+    dev = {
+      vpc_name              = "default"
+      second_octet          = 0               # The second octet our the VPC CIDR block
+      dms_source_cidr_block = "10.220.0.0/16" # MicroHealth cidr block, where the origin database for the DMS is located
+    }
+    staging = {
+      vpc_name              = "staging"
+      second_octet          = 1               # The second octet our the VPC CIDR block
+      dms_source_cidr_block = "10.220.0.0/16" # MicroHealth cidr block, where the origin database for the DMS is located
+    }
+    prod = {
+      vpc_name              = "default"
+      second_octet          = 3               # The second octet our the VPC CIDR block
+      dms_source_cidr_block = "10.220.0.0/16" # !PLACEHOLDER! We haven't been provided with this yet
+    }
   }
 }


### PR DESCRIPTION
## Summary

Rolls up to #1051

### Time to review: __5 mins__

## Changes proposed

- Pipes in some DMS stuff are variables.
- Changes the second octet (eg. `x` in `10.x.0.0`) in the VPC cidr to be a variable. `dev`s cidr is staying the same, `staging` and `prod` are changing.

## Context for reviewers

- I decided on this course of action after thinking about the DMS overnight. I concluded that the overlapping CIDRs might create a networking problem on the MicroHealth side.
- I'll need to redeploy staging and prod's VPCs in order to finish this PR. That'll take me a bit.
