### PR TITLE
[Issue #2231] Fix Checks failing on forked branches

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -49,7 +49,7 @@ jobs:
             coverage-file: coverage/report.json
             test-script: npm test
             working-directory: ./frontend
-            annotations: failed-tests
+            annotations: ${{ github.event.pull_request.head.repo.full_name == github.event.repository.name && 'failed-tests' || 'none' }}
             package-manager: npm
             icons: emoji
             skip-step: none

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -53,7 +53,7 @@ jobs:
             package-manager: npm
             icons: emoji
             skip-step: none
-            output: comment
+            output: ${{ github.event.pull_request.head.repo.full_name == github.event.repository.name && 'comment' || 'report-markdown' }}
 
   # Confirms the front end still builds successfully
   check-frontend-builds:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,4 +20,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4 # Uploads repository content to the runner
+      with:
+        repository: github.event.pull_request.head.repo.full_name
+        sparse-checkout: |
+          .github
     - uses: actions/labeler@v4


### PR DESCRIPTION
Summary
Fixes #2231

Time to review: 5 mins
Changes proposed
While the coverage commenting back is what is breaking things, this is the only place the tests are run, so we don't want to just skip the whole action. We instead want it to run the tests, and just not do things that forks don't have permissions to do with the coverage reporting.

Context for reviewers
Found this workaround/fix from the author on this ticket ArtiomTr/jest-coverage-report-action#313 (comment)