### PR TITLE
[Issue 966] Configure access log S3 buckets to allow SSL requests only

### DIFF
--- a/infra/modules/service/access-logs.tf
+++ b/infra/modules/service/access-logs.tf
@@ -52,6 +52,25 @@ data "aws_iam_policy_document" "access_logs_put_access" {
       identifiers = ["arn:aws:iam::${local.elb_account_map[data.aws_region.current.name]}:root"]
     }
   }
+
+  statement {
+    sid    = "AllowSSLRequestsOnly"
+    effect = "Deny"
+    resources = [
+      aws_s3_bucket.access_logs.arn,
+      "${aws_s3_bucket.access_logs.arn}/*"
+    ]
+    actions = ["s3:*"]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = [false]
+    }
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "access_logs" {


### PR DESCRIPTION
## Summary
Part of #966

### Time to review: __5 mins__

## Changes proposed
- Modify the bucket policy for the `*access-logs*` buckets to allow SSL requests only.

## Context for reviewers
This policy is required by Security Hub control S3.5. See https://repost.aws/knowledge-center/s3-bucket-policy-for-config-rule

## Additional information
Tested by deploying to dev using `make infra-update-app-service APP_NAME=api ENVIRONMENT=dev`.

Before deploy:
![Screenshot 2024-02-12 at 19-20-47 api-dev-access-logs20231023213552646900000003 - S3 bucket S3 Global](https://github.com/HHS/simpler-grants-gov/assets/3811269/09cf21ac-c034-4da3-b41d-9726c8ba07bf)

After deploy:
![Screenshot 2024-02-12 at 19-21-24 api-dev-access-logs20231023213552646900000003 - S3 bucket S3 Global](https://github.com/HHS/simpler-grants-gov/assets/3811269/9b1d5f76-8772-48ee-970d-4cf91e99d4ba)

Confirmed that the control switched from FAILED to PASSED on Security Hub:
![Screenshot 2024-02-12 at 19-30-46 S3 5 Controls Security Hub us-east-1](https://github.com/HHS/simpler-grants-gov/assets/3811269/cacd50d2-f303-49bc-8f34-1a44885f6220)
