### PR TITLE
[Issue 1051] Allow prod to remain on default DB subnet group

### DIFF
--- a/infra/api/database/main.tf
+++ b/infra/api/database/main.tf
@@ -97,5 +97,7 @@ module "database" {
   vpc_id                         = data.aws_vpc.network.id
   private_subnet_ids             = data.aws_subnets.database.ids
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]
-  db_subnet_group_name           = var.environment_name
+
+  # The database subnet group name is the same as the VPC name
+  db_subnet_group_name = module.project_config.network_configs[var.environment_name].vpc_name
 }


### PR DESCRIPTION
## Summary

Rolls up to #1051

### Time to review: __1 mins__

## Changes proposed

Follows up https://github.com/HHS/simpler-grants-gov/pull/1097 to allow prod to remain on the `default` VPC if necessary

## Stylistic Choice

1. Keep this PR as is, where `vpc_name` is being used as `db_subnet_group_name`
2. Create a new `db_subnet_group_name` variable

?
