### PR TITLE
Remove selective e2e test skips for webkit

### DIFF
--- a/frontend/tests/e2e/search/search-loading.spec.ts
+++ b/frontend/tests/e2e/search/search-loading.spec.ts
@@ -15,9 +15,7 @@ test.describe("Search page tests", () => {
     await page.goto("/search?_ff=showSearchV0:true");
   });
 
-  test("should show and hide loading state", async ({
-    page,
-  }: PageProps) => {
+  test("should show and hide loading state", async ({ page }: PageProps) => {
     const searchTerm = "advanced";
     await fillSearchInputAndSubmit(searchTerm, page);
 

--- a/frontend/tests/e2e/search/search-loading.spec.ts
+++ b/frontend/tests/e2e/search/search-loading.spec.ts
@@ -19,11 +19,6 @@ test.describe("Search page tests", () => {
     page,
     browserName,
   }: PageProps) => {
-    // TODO (Issue #2005): fix test for webkit
-    test.skip(
-      browserName === "webkit",
-      "Skipping test for WebKit due to a query param issue.",
-    );
     const searchTerm = "advanced";
     await fillSearchInputAndSubmit(searchTerm, page);
 

--- a/frontend/tests/e2e/search/search-loading.spec.ts
+++ b/frontend/tests/e2e/search/search-loading.spec.ts
@@ -17,7 +17,6 @@ test.describe("Search page tests", () => {
 
   test("should show and hide loading state", async ({
     page,
-    browserName,
   }: PageProps) => {
     const searchTerm = "advanced";
     await fillSearchInputAndSubmit(searchTerm, page);

--- a/frontend/tests/e2e/search/search-no-results.spec.ts
+++ b/frontend/tests/e2e/search/search-no-results.spec.ts
@@ -20,7 +20,6 @@ test.describe("Search page tests", () => {
 
   test("should return 0 results when searching for obscure term", async ({
     page,
-    browserName,
   }: PageProps) => {
     const searchTerm = "0resultearch";
 

--- a/frontend/tests/e2e/search/search-no-results.spec.ts
+++ b/frontend/tests/e2e/search/search-no-results.spec.ts
@@ -22,12 +22,6 @@ test.describe("Search page tests", () => {
     page,
     browserName,
   }: PageProps) => {
-    // TODO (Issue #2005): fix test for webkit
-    test.skip(
-      browserName === "webkit",
-      "Skipping test for WebKit due to a query param issue.",
-    );
-
     const searchTerm = "0resultearch";
 
     await fillSearchInputAndSubmit(searchTerm, page);


### PR DESCRIPTION
## Summary
Fixes #2005 

### Time to review: <10min

## Changes proposed
- Remove e2e test skips for webkit, the test appear to pass now, presumably as a result of search refactoring that previously happened.

## Context for reviewers
- Checkout branch locally and run webkit e2e tests to verify they pass.

## Additional information
<img width="331" alt="Screenshot 2024-10-10 at 1 22 02 PM" src="https://github.com/user-attachments/assets/1cb12073-12be-40c6-bc21-0c7c5a769654">
