### PR TITLE
[Issue 1086] Enable HTTP endpoint to RDS databases

### DIFF
--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -4,5 +4,6 @@ module "dev_config" {
   default_region                  = module.project_config.default_region
   environment                     = "dev"
   has_database                    = local.has_database
+  database_enable_http_endpoint   = true
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -9,6 +9,7 @@ output "database_config" {
     app_access_policy_name      = "${var.app_name}-${var.environment}-app-access"
     migrator_access_policy_name = "${var.app_name}-${var.environment}-migrator-access"
     instance_count              = var.database_instance_count
+    enable_http_endpoint        = var.database_enable_http_endpoint
   } : null
 }
 

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -22,6 +22,12 @@ variable "database_instance_count" {
   default     = 1
 }
 
+variable "database_enable_http_endpoint" {
+  description = "Enable HTTP endpoint (data API). Enables the Query Editor in the AWS Console."
+  type        = bool
+  default     = false
+}
+
 variable "has_incident_management_service" {
   type = bool
 }

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -5,5 +5,6 @@ module "prod_config" {
   environment                     = "prod"
   has_database                    = local.has_database
   database_instance_count         = 2
+  database_enable_http_endpoint   = false
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -4,5 +4,6 @@ module "staging_config" {
   default_region                  = module.project_config.default_region
   environment                     = "staging"
   has_database                    = local.has_database
+  database_enable_http_endpoint   = true
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/api/database/main.tf
+++ b/infra/api/database/main.tf
@@ -92,6 +92,8 @@ module "database" {
   schema_name       = local.database_config.schema_name
   instance_count    = local.database_config.instance_count
 
+  enable_http_endpoint = local.database_config.enable_http_endpoint
+
   vpc_id                         = data.aws_vpc.network.id
   private_subnet_ids             = data.aws_subnets.database.ids
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]

--- a/infra/modules/database/main.tf
+++ b/infra/modules/database/main.tf
@@ -43,6 +43,7 @@ resource "aws_rds_cluster" "db" {
   iam_database_authentication_enabled = true
   deletion_protection                 = true
   copy_tags_to_snapshot               = true
+  enable_http_endpoint                = var.enable_http_endpoint
   # final_snapshot_identifier = "${var.name}-final"
   skip_final_snapshot = true
 

--- a/infra/modules/database/variables.tf
+++ b/infra/modules/database/variables.tf
@@ -61,6 +61,12 @@ variable "instance_count" {
   }
 }
 
+variable "enable_http_endpoint" {
+  description = "Enable HTTP endpoint (data API). Enables the Query Editor in the AWS Console."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_id" {
   type        = string
   description = "Uniquely identifies the VPC."


### PR DESCRIPTION
## Summary
Part of #1086 

### Time to review: __5 mins__

## Changes proposed
- Add a `database_enable_http_endpoint` variable to the app config.
- If the variable is set, enable the HTTP endpoint for the RDS database.
- Set the new variable to `true` for all non-prod environments.

## Context for reviewers
To enable work on #1086, we need to view the existing roles in the database. This enables the HTTP endpoint, which in turn enables the Query Editor on the AWS Console.

## Additional information
Partial terraform plan from `make infra-update-app-database APP_NAME=api ENVIRONMENT=dev`:

```terraform
  # module.database.aws_rds_cluster.db will be updated in-place
  ~ resource "aws_rds_cluster" "db" {
      ~ enable_http_endpoint                = false -> true
        id                                  = "api-dev"
        tags                                = {}
        # (37 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```
