### PR TITLE
[Issue #1978] further optimizations for load chunking

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -139,7 +139,7 @@ class LoadOracleDataTask(src.task.task.Task):
                 foreign_table, staging_table, batch_of_update_ids
             ).values(transformed_at=None)
 
-            result = self.db_session.execute(update_sql)
+            self.db_session.execute(update_sql)
 
             update_chunk_count.append(len(batch_of_update_ids))
             logger.info(

--- a/api/src/data_migration/load/sql.py
+++ b/api/src/data_migration/load/sql.py
@@ -2,6 +2,8 @@
 # SQL building for data load process.
 #
 
+from typing import Iterable
+
 import sqlalchemy
 
 
@@ -25,7 +27,9 @@ def build_select_new_rows_sql(
 
 
 def build_insert_select_sql(
-    source_table: sqlalchemy.Table, destination_table: sqlalchemy.Table, ids: list[tuple[int, ...]]
+    source_table: sqlalchemy.Table,
+    destination_table: sqlalchemy.Table,
+    ids: Iterable[tuple | sqlalchemy.Row],
 ) -> sqlalchemy.Insert:
     """Build an `INSERT INTO ... SELECT ... FROM ...` query for new rows."""
 
@@ -69,7 +73,9 @@ def build_select_updated_rows_sql(
 
 
 def build_update_sql(
-    source_table: sqlalchemy.Table, destination_table: sqlalchemy.Table, ids: list[tuple[int, ...]]
+    source_table: sqlalchemy.Table,
+    destination_table: sqlalchemy.Table,
+    ids: Iterable[tuple | sqlalchemy.Row],
 ) -> sqlalchemy.Update:
     """Build an `UPDATE ... SET ... WHERE ...` statement for updated rows."""
 

--- a/api/src/data_migration/load/sql.py
+++ b/api/src/data_migration/load/sql.py
@@ -5,23 +5,13 @@
 import sqlalchemy
 
 
-def build_insert_select_sql(
-    source_table: sqlalchemy.Table, destination_table: sqlalchemy.Table, limit: int = 1000
-) -> tuple[sqlalchemy.Insert, sqlalchemy.Select]:
-    """Build an `INSERT INTO ... SELECT ... FROM ...` query for new rows."""
+def build_select_new_rows_sql(
+    source_table: sqlalchemy.Table, destination_table: sqlalchemy.Table
+) -> sqlalchemy.Select:
+    """Build a `SELECT id1, id2, ... FROM <source_table>` query that finds new rows in source_table."""
 
-    all_columns = tuple(c.name for c in source_table.columns)
-
-    # Optimization: use a Common Table Expression (`WITH`) marked as MATERIALIZED. This directs the PostgreSQL
-    # optimizer to run it first (prevents folding it into the parent query), so it only fetches the primary keys and
-    # last_upd_date columns from Oracle to perform the date comparison. Without this materialized CTE, it fetches all
-    # columns and all rows from Oracle before applying the WHERE, which is very slow for large tables.
-    #
-    # See https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CTE-MATERIALIZATION
-
-    # `WITH insert_pks AS MATERIALIZED (`
-    cte = (
-        # `SELECT id1, id2, id3, ... FROM <source_table>`    (id1, id2, ... is the multipart primary key)
+    # `SELECT id1, id2, id3, ... FROM <source_table>`    (id1, id2, ... is the multipart primary key)
+    return (
         sqlalchemy.select(*source_table.primary_key.columns)
         .where(
             # `WHERE (id1, id2, id3, ...) NOT IN`
@@ -30,43 +20,40 @@ def build_insert_select_sql(
                 sqlalchemy.select(*destination_table.primary_key.columns)
             )
         )
-        .limit(limit)
-        .cte("insert_pks")
-        .prefix_with("MATERIALIZED")
+        .order_by(*source_table.primary_key.columns)
     )
+
+
+def build_insert_select_sql(
+    source_table: sqlalchemy.Table, destination_table: sqlalchemy.Table, ids: list[tuple[int, ...]]
+) -> sqlalchemy.Insert:
+    """Build an `INSERT INTO ... SELECT ... FROM ...` query for new rows."""
+
+    all_columns = tuple(c.name for c in source_table.columns)
 
     # `SELECT col1, col2, ..., FALSE AS is_deleted FROM <source_table>`
     select_sql = sqlalchemy.select(
         source_table, sqlalchemy.literal_column("FALSE").label("is_deleted")
     ).where(
         # `WHERE (id1, id2, ...)
-        #  IN (SELECT insert_pks.id1, insert_pks.id2
-        #      FROM insert_pks)`
-        sqlalchemy.tuple_(*source_table.primary_key.columns).in_(sqlalchemy.select(*cte.columns)),
+        #  IN ((a1, a2), (b1, b2), ...)`
+        sqlalchemy.tuple_(*source_table.primary_key.columns).in_(ids),
     )
     # `INSERT INTO <destination_table> (col1, col2, ..., is_deleted) SELECT ...`
     insert_from_select_sql = sqlalchemy.insert(destination_table).from_select(
         all_columns + (destination_table.c.is_deleted,), select_sql
     )
 
-    return insert_from_select_sql, select_sql
+    return insert_from_select_sql
 
 
-def build_update_sql(
+def build_select_updated_rows_sql(
     source_table: sqlalchemy.Table, destination_table: sqlalchemy.Table
-) -> sqlalchemy.Update:
-    """Build an `UPDATE ... SET ... WHERE ...` statement for updated rows."""
+) -> sqlalchemy.Select:
+    """Build a `SELECT id1, id2, ... FROM <source_table>` query that finds updated rows in source_table."""
 
-    # Optimization: use a Common Table Expression (`WITH`) marked as MATERIALIZED. This directs the PostgreSQL
-    # optimizer to run it first (prevents folding it into the parent query), so it only fetches the primary keys and
-    # last_upd_date columns from Oracle to perform the date comparison. Without this materialized CTE, it fetches all
-    # columns and all rows from Oracle before applying the WHERE, which is very slow for large tables.
-    #
-    # See https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CTE-MATERIALIZATION
-
-    # `WITH update_pks AS MATERIALIZED (`
-    cte = (
-        # `SELECT id1, id2, id3, ... FROM <destination_table>`
+    # `SELECT id1, id2, id3, ... FROM <destination_table>`
+    return (
         sqlalchemy.select(*destination_table.primary_key.columns)
         .join(
             # `JOIN <source_table>
@@ -77,9 +64,14 @@ def build_update_sql(
         )
         # `WHERE ...`
         .where(destination_table.c.last_upd_date < source_table.c.last_upd_date)
-        .cte("update_pks")
-        .prefix_with("MATERIALIZED")
+        .order_by(*source_table.primary_key.columns)
     )
+
+
+def build_update_sql(
+    source_table: sqlalchemy.Table, destination_table: sqlalchemy.Table, ids: list[tuple[int, ...]]
+) -> sqlalchemy.Update:
+    """Build an `UPDATE ... SET ... WHERE ...` statement for updated rows."""
 
     return (
         # `UPDATE <destination_table>`
@@ -90,9 +82,7 @@ def build_update_sql(
         .where(
             sqlalchemy.tuple_(*destination_table.primary_key.columns)
             == sqlalchemy.tuple_(*source_table.primary_key.columns),
-            sqlalchemy.tuple_(*destination_table.primary_key.columns).in_(
-                sqlalchemy.select(*cte.columns)
-            ),
+            sqlalchemy.tuple_(*destination_table.primary_key.columns).in_(ids),
         )
     )
 


### PR DESCRIPTION
## Summary
Fixes #1978

### Time to review: __5 mins__

## Changes proposed
- Optimize chunked load further by moving chunking logic from database to PostgreSQL.

## Context for reviewers
Instead of using `LIMIT` to carry out chunking in PostgreSQL, read the full set of ids as a first step, then issue a series of INSERT / UPDATE queries.

This is expected to be faster. With the previous method, the PostgreSQL optimizer did not do an ideal plan, and did a full read of all rows and columns from the Oracle database. By splitting the query, we can do a read of only the id columns for the new or updated rows. Then additional queries select only the rows that have changed.

## Additional information
N/A
