### PR TITLE
[Issue #1943] Fix variable access

### DIFF
--- a/infra/analytics/metabase/main.tf
+++ b/infra/analytics/metabase/main.tf
@@ -109,10 +109,12 @@ module "service" {
       ssm_param_name = "/metabase/${var.environment_name}/db_pass"
     },
   ]
+
+  app_access_policy_arn      = null
+  migrator_access_policy_arn = null
+
   db_vars = {
-    security_group_ids         = data.aws_rds_cluster.db_cluster.vpc_security_group_ids
-    app_access_policy_arn      = null
-    migrator_access_policy_arn = null
+    security_group_ids = data.aws_rds_cluster.db_cluster.vpc_security_group_ids
     connection_info = {
       host        = data.aws_rds_cluster.db_cluster.endpoint
       port        = data.aws_rds_cluster.db_cluster.port

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -124,10 +124,11 @@ module "service" {
 
   cert_arn = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
 
+  app_access_policy_arn      = data.aws_iam_policy.app_db_access_policy[0].arn
+  migrator_access_policy_arn = data.aws_iam_policy.migrator_db_access_policy[0].arn
+
   db_vars = module.app_config.has_database ? {
-    security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids
-    app_access_policy_arn      = data.aws_iam_policy.app_db_access_policy[0].arn
-    migrator_access_policy_arn = data.aws_iam_policy.migrator_db_access_policy[0].arn
+    security_group_ids = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids
     connection_info = {
       host        = data.aws_rds_cluster.db_cluster[0].endpoint
       port        = data.aws_rds_cluster.db_cluster[0].port

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -126,10 +126,11 @@ module "service" {
   cert_arn              = terraform.workspace == "default" ? data.aws_acm_certificate.cert[0].arn : null
   hostname              = module.app_config.hostname
 
+  app_access_policy_arn      = null
+  migrator_access_policy_arn = null
+
   db_vars = module.app_config.has_database ? {
-    security_group_ids         = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids
-    app_access_policy_arn      = data.aws_iam_policy.app_db_access_policy[0].arn
-    migrator_access_policy_arn = data.aws_iam_policy.migrator_db_access_policy[0].arn
+    security_group_ids = data.aws_rds_cluster.db_cluster[0].vpc_security_group_ids
     connection_info = {
       host        = data.aws_rds_cluster.db_cluster[0].endpoint
       port        = data.aws_rds_cluster.db_cluster[0].port

--- a/infra/modules/service/database-access.tf
+++ b/infra/modules/service/database-access.tf
@@ -15,15 +15,15 @@ resource "aws_vpc_security_group_ingress_rule" "db_ingress_from_service" {
 }
 
 resource "aws_iam_role_policy_attachment" "app_service_db_access" {
-  count = var.db_vars != null && var.db_vars.app_access_policy_arn != null ? 1 : 0
+  count = var.app_access_policy_arn != null ? 1 : 0
 
   role       = aws_iam_role.app_service.name
-  policy_arn = var.db_vars.app_access_policy_arn
+  policy_arn = var.app_access_policy_arn
 }
 
 resource "aws_iam_role_policy_attachment" "migrator_db_access" {
-  count = var.db_vars != null && var.db_vars.migrator_access_policy_arn != null ? 1 : 0
+  count = var.migrator_access_policy_arn != null ? 1 : 0
 
   role       = aws_iam_role.migrator_task[0].name
-  policy_arn = var.db_vars.migrator_access_policy_arn
+  policy_arn = var.migrator_access_policy_arn
 }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -87,9 +87,7 @@ variable "secrets" {
 variable "db_vars" {
   description = "Variables for integrating the app service with a database"
   type = object({
-    security_group_ids         = list(string)
-    app_access_policy_arn      = string
-    migrator_access_policy_arn = string
+    security_group_ids = list(string)
     connection_info = object({
       host        = string
       port        = string
@@ -99,6 +97,18 @@ variable "db_vars" {
     })
   })
   default = null
+}
+
+variable "app_access_policy_arn" {
+  description = "The ARN of the IAM policy to attach to the app service role for database access"
+  type        = string
+  default     = null
+}
+
+variable "migrator_access_policy_arn" {
+  description = "The ARN of the IAM policy to attach to the migrator task role for database access"
+  type        = string
+  default     = null
 }
 
 variable "extra_policies" {


### PR DESCRIPTION
## Summary

Fixes #1943

### Time to review: __1 mins__

## Changes proposed

Changes `app_access_policy_arn` and `migrator_access_policy_arn` to not be nested under `db_vars`

## Testing

`terraform plan` now works in the following folders:

- infra/analytics/metabase
- infra/api/service
- infra/frontend/service