### PR TITLE
[Issue #1958]: Remove status message for 0 results

### DIFF
--- a/frontend/src/components/search/SearchResultsList.tsx
+++ b/frontend/src/components/search/SearchResultsList.tsx
@@ -34,7 +34,6 @@ const SearchResultsList: React.FC<SearchResultsListProps> = ({
     return (
       <div>
         <h2>Your search did not return any results.</h2>
-        <p>Select at least one status.</p>
         <ul>
           <li>{"Check any terms you've entered for typos"}</li>
           <li>Try different keywords</li>


### PR DESCRIPTION
## Summary
Fixes #1958 

### Time to review: 1 min

## Changes proposed
- Remove "Select at least one status..." from 0 results page



![image](https://github.com/HHS/simpler-grants-gov/assets/93001277/ef1aa526-2227-4887-8c85-f98ff1798d82)
