### PR TITLE
[Issues 1259] add frontend make build target

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -42,7 +42,7 @@ release-build:
 ##################################################
 build: # Build the Next.js local dev server in Docker
 	docker-compose build --no-cache nextjs
-
+	
 dev: # Run the Next.js local dev server in Docker
 	docker compose up --detach nextjs
 	docker compose logs --follow nextjs

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -40,6 +40,9 @@ release-build:
 ##################################################
 # Local development
 ##################################################
+build: # Build the Next.js local dev server in Docker
+	docker-compose build --no-cache nextjs
+
 dev: # Run the Next.js local dev server in Docker
 	docker compose up --detach nextjs
 	docker compose logs --follow nextjs
@@ -54,6 +57,9 @@ stop:
 ##################################################
 # Load testing
 ##################################################
+
+build
+
 load-test-local: # Load test the local environment at localhost:3000
 	artillery run -e local artillery-load-test.yml
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -57,9 +57,6 @@ stop:
 ##################################################
 # Load testing
 ##################################################
-
-build
-
 load-test-local: # Load test the local environment at localhost:3000
 	artillery run -e local artillery-load-test.yml
 

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -40,8 +40,11 @@ release-build:
 ##################################################
 # Local development
 ##################################################
-build: # Build the Next.js local dev server in Docker
-	docker-compose build --no-cache nextjs
+build-dev: # Build the Next.js local dev server in Docker
+	docker compose build --no-cache nextjs
+
+build-storybook: # Build Storybook in Docker
+	docker compose build --no-cache storybook
 
 dev: # Run the Next.js local dev server in Docker
 	docker compose up --detach nextjs

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -42,7 +42,7 @@ release-build:
 ##################################################
 build: # Build the Next.js local dev server in Docker
 	docker-compose build --no-cache nextjs
-	
+
 dev: # Run the Next.js local dev server in Docker
 	docker compose up --detach nextjs
 	docker compose logs --follow nextjs

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -70,6 +70,8 @@ From the `frontend/` directory:
    ```
 1. Navigate to [localhost:3000](http://localhost:3000) to view the application
 
+* If installing new packages locally with npm and using `make dev` with docker to run locally, you may need to run `make build` first to bring the new packages into the container
+
 ##### Testing Release Target Locally
 
 To test the release target locally, run:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -70,7 +70,7 @@ From the `frontend/` directory:
    ```
 1. Navigate to [localhost:3000](http://localhost:3000) to view the application
 
-* If installing new packages locally with npm and using `make dev` with docker to run locally, you may need to run `make build` first to bring the new packages into the container
+- If installing new packages locally with npm and using `make dev` with docker to run locally, you may need to run `make build` first to bring the new packages into the container
 
 ##### Testing Release Target Locally
 


### PR DESCRIPTION
## Summary
Fixes #1259 

### Time to review: 1 min

## Changes proposed
- add frontend make build target

## Context for reviewers
- when adding a new package with npm and running `make dev`, local docker needs to rebuild to pull in new dependencies 

