### PR TITLE
[Issue #1397] process roadmap accessibility

### DIFF
--- a/frontend/src/app/[locale]/process/ProcessMilestones.tsx
+++ b/frontend/src/app/[locale]/process/ProcessMilestones.tsx
@@ -47,46 +47,51 @@ const ProcessMilestones = () => {
         bottomBorder="dark"
         gridGap={6}
       >
-        {high_level_roadmap_items.map((_unusedItem, index) => {
-          const title = t(`high_level_roadmap_items.${index}.title`);
-          const content = t.rich(`high_level_roadmap_items.${index}.content`, {
-            p: (chunks) => (
-              <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
-                {chunks}
-              </p>
-            ),
-            italics: (chunks) => <em>{chunks}</em>,
-          });
+        <IconList className="usa-icon-list--size-lg">
+          <Grid row>
+            {high_level_roadmap_items.map((_unusedItem, index) => {
+              const title = t(`high_level_roadmap_items.${index}.title`);
+              const content = t.rich(
+                `high_level_roadmap_items.${index}.content`,
+                {
+                  p: (chunks) => (
+                    <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
+                      {chunks}
+                    </p>
+                  ),
+                  italics: (chunks) => <em>{chunks}</em>,
+                },
+              );
 
-          return (
-            <Grid key={title + "-key"} tabletLg={{ col: 4 }}>
-              <IconList className="usa-icon-list--size-lg">
-                <IconListItem className="margin-top-4">
-                  <IconListIcon>{getIcon(index)}</IconListIcon>
-                  <IconListContent className="tablet-lg:padding-right-3 desktop-lg:padding-right-105">
-                    <IconListTitle className="margin-bottom-2" type="h3">
-                      {title}
-                    </IconListTitle>
-                    <div className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
-                      {content}
-                    </div>
-                    {
-                      // Don't show the chevron in the last row item.
-                      index < high_level_roadmap_items.length - 1 ? (
-                        <USWDSIcon
-                          className="usa-icon usa-icon--size-9 display-none tablet-lg:display-block text-base-lighter position-absolute right-0 top-0 margin-right-neg-5"
-                          name="navigate_next"
-                        />
-                      ) : (
-                        ""
-                      )
-                    }
-                  </IconListContent>
-                </IconListItem>
-              </IconList>
-            </Grid>
-          );
-        })}
+              return (
+                <Grid key={title + "-key"} tabletLg={{ col: true }}>
+                  <IconListItem className="margin-top-4">
+                    <IconListIcon>{getIcon(index)}</IconListIcon>
+                    <IconListContent>
+                      <IconListTitle className="margin-bottom-2" type="h3">
+                        {title}
+                      </IconListTitle>
+                      <div className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6 tablet:padding-right-50">
+                        {content}
+                      </div>
+                      {
+                        // Don't show the chevron in the last row item.
+                        index < high_level_roadmap_items.length - 1 ? (
+                          <USWDSIcon
+                            className="usa-icon usa-icon--size-9 display-none tablet-lg:display-block text-base-lighter position-absolute right-0 top-0"
+                            name="navigate_next"
+                          />
+                        ) : (
+                          ""
+                        )
+                      }
+                    </IconListContent>
+                  </IconListItem>
+                </Grid>
+              );
+            })}
+          </Grid>
+        </IconList>
       </ContentLayout>
       <ContentLayout
         title={

--- a/frontend/src/app/[locale]/process/ProcessMilestones.tsx
+++ b/frontend/src/app/[locale]/process/ProcessMilestones.tsx
@@ -17,10 +17,13 @@ import ContentLayout from "src/components/ContentLayout";
 import { USWDSIcon } from "src/components/USWDSIcon";
 
 const ProcessMilestones = () => {
-  const t = useTranslations("Process");
+  const t = useTranslations("Process.milestones");
 
-  const messages = useMessages() as unknown as IntlMessages;
-  const keys = Object.keys(messages.Process.milestones.icon_list);
+  const {
+    Process: {
+      milestones: { high_level_roadmap_items },
+    },
+  } = useMessages() as unknown as IntlMessages;
 
   const getIcon = (iconIndex: number) => {
     switch (iconIndex) {
@@ -38,15 +41,15 @@ const ProcessMilestones = () => {
   return (
     <>
       <ContentLayout
-        title={t("milestones.tag")}
+        title={t("tag")}
         data-test-id="process-high-level-content"
         titleSize="m"
         bottomBorder="dark"
         gridGap={6}
       >
-        {keys.map((key, index) => {
-          const title = t(`milestones.icon_list.${key}.title`);
-          const content = t.rich(`milestones.icon_list.${key}.content`, {
+        {high_level_roadmap_items.map((_unusedItem, index) => {
+          const title = t(`high_level_roadmap_items.${index}.title`);
+          const content = t.rich(`high_level_roadmap_items.${index}.content`, {
             p: (chunks) => (
               <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
                 {chunks}
@@ -69,7 +72,7 @@ const ProcessMilestones = () => {
                     </div>
                     {
                       // Don't show the chevron in the last row item.
-                      index < keys.length - 1 ? (
+                      index < high_level_roadmap_items.length - 1 ? (
                         <USWDSIcon
                           className="usa-icon usa-icon--size-9 display-none tablet-lg:display-block text-base-lighter position-absolute right-0 top-0 margin-right-neg-5"
                           name="navigate_next"
@@ -89,14 +92,14 @@ const ProcessMilestones = () => {
         title={
           <>
             <small className="display-block font-sans-lg margin-bottom-105">
-              {t("milestones.roadmap_1")}
+              {t("roadmap_1")}
               <USWDSIcon
                 className="usa-icon usa-icon--size-4 text-middle text-base-light"
                 name="navigate_next"
               />
-              {t("milestones.title_1")}
+              {t("title_1")}
             </small>
-            {t("milestones.name_1")}
+            {t("name_1")}
           </>
         }
         data-testid="process-methodology-content"
@@ -104,24 +107,24 @@ const ProcessMilestones = () => {
         bottomBorder="none"
       >
         <Grid tabletLg={{ col: 6 }}>
-          <p className="usa-intro">{t("milestones.paragraph_1")}</p>
+          <p className="usa-intro">{t("paragraph_1")}</p>
         </Grid>
         <Grid tabletLg={{ col: 6 }}>
           <h3 className="tablet-lg:font-sans-lg tablet-lg:margin-bottom-05">
-            {t("milestones.sub_title_1")}
+            {t("sub_title_1")}
           </h3>
           <p className="margin-top-0 font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
-            {t("milestones.sub_paragraph_1")}
+            {t("sub_paragraph_1")}
           </p>
           <h3 className="tablet-lg:font-sans-lg margin-top-4 margin-bottom-2">
-            {t("milestones.sub_title_2")}
+            {t("sub_title_2")}
           </h3>
           <p className="margin-top-0 font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
-            {t("milestones.sub_paragraph_2")}
+            {t("sub_paragraph_2")}
           </p>
           <Link href={ExternalRoutes.MILESTONE_GET_OPPORTUNITIES} passHref>
             <Button className="margin-bottom-4" type="button" size="big">
-              <span className="margin-right-5">{t("milestones.cta_1")}</span>
+              <span className="margin-right-5">{t("cta_1")}</span>
               <USWDSIcon
                 name="launch"
                 className="usa-icon usa-icon--size-4 text-middle margin-left-neg-4"
@@ -134,14 +137,14 @@ const ProcessMilestones = () => {
         title={
           <>
             <small className="display-block font-sans-lg margin-bottom-105">
-              {t("milestones.roadmap_2")}
+              {t("roadmap_2")}
               <USWDSIcon
                 className="usa-icon usa-icon--size-4 text-middle text-base-light"
                 name="navigate_next"
               />
-              {t("milestones.title_2")}
+              {t("title_2")}
             </small>
-            {t("milestones.name_2")}
+            {t("name_2")}
           </>
         }
         data-testid="process-methodology-content"
@@ -150,17 +153,17 @@ const ProcessMilestones = () => {
         bottomBorder="none"
       >
         <Grid tabletLg={{ col: 6 }}>
-          <p className="usa-intro">{t("milestones.paragraph_2")}</p>
+          <p className="usa-intro">{t("paragraph_2")}</p>
         </Grid>
         <Grid tabletLg={{ col: 6 }}>
           <h3 className="tablet-lg:font-sans-lg tablet-lg:margin-bottom-05">
-            {t("milestones.sub_title_3")}
+            {t("sub_title_3")}
           </h3>
           <p className="margin-top-0 font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6"></p>
           <p className="margin-top-0 font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6"></p>
           <Link href={ExternalRoutes.MILESTONE_SEARCH_MVP} passHref>
             <Button className="margin-bottom-4" type="button" size="big">
-              <span className="margin-right-5">{t("milestones.cta_2")}</span>
+              <span className="margin-right-5">{t("cta_2")}</span>
               <USWDSIcon
                 name="launch"
                 className="usa-icon usa-icon--size-4 text-middle margin-left-neg-4"

--- a/frontend/src/app/[locale]/process/ProcessMilestones.tsx
+++ b/frontend/src/app/[locale]/process/ProcessMilestones.tsx
@@ -46,53 +46,52 @@ const ProcessMilestones = () => {
         bottomBorder="dark"
         gridGap={6}
       >
-        <IconList className="usa-icon-list--size-lg">
-          <Grid row>
-            {high_level_roadmap_items.map((_unusedItem, index) => {
-              const title = t(`high_level_roadmap_items.${index}.title`);
-              const content = t.rich(
-                `high_level_roadmap_items.${index}.content`,
-                {
-                  p: (chunks) => (
-                    <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
-                      {chunks}
-                    </p>
-                  ),
-                  italics: (chunks) => <em>{chunks}</em>,
-                },
-              );
+        <IconList className="usa-icon-list--size-lg grid-row">
+          {high_level_roadmap_items.map((_unusedItem, index) => {
+            const title = t(`high_level_roadmap_items.${index}.title`);
+            const content = t.rich(
+              `high_level_roadmap_items.${index}.content`,
+              {
+                p: (chunks) => (
+                  <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
+                    {chunks}
+                  </p>
+                ),
+                italics: (chunks) => <em>{chunks}</em>,
+              },
+            );
 
-              return (
-                <Grid key={title + "-key"} tabletLg={{ col: 4 }}>
-                  <IconListItem className="margin-top-4">
-                    <IconListIcon>{getIcon(index)}</IconListIcon>
-                    <IconListContent className="tablet:padding-right-7">
-                      <h4
-                        aria-label={`Step ${index + 1}: ${title}`}
-                        className="margin-bottom-2 usa-icon-list__title"
-                      >
-                        {title}
-                      </h4>
-                      <div className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
-                        {content}
-                      </div>
-                      {
-                        // Don't show the chevron in the last row item.
-                        index < high_level_roadmap_items.length - 1 ? (
-                          <USWDSIcon
-                            className="usa-icon usa-icon--size-9 display-none tablet-lg:display-block text-base-lighter position-absolute right-0 top-0"
-                            name="navigate_next"
-                          />
-                        ) : (
-                          ""
-                        )
-                      }
-                    </IconListContent>
-                  </IconListItem>
-                </Grid>
-              );
-            })}
-          </Grid>
+            return (
+              <IconListItem
+                key={title + "-key"}
+                className="margin-top-4 tablet-lg:grid-col-4"
+              >
+                <IconListIcon>{getIcon(index)}</IconListIcon>
+                <IconListContent className="tablet:padding-right-7">
+                  <h3
+                    aria-label={`Step ${index + 1}: ${title}`}
+                    className="margin-bottom-2 usa-icon-list__title"
+                  >
+                    {title}
+                  </h3>
+                  <div className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
+                    {content}
+                  </div>
+                  {
+                    // Don't show the chevron in the last row item.
+                    index < high_level_roadmap_items.length - 1 ? (
+                      <USWDSIcon
+                        className="usa-icon usa-icon--size-9 display-none tablet-lg:display-block text-base-lighter position-absolute right-0 top-0"
+                        name="navigate_next"
+                      />
+                    ) : (
+                      ""
+                    )
+                  }
+                </IconListContent>
+              </IconListItem>
+            );
+          })}
         </IconList>
       </ContentLayout>
       <ContentLayout

--- a/frontend/src/app/[locale]/process/ProcessMilestones.tsx
+++ b/frontend/src/app/[locale]/process/ProcessMilestones.tsx
@@ -10,7 +10,6 @@ import {
   IconListContent,
   IconListIcon,
   IconListItem,
-  IconListTitle,
 } from "@trussworks/react-uswds";
 
 import ContentLayout from "src/components/ContentLayout";
@@ -64,14 +63,17 @@ const ProcessMilestones = () => {
               );
 
               return (
-                <Grid key={title + "-key"} tabletLg={{ col: true }}>
+                <Grid key={title + "-key"} tabletLg={{ col: 4 }}>
                   <IconListItem className="margin-top-4">
                     <IconListIcon>{getIcon(index)}</IconListIcon>
-                    <IconListContent>
-                      <IconListTitle className="margin-bottom-2" type="h3">
+                    <IconListContent className="tablet:padding-right-7">
+                      <h4
+                        aria-label={`Step ${index + 1}: ${title}`}
+                        className="margin-bottom-2 usa-icon-list__title"
+                      >
                         {title}
-                      </IconListTitle>
-                      <div className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6 tablet:padding-right-50">
+                      </h4>
+                      <div className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
                         {content}
                       </div>
                       {

--- a/frontend/src/app/[locale]/process/ProcessMilestones.tsx
+++ b/frontend/src/app/[locale]/process/ProcessMilestones.tsx
@@ -15,14 +15,10 @@ import {
 import ContentLayout from "src/components/ContentLayout";
 import { USWDSIcon } from "src/components/USWDSIcon";
 
+const highLevelRoadmapItems = ["find", "advanced_reporting", "apply"] as const;
+
 const ProcessMilestones = () => {
   const t = useTranslations("Process.milestones");
-
-  const {
-    Process: {
-      milestones: { high_level_roadmap_items },
-    },
-  } = useMessages() as unknown as IntlMessages;
 
   const getIcon = (iconIndex: number) => {
     switch (iconIndex) {
@@ -47,10 +43,10 @@ const ProcessMilestones = () => {
         gridGap={6}
       >
         <IconList className="usa-icon-list--size-lg grid-row">
-          {high_level_roadmap_items.map((_unusedItem, index) => {
-            const title = t(`high_level_roadmap_items.${index}.title`);
+          {highLevelRoadmapItems.map((itemKey, index) => {
+            const title = t(`high_level_roadmap_items.${itemKey}.title`);
             const content = t.rich(
-              `high_level_roadmap_items.${index}.content`,
+              `high_level_roadmap_items.${itemKey}.content`,
               {
                 p: (chunks) => (
                   <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
@@ -79,7 +75,7 @@ const ProcessMilestones = () => {
                   </div>
                   {
                     // Don't show the chevron in the last row item.
-                    index < high_level_roadmap_items.length - 1 ? (
+                    index < highLevelRoadmapItems.length - 1 ? (
                       <USWDSIcon
                         className="usa-icon usa-icon--size-9 display-none tablet-lg:display-block text-base-lighter position-absolute right-0 top-0"
                         name="navigate_next"

--- a/frontend/src/app/[locale]/process/ProcessMilestones.tsx
+++ b/frontend/src/app/[locale]/process/ProcessMilestones.tsx
@@ -1,6 +1,6 @@
 import { ExternalRoutes } from "src/constants/routes";
 
-import { useMessages, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 import Link from "next/link";
 import React from "react";
 import {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -271,7 +271,7 @@ export const messages = {
     },
     milestones: {
       tag: "The high-level roadmap",
-      icon_list: [
+      high_level_roadmap_items: [
         {
           title: "Find",
           content:

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -271,23 +271,23 @@ export const messages = {
     },
     milestones: {
       tag: "The high-level roadmap",
-      high_level_roadmap_items: [
-        {
+      high_level_roadmap_items: {
+        find: {
           title: "Find",
           content:
             "<p>Improve how applicants discover funding opportunities that they’re qualified for and that meet their needs.</p>",
         },
-        {
+        advanced_reporting: {
           title: "Advanced reporting",
           content:
             "<p>Improve stakeholders’ capacity to understand, analyze, and assess grants from application to acceptance.</p><p>Make non-confidential Grants.gov data open for public analysis.</p>",
         },
-        {
+        apply: {
           title: "Apply",
           content:
             "<p>Streamline the application process to make it easier for all applicants to apply for funding opportunities.</p>",
         },
-      ],
+      },
       roadmap_1: "Find",
       title_1: "Milestone 1",
       name_1:

--- a/frontend/tests/utils/intlMocks.ts
+++ b/frontend/tests/utils/intlMocks.ts
@@ -15,7 +15,7 @@ export const mockMessages = {
       boxes: ["firstKey"],
     },
     milestones: {
-      icon_list: ["firstIcon"],
+      high_level_roadmap_items: ["firstIcon"],
     },
   },
   Research: {


### PR DESCRIPTION
## Summary
Fixes #1397

### Time to review: __20 mins__

## Changes proposed
* update DOM structure on process page to follow best practices for lists (previously implemented as three invidual lists with one item each, rather than one list with three items)
* update aria labels to make high level roadmap items more readable by screen readers
* a few refactors for better readability of process page code


## Context for reviewers
### Test steps

1. visit localhost:3000/process
2. visit https://simpler.grants.gov/process
3. _VERIFY_: the "high-level roadmap" section of each page matches visually
4. turn on screen reader (cmd + fn + f5 probably)
5. ctrl + opt + cmd + h to cycle through headings until you find "the high level roadmap"
6. ctrl + opt + a to read the content
7. _VERIFY_: roadmap headings are read out as "Step 1: Find" etc.



## Additional information
note that requirement in the ticket specifying removal of "launch" aria text for the chevron icons seems to have already been fixed

