### PR TITLE
[Issue #1295]: add env vars for local and prod

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -4,7 +4,7 @@
 # Learn more: https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
 
 # This is used to determin if this is a prod or a non prod environment for deployed environments. Currently used for noindex and google tag manager logic
-NEXT_PUBLIC_ENVIRONMENT=dev
+NEXT_PUBLIC_ENVIRONMENT=prod
 
 # If you deploy to a subpath, change this to the subpath so relative paths work correctly.
 NEXT_PUBLIC_BASE_PATH=

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -14,4 +14,4 @@ SENDY_API_KEY=
 SENDY_API_URL=
 SENDY_LIST_ID=
 
-NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_API_URL=http://api-prod-342430507.us-east-1.elb.amazonaws.com


### PR DESCRIPTION
## Summary
Fixes #1295 

### Time to review: 2 mins

## Changes proposed
 - add `NEXT_PUBLIC_API_URL` for local and prod
 
## Context for reviewers
 - Need to come back for a part 2 for this ticket for `dev` and `staging`. I propose getting this merged so as not to block the rest of search.
    - we could add to the staging work to this 10k: https://github.com/HHS/simpler-grants-gov/issues/1273 . Although it kind of makes sense to setup dev and staging for both at the same time?


## Additional information
- `npm run build` then `npm start` - this loads a production build locally . I printed `process.env.NEXT_PUBLIC_API_URL` seen here working from console:

![image](https://github.com/HHS/simpler-grants-gov/assets/93001277/3bd44374-9b5f-4281-a65b-e24ffd0f2a90)


- The local development env `npm run dev` loads `http://localhost`
