### PR TITLE
[Issue #1451] Put search page behind feature flag

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,20 @@
+import BetaAlert from "../components/BetaAlert";
+import { GridContainer } from "@trussworks/react-uswds";
+import Link from "next/link";
+
+// TODO: next-intl upgrade
+
+export default function NotFound() {
+  return (
+    <>
+      <BetaAlert />
+      <GridContainer className="padding-y-1 tablet:padding-y-3 desktop-lg:padding-y-15">
+        <h1 className="nj-h1">{"page_not_found.title"}</h1>
+        <p className="margin-bottom-2">{"page_not_found.message_content_1"}</p>
+        <Link className="usa-button" href="/" key="returnToHome">
+          {"page_not_found.visit_homepage_button"}
+        </Link>
+      </GridContainer>
+    </>
+  );
+}

--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -1,10 +1,13 @@
 import { APISearchFetcher } from "../../services/searchfetcher/APISearchFetcher";
+import { FeatureFlagsManager } from "../../services/FeatureFlagManager";
 import { MockSearchFetcher } from "../../services/searchfetcher/MockSearchFetcher";
 // Disable rule to allow server actions to be called without warning
 /* eslint-disable react/jsx-no-bind, @typescript-eslint/no-misused-promises */
 import React from "react";
 import { SearchForm } from "./SearchForm";
+import { cookies } from "next/headers";
 import { fetchSearchOpportunities } from "../../services/searchfetcher/SearchFetcher";
+import { notFound } from "next/navigation";
 
 const useMockData = false;
 const searchFetcher = useMockData
@@ -17,6 +20,12 @@ const searchFetcher = useMockData
 // }
 
 export default async function Search() {
+  const cookieStore = cookies();
+  const ffManager = new FeatureFlagsManager(cookieStore);
+  if (!ffManager.isFeatureEnabled("showSearchV0")) {
+    return notFound();
+  }
+
   const initialSearchResults = await fetchSearchOpportunities(searchFetcher);
   return (
     <>

--- a/frontend/src/components/BetaAlert.tsx
+++ b/frontend/src/components/BetaAlert.tsx
@@ -1,7 +1,8 @@
-import { ExternalRoutes } from "src/constants/routes";
+"use client";
 
 import { Trans, useTranslation } from "next-i18next";
 
+import { ExternalRoutes } from "src/constants/routes";
 import FullWidthAlert from "./FullWidthAlert";
 
 const BetaAlert = () => {

--- a/frontend/src/services/FeatureFlagManager.ts
+++ b/frontend/src/services/FeatureFlagManager.ts
@@ -54,7 +54,11 @@ export class FeatureFlagsManager {
   private _cookies;
 
   constructor(
-    cookies: NextRequest["cookies"] | CookiesStatic | NextServerSideCookies | ReadonlyRequestCookies,
+    cookies:
+      | NextRequest["cookies"]
+      | CookiesStatic
+      | NextServerSideCookies
+      | ReadonlyRequestCookies,
   ) {
     this._cookies = cookies;
   }

--- a/frontend/src/services/FeatureFlagManager.ts
+++ b/frontend/src/services/FeatureFlagManager.ts
@@ -2,10 +2,11 @@
  * @file Service for checking and managing feature flags
  */
 
-import { CookiesStatic } from "js-cookie";
-import { featureFlags } from "src/constants/featureFlags";
-
 import { NextRequest, NextResponse } from "next/server";
+
+import { CookiesStatic } from "js-cookie";
+import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
+import { featureFlags } from "src/constants/featureFlags";
 
 export type FeatureFlags = { [name: string]: boolean };
 // Parity with unexported getServerSideProps context cookie type
@@ -53,7 +54,7 @@ export class FeatureFlagsManager {
   private _cookies;
 
   constructor(
-    cookies: NextRequest["cookies"] | CookiesStatic | NextServerSideCookies,
+    cookies: NextRequest["cookies"] | CookiesStatic | NextServerSideCookies | ReadonlyRequestCookies,
   ) {
     this._cookies = cookies;
   }

--- a/frontend/tests/services/FeatureFlagManager.test.ts
+++ b/frontend/tests/services/FeatureFlagManager.test.ts
@@ -2,16 +2,15 @@
  * @jest-environment ./tests/utils/jsdomNodeEnvironment.ts
  */
 
-import Cookies from "js-cookie";
-
 import { NextRequest, NextResponse } from "next/server";
-
-import { FeatureFlagsManager } from "../../src/services/FeatureFlagManager";
-import { mockProcessEnv } from "../utils/commonTestUtils";
 import {
   mockDefaultFeatureFlags,
   mockFeatureFlagsCookie,
 } from "../utils/FeatureFlagTestUtils";
+
+import Cookies from "js-cookie";
+import { FeatureFlagsManager } from "../../src/services/FeatureFlagManager";
+import { mockProcessEnv } from "../utils/commonTestUtils";
 
 describe("FeatureFlagsManager", () => {
   const COOKIE_VALUE = { feature1: true };
@@ -412,5 +411,32 @@ describe("FeatureFlagsManager", () => {
       expectedNewFeatureFlags,
     );
     expect(featureFlagsManager.featureFlags).toEqual(expectedNewFeatureFlags);
+  });
+
+  describe("Calls feature flag from server component", () => {
+    const readonlyCookiesExample = {
+      _ff: '{"feature1": true, "feature2": false}',
+    };
+
+    test("correctly initializes from ReadonlyRequestCookies", () => {
+      const readonlyCookies = readonlyCookiesExample;
+      const featureFlagsManager = new FeatureFlagsManager(readonlyCookies);
+
+      expect(featureFlagsManager.isFeatureEnabled("feature1")).toBe(true);
+      expect(featureFlagsManager.isFeatureEnabled("feature2")).toBe(false);
+    });
+
+    test("throws error for invalid feature flag in ReadonlyRequestCookies", () => {
+      const invalidFlagCookies = {
+        _ff: '{"invalidFeature": true}',
+      };
+
+      const featureFlagsManager = new FeatureFlagsManager(invalidFlagCookies);
+
+      // Accessing an invalid feature flag throws an error
+      expect(() =>
+        featureFlagsManager.isFeatureEnabled("invalidFeature"),
+      ).toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #1451 

### Time to review: 5-10min

## Changes proposed
- Update `FeatureFlagManager` to handle server component request cookies
- Create new server component copy of `NotFound` page (called when FF off)
- Put search page behind `showSearchV0` feature flag
 
 

https://github.com/HHS/simpler-grants-gov/assets/93001277/644f5631-5fb4-431d-9b01-177c38d2b895


## More context

Since we moved the search page to a server component - we need to allow for the FeatureFlagManager to be called with server request cookies. For any client components, we still have the custom hook `useFeatureFlags` which wraps the `FeatureFlagManager`. 



