### PR TITLE
[Issue #1494] Modify agency filter to be an exact match

### DIFF
--- a/api/src/services/opportunities_v0_1/search_opportunities.py
+++ b/api/src/services/opportunities_v0_1/search_opportunities.py
@@ -143,11 +143,7 @@ def _add_filters(
         # Note that we filter against the agency code in the opportunity, not in the summary
         one_of_agencies = filters.agency.get("one_of")
         if one_of_agencies:
-            # This produces something like:
-            #   ..WHERE ((opportunity.agency ILIKE 'US-ABC%') OR (opportunity.agency ILIKE 'HHS%'))
-            stmt = stmt.where(
-                or_(*[Opportunity.agency.istartswith(agency) for agency in one_of_agencies])
-            )
+            stmt = stmt.where(Opportunity.agency.in_(one_of_agencies))
 
     return stmt
 

--- a/api/tests/src/api/opportunities_v0_1/test_opportunity_route.py
+++ b/api/tests/src/api/opportunities_v0_1/test_opportunity_route.py
@@ -884,11 +884,11 @@ class TestSearchScenarios(BaseTestClass):
                     Scenario.POSTED_OPPORTUNITY_TITLE_HAS_PERCENT,
                 ],
             ),
-            ### Agency field tests (note that agency works as a prefix)
+            ### Agency field tests
             ### By default agency is set to "DEFAULT-ABC" with a few overriding that to "DIFFERENT-<something>"
-            # Should only return the agencies that start "DIFFERENT-" (case-insensitive)
+            # Should only return the agencies that start "DIFFERENT-"
             (
-                get_search_request(page_size=25, agency_one_of=["DiFfErEnT"]),
+                get_search_request(page_size=25, agency_one_of=["DIFFERENT-ABC", "DIFFERENT-XYZ"]),
                 [
                     Scenario.POSTED_NON_DEFAULT_AGENCY_WITH_APP_TYPES,
                     Scenario.CLOSED_NON_DEFAULT_AGENCY_WITH_FUNDING_CATEGORIES,
@@ -898,12 +898,14 @@ class TestSearchScenarios(BaseTestClass):
             (get_search_request(page_size=25, agency_one_of=["no agency starts with this"]), []),
             # Should only return a single agency as it's the only one that has this name
             (
-                get_search_request(page_size=25, agency_one_of=["different-xyz"]),
+                get_search_request(page_size=25, agency_one_of=["DIFFERENT-XYZ"]),
                 [Scenario.CLOSED_NON_DEFAULT_AGENCY_WITH_FUNDING_CATEGORIES],
             ),
-            # Should return everything with agency set as it will be happy with both prefixes
+            # Should return everything with agency set as these are all the values we set
             (
-                get_search_request(page_size=25, agency_one_of=["DEFAULT", "different"]),
+                get_search_request(
+                    page_size=25, agency_one_of=["DEFAULT-ABC", "DIFFERENT-ABC", "DIFFERENT-XYZ"]
+                ),
                 [
                     Scenario.POSTED_ALL_ENUM_VALUES,
                     Scenario.POSTED_NON_DEFAULT_AGENCY_WITH_APP_TYPES,
@@ -1012,7 +1014,7 @@ class TestSearchScenarios(BaseTestClass):
             (
                 get_search_request(
                     page_size=25,
-                    agency_one_of=["different"],
+                    agency_one_of=["DIFFERENT-ABC"],
                     applicant_type_one_of=[ApplicantType.COUNTY_GOVERNMENTS],
                 ),
                 [Scenario.POSTED_NON_DEFAULT_AGENCY_WITH_APP_TYPES],
@@ -1076,7 +1078,7 @@ class TestSearchScenarios(BaseTestClass):
                 get_search_request(
                     page_size=25,
                     opportunity_status_one_of=[OpportunityStatus.FORECASTED],
-                    agency_one_of=["different"],
+                    agency_one_of=["DIFFERENT-ABC", "DIFFERENT-XYZ"],
                 ),
                 [],
             ),


### PR DESCRIPTION
## Summary
Fixes #1494

### Time to review: __2 mins__

## Changes proposed
Adjust the logic for filtering by agency to be an exact match instead of the prior "starts with" logic.

## Context for reviewers
This adjustments comes out of a recent discussion with our front-end folks. Turns out they intend to pass us every agency for sub-agencies (eg. `HHS-123`, `HHS-456`, etc). I had implemented sub-agency logic assuming we'd want prefixes, which is clunky. This makes the logic more intuitive by just being a simple match.

Note that previously the agencies were also case-insensitive which is no longer here, but that also isn't really necessary.

## Additional information
Updated a few tests that assumed prior logic - nothing too significant here

