### PR TITLE
[Issue 1051] Networking change mgmt

### DIFF
--- a/infra/modules/database/networking.tf
+++ b/infra/modules/database/networking.tf
@@ -11,6 +11,10 @@ resource "aws_security_group" "role_manager" {
   name_prefix = "${var.name}-role-manager"
   description = "Database role manager security group"
   vpc_id      = var.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_vpc_security_group_egress_rule" "role_manager_egress_to_db" {

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -33,7 +33,6 @@ resource "aws_lb" "alb" {
 
   lifecycle {
     create_before_destroy = true
-    prevent_destroy       = !var.is_temporary
   }
 }
 

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -33,7 +33,7 @@ resource "aws_lb" "alb" {
 
   lifecycle {
     create_before_destroy = true
-    prevent_destroy       = true
+    prevent_destroy       = !var.is_temporary
   }
 }
 

--- a/infra/modules/service/load-balancer.tf
+++ b/infra/modules/service/load-balancer.tf
@@ -5,7 +5,7 @@
 # ALB for an app running in ECS
 resource "aws_lb" "alb" {
   depends_on      = [aws_s3_bucket_policy.access_logs]
-  name            = var.service_name
+  name            = "${var.service_name}-lb"
   idle_timeout    = "120"
   internal        = false
   security_groups = [aws_security_group.alb.id]
@@ -29,6 +29,11 @@ resource "aws_lb" "alb" {
     bucket  = aws_s3_bucket.access_logs.id
     prefix  = "${var.service_name}-lb"
     enabled = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = true
   }
 }
 


### PR DESCRIPTION
## Summary

Rolls up to #1051

### Time to review: __2 mins__

## Changes proposed

- Adds some lifecycle policies to various resources
- Renames the load balancer slightly

## Context for reviewers

The load balancer needs to be deployed into the new VPC, which requires a new load balancer. This is going to kick off a wave of change management on my part, specifically:

- The new load balancer needs a new name, as LBs can't share name.
- The new load balancer needs to be _**up**_ before the old load balancer goes _**down**_, hence the `lifecycle` policy. As extra ammunition, when I deploy prod I'm going to do `terraform state rm module.service.aws_lb.alb` as a part of the prod deploy. That'll pop the old load balancer out of the terraform state, so terraform extra special won't delete it.
- In my testing I also had to `terraform state rm module.service.aws_security_group.alb` the ALB's security group, I'll be sure to replicate this in prod.
- I need to request that the DNS route get updated for the new load balancer URL.

All of this in service of better, seamless, networking 😩 

## Commands

```bash
terraform init -backend-config=dev.s3.tfbackend -reconfigure
terraform state rm module.service.aws_lb.alb
terraform state rm module.service.aws_security_group.alb
terraform apply -var="environment_name=dev"
```