### PR TITLE
[Issue 1240] Create a basic ECS script which will become the copy process for Oracle data

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -44,7 +44,7 @@ else
 PY_RUN_CMD := docker-compose run $(DOCKER_EXEC_ARGS) --rm $(APP_NAME) poetry run
 endif
 
-FLASK_CMD := $(PY_RUN_CMD) flask --env-file local.env
+FLASK_CMD := $(PY_RUN_CMD) flask
 
 # Docker user configuration
 # This logic is to avoid issues with permissions and mounting local volumes,
@@ -239,6 +239,9 @@ cmd: ## Run Flask app CLI command (Run `make cli args="--help"` to see list of C
 openapi-spec: init-db ## Generate OpenAPI spec
 	$(FLASK_CMD) spec --format yaml --output ./openapi.generated.yml
 
+
+copy-oracle-data:
+	$(FLASK_CMD) data-migration copy-oracle-data
 
 ##################################################
 # Miscellaneous Utilities

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -14,6 +14,7 @@ from src.api.opportunities import opportunity_blueprint
 from src.api.response import restructure_error_response
 from src.api.schemas import response_schema
 from src.auth.api_key_auth import get_app_security_scheme
+from src.data_migration.data_migration_blueprint import data_migration_blueprint
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,8 @@ def configure_app(app: APIFlask) -> None:
 def register_blueprints(app: APIFlask) -> None:
     app.register_blueprint(healthcheck_blueprint)
     app.register_blueprint(opportunity_blueprint)
+
+    app.register_blueprint(data_migration_blueprint)
 
 
 def get_project_root_dir() -> str:

--- a/api/src/data_migration/__init__.py
+++ b/api/src/data_migration/__init__.py
@@ -1,0 +1,6 @@
+from src.data_migration.data_migration_blueprint import data_migration_blueprint
+
+# import any of the other files so they get initialized and attached to the blueprint
+import src.data_migration.copy_oracle_data  # noqa: F401 E402 isort:skip
+
+__all__ = ["data_migration_blueprint"]

--- a/api/src/data_migration/copy_oracle_data.py
+++ b/api/src/data_migration/copy_oracle_data.py
@@ -9,7 +9,9 @@ from src.data_migration.data_migration_blueprint import data_migration_blueprint
 logger = logging.getLogger(__name__)
 
 
-@data_migration_blueprint.cli.command("copy-oracle-data", help="Copy data form the legacy Oracle data to the new Postgres database")
+@data_migration_blueprint.cli.command(
+    "copy-oracle-data", help="Copy data form the legacy Oracle data to the new Postgres database"
+)
 @flask_db.with_db_session()
 def copy_oracle_data(db_session: db.Session) -> None:
     logger.info("Beginning copy of data from Oracle database")

--- a/api/src/data_migration/copy_oracle_data.py
+++ b/api/src/data_migration/copy_oracle_data.py
@@ -1,0 +1,23 @@
+import logging
+
+from sqlalchemy import text
+
+import src.adapters.db as db
+import src.adapters.db.flask_db as flask_db
+from src.data_migration.data_migration_blueprint import data_migration_blueprint
+
+logger = logging.getLogger(__name__)
+
+
+@data_migration_blueprint.cli.command("copy-oracle-data", help="Copy data form the legacy Oracle data to the new Postgres database")
+@flask_db.with_db_session()
+def copy_oracle_data(db_session: db.Session) -> None:
+    logger.info("Beginning copy of data from Oracle database")
+
+    # TODO - in a follow-up ticket we'll implement the actual SQL commands
+    # we want to run for copying data - likely building out a few reusable utilities
+    with db_session.begin():
+        count = db_session.scalar(text("SELECT count(*) from transfer_topportunity"))
+        logger.info(f"Found {count} records in transfer_topportunity")
+
+    logger.info("Successfully ran copy-oracle-data")

--- a/api/src/data_migration/data_migration_blueprint.py
+++ b/api/src/data_migration/data_migration_blueprint.py
@@ -1,0 +1,5 @@
+from apiflask import APIBlueprint
+
+data_migration_blueprint = APIBlueprint(
+    "data-migration", __name__, enable_openapi=False, cli_group="data-migration"
+)


### PR DESCRIPTION
## Summary
Fixes #1240

### Time to review: __5 mins__

## Changes proposed
Setup a quick script that connects to the database

## Context for reviewers
Let me know if you think there would be a better name for any of these files, quickly named a lot of this.

While it may seem odd, we actually can run tasks via Flask (this doesn't actually run routes - just re-using app setup). Running this way automatically handles setting up DB sessions, logging, and a few other utilities that we can re-use easily in a backend ECS task script. This shows how simple it is to set something new up (minus the infra).

The actual implementation will come in a follow-up script, this is just to unblock any infra work and let them have something to try to run.

## Additional information
You can run the task with `make copy-oracle-data` - for now this works locally and produces the following output:
![Screenshot 2024-02-14 at 3 46 10 PM](https://github.com/HHS/simpler-grants-gov/assets/46358556/e3271fc6-b10d-4f4e-ae7c-d59ffc3cb46c)


