### PR TITLE
improve header loading process

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -43,7 +43,7 @@ const Header = ({ logoPath, locale }: Props) => {
     setIsMobileNavExpanded(!isMobileNavExpanded);
   };
 
-  const primaryLinksRef = useRef<PrimaryLinks>([
+  const primaryLinkConfigs = [
     { linkText: t("nav_link_home"), href: "/" },
     {
       linkText: t("nav_link_search"),
@@ -53,13 +53,21 @@ const Header = ({ logoPath, locale }: Props) => {
     { linkText: t("nav_link_process"), href: "/process" },
     { linkText: t("nav_link_research"), href: "/research" },
     { linkText: t("nav_link_subscribe"), href: "/subscribe" },
-  ]);
+  ];
+
+  const primaryLinksRef = useRef<PrimaryLinks>(
+    primaryLinkConfigs.filter((config) => !config.flag),
+  );
 
   // note that this will not update when feature flags are updated without a refresh
   useEffect(() => {
-    primaryLinksRef.current = primaryLinksRef.current.filter(
-      (link) => !link.flag || featureFlags[link.flag],
-    );
+    const navLinksFromFlags = primaryLinkConfigs.reduce((acc, link) => {
+      if (!link.flag || featureFlags[link.flag]) {
+        acc.push(link);
+      }
+      return acc;
+    }, [] as PrimaryLinks);
+    primaryLinksRef.current = navLinksFromFlags;
   }, [featureFlags]);
 
   const language = useMemo(

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -43,30 +43,41 @@ const Header = ({ logoPath, locale }: Props) => {
     setIsMobileNavExpanded(!isMobileNavExpanded);
   };
 
-  const primaryLinkConfigs = [
+  const primaryNavLinkConfigs: PrimaryLinks = [
     { linkText: t("nav_link_home"), href: "/" },
-    {
-      linkText: t("nav_link_search"),
-      href: "/search?status=forecasted,posted",
-      flag: "showSearchV0",
-    },
     { linkText: t("nav_link_process"), href: "/process" },
     { linkText: t("nav_link_research"), href: "/research" },
     { linkText: t("nav_link_subscribe"), href: "/subscribe" },
   ];
 
-  const primaryLinksRef = useRef<PrimaryLinks>(
-    primaryLinkConfigs.filter((config) => !config.flag),
-  );
+  const featureFlaggedNavLinkConfigs: PrimaryLinks = [
+    {
+      linkText: t("nav_link_search"),
+      href: "/search?status=forecasted,posted",
+      flag: "showSearchV0",
+    },
+  ];
+
+  const primaryLinksRef = useRef<PrimaryLinks>(primaryNavLinkConfigs);
 
   // note that this will not update when feature flags are updated without a refresh
   useEffect(() => {
-    const navLinksFromFlags = primaryLinkConfigs.reduce((acc, link) => {
-      if (!link.flag || featureFlags[link.flag]) {
-        acc.push(link);
-      }
-      return acc;
-    }, [] as PrimaryLinks);
+    const navLinksFromFlags = featureFlaggedNavLinkConfigs.reduce(
+      (acc, link) => {
+        const { flag = "" } = link;
+        console.log("####", featureFlags[flag]);
+        if (
+          featureFlags[flag] &&
+          !primaryLinksRef.current.some(
+            (existingLink) => existingLink.href === link.href,
+          )
+        ) {
+          acc.splice(1, 0, link);
+        }
+        return acc;
+      },
+      primaryNavLinkConfigs,
+    );
     primaryLinksRef.current = navLinksFromFlags;
   }, [featureFlags]);
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -24,12 +24,6 @@ type Props = {
   locale?: string;
 };
 
-const toNavLinkItem = (linkDetails: { linkText: string; href: string }) => (
-  <a href={linkDetails.href} key={linkDetails.href}>
-    {linkDetails.linkText}
-  </a>
-);
-
 const toNavLinkItems = (linkDetails: { linkText: string; href: string }[]) => {
   return linkDetails.map((link) => (
     <a href={link.href} key={link.href}>

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen } from "tests/react-utils";
+import { render, screen, waitFor } from "tests/react-utils";
 
 import Header from "src/components/Header";
 
@@ -17,7 +17,27 @@ const props = {
   ],
 };
 
+let searchFeatureFlag = false;
+
+const getSearchFeatureFlag = () => {
+  console.log("$$$", searchFeatureFlag);
+  return searchFeatureFlag;
+};
+
+jest.mock("src/hooks/useFeatureFlags", () => ({
+  useFeatureFlags: () => ({
+    featureFlagsManager: {
+      featureFlags: {
+        showSearchV0: getSearchFeatureFlag(),
+      },
+    },
+  }),
+}));
+
 describe("Header", () => {
+  afterEach(() => {
+    searchFeatureFlag = false;
+  });
   it("toggles the mobile nav menu", async () => {
     render(<Header {...props} />);
     const menuButton = screen.getByTestId("navMenuButton");
@@ -49,5 +69,29 @@ describe("Header", () => {
     await userEvent.click(govBanner);
 
     expect(govBanner).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("displays expected nav links without feature flags", () => {
+    render(<Header />);
+
+    const expectedNavLinks = ["Home", "Process", "Research", "Subscribe"];
+    expectedNavLinks.forEach((linkText) => {
+      const link = screen.getByText(linkText);
+      expect(link).toBeInTheDocument();
+    });
+    // ensure search is not included by default
+    try {
+      screen.getByText("Search");
+    } catch (_e) {
+      expect(false).toBeFalsy;
+    }
+  });
+
+  it("displays expected nav links without feature flags", async () => {
+    searchFeatureFlag = true;
+
+    render(<Header />);
+
+    waitFor(() => expect(screen.getByText("Search")).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Summary
Fixes (unticketed)

### Time to review: __15 mins__

## Changes proposed

updates to allow header nav items to remain consistent between page navigations.

## Context for reviewers

because the list of nav items was being instantiated as empty on first render, when loading the layout on navigation, there would be a flicker of the nav, waiting for the items to be created on the second render. With this change, the nav will be rendered by default without any feature flagged items, and feature flagged items will appear on second render. There are implementations that could prevent flickering, but we'd have to implement feature flags or translation a little differently, I think.

### Test steps

1. on main, with search feature flag off, navigate around different pages on the app
2. _VERIFY_: on each navigation the header nav links flicker on each navigation
3. on this branch, with search feature flag off, navigate around different pages on the app
4. _VERIFY_: nav links remain in place while navigating through the app
5. on this branch, with search feature flag on, navigate around different pages on the app
6. _VERIFY_: search link appears in nav on second render
7. turn off search feature at /dev/feature-flags
8. _VERIFY_: search link still appears in nav until page is refreshed. This is an existing issue that this change does not deal with, but we should consider refactoring the useFeatureFlags hook to respond to changes in feature flags without refreshing


## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

