### PR TITLE
[Issue #1810] add entrypoint to run load and transform tasks

### DIFF
--- a/api/src/data_migration/__init__.py
+++ b/api/src/data_migration/__init__.py
@@ -1,6 +1,6 @@
 from src.data_migration.data_migration_blueprint import data_migration_blueprint
 
-from . import command
+from . import command  # noqa: F401
 
 # import any of the other files so they get initialized and attached to the blueprint
 import src.data_migration.copy_oracle_data  # noqa: F401 E402 isort:skip

--- a/api/src/data_migration/__init__.py
+++ b/api/src/data_migration/__init__.py
@@ -1,5 +1,7 @@
 from src.data_migration.data_migration_blueprint import data_migration_blueprint
 
+from . import command
+
 # import any of the other files so they get initialized and attached to the blueprint
 import src.data_migration.copy_oracle_data  # noqa: F401 E402 isort:skip
 import src.data_migration.setup_foreign_tables  # noqa: F401 E402 isort:skip

--- a/api/src/data_migration/command/__init__.py
+++ b/api/src/data_migration/command/__init__.py
@@ -1,0 +1,2 @@
+# import all files so they get initialized and attached to the blueprint
+from . import load_transform

--- a/api/src/data_migration/command/__init__.py
+++ b/api/src/data_migration/command/__init__.py
@@ -1,2 +1,2 @@
 # import all files so they get initialized and attached to the blueprint
-from . import load_transform
+from . import load_transform  # noqa: F401

--- a/api/src/data_migration/command/load_transform.py
+++ b/api/src/data_migration/command/load_transform.py
@@ -4,6 +4,8 @@
 
 import logging
 
+import click
+
 import src.adapters.db as db
 import src.adapters.db.flask_db as flask_db
 import src.db.foreign
@@ -20,15 +22,23 @@ logger = logging.getLogger(__name__)
 @data_migration_blueprint.cli.command(
     "load-transform", help="Load and transform data from the legacy database into our database"
 )
+@click.option("--load/--no-load", default=True, help="run LoadOracleDataTask")
+@click.option("--transform/--no-transform", default=True, help="run TransformOracleDataTask")
+@click.option(
+    "--set-current/--no-set-current", default=True, help="run SetCurrentOpportunitiesTask"
+)
 @flask_db.with_db_session()
-def load_transform(db_session: db.Session) -> None:
+def load_transform(db_session: db.Session, load: bool, transform: bool, set_current: bool) -> None:
     logger.info("load and transform start")
 
     foreign_tables = {t.name: t for t in src.db.foreign.metadata.tables.values()}
     staging_tables = {t.name: t for t in src.db.models.staging.metadata.tables.values()}
 
-    LoadOracleDataTask(db_session, foreign_tables, staging_tables).run()
-    TransformOracleDataTask(db_session).run()
-    SetCurrentOpportunitiesTask(db_session).run()
+    if load:
+        LoadOracleDataTask(db_session, foreign_tables, staging_tables).run()
+    if transform:
+        TransformOracleDataTask(db_session).run()
+    if set_current:
+        SetCurrentOpportunitiesTask(db_session).run()
 
     logger.info("load and transform complete")

--- a/api/src/data_migration/command/load_transform.py
+++ b/api/src/data_migration/command/load_transform.py
@@ -1,0 +1,34 @@
+#
+# Entrypoint to load and transform data from the legacy database into our database.
+#
+
+import logging
+
+import src.adapters.db as db
+import src.adapters.db.flask_db as flask_db
+import src.db.foreign
+import src.db.models.staging
+from src.task.opportunities.set_current_opportunities_task import SetCurrentOpportunitiesTask
+
+from ..data_migration_blueprint import data_migration_blueprint
+from ..load.load_oracle_data_task import LoadOracleDataTask
+from ..transformation.transform_oracle_data_task import TransformOracleDataTask
+
+logger = logging.getLogger(__name__)
+
+
+@data_migration_blueprint.cli.command(
+    "load-transform", help="Load and transform data from the legacy database into our database"
+)
+@flask_db.with_db_session()
+def load_transform(db_session: db.Session) -> None:
+    logger.info("load and transform start")
+
+    foreign_tables = {t.name: t for t in src.db.foreign.metadata.tables.values()}
+    staging_tables = {t.name: t for t in src.db.models.staging.metadata.tables.values()}
+
+    LoadOracleDataTask(db_session, foreign_tables, staging_tables).run()
+    TransformOracleDataTask(db_session).run()
+    SetCurrentOpportunitiesTask(db_session).run()
+
+    logger.info("load and transform complete")

--- a/api/src/task/opportunities/set_current_opportunities_task.py
+++ b/api/src/task/opportunities/set_current_opportunities_task.py
@@ -27,12 +27,14 @@ logger = logging.getLogger(__name__)
 )
 @flask_db.with_db_session()
 def set_current_opportunities(db_session: db.Session) -> None:
-    SetCurrentOpportunitiesTask(db_session, get_now_us_eastern_date()).run()
+    SetCurrentOpportunitiesTask(db_session).run()
 
 
 class SetCurrentOpportunitiesTask(Task):
-    def __init__(self, db_session: db.Session, current_date: date) -> None:
+    def __init__(self, db_session: db.Session, current_date: date | None = None) -> None:
         super().__init__(db_session)
+        if current_date is None:
+            current_date = get_now_us_eastern_date()
         self.current_date = current_date
 
     class Metrics(StrEnum):


### PR DESCRIPTION
## Summary
Fixes #1810

### Time to review: __5 mins__

## Changes proposed
- Add an entrypoint that runs the 3 tasks for load and transform in series.

## Context for reviewers
The regular load and transform job runs 3 tasks in order:

1.  LoadOracleDataTask
2. TransformOracleDataTask
3. SetCurrentOpportunitiesTask

This is implemented as a flask command and can be run locally using
`poetry run flask data-migration load-transform`

## Additional information
Options are available to turn on or off each of the 3 tasks.

```
Options:
  --load / --no-load              run LoadOracleDataTask
  --transform / --no-transform    run TransformOracleDataTask
  --set-current / --no-set-current
                                  run SetCurrentOpportunitiesTask
```

![Screenshot 2024-05-08 at 12 36 49](https://github.com/HHS/simpler-grants-gov/assets/3811269/488a2045-8209-4046-986d-d55405b394ac)
