### PR TITLE
[Issue 906] Adds prod API domain

### DIFF
--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -34,3 +34,7 @@ output "api_auth_token" {
 output "enable_v01_endpoints" {
   value = var.enable_v01_endpoints
 }
+
+output "domain" {
+  value = var.domain
+}

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -37,3 +37,9 @@ variable "enable_v01_endpoints" {
   type        = bool
   default     = false
 }
+
+variable "domain" {
+  type        = string
+  description = "DNS domain of the website managed by HHS"
+  default     = null
+}

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -4,6 +4,7 @@ module "prod_config" {
   default_region                  = module.project_config.default_region
   environment                     = "prod"
   has_database                    = local.has_database
+  domain                          = "api.simpler.grants.gov"
   database_instance_count         = 2
   database_enable_http_endpoint   = true
   enable_v01_endpoints            = false

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -51,6 +51,7 @@ locals {
   database_config                                = local.environment_config.database_config
   incident_management_service_integration_config = local.environment_config.incident_management_service_integration
   api_auth_token_config                          = local.environment_config.api_auth_token
+  domain                                         = local.environment_config.domain
 }
 
 terraform {
@@ -88,6 +89,11 @@ data "aws_rds_cluster" "db_cluster" {
   cluster_identifier = local.database_config.cluster_name
 }
 
+data "aws_acm_certificate" "cert" {
+  count  = local.domain != null ? 1 : 0
+  domain = local.domain
+}
+
 data "aws_iam_policy" "app_db_access_policy" {
   count = module.app_config.has_database ? 1 : 0
   name  = local.database_config.app_access_policy_name
@@ -123,6 +129,7 @@ module "service" {
 
   api_auth_token       = data.aws_ssm_parameter.api_auth_token.value
   enable_v01_endpoints = module.app_config.environment_configs[var.environment_name].enable_v01_endpoints
+  cert_arn             = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids


### PR DESCRIPTION
## Summary

Fixes https://github.com/HHS/simpler-grants-gov/issues/906

### Time to review: __1 mins__

## Changes proposed

Adds configuration for deploying the `api.simpler.grants.gov` cert to the prod load balancer

## Terraform Plan output

```
data.terraform_remote_state.current_image_tag[0]: Reading...
module.service.data.aws_region.current: Reading...
module.service.data.aws_iam_policy_document.ecs_tasks_assume_role_policy: Reading...
data.aws_ssm_parameter.api_auth_token: Reading...
module.service.data.aws_region.current: Read complete after 0s [id=us-east-1]
module.service.data.aws_iam_policy_document.ecs_tasks_assume_role_policy: Read complete after 0s [id=597844978]
module.service.data.aws_caller_identity.current: Reading...
aws_scheduler_schedule_group.copy_oracle_data: Refreshing state... [id=api-prod-copy-oracle-data]
module.service.aws_cloudwatch_log_group.WafWebAclLoggroup: Refreshing state... [id=aws-waf-logs-wafv2-web-acl-api-prod]
data.aws_vpc.network: Reading...
data.aws_acm_certificate.cert[0]: Reading...
module.monitoring.aws_sns_topic.this: Refreshing state... [id=arn:aws:sns:us-east-1:315341936575:api-prod-monitoring]
module.service.aws_s3_bucket.access_logs: Refreshing state... [id=api-prod-access-logs20230912190435661100000003]
module.service.data.aws_caller_identity.current: Read complete after 0s [id=315341936575]
module.service.data.aws_ecr_repository.app: Reading...
module.service.aws_wafv2_web_acl.waf: Refreshing state... [id=f26b4df1-5d6f-4fd1-af75-03ae4ba25739]
data.aws_ssm_parameter.api_auth_token: Read complete after 1s [id=/api/prod/api-auth-token]
module.service.aws_ecs_cluster.cluster: Refreshing state... [id=arn:aws:ecs:us-east-1:315341936575:cluster/api-prod]
data.aws_iam_policy.migrator_db_access_policy[0]: Reading...
module.service.aws_cloudwatch_log_group.service_logs: Refreshing state... [id=service/api-prod]
data.aws_iam_policy.app_db_access_policy[0]: Reading...
data.aws_rds_cluster.db_cluster[0]: Reading...
data.aws_acm_certificate.cert[0]: Read complete after 1s [id=arn:aws:acm:us-east-1:315341936575:certificate/5d33cef8-b854-4753-9fec-84d138db3ad5]
module.service.aws_iam_role.task_executor: Refreshing state... [id=api-prod-task-executor]
data.terraform_remote_state.current_image_tag[0]: Read complete after 2s
module.service.aws_iam_role.app_service: Refreshing state... [id=api-prod-app]
module.monitoring.aws_sns_topic_subscription.email_integration["grantsalerts@navapbc.com"]: Refreshing state... [id=arn:aws:sns:us-east-1:315341936575:api-prod-monitoring:5e4fa37f-3a25-4dc5-8a3c-cea435b5971d]
data.aws_vpc.network: Read complete after 1s [id=vpc-03451ea43dc6c33da]
data.aws_subnets.public: Reading...
data.aws_subnets.private: Reading...
data.aws_subnets.public: Read complete after 1s [id=us-east-1]
module.service.aws_lb_target_group.app_tg: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:315341936575:targetgroup/app-20240205181316053000000001/8a3d3fd160553fa8]
module.service.data.aws_ecr_repository.app: Read complete after 2s [id=simpler-grants-gov-api]
module.service.aws_security_group.alb: Refreshing state... [id=sg-0c155296f44befdf9]
data.aws_rds_cluster.db_cluster[0]: Read complete after 1s [id=api-prod]
data.aws_subnets.private: Read complete after 1s [id=us-east-1]
module.service.data.aws_iam_policy_document.task_executor: Reading...
module.service.data.aws_iam_policy_document.task_executor: Read complete after 0s [id=466713680]
module.service.aws_iam_role_policy.task_executor: Refreshing state... [id=api-prod-task-executor:api-prod-task-executor-role-policy]
module.service.aws_security_group_rule.http_ingress: Refreshing state... [id=sgrule-2436615966]
module.service.aws_security_group.app: Refreshing state... [id=sg-03a511e37fa63ff84]
module.service.aws_s3_bucket_public_access_block.access_logs: Refreshing state... [id=api-prod-access-logs20230912190435661100000003]
module.service.aws_s3_bucket_server_side_encryption_configuration.encryption: Refreshing state... [id=api-prod-access-logs20230912190435661100000003]
module.service.data.aws_iam_policy_document.access_logs_put_access: Reading...
module.service.aws_s3_bucket_lifecycle_configuration.access_logs: Refreshing state... [id=api-prod-access-logs20230912190435661100000003]
module.service.data.aws_iam_policy_document.access_logs_put_access: Read complete after 0s [id=2704871303]
module.service.aws_s3_bucket_policy.access_logs: Refreshing state... [id=api-prod-access-logs20230912190435661100000003]
module.service.aws_lb.alb: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:315341936575:loadbalancer/app/api-prod/907c98bbc1e14f4e]
module.service.aws_lb_listener.alb_listener_http: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:315341936575:listener/app/api-prod/907c98bbc1e14f4e/825c38b6d7806229]
module.monitoring.aws_cloudwatch_metric_alarm.high_app_http_5xx_count: Refreshing state... [id=api-prod-high-app-5xx-count]
module.monitoring.aws_cloudwatch_metric_alarm.high_app_response_time: Refreshing state... [id=api-prod-high-app-response-time]
module.monitoring.aws_cloudwatch_metric_alarm.high_load_balancer_http_5xx_count: Refreshing state... [id=api-prod-high-load-balancer-5xx-count]
data.aws_iam_policy.migrator_db_access_policy[0]: Read complete after 2s [id=arn:aws:iam::315341936575:policy/api-prod-migrator-access]
data.aws_iam_policy.app_db_access_policy[0]: Read complete after 2s [id=arn:aws:iam::315341936575:policy/api-prod-app-access]
module.service.aws_iam_role_policy_attachment.app_service_db_access[0]: Refreshing state... [id=api-prod-app-20230912190436604900000005]
module.service.aws_iam_role.migrator_task[0]: Refreshing state... [id=api-prod-migrator]
module.service.aws_vpc_security_group_ingress_rule.db_ingress_from_service[0]: Refreshing state... [id=sgr-0610182b8818c1eb9]
module.service.aws_ecs_task_definition.app: Refreshing state... [id=api-prod]
aws_sfn_state_machine.copy_oracle_data: Refreshing state... [id=arn:aws:states:us-east-1:315341936575:stateMachine:api-prod-copy-oracle-data]
module.service.aws_ecs_service.app: Refreshing state... [id=arn:aws:ecs:us-east-1:315341936575:service/api-prod/api-prod]
module.service.aws_wafv2_web_acl_association.WafWebAclAssociation: Refreshing state... [id=arn:aws:wafv2:us-east-1:315341936575:regional/webacl/api-prod-wafv2-web-acl/f26b4df1-5d6f-4fd1-af75-03ae4ba25739,arn:aws:elasticloadbalancing:us-east-1:315341936575:loadbalancer/app/api-prod/907c98bbc1e14f4e]
module.service.aws_wafv2_web_acl_logging_configuration.WafWebAclLogging: Refreshing state... [id=arn:aws:wafv2:us-east-1:315341936575:regional/webacl/api-prod-wafv2-web-acl/f26b4df1-5d6f-4fd1-af75-03ae4ba25739]
module.service.aws_lb_listener_rule.app_http_forward: Refreshing state... [id=arn:aws:elasticloadbalancing:us-east-1:315341936575:listener-rule/app/api-prod/907c98bbc1e14f4e/825c38b6d7806229/0ab0c9d005849164]
module.service.aws_iam_role_policy_attachment.migrator_db_access[0]: Refreshing state... [id=api-prod-migrator-20230912190436629800000006]
aws_scheduler_schedule.copy_oracle_data: Refreshing state... [id=api-prod-copy-oracle-data/api-prod-copy-oracle-data]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.service.aws_lb_listener.alb_listener_https[0] will be created
  + resource "aws_lb_listener" "alb_listener_https" {
      + arn               = (known after apply)
      + certificate_arn   = "arn:aws:acm:us-east-1:315341936575:certificate/5d33cef8-b854-4753-9fec-84d138db3ad5"
      + id                = (known after apply)
      + load_balancer_arn = "arn:aws:elasticloadbalancing:us-east-1:315341936575:loadbalancer/app/api-prod/907c98bbc1e14f4e"
      + port              = 443
      + protocol          = "HTTPS"
      + ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
      + tags_all          = {
          + "description"         = "Application resources created in prod environment"
          + "environment"         = "prod"
          + "owner"               = "navapbc"
          + "project"             = "simpler-grants-gov"
          + "repository"          = "https://github.com/HHS/simpler-grants-gov"
          + "terraform"           = "true"
          + "terraform_workspace" = "default"
        }

      + default_action {
          + order = (known after apply)
          + type  = "fixed-response"

          + fixed_response {
              + content_type = "text/plain"
              + message_body = "Not Found"
              + status_code  = "404"
            }
        }
    }

  # module.service.aws_lb_listener_rule.app_https_forward[0] will be created
  + resource "aws_lb_listener_rule" "app_https_forward" {
      + arn          = (known after apply)
      + id           = (known after apply)
      + listener_arn = (known after apply)
      + priority     = 100
      + tags_all     = {
          + "description"         = "Application resources created in prod environment"
          + "environment"         = "prod"
          + "owner"               = "navapbc"
          + "project"             = "simpler-grants-gov"
          + "repository"          = "https://github.com/HHS/simpler-grants-gov"
          + "terraform"           = "true"
          + "terraform_workspace" = "default"
        }

      + action {
          + order            = (known after apply)
          + target_group_arn = "arn:aws:elasticloadbalancing:us-east-1:315341936575:targetgroup/app-20240205181316053000000001/8a3d3fd160553fa8"
          + type             = "forward"
        }

      + condition {
          + path_pattern {
              + values = [
                  + "/*",
                ]
            }
        }
    }

  # module.service.aws_lb_listener_rule.redirect_http_to_https[0] will be created
  + resource "aws_lb_listener_rule" "redirect_http_to_https" {
      + arn          = (known after apply)
      + id           = (known after apply)
      + listener_arn = "arn:aws:elasticloadbalancing:us-east-1:315341936575:listener/app/api-prod/907c98bbc1e14f4e/825c38b6d7806229"
      + priority     = 100
      + tags_all     = {
          + "description"         = "Application resources created in prod environment"
          + "environment"         = "prod"
          + "owner"               = "navapbc"
          + "project"             = "simpler-grants-gov"
          + "repository"          = "https://github.com/HHS/simpler-grants-gov"
          + "terraform"           = "true"
          + "terraform_workspace" = "default"
        }

      + action {
          + order = (known after apply)
          + type  = "redirect"

          + redirect {
              + host        = "#{host}"
              + path        = "/#{path}"
              + port        = "443"
              + protocol    = "HTTPS"
              + query       = "#{query}"
              + status_code = "HTTP_301"
            }
        }

      + condition {
          + path_pattern {
              + values = [
                  + "/*",
                ]
            }
        }
    }

  # module.service.aws_security_group_rule.https_ingress[0] will be created
  + resource "aws_security_group_rule" "https_ingress" {
      + cidr_blocks              = [
          + "0.0.0.0/0",
        ]
      + description              = "Allow HTTPS traffic from public internet"
      + from_port                = 443
      + id                       = (known after apply)
      + protocol                 = "tcp"
      + security_group_id        = "sg-0c155296f44befdf9"
      + security_group_rule_id   = (known after apply)
      + self                     = false
      + source_security_group_id = (known after apply)
      + to_port                  = 443
      + type                     = "ingress"
    }

Plan: 4 to add, 0 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```