### PR TITLE
[Issue #1482] Update to the correct simpler grants contact email

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -95,7 +95,7 @@ def configure_app(app: APIFlask) -> None:
         "contact": {
             "name": "Simpler Grants.gov",
             "url": "https://simpler.grants.gov/",
-            "email": "simplergrantsgov@hhs.gov",
+            "email": "simpler@grants.gov",
         },
     }
 


### PR DESCRIPTION
## Summary
Fixes #1482

### Time to review: __1 mins__

## Changes proposed
Updated the email contact on our openapi spec

## Context for reviewers
This is the one we want to be using

## Additional information
Running locally, hovering over the email you can see the value in the very bottom-left of this screenshot:
![Screenshot 2024-03-14 at 12 30 07 PM](https://github.com/HHS/simpler-grants-gov/assets/46358556/1fe3c08d-fe02-4a6e-bfd8-2e959f41c23a)


