### PR TITLE
[Issue #1519] Configure sendy with new secrets pattern

### DIFF
--- a/infra/frontend/app-config/dev.tf
+++ b/infra/frontend/app-config/dev.tf
@@ -6,7 +6,4 @@ module "dev_config" {
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
   domain                          = "beta.grants.gov"
-  sendy_api_key                   = "/${local.app_name}/dev/sendy-api-key"
-  sendy_api_url                   = "/${local.app_name}/dev/sendy-api-url"
-  sendy_list_id                   = "/${local.app_name}/dev/sendy-list-id"
 }

--- a/infra/frontend/app-config/env-config/environment-variables.tf
+++ b/infra/frontend/app-config/env-config/environment-variables.tf
@@ -14,10 +14,20 @@ locals {
   # store. Configurations are of the format
   # { name = "ENV_VAR_NAME", ssm_param_name = "/ssm/param/name" }
   secrets = [
-    # Example secret
-    # {
-    #   name           = "SECRET_SAUCE"
-    #   ssm_param_name = "/${var.app_name}-${var.environment}/secret-sauce"
-    # }
+    {
+      # Sendy API key to pass with requests for sendy subscriber endpoints.
+      name           = "SENDY_API_KEY"
+      ssm_param_name = "/${var.app_name}/${var.environment}/sendy-api-key"
+    },
+    {
+      # Sendy API base url for requests to manage subscribers.
+      name           = "SENDY_API_URL"
+      ssm_param_name = "/${var.app_name}/${var.environment}/sendy-api-url"
+    },
+    {
+      # Sendy list ID to for requests to manage subscribers to the Simpler Grants distribution list.
+      name           = "SENDY_LIST_ID"
+      ssm_param_name = "/${var.app_name}/${var.environment}/sendy-list-id"
+    }
   ]
 }

--- a/infra/frontend/app-config/env-config/outputs.tf
+++ b/infra/frontend/app-config/env-config/outputs.tf
@@ -32,16 +32,3 @@ output "incident_management_service_integration" {
 output "domain" {
   value = var.domain
 }
-
-output "sendy_api_key" {
-  value     = var.sendy_api_key
-  sensitive = true
-}
-
-output "sendy_api_url" {
-  value = var.sendy_api_url
-}
-
-output "sendy_list_id" {
-  value = var.sendy_list_id
-}

--- a/infra/frontend/app-config/env-config/variables.tf
+++ b/infra/frontend/app-config/env-config/variables.tf
@@ -26,24 +26,6 @@ variable "domain" {
   default     = null
 }
 
-variable "sendy_api_key" {
-  description = "Sendy API key to pass with requests for sendy subscriber endpoints."
-  type        = string
-  default     = null
-}
-
-variable "sendy_api_url" {
-  description = "Sendy API base url for requests to manage subscribers."
-  type        = string
-  default     = null
-}
-
-variable "sendy_list_id" {
-  description = "Sendy list ID to for requests to manage subscribers to the Simpler Grants distribution list."
-  type        = string
-  default     = null
-}
-
 variable "service_override_extra_environment_variables" {
   type        = map(string)
   description = <<EOT

--- a/infra/frontend/app-config/prod.tf
+++ b/infra/frontend/app-config/prod.tf
@@ -6,7 +6,4 @@ module "prod_config" {
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
   domain                          = "simpler.grants.gov"
-  sendy_api_key                   = "/${local.app_name}/prod/sendy-api-key"
-  sendy_api_url                   = "/${local.app_name}/prod/sendy-api-url"
-  sendy_list_id                   = "/${local.app_name}/prod/sendy-list-id"
 }

--- a/infra/frontend/app-config/staging.tf
+++ b/infra/frontend/app-config/staging.tf
@@ -6,7 +6,4 @@ module "staging_config" {
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
   domain                          = "beta.grants.gov"
-  sendy_api_key                   = "/${local.app_name}/staging/sendy-api-key"
-  sendy_api_url                   = "/${local.app_name}/staging/sendy-api-url"
-  sendy_list_id                   = "/${local.app_name}/staging/sendy-list-id"
 }

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -110,18 +110,6 @@ data "aws_acm_certificate" "cert" {
   domain = local.domain
 }
 
-data "aws_ssm_parameter" "sendy_api_key" {
-  name = local.environment_config.sendy_api_key
-}
-
-data "aws_ssm_parameter" "sendy_api_url" {
-  name = local.environment_config.sendy_api_url
-}
-
-data "aws_ssm_parameter" "sendy_list_id" {
-  name = local.environment_config.sendy_list_id
-}
-
 output "environment_name" {
   value = var.environment_name
 }
@@ -137,9 +125,6 @@ module "service" {
   enable_autoscaling    = module.app_config.enable_autoscaling
   cert_arn              = terraform.workspace == "default" ? data.aws_acm_certificate.cert[0].arn : null
   hostname              = module.app_config.hostname
-  sendy_api_key         = data.aws_ssm_parameter.sendy_api_key.value
-  sendy_api_url         = data.aws_ssm_parameter.sendy_api_url.value
-  sendy_list_id         = data.aws_ssm_parameter.sendy_list_id.value
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -12,15 +12,12 @@ locals {
   task_executor_role_name = "${var.service_name}-task-executor"
   image_url               = "${data.aws_ecr_repository.app.repository_url}:${var.image_tag}"
   hostname                = var.hostname != null ? [{ name = "HOSTNAME", value = var.hostname }] : []
-  sendy_api_key           = var.sendy_api_key != null ? [{ name = "SENDY_API_KEY", value = var.sendy_api_key }] : []
-  sendy_api_url           = var.sendy_api_url != null ? [{ name = "SENDY_API_URL", value = var.sendy_api_url }] : []
-  sendy_list_id           = var.sendy_list_id != null ? [{ name = "SENDY_LIST_ID", value = var.sendy_list_id }] : []
 
   base_environment_variables = concat([
     { name : "PORT", value : tostring(var.container_port) },
     { name : "AWS_REGION", value : data.aws_region.current.name },
     { name : "API_AUTH_TOKEN", value : var.api_auth_token },
-  ], local.hostname, local.sendy_api_key, local.sendy_api_url, local.sendy_list_id)
+  ], local.hostname)
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },
     { name : "DB_PORT", value : var.db_vars.connection_info.port },

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -47,24 +47,6 @@ variable "hostname" {
   default     = null
 }
 
-variable "sendy_api_key" {
-  description = "Sendy API key to pass with requests for sendy subscriber endpoints."
-  type        = string
-  default     = null
-}
-
-variable "sendy_api_url" {
-  description = "Sendy API base url for requests to manage subscribers."
-  type        = string
-  default     = null
-}
-
-variable "sendy_list_id" {
-  description = "Sendy list ID to for requests to manage subscribers to the Simpler Grants distribution list."
-  type        = string
-  default     = null
-}
-
 variable "vpc_id" {
   type        = string
   description = "Uniquely identifies the VPC."


### PR DESCRIPTION
## Summary

Closes https://github.com/HHS/simpler-grants-gov/issues/1519

### Time to review: __2 mins__

## Changes proposed

- removes old secrets pattern for sendy SSM secrets
- adds new fancy secrets pattern for sendy SSM secrets

## Context for reviewers

I did this so our repo would contain up to date examples of how to get the frontend to read SSM parameters.

Read the documentation for this system, if you haven't already: https://github.com/HHS/simpler-grants-gov/blob/main/documentation/infra/environment-variables-and-secrets.md

## Testing

I deployed to dev, inspected the task definition, and tested sendy

task definition with sendy secrets: 
<img width="395" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/5768468/f0f56b67-b8a8-41b1-9ed9-e39736e58d8f">

sendy test:
<img width="1235" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/5768468/8c5b64c2-ebf8-498b-8282-b6e760c315c4">
