### PR TITLE
[Issue 1285] Allow DNS resolution over peering

### DIFF
--- a/infra/modules/dms-networking/networking.tf
+++ b/infra/modules/dms-networking/networking.tf
@@ -8,6 +8,10 @@ resource "aws_vpc_peering_connection" "dms" {
   vpc_id        = var.our_vpc_id
   peer_region   = "us-east-2"
 
+  requester {
+    allow_remote_vpc_dns_resolution = true
+  }
+
   tags = {
     Name = "DMS VPC Peering"
   }


### PR DESCRIPTION
## Summary

Might help debug why https://github.com/HHS/simpler-grants-gov/issues/1285 isn't working

### Time to review: __1 mins__

## Changes & Context

Allows DNS resolution over the peering connection, which might help with debugging why the production foreign data wrapper isn't working.

This will allow for enhanced DNS resolution between Grants.gov and Simpler. I'm not sure that it's required, but I don't think that it will hurt.
