### PR TITLE
[Issue #2456] Remove flicker from navigation between pages

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { useFeatureFlags } from "src/hooks/useFeatureFlags";
 import { assetPath } from "src/utils/assetPath";
 
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import {
   GovBanner,
@@ -50,9 +51,9 @@ const Header = ({ logoPath, locale }: Props) => {
   }, [featureFlagsManager, t]);
 
   const navItems = primaryLinksRef.current.map((link) => (
-    <a href={link.href} key={link.href}>
+    <Link href={link.href} key={link.href}>
       {link.i18nKey}
-    </a>
+    </Link>
   ));
   const language = locale && locale.match("/^es/") ? "spanish" : "english";
 

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -5,6 +5,7 @@ import { formatDate } from "src/utils/dateUtil";
 import { AgencyNamyLookup } from "src/utils/search/generateAgencyNameLookup";
 
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 
 interface SearchResultsListItemProps {
   opportunity: Opportunity;
@@ -43,12 +44,12 @@ export default function SearchResultsListItem({
           <div className="grid-row flex-column">
             <div className="grid-col tablet:order-2">
               <h2 className="margin-y-105 line-height-serif-2">
-                <a
+                <Link
                   href={`/opportunity/${opportunity?.opportunity_id}`}
                   className="usa-link usa-link"
                 >
                   {opportunity?.opportunity_title}
-                </a>
+                </Link>
               </h2>
             </div>
             <div className="grid-col tablet:order-1 overflow-hidden font-body-xs">

--- a/frontend/tests/e2e/search/search-navigate.spec.ts
+++ b/frontend/tests/e2e/search/search-navigate.spec.ts
@@ -3,7 +3,6 @@ import { BrowserContextOptions } from "playwright-core";
 
 import {
   clickMobileNavMenu,
-  clickSearchNavLink,
   expectCheckboxIDIsChecked,
   expectURLContainsQueryParam,
   getMobileMenuButton,
@@ -28,15 +27,15 @@ test("should navigate from index to search page", async ({
     await clickMobileNavMenu(menuButton);
   }
 
-  await clickSearchNavLink(page);
-
-  // Verify that the new URL is correct
-  expectURLContainsQueryParam(page, "status", "forecasted,posted");
+  await page.click("nav >> text=Search");
 
   // Verify the presence of "Search" content on the page
   await expect(page.locator("h1")).toContainText(
     "Search funding opportunities",
   );
+
+  // Verify that the new URL is correct
+  expectURLContainsQueryParam(page, "status", "forecasted,posted");
 
   // Verify that the 'forecasted' and 'posted' are checked
   await expectCheckboxIDIsChecked(page, "#status-forecasted");

--- a/frontend/tests/e2e/search/searchSpecUtil.ts
+++ b/frontend/tests/e2e/search/searchSpecUtil.ts
@@ -55,10 +55,6 @@ export async function waitForURLContainsQueryParam(
   );
 }
 
-export async function clickSearchNavLink(page: Page) {
-  await page.click("nav >> text=Search");
-}
-
 export function getMobileMenuButton(page: Page) {
   return page.locator("button >> text=MENU");
 }


### PR DESCRIPTION
## Summary
Fixes #2456

### Time to review: __5 mins__

## Changes proposed
Moves from the HTML `<a/>` to Next App routers [`<Link/>`](https://nextjs.org/docs/app/api-reference/components/link) component which enables [client-side navigation](https://nextjs.org/learn-pages-router/basics/navigate-between-pages/client-side) between pages which keeps the navigation from re-render.

The navigation can still flicker upon initial load, so the approach taken in #2427 might still be necessary.



