### PR TITLE
[Issue #1455] Implement logic for query box in the search API

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -167,7 +167,7 @@ db-migrate-heads: ## Show migrations marked as a head
 	$(alembic_cmd) heads $(args)
 
 db-seed-local:
-	$(PY_RUN_CMD) db-seed-local
+	$(PY_RUN_CMD) db-seed-local $(args)
 
 db-check-migrations: ## Verify the DB schema matches the DB migrations generated
 	$(alembic_cmd) check || (echo -e "\n$(RED)Migrations are not up-to-date, make sure you generate migrations by running 'make db-migrate-create <msg>'$(NO_COLOR)"; exit 1)

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -932,6 +932,8 @@ components:
       properties:
         query:
           type: string
+          minLength: 1
+          maxLength: 100
           description: Query string which searches against several text fields
           example: research
         filters:

--- a/api/src/api/opportunities_v0_1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v0_1/opportunity_schemas.py
@@ -1,4 +1,4 @@
-from src.api.schemas.extension import Schema, fields
+from src.api.schemas.extension import Schema, fields, validators
 from src.api.schemas.search_schema import StrSearchSchemaBuilder
 from src.constants.lookup_constants import (
     ApplicantType,
@@ -276,7 +276,8 @@ class OpportunitySearchRequestSchema(Schema):
         metadata={
             "description": "Query string which searches against several text fields",
             "example": "research",
-        }
+        },
+        validate=[validators.Length(min=1, max=100)],
     )
 
     filters = fields.Nested(OpportunitySearchFilterSchema())

--- a/api/src/services/opportunities_v0_1/search_opportunities.py
+++ b/api/src/services/opportunities_v0_1/search_opportunities.py
@@ -12,6 +12,7 @@ from src.db.models.opportunity_models import (
     LinkOpportunitySummaryFundingCategory,
     LinkOpportunitySummaryFundingInstrument,
     Opportunity,
+    OpportunityAssistanceListing,
     OpportunitySummary,
 )
 from src.pagination.pagination_models import PaginationInfo, PaginationParams
@@ -51,7 +52,44 @@ def _add_query_filters(stmt: Select[tuple[Any]], query: str | None) -> Select[tu
     if query is None or len(query) == 0:
         return stmt
 
-    # TODO - will implement this in https://github.com/HHS/simpler-grants-gov/issues/1455
+    ilike_query = f"%{query}%"
+
+    # Add a left join to the assistance listing table to filter by any of its values
+    stmt = stmt.outerjoin(
+        OpportunityAssistanceListing,
+        Opportunity.opportunity_id == OpportunityAssistanceListing.opportunity_id,
+    )
+
+    """
+    This adds the following to the inner query (assuming the query value is "example")
+
+    WHERE
+        (opportunity.opportunity_title ILIKE '%example%'
+        OR opportunity.opportunity_number ILIKE '%example%'
+        OR opportunity.agency ILIKE '%example%'
+        OR opportunity_summary.summary_description ILIKE '%example%'
+        OR opportunity_assistance_listing.assistance_listing_number = 'example'
+        OR opportunity_assistance_listing.program_title ILIKE '%example%'))
+
+    Note that SQLAlchemy escapes everything and queries are actually written like:
+
+        opportunity.opportunity_number ILIKE % (opportunity_number_1)
+    """
+    stmt = stmt.where(
+        or_(
+            # Title partial match
+            Opportunity.opportunity_title.ilike(ilike_query),
+            # Number partial match
+            Opportunity.opportunity_number.ilike(ilike_query),
+            # Agency (code) partial match
+            Opportunity.agency.ilike(ilike_query),
+            # Summary description partial match
+            OpportunitySummary.summary_description.ilike(ilike_query),
+            # assistance listing number matches exactly or program title partial match
+            OpportunityAssistanceListing.assistance_listing_number == query,
+            OpportunityAssistanceListing.program_title.ilike(ilike_query),
+        )
+    )
 
     return stmt
 

--- a/documentation/api/database/database-local-usage.md
+++ b/documentation/api/database/database-local-usage.md
@@ -27,5 +27,7 @@ For example:
 
 You can populate our opportunity data by running: `make db-seed-local` when you have the DB running.
 
-This script currently creates 25 new opportunities each time you run it. In the future, as we expand the amount of data we support, we'll
-add more options and data to the DB, but this should give a rough set of data to work with.
+This script currently creates a few dozen opportunities each time you run it in various scenarios (differing opportunity statuses, titles, etc.).
+
+If you require a large amount of data locally, you can run `make db-seed-local args="--iterations 5"` setting the iterations count to your desired number.
+This effectively behaves like running the script multiple times in succession, and creates that many batches of opportunities.


### PR DESCRIPTION
## Summary
Fixes #1455

### Time to review: __10 mins__

## Changes proposed
Implements logic for the query field in the search API

Updated the seed script to allow you to generate more opportunities locally

## Context for reviewers
This logic is deliberately very, very simple at the moment. It basically just does a text contains check across several columns. This is the most naive approach, and it is expected that if you tried to search two separate words at the same time, you probably won't get any results.

A few options we may consider later (depending on the level of effort we want to put into a non-search-index approach):
- Postgres text search / tsvectors: https://www.postgresql.org/docs/current/textsearch.html
- Postgres text similarity: https://www.postgresql.org/docs/current/pgtrgm.html

## Additional information
The `ids` function I added for the tests was because there are a lot of tests and when test `16` fails, its really hard to figure out which one that is. Now it outputs the request+expected results:
![Screenshot 2024-03-21 at 10 47 34 AM](https://github.com/HHS/simpler-grants-gov/assets/46358556/a7732375-00a8-4e4f-8e16-c00114a80342)



