### PR TITLE
[Issue #1919] Deploying to (dev, or staging) fails because trying to release the same image tag twice part 1

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     strategy:
       matrix:
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
+        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev"]') || fromJSON('["dev"]') }} # temporarily removing staging from matrix. See: https://github.com/HHS/simpler-grants-gov/issues/1919
     with:
       app_name: "frontend"
       environment: ${{ matrix.envs }}


### PR DESCRIPTION
## Summary
Fixes #{ISSUE}

### Time to review: __x mins__

## Changes proposed
* temporarily remove "staging" from the frontend deployment matrix to unblock others

## Context for reviewers
> The staging deploy fails because both dev and staging try to release the same tag

## Additional information
See #1919 for more detail


