### PR TITLE
[Issue 1281] Allow RDS Data API in prod

### DIFF
--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -5,6 +5,6 @@ module "prod_config" {
   environment                     = "prod"
   has_database                    = local.has_database
   database_instance_count         = 2
-  database_enable_http_endpoint   = false
+  database_enable_http_endpoint   = true
   has_incident_management_service = local.has_incident_management_service
 }


### PR DESCRIPTION
## Summary
Contributes to #1281

### Time to review: __0.1 mins__

## Changes proposed

Allow the RDS data API in prod, so I can use it for https://github.com/HHS/simpler-grants-gov/issues/1281, per conversation here: https://betagrantsgov.slack.com/archives/C05TSL64VUH/p1708451899268239