### PR TITLE
Require build and publish before database migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
   database-migrations:
     name: Database migrations
     uses: ./.github/workflows/database-migrations.yml
+    needs: [build-and-publish]
     with:
       app_name: ${{ inputs.app_name }}
       environment: ${{ inputs.environment }}


### PR DESCRIPTION
## Context

Right now builds are failing because of a race condition between migrations and build and publish. This fixes that by making the dependency explicit.