### PR TITLE
[Issue #1593]: Add eligibility and category filters

### DIFF
--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -30,6 +30,7 @@ export default class SearchOpportunityAPI extends BaseApi {
   async searchOpportunities(searchInputs: SearchFetcherProps) {
     const { query } = searchInputs;
     const filters = this.buildFilters(searchInputs);
+    console.log("filters => ", filters);
     const pagination = this.buildPagination(searchInputs);
 
     const requestBody: SearchRequestBody = { pagination };
@@ -43,6 +44,8 @@ export default class SearchOpportunityAPI extends BaseApi {
       requestBody.query = query;
     }
 
+    console.log("request boyd => ", requestBody);
+
     const subPath = "search";
     const response = await this.request(
       "POST",
@@ -52,6 +55,7 @@ export default class SearchOpportunityAPI extends BaseApi {
       requestBody,
     );
 
+    console.log("response => ", response.data.length);
     return response;
   }
 
@@ -59,19 +63,27 @@ export default class SearchOpportunityAPI extends BaseApi {
   private buildFilters(
     searchInputs: SearchFetcherProps,
   ): SearchFilterRequestBody {
-    const { agency, status, fundingInstrument } = searchInputs;
+    const { status, fundingInstrument, eligibility, agency, category } =
+      searchInputs;
     const filters: SearchFilterRequestBody = {};
+
+    if (status && status.size > 0) {
+      filters.opportunity_status = { one_of: Array.from(status) };
+    }
+    if (fundingInstrument && fundingInstrument.size > 0) {
+      filters.funding_instrument = { one_of: Array.from(fundingInstrument) };
+    }
+
+    if (eligibility && eligibility.size > 0) {
+      filters.applicant_type = { one_of: Array.from(eligibility) };
+    }
 
     if (agency && agency.size > 0) {
       filters.agency = { one_of: Array.from(agency) };
     }
 
-    if (status && status.size > 0) {
-      filters.opportunity_status = { one_of: Array.from(status) };
-    }
-
-    if (fundingInstrument && fundingInstrument.size > 0) {
-      filters.funding_instrument = { one_of: Array.from(fundingInstrument) };
+    if (category && category.size > 0) {
+      filters.funding_category = { one_of: Array.from(category) };
     }
 
     return filters;

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -30,7 +30,6 @@ export default class SearchOpportunityAPI extends BaseApi {
   async searchOpportunities(searchInputs: SearchFetcherProps) {
     const { query } = searchInputs;
     const filters = this.buildFilters(searchInputs);
-    console.log("filters => ", filters);
     const pagination = this.buildPagination(searchInputs);
 
     const requestBody: SearchRequestBody = { pagination };
@@ -44,8 +43,6 @@ export default class SearchOpportunityAPI extends BaseApi {
       requestBody.query = query;
     }
 
-    console.log("request boyd => ", requestBody);
-
     const subPath = "search";
     const response = await this.request(
       "POST",
@@ -55,7 +52,6 @@ export default class SearchOpportunityAPI extends BaseApi {
       requestBody,
     );
 
-    console.log("response => ", response.data.length);
     return response;
   }
 
@@ -75,6 +71,7 @@ export default class SearchOpportunityAPI extends BaseApi {
     }
 
     if (eligibility && eligibility.size > 0) {
+      // Note that eligibility gets remapped to the API name of "applicant_type"
       filters.applicant_type = { one_of: Array.from(eligibility) };
     }
 
@@ -83,6 +80,7 @@ export default class SearchOpportunityAPI extends BaseApi {
     }
 
     if (category && category.size > 0) {
+      // Note that category gets remapped to the API name of "funding_category"
       filters.funding_category = { one_of: Array.from(category) };
     }
 

--- a/frontend/src/app/search/SearchForm.tsx
+++ b/frontend/src/app/search/SearchForm.tsx
@@ -4,6 +4,8 @@ import { SearchAPIResponse } from "../../types/search/searchResponseTypes";
 import SearchBar from "../../components/search/SearchBar";
 import { SearchFetcherProps } from "../../services/search/searchfetcher/SearchFetcher";
 import SearchFilterAgency from "src/components/search/SearchFilterAgency";
+import SearchFilterCategory from "../../components/search/SearchFilterCategory";
+import SearchFilterEligibility from "../../components/search/SearchFilterEligibility";
 import SearchFilterFundingInstrument from "../../components/search/SearchFilterFundingInstrument";
 import SearchOpportunityStatus from "../../components/search/SearchOpportunityStatus";
 import SearchPagination from "../../components/search/SearchPagination";
@@ -28,8 +30,10 @@ export function SearchForm({
     statusQueryParams,
     queryQueryParams,
     sortbyQueryParams,
-    agencyQueryParams,
     fundingInstrumentQueryParams,
+    eligibilityQueryParams,
+    agencyQueryParams,
+    categoryQueryParams,
     maxPaginationError,
     fieldChangedRef,
     page,
@@ -58,9 +62,17 @@ export function SearchForm({
               formRef={formRef}
               initialQueryParams={fundingInstrumentQueryParams}
             />
+            <SearchFilterEligibility
+              formRef={formRef}
+              initialQueryParams={eligibilityQueryParams}
+            />
             <SearchFilterAgency
               formRef={formRef}
               initialQueryParams={agencyQueryParams}
+            />
+            <SearchFilterCategory
+              formRef={formRef}
+              initialQueryParams={categoryQueryParams}
             />
           </div>
           <div className="tablet:grid-col-8">

--- a/frontend/src/app/search/actions.ts
+++ b/frontend/src/app/search/actions.ts
@@ -16,5 +16,7 @@ export async function updateResults(
   const formDataService = new FormDataService(formData);
   const searchProps = formDataService.processFormData();
 
+  console.log("searchProps => ", searchProps);
+
   return await searchFetcher.fetchOpportunities(searchProps);
 }

--- a/frontend/src/app/search/actions.ts
+++ b/frontend/src/app/search/actions.ts
@@ -16,7 +16,5 @@ export async function updateResults(
   const formDataService = new FormDataService(formData);
   const searchProps = formDataService.processFormData();
 
-  console.log("searchProps => ", searchProps);
-
   return await searchFetcher.fetchOpportunities(searchProps);
 }

--- a/frontend/src/components/search/SearchFilterCategory.tsx
+++ b/frontend/src/components/search/SearchFilterCategory.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  FilterOption,
+  SearchFilterAccordion,
+} from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
+
+export interface SearchFilterCategoryyProps {
+  initialQueryParams: Set<string>;
+  formRef: React.RefObject<HTMLFormElement>;
+}
+
+export default function SearchFilterCategory({
+  formRef,
+  initialQueryParams,
+}: SearchFilterCategoryyProps) {
+  const initialFilterOptions: FilterOption[] = [
+    {
+      id: "category-recovery_act",
+      label: "Recovery Act",
+      value: "recovery_act",
+    },
+    { id: "category-agriculture", label: "Agriculture", value: "agriculture" },
+    { id: "category-arts", label: "Arts", value: "arts" },
+    {
+      id: "category-business_and_commerce",
+      label: "Business and Commerce",
+      value: "business_and_commerce",
+    },
+    {
+      id: "category-community_development",
+      label: "Community Development",
+      value: "community_development",
+    },
+    {
+      id: "category-consumer_protection",
+      label: "Consumer Protection",
+      value: "consumer_protection",
+    },
+    {
+      id: "category-disaster_prevention_and_relief",
+      label: "Disaster Prevention and Relief",
+      value: "disaster_prevention_and_relief",
+    },
+    { id: "category-education", label: "Education", value: "education" },
+    {
+      id: "category-employment_labor_and_training",
+      label: "Employment, Labor, and Training",
+      value: "employment_labor_and_training",
+    },
+    { id: "category-energy", label: "Energy", value: "energy" },
+    { id: "category-environment", label: "Environment", value: "environment" },
+    {
+      id: "category-food_and_nutrition",
+      label: "Food and Nutrition",
+      value: "food_and_nutrition",
+    },
+    { id: "category-health", label: "Health", value: "health" },
+    { id: "category-housing", label: "Housing", value: "housing" },
+    { id: "category-humanities", label: "Humanities", value: "humanities" },
+    {
+      id: "category-information_and_statistics",
+      label: "Information and Statistics",
+      value: "information_and_statistics",
+    },
+    {
+      id: "category-infrastructure_investment_and_jobs_act",
+      label: "Infrastructure Investment and Jobs Act",
+      value: "infrastructure_investment_and_jobs_act",
+    },
+    {
+      id: "category-income_security_and_social_services",
+      label: "Income Security and Social Services",
+      value: "income_security_and_social_services",
+    },
+    {
+      id: "category-law_justice_and_legal_services",
+      label: "Law, Justice, and Legal Services",
+      value: "law_justice_and_legal_services",
+    },
+    {
+      id: "category-natural_resources",
+      label: "Natural Resources",
+      value: "natural_resources",
+    },
+    {
+      id: "category-opportunity_zone_benefits",
+      label: "Opportunity Zone Benefits",
+      value: "opportunity_zone_benefits",
+    },
+    {
+      id: "category-regional_development",
+      label: "Regional Development",
+      value: "regional_development",
+    },
+    {
+      id: "category-science_technology_and_other_research_and_development",
+      label: "Science, Technology, and Other Research and Development",
+      value: "science_technology_and_other_research_and_development",
+    },
+    {
+      id: "category-transportation",
+      label: "Transportation",
+      value: "transportation",
+    },
+    {
+      id: "category-affordable_care_act",
+      label: "Affordable Care Act",
+      value: "affordable_care_act",
+    },
+    { id: "category-other", label: "Other", value: "other" },
+  ];
+
+  return (
+    <SearchFilterAccordion
+      initialFilterOptions={initialFilterOptions}
+      title="Category"
+      queryParamKey="category"
+      formRef={formRef}
+      initialQueryParams={initialQueryParams}
+    />
+  );
+}

--- a/frontend/src/components/search/SearchFilterEligibility.tsx
+++ b/frontend/src/components/search/SearchFilterEligibility.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import {
+  FilterOption,
+  SearchFilterAccordion,
+} from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
+
+export interface SearchFilterEligibilityProps {
+  initialQueryParams: Set<string>;
+  formRef: React.RefObject<HTMLFormElement>;
+}
+
+export default function SearchFilterEligibility({
+  formRef,
+  initialQueryParams,
+}: SearchFilterEligibilityProps) {
+  const initialFilterOptions: FilterOption[] = [
+    {
+      id: "eligibility-state_governments",
+      label: "State Governments",
+      value: "state_governments",
+    },
+    {
+      id: "eligibility-county_governments",
+      label: "County Governments",
+      value: "county_governments",
+    },
+    {
+      id: "eligibility-city_or_township_governments",
+      label: "City or Township Governments",
+      value: "city_or_township_governments",
+    },
+    {
+      id: "eligibility-special_district_governments",
+      label: "Special District Governments",
+      value: "special_district_governments",
+    },
+    {
+      id: "eligibility-independent_school_districts",
+      label: "Independent School Districts",
+      value: "independent_school_districts",
+    },
+    {
+      id: "eligibility-public_and_state_institutions_of_higher_education",
+      label: "Public and State Institutions of Higher Education",
+      value: "public_and_state_institutions_of_higher_education",
+    },
+    {
+      id: "eligibility-private_institutions_of_higher_education",
+      label: "Private Institutions of Higher Education",
+      value: "private_institutions_of_higher_education",
+    },
+    {
+      id: "eligibility-federally_recognized_native_american_tribal_governments",
+      label: "Federally Recognized Native American Tribal Governments",
+      value: "federally_recognized_native_american_tribal_governments",
+    },
+    {
+      id: "eligibility-other_native_american_tribal_organizations",
+      label: "Other Native American Tribal Organizations",
+      value: "other_native_american_tribal_organizations",
+    },
+    {
+      id: "eligibility-public_and_indian_housing_authorities",
+      label: "Public and Indian Housing Authorities",
+      value: "public_and_indian_housing_authorities",
+    },
+    {
+      id: "eligibility-nonprofits_non_higher_education_with_501c3",
+      label: "Nonprofits Non Higher Education with 501c3",
+      value: "nonprofits_non_higher_education_with_501c3",
+    },
+    {
+      id: "eligibility-nonprofits_non_higher_education_without_501c3",
+      label: "Nonprofits Non Higher Education without 501c3",
+      value: "nonprofits_non_higher_education_without_501c3",
+    },
+    {
+      id: "eligibility-individuals",
+      label: "Individuals",
+      value: "individuals",
+    },
+    {
+      id: "eligibility-for_profit_organizations_other_than_small_businesses",
+      label: "For-Profit Organizations Other Than Small Businesses",
+      value: "for_profit_organizations_other_than_small_businesses",
+    },
+    {
+      id: "eligibility-small_businesses",
+      label: "Small Businesses",
+      value: "small_businesses",
+    },
+    {
+      id: "eligibility-other",
+      label: "Other",
+      value: "other",
+    },
+    {
+      id: "eligibility-unrestricted",
+      label: "Unrestricted",
+      value: "unrestricted",
+    },
+  ];
+
+  return (
+    <SearchFilterAccordion
+      initialFilterOptions={initialFilterOptions}
+      title="Eligibility"
+      queryParamKey="eligibility"
+      formRef={formRef}
+      initialQueryParams={initialQueryParams}
+    />
+  );
+}

--- a/frontend/src/components/search/SearchFilterEligibility.tsx
+++ b/frontend/src/components/search/SearchFilterEligibility.tsx
@@ -72,7 +72,8 @@ export default function SearchFilterEligibility({
     },
     {
       id: "eligibility-nonprofits_non_higher_education_without_501c3",
-      label: "Nonprofits having a 501(c)(3) status with the IRS, other than institutions of higher education",
+      label:
+        "Nonprofits having a 501(c)(3) status with the IRS, other than institutions of higher education",
       value: "nonprofits_non_higher_education_without_501c3",
     },
     {

--- a/frontend/src/components/search/SearchFilterEligibility.tsx
+++ b/frontend/src/components/search/SearchFilterEligibility.tsx
@@ -72,7 +72,7 @@ export default function SearchFilterEligibility({
     },
     {
       id: "eligibility-nonprofits_non_higher_education_without_501c3",
-      label: "Nonprofits Non Higher Education without 501c3",
+      label: "Nonprofits having a 501(c)(3) status with the IRS, other than institutions of higher education",
       value: "nonprofits_non_higher_education_without_501c3",
     },
     {

--- a/frontend/src/hooks/useSearchFormState.ts
+++ b/frontend/src/hooks/useSearchFormState.ts
@@ -23,8 +23,10 @@ export function useSearchFormState(
   let {
     status: statusQueryParams,
     page: pageQueryParams,
-    agency: agencyQueryParams,
     fundingInstrument: fundingInstrumentQueryParams,
+    eligibility: eligibilityQueryParams,
+    agency: agencyQueryParams,
+    category: categoryQueryParams,
     query: queryQueryParams,
     sortby: sortbyQueryParams,
   } = requestURLQueryParams;
@@ -91,8 +93,10 @@ export function useSearchFormState(
     queryQueryParams,
     sortbyQueryParams,
     pageQueryParams,
-    agencyQueryParams,
     fundingInstrumentQueryParams,
+    eligibilityQueryParams,
+    agencyQueryParams,
+    categoryQueryParams,
     fieldChangedRef,
     resetPagination,
     page,

--- a/frontend/src/services/search/FormDataService.ts
+++ b/frontend/src/services/search/FormDataService.ts
@@ -47,99 +47,44 @@ export class FormDataService {
     return queryValue !== "" ? queryValue?.toString() : null;
   }
 
-  // Builds a set of selected status values from the formData
-  get status(): Set<string> {
-    const statuses = new Set<string>();
-    const statusKeys = [
-      "status-forecasted",
-      "status-posted",
-      "status-closed",
-      "status-archived",
-    ];
+  getValuesByKeyPrefix(prefix: string, splitAtSecondPart = false): Set<string> {
+    const values = new Set<string>();
 
-    for (const key of statusKeys) {
-      const value = this.getFormDataWithValue(key);
-      if (value !== null) {
-        statuses.add(key.split("-")[1]); // Add the part after 'status-', e.g., 'forecasted'
-      }
-    }
-    return statuses;
-  }
+    for (const [key] of this.formData.entries()) {
+      if (key.startsWith(prefix)) {
+        // Determine the index to split at, which is 1 by default,
+        // but 2 if we're looking at 'funding-instrument-'.
+        const indexToSplit = splitAtSecondPart ? 2 : 1;
+        const value = key.split("-").slice(indexToSplit).join();
 
-  // Getting a set of selected funding instruments
-  get fundingInstrument(): Set<string> {
-    const fundingInstruments = new Set<string>();
-
-    const fundingInstrumentTypes = [
-      "funding-instrument-cooperative_agreement",
-      "funding-instrument-grant",
-      "funding-instrument-procurement_contract",
-      "funding-instrument-other",
-    ];
-
-    for (const key of fundingInstrumentTypes) {
-      const value = this.getFormDataWithValue(key);
-      if (value !== null) {
-        // Extracting the part after 'funding-instrument-', e.g., 'grant'
-        const instrument = key.split("-")[2];
-        if (instrument) {
-          fundingInstruments.add(instrument);
+        if (value) {
+          values.add(value);
         }
       }
     }
 
-    return fundingInstruments;
+    return values;
+  }
+
+  get status(): Set<string> {
+    return this.getValuesByKeyPrefix("status-");
+  }
+
+  get fundingInstrument(): Set<string> {
+    // Pass 'true' to handle the special case of splitting 'funding-instrument-'after the second dash
+    return this.getValuesByKeyPrefix("funding-instrument-", true);
   }
 
   get eligibility(): Set<string> {
-    const eligibilities = new Set<string>();
-
-    // Iterate over all entries in the FormData
-    for (const [key] of this.formData.entries()) {
-      if (key.startsWith("eligibility-")) {
-        // Remove the initial 'eligibility-' prefix and add the remainder to the set
-        const eligibilityId = key.substring("eligibility-".length);
-        if (eligibilityId) {
-          eligibilities.add(eligibilityId);
-        }
-      }
-    }
-
-    return eligibilities;
+    return this.getValuesByKeyPrefix("eligibility-");
   }
 
   get agency(): Set<string> {
-    const agencies = new Set<string>();
-
-    // Iterate over all entries in the FormData
-    for (const [key] of this.formData.entries()) {
-      if (key.startsWith("agency-")) {
-        // Remove the initial 'agency-' prefix and add the remainder to the set
-        const agencyId = key.substring("agency-".length);
-        if (agencyId) {
-          agencies.add(agencyId);
-        }
-      }
-    }
-
-    return agencies;
+    return this.getValuesByKeyPrefix("agency-");
   }
 
   get category(): Set<string> {
-    const categories = new Set<string>();
-
-    // Iterate over all entries in the FormData
-    for (const [key] of this.formData.entries()) {
-      if (key.startsWith("category-")) {
-        // Remove the initial 'category-' prefix and add the remainder to the set
-        const categoryId = key.substring("category-".length);
-        if (categoryId) {
-          categories.add(categoryId);
-        }
-      }
-    }
-
-    return categories;
+    return this.getValuesByKeyPrefix("category-");
   }
 
   get sortBy(): string | null {

--- a/frontend/src/services/search/FormDataService.ts
+++ b/frontend/src/services/search/FormDataService.ts
@@ -15,7 +15,9 @@ export class FormDataService {
       page: this.page,
       status: this.status,
       fundingInstrument: this.fundingInstrument,
+      eligibility: this.eligibility,
       agency: this.agency,
+      category: this.category,
       query: this.query,
       sortby: this.sortBy,
 
@@ -89,6 +91,23 @@ export class FormDataService {
     return fundingInstruments;
   }
 
+  get eligibility(): Set<string> {
+    const eligibilities = new Set<string>();
+
+    // Iterate over all entries in the FormData
+    for (const [key] of this.formData.entries()) {
+      if (key.startsWith("eligibility-")) {
+        // Remove the initial 'eligibility-' prefix and add the remainder to the set
+        const eligibilityId = key.substring("eligibility-".length);
+        if (eligibilityId) {
+          eligibilities.add(eligibilityId);
+        }
+      }
+    }
+
+    return eligibilities;
+  }
+
   get agency(): Set<string> {
     const agencies = new Set<string>();
 
@@ -104,6 +123,23 @@ export class FormDataService {
     }
 
     return agencies;
+  }
+
+  get category(): Set<string> {
+    const categories = new Set<string>();
+
+    // Iterate over all entries in the FormData
+    for (const [key] of this.formData.entries()) {
+      if (key.startsWith("category-")) {
+        // Remove the initial 'category-' prefix and add the remainder to the set
+        const categoryId = key.substring("category-".length);
+        if (categoryId) {
+          categories.add(categoryId);
+        }
+      }
+    }
+
+    return categories;
   }
 
   get sortBy(): string | null {

--- a/frontend/src/services/search/searchfetcher/SearchFetcher.ts
+++ b/frontend/src/services/search/searchfetcher/SearchFetcher.ts
@@ -7,8 +7,10 @@ export interface SearchFetcherProps {
   page: number;
   query: string | null | undefined;
   status: Set<string>;
-  agency: Set<string>;
   fundingInstrument: Set<string>;
+  eligibility: Set<string>;
+  agency: Set<string>;
+  category: Set<string>;
   sortby: string | null;
   actionType?: SearchFetcherActionType;
   fieldChanged?: string;

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -1,7 +1,9 @@
 export interface SearchFilterRequestBody {
-  agency?: { one_of: string[] };
   opportunity_status?: { one_of: string[] };
   funding_instrument?: { one_of: string[] };
+  applicant_type?: { one_of: string[] };
+  agency?: { one_of: string[] };
+  funding_category?: { one_of: string[] };
 }
 
 export type PaginationOrderBy = "opportunity_id" | "opportunity_number";

--- a/frontend/src/utils/search/convertSearchParamsToProperTypes.ts
+++ b/frontend/src/utils/search/convertSearchParamsToProperTypes.ts
@@ -12,8 +12,10 @@ export function convertSearchParamsToProperTypes(
     ...params,
     query: params.query || "", // Convert empty string to null if needed
     status: paramToSet(params.status),
-    agency: paramToSet(params.agency),
     fundingInstrument: paramToSet(params.fundingInstrument),
+    eligibility: paramToSet(params.eligibility),
+    agency: paramToSet(params.agency),
+    category: paramToSet(params.category),
     sortby: params.sortby || null, // Convert empty string to null if needed
 
     // Ensure page is at least 1 or default to 1 if undefined

--- a/frontend/tests/api/SearchOpportunityApi.test.ts
+++ b/frontend/tests/api/SearchOpportunityApi.test.ts
@@ -52,6 +52,8 @@ describe("SearchOpportunityAPI", () => {
         status: new Set(["forecasted", "posted"]),
         fundingInstrument: new Set(["grant", "cooperative_agreement"]),
         agency: new Set(),
+        category: new Set(),
+        eligibility: new Set(),
         query: "research",
         sortby: "opportunityNumberAsc",
       };

--- a/frontend/tests/hooks/useSearchFormState.test.ts
+++ b/frontend/tests/hooks/useSearchFormState.test.ts
@@ -37,6 +37,8 @@ describe("useSearchFormState", () => {
     page: 1,
     agency: new Set(["NASA"]),
     fundingInstrument: new Set(["grant"]),
+    eligibility: new Set(),
+    category: new Set(),
   };
 
   it("initializes with the correct search results", () => {


### PR DESCRIPTION
## Summary
Fixes #1593 

### Time to review: 5-10 mins

## Changes proposed
- Add  eligibility and category filters
    - working with API request, checked boxes load with initial query params, and results actually filter based on values   

## Context for reviewers
- `category` in the frontend becomes `funding_category` for the API request
- `elgibility` in the frontend becomes `applicant_type` for the API request



https://github.com/HHS/simpler-grants-gov/assets/93001277/2a4afc2a-b566-45a9-a95d-ea6d1f81da60



