### PR TITLE
Add Renovate "dependency dashboard"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "group:monorepos"
+    "group:monorepos",
+    "config:recommended",
+    ":dependencyDashboard"
   ],
   "schedule": [
     "on the 2nd and 4th day instance on sunday after 9pm"


### PR DESCRIPTION
This allows renovate to create issue(s). Having an open issue to reference will help with enabling open source contributors. The documentation for the dependency dashboard is here:

https://docs.renovatebot.com/key-concepts/dashboard/

### Time to review: __1 mins__

## Context for reviewers

This is the kind of thing that you can't test without merging