### PR TITLE
[Issue 1323] Fix a mis-firing alarm 

### DIFF
--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
   statistic           = "Average"
   threshold           = 0.2
   alarm_description   = "High target latency alert"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "ignore"
   alarm_actions       = [aws_sns_topic.this.arn]
   ok_actions          = [aws_sns_topic.this.arn]
 

--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -57,6 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
   statistic           = "Average"
   threshold           = 0.2
   alarm_description   = "High target latency alert"
+  treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.this.arn]
   ok_actions          = [aws_sns_topic.this.arn]
 


### PR DESCRIPTION
## Summary 

Fixes #1323

### Time to review: __1 mins__

## Changes proposed

Makes the `high-app-response-time` alarm treat missing data as not breaching.

## Context for reviewers

Right now this alarm is blowing up our inboxes because its swapping back and forth between `INSUFFICIENT_DATA` and `OK`. It's doing this because there's truly not enough data for most of the evaluation periods. My suggested fix for this is to treat missing data as a non-issue, so we don't get alerts when there is simply low traffic on the API.

## Testing

This is a "plan and pray" situation, I haven't tested this.