### PR TITLE
Issue 823 linter for milestones

### DIFF
--- a/.github/linters/queries/get-deliverable-options.graphql
+++ b/.github/linters/queries/get-deliverable-options.graphql
@@ -1,0 +1,16 @@
+query ($login: String!, $project: Int!) {
+  organization(login: $login) {
+    projectV2(number: $project) {
+      # fetch the list of options for the "Deliverable" field
+      field(name: "Deliverable") {
+        # for each option, get its id and name
+        ... on ProjectV2SingleSelectField {
+          options {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/linters/queries/get-project-milestones.graphql
+++ b/.github/linters/queries/get-project-milestones.graphql
@@ -1,0 +1,42 @@
+query ($endCursor: String, $login: String!, $project: Int!, $batch: Int!) {
+  # get the project by the user login and project number
+  organization(login: $login) {
+    projectV2(number: $project) {
+      # insert the projectFields fragment below
+      ...projectFields
+    }
+  }
+}
+
+fragment projectFields on ProjectV2 {
+  # get project items in batches of 100, which is the match batch size
+  items(first: $batch, after: $endCursor) {
+    # allows us to use --paginate in the gh api call
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+
+    # fetch details per item in the list
+    nodes {
+      # fetch the id of the project item
+      id
+
+      # fetch the value of the deliverable column
+      deliverable: fieldValueByName(name: "Deliverable") {
+        ... on ProjectV2ItemFieldSingleSelectValue {
+          name
+        }
+      }
+
+      # fetch the URL of the milestone associated with the project item
+      milestone: fieldValueByName(name: "Milestone") {
+        ... on ProjectV2ItemFieldMilestoneValue {
+          milestone {
+            url
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/linters/scripts/update-deliverable-values.sh
+++ b/.github/linters/scripts/update-deliverable-values.sh
@@ -1,0 +1,124 @@
+#! /bin/bash
+# Usage: ./scripts/update-deliverable-values.sh --dry-run
+# Updates
+
+# parse command line args with format `--option arg`
+# see this stack overflow for more details:
+# https://stackoverflow.com/a/14203146/7338319
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dry-run)
+      echo "Running in dry run mode"
+      DRY_RUN=YES
+      shift # past argument
+      ;;
+    --batch)
+      BATCH="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --org)
+      ORG="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --status)
+      STATUS="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --roadmap-project)
+      ROADMAP_PROJECT="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    --sprint-project)
+      SPRINT_PROJECT="$2"
+      shift # past argument
+      shift # past value
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+
+
+# set script-specific variables
+mkdir -p tmp
+roadmap_milestones_file="./tmp/roadmap-milestones.json"
+sprint_milestones_file="./tmp/sprint-milestones.json"
+deliverable_options_file="./tmp/deliverable-options.json"
+milestone_query=$(cat ./queries/get-project-milestones.graphql)
+deliverable_query=$(cat ./queries/get-deliverable-options.graphql)
+
+# print the parsed variables for debugging
+
+# get all tickets from the product roadmap project with their
+# milestone and their value for the deliverable column
+echo "Exporting milestones and deliverables from the GitHub project: ${ORG}/${ROADMAP_PROJECT}"
+gh api graphql \
+ --paginate \
+ --field login="${ORG}" \
+ --field project="${ROADMAP_PROJECT}" \
+ --field batch="${BATCH}" \
+ -f query="${milestone_query}" \
+ --jq ".data.organization.projectV2.items.nodes" |\
+ # combine results into a single array
+ jq --slurp 'add' |\
+ # convert results into a map from milestone URL to its parent deliverable
+ jq "[ .[]
+    # select project items that have a deliverable and milestone set
+    | select((.deliverable) and (.milestone))
+    # map milestone URL to the name of the deliverable column value
+    | {(.milestone.milestone.url): .deliverable.name} ]
+    # combine list of objects into a single object
+    | add" > $roadmap_milestones_file
+
+# get id and name for the options in the deliverable column in the sprint board
+# we'll use this to map the milestones to the deliverable value in that project
+echo "Exporting deliverables options from the GitHub project: ${ORG}/${SPRINT_PROJECT}"
+gh api graphql \
+ --paginate \
+ --field login="${ORG}" \
+ --field project="${SPRINT_PROJECT}" \
+ -f query="${deliverable_query}" \
+ --jq "[ .data.organization.projectV2.field.options[] | {(.name): .id} ] | add" \
+ > $deliverable_options_file
+
+# get issues
+echo "Exporting milestones and deliverables from the GitHub project: ${ORG}/${SPRINT_PROJECT}"
+gh api graphql \
+ --paginate \
+ --field login="${ORG}" \
+ --field project="${SPRINT_PROJECT}" \
+ --field batch="${BATCH}" \
+ -f query="${milestone_query}" \
+ --jq ".data.organization.projectV2.items.nodes" |\
+ # combine results into a single array
+ jq --slurp 'add' |\
+ # convert results into an array of objects with the following structure:
+ # {
+ #    milestone: "<milestone-url>",
+ #    items: [
+ #      {id: "<item-id>", deliverable: "<deliverable-name>"},
+ #      {id: "<item-id>", deliverable: "<deliverable-name>"}
+ #    ]
+ # }
+ jq "[ .[]
+    # select project items that are open and have a deliverable and milestone set
+    | select((.deliverable) and (.milestone) and (.status.name != \"${STATUS}\")) ]
+    # group by milestone
+    | group_by(.milestone.milestone.url)
+    # reformat so it returns a list of objects with a milestone and items key
+    | map(
+        {
+            milestone: .[0].milestone.milestone.url,
+            items: map({id: .id, deliverable: .deliverable.name})
+        }
+    )" > $sprint_milestones_file

--- a/.github/workflows/lint-create-milestone-for-10k.yml
+++ b/.github/workflows/lint-create-milestone-for-10k.yml
@@ -1,0 +1,40 @@
+name: Lint - Create milestone for 10k
+
+# run when an issue is opened or when a new label is applied
+on:
+  issues:
+    types: [opened, labeled]
+
+# avoid duplicate runs when an issue is created with a label
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  create-milestone:
+    name: Create milestone for 10k issue
+    # only run this if the issue has the 'deliverable: 10k' label and is *not* assigned to a milestone
+    if: "${{ contains(github.event.issue.labels.*.name, 'deliverable: 10k ft') && (! github.event.issue.milestone) }}"
+    runs-on: ubuntu-latest
+
+    # set permissions of automatically created GitHub token to issue: write
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      ISSUE_TITLE: ${{ github.event.issue.title }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+    # create the milestone using the issue title then assign the issue to that milestone
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create the milestone
+        run: |
+          gh api \
+            --method POST \
+            /repos/$REPO/milestones \
+            -f title="${ISSUE_TITLE}"
+      - name: Assign issue to milestone
+        run: |
+          gh issue edit $ISSUE_NUMBER --milestone "${ISSUE_TITLE}" --repo $REPO


### PR DESCRIPTION
## Summary

Creates a set of linting scripts for GitHub milestones and their associated deliverables.

Fixes #823 

### Time to review: __10 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Adds GitHub action that automatically creates a milestone when a new 10k ft GitHub issue is created
- Creates a script that automatically updates the value of the "deliverable" column for a given ticket based on the milestone it's assigned to

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

