### PR TITLE
add funding opp component, stub markup

### DIFF
--- a/frontend/src/app/search/SearchForm.tsx
+++ b/frontend/src/app/search/SearchForm.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import SearchBar from "../../components/search/SearchBar";
+import SearchFundingOpportunity from "../../components/search/SearchFundingOpportunity";
 import SearchOpportunityStatus from "../../components/search/SearchOpportunityStatus";
 import SearchPagination from "../../components/search/SearchPagination";
 import { SearchResponseData } from "../api/SearchOpportunityAPI";
@@ -29,7 +30,7 @@ export function SearchForm({ initialSearchResults }: SearchFormProps) {
         <div className="grid-row grid-gap">
           <div className="tablet:grid-col-4">
             <SearchOpportunityStatus />
-            <fieldset className="usa-fieldset">Filters</fieldset>
+            <SearchFundingOpportunity />
           </div>
           <div className="tablet:grid-col-8">
             <div className="usa-prose">

--- a/frontend/src/components/search/SearchFundingOpportunity.tsx
+++ b/frontend/src/components/search/SearchFundingOpportunity.tsx
@@ -1,0 +1,81 @@
+import { Accordion, Checkbox } from "@trussworks/react-uswds";
+import React from "react";
+
+interface AccordionItemProps {
+  title: React.ReactNode | string;
+  content: React.ReactNode;
+  expanded: boolean;
+  id: string;
+  headingLevel: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  className?: string;
+  // handleToggle?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+interface FilterOption {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export default function SearchFundingOpportunity() {
+  const filterOptions: FilterOption[] = [
+    {
+      id: "funding-opportunity-cooperative_agreement",
+      label: "Cooperative Agreement",
+      value: "cooperative_agreement",
+    },
+    { id: "funding-opportunity-grant", label: "Grant", value: "grant" },
+    {
+      id: "funding-opportunity-procurement_contract",
+      label: "Procurement Contract ",
+      value: "procurement_contract",
+    },
+    { id: "funding-opportunity-other", label: "Other", value: "other" },
+  ];
+
+  const accordionOptions: AccordionItemProps[] = [
+    {
+      title: "Funding instrument type",
+      content: (
+        <>
+          <div className="grid-row">
+            <div className="grid-col-fill">
+              <button className="usa-button usa-button--unstyled font-sans-xs">
+                Select All
+              </button>
+            </div>
+            <div className="grid-col-fill text-right">
+              <button className="usa-button usa-button--unstyled font-sans-xs">
+                Clear All
+              </button>
+            </div>
+          </div>
+
+          {filterOptions.map((option) => (
+            <div key={option.id} className="">
+              <Checkbox
+                id={option.id}
+                name={option.id}
+                label={option.label}
+                // onChange={(e) => handleCheck(option.value, e.target.checked)}
+                // disabled={!mounted} // Required to be disabled until hydrated so query params are updated properly
+              />
+            </div>
+          ))}
+        </>
+      ),
+      expanded: false,
+      id: "funding-instrument-filter",
+      headingLevel: "h4",
+    },
+  ];
+
+  return (
+    <Accordion
+      bordered={true}
+      items={accordionOptions}
+      multiselectable={true}
+      className="margin-top-4"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
Fixes #1469

### Time to review: __5 mins__

## Changes proposed
- Add `SearchFundingOpportunity` component

## Context for reviewers
This just stubs in the markup. Still needs to be hooked up so it functions 

## Additional information

![image](https://github.com/HHS/simpler-grants-gov/assets/409279/bca10843-1014-4cb9-a1c1-c20b95ddd58d)
