### PR TITLE
[Issue #1493] Update search schema to disallow empty filters

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -773,6 +773,7 @@ components:
       properties:
         one_of:
           type: array
+          minItems: 1
           items:
             enum:
             - cooperative_agreement
@@ -786,6 +787,7 @@ components:
       properties:
         one_of:
           type: array
+          minItems: 1
           items:
             enum:
             - recovery_act
@@ -821,6 +823,7 @@ components:
       properties:
         one_of:
           type: array
+          minItems: 1
           items:
             enum:
             - state_governments
@@ -847,6 +850,7 @@ components:
       properties:
         one_of:
           type: array
+          minItems: 1
           items:
             enum:
             - forecasted
@@ -860,6 +864,7 @@ components:
       properties:
         one_of:
           type: array
+          minItems: 1
           items:
             type: string
             minLength: 2

--- a/api/src/api/schemas/search_schema.py
+++ b/api/src/api/schemas/search_schema.py
@@ -1,7 +1,38 @@
 from enum import StrEnum
-from typing import Type
+from typing import Any, Type
 
-from src.api.schemas.extension import Schema, fields, validators
+from marshmallow import ValidationError, validates_schema
+
+from src.api.schemas.extension import MarshmallowErrorContainer, Schema, fields, validators
+from src.validation.validation_constants import ValidationErrorType
+
+
+class BaseSearchSchema(Schema):
+    @validates_schema
+    def validates_non_empty(self, data: dict, **kwargs: Any) -> None:
+        """
+        For any search schema, validates that the value provided actually has a filter set.
+
+        For example, a request like:
+
+            {
+                "filters": {
+                    "my_field": {}
+                }
+            }
+
+        would be invalid as "my_field" needs at least something within it. Note that providing
+        no filters / excluding "my_field" entirely is perfectly fine, we're just trying to avoid
+        having something partially filled out to keep the logic downstream a bit simpler.
+        """
+        if data == {}:
+            raise ValidationError(
+                [
+                    MarshmallowErrorContainer(
+                        ValidationErrorType.INVALID, "At least one filter rule must be provided."
+                    )
+                ]
+            )
 
 
 class StrSearchSchemaBuilder:
@@ -67,9 +98,10 @@ class StrSearchSchemaBuilder:
         else:
             list_type = fields.Enum(allowed_values, metadata=metadata)
 
-        self.schema_fields["one_of"] = fields.List(list_type)
+        # Note that the list requires at least one value (sending us just [] will raise a validation error)
+        self.schema_fields["one_of"] = fields.List(list_type, validate=[validators.Length(min=1)])
 
         return self
 
     def build(self) -> Schema:
-        return Schema.from_dict(self.schema_fields, name=self.schema_class_name)  # type: ignore
+        return BaseSearchSchema.from_dict(self.schema_fields, name=self.schema_class_name)  # type: ignore

--- a/api/tests/src/api/opportunities_v0_1/test_opportunity_route.py
+++ b/api/tests/src/api/opportunities_v0_1/test_opportunity_route.py
@@ -72,19 +72,19 @@ def get_search_request(
 
     filters = {}
 
-    if funding_instrument_one_of:
+    if funding_instrument_one_of is not None:
         filters["funding_instrument"] = {"one_of": funding_instrument_one_of}
 
-    if funding_category_one_of:
+    if funding_category_one_of is not None:
         filters["funding_category"] = {"one_of": funding_category_one_of}
 
-    if applicant_type_one_of:
+    if applicant_type_one_of is not None:
         filters["applicant_type"] = {"one_of": applicant_type_one_of}
 
-    if opportunity_status_one_of:
+    if opportunity_status_one_of is not None:
         filters["opportunity_status"] = {"one_of": opportunity_status_one_of}
 
-    if agency_one_of:
+    if agency_one_of is not None:
         filters["agency"] = {"one_of": agency_one_of}
 
     if len(filters) > 0:
@@ -650,6 +650,90 @@ def setup_opportunity(
                     "message": "Length must be between 1 and 100.",
                     "type": "min_or_max_length",
                 }
+            ],
+        ),
+        # Verify that if the one_of lists are empty, we get a validation error
+        (
+            get_search_request(
+                funding_instrument_one_of=[],
+                funding_category_one_of=[],
+                applicant_type_one_of=[],
+                opportunity_status_one_of=[],
+                agency_one_of=[],
+            ),
+            [
+                {
+                    "field": "filters.funding_instrument.one_of",
+                    "message": "Shorter than minimum length 1.",
+                    "type": "min_length",
+                },
+                {
+                    "field": "filters.funding_category.one_of",
+                    "message": "Shorter than minimum length 1.",
+                    "type": "min_length",
+                },
+                {
+                    "field": "filters.applicant_type.one_of",
+                    "message": "Shorter than minimum length 1.",
+                    "type": "min_length",
+                },
+                {
+                    "field": "filters.opportunity_status.one_of",
+                    "message": "Shorter than minimum length 1.",
+                    "type": "min_length",
+                },
+                {
+                    "field": "filters.agency.one_of",
+                    "message": "Shorter than minimum length 1.",
+                    "type": "min_length",
+                },
+            ],
+        ),
+        # Validate that if a filter is provided, but empty, we'll provide an exception
+        # note that the get_search_request() method isn't great for constructing this particular
+        # case - so we manually define the request instead
+        (
+            {
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 5,
+                    "order_by": "opportunity_id",
+                    "sort_direction": "descending",
+                },
+                "filters": {
+                    "funding_instrument": {},
+                    "funding_category": {},
+                    "applicant_type": {},
+                    "opportunity_status": {},
+                    "agency": {},
+                },
+            },
+            [
+                {
+                    "field": "filters.funding_instrument",
+                    "message": "At least one filter rule must be provided.",
+                    "type": "invalid",
+                },
+                {
+                    "field": "filters.funding_category",
+                    "message": "At least one filter rule must be provided.",
+                    "type": "invalid",
+                },
+                {
+                    "field": "filters.applicant_type",
+                    "message": "At least one filter rule must be provided.",
+                    "type": "invalid",
+                },
+                {
+                    "field": "filters.opportunity_status",
+                    "message": "At least one filter rule must be provided.",
+                    "type": "invalid",
+                },
+                {
+                    "field": "filters.agency",
+                    "message": "At least one filter rule must be provided.",
+                    "type": "invalid",
+                },
             ],
         ),
     ],


