### PR TITLE
[Issue #1910] Configure a local Metabase instance

### DIFF
--- a/analytics/docker-compose.yml
+++ b/analytics/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
     - /dev/urandom:/dev/random:ro
     ports:
-      - 3000:3000
+      - 3100:3000
     env_file: ./local.env
 
 volumes:

--- a/analytics/docker-compose.yml
+++ b/analytics/docker-compose.yml
@@ -26,5 +26,14 @@ services:
     depends_on:
       - grants-analytics-db
 
+  grants-metabase:
+    image: metabase/metabase:latest
+    container_name: grants-metabase
+    volumes:
+    - /dev/urandom:/dev/random:ro
+    ports:
+      - 3000:3000
+    env_file: ./local.env
+
 volumes:
   grantsanalyticsdbdata:

--- a/analytics/local.env
+++ b/analytics/local.env
@@ -1,5 +1,5 @@
 ############################
-# DB Environment Variables
+# DB Environment Variables #
 ############################
 
 # These are used by the Postgres image to create the admin user
@@ -17,3 +17,14 @@ DB_SSL_MODE=allow
 # whether or not to hide the parameters which
 # could contain sensitive information.
 HIDE_SQL_PARAMETER_LOGS=TRUE
+
+##################################
+# Metabase Environment Variables #
+##################################
+
+MB_DB_TYPE=postgres
+MB_DB_DBNAME=app
+MB_DB_PORT=5432
+MB_DB_USER=app
+MB_DB_PASS=secret123
+MB_DB_HOST=grants-analytics-db


### PR DESCRIPTION
## Summary

Fixes https://github.com/HHS/simpler-grants-gov/issues/1910

### Time to review: __2 mins__

## Changes proposed

Adds Metabase to the analytics docker compose file

## Context for reviewers

This PR simply configures that local Metabase instance so that it stands up. It doesn't yet do anything with Metabase. Hence the lack of documentation. 

## Testing & Usage

```bash
docker compose up
```

<img width="1502" alt="image" src="https://github.com/HHS/simpler-grants-gov/assets/5768468/df7096a0-401f-411b-89fd-e09252a77698">

