### PR TITLE
[Issue #1446] Fix `make login-db` to set schema path

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -256,8 +256,9 @@ setup-foreign-tables:
 login: start ## Start shell in running container
 	docker exec -it $(APP_NAME) bash
 
+DB_URI := postgresql://$(DB_USER)@$(DB_HOST):$(DB_PORT)/$(DB_NAME)?options=-csearch_path%3dapi
 login-db: ## Start psql with project environment variables
-	PGPASSWORD=$$DB_PASSWORD psql --host=$$DB_HOST --port=$$DB_PORT --username=$$DB_USER $$DB_NAME
+	PGPASSWORD=$$DB_PASSWORD psql $(DB_URI)
 
 console: ## Start interactive Python console
 	$(PY_RUN_CMD) python3 -i -m src.tool.console.interactive


### PR DESCRIPTION
## Summary
Fixes #1446

### Time to review: __1 mins__

## Changes proposed

- Fix `make login-db` to set the schema search path.

## Context for reviewers

Follow up to #1444 and #1520 so that `make login-db` sets the schema search path to `api`

## Additional information

Example of `make login-db` followed by `\dt` (list tables):

![Screenshot 2024-04-03 at 17 24 38](https://github.com/HHS/simpler-grants-gov/assets/3811269/222996da-02d2-4283-9290-35caf3e55a9b)
