### PR TITLE
[Issue #1625] Deploy to staging and prod, fix path

### DIFF
--- a/analytics/Makefile
+++ b/analytics/Makefile
@@ -7,6 +7,7 @@ REPO ?= simpler-grants-gov
 SPRINT_PROJECT ?= 13
 SPRINT_FILE ?= data/sprint-data.json
 ISSUE_FILE ?= data/issue-data.json
+OUTPUT_DIR ?= data
 SPRINT ?= @current
 UNIT ?= points
 ACTION ?= show-results
@@ -159,6 +160,7 @@ sprint-burndown:
 	$(POETRY) analytics calculate sprint_burndown \
 	--sprint-file $(SPRINT_FILE) \
 	--issue-file $(ISSUE_FILE) \
+	--output-dir $(OUTPUT_DIR) \
 	--sprint  "$(SPRINT)" \
 	--unit $(UNIT) \
 	--$(ACTION)
@@ -169,6 +171,7 @@ percent-complete:
 	$(POETRY) analytics calculate deliverable_percent_complete \
 	--sprint-file $(SPRINT_FILE) \
 	--issue-file $(ISSUE_FILE) \
+	--output-dir $(OUTPUT_DIR) \
 	--unit $(UNIT) \
 	--$(ACTION)
 

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -1,6 +1,7 @@
 # pylint: disable=C0415
 """Expose a series of CLI entrypoints for the analytics package."""
 from typing import Annotated, Optional
+from pathlib import Path
 
 import typer
 from slack_sdk import WebClient
@@ -19,6 +20,7 @@ SPRINT_FILE_ARG = typer.Option(help="Path to file with exported sprint data")
 ISSUE_FILE_ARG = typer.Option(help="Path to file with exported issue data")
 ROADMAP_FILE_ARG = typer.Option(help="Path to file with exported roadmap data")
 OUTPUT_FILE_ARG = typer.Option(help="Path to file where exported data will be saved")
+OUTPUT_DIR_ARG = typer.Option(help="Path to directory where output files will be saved")
 OWNER_ARG = typer.Option(help="GitHub handle of the repo or project owner")
 REPO_ARG = typer.Option(help="Name of the GitHub repo")
 PROJECT_ARG = typer.Option(help="Number of the GitHub project")
@@ -75,6 +77,7 @@ def calculate_sprint_burndown(
     *,  # makes the following args keyword only
     show_results: Annotated[bool, SHOW_RESULTS_ARG] = False,
     post_results: Annotated[bool, POST_RESULTS_ARG] = False,
+    output_dir: Annotated[str, OUTPUT_DIR_ARG] = "data",
 ) -> None:
     """Calculate the burndown for a particular sprint."""
     # load the input data
@@ -88,6 +91,7 @@ def calculate_sprint_burndown(
         metric=burndown,
         show_results=show_results,
         post_results=post_results,
+        output_dir=output_dir,
     )
 
 
@@ -100,6 +104,7 @@ def calculate_sprint_burnup(
     *,  # makes the following args keyword only
     show_results: Annotated[bool, SHOW_RESULTS_ARG] = False,
     post_results: Annotated[bool, POST_RESULTS_ARG] = False,
+    output_dir: Annotated[str, OUTPUT_DIR_ARG] = "data",
 ) -> None:
     """Calculate the burnup of a particular sprint."""
     # load the input data
@@ -113,6 +118,7 @@ def calculate_sprint_burnup(
         metric=burnup,
         show_results=show_results,
         post_results=post_results,
+        output_dir=output_dir,
     )
 
 
@@ -126,6 +132,7 @@ def calculate_deliverable_percent_complete(
     *,  # makes the following args keyword only
     show_results: Annotated[bool, SHOW_RESULTS_ARG] = False,
     post_results: Annotated[bool, POST_RESULTS_ARG] = False,
+    output_dir: Annotated[str, OUTPUT_DIR_ARG] = "data",
     roadmap_file: Annotated[Optional[str], ROADMAP_FILE_ARG] = None,  # noqa: UP007
     include_status: Annotated[Optional[list[str]], STATUS_ARG] = None,  # noqa: UP007
 ) -> None:
@@ -153,6 +160,7 @@ def calculate_deliverable_percent_complete(
         metric=metric,
         show_results=show_results,
         post_results=post_results,
+        output_dir=output_dir,
     )
 
 
@@ -161,6 +169,7 @@ def show_and_or_post_results(
     *,  # makes the following args keyword only
     show_results: bool,
     post_results: bool,
+    output_dir: str,
 ) -> None:
     """Optionally show the results of a metric and/or post them to slack."""
     # defer load of settings until this command is called
@@ -175,6 +184,5 @@ def show_and_or_post_results(
     if post_results:
         slackbot = slack.SlackBot(client=WebClient(token=settings.slack_bot_token))
         metric.post_results_to_slack(
-            slackbot=slackbot,
-            channel_id=settings.reporting_channel_id,
+            slackbot=slackbot, channel_id=settings.reporting_channel_id, output_dir=Path(output_dir)
         )

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -1,7 +1,7 @@
 # pylint: disable=C0415
 """Expose a series of CLI entrypoints for the analytics package."""
-from typing import Annotated, Optional
 from pathlib import Path
+from typing import Annotated, Optional
 
 import typer
 from slack_sdk import WebClient
@@ -184,5 +184,7 @@ def show_and_or_post_results(
     if post_results:
         slackbot = slack.SlackBot(client=WebClient(token=settings.slack_bot_token))
         metric.post_results_to_slack(
-            slackbot=slackbot, channel_id=settings.reporting_channel_id, output_dir=Path(output_dir)
+            slackbot=slackbot,
+            channel_id=settings.reporting_channel_id,
+            output_dir=Path(output_dir),
         )

--- a/infra/analytics/database/prod.s3.tfbackend
+++ b/infra/analytics/database/prod.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/analytics/database/prod.tfstate"
+dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
+region         = "us-east-1"

--- a/infra/analytics/database/staging.s3.tfbackend
+++ b/infra/analytics/database/staging.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/analytics/database/staging.tfstate"
+dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
+region         = "us-east-1"

--- a/infra/analytics/service/prod.s3.tfbackend
+++ b/infra/analytics/service/prod.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/analytics/service/prod.tfstate"
+dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
+region         = "us-east-1"

--- a/infra/analytics/service/sfn_sprint_reports.tf
+++ b/infra/analytics/service/sfn_sprint_reports.tf
@@ -48,6 +48,10 @@ resource "aws_sfn_state_machine" "sprint_reports" {
                   {
                     "Name" : "ISSUE_FILE",
                     "Value" : "/tmp/issue-data.json",
+                  },
+                  {
+                    "Name" : "OUTPUT_DIR",
+                    "Value" : "/tmp/",
                   }
                 ]
                 "Command" : [

--- a/infra/analytics/service/staging.s3.tfbackend
+++ b/infra/analytics/service/staging.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/analytics/service/staging.tfstate"
+dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
+region         = "us-east-1"


### PR DESCRIPTION
## Summary
Fixes #1625

### Time to review: __2 mins__

## Changes proposed

- fixes an instance of a path being hardcoded to `./data`
- adds staging and prod terraform configuration

## Testing

### staging

Staging step function running successfully:

<img width="883" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/5768468/253c2498-5964-41d8-af8b-5452b526fcb2">

output is here: https://betagrantsgov.slack.com/archives/C06L7JGT9M0/p1712613628944219

### prod

Prod step function running successfully:

<img width="886" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/5768468/6cf1b53e-ab97-419f-9d19-0f2e1b65c07e">

output is here: https://betagrantsgov.slack.com/archives/C064Y8VNW14/p1712613702615029