### PR TITLE
[Issue #1082] transform proof-of-concept as SQL

### DIFF
--- a/api/src/data_migration/transform.sql
+++ b/api/src/data_migration/transform.sql
@@ -1,0 +1,80 @@
+--
+-- Transform queries as SQL.
+--
+
+-- ----------------------------------------------------------------------------
+-- Insert new records.
+WITH transformed_source AS (
+    SELECT
+      f.opportunity_id::BIGINT,
+      f.oppnumber::TEXT AS opportunity_number,
+      f.opptitle::TEXT AS opportunity_title,
+      f.owningagency::TEXT AS agency,
+      CASE f.oppcategory
+        WHEN 'D' THEN 1
+        WHEN 'M' THEN 2
+        WHEN 'C' THEN 3
+        WHEN 'E' THEN 4
+        WHEN 'O' THEN 5
+      END AS opportunity_category_id,
+      f.category_explanation::TEXT AS category_explanation,
+      f.is_draft = 'Y' AS is_draft,
+      f.revision_number::INTEGER AS revision_number,
+      f.modified_comments::TEXT AS modified_comments,
+      f.publisheruid::TEXT AS publisher_user_id,
+      f.publisher_profile_id::BIGINT AS publisher_profile_id
+    FROM
+      api.foreign_topportunity f
+)
+INSERT INTO api.opportunity
+SELECT * FROM transformed_source
+WHERE opportunity_id NOT IN (SELECT opportunity_id FROM api.opportunity);
+
+-- ----------------------------------------------------------------------------
+-- Update existing records.
+WITH transformed_source AS (
+    SELECT
+      f.opportunity_id::BIGINT,
+      f.oppnumber::TEXT AS opportunity_number,
+      f.opptitle::TEXT AS opportunity_title,
+      f.owningagency::TEXT AS agency,
+      CASE f.oppcategory
+        WHEN 'D' THEN 1
+        WHEN 'M' THEN 2
+        WHEN 'C' THEN 3
+        WHEN 'E' THEN 4
+        WHEN 'O' THEN 5
+      END AS opportunity_category_id,
+      f.category_explanation::TEXT AS category_explanation,
+      f.is_draft = 'Y' AS is_draft,
+      f.revision_number::INTEGER AS revision_number,
+      f.modified_comments::TEXT AS modified_comments,
+      f.publisheruid::TEXT AS publisher_user_id,
+      f.publisher_profile_id::BIGINT AS publisher_profile_id
+    FROM
+      api.foreign_topportunity f
+),
+current_data AS (
+    SELECT opportunity_id, opportunity_number, opportunity_title, agency,
+    opportunity_category_id, category_explanation, is_draft,
+    revision_number::INTEGER, modified_comments, publisher_user_id, publisher_profile_id
+    FROM api.opportunity
+),
+updated_opportunities AS (
+    (SELECT * FROM transformed_source WHERE opportunity_id IN (SELECT opportunity_id FROM current_data))
+    EXCEPT
+    (SELECT * FROM current_data)
+)
+UPDATE api.opportunity opp
+SET opportunity_title       = updated_opportunities.opportunity_title,
+    agency                  = updated_opportunities.agency,
+    opportunity_category_id = updated_opportunities.opportunity_category_id,
+    category_explanation    = updated_opportunities.category_explanation,
+    is_draft                = updated_opportunities.is_draft,
+    revision_number         = updated_opportunities.revision_number,
+    modified_comments       = updated_opportunities.modified_comments,
+    publisher_user_id       = updated_opportunities.publisher_user_id,
+    publisher_profile_id    = updated_opportunities.publisher_profile_id,
+    updated_at              = CURRENT_TIMESTAMP
+FROM updated_opportunities
+WHERE opp.opportunity_id = updated_opportunities.opportunity_id;


### PR DESCRIPTION
## Summary
Fixes #1082

### Time to review: __x mins__

## Changes proposed

- Transform queries as SQL.

## Context for reviewers

Draft SQL queries to update the `opportunity` table from `foreign_topportunity`.

1. An insert query looks for new `opportunity_id`s and inserts them.
2. An update query looks for `opportunity_id`s that exists in both the source and destination, but have changes. The comparison is done using `EXCEPT` to remove unchanged data from the possible updates.

## Additional information

Example of how these work.

First, the database was cleaned using `TRUNCATE api.opportunity CASCADE; TRUNCATE api.foreign_topportunity;`.

Test data generated using `make db-seed-local-source-tables` (100,000 rows in `foreign_topportunity`).

Running the insert query:
![Screenshot 2024-04-15 at 17 00 11](https://github.com/HHS/simpler-grants-gov/assets/3811269/324c25e4-1d72-461d-bb1d-9c20696a2302)

Run `make db-seed-local-source-tables` again (2,000 new rows, and approx 1% updated).

Run both the insert and update queries:
![Screenshot 2024-04-15 at 17 02 06](https://github.com/HHS/simpler-grants-gov/assets/3811269/3321c969-b0f5-442e-b8a5-803265967daa)
![Screenshot 2024-04-15 at 17 02 31](https://github.com/HHS/simpler-grants-gov/assets/3811269/882de6b6-c543-4d48-98e6-927148476478)

For example `opportunity_id = 1` was updated:
![Screenshot 2024-04-15 at 17 02 51](https://github.com/HHS/simpler-grants-gov/assets/3811269/3d8efd18-4ebd-4a41-b5e6-4ce6351c1b3f)

Breakdown of rows by `created_at` and `updated_at` looks good:
![Screenshot 2024-04-15 at 17 03 40](https://github.com/HHS/simpler-grants-gov/assets/3811269/55011ff4-6e83-4886-8571-df8b626e78ab)
