### PR TITLE
[Issue #1985] Allow yes/no for transformed booleans

### DIFF
--- a/api/src/data_migration/transformation/transform_util.py
+++ b/api/src/data_migration/transformation/transform_util.py
@@ -418,14 +418,14 @@ def transform_update_create_timestamp(
 
 def convert_yn_bool(value: str | None) -> bool | None:
     # Booleans in the Oracle database are stored as varchar/char
-    # columns with the values as Y/N
+    # columns with the values as Y/N (very rarely Yes/No)
     if value is None or value == "":
         return None
 
-    if value == "Y":
+    if value == "Y" or value == "Yes":
         return True
 
-    if value == "N":
+    if value == "N" or value == "No":
         return False
 
     # Just in case the column isn't actually a boolean

--- a/api/src/data_migration/transformation/transform_util.py
+++ b/api/src/data_migration/transformation/transform_util.py
@@ -416,16 +416,20 @@ def transform_update_create_timestamp(
         target.updated_at = target.created_at
 
 
+TRUTHY = {"Y", "Yes"}
+FALSEY = {"N", "No"}
+
+
 def convert_yn_bool(value: str | None) -> bool | None:
     # Booleans in the Oracle database are stored as varchar/char
     # columns with the values as Y/N (very rarely Yes/No)
     if value is None or value == "":
         return None
 
-    if value == "Y" or value == "Yes":
+    if value in TRUTHY:
         return True
 
-    if value == "N" or value == "No":
+    if value in FALSEY:
         return False
 
     # Just in case the column isn't actually a boolean

--- a/api/tests/src/data_migration/transformation/test_transform_util.py
+++ b/api/tests/src/data_migration/transformation/test_transform_util.py
@@ -79,13 +79,13 @@ def test_transform_update_create_timestamp(
 
 
 @pytest.mark.parametrize(
-    "value,expected_value", [("Y", True), ("N", False), ("", None), (None, None)]
+    "value,expected_value", [("Y", True), ("N", False), ("Yes", True), ("No", False), ("", None), (None, None)]
 )
 def test_convert_yn_boolean(value, expected_value):
     assert transform_util.convert_yn_bool(value) == expected_value
 
 
-@pytest.mark.parametrize("value", ["X", "Z", "y", "n", "1", "0"])
+@pytest.mark.parametrize("value", ["X", "Z", "y", "n", "1", "0", "yes", "no"])
 def test_convert_yn_boolean_unexpected_value(value):
     with pytest.raises(ValueError, match="Unexpected Y/N bool value"):
         transform_util.convert_yn_bool(value)

--- a/api/tests/src/data_migration/transformation/test_transform_util.py
+++ b/api/tests/src/data_migration/transformation/test_transform_util.py
@@ -79,7 +79,8 @@ def test_transform_update_create_timestamp(
 
 
 @pytest.mark.parametrize(
-    "value,expected_value", [("Y", True), ("N", False), ("Yes", True), ("No", False), ("", None), (None, None)]
+    "value,expected_value",
+    [("Y", True), ("N", False), ("Yes", True), ("No", False), ("", None), (None, None)],
 )
 def test_convert_yn_boolean(value, expected_value):
     assert transform_util.convert_yn_bool(value) == expected_value

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -137,7 +137,7 @@ class CustomProvider(BaseProvider):
         "{{word}}-###-##",
     ]
 
-    YN_BOOLEAN_VALUES = ["Y", "N"]
+    YN_BOOLEAN_VALUES = ["Y", "N", "Yes", "No"]
 
     def agency(self) -> str:
         return self.random_element(self.AGENCIES)


### PR DESCRIPTION
## Summary
Fixes #1985

### Time to review: __2 mins__

## Changes proposed
When handling transformations of booleans, allow `Yes` and `No` as valid values in addition to `Y` and `N`.

## Context for reviewers
These new values are immensely uncommon, but there are a few rare occurrences of them. Easier to just support them than work around in any other way.

## Additional information
For example, in `TSYNOPSIS_HIST`, the count of values for the cost_sharing bool:

```
No	971
N	60820
Y	13723
Yes	581
```
The non-history table does not have this value.