### PR TITLE
[Issue 853] Filter 30k deliverables based on status

### DIFF
--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -25,7 +25,7 @@ SPRINT_ARG = typer.Option(help="Name of the sprint for which we're calculating b
 UNIT_ARG = typer.Option(help="Whether to calculate completion by 'points' or 'tickets'")
 SHOW_RESULTS_ARG = typer.Option(help="Display a chart of the results in a browser")
 POST_RESULTS_ARG = typer.Option(help="Post the results to slack")
-STATUSES_ARG = typer.Option(help="List of deliverable statuses to include in reports")
+STATUS_ARG = typer.Option(help="Deliverable status to include in reports, can be passed multiple times")  # noqa: E501
 # fmt: on
 
 # instantiate the main CLI entrypoint
@@ -99,7 +99,7 @@ def calculate_deliverable_percent_complete(
     show_results: Annotated[bool, SHOW_RESULTS_ARG] = False,
     post_results: Annotated[bool, POST_RESULTS_ARG] = False,
     roadmap_file: Annotated[Optional[str], ROADMAP_FILE_ARG] = None,  # noqa: UP007
-    statuses: Annotated[Optional[list[str]], STATUSES_ARG] = None,  # noqa: UP007
+    include_status: Annotated[Optional[list[str]], STATUS_ARG] = None,  # noqa: UP007
 ) -> None:
     """Calculate percentage completion by deliverable."""
     if roadmap_file:
@@ -119,7 +119,7 @@ def calculate_deliverable_percent_complete(
     metric = DeliverablePercentComplete(
         dataset=task_data,
         unit=unit,
-        statuses_to_include=statuses,
+        statuses_to_include=include_status,
     )
     show_and_or_post_results(
         metric=metric,

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -25,6 +25,7 @@ SPRINT_ARG = typer.Option(help="Name of the sprint for which we're calculating b
 UNIT_ARG = typer.Option(help="Whether to calculate completion by 'points' or 'tickets'")
 SHOW_RESULTS_ARG = typer.Option(help="Display a chart of the results in a browser")
 POST_RESULTS_ARG = typer.Option(help="Post the results to slack")
+STATUSES_ARG = typer.Option(help="List of deliverable statuses to include in reports")
 # fmt: on
 
 # instantiate the main CLI entrypoint
@@ -98,6 +99,7 @@ def calculate_deliverable_percent_complete(
     show_results: Annotated[bool, SHOW_RESULTS_ARG] = False,
     post_results: Annotated[bool, POST_RESULTS_ARG] = False,
     roadmap_file: Annotated[Optional[str], ROADMAP_FILE_ARG] = None,  # noqa: UP007
+    statuses: Annotated[Optional[list[str]], STATUSES_ARG] = None,  # noqa: UP007
 ) -> None:
     """Calculate percentage completion by deliverable."""
     if roadmap_file:
@@ -114,7 +116,11 @@ def calculate_deliverable_percent_complete(
             issue_file=issue_file,
         )
     # calculate percent complete
-    metric = DeliverablePercentComplete(task_data, unit=unit)
+    metric = DeliverablePercentComplete(
+        dataset=task_data,
+        unit=unit,
+        statuses_to_include=statuses,
+    )
     show_and_or_post_results(
         metric=metric,
         show_results=show_results,

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -25,7 +25,9 @@ SPRINT_ARG = typer.Option(help="Name of the sprint for which we're calculating b
 UNIT_ARG = typer.Option(help="Whether to calculate completion by 'points' or 'tickets'")
 SHOW_RESULTS_ARG = typer.Option(help="Display a chart of the results in a browser")
 POST_RESULTS_ARG = typer.Option(help="Post the results to slack")
-STATUS_ARG = typer.Option(help="Deliverable status to include in reports, can be passed multiple times")  # noqa: E501
+STATUS_ARG = typer.Option(
+    help="Deliverable status to include in report, can be passed multiple times",
+)
 # fmt: on
 
 # instantiate the main CLI entrypoint

--- a/analytics/src/analytics/datasets/deliverable_tasks.py
+++ b/analytics/src/analytics/datasets/deliverable_tasks.py
@@ -56,6 +56,7 @@ class DeliverableTasks(BaseDataset):
     FINAL_COLUMNS = [
         "deliverable_number",
         "deliverable_title",
+        "deliverable_status",
         "issue_title",
         "issue_number",
         "points",
@@ -142,6 +143,8 @@ class DeliverableTasks(BaseDataset):
         df_deliverable = df_deliverable.rename(columns=deliverable_cols)
         # left join to df on "deliverable_number" to get the deliverable title
         df = df_deliverable.merge(df_all, on="deliverable_number", how="left")
+        # add placeholder col to support filtering on deliverable status
+        df["deliverable_status"] = None
         return df[cls.FINAL_COLUMNS]
 
     @classmethod

--- a/analytics/src/analytics/metrics/percent_complete.py
+++ b/analytics/src/analytics/metrics/percent_complete.py
@@ -104,7 +104,7 @@ class DeliverablePercentComplete(BaseMetric[DeliverableTasks]):
         message = f"*:github: Percent of {self.unit.value} completed by deliverable*\n"
         if self.statuses_to_include:
             statuses = ", ".join(self.statuses_to_include)
-            message += f"Limited to deliverables with these statuses: {statuses}"
+            message += f"Limited to deliverables with these statuses: {statuses}\n\n"
         for label, stat in self.stats.items():
             message += f"• *{label}:* {stat.value}{stat.suffix}\n"
         return message

--- a/analytics/tests/datasets/test_deliverable_tasks.py
+++ b/analytics/tests/datasets/test_deliverable_tasks.py
@@ -41,6 +41,7 @@ class TestLoadFromJsonFile:
         assert list(tasks.df.columns) == [
             "deliverable_number",
             "deliverable_title",
+            "deliverable_status",
             "issue_title",
             "issue_number",
             "points",
@@ -176,6 +177,7 @@ class TestLoadFromJsonFilesWithRoadmapData:
         assert list(df.columns) == [
             "deliverable_number",
             "deliverable_title",
+            "deliverable_status",
             "issue_title",
             "issue_number",
             "points",

--- a/documentation/analytics/usage.md
+++ b/documentation/analytics/usage.md
@@ -73,7 +73,7 @@ The `analytics` package comes with a built-in CLI that you can use to discover t
 
 Start by simply typing `poetry run analytics --help` which will print out a list of available commands:
 
-![Screenshot of passing the --help flag to CLI entry point](static/screenshot-cli-help.png)
+![Screenshot of passing the --help flag to CLI entry point](../../analytics/static/screenshot-cli-help.png)
 
 Discover the arguments required for a particular command by appending the `--help` flag to that command:
 
@@ -81,7 +81,7 @@ Discover the arguments required for a particular command by appending the `--hel
 poetry run analytics export gh_issue_data --help
 ```
 
-![Screenshot of passing the --help flag to a specific command](static/screenshot-command-help.png)
+![Screenshot of passing the --help flag to a specific command](../../analytics/static/screenshot-command-help.png)
 
 ### Exporting GitHub data
 
@@ -126,7 +126,7 @@ A couple of important notes about this command:
 - `--unit points` In order to calculate burndown based on story points, you pass `points` to the `--unit` option. The other option for unit is `issues`
 - `--show-results` In order to the see the output in a browser you'll need to pass this flag.
 
-![Screenshot of burndown for sprint 10](static/screenshot-sprint-burndown.png)
+![Screenshot of burndown for sprint 10](../../analytics/static/screenshot-sprint-burndown.png)
 
 You can also post the results of this metric to a Slack channel:
 
@@ -136,7 +136,7 @@ poetry run analytics calculate sprint_burndown --sprint-file data/sprint-data.js
 
 > **NOTE:** This requires you to have the `.secrets.toml` configured according to the directions in step 5 of the [installation section](#installation)
 
-![Screenshot of burndown report in slack](static/screenshot-slack-burndown.png)
+![Screenshot of burndown report in slack](../../analytics/static/screenshot-slack-burndown.png)
 
 ### Calculating deliverable percent complete
 
@@ -148,7 +148,7 @@ For example, here we're calculating percentage completion based on the number of
 ```bash
 poetry run analytics calculate deliverable_percent_complete --sprint-file data/sprint-data.json --issue-file data/issue-data.json --show-results --unit issues
 ```
-![Screenshot of deliverable percent complete by issues](static/screenshot-deliverable-pct-complete-tasks.png)
+![Screenshot of deliverable percent complete by issues](../../analytics/static/screenshot-deliverable-pct-complete-tasks.png)
 
 And here we're calculating it based on the total story point value of those tickets.
 
@@ -156,6 +156,27 @@ And here we're calculating it based on the total story point value of those tick
 poetry run analytics calculate deliverable_percent_complete --sprint-file data/sprint-data.json --issue-file data/issue-data.json --show-results --unit points
 ```
 
-![Screenshot of deliverable percent complete by points](static/screenshot-deliverable-pct-complete-points.png)
+![Screenshot of deliverable percent complete by points](../../analytics/static/screenshot-deliverable-pct-complete-points.png)
 
 The `deliverable_pct_complete` sub-command also supports the `--post-results` flag if you want to post this data to slack.
+
+
+### Experimental features
+
+We also have some flags that enable experimental features for the deliverables. The currently supported flags for `calculate deliverable_percent_complete` are:
+
+- `--roadmap-file` Accepts a path to a file that loads data exported from the Product roadmap GitHub project. This also uses a different join path to associate issues with their parent deliverables.
+- `--include-status` Accepts the name of a status to include in the report. Can be passed multiple times to include multiple statuses.
+
+Here's an example of how to use these in practice:
+
+```bash
+poetry run analytics calculate deliverable_percent_complete \
+  --sprint-file data/sprint-data.json \
+  --issue-file data/issue-data.json \
+  --roadmap-file data/roadmap-data.json \
+  --include-status "In Progress" \
+  --include-status "Planning" \
+  --show-results \
+  --unit points
+```


### PR DESCRIPTION
## Summary
Fixes #853 

### Time to review: __7 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Adds `deliverable_status` as a column to the `DeliverableTasks` dataset to use in filtering
- Adds a private method `_isolate_deliverables_by_status()` that optionally filters deliverables if `statuses_to_include` is passed during instantiation
- Updates the other methods to use `self.deliverable_data` which stores the output of `_isolate_deliverables_by_status()`

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This PR is stacked with #1319 and should be merged into that PR before both are merged into `main`

### TODO
I need to complete the following items before this ready to be merged:

- [x] Expand unit tests to cover filtering deliverables by status
- [x] Add optional flag to `calculate_deliverable_percent_complete()` that allows users to pass in a list of statuses to filter the report by.

### Running it locally

If you've checked out the PR locally, you can test the new functionality with:

Run the exports:
```bash
poetry run analytics export gh_issue_data --owner HHS --repo simpler-grants-gov --output-file data/issue-data.json
poetry run analytics export gh_project_data --owner HHS --project 13 --output-file data/sprint-data.json
poetry run analytics export gh_project_data --owner HHS --project 12 --output-file data/roadmap-data.json
```

```bash
poetry run analytics calculate deliverable_percent_complete \ 
  --sprint-file data/sprint-data.json \
  --issue-file data/issue-data.json \
  --roadmap-file data/roadmap-data.json \
  --include-status "In Progress" \
  --include-status "Planning" \
  --show-results \
  --unit points
```

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Here's a link to [the resulting slack post](https://betagrantsgov.slack.com/archives/C06L7JGT9M0/p1708707661472649)

<img width="1104" alt="Screenshot 2024-02-23 at 12 11 24 PM" src="https://github.com/HHS/simpler-grants-gov/assets/21350331/00ff3916-e49e-4a19-ba92-65b3b2df645f">

And here's an example of the resulting graph:

<img width="1428" alt="Screenshot 2024-02-23 at 12 12 33 PM" src="https://github.com/HHS/simpler-grants-gov/assets/21350331/1c42df6f-9841-4a89-9269-d412f1278147">
