### PR TITLE
[Issue #1937] Translate Loading component text

### DIFF
--- a/frontend/src/app/[locale]/search/loading.tsx
+++ b/frontend/src/app/[locale]/search/loading.tsx
@@ -1,16 +1,17 @@
-import { useTranslations } from "next-intl";
 import React from "react";
 
 import Spinner from "src/components/Spinner";
 
-export default function Loading() {
-  const t = useTranslations("Loading");
+export interface LoadingProps {
+  message?: string;
+}
 
+export default function Loading({ message }: LoadingProps) {
   return (
     <div className="display-flex flex-align-center flex-justify-center margin-bottom-15 margin-top-15">
       <Spinner />
       <span className="font-body-2xl text-bold margin-left-2">
-        {t("search")}...
+        {message || "Loading"}...
       </span>
     </div>
   );

--- a/frontend/src/app/[locale]/search/loading.tsx
+++ b/frontend/src/app/[locale]/search/loading.tsx
@@ -10,7 +10,10 @@ export default function Loading({ message }: LoadingProps) {
   return (
     <div className="display-flex flex-align-center flex-justify-center margin-bottom-15 margin-top-15">
       <Spinner />
-      <span className="font-body-2xl text-bold margin-left-2">
+      <span
+        className="font-body-2xl text-bold margin-left-2"
+        data-testid="loading-message"
+      >
         {message || "Loading"}...
       </span>
     </div>

--- a/frontend/src/app/[locale]/search/loading.tsx
+++ b/frontend/src/app/[locale]/search/loading.tsx
@@ -1,14 +1,16 @@
+import { useTranslations } from "next-intl";
 import React from "react";
 
 import Spinner from "src/components/Spinner";
 
 export default function Loading() {
-  // TODO (Issue #1937): Use translation utility for strings in this file
+  const t = useTranslations("Loading");
+
   return (
     <div className="display-flex flex-align-center flex-justify-center margin-bottom-15 margin-top-15">
       <Spinner />
       <span className="font-body-2xl text-bold margin-left-2">
-        Loading results...
+        {t("search")}...
       </span>
     </div>
   );

--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -139,7 +139,10 @@ function Search({ searchParams }: { searchParams: searchParamsTypes }) {
                     scroll={false}
                   />
                 </Suspense>
-                <Suspense key={key} fallback={<Loading />}>
+                <Suspense
+                  key={key}
+                  fallback={<Loading message={t("loading")} />}
+                >
                   <SearchResultsListFetch
                     searchParams={convertedSearchParams}
                   />

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -497,9 +497,6 @@ export const messages = {
       select: "Select All",
       clear: "Clear All",
     },
-  },
-  Loading: {
-    default: "Loading",
-    search: "Loading Results",
+    loading: "Loading Results",
   },
 };

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -498,4 +498,8 @@ export const messages = {
       clear: "Clear All",
     },
   },
+  Loading: {
+    default: "Loading",
+    search: "Loading Results",
+  },
 };

--- a/frontend/stories/pages/loading.stories.tsx
+++ b/frontend/stories/pages/loading.stories.tsx
@@ -7,4 +7,8 @@ const meta: Meta<typeof Loading> = {
 };
 export default meta;
 
-export const Default = {};
+export const Default = {
+  args: {
+    message: "Loading Storybook",
+  },
+};

--- a/frontend/stories/pages/loading.stories.tsx
+++ b/frontend/stories/pages/loading.stories.tsx
@@ -1,0 +1,10 @@
+import { Meta } from "@storybook/react";
+
+import Loading from "../../src/app/[locale]/search/loading";
+
+const meta: Meta<typeof Loading> = {
+  component: Loading,
+};
+export default meta;
+
+export const Default = {};

--- a/frontend/tests/e2e/search/search-loading.spec.ts
+++ b/frontend/tests/e2e/search/search-loading.spec.ts
@@ -27,7 +27,7 @@ test.describe("Search page tests", () => {
     const searchTerm = "advanced";
     await fillSearchInputAndSubmit(searchTerm, page);
 
-    const loadingIndicator = page.locator("text='Loading results...'");
+    const loadingIndicator = page.getByTestId("loading-message");
     await expect(loadingIndicator).toBeVisible();
     await expect(loadingIndicator).toBeHidden();
 


### PR DESCRIPTION
## Summary
Fixes #1937

### Time to review: __5 mins__

## Changes proposed
Implemented the translation library for the text on the Search loading spinner

## Context for reviewers
This component is currently under the Search page, but seems like we'd likely reuse it elsewhere. Since file moves are weird to PR and revert I wanted to get more input before moving stuff around.

## Additional information
Tested by implementing Storybook for this component
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/d03d5973-ec62-49b2-85d2-f5f204de6f9f">


