### PR TITLE
[Issue #1446] Add `make login-db` and add `Base.__rich_repr__` method

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -253,6 +253,9 @@ setup-foreign-tables:
 login: start ## Start shell in running container
 	docker exec -it $(APP_NAME) bash
 
+login-db: ## Start psql with project environment variables
+	PGPASSWORD=$$DB_PASSWORD psql --host=$$DB_HOST --port=$$DB_PORT --username=$$DB_USER $$DB_NAME
+
 console: ## Start interactive Python console
 	$(PY_RUN_CMD) python3 -i -m src.tool.console.interactive
 

--- a/api/src/db/models/base.py
+++ b/api/src/db/models/base.py
@@ -88,6 +88,13 @@ class Base(DeclarativeBase):
 
         return f"<{self.__class__.__name__}({','.join(values)})"
 
+    def __rich_repr__(self):
+        """Rich repr for interactive console.
+
+        See https://rich.readthedocs.io/en/latest/pretty.html#rich-repr-protocol
+        """
+        return self._dict().items()
+
 
 @declarative_mixin
 class IdMixin:

--- a/api/src/db/models/base.py
+++ b/api/src/db/models/base.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Iterable
 from uuid import UUID
 
 from sqlalchemy import TIMESTAMP, MetaData, Text, inspect
@@ -88,7 +88,7 @@ class Base(DeclarativeBase):
 
         return f"<{self.__class__.__name__}({','.join(values)})"
 
-    def __rich_repr__(self):
+    def __rich_repr__(self) -> Iterable[tuple[str, Any]]:
         """Rich repr for interactive console.
 
         See https://rich.readthedocs.io/en/latest/pretty.html#rich-repr-protocol

--- a/api/src/tool/console/interactive.py
+++ b/api/src/tool/console/interactive.py
@@ -27,12 +27,18 @@ Simpler Grants Gov Python console
 
 Useful things:
 
-│ db = database session
+│ dbs = database session {db_session}
 │ f = DB factories module
 │ u = utilities module
 │ r = function to reload REPL
 
+Examples:
+
+│ dbs.query(Opportunity).first()
+| f.OpportunityFactory.create()
+
 Tips:
+
 ★ Tab-completion is available
 ★ History is available (use ↑↓ keys)
 ★ Use Ctrl+D to exit


### PR DESCRIPTION
## Summary
Fixes #1446

### Time to review: __1 mins__

## Changes proposed
- Add `make login-db` command to connect to the local database using the `psql` cli.
- Add a `__rich_repr__` method to `class Base` so that database objects are rendered more readably in `make console` sessions.

## Context for reviewers
These changes are for developer convenience in local development.

Example of using `make login-db`:
![Screenshot 2024-03-06 at 11 59 12](https://github.com/HHS/simpler-grants-gov/assets/3811269/fd2fa282-8652-4bac-a4d4-afade4f01943)

Example of `make console` output of a database object:
![Screenshot 2024-03-06 at 11 58 39](https://github.com/HHS/simpler-grants-gov/assets/3811269/2f317b15-b977-4bf1-8bcb-55025f8564c0)

Current output in comparison:
![Screenshot 2024-03-06 at 12 03 48](https://github.com/HHS/simpler-grants-gov/assets/3811269/7b31a0c2-b785-400d-b432-3121731ebb15)
