### PR TITLE
[Issue #1886]: Fix duplicate id bug in SearchFilterAccordion

### DIFF
--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -115,7 +115,7 @@ export function SearchFilterAccordion({
       title: getAccordionTitle(),
       content: getAccordionContent(),
       expanded: false,
-      id: "funding-instrument-filter",
+      id: `funding-instrument-filter-${queryParamKey}`,
       headingLevel: "h4",
     },
   ];

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
@@ -108,10 +108,10 @@ describe("SearchFilterAccordion", () => {
     );
 
     const accordionToggleButton = screen.getByTestId(
-      "accordionButton_funding-instrument-filter",
+      "accordionButton_funding-instrument-filter-status",
     );
     const contentDiv = screen.getByTestId(
-      "accordionItem_funding-instrument-filter",
+      "accordionItem_funding-instrument-filter-status",
     );
     expect(contentDiv).toHaveAttribute("hidden");
 


### PR DESCRIPTION
## Summary
Fixes #1886 

### Time to review: 1 min

## Changes proposed
- add the query param key to the end of the accordion id 

## Context for reviewers
- We had duplicate id's for each accordion div - so just append the specific query param key that we use to the id

- the remaining Lighthouse a11y issue is due to the `<span>...</span>` that's in the component (only `<li>` tags are allowed inside `<ul>`) . But this is the USWDS implementation so I'm not sure if we can get around that bug? 


## Additional information
Lighthouse doesn't have this error anymore:

![image](https://github.com/HHS/simpler-grants-gov/assets/93001277/e24fa6eb-3a66-466c-95bf-21db51699888)

![image](https://github.com/HHS/simpler-grants-gov/assets/93001277/1fc98c93-871b-4f5d-8d3d-b59dd24de752)

