### PR TITLE
[Issue 1016] Switch to using deliverable column to join issues and deliverables

### DIFF
--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN_PROJECT_ACCESS }}
       ANALYTICS_SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      ANALYTICS_REPORTING_CHANNEL_ID: ${{ secrets.REPORTING_CHANNEL_ID }}
+      ANALYTICS_REPORTING_CHANNEL_ID: ${{ secrets.REPORTING_CHANNEL_ID_TEST }}
       ACTION: show-results # show results, but don't post them to slack
     steps:
       # set up python

--- a/analytics/.vscode/settings.json
+++ b/analytics/.vscode/settings.json
@@ -2,5 +2,6 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
-    "python.formatting.provider": "none"
+    "python.formatting.provider": "none",
+    "python.analysis.typeCheckingMode": "basic"
 }

--- a/analytics/Makefile
+++ b/analytics/Makefile
@@ -41,9 +41,9 @@ unit-test:
 e2e-test:
 	@echo "=> Running end-to-end tests"
 	@echo "============================="
-	$(POETRY) run pytest tests/integrations --cov-append=src
+	$(POETRY) run pytest tests/integrations --cov=src --cov-append
 
-test-audit: unit-test
+test-audit: unit-test e2e-test
 	@echo "=> Running test coverage report"
 	@echo "============================="
 	$(POETRY) run coverage report --show-missing --fail-under=$(MIN_TEST_COVERAGE)

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -25,6 +25,9 @@ SPRINT_ARG = typer.Option(help="Name of the sprint for which we're calculating b
 UNIT_ARG = typer.Option(help="Whether to calculate completion by 'points' or 'tickets'")
 SHOW_RESULTS_ARG = typer.Option(help="Display a chart of the results in a browser")
 POST_RESULTS_ARG = typer.Option(help="Post the results to slack")
+STATUS_ARG = typer.Option(
+    help="Deliverable status to include in report, can be passed multiple times",
+)
 # fmt: on
 
 # instantiate the main CLI entrypoint
@@ -98,6 +101,7 @@ def calculate_deliverable_percent_complete(
     show_results: Annotated[bool, SHOW_RESULTS_ARG] = False,
     post_results: Annotated[bool, POST_RESULTS_ARG] = False,
     roadmap_file: Annotated[Optional[str], ROADMAP_FILE_ARG] = None,  # noqa: UP007
+    include_status: Annotated[Optional[list[str]], STATUS_ARG] = None,  # noqa: UP007
 ) -> None:
     """Calculate percentage completion by deliverable."""
     if roadmap_file:
@@ -114,7 +118,11 @@ def calculate_deliverable_percent_complete(
             issue_file=issue_file,
         )
     # calculate percent complete
-    metric = DeliverablePercentComplete(task_data, unit=unit)
+    metric = DeliverablePercentComplete(
+        dataset=task_data,
+        unit=unit,
+        statuses_to_include=include_status,
+    )
     show_and_or_post_results(
         metric=metric,
         show_results=show_results,

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -1,6 +1,6 @@
 # pylint: disable=C0415
 """Expose a series of CLI entrypoints for the analytics package."""
-from typing import Annotated
+from typing import Annotated, Optional
 
 import typer
 from slack_sdk import WebClient
@@ -16,6 +16,7 @@ from analytics.metrics.percent_complete import DeliverablePercentComplete
 # Instantiate typer options with help text for the commands below
 SPRINT_FILE_ARG = typer.Option(help="Path to file with exported sprint data")
 ISSUE_FILE_ARG = typer.Option(help="Path to file with exported issue data")
+ROADMAP_FILE_ARG = typer.Option(help="Path to file with exported roadmap data")
 OUTPUT_FILE_ARG = typer.Option(help="Path to file where exported data will be saved")
 OWNER_ARG = typer.Option(help="GitHub handle of the repo or project owner")
 REPO_ARG = typer.Option(help="Name of the GitHub repo")
@@ -96,13 +97,22 @@ def calculate_deliverable_percent_complete(
     *,  # makes the following args keyword only
     show_results: Annotated[bool, SHOW_RESULTS_ARG] = False,
     post_results: Annotated[bool, POST_RESULTS_ARG] = False,
+    roadmap_file: Annotated[Optional[str], ROADMAP_FILE_ARG] = None,  # noqa: UP007
 ) -> None:
     """Calculate percentage completion by deliverable."""
-    # load the input data
-    task_data = DeliverableTasks.load_from_json_files(
-        sprint_file=sprint_file,
-        issue_file=issue_file,
-    )
+    if roadmap_file:
+        # load the input data using the new join path with roadmap data
+        task_data = DeliverableTasks.load_from_json_files_with_roadmap_data(
+            sprint_file=sprint_file,
+            issue_file=issue_file,
+            roadmap_file=roadmap_file,
+        )
+    else:
+        # load the input data using the original join path without roadmap data
+        task_data = DeliverableTasks.load_from_json_files(
+            sprint_file=sprint_file,
+            issue_file=issue_file,
+        )
     # calculate percent complete
     metric = DeliverablePercentComplete(task_data, unit=unit)
     show_and_or_post_results(

--- a/analytics/src/analytics/datasets/base.py
+++ b/analytics/src/analytics/datasets/base.py
@@ -13,7 +13,7 @@ class BaseDataset:
         self.df = df
 
     @classmethod
-    def from_csv(cls, file_path: str) -> Self:
+    def from_csv(cls, file_path: str | Path) -> Self:
         """Load and instantiate the dataset from a csv file."""
         return cls(df=pd.read_csv(file_path))
 

--- a/analytics/src/analytics/datasets/deliverable_tasks.py
+++ b/analytics/src/analytics/datasets/deliverable_tasks.py
@@ -56,6 +56,7 @@ class DeliverableTasks(BaseDataset):
     FINAL_COLUMNS = [
         "deliverable_number",
         "deliverable_title",
+        "deliverable_status",
         "issue_title",
         "issue_number",
         "points",
@@ -142,6 +143,8 @@ class DeliverableTasks(BaseDataset):
         df_deliverable = df_deliverable.rename(columns=deliverable_cols)
         # left join to df on "deliverable_number" to get the deliverable title
         df = df_deliverable.merge(df_all, on="deliverable_number", how="left")
+        # add placeholder col to support filtering on deliverable status
+        df["deliverable_status"] = None
         return df[cls.FINAL_COLUMNS]
 
     @classmethod

--- a/analytics/src/analytics/datasets/deliverable_tasks.py
+++ b/analytics/src/analytics/datasets/deliverable_tasks.py
@@ -53,7 +53,6 @@ class DeliverableTasks(BaseDataset):
         "status": "deliverable_status",
         "deliverable": "deliverable",
     }
-    FINAL_COLUMNS_WITH_ROADMAP = []
     FINAL_COLUMNS = [
         "deliverable_number",
         "deliverable_title",

--- a/analytics/src/analytics/datasets/utils.py
+++ b/analytics/src/analytics/datasets/utils.py
@@ -7,7 +7,7 @@ import pandas as pd
 def load_json_data_as_df(
     file_path: str,
     column_map: dict,
-    date_cols: list[str],
+    date_cols: list[str] | None = None,
     key_for_nested_items: str | None = None,
 ) -> pd.DataFrame:
     """
@@ -47,7 +47,8 @@ def load_json_data_as_df(
     df = df[column_map.keys()]
     df = df.rename(columns=column_map)
     # convert datetime columns to date
-    for col in date_cols:
-        # strip off the timestamp portion of the date
-        df[col] = pd.to_datetime(df[col]).dt.floor("d")
+    if date_cols:
+        for col in date_cols:
+            # strip off the timestamp portion of the date
+            df[col] = pd.to_datetime(df[col]).dt.floor("d")
     return df

--- a/analytics/src/analytics/metrics/percent_complete.py
+++ b/analytics/src/analytics/metrics/percent_complete.py
@@ -16,11 +16,16 @@ class DeliverablePercentComplete(BaseMetric[DeliverableTasks]):
         self,
         dataset: DeliverableTasks,
         unit: Unit,
+        statuses_to_include: list[str] | None = None,
     ) -> None:
         """Initialize the DeliverablePercentComplete metric."""
+        self.dataset = dataset
         self.deliverable_col = "deliverable_title"
         self.status_col = "status"
+        self.deliverable_status_col = "deliverable_status"
         self.unit = unit
+        self.statuses_to_include = statuses_to_include
+        self.deliverable_data = self._isolate_deliverables_by_status()
         super().__init__(dataset)
 
     def calculate(self) -> pd.DataFrame:
@@ -72,7 +77,7 @@ class DeliverablePercentComplete(BaseMetric[DeliverableTasks]):
 
     def get_stats(self) -> dict[str, Statistic]:
         """Calculate stats for this metric."""
-        df_src = self.dataset.df
+        df_src = self.deliverable_data
         # get the total number of issues and the number of issues with points per deliverable
         is_pointed = df_src[Unit.points.value] >= 1
         issues_total = df_src.value_counts(self.deliverable_col).to_frame()
@@ -97,9 +102,22 @@ class DeliverablePercentComplete(BaseMetric[DeliverableTasks]):
     def format_slack_message(self) -> str:
         """Format the message that will be included with the charts posted to slack."""
         message = f"*:github: Percent of {self.unit.value} completed by deliverable*\n"
+        if self.statuses_to_include:
+            statuses = ", ".join(self.statuses_to_include)
+            message += f"Limited to deliverables with these statuses: {statuses}\n\n"
         for label, stat in self.stats.items():
             message += f"• *{label}:* {stat.value}{stat.suffix}\n"
         return message
+
+    def _isolate_deliverables_by_status(self) -> pd.DataFrame:
+        """Isolate the deliverables to include in the report based on their status."""
+        df = self.dataset.df
+        # if statuses_to_include is provided, use it to filter the dataset
+        statuses_provided = self.statuses_to_include
+        if statuses_provided:
+            status_filter = df[self.deliverable_status_col].isin(statuses_provided)
+            df = df[status_filter]
+        return df
 
     def _get_count_by_deliverable(
         self,
@@ -107,7 +125,7 @@ class DeliverablePercentComplete(BaseMetric[DeliverableTasks]):
     ) -> pd.DataFrame:
         """Get the count of issues (or points) by deliverable and status."""
         # create local copies of the dataset and key column names
-        df = self.dataset.df.copy()
+        df = self.deliverable_data.copy()
         unit_col = self.unit.value
         key_cols = [self.deliverable_col, unit_col]
         # create a dummy column to sum per row if the unit is issues

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -21,6 +21,9 @@ DAY_3 = "2023-11-03"
 DAY_4 = "2023-11-04"
 DAY_5 = "2023-11-05"
 
+LABEL_30K = "deliverable: 30k ft"
+LABEL_10K = "deliverable: 10k ft"
+
 
 class MockSlackbot:
     """Create a mock slackbot issue for unit tests."""
@@ -71,6 +74,41 @@ def json_issue_row(
     }
 
 
+def json_roadmap_row(
+    deliverable: int,
+    status: str,
+    labels: list[str] | None = None,
+) -> dict:
+    """
+    Generate a row of JSON roadmap data for testing.
+
+    This is the format returned by the export_project_data() command
+    """
+    return {
+        "assignees": ["mickeymouse"],
+        "content": {
+            "type": "Issue",
+            "body": f"Description of test deliverable {deliverable}",
+            "title": f"Deliverable {deliverable}",
+            "number": deliverable,
+            "repository": "HHS/simpler-grants-gov",
+            "url": f"https://github.com/HHS/simpler-grants-gov/issues/{deliverable}",
+        },
+        "id": "PVTI_lADOABZxns4ASDf3zgJhmCk",
+        "labels": labels or [LABEL_30K],
+        "linked pull requests": [],
+        "milestone": {
+            "title": "Sample milestone",
+            "description": "Deliverable for milestone",
+            "dueOn": "2023-10-20T00:00:00Z",
+        },
+        "repository": "https://github.com/HHS/simpler-grants-gov",
+        "status": status,
+        "deliverable": f"Deliverable {deliverable}",
+        "title": f"Deliverable {deliverable}",
+    }
+
+
 def json_sprint_row(
     issue: int,
     parent_number: int = -99,
@@ -78,8 +116,13 @@ def json_sprint_row(
     sprint_date: str = "2023-11-01",
     status: str = "Done",
     points: int = 5,
+    deliverable: int = 1,
 ) -> dict:
-    """Generate a row of JSON sprint data for testing."""
+    """
+    Generate a row of JSON sprint data for testing.
+
+    This is the format returned by the export_project_data() function.
+    """
     return {
         "assignees": ["mickeymouse"],
         "content": {
@@ -102,7 +145,8 @@ def json_sprint_row(
         "sprint": {"title": sprint_name, "startDate": sprint_date, "duration": 14},
         "status": status,
         "story Points": points,
-        "title": "Test issue 1",
+        "deliverable": f"Deliverable {deliverable}",
+        "title": f"Issue {issue}",
     }
 
 
@@ -132,6 +176,7 @@ def sprint_row(
         "status": "Done" if closed else status,
         "assignees": "mickeymouse",
         "labels": [],
+        "deliverable": "Deliverable 1",
         "url": f"https://github.com/HHS/simpler-grants-gov/issues/{issue}",
         "points": points,
         "milestone": "Milestone 1",

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -44,7 +44,7 @@ def mock_slackbot_fixture():
     return MockSlackbot()
 
 
-def write_test_data_to_file(data: dict, output_file: str):
+def write_test_data_to_file(data: dict | list[dict], output_file: str):
     """Write test JSON data to a file for use in a test."""
     parent_dir = Path(output_file).parent
     parent_dir.mkdir(exist_ok=True, parents=True)
@@ -55,8 +55,8 @@ def write_test_data_to_file(data: dict, output_file: str):
 def json_issue_row(
     issue: int,
     labels: list[str] | None = None,
-    created_at: str = "2023-11-01T00:00:00Z",
-    closed_at: str = "2023-11-01T00:00:00Z",
+    created_at: str | None = "2023-11-01T00:00:00Z",
+    closed_at: str | None = "2023-11-01T00:00:00Z",
 ) -> dict:
     """Generate a row of JSON issue data for testing."""
     new_labels = (

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -75,8 +75,9 @@ def json_issue_row(
 
 
 def json_roadmap_row(
+    issue: int,
     deliverable: int,
-    status: str,
+    status: str = "In Progress",
     labels: list[str] | None = None,
 ) -> dict:
     """
@@ -88,11 +89,11 @@ def json_roadmap_row(
         "assignees": ["mickeymouse"],
         "content": {
             "type": "Issue",
-            "body": f"Description of test deliverable {deliverable}",
-            "title": f"Deliverable {deliverable}",
-            "number": deliverable,
+            "body": f"Description of test deliverable {issue}",
+            "title": f"Deliverable {issue}",
+            "number": issue,
             "repository": "HHS/simpler-grants-gov",
-            "url": f"https://github.com/HHS/simpler-grants-gov/issues/{deliverable}",
+            "url": f"https://github.com/HHS/simpler-grants-gov/issues/{issue}",
         },
         "id": "PVTI_lADOABZxns4ASDf3zgJhmCk",
         "labels": labels or [LABEL_30K],
@@ -105,7 +106,7 @@ def json_roadmap_row(
         "repository": "https://github.com/HHS/simpler-grants-gov",
         "status": status,
         "deliverable": f"Deliverable {deliverable}",
-        "title": f"Deliverable {deliverable}",
+        "title": f"Deliverable {issue}",
     }
 
 

--- a/analytics/tests/datasets/test_deliverable_tasks.py
+++ b/analytics/tests/datasets/test_deliverable_tasks.py
@@ -4,6 +4,7 @@ import numpy as np  # noqa: I001
 from analytics.datasets.deliverable_tasks import DeliverableTasks
 from tests.conftest import (
     DAY_1,
+    LABEL_10K,
     LABEL_30K,
     json_issue_row,
     json_sprint_row,
@@ -136,6 +137,7 @@ class TestLoadFromJsonFilesWithRoadmapData:
     """Test the load_from_json_files_with_roadmap_data() method."""
 
     LABEL_30K = LABEL_30K
+    LABEL_10K = LABEL_10K
     ISSUE_FILE = "data/test-issue.json"
     SPRINT_FILE = "data/test-sprint.json"
     ROADMAP_FILE = "data/test-roadmap.json"
@@ -154,8 +156,8 @@ class TestLoadFromJsonFilesWithRoadmapData:
             json_issue_row(issue=3),
         ]
         roadmap_data = [
-            json_roadmap_row(deliverable=4, status="Planning"),
-            json_roadmap_row(deliverable=5, status="In progress"),
+            json_roadmap_row(issue=4, deliverable=4, status="Planning"),
+            json_roadmap_row(issue=5, deliverable=5, status="In progress"),
         ]
         # setup - write test data to json files
         write_test_data_to_file(issue_data, self.ISSUE_FILE)
@@ -179,3 +181,71 @@ class TestLoadFromJsonFilesWithRoadmapData:
             "points",
             "status",
         ]
+
+    def test_status_is_closed_if_closed_date_is_none(self):
+        """The status should be 'closed' if closed_date field is None."""
+        # setup - create test data for two different sprints
+        sprint_data = [
+            json_sprint_row(issue=1, deliverable=3),
+            json_sprint_row(issue=2, deliverable=3),
+        ]
+        issue_data = [
+            json_issue_row(issue=1, closed_at=DAY_1),  # closed
+            json_issue_row(issue=2, closed_at=None),  # open
+        ]
+        roadmap_data = [
+            json_roadmap_row(issue=3, deliverable=3, status="Planning"),
+        ]
+        # setup - write test data to json files
+        write_test_data_to_file(issue_data, self.ISSUE_FILE)
+        write_test_data_to_file({"items": sprint_data}, self.SPRINT_FILE)
+        write_test_data_to_file({"items": roadmap_data}, self.ROADMAP_FILE)
+        # execution - load data into a sprint board
+        df = DeliverableTasks.load_from_json_files_with_roadmap_data(
+            deliverable_label=self.LABEL_30K,
+            sprint_file=self.SPRINT_FILE,
+            issue_file=self.ISSUE_FILE,
+            roadmap_file=self.ROADMAP_FILE,
+        ).df
+        df = df.set_index("issue_number")
+        # validation - check length of results
+        assert len(df) == 2
+        # validation - check
+        assert df.loc[1, "status"] == "closed"
+        assert df.loc[2, "status"] == "open"
+
+    def test_exclude_10k_deliverables_from_results(self):
+        """
+        10k deliverables should not be included in the final dataset.
+
+        If we don't drop the 10k deliverables, then joining on "deliverable"
+        will result in a fan out that duplicates task-level issues
+        """
+        # setup - create test data for two different sprints
+        sprint_data = [
+            json_sprint_row(issue=1, deliverable=3),
+            json_sprint_row(issue=2, deliverable=3),
+        ]
+        issue_data = [
+            json_issue_row(issue=1),
+            json_issue_row(issue=2),
+        ]
+        roadmap_data = [  # exclude the second item from final dataset
+            json_roadmap_row(issue=3, deliverable=3, labels=[self.LABEL_30K]),
+            json_roadmap_row(issue=4, deliverable=3, labels=[self.LABEL_10K]),
+        ]
+        # setup - write test data to json files
+        write_test_data_to_file(issue_data, self.ISSUE_FILE)
+        write_test_data_to_file({"items": sprint_data}, self.SPRINT_FILE)
+        write_test_data_to_file({"items": roadmap_data}, self.ROADMAP_FILE)
+        # execution
+        df = DeliverableTasks.load_from_json_files_with_roadmap_data(
+            deliverable_label=self.LABEL_30K,
+            sprint_file=self.SPRINT_FILE,
+            issue_file=self.ISSUE_FILE,
+            roadmap_file=self.ROADMAP_FILE,
+        ).df
+        df = df.set_index("issue_number")
+        # validation - confirm 10k was dropped and join didn't produce a fan out
+        assert len(df) == 2
+        assert list(df.index) == [1, 2]

--- a/analytics/tests/datasets/test_deliverable_tasks.py
+++ b/analytics/tests/datasets/test_deliverable_tasks.py
@@ -41,6 +41,7 @@ class TestLoadFromJsonFile:
         assert list(tasks.df.columns) == [
             "deliverable_number",
             "deliverable_title",
+            "deliverable_status",
             "issue_title",
             "issue_number",
             "points",
@@ -176,6 +177,7 @@ class TestLoadFromJsonFilesWithRoadmapData:
         assert list(df.columns) == [
             "deliverable_number",
             "deliverable_title",
+            "deliverable_status",
             "issue_title",
             "issue_number",
             "points",

--- a/analytics/tests/datasets/test_deliverable_tasks.py
+++ b/analytics/tests/datasets/test_deliverable_tasks.py
@@ -4,8 +4,10 @@ import numpy as np  # noqa: I001
 from analytics.datasets.deliverable_tasks import DeliverableTasks
 from tests.conftest import (
     DAY_1,
+    LABEL_30K,
     json_issue_row,
     json_sprint_row,
+    json_roadmap_row,
     write_test_data_to_file,
 )
 
@@ -13,13 +15,13 @@ from tests.conftest import (
 class TestLoadFromJsonFile:
     """Tests the DeliverableTasks.load_from_json_file() class method."""
 
-    LABEL = "deliverable: 30k ft"
+    LABEL = LABEL_30K
     ISSUE_FILE = "data/test-issue.json"
     SPRINT_FILE = "data/test-sprint.json"
 
     def test_returns_correct_columns(self):
         """The method should return a dataframe with the correct set of columns."""
-        # setup - create test data for two different sprints
+        # setup - create test data for two different deliverables
         sprint_data = [json_sprint_row(issue=1, parent_number=2)]
         issue_data = [
             json_issue_row(issue=1, labels=["task"]),
@@ -46,7 +48,7 @@ class TestLoadFromJsonFile:
 
     def test_join_correctly_on_deliverable_number(self):
         """Tasks should be joined to 30k deliverables on deliverable number."""
-        # setup - create test data for two different sprints
+        # setup - create test data for two different deliverables
         sprint_data = [
             json_sprint_row(issue=1, parent_number=4),
             json_sprint_row(issue=2, parent_number=4),
@@ -62,7 +64,7 @@ class TestLoadFromJsonFile:
         # setup - write test data to json files
         write_test_data_to_file(issue_data, self.ISSUE_FILE)
         write_test_data_to_file({"items": sprint_data}, self.SPRINT_FILE)
-        # execution - load data into a sprint board
+        # execution - load data
         df = DeliverableTasks.load_from_json_files(
             deliverable_label=self.LABEL,
             sprint_file=self.SPRINT_FILE,
@@ -78,7 +80,7 @@ class TestLoadFromJsonFile:
 
     def test_keep_30k_deliverables_without_tasks(self):
         """30k deliverable tickets without tasks should still appear in the dataset."""
-        # setup - create test data for two different sprints
+        # setup - create test data for two different deliverables
         sprint_data = [json_sprint_row(issue=1, parent_number=2)]
         issue_data = [
             json_issue_row(issue=1, labels=["task", "topic: frontend"]),
@@ -88,7 +90,7 @@ class TestLoadFromJsonFile:
         # setup - write test data to json files
         write_test_data_to_file(issue_data, self.ISSUE_FILE)
         write_test_data_to_file({"items": sprint_data}, self.SPRINT_FILE)
-        # execution - load data into a sprint board
+        # execution - load data
         df = DeliverableTasks.load_from_json_files(
             deliverable_label=self.LABEL,
             sprint_file=self.SPRINT_FILE,
@@ -128,3 +130,52 @@ class TestLoadFromJsonFile:
         # validation - check
         assert df.loc[1, "status"] == "closed"
         assert df.loc[2, "status"] == "open"
+
+
+class TestLoadFromJsonFilesWithRoadmapData:
+    """Test the load_from_json_files_with_roadmap_data() method."""
+
+    LABEL_30K = LABEL_30K
+    ISSUE_FILE = "data/test-issue.json"
+    SPRINT_FILE = "data/test-sprint.json"
+    ROADMAP_FILE = "data/test-roadmap.json"
+
+    def test_returns_correct_columns(self):
+        """Return the correct columns in DeliverableTasks."""
+        # setup - create test data for two different deliverables
+        sprint_data = [
+            json_sprint_row(issue=1, deliverable=4),
+            json_sprint_row(issue=2, deliverable=4),
+            json_sprint_row(issue=3, deliverable=5),
+        ]
+        issue_data = [
+            json_issue_row(issue=1),
+            json_issue_row(issue=2),
+            json_issue_row(issue=3),
+        ]
+        roadmap_data = [
+            json_roadmap_row(deliverable=4, status="Planning"),
+            json_roadmap_row(deliverable=5, status="In progress"),
+        ]
+        # setup - write test data to json files
+        write_test_data_to_file(issue_data, self.ISSUE_FILE)
+        write_test_data_to_file({"items": sprint_data}, self.SPRINT_FILE)
+        write_test_data_to_file({"items": roadmap_data}, self.ROADMAP_FILE)
+        # execution - load data
+        df = DeliverableTasks.load_from_json_files_with_roadmap_data(
+            deliverable_label=self.LABEL_30K,
+            sprint_file=self.SPRINT_FILE,
+            issue_file=self.ISSUE_FILE,
+            roadmap_file=self.ROADMAP_FILE,
+        ).df
+        # validation - check length of results
+        assert len(df) == 3
+        # validation - check output columns
+        assert list(df.columns) == [
+            "deliverable_number",
+            "deliverable_title",
+            "issue_title",
+            "issue_number",
+            "points",
+            "status",
+        ]

--- a/analytics/tests/integrations/test_slack.py
+++ b/analytics/tests/integrations/test_slack.py
@@ -20,7 +20,7 @@ def test_fetch_slack_channels(slackbot: SlackBot):
     """The fetch_slack_channels() function should execute correctly."""
     result = slackbot.fetch_slack_channel_info(channel_id=settings.reporting_channel_id)
     assert result["ok"] is True
-    assert result["channel"]["name"] == "z_bot-sprint-reporting-test"
+    assert result["channel"]["name"] == "z_bot-analytics-ci-test"
 
 
 def test_upload_files_to_slack_channel(slackbot: SlackBot):

--- a/documentation/analytics/usage.md
+++ b/documentation/analytics/usage.md
@@ -73,7 +73,7 @@ The `analytics` package comes with a built-in CLI that you can use to discover t
 
 Start by simply typing `poetry run analytics --help` which will print out a list of available commands:
 
-![Screenshot of passing the --help flag to CLI entry point](static/screenshot-cli-help.png)
+![Screenshot of passing the --help flag to CLI entry point](../../analytics/static/screenshot-cli-help.png)
 
 Discover the arguments required for a particular command by appending the `--help` flag to that command:
 
@@ -81,7 +81,7 @@ Discover the arguments required for a particular command by appending the `--hel
 poetry run analytics export gh_issue_data --help
 ```
 
-![Screenshot of passing the --help flag to a specific command](static/screenshot-command-help.png)
+![Screenshot of passing the --help flag to a specific command](../../analytics/static/screenshot-command-help.png)
 
 ### Exporting GitHub data
 
@@ -126,7 +126,7 @@ A couple of important notes about this command:
 - `--unit points` In order to calculate burndown based on story points, you pass `points` to the `--unit` option. The other option for unit is `issues`
 - `--show-results` In order to the see the output in a browser you'll need to pass this flag.
 
-![Screenshot of burndown for sprint 10](static/screenshot-sprint-burndown.png)
+![Screenshot of burndown for sprint 10](../../analytics/static/screenshot-sprint-burndown.png)
 
 You can also post the results of this metric to a Slack channel:
 
@@ -136,7 +136,7 @@ poetry run analytics calculate sprint_burndown --sprint-file data/sprint-data.js
 
 > **NOTE:** This requires you to have the `.secrets.toml` configured according to the directions in step 5 of the [installation section](#installation)
 
-![Screenshot of burndown report in slack](static/screenshot-slack-burndown.png)
+![Screenshot of burndown report in slack](../../analytics/static/screenshot-slack-burndown.png)
 
 ### Calculating deliverable percent complete
 
@@ -148,7 +148,7 @@ For example, here we're calculating percentage completion based on the number of
 ```bash
 poetry run analytics calculate deliverable_percent_complete --sprint-file data/sprint-data.json --issue-file data/issue-data.json --show-results --unit issues
 ```
-![Screenshot of deliverable percent complete by issues](static/screenshot-deliverable-pct-complete-tasks.png)
+![Screenshot of deliverable percent complete by issues](../../analytics/static/screenshot-deliverable-pct-complete-tasks.png)
 
 And here we're calculating it based on the total story point value of those tickets.
 
@@ -156,6 +156,27 @@ And here we're calculating it based on the total story point value of those tick
 poetry run analytics calculate deliverable_percent_complete --sprint-file data/sprint-data.json --issue-file data/issue-data.json --show-results --unit points
 ```
 
-![Screenshot of deliverable percent complete by points](static/screenshot-deliverable-pct-complete-points.png)
+![Screenshot of deliverable percent complete by points](../../analytics/static/screenshot-deliverable-pct-complete-points.png)
 
 The `deliverable_pct_complete` sub-command also supports the `--post-results` flag if you want to post this data to slack.
+
+
+### Experimental features
+
+We also have some flags that enable experimental features for the deliverables. The currently supported flags for `calculate deliverable_percent_complete` are:
+
+- `--roadmap-file` Accepts a path to a file that loads data exported from the Product roadmap GitHub project. This also uses a different join path to associate issues with their parent deliverables.
+- `--include-status` Accepts the name of a status to include in the report. Can be passed multiple times to include multiple statuses.
+
+Here's an example of how to use these in practice:
+
+```bash
+poetry run analytics calculate deliverable_percent_complete \
+  --sprint-file data/sprint-data.json \
+  --issue-file data/issue-data.json \
+  --roadmap-file data/roadmap-data.json \
+  --include-status "In Progress" \
+  --include-status "Planning" \
+  --show-results \
+  --unit points
+```


### PR DESCRIPTION
## Summary

Adds a flag to the `analytics calculate deliverable_percent_complete` method for us to use the strategy for assigning issues to deliverables as described in [this ADR](https://github.com/HHS/simpler-grants-gov/blob/main/documentation/decisions/adr/2023-12-15-deliverable-reporting-strategy.md)

- Fixes #1016 
- Fixes #885 
- Fixes #853 

Also includes code from #1326 

### Time to review: __8 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Added a new class method `DeliverableTasks.load_from_json_files_with_roadmap_data()` that creates the DeliverableTasks dataset by joining roadmap and sprint data using the `deliverable` column
- Adds a new flag to the `calculate_deliverable_percent_complete()` CLI entrypoint function that, when passed, will use this new strategy.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

- This PR will be stacked with the PR for #853 to limit the set of deliverables included in reporting
- Eventually these class methods will be pulled into a separate ETL sub-package in #1022 
- This PR doesn't immediately switch the strategy used to calculate metrics and post them to slack, it just adds the new strategy behind a feature flag so we can compare the outputs

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1439" alt="Screenshot 2024-02-22 at 10 53 49 AM" src="https://github.com/HHS/simpler-grants-gov/assets/21350331/889c9593-78d9-4835-b47e-b2cb4163d6e6">
