### PR TITLE
[Issue 2448] use v1 search endpoint and frontend fetch pattern refactors

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Start API Server for e2e tests
         run: |
           cd ../api
-          make init db-seed-local start &
+          make init db-seed-local populate-search-opportunities start &
           cd ../frontend
           # Ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
+    "debug": "NODE_OPTIONS='--inspect' next dev",
     "format": "prettier --write '**/*.{js,json,md,mdx,ts,tsx,scss,yaml,yml}'",
     "format-check": "prettier --check '**/*.{js,json,md,mdx,ts,tsx,scss,yaml,yml}'",
     "lint": "next lint --dir src --dir stories --dir .storybook --dir tests --dir scripts --dir frontend --dir lib --dir types",

--- a/frontend/src/app/api/BaseApi.ts
+++ b/frontend/src/app/api/BaseApi.ts
@@ -38,9 +38,9 @@ export default abstract class BaseApi {
   // Root path of API resource without leading slash.
   abstract get basePath(): string;
 
-  // API version
+  // API version, can be overridden by implementing API classes as necessary
   get version() {
-    return "v0.1";
+    return "v1";
   }
 
   // Namespace representing the API resource

--- a/frontend/src/app/api/BaseApi.ts
+++ b/frontend/src/app/api/BaseApi.ts
@@ -64,7 +64,6 @@ export default abstract class BaseApi {
       additionalHeaders?: HeadersDict;
     } = {},
   ): Promise<ResponseType> {
-    console.log("!!! actual request");
     const { additionalHeaders = {} } = options;
     const url = createRequestUrl(
       method,
@@ -133,14 +132,14 @@ export function createRequestUrl(
   let url = [...cleanedPaths].join("/");
   if (method === "GET" && body && !(body instanceof FormData)) {
     // Append query string to URL
-    const body: { [key: string]: string } = {};
+    const newBody: { [key: string]: string } = {};
     Object.entries(body).forEach(([key, value]) => {
       const stringValue =
         typeof value === "string" ? value : JSON.stringify(value);
-      body[key] = stringValue;
+      newBody[key] = stringValue;
     });
 
-    const params = new URLSearchParams(body).toString();
+    const params = new URLSearchParams(newBody).toString();
     url = `${url}?${params}`;
   }
   return url;

--- a/frontend/src/app/api/BaseApi.ts
+++ b/frontend/src/app/api/BaseApi.ts
@@ -64,6 +64,7 @@ export default abstract class BaseApi {
       additionalHeaders?: HeadersDict;
     } = {},
   ): Promise<ResponseType> {
+    console.log("!!! actual request");
     const { additionalHeaders = {} } = options;
     const url = createRequestUrl(
       method,

--- a/frontend/src/app/api/OpportunityListingAPI.ts
+++ b/frontend/src/app/api/OpportunityListingAPI.ts
@@ -12,12 +12,9 @@ export default class OpportunityListingAPI extends BaseApi {
   async getOpportunityById(
     opportunityId: number,
   ): Promise<OpportunityApiResponse> {
-    const subPath = `${opportunityId}`;
     const response = await this.request<OpportunityApiResponse>(
       "GET",
-      // this.basePath,
-      // this.namespace,
-      subPath,
+      `${opportunityId}`,
     );
     return response;
   }

--- a/frontend/src/app/api/OpportunityListingAPI.ts
+++ b/frontend/src/app/api/OpportunityListingAPI.ts
@@ -1,19 +1,10 @@
 import "server-only";
 
-import { environment } from "src/constants/environments";
 import { OpportunityApiResponse } from "src/types/opportunity/opportunityResponseTypes";
 
 import BaseApi from "./BaseApi";
 
 export default class OpportunityListingAPI extends BaseApi {
-  get version(): string {
-    return "v1";
-  }
-
-  get basePath(): string {
-    return environment.API_URL;
-  }
-
   get namespace(): string {
     return "opportunities";
   }
@@ -22,12 +13,12 @@ export default class OpportunityListingAPI extends BaseApi {
     opportunityId: number,
   ): Promise<OpportunityApiResponse> {
     const subPath = `${opportunityId}`;
-    const response = (await this.request(
+    const response = await this.request<OpportunityApiResponse>(
       "GET",
-      this.basePath,
-      this.namespace,
+      // this.basePath,
+      // this.namespace,
       subPath,
-    )) as OpportunityApiResponse;
+    );
     return response;
   }
 }

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -14,6 +14,10 @@ import {
 import BaseApi from "./BaseApi";
 
 export default class SearchOpportunityAPI extends BaseApi {
+  get version(): string {
+    return "v1";
+  }
+
   get basePath(): string {
     return environment.API_URL;
   }

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -12,21 +12,93 @@ import {
 } from "src/types/search/searchRequestTypes";
 import { SearchAPIResponse } from "src/types/search/searchResponseTypes";
 
+const orderByFieldLookup = {
+  opportunityNumber: "opportunity_number",
+  opportunityTitle: "opportunity_title",
+  agency: "agency_code",
+  postedDate: "post_date",
+  closeDate: "close_date",
+};
+
+// Build with one_of syntax
+export const buildFilters = (
+  searchInputs: QueryParamData,
+): SearchFilterRequestBody => {
+  const { status, fundingInstrument, eligibility, agency, category } =
+    searchInputs;
+  const filters: SearchFilterRequestBody = {};
+
+  if (status && status.size > 0) {
+    filters.opportunity_status = { one_of: Array.from(status) };
+  }
+  if (fundingInstrument && fundingInstrument.size > 0) {
+    filters.funding_instrument = { one_of: Array.from(fundingInstrument) };
+  }
+
+  if (eligibility && eligibility.size > 0) {
+    // Note that eligibility gets remapped to the API name of "applicant_type"
+    filters.applicant_type = { one_of: Array.from(eligibility) };
+  }
+
+  if (agency && agency.size > 0) {
+    filters.agency = { one_of: Array.from(agency) };
+  }
+
+  if (category && category.size > 0) {
+    // Note that category gets remapped to the API name of "funding_category"
+    filters.funding_category = { one_of: Array.from(category) };
+  }
+
+  return filters;
+};
+
+export const buildPagination = (
+  searchInputs: QueryParamData,
+): PaginationRequestBody => {
+  const { sortby, page, fieldChanged } = searchInputs;
+
+  // When performing an update (query, filter, sortby change) - we want to
+  // start back at the 1st page (we never want to retain the current page).
+  // In addition to this statement - on the client (handleSubmit in useSearchFormState), we
+  // clear the page query param and set the page back to 1.
+  // On initial load (SearchFetcherActionType.InitialLoad) we honor the page the user sent. There is validation guards
+  // in convertSearchParamstoProperTypes keep 1<= page <= max_possible_page
+  const page_offset =
+    searchInputs.actionType === SearchFetcherActionType.Update &&
+    fieldChanged !== "pagination"
+      ? 1
+      : page;
+
+  let order_by: PaginationOrderBy = "post_date";
+  if (sortby) {
+    for (const [key, value] of Object.entries(orderByFieldLookup)) {
+      if (sortby.startsWith(key)) {
+        order_by = value as PaginationOrderBy;
+        break; // Stop searching after the first match is found
+      }
+    }
+  }
+
+  const sort_direction =
+    sortby && !sortby.endsWith("Desc") ? "ascending" : "descending";
+
+  return {
+    order_by,
+    page_offset,
+    page_size: 25,
+    sort_direction,
+  };
+};
+
 export default class SearchOpportunityAPI extends BaseApi {
   get namespace(): string {
     return "opportunities";
   }
 
-  get headers() {
-    const baseHeaders = super.headers;
-    const searchHeaders = {};
-    return { ...baseHeaders, ...searchHeaders };
-  }
-
   async searchOpportunities(searchInputs: QueryParamData) {
     const { query } = searchInputs;
-    const filters = this.buildFilters(searchInputs);
-    const pagination = this.buildPagination(searchInputs);
+    const filters = buildFilters(searchInputs);
+    const pagination = buildPagination(searchInputs);
 
     const requestBody: SearchRequestBody = { pagination };
 
@@ -39,91 +111,13 @@ export default class SearchOpportunityAPI extends BaseApi {
       requestBody.query = query;
     }
 
-    const subPath = "search";
     const response = await this.request<SearchAPIResponse>(
       "POST",
-      subPath,
+      "search",
       searchInputs,
       requestBody,
     );
 
     return response;
-  }
-
-  // Build with one_of syntax
-  private buildFilters(searchInputs: QueryParamData): SearchFilterRequestBody {
-    const { status, fundingInstrument, eligibility, agency, category } =
-      searchInputs;
-    const filters: SearchFilterRequestBody = {};
-
-    if (status && status.size > 0) {
-      filters.opportunity_status = { one_of: Array.from(status) };
-    }
-    if (fundingInstrument && fundingInstrument.size > 0) {
-      filters.funding_instrument = { one_of: Array.from(fundingInstrument) };
-    }
-
-    if (eligibility && eligibility.size > 0) {
-      // Note that eligibility gets remapped to the API name of "applicant_type"
-      filters.applicant_type = { one_of: Array.from(eligibility) };
-    }
-
-    if (agency && agency.size > 0) {
-      filters.agency = { one_of: Array.from(agency) };
-    }
-
-    if (category && category.size > 0) {
-      // Note that category gets remapped to the API name of "funding_category"
-      filters.funding_category = { one_of: Array.from(category) };
-    }
-
-    return filters;
-  }
-
-  private buildPagination(searchInputs: QueryParamData): PaginationRequestBody {
-    const { sortby, page, fieldChanged } = searchInputs;
-
-    // When performing an update (query, filter, sortby change) - we want to
-    // start back at the 1st page (we never want to retain the current page).
-    // In addition to this statement - on the client (handleSubmit in useSearchFormState), we
-    // clear the page query param and set the page back to 1.
-    // On initial load (SearchFetcherActionType.InitialLoad) we honor the page the user sent. There is validation guards
-    // in convertSearchParamstoProperTypes keep 1<= page <= max_possible_page
-    const page_offset =
-      searchInputs.actionType === SearchFetcherActionType.Update &&
-      fieldChanged !== "pagination"
-        ? 1
-        : page;
-
-    const orderByFieldLookup = {
-      opportunityNumber: "opportunity_number",
-      opportunityTitle: "opportunity_title",
-      agency: "agency_code",
-      postedDate: "post_date",
-      closeDate: "close_date",
-    };
-
-    let order_by: PaginationOrderBy = "post_date";
-    if (sortby) {
-      for (const [key, value] of Object.entries(orderByFieldLookup)) {
-        if (sortby.startsWith(key)) {
-          order_by = value as PaginationOrderBy;
-          break; // Stop searching after the first match is found
-        }
-      }
-    }
-
-    // default to descending
-    let sort_direction: PaginationSortDirection = "descending";
-    if (sortby) {
-      sort_direction = sortby?.endsWith("Desc") ? "descending" : "ascending";
-    }
-
-    return {
-      order_by,
-      page_offset,
-      page_size: 25,
-      sort_direction,
-    };
   }
 }

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -5,7 +5,6 @@ import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher"
 import {
   PaginationOrderBy,
   PaginationRequestBody,
-  PaginationSortDirection,
   SearchFetcherActionType,
   SearchFilterRequestBody,
   SearchRequestBody,

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { environment } from "src/constants/environments";
+import BaseApi from "src/app/api/BaseApi";
 import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher";
 import {
   PaginationOrderBy,
@@ -10,18 +10,9 @@ import {
   SearchFilterRequestBody,
   SearchRequestBody,
 } from "src/types/search/searchRequestTypes";
-
-import BaseApi from "./BaseApi";
+import { SearchAPIResponse } from "src/types/search/searchResponseTypes";
 
 export default class SearchOpportunityAPI extends BaseApi {
-  get version(): string {
-    return "v1";
-  }
-
-  get basePath(): string {
-    return environment.API_URL;
-  }
-
   get namespace(): string {
     return "opportunities";
   }
@@ -49,10 +40,8 @@ export default class SearchOpportunityAPI extends BaseApi {
     }
 
     const subPath = "search";
-    const response = await this.request(
+    const response = await this.request<SearchAPIResponse>(
       "POST",
-      this.basePath,
-      this.namespace,
       subPath,
       searchInputs,
       requestBody,

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -20,36 +20,36 @@ const orderByFieldLookup = {
   closeDate: "close_date",
 };
 
-// Build with one_of syntax
+type FrontendFilterNames =
+  | "status"
+  | "fundingInstrument"
+  | "eligibility"
+  | "agency"
+  | "category";
+
+const filterNameMap = {
+  status: "opportunity_status",
+  fundingInstrument: "funding_instrument",
+  eligibility: "applicant_type",
+  agency: "agency",
+  category: "funding_category",
+} as const;
+
+// Translate frontend filter param names to expected backend parameter names, and use one_of syntax
 export const buildFilters = (
   searchInputs: QueryParamData,
 ): SearchFilterRequestBody => {
-  const { status, fundingInstrument, eligibility, agency, category } =
-    searchInputs;
-  const filters: SearchFilterRequestBody = {};
-
-  if (status && status.size > 0) {
-    filters.opportunity_status = { one_of: Array.from(status) };
-  }
-  if (fundingInstrument && fundingInstrument.size > 0) {
-    filters.funding_instrument = { one_of: Array.from(fundingInstrument) };
-  }
-
-  if (eligibility && eligibility.size > 0) {
-    // Note that eligibility gets remapped to the API name of "applicant_type"
-    filters.applicant_type = { one_of: Array.from(eligibility) };
-  }
-
-  if (agency && agency.size > 0) {
-    filters.agency = { one_of: Array.from(agency) };
-  }
-
-  if (category && category.size > 0) {
-    // Note that category gets remapped to the API name of "funding_category"
-    filters.funding_category = { one_of: Array.from(category) };
-  }
-
-  return filters;
+  return Object.entries(filterNameMap).reduce(
+    (filters, [frontendFilterName, backendFilterName]) => {
+      const filterData =
+        searchInputs[frontendFilterName as FrontendFilterNames];
+      if (filterData && filterData.size) {
+        filters[backendFilterName] = { one_of: Array.from(filterData) };
+      }
+      return filters;
+    },
+    {} as SearchFilterRequestBody,
+  );
 };
 
 export const buildPagination = (

--- a/frontend/src/app/api/SearchOpportunityAPI.ts
+++ b/frontend/src/app/api/SearchOpportunityAPI.ts
@@ -35,6 +35,38 @@ const filterNameMap = {
   category: "funding_category",
 } as const;
 
+export default class SearchOpportunityAPI extends BaseApi {
+  get namespace(): string {
+    return "opportunities";
+  }
+
+  async searchOpportunities(searchInputs: QueryParamData) {
+    const { query } = searchInputs;
+    const filters = buildFilters(searchInputs);
+    const pagination = buildPagination(searchInputs);
+
+    const requestBody: SearchRequestBody = { pagination };
+
+    // Only add filters if there are some
+    if (Object.keys(filters).length > 0) {
+      requestBody.filters = filters;
+    }
+
+    if (query) {
+      requestBody.query = query;
+    }
+
+    const response = await this.request<SearchAPIResponse>(
+      "POST",
+      "search",
+      searchInputs,
+      requestBody,
+    );
+
+    return response;
+  }
+}
+
 // Translate frontend filter param names to expected backend parameter names, and use one_of syntax
 export const buildFilters = (
   searchInputs: QueryParamData,
@@ -89,35 +121,3 @@ export const buildPagination = (
     sort_direction,
   };
 };
-
-export default class SearchOpportunityAPI extends BaseApi {
-  get namespace(): string {
-    return "opportunities";
-  }
-
-  async searchOpportunities(searchInputs: QueryParamData) {
-    const { query } = searchInputs;
-    const filters = buildFilters(searchInputs);
-    const pagination = buildPagination(searchInputs);
-
-    const requestBody: SearchRequestBody = { pagination };
-
-    // Only add filters if there are some
-    if (Object.keys(filters).length > 0) {
-      requestBody.filters = filters;
-    }
-
-    if (query) {
-      requestBody.query = query;
-    }
-
-    const response = await this.request<SearchAPIResponse>(
-      "POST",
-      "search",
-      searchInputs,
-      requestBody,
-    );
-
-    return response;
-  }
-}

--- a/frontend/src/services/search/searchfetcher/APISearchFetcher.ts
+++ b/frontend/src/services/search/searchfetcher/APISearchFetcher.ts
@@ -21,9 +21,7 @@ export class APISearchFetcher extends SearchFetcher {
       // await new Promise((resolve) => setTimeout(resolve, 13250));
 
       const response: SearchAPIResponse =
-        (await this.searchApi.searchOpportunities(
-          searchInputs,
-        )) as SearchAPIResponse;
+        await this.searchApi.searchOpportunities(searchInputs);
       response.actionType = searchInputs.actionType;
       response.fieldChanged = searchInputs.fieldChanged;
 

--- a/frontend/src/types/apiResponseTypes.ts
+++ b/frontend/src/types/apiResponseTypes.ts
@@ -1,9 +1,3 @@
-interface APIResponseError {
-  field: string;
-  message: string;
-  type: string;
-}
-
 export interface PaginationInfo {
   order_by: string;
   page_offset: number;
@@ -21,9 +15,3 @@ export interface APIResponse {
   warnings?: unknown[] | null | undefined;
   errors?: unknown[] | null | undefined;
 }
-
-// export interface BaseResponse {
-//   errors?: APIResponseError[];
-//   message?: string;
-//   status_code?: number;
-// }

--- a/frontend/src/types/apiResponseTypes.ts
+++ b/frontend/src/types/apiResponseTypes.ts
@@ -1,3 +1,9 @@
+interface APIResponseError {
+  field: string;
+  message: string;
+  type: string;
+}
+
 export interface PaginationInfo {
   order_by: string;
   page_offset: number;
@@ -15,3 +21,9 @@ export interface APIResponse {
   warnings?: unknown[] | null | undefined;
   errors?: unknown[] | null | undefined;
 }
+
+// export interface BaseResponse {
+//   errors?: APIResponseError[];
+//   message?: string;
+//   status_code?: number;
+// }

--- a/frontend/src/types/opportunity/opportunityResponseTypes.ts
+++ b/frontend/src/types/opportunity/opportunityResponseTypes.ts
@@ -1,3 +1,5 @@
+import { APIResponse } from "src/types/apiResponseTypes";
+
 export interface OpportunityAssistanceListing {
   assistance_listing_number: string;
   program_title: string;
@@ -52,8 +54,6 @@ export interface Opportunity {
   updated_at: string;
 }
 
-export interface OpportunityApiResponse {
+export interface OpportunityApiResponse extends APIResponse {
   data: Opportunity;
-  message: string;
-  status_code: number;
 }

--- a/frontend/src/types/search/searchResponseTypes.ts
+++ b/frontend/src/types/search/searchResponseTypes.ts
@@ -1,4 +1,4 @@
-import { PaginationInfo } from "src/types/apiResponseTypes";
+import { APIResponse, PaginationInfo } from "src/types/apiResponseTypes";
 
 import { SearchFetcherActionType } from "./searchRequestTypes";
 
@@ -55,13 +55,9 @@ export interface Opportunity {
   updated_at: string;
 }
 
-export interface SearchAPIResponse {
+export interface SearchAPIResponse extends APIResponse {
   data: Opportunity[];
-  message: string;
   pagination_info: PaginationInfo;
-  status_code: number;
-  warnings?: unknown[] | null | undefined;
-  errors?: unknown[] | null | undefined;
   actionType?: SearchFetcherActionType;
   fieldChanged?: string;
 }

--- a/frontend/tests/api/OpportunityListingApi.test.ts
+++ b/frontend/tests/api/OpportunityListingApi.test.ts
@@ -1,33 +1,38 @@
 import OpportunityListingAPI from "src/app/api/OpportunityListingAPI";
 import { OpportunityApiResponse } from "src/types/opportunity/opportunityResponseTypes";
 
-jest.mock("src/app/api/BaseApi");
+let opportunityListingAPI: OpportunityListingAPI;
+const mockResponse = getValidMockResponse();
+
+const mockedRequest = jest.fn();
 
 describe("OpportunityListingAPI", () => {
-  const mockedRequest = jest.fn();
-  const opportunityListingAPI = new OpportunityListingAPI();
-
-  beforeAll(() => {
-    opportunityListingAPI.request = mockedRequest;
+  beforeEach(() => {
+    opportunityListingAPI = new OpportunityListingAPI();
+    jest
+      .spyOn(opportunityListingAPI, "request")
+      .mockImplementation(mockedRequest);
   });
 
   afterEach(() => {
-    mockedRequest.mockReset();
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("instantiates correctly", () => {
+    expect(opportunityListingAPI.namespace).toEqual("opportunities");
   });
 
   it("should return opportunity data for a valid ID", async () => {
-    const mockResponse: OpportunityApiResponse = getValidMockResponse();
-
-    mockedRequest.mockResolvedValue(mockResponse);
-
+    mockedRequest.mockImplementation(() => {
+      return Promise.resolve(mockResponse);
+    });
     const result = await opportunityListingAPI.getOpportunityById(12345);
 
-    expect(mockedRequest).toHaveBeenCalledWith(
-      "GET",
-      opportunityListingAPI.basePath,
-      opportunityListingAPI.namespace,
-      "12345",
-    );
+    expect(mockedRequest).toHaveBeenCalledWith("GET", "12345");
     expect(result).toEqual(mockResponse);
   });
 
@@ -41,7 +46,7 @@ describe("OpportunityListingAPI", () => {
   });
 });
 
-function getValidMockResponse() {
+function getValidMockResponse(): OpportunityApiResponse {
   return {
     data: {
       agency: "US-ABC",

--- a/frontend/tests/api/SearchOpportunityApi.test.ts
+++ b/frontend/tests/api/SearchOpportunityApi.test.ts
@@ -1,113 +1,219 @@
-import SearchOpportunityAPI from "src/app/api/SearchOpportunityAPI";
+import SearchOpportunityAPI, {
+  buildFilters,
+  buildPagination,
+} from "src/app/api/SearchOpportunityAPI";
 import { QueryParamData } from "src/services/search/searchfetcher/SearchFetcher";
-import { SearchRequestBody } from "src/types/search/searchRequestTypes";
+import { SearchFetcherActionType } from "src/types/search/searchRequestTypes";
 
-// mockFetch should match the SearchAPIResponse type structure
-const mockFetch = ({
-  response = {
-    data: [],
-    message: "Success",
-    pagination_info: {
-      order_by: "opportunity_id",
-      page_offset: 1,
-      page_size: 25,
-      sort_direction: "ascending",
-      total_pages: 1,
-      total_records: 0,
-    },
-    status_code: 200,
-    errors: [],
-    warnings: [],
+const validMockedResponse = {
+  data: [],
+  message: "Success",
+  pagination_info: {
+    // TODO: the response order_by should
+    // by what the request had: opportunity_number
+    order_by: "opportunity_id",
+    page_offset: 1,
+    page_size: 25,
+    sort_direction: "ascending",
+    total_pages: 1,
+    total_records: 0,
   },
-  ok = true,
-  status = 200,
-}) => {
-  return jest.fn().mockResolvedValueOnce({
-    json: jest.fn().mockResolvedValueOnce(response),
-    ok,
-    status,
-  });
+  status_code: 200,
+  warnings: [],
 };
 
+const searchProps: QueryParamData = {
+  page: 1,
+  status: new Set(["forecasted", "posted"]),
+  fundingInstrument: new Set(["grant", "cooperative_agreement"]),
+  agency: new Set(),
+  category: new Set(),
+  eligibility: new Set(),
+  query: "research",
+  sortby: "opportunityNumberAsc",
+};
+
+let searchApi: SearchOpportunityAPI;
+const mockedRequest = jest.fn();
+
 describe("SearchOpportunityAPI", () => {
-  let searchApi: SearchOpportunityAPI;
-  const baseRequestHeaders = {
-    "Content-Type": "application/json",
-  };
-
   beforeEach(() => {
-    jest.resetAllMocks();
-
     searchApi = new SearchOpportunityAPI();
+    jest.spyOn(searchApi, "request").mockImplementation(mockedRequest);
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("instantiates correctly", () => {
+    expect(searchApi.namespace).toEqual("opportunities");
   });
 
   describe("searchOpportunities", () => {
-    beforeEach(() => {
-      global.fetch = mockFetch({});
-    });
+    it("calls request function with correct parameters", async () => {
+      mockedRequest.mockImplementation(() =>
+        Promise.resolve(validMockedResponse),
+      );
+      const result = await searchApi.searchOpportunities(searchProps);
 
-    it("sends POST request to search opportunities endpoint with query parameters", async () => {
-      const searchProps: QueryParamData = {
-        page: 1,
-        status: new Set(["forecasted", "posted"]),
-        fundingInstrument: new Set(["grant", "cooperative_agreement"]),
-        agency: new Set(),
-        category: new Set(),
-        eligibility: new Set(),
-        query: "research",
-        sortby: "opportunityNumberAsc",
-      };
-
-      const response = await searchApi.searchOpportunities(searchProps);
-
-      const method = "POST";
-      const headers = baseRequestHeaders;
-
-      const requestBody: SearchRequestBody = {
-        pagination: {
-          order_by: "opportunity_number", // This should be the actual value being used in the API method
-          page_offset: 1,
-          page_size: 25,
-          sort_direction: "ascending", // or "descending" based on your sortby parameter
-        },
-        filters: {
-          opportunity_status: {
-            one_of: Array.from(searchProps.status),
+      expect(mockedRequest).toHaveBeenCalledWith(
+        "POST",
+        "search",
+        searchProps,
+        {
+          pagination: {
+            order_by: "opportunity_number", // This should be the actual value being used in the API method
+            page_offset: 1,
+            page_size: 25,
+            sort_direction: "ascending", // or "descending" based on your sortby parameter
           },
-          funding_instrument: {
-            one_of: Array.from(searchProps.fundingInstrument),
+          query: "research",
+          filters: {
+            opportunity_status: {
+              one_of: ["forecasted", "posted"],
+            },
+            funding_instrument: {
+              one_of: ["grant", "cooperative_agreement"],
+            },
           },
         },
-        query: searchProps.query || "",
-      };
-
-      const expectedUrl = `${searchApi.version}${searchApi.basePath}/${searchApi.namespace}/search`;
-
-      expect(fetch).toHaveBeenCalledWith(
-        expectedUrl,
-        expect.objectContaining({
-          method,
-          headers,
-          body: JSON.stringify(requestBody),
-        }),
       );
 
-      expect(response).toEqual({
-        data: [],
-        message: "Success",
-        pagination_info: {
-          // TODO: the response order_by should
-          // by what the request had: opportunity_number
-          order_by: "opportunity_id",
-          page_offset: 1,
-          page_size: 25,
-          sort_direction: "ascending",
-          total_pages: 1,
-          total_records: 0,
+      expect(result).toEqual(validMockedResponse);
+    });
+  });
+
+  describe("buildFilters", () => {
+    it("maps all params to the correct filter names", () => {
+      const filters = buildFilters({
+        ...searchProps,
+        ...{
+          agency: new Set(["agency 1", "agency 2"]),
+          category: new Set(["category 1", "category 2"]),
+          eligibility: new Set(["applicant type 1", "applicant type 2"]),
         },
-        status_code: 200,
-        warnings: [],
       });
+      expect(filters.opportunity_status).toEqual({
+        one_of: ["forecasted", "posted"],
+      });
+      expect(filters.funding_instrument).toEqual({
+        one_of: ["grant", "cooperative_agreement"],
+      });
+      expect(filters.applicant_type).toEqual({
+        one_of: ["applicant type 1", "applicant type 2"],
+      });
+      expect(filters.agency).toEqual({
+        one_of: ["agency 1", "agency 2"],
+      });
+      expect(filters.funding_category).toEqual({
+        one_of: ["category 1", "category 2"],
+      });
+    });
+    it("does not add filters where params are absent", () => {
+      const filters = buildFilters(searchProps);
+      expect(filters.opportunity_status).toEqual({
+        one_of: ["forecasted", "posted"],
+      });
+      expect(filters.funding_instrument).toEqual({
+        one_of: ["grant", "cooperative_agreement"],
+      });
+      expect(filters.applicant_type).toEqual(undefined);
+      expect(filters.agency).toEqual(undefined);
+      expect(filters.funding_category).toEqual(undefined);
+    });
+  });
+
+  describe("buildPagination", () => {
+    it("builds correct pagination with defaults", () => {
+      const pagination = buildPagination({
+        ...searchProps,
+        ...{ page: 5, sortby: null },
+      });
+
+      expect(pagination.order_by).toEqual("post_date");
+      expect(pagination.page_offset).toEqual(5);
+      expect(pagination.sort_direction).toEqual("descending");
+    });
+
+    it("builds correct offset based on action type and field changed", () => {
+      const pagination = buildPagination({
+        ...searchProps,
+        ...{ page: 5, actionType: SearchFetcherActionType.Update },
+      });
+
+      expect(pagination.page_offset).toEqual(1);
+
+      const secondPagination = buildPagination({
+        ...searchProps,
+        ...{ page: 5, actionType: SearchFetcherActionType.InitialLoad },
+      });
+
+      expect(secondPagination.page_offset).toEqual(5);
+
+      const thirdPagination = buildPagination({
+        ...searchProps,
+        ...{
+          page: 5,
+          actionType: SearchFetcherActionType.Update,
+          fieldChanged: "pagination",
+        },
+      });
+
+      expect(thirdPagination.page_offset).toEqual(5);
+
+      const fourthPagination = buildPagination({
+        ...searchProps,
+        ...{
+          page: 5,
+          actionType: SearchFetcherActionType.Update,
+          fieldChanged: "not_pagination",
+        },
+      });
+
+      expect(fourthPagination.page_offset).toEqual(1);
+    });
+
+    it("builds correct order_by based on sortby", () => {
+      const pagination = buildPagination({
+        ...searchProps,
+        ...{ sortby: "closeDate" },
+      });
+
+      expect(pagination.order_by).toEqual("close_date");
+
+      const secondPagination = buildPagination({
+        ...searchProps,
+        ...{ sortby: "postedDate" },
+      });
+
+      expect(secondPagination.order_by).toEqual("post_date");
+    });
+
+    it("builds correct sort_direction based on sortby", () => {
+      const pagination = buildPagination({
+        ...searchProps,
+        ...{ sortby: "opportunityNumberDesc" },
+      });
+
+      expect(pagination.sort_direction).toEqual("descending");
+
+      const secondPagination = buildPagination({
+        ...searchProps,
+        ...{ sortby: "postedDateAsc" },
+      });
+
+      expect(secondPagination.sort_direction).toEqual("ascending");
+
+      const thirdPagination = buildPagination({
+        ...searchProps,
+        ...{ sortby: null },
+      });
+
+      expect(thirdPagination.sort_direction).toEqual("descending");
     });
   });
 });

--- a/frontend/tests/e2e/newsletter.spec.ts
+++ b/frontend/tests/e2e/newsletter.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable testing-library/prefer-screen-queries */
 import { expect, test } from "@playwright/test";
 
+import { generateRandomString } from "./search/searchSpecUtil";
+
 test.beforeEach(async ({ page }) => {
   await page.goto("/subscribe");
 });
@@ -32,7 +34,9 @@ test("successful signup", async ({ page }) => {
   );
 
   // Fill out form
-  await page.getByLabel("First Name (required)").fill("Apple");
+  await page
+    .getByLabel("First Name (required)")
+    .fill(generateRandomString([10]));
   await page.getByLabel("Email (required)").fill("name@example.com");
 
   await page.getByRole("button", { name: /subscribe/i }).click();
@@ -54,7 +58,9 @@ test("error during signup", async ({ page }) => {
   );
 
   // Fill out form
-  await page.getByLabel("First Name (required)").fill("Apple");
+  await page
+    .getByLabel("First Name (required)")
+    .fill(generateRandomString([10]));
   await page.getByLabel("Email (required)").fill("name@example.com");
 
   await page.getByRole("button", { name: /subscribe/i }).click();

--- a/frontend/tests/e2e/search/search-loading.spec.ts
+++ b/frontend/tests/e2e/search/search-loading.spec.ts
@@ -6,32 +6,22 @@ import {
 } from "tests/e2e/search/searchSpecUtil";
 
 test.describe("Search page tests", () => {
-  // test.beforeEach(async ({ page }: { page: Page }) => {
-  //   // Navigate to the search page with the feature flag set
-  //   await page.goto("/search?_ff=showSearchV0:true");
-  // });
-
   test("should show and hide loading state", async () => {
+    const searchTerm = generateRandomString([4, 5]);
+    const searchTerm2 = generateRandomString([8]);
+
     const browser = await chromium.launch({ slowMo: 100 });
+
     const page = await browser.newPage();
     await page.goto("/search?_ff=showSearchV0:true");
-    // if this doesn't work we can try https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-slow-mo
-    const searchTerm = generateRandomString([4, 5]);
     const loadingIndicator = page.getByTestId("loading-message");
-    // await Promise.all([
-    //   fillSearchInputAndSubmit(searchTerm, page),
-    //   expect(loadingIndicator).toBeVisible(),
-    // ]);
 
     await fillSearchInputAndSubmit(searchTerm, page);
     await expect(loadingIndicator).toBeVisible();
     await expect(loadingIndicator).toBeHidden();
 
-    // const searchTerm2 = generateRandomString([8]);
-    // await Promise.all([
-    //   fillSearchInputAndSubmit(searchTerm2, page),
-    //   expect(loadingIndicator).toBeVisible(),
-    // ]);
-    // await expect(loadingIndicator).toBeHidden();
+    await fillSearchInputAndSubmit(searchTerm2, page);
+    await expect(loadingIndicator).toBeVisible();
+    await expect(loadingIndicator).toBeHidden();
   });
 });

--- a/frontend/tests/e2e/search/search-loading.spec.ts
+++ b/frontend/tests/e2e/search/search-loading.spec.ts
@@ -1,31 +1,37 @@
-import { expect, Page, test } from "@playwright/test";
-import { BrowserContextOptions } from "playwright-core";
-
-import { fillSearchInputAndSubmit } from "./searchSpecUtil";
-
-interface PageProps {
-  page: Page;
-  browserName?: string;
-  contextOptions?: BrowserContextOptions;
-}
+import { expect, test } from "@playwright/test";
+import { chromium } from "playwright-core";
+import {
+  fillSearchInputAndSubmit,
+  generateRandomString,
+} from "tests/e2e/search/searchSpecUtil";
 
 test.describe("Search page tests", () => {
-  test.beforeEach(async ({ page }: PageProps) => {
-    // Navigate to the search page with the feature flag set
+  // test.beforeEach(async ({ page }: { page: Page }) => {
+  //   // Navigate to the search page with the feature flag set
+  //   await page.goto("/search?_ff=showSearchV0:true");
+  // });
+
+  test("should show and hide loading state", async () => {
+    const browser = await chromium.launch({ slowMo: 100 });
+    const page = await browser.newPage();
     await page.goto("/search?_ff=showSearchV0:true");
-  });
-
-  test("should show and hide loading state", async ({ page }: PageProps) => {
-    const searchTerm = "advanced";
-    await fillSearchInputAndSubmit(searchTerm, page);
-
+    // if this doesn't work we can try https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-slow-mo
+    const searchTerm = generateRandomString([4, 5]);
     const loadingIndicator = page.getByTestId("loading-message");
+    // await Promise.all([
+    //   fillSearchInputAndSubmit(searchTerm, page),
+    //   expect(loadingIndicator).toBeVisible(),
+    // ]);
+
+    await fillSearchInputAndSubmit(searchTerm, page);
     await expect(loadingIndicator).toBeVisible();
     await expect(loadingIndicator).toBeHidden();
 
-    const searchTerm2 = "agency";
-    await fillSearchInputAndSubmit(searchTerm2, page);
-    await expect(loadingIndicator).toBeVisible();
-    await expect(loadingIndicator).toBeHidden();
+    // const searchTerm2 = generateRandomString([8]);
+    // await Promise.all([
+    //   fillSearchInputAndSubmit(searchTerm2, page),
+    //   expect(loadingIndicator).toBeVisible(),
+    // ]);
+    // await expect(loadingIndicator).toBeHidden();
   });
 });

--- a/frontend/tests/e2e/search/search-no-results.spec.ts
+++ b/frontend/tests/e2e/search/search-no-results.spec.ts
@@ -4,6 +4,7 @@ import { BrowserContextOptions } from "playwright-core";
 import {
   expectURLContainsQueryParam,
   fillSearchInputAndSubmit,
+  generateRandomString,
 } from "./searchSpecUtil";
 
 interface PageProps {
@@ -21,7 +22,7 @@ test.describe("Search page tests", () => {
   test("should return 0 results when searching for obscure term", async ({
     page,
   }: PageProps) => {
-    const searchTerm = "0resultearch";
+    const searchTerm = generateRandomString([10]);
 
     await fillSearchInputAndSubmit(searchTerm, page);
     await new Promise((resolve) => setTimeout(resolve, 3250));

--- a/frontend/tests/e2e/search/searchSpecUtil.ts
+++ b/frontend/tests/e2e/search/searchSpecUtil.ts
@@ -14,6 +14,37 @@ export async function fillSearchInputAndSubmit(term: string, page: Page) {
   await page.click(".usa-search > button[type='submit']");
 }
 
+const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+// adapted from https://stackoverflow.com/a/1349426
+export const generateRandomString = (desiredPattern: number[]) => {
+  const numberOfPossibleCharacters = characters.length;
+  return desiredPattern.reduce((randomString, numberOfCharacters, index) => {
+    let counter = 0;
+    while (counter < numberOfCharacters) {
+      randomString += characters.charAt(
+        Math.floor(Math.random() * numberOfPossibleCharacters),
+      );
+      counter += 1;
+    }
+    if (index < desiredPattern.length - 1) {
+      randomString += " ";
+    }
+    return randomString;
+  }, "");
+};
+
+//   let result = "";
+//   const charactersLength = characters.length;
+//   let counter = 0;
+//   while (counter < length) {
+//     result += characters.charAt(Math.floor(Math.random() * charactersLength));
+//     counter += 1;
+//   }
+//   return result;
+// };
+// (Math.random() + 1).toString(36).substring(7);
+
 export function expectURLContainsQueryParam(
   page: Page,
   queryParamName: string,

--- a/frontend/tests/e2e/search/searchSpecUtil.ts
+++ b/frontend/tests/e2e/search/searchSpecUtil.ts
@@ -34,17 +34,6 @@ export const generateRandomString = (desiredPattern: number[]) => {
   }, "");
 };
 
-//   let result = "";
-//   const charactersLength = characters.length;
-//   let counter = 0;
-//   while (counter < length) {
-//     result += characters.charAt(Math.floor(Math.random() * charactersLength));
-//     counter += 1;
-//   }
-//   return result;
-// };
-// (Math.random() + 1).toString(36).substring(7);
-
 export function expectURLContainsQueryParam(
   page: Page,
   queryParamName: string,


### PR DESCRIPTION
## Summary
Fixes #2448

### Time to review: __45 mins__

## Changes proposed
**DISCLAIMER**: there is a lot of scope creep in this PR. Feel free to push back on anything you feel goes to far here.

The primary purpose of this change is to change the search API to use the `v1` version of the search endpoint in order to activate the use of Open Search on the backend. This purpose is accomplished in the first commit, which can be split into a separate PR or commit if called for.

The rest of the PR contains refactors to the `API` fetch system that:

* should reduce redundancy and make better use of the classical setup in place here
* makes better use of available TS functionality
* better encapsulates domain specific logic (eg moving search specific functionality out of the base class)
* fixes bugs

## Context for reviewers
### Test Steps

1. visit the search page, and perform all manner of searches with different filters, queries, and sort options
2. _VALIDATE_: everything works as expected
3. visit various opportunity pages
4. _VALIDATE_: everything works as expected

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

