### PR TITLE
[Task 1871] Finish configuring WAF

### DIFF
--- a/infra/modules/service/waf.tf
+++ b/infra/modules/service/waf.tf
@@ -201,6 +201,34 @@ resource "aws_wafv2_web_acl_logging_configuration" "WafWebAclLogging" {
   ]
 }
 
+resource "aws_cloudwatch_log_resource_policy" "WafWebAclLoggingPolicy" {
+  policy_document = data.aws_iam_policy_document.WafWebAclLoggingDoc.json
+  policy_name     = "service-webacl-policy"
+}
+
+# Policy from terraform docs
+data "aws_iam_policy_document" "WafWebAclLoggingDoc" {
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["${aws_cloudwatch_log_group.WafWebAclLoggroup.arn}:*"]
+    condition {
+      test     = "ArnLike"
+      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      variable = "aws:SourceArn"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [tostring(data.aws_caller_identity.current.account_id)]
+      variable = "aws:SourceAccount"
+    }
+  }
+}
+
 # Associate WAF with load balancer
 resource "aws_wafv2_web_acl_association" "WafWebAclAssociation" {
   resource_arn = aws_lb.alb.arn


### PR DESCRIPTION
## Summary
Fixes #1871 

### Time to review: __x mins__

## Changes proposed
* add policy for cloudwatch logging group

## Context for reviewers
This has been a recurring issue with the `aws_wafv2_web_acl_logging_configuration` resource for quite some time. For context, the WAF service will automatically create its own associated policy (it's called `WAF-LOGS` or something like that).

This policy doesn't appear to get "cleaned up", etc if its created automatically, which means, if the aws account is either:
1. constantly creating new ACLs
2. has a lot of ACLs to begin with

The policy will end up exceeding its maximum size and prevent the resource from being created. This is what's currently breaking deploys related to the frontend and metabase.

## Additional information
[Terraform Docs explaining the workaround](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration.html#with-cloudwatch-log-group-and-managed-cloudwatch-log-resource-policy)
[Terraform github issue with more details](https://github.com/hashicorp/terraform-provider-aws/issues/25296)

Terraform plan `frontend/service` ran locally in staging (success):

```

Terraform will perform the following actions:

  # module.service.aws_cloudwatch_log_resource_policy.WafWebAclLoggingPolicy will be created
  + resource "aws_cloudwatch_log_resource_policy" "WafWebAclLoggingPolicy" {
      + id              = (known after apply)
      + policy_document = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "logs:PutLogEvents",
                          + "logs:CreateLogStream",
                        ]
                      + Condition = {
                          + ArnLike      = {
                              + "aws:SourceArn" = "arn:aws:logs:us-east-1:315341936575:*"
                            }
                          + StringEquals = {
                              + "aws:SourceAccount" = "315341936575"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "delivery.logs.amazonaws.com"
                        }
                      + Resource  = "arn:aws:logs:us-east-1:315341936575:log-group:aws-waf-logs-wafv2-web-acl-frontend-staging:*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_name     = "service-webacl-policy"
    }

  # module.service.aws_ecs_service.app will be updated in-place
  ~ resource "aws_ecs_service" "app" {
        id                                 = "arn:aws:ecs:us-east-1:315341936575:service/frontend-staging/frontend-staging"
        name                               = "frontend-staging"
        tags                               = {}
      ~ task_definition                    = "arn:aws:ecs:us-east-1:315341936575:task-definition/frontend-staging:22" -> (known after apply)
        # (15 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # module.service.aws_ecs_task_definition.app must be replaced
-/+ resource "aws_ecs_task_definition" "app" {
      ~ arn                      = "arn:aws:ecs:us-east-1:315341936575:task-definition/frontend-staging:22" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:315341936575:task-definition/frontend-staging" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  ~ linuxParameters        = {
                      ~ capabilities       = {
                          - add  = []
                            # (1 unchanged attribute hidden)
                        }
                        # (1 unchanged attribute hidden)
                    }
                  - mountPoints            = []
                    name                   = "frontend-staging"
                  ~ portMappings           = [
                      ~ {
                          - hostPort      = 8000
                          - protocol      = "tcp"
                            # (1 unchanged attribute hidden)
                        },
                    ]
                  - systemControls         = []
                  - volumesFrom            = []
                    # (9 unchanged attributes hidden)
                },
            ] # forces replacement
        )
      ~ id                       = "frontend-staging" -> (known after apply)
      ~ revision                 = 22 -> (known after apply)
      - tags                     = {} -> null
        # (11 unchanged attributes hidden)
    }

  # module.service.aws_wafv2_web_acl_logging_configuration.WafWebAclLogging will be created
  + resource "aws_wafv2_web_acl_logging_configuration" "WafWebAclLogging" {
      + id                      = (known after apply)
      + log_destination_configs = [
          + "arn:aws:logs:us-east-1:315341936575:log-group:aws-waf-logs-wafv2-web-acl-frontend-staging",
        ]
      + resource_arn            = "arn:aws:wafv2:us-east-1:315341936575:regional/webacl/frontend-staging-wafv2-web-acl/38a04ec9-6646-45e9-818c-8f29fa88ce0f"
    }

```

Terraform plan `analytics/metabase` (success)

```
Terraform will perform the following actions:

  # module.service.aws_cloudwatch_log_resource_policy.WafWebAclLoggingPolicy will be created
  + resource "aws_cloudwatch_log_resource_policy" "WafWebAclLoggingPolicy" {
      + id              = (known after apply)
      + policy_document = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "logs:PutLogEvents",
                          + "logs:CreateLogStream",
                        ]
                      + Condition = {
                          + ArnLike      = {
                              + "aws:SourceArn" = "arn:aws:logs:us-east-1:315341936575:*"
                            }
                          + StringEquals = {
                              + "aws:SourceAccount" = "315341936575"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "delivery.logs.amazonaws.com"
                        }
                      + Resource  = "arn:aws:logs:us-east-1:315341936575:log-group:aws-waf-logs-wafv2-web-acl-metabase-dev:*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_name     = "analytics-webacl-policy"
    }

  # module.service.aws_wafv2_web_acl_logging_configuration.WafWebAclLogging will be created
  + resource "aws_wafv2_web_acl_logging_configuration" "WafWebAclLogging" {
      + id                      = (known after apply)
      + log_destination_configs = [
          + "arn:aws:logs:us-east-1:315341936575:log-group:aws-waf-logs-wafv2-web-acl-metabase-dev",
        ]
      + resource_arn            = "arn:aws:wafv2:us-east-1:315341936575:regional/webacl/metabase-dev-wafv2-web-acl/db82e49c-a917-4e30-9a1c-a5f78749bf5a"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```