### PR TITLE
[Issue #1343] Fix codeowners syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # We are limiting this to 4 engineers and choosing not to select "Require review from Code Owners."
 * @acouch @aplybeah @chouinar @SammySteiner
 
-documentation/ @sumiat @widal001 @andycochran @acouch @SammySteiner
-frontend/ @andycochran @acouch @SammySteiner
-infra/ @aplybeah @coilysiren
+/documentation/ @sumiat @widal001 @andycochran @acouch @SammySteiner
+/frontend/ @andycochran @acouch @SammySteiner
+/infra/ @aplybeah @coilysiren

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # We are limiting this to 4 engineers and choosing not to select "Require review from Code Owners."
 * @acouch @aplybeah @chouinar @SammySteiner
 
-documentation/* @sumiat @widal001 @andycochran @acouch @SammySteiner
-frontend/* @andycochran @acouch @SammySteiner
-infra/* @aplybeah @coilysiren
+documentation/ @sumiat @widal001 @andycochran @acouch @SammySteiner
+frontend/ @andycochran @acouch @SammySteiner
+infra/ @aplybeah @coilysiren


### PR DESCRIPTION
## Summary

Helps with #1343

### Time to review: __1 mins__

## Changes proposed

Fixes the folder matching pattern

## Context for reviewers

According to the docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com

...

# In this example, @doctocat owns any file in the `/docs`
# directory in the root of your repository and any of its
# subdirectories.
/docs/ @doctocat
```

The second pattern is actually what we want
