### PR TITLE
[Issue #1548] Update Oracle SFN logs

### DIFF
--- a/infra/api/service/copy_oracle_data.tf
+++ b/infra/api/service/copy_oracle_data.tf
@@ -1,3 +1,14 @@
+# docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group
+resource "aws_cloudwatch_log_group" "copy_oracle_data" {
+  name_prefix = "/aws/vendedlogs/states/${local.service_name}-copy-oracle-data"
+
+  # Conservatively retain logs for 5 years.
+  # Looser requirements may allow shorter retention periods
+  retention_in_days = 1827
+
+  # checkov:skip=CKV_AWS_158:skip requirement to encrypt with customer managed KMS key
+}
+
 # docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sfn_state_machine
 resource "aws_sfn_state_machine" "copy_oracle_data" {
 
@@ -48,7 +59,7 @@ resource "aws_sfn_state_machine" "copy_oracle_data" {
   })
 
   logging_configuration {
-    log_destination        = "${module.service.service_logs_arn}:*"
+    log_destination        = "${aws_cloudwatch_log_group.copy_oracle_data.arn}:*"
     include_execution_data = true
     level                  = "ERROR"
   }


### PR DESCRIPTION
## Summary

Relates to #1548

### Time to review: __1 mins__

## Changes proposed

- added `aws_cloudwatch_log_group` to fix an error:

> Error: creating Step Functions State Machine (...): InvalidLoggingConfiguration: Invalid Logging Configuration: The CloudWatch Logs Resource Policy size was exceeded. We suggest prefixing your CloudWatch log group name with /aws/vendedlogs/states/.

This error occurs periodically (eg. not every time) when trying to deploy this configuration

## Context for reviewers

This change originated in https://github.com/HHS/simpler-grants-gov/pull/1604