### PR TITLE
use showSearchV0 flag

### DIFF
--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -1,19 +1,24 @@
 import type { GetStaticProps, NextPage } from "next";
+import { useFeatureFlags } from "src/hooks/useFeatureFlags";
 
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
+import PageNotFound from "./404";
+
 const Search: NextPage = () => {
+  const { featureFlagsManager, mounted } = useFeatureFlags();
+
+  if (!mounted) return null;
+  if (!featureFlagsManager.isFeatureEnabled("showSearchV0")) {
+    return <PageNotFound />;
+  }
+
   return <>Search Boilerplate</>;
 };
 
 // Change this to GetServerSideProps if you're using server-side rendering
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
   const translations = await serverSideTranslations(locale ?? "en");
-
-  // TODO: update the statement below with a feature flag check
-  const hideSearchPage = true;
-  // redirects to default 404 page
-  if (hideSearchPage) return { notFound: true };
 
   return { props: { ...translations } };
 };


### PR DESCRIPTION
## Summary
Fixes #1193 

### Time to review: __3 mins__

## Changes proposed
Use `showSearchV0` flag to programmatically show search page or redirect to 404 page.

## Context for reviewers
use query string `?_ff=showSearchV0:true` to toggle the page on.
use query string `?_ff=showSearchV0:false` to toggle the page off.
Or use the route `/dev/feature-flags` to update the flag.

