### PR TITLE
[Issue #1510]: Split FE / BE docker-compose

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+services:
+
+  grants-db:
+    image: postgres:14-alpine
+    container_name: grants-db
+    command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
+    env_file: ./local.env
+    ports:
+      - "5432:5432"
+    volumes:
+      - grantsdbdata:/var/lib/postgresql/data
+
+  grants-api:
+    build:
+      context: .
+      target: dev
+      args:
+        - RUN_UID=${RUN_UID:-4000}
+        - RUN_USER=${RUN_USER:-api}
+    command: ["poetry", "run", "flask", "--app", "src.app", "run", "--host", "0.0.0.0", "--port", "8080", "--reload"]
+    container_name: grants-api
+    env_file: ./local.env
+    ports:
+      - 8080:8080
+    volumes:
+      - .:/api
+    depends_on:
+      - grants-db
+
+volumes:
+  grantsdbdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,65 +1,8 @@
 version: '3'
 
-services:
+include:
+  - path: ./api/docker-compose.yml
+  - path: ./frontend/docker-compose.yml
 
-  grants-db:
-    image: postgres:14-alpine
-    container_name: grants-db
-    command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
-    env_file: ./api/local.env
-    ports:
-      - "5432:5432"
-    volumes:
-      - grantsdbdata:/var/lib/postgresql/data
-
-  grants-api:
-    build:
-      context: ./api
-      target: dev
-      args:
-        - RUN_UID=${RUN_UID:-4000}
-        - RUN_USER=${RUN_USER:-api}
-    command: ["poetry", "run", "flask", "--app", "src.app", "run", "--host", "0.0.0.0", "--port", "8080", "--reload"]
-    container_name: grants-api
-    env_file: ./api/local.env
-    ports:
-      - 8080:8080
-    volumes:
-      - ./api:/api
-    depends_on:
-      - grants-db
-
-  nextjs:
-    container_name: next-dev
-    build:
-      context: ./frontend
-      target: dev
-    env_file:
-      # Add your non-secret environment variables to this file:
-      - ./frontend/.env.development
-      # If you have secrets, add them to this file and uncomment this line:
-      # - ./frontend/.env.local
-    volumes:
-      - ./frontend/src:/frontend/src
-      - ./frontend/public:/frontend/public
-    restart: always
-    ports:
-      - 3000:3000
-
-  storybook:
-    container_name: storybook
-    build:
-      context: ./frontend
-      target: dev
-    command: npm run storybook
-    volumes:
-      - ./frontend/src:/frontend/src
-      - ./frontend/public:/frontend/public
-      - ./frontend/.storybook:/frontend/.storybook
-      - ./frontend/stories:/frontend/stories
-    restart: always
-    ports:
-      - 6006:6006
-
-volumes:
-  grantsdbdata:
+# services:
+  # Define other services or override configurations

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+
+  nextjs:
+    container_name: next-dev
+    build:
+      context: .
+      target: dev
+    env_file:
+      - ./.env.development
+    volumes:
+      - ./src:/frontend/src
+      - ./public:/frontend/public
+    restart: always
+    ports:
+      - 3000:3000
+
+  storybook:
+    container_name: storybook
+    build:
+      context: .
+      target: dev
+    command: npm run storybook
+    volumes:
+      - ./src:/frontend/src
+      - ./public:/frontend/public
+      - ./.storybook:/frontend/.storybook
+      - ./stories:/frontend/stories
+    restart: always
+    ports:
+      - 6006:6006

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3'
+version: "3"
 
 services:
-
   nextjs:
     container_name: next-dev
     build:


### PR DESCRIPTION
## Summary
Fixes #1510

### Time to review: 5 min

## Changes proposed
- Move `nextjs` and `storybook` service to `./frontend/docker-compose.yml`
- Move `grants-api` and `grants-db` service to `./api/docker-compose.yml`
- Top level `./docker-compose.yml`



## Demo:

- Command from FE folder => `make build-dev dev storybook`
- Command from BE folder => `make build start run-logs`

<img width="1323" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/93001277/81141be8-8426-4a56-84b7-e177bd8c9501">


