### PR TITLE
Revert pull request labeler version upgrade

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,4 +20,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4


### PR DESCRIPTION
https://github.com/HHS/simpler-grants-gov/pull/2188 broke it, and I don't feel like fixing it right now

I case someone feel like fixing it, the documentation is here: https://github.com/actions/labeler/tree/main

Bear in mind that renovate bot is going to try to recreate the PR to upgrade this action version again. We'll just have to tell it to skip this one.