### PR TITLE
[Issue 878] Respond to log failures

### DIFF
--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -66,6 +66,19 @@ resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
   }
 }
 
+# Alarm if logs aren't being created for the containers
+resource "aws_cloudwatch_metric_alarm" "container_log_failure" {
+  alarm_name          = "${var.service_name}-logs-missing"
+  alarm_description   = "Logs failing for containers"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  metric_name         = "DeliveryErrors"
+  namespace           = "AWS/Logs"
+  statistic           = "Sum"
+  treat_missing_data  = "ignore"
+  alarm_actions       = [aws_sns_topic.this.arn]
+}
+
 #email integration
 
 resource "aws_sns_topic_subscription" "email_integration" {


### PR DESCRIPTION
## Summary
Fixes #878

### Time to review: __2 mins__

## Changes proposed
* added cloudwatch alarm that watches for log activity

## Context for reviewers
One of the security controls requires alerts in the event the audit process (i.e. logs) fail.

## Additional information
TBA:
- Fine tune some of the alarm settings
- Add documentation

