### PR TITLE
[Issue #2338] Adjust set-current-opportunities script to remove status from drafts

### DIFF
--- a/api/src/data_migration/transformation/transform_util.py
+++ b/api/src/data_migration/transformation/transform_util.py
@@ -421,8 +421,8 @@ def transform_update_create_timestamp(
     target.updated_at = updated_timestamp
 
 
-TRUTHY = {"Y", "Yes"}
-FALSEY = {"N", "No"}
+TRUTHY = {"Y", "Yes", "y", "yes"}
+FALSEY = {"N", "No", "n", "no"}
 
 
 def convert_yn_bool(value: str | None) -> bool | None:

--- a/api/src/task/opportunities/set_current_opportunities_task.py
+++ b/api/src/task/opportunities/set_current_opportunities_task.py
@@ -81,6 +81,7 @@ class SetCurrentOpportunitiesTask(Task):
 
         log_extra = {
             "opportunity_id": opportunity.opportunity_id,
+            "is_draft": opportunity.is_draft,
             "existing_opportunity_status": opportunity.opportunity_status,
         }
         log_extra |= get_log_extra_for_summary(
@@ -147,6 +148,10 @@ class SetCurrentOpportunitiesTask(Task):
         # Determine latest forecasted and non-forecasted opportunity summaries
         latest_forecasted_summary: OpportunitySummary | None = None
         latest_non_forecasted_summary: OpportunitySummary | None = None
+
+        # If the opportunity is a draft, we don't want to create a status
+        if opportunity.is_draft:
+            return None, None
 
         # Latest is based entirely off of the revision number, the latest
         # will always have a null revision number, and because of how the

--- a/api/tests/src/data_migration/transformation/test_transform_util.py
+++ b/api/tests/src/data_migration/transformation/test_transform_util.py
@@ -80,13 +80,24 @@ def test_transform_update_create_timestamp(
 
 @pytest.mark.parametrize(
     "value,expected_value",
-    [("Y", True), ("N", False), ("Yes", True), ("No", False), ("", None), (None, None)],
+    [
+        ("Y", True),
+        ("N", False),
+        ("Yes", True),
+        ("No", False),
+        ("Y", True),
+        ("n", False),
+        ("yes", True),
+        ("no", False),
+        ("", None),
+        (None, None),
+    ],
 )
 def test_convert_yn_boolean(value, expected_value):
     assert transform_util.convert_yn_bool(value) == expected_value
 
 
-@pytest.mark.parametrize("value", ["X", "Z", "y", "n", "1", "0", "yes", "no"])
+@pytest.mark.parametrize("value", ["X", "Z", "1", "0", "yEs", "nO"])
 def test_convert_yn_boolean_unexpected_value(value):
     with pytest.raises(ValueError, match="Unexpected Y/N bool value"):
         transform_util.convert_yn_bool(value)


### PR DESCRIPTION
## Summary
Fixes #2338

### Time to review: __5 mins__

## Changes proposed
Modified the set-current-opportunities script to remove the opportunity_status + current opportunity from any opportunity where is_draft=True

Minor adjustment to the transformation logic to allow different capitalization for str booleans as the Oracle test DB had a few variations different from prod for some fields

## Context for reviewers
The set-current-opportunities script is the last step of the transformation process which handles calculating both the current opportunity summary (in short - figure out which forecast/non-forecast record is "active") as well as that summaries status.

We don't want to calculate these values if the opportunity is a draft as there is no current summary technically as it isn't "ready" yet. We already filter drafts out of our endpoints, this just keeps the data in the DB simpler and matching the behavior of the APIs as well.

