### PR TITLE
[Issue 1215] Trivy Ignore CVE-2024-0567 and CVE-2023-5981

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -14,3 +14,6 @@ CVE-2023-5869
 CVE-2023-39418
 CVE-2023-5868
 CVE-2023-5870
+# 2/12/2024 - libgnutls30 in node:20-bullseye-slim not updated with latest fix. Check again after 2/20/2024 to remove
+CVE-2024-0567
+CVE-2023-5981


### PR DESCRIPTION
## Summary
Fixes #1215 

### Time to review: __5 mins__

## Changes proposed
Added CVE-2024-0567 and CVE-2023-5981 to trivy ignore whitelist.

