### PR TITLE
[Issue 1285] Configure prod peering connection

### DIFF
--- a/infra/modules/dms-networking/main.tf
+++ b/infra/modules/dms-networking/main.tf
@@ -1,23 +1,23 @@
 locals {
-  our_target_cidr_block   = var.dms_target_cidr_block        # our [Nava] cidr block, where the target database for the DMS is located
+  our_target_cidr_block   = var.our_cidr_block               # our [Nava] cidr block, where the target database for the DMS is located
   their_source_cidr_block = var.grants_gov_oracle_cidr_block # their [MicroHealth] cidr block, where the origin database for the DMS is located
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter
 data "aws_ssm_parameter" "dms_peer_owner_id" {
-  name = "/network/dms/peer-owner-id"
+  name = "/network/${var.environment_name}/dms/peer-owner-id"
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter
 data "aws_ssm_parameter" "dms_peer_vpc_id" {
-  name = "/network/dms/peer-vpc-id"
+  name = "/network/${var.environment_name}/dms/peer-vpc-id"
 }
 
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc
 data "aws_vpc" "main" {
-  id = var.vpc_id
+  id = var.our_vpc_id
 }
 
 data "aws_route_tables" "rts" {
-  vpc_id = var.vpc_id
+  vpc_id = var.our_vpc_id
 }

--- a/infra/modules/dms-networking/networking.tf
+++ b/infra/modules/dms-networking/networking.tf
@@ -5,7 +5,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_peering_connection" "dms" {
   peer_owner_id = data.aws_ssm_parameter.dms_peer_owner_id.value
   peer_vpc_id   = data.aws_ssm_parameter.dms_peer_vpc_id.value
-  vpc_id        = var.vpc_id
+  vpc_id        = var.our_vpc_id
   peer_region   = "us-east-2"
 
   tags = {

--- a/infra/modules/dms-networking/security.tf
+++ b/infra/modules/dms-networking/security.tf
@@ -5,15 +5,15 @@ resource "aws_security_group" "dms" {
   # checkov:skip= CKV2_AWS_5:DMS instance not created yet
   name        = "dms"
   description = "Database DMS security group"
-  vpc_id      = var.vpc_id
+  vpc_id      = var.our_vpc_id
 }
 
 # Allow all egrees traffic from DMS instance, which allows it to (for example)
 # request secrets from AWS Secrets Manager.
 resource "aws_vpc_security_group_egress_rule" "all_egress" {
   description       = "Allow all egress"
-  from_port         = 0
-  to_port           = 0
+  from_port         = "-1"
+  to_port           = "-1"
   ip_protocol       = "-1"
   cidr_ipv4         = "0.0.0.0/0"
   security_group_id = aws_security_group.dms.id

--- a/infra/modules/dms-networking/variables.tf
+++ b/infra/modules/dms-networking/variables.tf
@@ -1,11 +1,15 @@
-variable "vpc_id" {
+variable "our_vpc_id" {
   type = string
 }
 
-variable "dms_target_cidr_block" {
+variable "our_cidr_block" {
   type = string
 }
 
 variable "grants_gov_oracle_cidr_block" {
+  type = string
+}
+
+variable "environment_name" {
   type = string
 }

--- a/infra/networks/main.tf
+++ b/infra/networks/main.tf
@@ -58,7 +58,8 @@ module "network" {
 
 module "dms_networking" {
   source                       = "../modules/dms-networking"
-  vpc_id                       = module.network.vpc_id
-  dms_target_cidr_block        = module.network.vpc_cidr
+  environment_name             = var.environment_name
+  our_vpc_id                   = module.network.vpc_id
+  our_cidr_block               = module.network.vpc_cidr
   grants_gov_oracle_cidr_block = module.project_config.network_configs[var.environment_name].grants_gov_oracle_cidr_block
 }

--- a/infra/project-config/main.tf
+++ b/infra/project-config/main.tf
@@ -22,17 +22,17 @@ locals {
     dev = {
       vpc_name                     = "dev"
       second_octet                 = 0               # The second octet our the VPC CIDR block
-      grants_gov_oracle_cidr_block = "10.220.0.0/16" # MicroHealth managed CIDR block where the origin Oracle database for Grants.gov is located
+      grants_gov_oracle_cidr_block = "10.220.0.0/16" # MicroHealth managed CIDR block where the dev origin Oracle database for Grants.gov is located
     }
     staging = {
       vpc_name                     = "staging"
       second_octet                 = 1               # The second octet our the VPC CIDR block
-      grants_gov_oracle_cidr_block = "10.220.0.0/16" # MicroHealth managed CIDR block where the origin Oracle database for Grants.gov is located
+      grants_gov_oracle_cidr_block = "10.220.0.0/16" # MicroHealth managed CIDR block where the dev origin Oracle database for Grants.gov is located
     }
     prod = {
       vpc_name                     = "prod"
       second_octet                 = 3               # The second octet our the VPC CIDR block
-      grants_gov_oracle_cidr_block = "10.220.0.0/16" # !PLACEHOLDER! We haven't been provided with this yet
+      grants_gov_oracle_cidr_block = "10.250.0.0/16" # MicroHealth managed CIDR block where the prod origin Oracle database for Grants.gov is located
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #1285

### Time to review: __5 mins__

## Changes proposed

### dev / staging

no changes!

### prod

- replace the fake placeholder VPC cidr with the real one
- re-create the peering connection

terraform diff:

```
  # module.dms_networking.aws_route.dms["rtb-031ad0ccaf4d5da41"] must be replaced
-/+ resource "aws_route" "dms" {
      ~ destination_cidr_block    = "10.220.0.0/16" -> "10.250.0.0/16" # forces replacement
      ~ id                        = "r-rtb-031ad0ccaf4d5da413548427919" -> (known after apply)
      + instance_id               = (known after apply)
      + instance_owner_id         = (known after apply)
      + network_interface_id      = (known after apply)
      ~ origin                    = "CreateRoute" -> (known after apply)
      ~ state                     = "blackhole" -> (known after apply)
      ~ vpc_peering_connection_id = "pcx-00e7861e707a69690" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.dms_networking.aws_route.dms["rtb-07431716b9cc7d61c"] must be replaced
-/+ resource "aws_route" "dms" {
      ~ destination_cidr_block    = "10.220.0.0/16" -> "10.250.0.0/16" # forces replacement
      ~ id                        = "r-rtb-07431716b9cc7d61c3548427919" -> (known after apply)
      + instance_id               = (known after apply)
      + instance_owner_id         = (known after apply)
      + network_interface_id      = (known after apply)
      ~ origin                    = "CreateRoute" -> (known after apply)
      ~ state                     = "blackhole" -> (known after apply)
      ~ vpc_peering_connection_id = "pcx-00e7861e707a69690" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.dms_networking.aws_route.dms["rtb-074bf8c3606807c41"] must be replaced
-/+ resource "aws_route" "dms" {
      ~ destination_cidr_block    = "10.220.0.0/16" -> "10.250.0.0/16" # forces replacement
      ~ id                        = "r-rtb-074bf8c3606807c413548427919" -> (known after apply)
      + instance_id               = (known after apply)
      + instance_owner_id         = (known after apply)
      + network_interface_id      = (known after apply)
      ~ origin                    = "CreateRoute" -> (known after apply)
      ~ state                     = "blackhole" -> (known after apply)
      ~ vpc_peering_connection_id = "pcx-00e7861e707a69690" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.dms_networking.aws_route.dms["rtb-0b6fb462068e717a7"] must be replaced
-/+ resource "aws_route" "dms" {
      ~ destination_cidr_block    = "10.220.0.0/16" -> "10.250.0.0/16" # forces replacement
      ~ id                        = "r-rtb-0b6fb462068e717a73548427919" -> (known after apply)
      + instance_id               = (known after apply)
      + instance_owner_id         = (known after apply)
      + network_interface_id      = (known after apply)
      ~ origin                    = "CreateRoute" -> (known after apply)
      ~ state                     = "blackhole" -> (known after apply)
      ~ vpc_peering_connection_id = "pcx-00e7861e707a69690" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.dms_networking.aws_route.dms["rtb-0fe6b2188de4c0d55"] must be replaced
-/+ resource "aws_route" "dms" {
      ~ destination_cidr_block    = "10.220.0.0/16" -> "10.250.0.0/16" # forces replacement
      ~ id                        = "r-rtb-0fe6b2188de4c0d553548427919" -> (known after apply)
      + instance_id               = (known after apply)
      + instance_owner_id         = (known after apply)
      + network_interface_id      = (known after apply)
      ~ origin                    = "CreateRoute" -> (known after apply)
      ~ state                     = "blackhole" -> (known after apply)
      ~ vpc_peering_connection_id = "pcx-00e7861e707a69690" -> (known after apply)
        # (1 unchanged attribute hidden)
    }

  # module.dms_networking.aws_vpc_peering_connection.dms will be created
  + resource "aws_vpc_peering_connection" "dms" {
      + accept_status = (known after apply)
      + id            = (known after apply)
      + peer_owner_id = (sensitive value)
      + peer_region   = "us-east-2"
      + peer_vpc_id   = (sensitive value)
      + tags          = {
          + "Name" = "DMS VPC Peering"
        }
      + tags_all      = {
          + "Name"                = "DMS VPC Peering"
          + "description"         = "VPC resources"
          + "owner"               = "navapbc"
          + "project"             = "simpler-grants-gov"
          + "repository"          = "https://github.com/HHS/simpler-grants-gov"
          + "terraform"           = "true"
          + "terraform_workspace" = "default"
        }
      + vpc_id        = "vpc-03451ea43dc6c33da"
    }

  # module.dms_networking.aws_vpc_security_group_egress_rule.oracle_egress_from_dms will be updated in-place
  ~ resource "aws_vpc_security_group_egress_rule" "oracle_egress_from_dms" {
      ~ cidr_ipv4              = "10.220.0.0/16" -> "10.250.0.0/16"
        id                     = "sgr-077713bf617951d64"
        # (8 unchanged attributes hidden)
    }

  # module.dms_networking.aws_vpc_security_group_ingress_rule.oracle_ingress_from_dms will be updated in-place
  ~ resource "aws_vpc_security_group_ingress_rule" "oracle_ingress_from_dms" {
      ~ cidr_ipv4              = "10.220.0.0/16" -> "10.250.0.0/16"
        id                     = "sgr-01b3bfc1820eef6bc"
        # (8 unchanged attributes hidden)
    }

Plan: 6 to add, 2 to change, 5 to destroy.
```
