### PR TITLE
[Issue: #2395] Try not installing packages that were added to fix a prior trivy issue

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get update \
     # https://pythonspeed.com/articles/security-updates-in-docker/
     && apt-get upgrade --yes \
     && apt-get install --no-install-recommends --yes \
-        libc-bin libc6 \
         build-essential \
         libpq-dev \
         postgresql \


### PR DESCRIPTION
## Summary
Fixes #2395

### Time to review: __3 mins__

## Changes proposed
Stop installing some Linux packages that were added previously to "fix a trivy failure"

## Context for reviewers
This started failing randomly, so removing the stuff we added the last time it failed randomly seems to stop the random failures...

