### PR TITLE
[Issue #647] artillery load testing for the backend

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,7 +119,7 @@ To run the load test:
 3. `$ make load-test-<env>` where env is either `local`, `dev`, `staging`, or `production`
 
 - `make load-test-local`
-  - requires running a local container in another console tab
+  - requires running a local container in another console
 - `make load-test-dev`
 - `make load-test-staging`
-- `make load-test-production`
+- `make load-test-prod`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,7 +119,7 @@ To run the load test:
 3. `$ make load-test-<env>` where env is either `local`, `dev`, `staging`, or `production`
 
 - `make load-test-local`
-  - requires running a local container
+  - requires running a local container in another console tab
 - `make load-test-dev`
 - `make load-test-staging`
 - `make load-test-production`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,3 @@
-<!--- # NOTE: Modify sections marked with `TODO` and then rename the file.-->
-
 # Development and Software Delivery Lifecycle
 
 The following guide is for members of the project team who have access to the repository as well as code contributors. The main difference between internal and external contributions is that externabl contributors will need to fork the project and will not be able to merge their own pull requests. For more information on contribributing, see: [CONTRIBUTING.md](./CONTRIBUTING.md).
@@ -109,3 +107,19 @@ Step by step instructions for creating a release:
 ## Documentation
 
 Any changes to features, tools, or workflows should include updates or additions to documentation.
+
+## Load Testing
+
+[Artillery.io](https://www.artillery.io/docs) is the open source tool used to load test the application. You can find the yml file for the frontend load test at [`/frontend/artillery-load-test.yml`](./frontend/artillery-load-test.yml). You can find the yml file for the backend API load test at [`/api/artillery-load-test.yml`](./api/artillery-load-test.yml).
+
+To run the load test:
+
+1. Install artillery locally if you haven't done so with `npm install -g artillery@latest`
+2. `$ cd api` or or `$ cd frontend`
+3. `$ make load-test-<env>` where env is either `local`, `dev`, `staging`, or `production`
+
+- `make load-test-local`
+  - requires running a local container
+- `make load-test-dev`
+- `make load-test-staging`
+- `make load-test-production`

--- a/api/Makefile
+++ b/api/Makefile
@@ -255,3 +255,18 @@ console: ## Start interactive Python console
 
 help: ## Prints the help documentation and info about each command
 	@grep -E '^[/a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+##################################################
+# Load testing
+##################################################
+load-test-local: # Load test the local environment at localhost:3000
+	artillery run artillery-load-test.yml
+
+load-test-dev: # Load test the dev environment in aws
+	artillery run -e dev artillery-load-test.yml
+
+load-test-staging: # Load test the staging environment in aws
+	artillery run -e staging artillery-load-test.yml
+
+load-test-production: # Load test the production environment in aws. Please test responsibly
+	artillery run -e production artillery-load-test.yml

--- a/api/Makefile
+++ b/api/Makefile
@@ -259,6 +259,7 @@ help: ## Prints the help documentation and info about each command
 ##################################################
 # Load testing
 ##################################################
+
 load-test-local: # Load test the local environment at localhost:3000
 	artillery run artillery-load-test.yml
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -272,5 +272,5 @@ load-test-dev: # Load test the dev environment in aws
 load-test-staging: # Load test the staging environment in aws
 	artillery run -e staging artillery-load-test.yml
 
-load-test-production: # Load test the production environment in aws. Please test responsibly
-	artillery run -e production artillery-load-test.yml
+load-test-prod: # Load test the production environment in aws. Please test responsibly
+	artillery run -e prod artillery-load-test.yml

--- a/api/Makefile
+++ b/api/Makefile
@@ -267,10 +267,13 @@ load-test-local: # Load test the local environment at localhost:3000
 	artillery run artillery-load-test.yml
 
 load-test-dev: # Load test the dev environment in aws
-	artillery run -e dev artillery-load-test.yml
+	$(eval API_AUTH_TOKEN := $(shell aws ssm get-parameter --name /api/dev/api-auth-token --query Parameter.Value --with-decryption --output text | cut -d',' -f1))
+	env API_AUTH_TOKEN=$(API_AUTH_TOKEN) artillery run -e dev artillery-load-test.yml
 
 load-test-staging: # Load test the staging environment in aws
-	artillery run -e staging artillery-load-test.yml
+	$(eval API_AUTH_TOKEN := $(shell aws ssm get-parameter --name /api/staging/api-auth-token --query Parameter.Value --with-decryption --output text | cut -d',' -f1))
+	env API_AUTH_TOKEN=$(API_AUTH_TOKEN) artillery run -e staging artillery-load-test.yml
 
 load-test-prod: # Load test the production environment in aws. Please test responsibly
-	artillery run -e prod artillery-load-test.yml
+	$(eval API_AUTH_TOKEN := $(shell aws ssm get-parameter --name /api/prod/api-auth-token --query Parameter.Value --with-decryption --output text | cut -d',' -f1))
+	env API_AUTH_TOKEN=$(API_AUTH_TOKEN) artillery run -e prod artillery-load-test.yml

--- a/api/artillery-load-test.yml
+++ b/api/artillery-load-test.yml
@@ -18,7 +18,7 @@ config:
       maxVusers: 1000
       name: Spike phase
   environments:
-    production:
+    prod:
       target: http://api-prod-342430507.us-east-1.elb.amazonaws.com
     staging:
       target: http://api-staging-770293556.us-east-1.elb.amazonaws.com

--- a/api/artillery-load-test.yml
+++ b/api/artillery-load-test.yml
@@ -19,11 +19,11 @@ config:
       name: Spike phase
   environments:
     production:
-      target: https://api-prod-342430507.us-east-1.elb.amazonaws.com
+      target: http://api-prod-342430507.us-east-1.elb.amazonaws.com
     staging:
-      target: https://api-staging-770293556.us-east-1.elb.amazonaws.com
+      target: http://api-staging-770293556.us-east-1.elb.amazonaws.com
     dev:
-      target: https://api-dev-1839587515.us-east-1.elb.amazonaws.com
+      target: http://api-dev-1839587515.us-east-1.elb.amazonaws.com
   plugins:
     expect:
       outputFormat: prettyError

--- a/api/artillery-load-test.yml
+++ b/api/artillery-load-test.yml
@@ -33,12 +33,6 @@ config:
   apdex:
     threshold: 100
 scenarios:
-  - name: root
-    flow:
-      - get:
-          url: "/"
-          expect:
-            - statusCode: 200
   - name: health
     flow:
       - get:
@@ -49,5 +43,20 @@ scenarios:
     flow:
       - get:
           url: "/docs"
+          expect:
+            - statusCode: 200
+  - name: search
+    flow:
+      - post:
+          url: "/v0/opportunities/search"
+          headers:
+            X-Auth: "{{ $env.API_AUTH_TOKEN }}"
+          json:
+            paging:
+              page_offset: 1
+              page_size: 25
+            sorting:
+              order_by: opportunity_id
+              sort_direction: ascending
           expect:
             - statusCode: 200

--- a/api/artillery-load-test.yml
+++ b/api/artillery-load-test.yml
@@ -1,5 +1,5 @@
 config:
-  target: http://localhost:3000
+  target: http://localhost:8080
   tls:
     rejectUnauthorized: false
   http:
@@ -19,11 +19,11 @@ config:
       name: Spike phase
   environments:
     production:
-      target: https://simpler.grants.gov
+      target: https://api-prod-342430507.us-east-1.elb.amazonaws.com
     staging:
-      target: https://frontend-staging-1506108424.us-east-1.elb.amazonaws.com
+      target: https://api-staging-770293556.us-east-1.elb.amazonaws.com
     dev:
-      target: https://frontend-dev-1739892538.us-east-1.elb.amazonaws.com
+      target: https://api-dev-1839587515.us-east-1.elb.amazonaws.com
   plugins:
     expect:
       outputFormat: prettyError
@@ -45,9 +45,9 @@ scenarios:
           url: "/health"
           expect:
             - statusCode: 200
-  - name: hello
+  - name: docs
     flow:
       - get:
-          url: "/api/hello"
+          url: "/docs"
           expect:
             - statusCode: 200

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -65,10 +65,13 @@ stop:
 # Load testing
 ##################################################
 load-test-local: # Load test the local environment at localhost:3000
-	artillery run -e local artillery-load-test.yml
+	artillery run artillery-load-test.yml
+
+load-test-dev: # Load test the dev environment in aws
+	artillery run -e dev artillery-load-test.yml
 
 load-test-staging: # Load test the staging environment in aws
-	artillery run artillery-load-test.yml
+	artillery run -e staging artillery-load-test.yml
 
 load-test-production: # Load test the production environment in aws. Please test responsibly
 	artillery run -e production artillery-load-test.yml

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -74,5 +74,5 @@ load-test-dev: # Load test the dev environment in aws
 load-test-staging: # Load test the staging environment in aws
 	artillery run -e staging artillery-load-test.yml
 
-load-test-production: # Load test the production environment in aws. Please test responsibly
-	artillery run -e production artillery-load-test.yml
+load-test-prod: # Load test the production environment in aws. Please test responsibly
+	artillery run -e prod artillery-load-test.yml

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -64,6 +64,7 @@ stop:
 ##################################################
 # Load testing
 ##################################################
+
 load-test-local: # Load test the local environment at localhost:3000
 	artillery run artillery-load-test.yml
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -127,19 +127,6 @@ A subset of tests can be ran by passing a pattern to the script. For example, to
 npm run test-watch -- pages
 ```
 
-## Load Testing
-
-[Artillery.io](https://www.artillery.io/docs) is the open source tool used to load test the application. You can find the yml file for the frontend load test at [`/frontend/artillery-load-test.yml`](./artillery-load-test.yml).
-
-To run the load test:
-
-1. Install artillery locally if you haven't done so with `npm install -g artillery@latest`
-2. From the root directory run `make load-test-<env>` where env is either `local`, `staging`, or `production`
-
-- `make load-test-local`
-- `make load-test-staging`
-- `make load-test-production`
-
 ## 🤖 Type checking, linting, and formatting
 
 - [TypeScript](https://www.typescriptlang.org/) is used for type checking.

--- a/frontend/artillery-load-test.yml
+++ b/frontend/artillery-load-test.yml
@@ -18,7 +18,7 @@ config:
       maxVusers: 1000
       name: Spike phase
   environments:
-    production:
+    prod:
       target: https://simpler.grants.gov
     staging:
       target: http://frontend-staging-1506108424.us-east-1.elb.amazonaws.com

--- a/frontend/artillery-load-test.yml
+++ b/frontend/artillery-load-test.yml
@@ -21,9 +21,9 @@ config:
     production:
       target: https://simpler.grants.gov
     staging:
-      target: https://frontend-staging-1506108424.us-east-1.elb.amazonaws.com
+      target: http://frontend-staging-1506108424.us-east-1.elb.amazonaws.com
     dev:
-      target: https://frontend-dev-1739892538.us-east-1.elb.amazonaws.com
+      target: http://frontend-dev-1739892538.us-east-1.elb.amazonaws.com
   plugins:
     expect:
       outputFormat: prettyError


### PR DESCRIPTION
## Summary
Fixes #647

### Time to review: __5 mins__

## Changes proposed

- Moves the load testing documentation to the root of the repo
- adds load testing scripts to the `api/Makefile`
- copies `artillery-load-test.yml` from `frontend` to `api`, then modifies the load balancer host + routes for the API

## Context for reviewers

I used the same load characteristics that @SammySteiner added in https://github.com/HHS/simpler-grants-gov/pull/739

## Testing

See `DEVELOPMENT.md` documentation. You should be able to run it locally. I suggest running it against staging.