### PR TITLE
chore: standardize access to process.env [unticketed]

### DIFF
--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -4,7 +4,7 @@ import { GoogleAnalytics } from "@next/third-parties/google";
  * @see https://nextjs.org/docs/app/api-reference/file-conventions/layout
  */
 import { Metadata } from "next";
-import { PUBLIC_ENV } from "src/constants/environments";
+import { environment, PUBLIC_ENV } from "src/constants/environments";
 
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, unstable_setRequestLocale } from "next-intl/server";
@@ -12,7 +12,7 @@ import { getMessages, unstable_setRequestLocale } from "next-intl/server";
 import Layout from "src/components/Layout";
 
 export const metadata: Metadata = {
-  icons: [`${process.env.NEXT_PUBLIC_BASE_PATH ?? ""}/img/favicon.ico`],
+  icons: [`${environment.NEXT_PUBLIC_BASE_PATH}}/img/favicon.ico`],
 };
 
 interface Props {

--- a/frontend/src/app/api/BaseApi.ts
+++ b/frontend/src/app/api/BaseApi.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { compact, isEmpty } from "lodash";
+import { environment } from "src/constants/environments";
 import {
   ApiRequestError,
   BadRequestError,
@@ -50,8 +51,8 @@ export default abstract class BaseApi {
   get headers(): HeadersDict {
     const headers: HeadersDict = {};
 
-    if (process.env.API_AUTH_TOKEN) {
-      headers["X-AUTH"] = process.env.API_AUTH_TOKEN;
+    if (environment.API_AUTH_TOKEN) {
+      headers["X-AUTH"] = environment.API_AUTH_TOKEN;
     }
     return headers;
   }

--- a/frontend/src/app/api/OpportunityListingAPI.ts
+++ b/frontend/src/app/api/OpportunityListingAPI.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { environment } from "src/constants/environments";
 import { OpportunityApiResponse } from "src/types/opportunity/opportunityResponseTypes";
 
 import BaseApi from "./BaseApi";
@@ -10,7 +11,7 @@ export default class OpportunityListingAPI extends BaseApi {
   }
 
   get basePath(): string {
-    return process.env.API_URL || "";
+    return environment.API_URL;
   }
 
   get namespace(): string {

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { environment } from "src/constants/environments";
 import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher";
 import {
   PaginationOrderBy,
@@ -14,7 +15,7 @@ import BaseApi from "./BaseApi";
 
 export default class SearchOpportunityAPI extends BaseApi {
   get basePath(): string {
-    return process.env.API_URL || "";
+    return environment.API_URL;
   }
 
   get namespace(): string {

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,10 +1,11 @@
 import { MetadataRoute } from "next";
+import { environment } from "src/constants/environments";
 import { getNextRoutes } from "src/utils/getRoutes";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const routes = getNextRoutes("./src/app");
 
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const baseUrl = environment.NEXT_PUBLIC_BASE_URL;
   const sitemap: MetadataRoute.Sitemap = routes.map((route) => ({
     url: `${baseUrl}${route || ""}`,
     lastModified: new Date().toISOString(),

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -20,12 +20,12 @@ export type NextPublicAppEnv = (typeof NEXT_ENVS)[number];
 const {
   NODE_ENV,
   NEXT_PUBLIC_BASE_PATH,
-  USE_SEARCH_MOCK_DATA,
+  USE_SEARCH_MOCK_DATA = "",
   SENDY_API_URL,
   SENDY_API_KEY,
   SENDY_LIST_ID,
   API_URL,
-  API_AUTH_TOKEN,
+  API_AUTH_TOKEN = "",
   NEXT_PUBLIC_BASE_URL,
 } = process.env;
 
@@ -34,7 +34,7 @@ const CURRENT_ENV = NODE_ENV ?? "development";
 export const PUBLIC_ENV = PUBLIC_ENV_VARS_BY_ENV[CURRENT_ENV];
 
 // home for all interpreted server side environment variables
-export const environment = {
+export const environment: { [key: string]: string } = {
   NEXT_PUBLIC_BASE_PATH: NEXT_PUBLIC_BASE_PATH ?? "",
   USE_SEARCH_MOCK_DATA,
   SENDY_API_URL: SENDY_API_URL || "",

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -17,6 +17,30 @@ const PUBLIC_ENV_VARS_BY_ENV = {
 const NEXT_ENVS = ["development", "test", "production"] as const;
 export type NextPublicAppEnv = (typeof NEXT_ENVS)[number];
 
-const CURRENT_ENV = process.env.NODE_ENV ?? "development";
+const {
+  NODE_ENV,
+  NEXT_PUBLIC_BASE_PATH,
+  USE_SEARCH_MOCK_DATA,
+  SENDY_API_URL,
+  SENDY_API_KEY,
+  SENDY_LIST_ID,
+  API_URL,
+  API_AUTH_TOKEN,
+  NEXT_PUBLIC_BASE_URL,
+} = process.env;
+
+const CURRENT_ENV = NODE_ENV ?? "development";
 
 export const PUBLIC_ENV = PUBLIC_ENV_VARS_BY_ENV[CURRENT_ENV];
+
+// home for all interpreted server side environment variables
+export const environment = {
+  NEXT_PUBLIC_BASE_PATH: NEXT_PUBLIC_BASE_PATH ?? "",
+  USE_SEARCH_MOCK_DATA,
+  SENDY_API_URL: SENDY_API_URL || "",
+  SENDY_API_KEY: SENDY_API_KEY || "",
+  SENDY_LIST_ID: SENDY_LIST_ID || "",
+  API_URL: API_URL || "",
+  API_AUTH_TOKEN,
+  NEXT_PUBLIC_BASE_URL: NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
+};

--- a/frontend/src/pages/api/subscribe.ts
+++ b/frontend/src/pages/api/subscribe.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { environment } from "src/constants/environments";
 import { SendySubscribeForm } from "src/types/sendy";
 
 export type Data = {
@@ -28,9 +29,9 @@ export default async function handler(
   }
 
   try {
-    const sendyApiUrl = process.env.SENDY_API_URL || "";
-    const sendyApiKey = process.env.SENDY_API_KEY || "";
-    const list = process.env.SENDY_LIST_ID || "";
+    const sendyApiUrl = environment.SENDY_API_URL;
+    const sendyApiKey = environment.SENDY_API_KEY;
+    const list = environment.SENDY_LIST_ID;
     const requestData = {
       list,
       subform: "yes",

--- a/frontend/src/services/search/searchfetcher/SearchFetcherUtil.ts
+++ b/frontend/src/services/search/searchfetcher/SearchFetcherUtil.ts
@@ -1,9 +1,11 @@
+import { environment } from "src/constants/environments";
+
 import { APISearchFetcher } from "./APISearchFetcher";
 import { MockSearchFetcher } from "./MockSearchFetcher";
 import { SearchFetcher } from "./SearchFetcher";
 
 export const getSearchFetcher = (): SearchFetcher => {
-  return process.env.USE_SEARCH_MOCK_DATA === "true"
+  return environment.USE_SEARCH_MOCK_DATA === "true"
     ? new MockSearchFetcher()
     : new APISearchFetcher();
 };

--- a/frontend/src/utils/assetPath.ts
+++ b/frontend/src/utils/assetPath.ts
@@ -1,4 +1,6 @@
+import { environment } from "src/constants/environments";
+
 export function assetPath(relativePath: string) {
-  const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+  const basePath = environment.NEXT_PUBLIC_BASE_PATH ?? "";
   return `${basePath}${relativePath}`;
 }

--- a/frontend/src/utils/assetPath.ts
+++ b/frontend/src/utils/assetPath.ts
@@ -1,6 +1,5 @@
 import { environment } from "src/constants/environments";
 
 export function assetPath(relativePath: string) {
-  const basePath = environment.NEXT_PUBLIC_BASE_PATH ?? "";
-  return `${basePath}${relativePath}`;
+  return `${environment.NEXT_PUBLIC_BASE_PATH}${relativePath}`;
 }


### PR DESCRIPTION
## Summary
Fixes ... unticketed

### Time to review: __15 mins__

## Changes proposed
All access to `process.env` moved to a central location, and update any consuming files, in order to:

* allow for easy reference to environment variables used throughout the application
* perform any necessary defaulting or interpretation of environment variables in one place\
* allow for easier testing / mocking of environment variable values
* improve performance (?)
* * based on somewhat anecdotal concerns as referenced here https://github.com/motdotla/dotenv/issues/562

## Context for reviewers

### Test steps

1. `npx run test`
2. _VERIFY_: all tests pass
3. `npm run dev`
4. run through all pages and basic functionality of the app
5. _VERIFY_: all functions as normal

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

