### PR TITLE
Update footer X/Twitter link

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -37,9 +37,9 @@ const Footer = () => {
 
   const links = [
     {
-      href: ExternalRoutes.GRANTS_TWITTER,
-      name: t("link_twitter"),
-      icon: "twitter",
+      href: ExternalRoutes.GRANTS_X_TWITTER,
+      name: t("link_x_twitter"),
+      icon: "x",
     },
     {
       href: ExternalRoutes.GRANTS_YOUTUBE,

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -16,7 +16,7 @@ export const ExternalRoutes = {
   GRANTS_NEWSLETTER:
     "https://www.grants.gov/web/grants/connect/newsletter-archive.html",
   GRANTS_RSS: "https://grants.gov/connect/rss-feeds",
-  GRANTS_TWITTER: "https://twitter.com/grantsdotgov",
+  GRANTS_X_TWITTER: "https://x.com/grantsdotgov",
   GRANTS_YOUTUBE: "https://www.youtube.com/user/GrantsGovUS",
   GRANTS_BLOG: "https://grantsgovprod.wordpress.com/",
   HHS: "https://www.hhs.gov",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -397,7 +397,7 @@ export const messages = {
     agency_contact_center: "Grants.gov Program Management Office",
     telephone: "1-877-696-6775",
     return_to_top: "Return to top",
-    link_twitter: "Twitter",
+    link_x_twitter: "X (Twitter)",
     link_youtube: "YouTube",
     link_github: "Github",
     link_rss: "RSS",

--- a/frontend/tests/components/Footer.test.tsx
+++ b/frontend/tests/components/Footer.test.tsx
@@ -13,15 +13,15 @@ describe("Footer", () => {
   it("Renders social links", () => {
     render(<Footer />);
 
-    const twitter = screen.getByTitle("Twitter");
+    const x_twitter = screen.getByTitle("X (Twitter)");
     const youtube = screen.getByTitle("YouTube");
     const github = screen.getByTitle("Github");
     const rss = screen.getByTitle("RSS");
     const newsletter = screen.getByTitle("Newsletter");
     const blog = screen.getByTitle("Blog");
 
-    expect(twitter).toBeInTheDocument();
-    expect(twitter).toHaveAttribute("href", ExternalRoutes.GRANTS_TWITTER);
+    expect(x_twitter).toBeInTheDocument();
+    expect(x_twitter).toHaveAttribute("href", ExternalRoutes.GRANTS_X_TWITTER);
 
     expect(youtube).toBeInTheDocument();
     expect(youtube).toHaveAttribute("href", ExternalRoutes.GRANTS_YOUTUBE);


### PR DESCRIPTION
## Summary
Fixes #1588 

### Time to review: <5min

## Changes proposed
Update twitter link in footer to 'X': logo, hint/name, and link route itself

## Additional information
<img width="628" alt="Screenshot 2024-09-30 at 3 25 25 PM" src="https://github.com/user-attachments/assets/3bf0c499-4393-421d-9cb1-24c07c84de53">
