### PR TITLE
[Issue #2177] Fix facet count name issue

### DIFF
--- a/api/src/services/opportunities_v1/search_opportunities.py
+++ b/api/src/services/opportunities_v1/search_opportunities.py
@@ -128,7 +128,7 @@ def _add_search_filters(
 def _add_aggregations(builder: search.SearchQueryBuilder) -> None:
     # TODO - we'll likely want to adjust the total number of values returned, especially
     # for agency as there could be hundreds of different agencies, and currently it's limited to 25.
-    builder.aggregation_terms("opportunity_status", _adjust_field_name("applicant_type"))
+    builder.aggregation_terms("opportunity_status", _adjust_field_name("opportunity_status"))
     builder.aggregation_terms("applicant_type", _adjust_field_name("applicant_type"))
     builder.aggregation_terms("funding_instrument", _adjust_field_name("funding_instrument"))
     builder.aggregation_terms("funding_category", _adjust_field_name("funding_category"))

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
@@ -1288,3 +1288,20 @@ class TestOpportunityRouteSearch(BaseTestClass):
         # This test isn't looking to validate opensearch behavior, just that we've connected fields properly and
         # results being returned are as expected.
         call_search_and_validate(client, api_auth_token, search_request, expected_results)
+
+    def test_search_query_facets_200(self, client, api_auth_token):
+        search_response = client.post(
+            "/v1/opportunities/search",
+            json=get_search_request(),
+            headers={"X-Auth": api_auth_token},
+        )
+
+        assert search_response.status_code == 200
+        facet_counts = search_response.get_json()["facet_counts"]
+        assert facet_counts.keys() == {
+            "agency",
+            "applicant_type",
+            "funding_instrument",
+            "funding_category",
+            "opportunity_status",
+        }


### PR DESCRIPTION
## Summary
Fixes #2177

### Time to review: __3 mins__

## Changes proposed
Fixed issue with facet count names which was causing the opportunity status to be populated incorrectly

Added a test to prevent issue in the future

## Context for reviewers
These fields aren't used yet - just a minor bug I noticed when setting up the demo the other day


