### PR TITLE
[Issue #1965]: Reintroduce totalPages to Pagination component

### DIFF
--- a/frontend/src/app/search/SearchForm.tsx
+++ b/frontend/src/app/search/SearchForm.tsx
@@ -95,6 +95,7 @@ export function SearchForm({
                 handlePageChange={handlePageChange}
                 showHiddenInput={true}
                 paginationRef={topPaginationRef}
+                totalPages={searchResults?.pagination_info?.total_pages}
                 position={PaginationPosition.Top}
                 searchResultsLength={searchResults.data.length}
               />
@@ -107,6 +108,7 @@ export function SearchForm({
               <SearchPagination
                 page={page}
                 handlePageChange={handlePageChange}
+                totalPages={searchResults?.pagination_info?.total_pages}
                 position={PaginationPosition.Bottom}
                 searchResultsLength={searchResults.data.length}
               />

--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -18,7 +18,7 @@ interface SearchPaginationProps {
   searchResultsLength: number;
 }
 
-const MAX_SLOTS = 5;
+const MAX_SLOTS = 7;
 
 export default function SearchPagination({
   showHiddenInput,

--- a/frontend/src/components/search/SearchPagination.tsx
+++ b/frontend/src/components/search/SearchPagination.tsx
@@ -13,6 +13,7 @@ interface SearchPaginationProps {
   page: number;
   handlePageChange: (handlePage: number) => void; // managed in useSearchFormState
   paginationRef?: React.RefObject<HTMLInputElement>; // managed in useSearchFormState
+  totalPages: number;
   position: PaginationPosition;
   searchResultsLength: number;
 }
@@ -24,6 +25,7 @@ export default function SearchPagination({
   page,
   handlePageChange,
   paginationRef,
+  totalPages,
   position,
   searchResultsLength,
 }: SearchPaginationProps) {
@@ -54,6 +56,7 @@ export default function SearchPagination({
       )}
       <Pagination
         pathname="/search"
+        totalPages={totalPages}
         currentPage={page}
         maxSlots={MAX_SLOTS}
         onClickNext={() => handlePageChange(page + 1)}

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -78,10 +78,3 @@ in the form $setting: value,
       "palette-color-system-red-warm"
     )
 );
-
-// Custom overrides
-
-// Pagination sizing
-.usa-pagination .usa-button {
-  font-size: 22px;
-}

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -78,3 +78,10 @@ in the form $setting: value,
       "palette-color-system-red-warm"
     )
 );
+
+// Custom overrides
+
+// Pagination sizing
+.usa-pagination .usa-button {
+  font-size: 22px;
+}


### PR DESCRIPTION
## Summary
Fixes #1965 

### Time to review: 5 min

## Changes proposed
- Reintroduce totalPages
- set max pagination slots to 7



Fixing the size of the pagination and overflow issues around the 600px viewport width will be done in a separate effort

https://github.com/HHS/simpler-grants-gov/assets/93001277/eb13eb29-d91a-4f7d-8c78-bbafe2590fb7



