### PR TITLE
[Issue #1919] Deploying to (dev, or staging) fails because trying to release the same image tag twice

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -33,7 +33,26 @@ on:
         type: string
 
 jobs:
+  # check ECR image job here
+  # see: https://github.com/navapbc/archive-massgov-pfml/blob/5381834193ac9da8066180a8ab1d0589b014d26b/.github/workflows/api-deploy.yml#L319-L324
+  # Skip if its there
+  # make release-image-tag
+  check-ecr-image:
+    name: Check if ECR image has been created
+    runs-on: ubuntu-latest
+
+    steps: 
+      - uses: actions/checkout@v3
+
+      - name: Check ECR Image
+        id: image-tag
+        run: |
+          IMAGE_TAG=$(make release-image-tag)
+          aws ecr describe-images --repository-name=CHANGE_THIS--image-ids=imageTag=$IMAGE_TAG --region us-east-1
+
   build-and-publish:
+    depends-on: [check-ecr-image]
+    # TODO find a way to reference the above
     name: Build and publish
     runs-on: ubuntu-latest
 
@@ -47,7 +66,7 @@ jobs:
           ref: ${{ inputs.ref }}
 
       - name: Build release
-        run: make APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} release-build
+        run: make APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }} release-build # does the environment actually matter here?
 
       - name: Configure AWS credentials
         uses: ./.github/actions/configure-aws-credentials

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -27,7 +27,15 @@ jobs:
   api-checks:
     name: Run API Checks
     uses: ./.github/workflows/ci-api.yml
-
+  
+  build-and-publish:
+  # run build-and publish here so that both envs won't try to build the image 
+    name: Build
+    uses: ./.github/workflows/build-and-publish.yml
+    with:
+      app_name: "api"
+      ref: ${{ github.ref }}
+      
   deploy:
     name: Deploy
     needs: api-checks

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -28,6 +28,7 @@ jobs:
     uses: ./.github/workflows/ci-frontend.yml
 
   deploy:
+    # run build-and publish here so that both envs won't try to build the image 
     name: Deploy
     needs: frontend-checks
     uses: ./.github/workflows/deploy.yml


### PR DESCRIPTION
## Summary
Fixes #1919 

### Time to review: __x mins__

## Changes proposed
* add `check-ecr-image` job
* add `build-and-publish` call to the "app" level workflow calls (e.g. `cd-api.yml`)

## Context for reviewers
> The staging deploy fails above because both dev and staging try to release the same tag, eg.

> tag invalid: The image tag '4b73f7e39ab05c62194ccf3d33bda9f51419495b' already exists in the 'simpler-grants-gov-api' repository and cannot be overwritten because the repository is immutable.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

