### PR TITLE
[Issue #2459] Speed up e2e tests by testing against built frontend

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -51,7 +51,10 @@ jobs:
         shell: bash
 
       - name: Run E2E Tests
-        run: npm run test:e2e
+        run: |
+          npm run build
+          cat .env.development >> .env.local
+          npm run test:e2e
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev",
+    command: "npm run start",
     url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
   },


### PR DESCRIPTION
## Summary
Fixes #2459

### Time to review: __5 mins__

## Changes proposed
This is a small fix to run the e2e tests against the built version of the frontend. The test for this PR ran a minute slower than the previous PR (3 mins 51 secs vs 4 min 49 secs).
