### PR TITLE
[Issue #2222] Account for empty summaries

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: { params: { id: string } }) {
 async function getOpportunityData(id: number) {
   const api = new OpportunityListingAPI();
   try {
-    const oppportunity = await api.getOpportunityById(id);
+    const opportunity = await api.getOpportunityById(id);
     return oppportunity.data;
   } catch (error) {
     console.error("Failed to fetch opportunity:", error);

--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -3,10 +3,7 @@ import OpportunityListingAPI from "src/app/api/OpportunityListingAPI";
 import NotFound from "src/app/not-found";
 import { OPPORTUNITY_CRUMBS } from "src/constants/breadcrumbs";
 import withFeatureFlag from "src/hoc/search/withFeatureFlag";
-import {
-  Opportunity,
-  OpportunityApiResponse,
-} from "src/types/opportunity/opportunityResponseTypes";
+import { Opportunity } from "src/types/opportunity/opportunityResponseTypes";
 
 import { getTranslations } from "next-intl/server";
 import { GridContainer } from "@trussworks/react-uswds";
@@ -20,13 +17,61 @@ import OpportunityIntro from "src/components/opportunity/OpportunityIntro";
 import OpportunityLink from "src/components/opportunity/OpportunityLink";
 import OpportunityStatusWidget from "src/components/opportunity/OpportunityStatusWidget";
 
-export async function generateMetadata() {
+export async function generateMetadata({ params }: { params: { id: string } }) {
   const t = await getTranslations({ locale: "en" });
+  const id = Number(params.id);
+  const opportunityData = (await getOpportunityData(id)) as Opportunity;
   const meta: Metadata = {
-    title: t("OpportunityListing.page_title"),
+    title: `${t("OpportunityListing.page_title")} - ${opportunityData.opportunity_title}`,
     description: t("OpportunityListing.meta_description"),
   };
   return meta;
+}
+
+async function getOpportunityData(id: number) {
+  const api = new OpportunityListingAPI();
+  try {
+    const oppportunity = await api.getOpportunityById(id);
+    return oppportunity.data;
+  } catch (error) {
+    console.error("Failed to fetch opportunity:", error);
+    return null;
+  }
+}
+
+function emptySummary() {
+  return {
+    additional_info_url: null,
+    additional_info_url_description: null,
+    agency_code: null,
+    agency_contact_description: null,
+    agency_email_address: null,
+    agency_email_address_description: null,
+    agency_name: null,
+    agency_phone_number: null,
+    applicant_eligibility_description: null,
+    applicant_types: [],
+    archive_date: null,
+    award_ceiling: null,
+    award_floor: null,
+    close_date: null,
+    close_date_description: null,
+    estimated_total_program_funding: null,
+    expected_number_of_awards: null,
+    fiscal_year: null,
+    forecasted_award_date: null,
+    forecasted_close_date: null,
+    forecasted_close_date_description: null,
+    forecasted_post_date: null,
+    forecasted_project_start_date: null,
+    funding_categories: [],
+    funding_category_description: null,
+    funding_instruments: [],
+    is_cost_sharing: false,
+    is_forecast: false,
+    post_date: null,
+    summary_description: null,
+  };
 }
 
 async function OpportunityListing({ params }: { params: { id: string } }) {
@@ -37,20 +82,14 @@ async function OpportunityListing({ params }: { params: { id: string } }) {
     return <NotFound />;
   }
 
-  const api = new OpportunityListingAPI();
-  let opportunity: OpportunityApiResponse;
-  try {
-    opportunity = await api.getOpportunityById(id);
-  } catch (error) {
-    console.error("Failed to fetch opportunity:", error);
+  const opportunityData = (await getOpportunityData(id)) as Opportunity;
+  opportunityData.summary = opportunityData.summary
+    ? opportunityData.summary
+    : emptySummary();
+
+  if (!opportunityData) {
     return <NotFound />;
   }
-
-  if (!opportunity.data) {
-    return <NotFound />;
-  }
-
-  const opportunityData: Opportunity = opportunity.data;
 
   breadcrumbs.push({
     title: opportunityData.opportunity_title,
@@ -63,7 +102,7 @@ async function OpportunityListing({ params }: { params: { id: string } }) {
       <Breadcrumbs breadcrumbList={breadcrumbs} />
       <OpportunityIntro opportunityData={opportunityData} />
       <GridContainer>
-        <div className="grid-row">
+        <div className="grid-row grid-gap">
           <div className="desktop:grid-col-8 tablet:grid-col-12 tablet:order-1 desktop:order-first">
             <OpportunityDescription opportunityData={opportunityData} />
             <OpportunityLink opportunityData={opportunityData} />

--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -21,8 +21,11 @@ export async function generateMetadata({ params }: { params: { id: string } }) {
   const t = await getTranslations({ locale: "en" });
   const id = Number(params.id);
   const opportunityData = (await getOpportunityData(id)) as Opportunity;
+  const title = opportunityData?.opportunity_title
+    ? opportunityData?.opportunity_title
+    : "";
   const meta: Metadata = {
-    title: `${t("OpportunityListing.page_title")} - ${opportunityData.opportunity_title}`,
+    title: `${t("OpportunityListing.page_title")} - ${title}`,
     description: t("OpportunityListing.meta_description"),
   };
   return meta;
@@ -83,13 +86,12 @@ async function OpportunityListing({ params }: { params: { id: string } }) {
   }
 
   const opportunityData = (await getOpportunityData(id)) as Opportunity;
-  opportunityData.summary = opportunityData.summary
-    ? opportunityData.summary
-    : emptySummary();
-
   if (!opportunityData) {
     return <NotFound />;
   }
+  opportunityData.summary = opportunityData?.summary
+    ? opportunityData.summary
+    : emptySummary();
 
   breadcrumbs.push({
     title: opportunityData.opportunity_title,

--- a/frontend/src/app/api/OpportunityListingAPI.ts
+++ b/frontend/src/app/api/OpportunityListingAPI.ts
@@ -7,7 +7,7 @@ import BaseApi from "./BaseApi";
 
 export default class OpportunityListingAPI extends BaseApi {
   get version(): string {
-    return "v0.1";
+    return "v1";
   }
 
   get basePath(): string {

--- a/frontend/src/app/api/OpportunityListingAPI.ts
+++ b/frontend/src/app/api/OpportunityListingAPI.ts
@@ -7,7 +7,7 @@ import BaseApi from "./BaseApi";
 
 export default class OpportunityListingAPI extends BaseApi {
   get version(): string {
-    return "v1";
+    return "v0.1";
   }
 
   get basePath(): string {

--- a/frontend/src/components/opportunity/OpportunityAwardGridRow.tsx
+++ b/frontend/src/components/opportunity/OpportunityAwardGridRow.tsx
@@ -2,7 +2,7 @@ import { useTranslations } from "next-intl";
 
 type Props = {
   title: string | number;
-  content: string | number;
+  content: string | number | null;
 };
 
 type TranslationKeys =

--- a/frontend/src/components/opportunity/OpportunityAwardInfo.tsx
+++ b/frontend/src/components/opportunity/OpportunityAwardInfo.tsx
@@ -20,12 +20,16 @@ type TranslationKeys =
 const OpportunityAwardInfo = ({ opportunityData }: Props) => {
   const t = useTranslations("OpportunityListing.award_info");
 
-  const formatCurrency = (number: number) => {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 0,
-    }).format(number);
+  const formatCurrency = (number: number | null) => {
+    if (number) {
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 0,
+      }).format(number);
+    } else {
+      return "";
+    }
   };
 
   const formatSubContent = (content: boolean | string | null | string[]) => {

--- a/frontend/src/components/opportunity/OpportunityAwardInfo.tsx
+++ b/frontend/src/components/opportunity/OpportunityAwardInfo.tsx
@@ -27,9 +27,8 @@ const OpportunityAwardInfo = ({ opportunityData }: Props) => {
         currency: "USD",
         minimumFractionDigits: 0,
       }).format(number);
-    } else {
-      return "";
     }
+    return "";
   };
 
   const formatSubContent = (content: boolean | string | null | string[]) => {

--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -59,9 +59,7 @@ const OpportunityDescription = ({ opportunityData }: Props) => {
         <div
           dangerouslySetInnerHTML={{
             __html: DOMPurify.sanitize(
-              opportunityData.summary.summary_description
-                ? opportunityData.summary.summary_description
-                : "",
+              opportunityData.summary.summary_description ?? "",
             ),
           }}
         />

--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -87,7 +87,7 @@ const OpportunityDescription = ({ opportunityData }: Props) => {
             ),
           }}
         />
-        <p>{opportunityData.summary.agency_email_address}</p>
+        <p>{agency_email}</p>
         <p>
           <a href={`mailto:${agency_email}`}>
             {opportunityData.summary.agency_email_address_description}

--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -53,6 +53,9 @@ const OpportunityDescription = ({ opportunityData }: Props) => {
     .applicant_eligibility_description
     ? opportunityData.summary.applicant_eligibility_description
     : "--";
+  const agency_email = opportunityData.summary.agency_email_address
+    ? opportunityData.summary.agency_email_address
+    : "";
   return (
     <>
       <div className="usa-prose">
@@ -60,7 +63,9 @@ const OpportunityDescription = ({ opportunityData }: Props) => {
         <div
           dangerouslySetInnerHTML={{
             __html: DOMPurify.sanitize(
-              opportunityData.summary.summary_description,
+              opportunityData.summary.summary_description
+                ? opportunityData.summary.summary_description
+                : "",
             ),
           }}
         />
@@ -76,13 +81,15 @@ const OpportunityDescription = ({ opportunityData }: Props) => {
         <div
           dangerouslySetInnerHTML={{
             __html: DOMPurify.sanitize(
-              opportunityData.summary.agency_contact_description,
+              opportunityData.summary.agency_contact_description
+                ? opportunityData.summary.agency_contact_description
+                : "",
             ),
           }}
         />
         <p>{opportunityData.summary.agency_email_address}</p>
         <p>
-          <a href={`mailto:${opportunityData.summary.agency_email_address}`}>
+          <a href={`mailto:${agency_email}`}>
             {opportunityData.summary.agency_email_address_description}
           </a>
         </p>

--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -49,13 +49,9 @@ const OpportunityDescription = ({ opportunityData }: Props) => {
     ? opportunityData.summary.agency_phone_number.replace(/-/g, "")
     : "";
 
-  const additionalInformationOnEligibility = opportunityData.summary
-    .applicant_eligibility_description
-    ? opportunityData.summary.applicant_eligibility_description
-    : "--";
-  const agency_email = opportunityData.summary.agency_email_address
-    ? opportunityData.summary.agency_email_address
-    : "";
+  const additionalInformationOnEligibility =
+    opportunityData.summary.applicant_eligibility_description ?? "--";
+  const agency_email = opportunityData.summary.agency_email_address ?? "";
   return (
     <>
       <div className="usa-prose">

--- a/frontend/src/components/opportunity/OpportunityIntro.tsx
+++ b/frontend/src/components/opportunity/OpportunityIntro.tsx
@@ -14,10 +14,9 @@ type Props = {
 const OpportunityIntro = ({ opportunityData }: Props) => {
   const t = useTranslations("OpportunityListing.intro");
 
-  const agencyName =
-    opportunityData.summary.agency_name === ""
-      ? "--"
-      : opportunityData.summary.agency_name;
+  const agencyName = opportunityData.summary.agency_name
+    ? opportunityData.summary.agency_name
+    : "--";
 
   const assistanceListings = ({
     opportunity_assistance_listings,

--- a/frontend/src/components/opportunity/OpportunityIntro.tsx
+++ b/frontend/src/components/opportunity/OpportunityIntro.tsx
@@ -14,8 +14,8 @@ type Props = {
 const OpportunityIntro = ({ opportunityData }: Props) => {
   const t = useTranslations("OpportunityListing.intro");
 
-  const agencyName = opportunityData.summary.agency_name
-    ? opportunityData.summary.agency_name
+  const agencyName = opportunityData.agency_name
+    ? opportunityData.agency_name
     : "--";
 
   const assistanceListings = ({

--- a/frontend/src/components/opportunity/OpportunityStatusWidget.tsx
+++ b/frontend/src/components/opportunity/OpportunityStatusWidget.tsx
@@ -16,8 +16,8 @@ const OpportunityStatusWidget = ({ opportunityData }: Props) => {
 
   const statusTagFormatter = (
     status: string,
-    closeDate: string,
-    archiveDate: string,
+    closeDate: string | null,
+    archiveDate: string | null,
   ) => {
     switch (status) {
       case "archived":

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -45,7 +45,7 @@ export default function SearchResultsListItem({
               <h2 className="margin-y-105 line-height-serif-2">
                 <a
                   href={`/opportunity/${opportunity?.opportunity_id}`}
-                  className="usa-link usa-link--external"
+                  className="usa-link usa-link"
                 >
                   {opportunity?.opportunity_title}
                 </a>

--- a/frontend/src/constants/breadcrumbs.ts
+++ b/frontend/src/constants/breadcrumbs.ts
@@ -4,7 +4,10 @@ const HOME: Breadcrumb = { title: "Home", path: "/" };
 const RESEARCH: Breadcrumb = { title: "Research", path: "/research/" };
 const PROCESS: Breadcrumb = { title: "Process", path: "/process/" };
 const NEWSLETTER: Breadcrumb = { title: "Newsletter", path: "/newsletter/" };
-const SEARCH: Breadcrumb = { title: "Search", path: "/search/" };
+const SEARCH: Breadcrumb = {
+  title: "Search",
+  path: "/search?status=forecasted,posted",
+};
 export const NEWSLETTER_CONFIRMATION: Breadcrumb = {
   title: "Confirmation",
   path: "/newsletter/confirmation/",

--- a/frontend/src/types/opportunity/opportunityResponseTypes.ts
+++ b/frontend/src/types/opportunity/opportunityResponseTypes.ts
@@ -38,6 +38,7 @@ export interface Summary {
 
 export interface Opportunity {
   agency: string;
+  agency_name: string;
   category: string;
   category_explanation: string | null;
   created_at: string;

--- a/frontend/src/types/opportunity/opportunityResponseTypes.ts
+++ b/frontend/src/types/opportunity/opportunityResponseTypes.ts
@@ -6,34 +6,34 @@ export interface OpportunityAssistanceListing {
 export interface Summary {
   additional_info_url: string | null;
   additional_info_url_description: string | null;
-  agency_code: string;
-  agency_contact_description: string;
-  agency_email_address: string;
-  agency_email_address_description: string;
-  agency_name: string;
-  agency_phone_number: string;
-  applicant_eligibility_description: string;
+  agency_code: string | null;
+  agency_contact_description: string | null;
+  agency_email_address: string | null;
+  agency_email_address_description: string | null;
+  agency_name: string | null;
+  agency_phone_number: string | null;
+  applicant_eligibility_description: string | null;
   applicant_types: string[];
-  archive_date: string;
-  award_ceiling: number;
-  award_floor: number;
-  close_date: string;
-  close_date_description: string;
-  estimated_total_program_funding: number;
-  expected_number_of_awards: number;
-  fiscal_year: number;
-  forecasted_award_date: string;
-  forecasted_close_date: string;
-  forecasted_close_date_description: string;
-  forecasted_post_date: string;
-  forecasted_project_start_date: string;
+  archive_date: string | null;
+  award_ceiling: number | null;
+  award_floor: number | null;
+  close_date: string | null;
+  close_date_description: string | null;
+  estimated_total_program_funding: number | null;
+  expected_number_of_awards: number | null;
+  fiscal_year: number | null;
+  forecasted_award_date: string | null;
+  forecasted_close_date: string | null;
+  forecasted_close_date_description: string | null;
+  forecasted_post_date: string | null;
+  forecasted_project_start_date: string | null;
   funding_categories: string[];
-  funding_category_description: string;
+  funding_category_description: string | null;
   funding_instruments: string[];
   is_cost_sharing: boolean;
   is_forecast: boolean;
-  post_date: string;
-  summary_description: string;
+  post_date: string | null;
+  summary_description: string | null;
 }
 
 export interface Opportunity {

--- a/frontend/tests/api/OpportunityListingApi.test.ts
+++ b/frontend/tests/api/OpportunityListingApi.test.ts
@@ -45,6 +45,7 @@ function getValidMockResponse() {
   return {
     data: {
       agency: "US-ABC",
+      agency_name: "National Aeronautics and Space Administration",
       category: "discretionary",
       category_explanation: null,
       created_at: "2024-06-20T18:43:04.555Z",

--- a/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
@@ -114,13 +114,9 @@ describe("OpportunityDescription", () => {
     expect(mailtoLink).toHaveAttribute("href", `mailto:${agency_email}`);
 
     const telLink = screen.getByRole("link", {
-      name: mockOpportunityData.summary.agency_phone_number
-        ? mockOpportunityData.summary.agency_phone_number
-        : "",
+      name: "123-456-7890",
     });
-    const number = mockOpportunityData.summary.agency_phone_number
-      ? mockOpportunityData.summary.agency_phone_number.replace(/-/g, "")
-      : "";
+    const number = "1234567890";
     expect(telLink).toHaveAttribute("href", `tel:${number}`);
   });
 });

--- a/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
@@ -59,7 +59,9 @@ describe("OpportunityDescription", () => {
     expect(descriptionHeading).toBeInTheDocument();
 
     const sanitizedSummaryDescription = DOMPurify.sanitize(
-      mockOpportunityData.summary.summary_description,
+      mockOpportunityData.summary.summary_description
+        ? mockOpportunityData.summary.summary_description
+        : "",
     );
     expect(screen.getByText("Summary Description")).toBeInTheDocument();
     expect(DOMPurify.sanitize).toHaveBeenCalledWith(
@@ -87,7 +89,9 @@ describe("OpportunityDescription", () => {
     expect(additionalInfoHeading).toBeInTheDocument();
 
     const sanitizedEligibilityDescription = DOMPurify.sanitize(
-      mockOpportunityData.summary.applicant_eligibility_description,
+      mockOpportunityData.summary.applicant_eligibility_description
+        ? mockOpportunityData.summary.applicant_eligibility_description
+        : "",
     );
     expect(screen.getByText("Eligibility Description")).toBeInTheDocument();
     expect(DOMPurify.sanitize).toHaveBeenCalledWith(
@@ -108,17 +112,19 @@ describe("OpportunityDescription", () => {
     const mailtoLink = screen.getByRole("link", {
       name: "Contact Email Description",
     });
-    expect(mailtoLink).toHaveAttribute(
-      "href",
-      `mailto:${mockOpportunityData.summary.agency_email_address}`,
-    );
+    const agency_email = mockOpportunityData.summary.agency_email_address
+      ? mockOpportunityData.summary.agency_email_address
+      : "";
+    expect(mailtoLink).toHaveAttribute("href", `mailto:${agency_email}`);
 
     const telLink = screen.getByRole("link", {
-      name: mockOpportunityData.summary.agency_phone_number,
+      name: mockOpportunityData.summary.agency_phone_number
+        ? mockOpportunityData.summary.agency_phone_number
+        : "",
     });
-    expect(telLink).toHaveAttribute(
-      "href",
-      `tel:${mockOpportunityData.summary.agency_phone_number.replace(/-/g, "")}`,
-    );
+    const number = mockOpportunityData.summary.agency_phone_number
+      ? mockOpportunityData.summary.agency_phone_number.replace(/-/g, "")
+      : "";
+    expect(telLink).toHaveAttribute("href", `tel:${number}`);
   });
 });

--- a/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
@@ -59,9 +59,7 @@ describe("OpportunityDescription", () => {
     expect(descriptionHeading).toBeInTheDocument();
 
     const sanitizedSummaryDescription = DOMPurify.sanitize(
-      mockOpportunityData.summary.summary_description
-        ? mockOpportunityData.summary.summary_description
-        : "",
+      "<p>Summary Description</p>",
     );
     expect(screen.getByText("Summary Description")).toBeInTheDocument();
     expect(DOMPurify.sanitize).toHaveBeenCalledWith(
@@ -112,9 +110,7 @@ describe("OpportunityDescription", () => {
     const mailtoLink = screen.getByRole("link", {
       name: "Contact Email Description",
     });
-    const agency_email = mockOpportunityData.summary.agency_email_address
-      ? mockOpportunityData.summary.agency_email_address
-      : "";
+    const agency_email = "contact@example.com";
     expect(mailtoLink).toHaveAttribute("href", `mailto:${agency_email}`);
 
     const telLink = screen.getByRole("link", {

--- a/frontend/tests/components/opportunity/OpportunityIntro.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityIntro.test.tsx
@@ -1,8 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import {
-  Opportunity,
-  Summary,
-} from "src/types/opportunity/opportunityResponseTypes";
+import { Opportunity } from "src/types/opportunity/opportunityResponseTypes";
 
 import OpportunityIntro from "src/components/opportunity/OpportunityIntro";
 
@@ -20,9 +17,7 @@ jest.mock("next-intl", () => ({
 
 const mockOpportunityData: Opportunity = {
   opportunity_title: "Test Opportunity",
-  summary: {
-    agency_name: "Test Agency",
-  },
+  agency_name: "Test Agency",
   opportunity_assistance_listings: [
     {
       assistance_listing_number: "12345",
@@ -64,9 +59,7 @@ describe("OpportunityIntro", () => {
   it("handles null agency name and null assistance listings", () => {
     const opportunityDataWithNulls: Opportunity = {
       ...mockOpportunityData,
-      summary: {
-        agency_name: "",
-      } as Summary,
+      agency_name: "",
       opportunity_assistance_listings: [],
     };
 


### PR DESCRIPTION
## Summary
Fixes #2222

### Time to review: __5 mins__

## Changes proposed
* Account for empty summaries which we can expect from the API
* Fix some of the type definitions for API fields that can be null
* bonus: Add title of the opp to the page
  * note that next encourages multiple fetch (only GET) in the same component tree: https://nextjs.org/docs/app/building-your-application/caching
* bonus: Fix lack of gap with the description:

  ![image](https://github.com/user-attachments/assets/5fb055d5-e0e3-4db8-b519-c4e5ea2c7e31)
  becomes:
  
![image](https://github.com/user-attachments/assets/bef7d064-674e-41cf-8239-ec151a8eb7c2)
 
* bonus: search breadcrumbs updated to link from `/search` to `/search?status=forecasted,posted`
 
