### PR TITLE
[Issue #1998] optimize the WHERE in load updates

### DIFF
--- a/api/src/data_migration/load/sql.py
+++ b/api/src/data_migration/load/sql.py
@@ -88,7 +88,7 @@ def build_update_sql(
         .where(
             sqlalchemy.tuple_(*destination_table.primary_key.columns)
             == sqlalchemy.tuple_(*source_table.primary_key.columns),
-            sqlalchemy.tuple_(*destination_table.primary_key.columns).in_(ids),
+            sqlalchemy.tuple_(*source_table.primary_key.columns).in_(ids),
         )
     )
 

--- a/api/tests/src/data_migration/load/test_sql.py
+++ b/api/tests/src/data_migration/load/test_sql.py
@@ -83,7 +83,7 @@ def test_build_update_sql(source_table, destination_table):
         "last_upd_date=test_source_table.last_upd_date FROM test_source_table "
         "WHERE (test_destination_table.id1, test_destination_table.id2) = "
         "(test_source_table.id1, test_source_table.id2) AND "
-        "(test_destination_table.id1, test_destination_table.id2) "
+        "(test_source_table.id1, test_source_table.id2) "
         "IN (__[POSTCOMPILE_param_1])"
     )
 


### PR DESCRIPTION
## Summary
Fixes #1998

### Time to review: __5 mins__

## Changes proposed
- Change the `WHERE` in the update query to use the source table columns.
- Commit to the database after each chunk, not after each table.

## Context for reviewers
Observing the queries on the PostgreSQL RDS and Oracle sides, we saw that the `WHERE ... IN (...)` was not being pushed down to Oracle. This is an attempt to fix that.

## Additional information
N/A
