### PR TITLE
[Issue 1038] Explicitly associate the DMS with every subnet

### DIFF
--- a/infra/modules/dms-networking/main.tf
+++ b/infra/modules/dms-networking/main.tf
@@ -17,3 +17,7 @@ data "aws_ssm_parameter" "dms_peer_vpc_id" {
 data "aws_vpc" "main" {
   id = var.vpc_id
 }
+
+data "aws_route_tables" "rts" {
+  vpc_id = var.vpc_id
+}

--- a/infra/modules/dms-networking/networking.tf
+++ b/infra/modules/dms-networking/networking.tf
@@ -15,7 +15,8 @@ resource "aws_vpc_peering_connection" "dms" {
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route
 resource "aws_route" "dms" {
-  route_table_id            = data.aws_vpc.main.main_route_table_id
+  for_each                  = toset(data.aws_route_tables.rts.ids)
+  route_table_id            = each.value
   destination_cidr_block    = local.their_source_cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.dms.id
 }


### PR DESCRIPTION
## Summary

Rolls up to #1038

### Time to review: __1 mins__

## Changes proposed

Instead of associating the DMS exclusively with the main route table, I made it associate with all the route tables.

## Motivation

The new DMS connection isn't working ☹️ and this is a part of my debugging