### PR TITLE
[Issue #1597] Add analytics local docker database

### DIFF
--- a/analytics/docker-compose.yml
+++ b/analytics/docker-compose.yml
@@ -2,6 +2,16 @@ version: '3'
 
 services:
 
+  grants-analytics-db:
+    image: postgres:14-alpine
+    container_name: grants-analytics-db
+    command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
+    env_file: ./local.env
+    ports:
+      - "5432:5432"
+    volumes:
+      - grantsanalyticsdbdata:/var/lib/postgresql/data
+
   grants-analytics:
     build:
       context: .
@@ -13,3 +23,8 @@ services:
     volumes:
       - .:/analytics
       - ~/.ssh:/home/${RUN_USER:-analytics}/.ssh
+    depends_on:
+      - grants-analytics-db
+
+volumes:
+  grantsanalyticsdbdata:

--- a/analytics/docker-compose.yml
+++ b/analytics/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   grants-analytics-db:
-    image: postgres:14-alpine
+    image: postgres:15-alpine
     container_name: grants-analytics-db
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     env_file: ./local.env

--- a/analytics/local.env
+++ b/analytics/local.env
@@ -7,7 +7,7 @@ POSTGRES_USER=app
 POSTGRES_PASSWORD=secret123
 
 # Set DB_HOST to localhost if accessing a non-dockerized database
-DB_HOST=grants-db
+DB_HOST=grants-analytics-db
 DB_NAME=app
 DB_USER=app
 DB_PASSWORD=secret123

--- a/analytics/local.env
+++ b/analytics/local.env
@@ -1,0 +1,19 @@
+############################
+# DB Environment Variables
+############################
+
+# These are used by the Postgres image to create the admin user
+POSTGRES_USER=app
+POSTGRES_PASSWORD=secret123
+
+# Set DB_HOST to localhost if accessing a non-dockerized database
+DB_HOST=grants-db
+DB_NAME=app
+DB_USER=app
+DB_PASSWORD=secret123
+DB_SSL_MODE=allow
+
+# When an error occurs with a SQL query,
+# whether or not to hide the parameters which
+# could contain sensitive information.
+HIDE_SQL_PARAMETER_LOGS=TRUE


### PR DESCRIPTION
## Summary

Fixes https://github.com/HHS/simpler-grants-gov/issues/1597

### Time to review: __1 mins__

## Changes proposed

Adds a dockerized postgres database for the analytics service to connect to. Does not yet actually connect to that database, that'll come in future PRs.

## Testing

```bash
$ docker compose up
```

```bash
$ psql postgresql://app:secret123@localhost:5432/app
```