### PR TITLE
[Issue #2175] Ignore Postgres in Docker for renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -116,6 +116,15 @@
         "peerDependencies"
       ],
       "enabled": false
+    },
+    {
+      "description": "Leave Postgres Docker version alone - we want it to match our AWS version",
+      "enabled": false,
+      "matchFileNames": [
+        "analytics/docker-compose.yml",
+        "api/docker-compose.yml"
+      ],
+      "matchPackagePatterns": ["postgres"]
     }
   ]
 }

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -29,3 +29,6 @@ coverage.*
 
 #e2e
 /test-results/
+
+# localstack
+/volume


### PR DESCRIPTION
## Summary
Fixes #2175

### Time to review: __3 mins__

## Changes proposed
Adjusted the renovate config to not tell us to upgrade Postgres version in our docker-compose file

Minor fix for something missed in the merge for the .gitignore - otherwise that also gets included by Renovate / anyone who stands up localstack

## Context for reviewers
See for example: https://github.com/HHS/simpler-grants-gov/pull/2023

## Additional information
I'm not certain how we can test Renovate, I need to see if I can make it use this branch when running

