### PR TITLE
[Issue #1391] Set the gunicorn workers based on CPU count

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -21,9 +21,6 @@ bind = app_config.host + ':' + str(app_config.port)
 # We use 'os.sched_getaffinity(pid)' not 'os.cpu_count()' because it returns only allowable CPUs.
 # os.sched_getaffinity(pid): Return the set of CPUs the process with PID pid is restricted to.
 # os.cpu_count(): Return the number of CPUs in the system.
-# workers = len(os.sched_getaffinity(0)) * 2
 
-# Until we figure out better math, ignore the above. Hardcoding # workers because Python gets EC2 CPU not Fargate
-# 1 vCPU is equivalent to 1 core of a hyperthreaded processor, which will give you 1 physical core & 2 threads
-workers = 2
+workers = (len(os.sched_getaffinity(0)) * 2) + 1
 threads = 4


### PR DESCRIPTION
## Summary
Fixes #1391

### Time to review: __3 mins__

## Changes proposed
Set the number of gunicorn workers to 2*cpu count + 1

## Context for reviewers
We temporarily set the number of workers to exactly 2 while getting the API running initially. This shouldn't be needed anymore, and would mean we are potentially underutilitizing our API instances. This number follows the recommended values:
See: https://docs.gunicorn.org/en/stable/design.html#how-many-workers
also: https://docs.gunicorn.org/en/latest/configure.html#configuration-file

Currently, we run 2 workers always. With our current API configuration, this should change to 5. We actually log the `sched_getaffinity` value when the process starts up. Pulling from the prod logs, this gives (trimming extra info for brevity):
```json
{
    "name": "src.logging.config",
    "levelname": "INFO",
    "levelno": 20,
    "pathname": "/api/src/logging/config.py",
    "funcName": "log_program_info",
    "cpu_count": 2,
    "cpu_usable": 2,
    "message": "start src: CPython 3.12.2 Linux, hostname ip-10-3-0-56.ec2.internal, pid 7, user 1001(runner)"
}
```
The `cpu_usable` metric is just the `len(sched_getaffinity(0))` value: https://github.com/HHS/simpler-grants-gov/blob/main/api/src/logging/config.py#L140


## Additional information
To test this, you need to adjust the docker-compose file to run the following command: `["poetry", "run", "gunicorn", "src.app:create_app()"]` That'll create several workers, which run uneventfully locally, but produce a lot of logs.
