### PR TITLE
[Issue #1680]: rename SearchFetcherProps to QueryParamData

### DIFF
--- a/frontend/src/app/api/BaseApi.ts
+++ b/frontend/src/app/api/BaseApi.ts
@@ -18,10 +18,10 @@ import {
 } from "src/errors";
 import { compact, isEmpty } from "lodash";
 
+import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher";
 // TODO (#1682): replace search specific references (since this is a generic API file that any
 // future page or different namespace could use)
 import { SearchAPIResponse } from "../../types/search/searchResponseTypes";
-import { SearchFetcherProps } from "src/services/search/searchfetcher/SearchFetcher";
 
 export type ApiMethod = "DELETE" | "GET" | "PATCH" | "POST" | "PUT";
 export interface JSONRequestBody {
@@ -70,7 +70,7 @@ export default abstract class BaseApi {
     namespace: string,
     subPath: string,
 
-    searchInputs: SearchFetcherProps,
+    searchInputs: QueryParamData,
     body?: JSONRequestBody,
     options: {
       additionalHeaders?: HeadersDict;
@@ -110,7 +110,7 @@ export default abstract class BaseApi {
   private async sendRequest(
     url: string,
     fetchOptions: RequestInit,
-    searchInputs: SearchFetcherProps,
+    searchInputs: QueryParamData,
   ) {
     let response: Response;
     let responseBody: SearchAPIResponse;
@@ -190,7 +190,7 @@ function createRequestBody(payload?: JSONRequestBody): XMLHttpRequestBodyInit {
  */
 export function fetchErrorToNetworkError(
   error: unknown,
-  searchInputs: SearchFetcherProps,
+  searchInputs: QueryParamData,
 ) {
   // Request failed to send or something failed while parsing the response
   // Log the JS error to support troubleshooting
@@ -202,7 +202,7 @@ function handleNotOkResponse(
   response: SearchAPIResponse,
   message: string,
   status_code: number,
-  searchInputs: SearchFetcherProps,
+  searchInputs: QueryParamData,
 ) {
   const { errors } = response;
   if (isEmpty(errors)) {
@@ -219,7 +219,7 @@ function handleNotOkResponse(
 const throwError = (
   message: string,
   status_code: number,
-  searchInputs: SearchFetcherProps,
+  searchInputs: QueryParamData,
   firstError?: APIResponseError,
 ) => {
   console.log("Throwing error: ", message, status_code, searchInputs);

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -10,7 +10,7 @@ import {
 } from "../../types/search/searchRequestTypes";
 
 import BaseApi from "./BaseApi";
-import { SearchFetcherProps } from "../../services/search/searchfetcher/SearchFetcher";
+import { QueryParamData } from "../../services/search/searchfetcher/SearchFetcher";
 
 export default class SearchOpportunityAPI extends BaseApi {
   get basePath(): string {
@@ -27,7 +27,7 @@ export default class SearchOpportunityAPI extends BaseApi {
     return { ...baseHeaders, ...searchHeaders };
   }
 
-  async searchOpportunities(searchInputs: SearchFetcherProps) {
+  async searchOpportunities(searchInputs: QueryParamData) {
     const { query } = searchInputs;
     const filters = this.buildFilters(searchInputs);
     const pagination = this.buildPagination(searchInputs);
@@ -57,9 +57,7 @@ export default class SearchOpportunityAPI extends BaseApi {
   }
 
   // Build with one_of syntax
-  private buildFilters(
-    searchInputs: SearchFetcherProps,
-  ): SearchFilterRequestBody {
+  private buildFilters(searchInputs: QueryParamData): SearchFilterRequestBody {
     const { status, fundingInstrument, eligibility, agency, category } =
       searchInputs;
     const filters: SearchFilterRequestBody = {};
@@ -88,9 +86,7 @@ export default class SearchOpportunityAPI extends BaseApi {
     return filters;
   }
 
-  private buildPagination(
-    searchInputs: SearchFetcherProps,
-  ): PaginationRequestBody {
+  private buildPagination(searchInputs: QueryParamData): PaginationRequestBody {
     const { sortby, page, fieldChanged } = searchInputs;
 
     // When performing an update (query, filter, sortby change) - we want to

--- a/frontend/src/app/search/SearchForm.tsx
+++ b/frontend/src/app/search/SearchForm.tsx
@@ -5,9 +5,9 @@ import SearchPagination, {
 } from "../../components/search/SearchPagination";
 
 import { AgencyNamyLookup } from "src/utils/search/generateAgencyNameLookup";
+import { QueryParamData } from "../../services/search/searchfetcher/SearchFetcher";
 import { SearchAPIResponse } from "../../types/search/searchResponseTypes";
 import SearchBar from "../../components/search/SearchBar";
-import { SearchFetcherProps } from "../../services/search/searchfetcher/SearchFetcher";
 import SearchFilterAgency from "src/components/search/SearchFilterAgency";
 import SearchFilterCategory from "../../components/search/SearchFilterCategory";
 import SearchFilterEligibility from "../../components/search/SearchFilterEligibility";
@@ -19,7 +19,7 @@ import { useSearchFormState } from "../../hooks/useSearchFormState";
 
 interface SearchFormProps {
   initialSearchResults: SearchAPIResponse;
-  requestURLQueryParams: SearchFetcherProps;
+  requestURLQueryParams: QueryParamData;
   agencyNameLookup?: AgencyNamyLookup;
 }
 

--- a/frontend/src/app/search/error.tsx
+++ b/frontend/src/app/search/error.tsx
@@ -6,8 +6,8 @@ import {
 } from "src/types/search/searchResponseTypes";
 
 import PageSEO from "src/components/PageSEO";
+import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher";
 import SearchCallToAction from "src/components/search/SearchCallToAction";
-import { SearchFetcherProps } from "src/services/search/searchfetcher/SearchFetcher";
 import { SearchForm } from "src/app/search/SearchForm";
 import { useEffect } from "react";
 
@@ -19,7 +19,7 @@ interface ErrorProps {
 
 export interface ParsedError {
   message: string;
-  searchInputs: SearchFetcherProps;
+  searchInputs: QueryParamData;
   status: number;
   type: string;
 }
@@ -103,8 +103,8 @@ function getErrorPaginationInfo() {
 }
 
 function convertSearchInputArraysToSets(
-  searchInputs: SearchFetcherProps,
-): SearchFetcherProps {
+  searchInputs: QueryParamData,
+): QueryParamData {
   return {
     ...searchInputs,
     status: new Set(searchInputs.status || []),

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -2,7 +2,7 @@
  * @file Custom Error classes. Useful as a way to see all potential errors that our system may throw/catch
  */
 
-import { SearchFetcherProps } from "src/services/search/searchfetcher/SearchFetcher";
+import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher";
 
 /**
  * A fetch request failed due to a network error. The error wasn't the fault of the user,
@@ -12,7 +12,7 @@ import { SearchFetcherProps } from "src/services/search/searchfetcher/SearchFetc
  */
 
 export class NetworkError extends Error {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     const serializedSearchInputs = convertSearchInputSetsToArrays(searchInputs);
 
     const serializedData = JSON.stringify({
@@ -29,7 +29,7 @@ export class NetworkError extends Error {
 export class BaseFrontendError extends Error {
   constructor(
     error: unknown,
-    searchInputs: SearchFetcherProps,
+    searchInputs: QueryParamData,
     type: string,
     status?: number,
   ) {
@@ -61,7 +61,7 @@ export class BaseFrontendError extends Error {
 export class ApiRequestError extends BaseFrontendError {
   constructor(
     error: unknown,
-    searchInputs: SearchFetcherProps,
+    searchInputs: QueryParamData,
     type: string,
     status: number,
   ) {
@@ -73,7 +73,7 @@ export class ApiRequestError extends BaseFrontendError {
  * An API response returned a 400 status code and its JSON body didn't include any `errors`
  */
 export class BadRequestError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "BadRequestError", 400);
   }
 }
@@ -82,7 +82,7 @@ export class BadRequestError extends ApiRequestError {
  * An API response returned a 401 status code
  */
 export class UnauthorizedError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "UnauthorizedError", 401);
   }
 }
@@ -93,7 +93,7 @@ export class UnauthorizedError extends ApiRequestError {
  * being created, or the user hasn't consented to the data sharing agreement.
  */
 export class ForbiddenError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "ForbiddenError", 403);
   }
 }
@@ -102,7 +102,7 @@ export class ForbiddenError extends ApiRequestError {
  * A fetch request failed due to a 404 error
  */
 export class NotFoundError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "NotFoundError", 404);
   }
 }
@@ -111,7 +111,7 @@ export class NotFoundError extends ApiRequestError {
  * An API response returned a 408 status code
  */
 export class RequestTimeoutError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "RequestTimeoutError", 408);
   }
 }
@@ -120,7 +120,7 @@ export class RequestTimeoutError extends ApiRequestError {
  * An API response returned a 422 status code
  */
 export class ValidationError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "ValidationError", 422);
   }
 }
@@ -133,7 +133,7 @@ export class ValidationError extends ApiRequestError {
  * An API response returned a 500 status code
  */
 export class InternalServerError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "InternalServerError", 500);
   }
 }
@@ -142,7 +142,7 @@ export class InternalServerError extends ApiRequestError {
  *  An API response returned a 503 status code
  */
 export class ServiceUnavailableError extends ApiRequestError {
-  constructor(error: unknown, searchInputs: SearchFetcherProps) {
+  constructor(error: unknown, searchInputs: QueryParamData) {
     super(error, searchInputs, "ServiceUnavailableError", 503);
   }
 }
@@ -152,7 +152,7 @@ type SearchInputsSimple = {
 };
 
 function convertSearchInputSetsToArrays(
-  searchInputs: SearchFetcherProps,
+  searchInputs: QueryParamData,
 ): SearchInputsSimple {
   return {
     ...searchInputs,

--- a/frontend/src/hooks/useSearchFormState.ts
+++ b/frontend/src/hooks/useSearchFormState.ts
@@ -2,15 +2,15 @@
 
 import { useRef, useState } from "react";
 
+import { QueryParamData } from "../services/search/searchfetcher/SearchFetcher";
 import { SearchAPIResponse } from "../types/search/searchResponseTypes";
-import { SearchFetcherProps } from "../services/search/searchfetcher/SearchFetcher";
 import { updateResults } from "../app/search/actions";
 import { useFormState } from "react-dom";
 import { useSearchParamUpdater } from "./useSearchParamUpdater";
 
 export function useSearchFormState(
   initialSearchResults: SearchAPIResponse,
-  requestURLQueryParams: SearchFetcherProps,
+  requestURLQueryParams: QueryParamData,
 ) {
   const { updateQueryParams } = useSearchParamUpdater();
   const formRef = useRef<HTMLFormElement>(null);

--- a/frontend/src/services/search/FormDataService.ts
+++ b/frontend/src/services/search/FormDataService.ts
@@ -1,5 +1,5 @@
+import { QueryParamData } from "./searchfetcher/SearchFetcher";
 import { SearchFetcherActionType } from "../../types/search/searchRequestTypes";
-import { SearchFetcherProps } from "./searchfetcher/SearchFetcher";
 
 export class FormDataService {
   formData: FormData;
@@ -11,7 +11,7 @@ export class FormDataService {
   // Processes formData entries and returns a searchProps
   // object to get updated results
   processFormData() {
-    const searchProps: SearchFetcherProps = {
+    const searchProps: QueryParamData = {
       page: this.page,
       status: this.status,
       fundingInstrument: this.fundingInstrument,

--- a/frontend/src/services/search/searchfetcher/APISearchFetcher.ts
+++ b/frontend/src/services/search/searchfetcher/APISearchFetcher.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { SearchFetcher, SearchFetcherProps } from "./SearchFetcher";
+import { QueryParamData, SearchFetcher } from "./SearchFetcher";
 
 import { SearchAPIResponse } from "../../../types/search/searchResponseTypes";
 import SearchOpportunityAPI from "../../../app/api/SearchOpportunityAPI";
@@ -14,7 +14,7 @@ export class APISearchFetcher extends SearchFetcher {
   }
 
   async fetchOpportunities(
-    searchInputs: SearchFetcherProps,
+    searchInputs: QueryParamData,
   ): Promise<SearchAPIResponse> {
     try {
       // Keep commented in case we need to simulate a delay to test loaders

--- a/frontend/src/services/search/searchfetcher/SearchFetcher.ts
+++ b/frontend/src/services/search/searchfetcher/SearchFetcher.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { SearchAPIResponse } from "../../../types/search/searchResponseTypes";
 import { SearchFetcherActionType } from "../../../types/search/searchRequestTypes";
 
-export interface SearchFetcherProps {
+export interface QueryParamData {
   page: number;
   query: string | null | undefined;
   status: Set<string>;
@@ -18,6 +18,6 @@ export interface SearchFetcherProps {
 
 export abstract class SearchFetcher {
   abstract fetchOpportunities(
-    props: SearchFetcherProps,
+    props: QueryParamData,
   ): Promise<SearchAPIResponse>;
 }

--- a/frontend/src/utils/search/convertSearchParamsToProperTypes.ts
+++ b/frontend/src/utils/search/convertSearchParamsToProperTypes.ts
@@ -1,5 +1,5 @@
+import { QueryParamData } from "../../services/search/searchfetcher/SearchFetcher";
 import { SearchFetcherActionType } from "../../types/search/searchRequestTypes";
-import { SearchFetcherProps } from "../../services/search/searchfetcher/SearchFetcher";
 import { ServerSideSearchParams } from "../../types/searchRequestURLTypes";
 
 // Search params (query string) coming from the request URL into the server
@@ -7,7 +7,7 @@ import { ServerSideSearchParams } from "../../types/searchRequestURLTypes";
 // Process all of them so they're just a string (or number for page)
 export function convertSearchParamsToProperTypes(
   params: ServerSideSearchParams,
-): SearchFetcherProps {
+): QueryParamData {
   return {
     ...params,
     query: params.query || "", // Convert empty string to null if needed

--- a/frontend/tests/api/SearchOpportunityApi.test.ts
+++ b/frontend/tests/api/SearchOpportunityApi.test.ts
@@ -1,4 +1,4 @@
-import { SearchFetcherProps } from "../../src/services/search/searchfetcher/SearchFetcher";
+import { QueryParamData } from "../../src/services/search/searchfetcher/SearchFetcher";
 import SearchOpportunityAPI from "../../src/app/api/SearchOpportunityAPI";
 import { SearchRequestBody } from "../../src/types/search/searchRequestTypes";
 
@@ -47,7 +47,7 @@ describe("SearchOpportunityAPI", () => {
     });
 
     it("sends POST request to search opportunities endpoint with query parameters", async () => {
-      const searchProps: SearchFetcherProps = {
+      const searchProps: QueryParamData = {
         page: 1,
         status: new Set(["forecasted", "posted"]),
         fundingInstrument: new Set(["grant", "cooperative_agreement"]),

--- a/frontend/tests/errors.test.ts
+++ b/frontend/tests/errors.test.ts
@@ -1,9 +1,9 @@
 import { BadRequestError } from "src/errors";
 import { ParsedError } from "src/app/search/error";
-import { SearchFetcherProps } from "src/services/search/searchfetcher/SearchFetcher";
+import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher";
 
 describe("BadRequestError", () => {
-  const dummySearchInputs: SearchFetcherProps = {
+  const dummySearchInputs: QueryParamData = {
     status: new Set(["active"]),
     fundingInstrument: new Set(["grant"]),
     eligibility: new Set(["public"]),

--- a/frontend/tests/hooks/useSearchFormState.test.ts
+++ b/frontend/tests/hooks/useSearchFormState.test.ts
@@ -1,7 +1,7 @@
+import { QueryParamData } from "../../src/services/search/searchfetcher/SearchFetcher";
 import ReactDOM from "react-dom";
 // import ReactDOM from "react-dom";
 import { SearchAPIResponse } from "../../src/types/search/searchResponseTypes";
-import { SearchFetcherProps } from "../../src/services/search/searchfetcher/SearchFetcher";
 import { renderHook } from "@testing-library/react";
 import { useSearchFormState } from "../../src/hooks/useSearchFormState";
 
@@ -30,7 +30,7 @@ jest.mock("react-dom", () => {
   };
 });
 describe("useSearchFormState", () => {
-  const mockRequestURLQueryParams: SearchFetcherProps = {
+  const mockRequestURLQueryParams: QueryParamData = {
     status: new Set(["open"]),
     query: "",
     sortby: "date",


### PR DESCRIPTION
## Summary
Fixes #1680 

### Time to review: 2 min

## Changes proposed
 - rename `SearchFetcherProps` to `QueryParamData` to more accurately represent this interface

