### PR TITLE
[Issue #1277] add enable_v01_endpoints env var

### DIFF
--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -5,5 +5,6 @@ module "dev_config" {
   environment                     = "dev"
   has_database                    = local.has_database
   database_enable_http_endpoint   = true
+  enable_v01_endpoints            = true
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -30,3 +30,7 @@ output "api_auth_token" {
     api_auth_token_param_name = "/api/${var.environment}/api-auth-token"
   }
 }
+
+output "enable_v01_endpoints" {
+  value = var.enable_v01_endpoints
+}

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -31,3 +31,9 @@ variable "database_enable_http_endpoint" {
 variable "has_incident_management_service" {
   type = bool
 }
+
+variable "enable_v01_endpoints" {
+  description = "determines whether the v0.1 endpoints are available in the API"
+  type        = bool
+  default     = false
+}

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -6,5 +6,6 @@ module "prod_config" {
   has_database                    = local.has_database
   database_instance_count         = 2
   database_enable_http_endpoint   = true
+  enable_v01_endpoints            = false
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -5,5 +5,6 @@ module "staging_config" {
   environment                     = "staging"
   has_database                    = local.has_database
   database_enable_http_endpoint   = true
+  enable_v01_endpoints            = true
   has_incident_management_service = local.has_incident_management_service
 }

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -121,7 +121,8 @@ module "service" {
   cpu                   = 1024
   memory                = 2048
 
-  api_auth_token = data.aws_ssm_parameter.api_auth_token.value
+  api_auth_token       = data.aws_ssm_parameter.api_auth_token.value
+  enable_v01_endpoints = module.app_config.environment_configs[var.environment_name].enable_v01_endpoints
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -15,12 +15,13 @@ locals {
   sendy_api_key           = var.sendy_api_key != null ? [{ name = "SENDY_API_KEY", value = var.sendy_api_key }] : []
   sendy_api_url           = var.sendy_api_url != null ? [{ name = "SENDY_API_URL", value = var.sendy_api_url }] : []
   sendy_list_id           = var.sendy_list_id != null ? [{ name = "SENDY_LIST_ID", value = var.sendy_list_id }] : []
+  enable_v01_endpoints    = var.enable_v01_endpoints == true ? [{ name = "ENABLE_V_0_1_ENDPOINTS", value = "true" }] : []
 
   base_environment_variables = concat([
     { name : "PORT", value : tostring(var.container_port) },
     { name : "AWS_REGION", value : data.aws_region.current.name },
     { name : "API_AUTH_TOKEN", value : var.api_auth_token },
-  ], local.hostname, local.sendy_api_key, local.sendy_api_url, local.sendy_list_id)
+  ], local.hostname, local.sendy_api_key, local.sendy_api_url, local.sendy_list_id, local.enable_v01_endpoints)
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },
     { name : "DB_PORT", value : var.db_vars.connection_info.port },

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -139,6 +139,12 @@ variable "api_auth_token" {
   description = "Auth token for connecting to the API"
 }
 
+variable "enable_v01_endpoints" {
+  description = "determines whether the v0.1 endpoints are available in the API"
+  type        = bool
+  default     = false
+}
+
 variable "is_temporary" {
   description = "Whether the service is meant to be spun up temporarily (e.g. for automated infra tests). This is used to disable deletion protection for the load balancer."
   type        = bool


### PR DESCRIPTION
## Summary
Fixes #1277

### Time to review: __1 mins__

### Additional Context

It feels like we require too much boilerplate to setup env vars, but I don't feel compelled to solve that today.
