### PR TITLE
[Issue #1688] Remove feature flag for v0.1 endpoints

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -85,7 +85,7 @@ ENABLE_OPPORTUNITY_LOG_MSG=false
 ############################
 # Endpoint Configuration
 ############################
-ENABLE_V_0_1_ENDPOINTS=true
+# Nothing needs to be configured at the moment
 
 ############################
 # Script Configuration

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -4,7 +4,6 @@ from typing import Any, Tuple
 
 from apiflask import APIFlask, exceptions
 from flask_cors import CORS
-from pydantic import Field
 
 import src.adapters.db as db
 import src.adapters.db.flask_db as flask_db
@@ -19,7 +18,6 @@ from src.api.schemas import response_schema
 from src.auth.api_key_auth import get_app_security_scheme
 from src.data_migration.data_migration_blueprint import data_migration_blueprint
 from src.task import task_blueprint
-from src.util.env_config import PydanticBaseEnvConfig
 
 logger = logging.getLogger(__name__)
 
@@ -32,17 +30,6 @@ This API is an ALPHA VERSION! Its current form is primarily for testing and feed
 
 See [Release Phases](https://github.com/github/roadmap?tab=readme-ov-file#release-phases) for further details.
 """
-
-
-class EndpointConfig(PydanticBaseEnvConfig):
-    """
-    Class which holds environments variables for enabling/disabling API
-    endpoint blueprints. Useful while we develop new endpoints that we want
-    to keep hidden in production (or other) environments temporarily while
-    we build out the features.
-    """
-
-    enable_v_0_1_endpoints: bool = Field(False, alias="ENABLE_V_0_1_ENDPOINTS")
 
 
 def create_app() -> APIFlask:
@@ -111,16 +98,9 @@ def configure_app(app: APIFlask) -> None:
 
 
 def register_blueprints(app: APIFlask) -> None:
-    endpoint_config = EndpointConfig()
-
     app.register_blueprint(healthcheck_blueprint)
     app.register_blueprint(opportunities_v0_blueprint)
-    if endpoint_config.enable_v_0_1_endpoints:
-        logger.info("Enabling v0.1 endpoints")
-        app.register_blueprint(opportunities_v0_1_blueprint)
-    else:
-        logger.info("v0.1 endpoints are not enabled")
-
+    app.register_blueprint(opportunities_v0_1_blueprint)
     app.register_blueprint(data_migration_blueprint)
     app.register_blueprint(task_blueprint)
 

--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -11,7 +11,5 @@ module "dev_config" {
   database_min_capacity           = 2
 
   service_override_extra_environment_variables = {
-    # determines whether the v0.1 endpoints are available in the API
-    ENABLE_V_0_1_ENDPOINTS = "true"
   }
 }

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -12,7 +12,5 @@ module "prod_config" {
   database_min_capacity           = 2
 
   service_override_extra_environment_variables = {
-    # determines whether the v0.1 endpoints are available in the API
-    ENABLE_V_0_1_ENDPOINTS = "false"
   }
 }

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -11,7 +11,5 @@ module "staging_config" {
   database_min_capacity           = 2
 
   service_override_extra_environment_variables = {
-    # determines whether the v0.1 endpoints are available in the API
-    ENABLE_V_0_1_ENDPOINTS = "true"
   }
 }


### PR DESCRIPTION
## Summary
Fixes #1688

### Time to review: __2 mins__

## Changes proposed
Remove the `ENABLE_V_0_1_ENDPOINTS` feature flag as we just want these endpoints enabled everywhere now

## Context for reviewers
This flag was to hide our endpoints while we built them out, we want these enabled everywhere now, so not much reason to keep it.


