### PR TITLE
[Issue #1343] Address a CODEOWNERS issue

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # We are limiting this to 4 engineers and choosing not to select "Require review from Code Owners."
-@acouch @aplybeah @chouinar @SammySteiner
+* @acouch @aplybeah @chouinar @SammySteiner
 
 documentation/* @sumiat @widal001 @andycochran @acouch @SammySteiner
 frontend/* @andycochran @acouch @SammySteiner


### PR DESCRIPTION
## Summary

The CODEOWNERS file syntax is

```
filename reviewers
filename reviewers
...
```

As shown here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

With this syntax, I believe it was assuming that `@acouch` was a filename. 

