### PR TITLE
[Issue #1521]: fix API_AUTH_TOKEN clash between backend and frontend

### DIFF
--- a/infra/api/app-config/env-config/environment-variables.tf
+++ b/infra/api/app-config/env-config/environment-variables.tf
@@ -14,10 +14,9 @@ locals {
   # store. Configurations are of the format
   # { name = "ENV_VAR_NAME", ssm_param_name = "/ssm/param/name" }
   secrets = [
-    # Example secret
-    # {
-    #   name           = "SECRET_SAUCE"
-    #   ssm_param_name = "/${var.app_name}-${var.environment}/secret-sauce"
-    # }
+    {
+      name           = "API_AUTH_TOKEN"
+      ssm_param_name = "/api/${var.environment}/api-auth-token"
+    }
   ]
 }

--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -31,12 +31,6 @@ output "incident_management_service_integration" {
   } : null
 }
 
-output "api_auth_token" {
-  value = {
-    api_auth_token_param_name = "/api/${var.environment}/api-auth-token"
-  }
-}
-
 output "domain" {
   value = var.domain
 }

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -50,7 +50,6 @@ locals {
   service_config                                 = local.environment_config.service_config
   database_config                                = local.environment_config.database_config
   incident_management_service_integration_config = local.environment_config.incident_management_service_integration
-  api_auth_token_config                          = local.environment_config.api_auth_token
   domain                                         = local.environment_config.domain
 }
 
@@ -111,10 +110,6 @@ data "aws_ssm_parameter" "incident_management_service_integration_url" {
   name  = local.incident_management_service_integration_config.integration_url_param_name
 }
 
-data "aws_ssm_parameter" "api_auth_token" {
-  name = local.api_auth_token_config.api_auth_token_param_name
-}
-
 module "service" {
   source                = "../../modules/service"
   service_name          = local.service_name
@@ -127,8 +122,7 @@ module "service" {
   cpu                   = 1024
   memory                = 2048
 
-  api_auth_token = data.aws_ssm_parameter.api_auth_token.value
-  cert_arn       = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
+  cert_arn = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
 
   db_vars = module.app_config.has_database ? {
     security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -16,7 +16,6 @@ locals {
   base_environment_variables = concat([
     { name : "PORT", value : tostring(var.container_port) },
     { name : "AWS_REGION", value : data.aws_region.current.name },
-    { name : "API_AUTH_TOKEN", value : var.api_auth_token },
   ], local.hostname)
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -124,12 +124,6 @@ variable "min_capacity" {
   default     = 2
 }
 
-variable "api_auth_token" {
-  type        = string
-  default     = null
-  description = "Auth token for connecting to the API"
-}
-
 variable "is_temporary" {
   description = "Whether the service is meant to be spun up temporarily (e.g. for automated infra tests). This is used to disable deletion protection for the load balancer."
   type        = bool

--- a/infra/modules/task-service/main.tf
+++ b/infra/modules/task-service/main.tf
@@ -16,7 +16,6 @@ locals {
   base_environment_variables = concat([
     { name : "PORT", value : tostring(var.container_port) },
     { name : "AWS_REGION", value : data.aws_region.current.name },
-    { name : "API_AUTH_TOKEN", value : var.api_auth_token },
   ], local.hostname)
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },

--- a/infra/modules/task-service/variables.tf
+++ b/infra/modules/task-service/variables.tf
@@ -124,12 +124,6 @@ variable "min_capacity" {
   default     = 2
 }
 
-variable "api_auth_token" {
-  type        = string
-  default     = null
-  description = "Auth token for connecting to the API"
-}
-
 variable "is_temporary" {
   description = "Whether the service is meant to be spun up temporarily (e.g. for automated infra tests). This is used to disable deletion protection for the load balancer."
   type        = bool


### PR DESCRIPTION
## Summary

Fixes #1521

### Time to review: __2 mins__

## Context

Both `infra/api` and `infra/frontend` were defining a variable called `API_AUTH_TOKEN`. The way they were defined made them clash, leading to the following error message:

> Error: creating ECS Task Definition (frontend-dev): ClientException: The secret name must be unique and not shared with any new or existing environment variables set on the container, such as 'API_AUTH_TOKEN'

## Changes proposed

Refactors the terraform configuration so the `API_AUTH_TOKEN` definition is no longer clashing between the frontend and backend

## Testing

I have already deployed both the API and the frontend to dev to test that this is working.