### PR TITLE
Change reference location in api object for agency name on search

### DIFF
--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -99,12 +99,13 @@ export default function SearchResultsListItem({
             <div className="grid-col tablet:order-3 overflow-hidden font-body-xs">
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.summary.agency")}</strong>
-                {opportunity?.summary?.agency_name &&
+                {opportunity?.agency ||
+                (opportunity?.summary?.agency_name &&
                 opportunity?.summary?.agency_code &&
                 agencyNameLookup
                   ? // Use same exact label we're using for the agency filter list
                     agencyNameLookup[opportunity?.summary?.agency_code]
-                  : "--"}
+                  : "--")}
               </span>
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.opportunity_number")}</strong>

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -100,12 +100,12 @@ export default function SearchResultsListItem({
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.summary.agency")}</strong>
                 {opportunity?.agency ||
-                (opportunity?.summary?.agency_name &&
-                opportunity?.summary?.agency_code &&
-                agencyNameLookup
-                  ? // Use same exact label we're using for the agency filter list
-                    agencyNameLookup[opportunity?.summary?.agency_code]
-                  : "--")}
+                  (opportunity?.summary?.agency_name &&
+                  opportunity?.summary?.agency_code &&
+                  agencyNameLookup
+                    ? // Use same exact label we're using for the agency filter list
+                      agencyNameLookup[opportunity?.summary?.agency_code]
+                    : "--")}
               </span>
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.opportunity_number")}</strong>


### PR DESCRIPTION
## Summary
Fixes #2172 

### Time to review: 5mins

## Changes proposed
I changed the render logic to pull agency name from the root of the object as specified in the original issue. I chose to leave the agency code lookup as a fallback. Open to removing that fall back if we think that'd make more sense? Thoughts r.e. leaving agency code lookup as a backup @acouch ?

## Context for reviewers
Make sure search results still have agency results where expected locally.

## Additional information
<img width="804" alt="Screenshot 2024-09-26 at 11 55 14 AM" src="https://github.com/user-attachments/assets/741c2bc8-f3ab-4558-9537-4542e9b33ffb">
