### PR TITLE
Add width auto to fix aspect ratio warning but retain max height

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -84,7 +84,7 @@ const Footer = () => {
         <Grid row gap>
           <Grid tablet={{ col: 4 }} desktop={{ col: 6 }}>
             <Image
-              className="maxh-15 margin-bottom-2 tablet:margin-bottom-0"
+              className="maxh-15 width-auto margin-bottom-2 tablet:margin-bottom-0"
               alt={t("logo_alt")}
               src={GrantsLogo}
               height={168}


### PR DESCRIPTION
## Summary
Fixes #2099 

### Time to review: <5min

## Changes proposed
Add class to set width to auto to remove browser console warning about aspect ratio and retain max height class.

## Context for reviewers
Load site locally and assure no warning appears in the console r.e. image size