### PR TITLE
TODO: Ignore local vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 
 # asdf
 .tool-versions
+
+# vscode
+.vscode*


### PR DESCRIPTION
## Summary
Fixes #{ISSUE}

### Time to review: 1 min

## Changes proposed

- Add `.vscode` folder to `.gitignore` to match setup instructions in docs

## Context for reviewers

- frontend docs call for creating `.vscode/` workspace-specific settings to allow for prettier and eslint to run (on save) - so if developers add this folder, I believe it should be ignored?
    - `.vscode/settings.json` controls the workspace settings


- Not sure if we need a ticket for this kind of quick change?

