### PR TITLE
[Issue #1842]: Add jest coverage report in PR

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -49,9 +49,9 @@ jobs:
       - run: npm run test -- --testLocationInResults --json --outputFile=coverage/report.json
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-            coverage-file: coverage/report.json
+            coverage-file: coverage/coverage-final.json
             test-script: npm test
-            working-directory: ./
+            working-directory: ./frontend
             annotations: failed-tests
 
       - name: Run e2e tests

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -46,8 +46,13 @@ jobs:
       - name: Run format
         run: npm run format-check
 
-      - name: Run tests
-        run: npm run test
+      - run: npm run test -- --testLocationInResults --json --outputFile=coverage/report.json
+      - uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+            coverage-file: coverage/report.json
+            test-script: npm test
+            working-directory: ./
+            annotations: failed-tests
 
       - name: Run e2e tests
         run: npm run test:e2e

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -49,10 +49,14 @@ jobs:
       - run: npm run test -- --testLocationInResults --json --outputFile=coverage/report.json
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-            coverage-file: coverage/coverage-final.json
+            coverage-file: coverage/report.json
             test-script: npm test
             working-directory: ./frontend
             annotations: failed-tests
+            package-manager: npm
+            icons: emoji
+            skip-step: none
+            output: comment
 
       - name: Run e2e tests
         run: npm run test:e2e


### PR DESCRIPTION
## Summary
Fixes #1842

### Time to review: 2 min

## Changes proposed
- update workflow to use jest coverage report 
https://github.com/marketplace/actions/jest-coverage-report



I believe subsequent PRs should show the diffs in coverage report that the respective PR introduces -  for example this is a snapshot of a PR from the template project 
![image](https://github.com/HHS/simpler-grants-gov/assets/93001277/3e52b5eb-905f-485d-b35e-3c56302b2324)

* this is a much smaller project so it's easier over there to get above 90% coverage