### PR DESCRIPTION
## Summary
Fixes #1493

### Time to review: __5 mins__

## Changes proposed
Updated search schema logic to disallow:
1. Empty `one_of` lists
2. Empty filter lists

## Context for reviewers
These changes remove a few edge cases that have undefined / difficult to define behavior if we allow them (ie. what do we do if a list is empty, `opportunity_status in [ ]`). Rather than try to sort out what the behavior might mean / modify a users search request and interpret what we think they probably mean, we don't allow that type of request and chalk it up to user error in constructing a request.

Note that this does not modify the behavior of just not passing filters, that's still perfectly fine, we just want to avoid being passed filters that are half-built. See the additional section below for what is / isn't allowed.

## Additional information
An example request looks like:
```json
{
  "filters": {
    "agency": {
      "one_of": [
        "US-ABC",
        "HHS"
      ]
    },
    "applicant_type": {
      "one_of": [
        "state_governments",
        "county_governments",
        "individuals"
      ]
    },
    "funding_category": {
      "one_of": [
        "recovery_act",
        "arts",
        "natural_resources"
      ]
    },
    "funding_instrument": {
      "one_of": [
        "cooperative_agreement",
        "grant"
      ]
    },
    "opportunity_status": {
      "one_of": [
        "forecasted",
        "posted"
      ]
    }
  },
  "pagination": {
    "order_by": "opportunity_id",
    "page_offset": 1,
    "page_size": 25,
    "sort_direction": "descending"
  },
  "query": "research"
}
```

Technically only the pagination is required, and so you can also pass us:
```json
{
  "pagination": {
    "order_by": "opportunity_id",
    "page_offset": 1,
    "page_size": 25,
    "sort_direction": "descending"
  }
}
```

### Error cases

However, the following are now no longer allowed.

#### An empty list

logically this wouldn't ever return results as the intersection of an empty set always is nothing
```json
{
  "filters": {
    "agency": {
      "one_of": []
    }
  },

  "pagination": {
    "order_by": "opportunity_id",
    "page_offset": 1,
    "page_size": 25,
    "sort_direction": "descending"
  }
}
```
Which returns:
```json
{
  "data": {},
  "errors": [
    {
      "field": "filters.agency.one_of",
      "message": "Shorter than minimum length 1.",
      "type": "min_length"
    }
  ],
  "message": "Validation error",
  "status_code": 422
}
```

#### An empty set of filter rules for a field 

this technically doesn't cause issues, but lets us be more flexible in our implementation

```json
{
  "filters": {
    "agency": {
    }
  },

  "pagination": {
    "order_by": "opportunity_id",
    "page_offset": 1,
    "page_size": 25,
    "sort_direction": "descending"
  }
}
```
Which returns:
```json
{
  "data": {},
  "errors": [
    {
      "field": "filters.agency",
      "message": "At least one filter rule must be provided.",
      "type": "invalid"
    }
  ],
  "message": "Validation error",
  "status_code": 422
}
```