### PR TITLE
[Issue #2538] Show the path of a vulnerability

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -151,14 +151,18 @@ jobs:
           fail-build: true
           severity-cutoff: medium
 
-      - name: Save output to workflow summary
+      - name: Inspect action SARIF report
         if: always() # Runs even if there is a failure
-        run: |
-          {
-            echo '```json'
-            jq ".matches | map(.artifact | { name, version, "location": .e[0].path })" < ${{ steps.anchore-scan-action.outputs.json }}
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: jq < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
+
+      # - name: Save output to workflow summary
+      #   if: always() # Runs even if there is a failure
+      #   run: |
+      #     {
+      #       echo '```json'
+      #       jq ".matches | map(.artifact | { name, version, "location": .e[0].path })" < ${{ steps.anchore-scan-action.outputs.json }}
+      #       echo '```'
+      #     } >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -151,18 +151,10 @@ jobs:
           fail-build: true
           severity-cutoff: medium
 
-      - name: Inspect action SARIF report
+      - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
-        run: jq < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
-
-      # - name: Save output to workflow summary
-      #   if: always() # Runs even if there is a failure
-      #   run: |
-      #     {
-      #       echo '```json'
-      #       jq ".matches | map(.artifact | { name, version, "location": .e[0].path })" < ${{ steps.anchore-scan-action.outputs.json }}
-      #       echo '```'
-      #     } >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          jq '.matches | map(.artifact | { name, version, "location": .e[0].path })' < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,11 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          {
-            echo '```json'
-            jq '.' ${{ steps.anchore-scan-action.outputs.json }}
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          jq '.matches | map(.artifact | { name, version, "location": .locations[*].path })' ${{ steps.anchore-scan-action.outputs.json }}
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, "location": .locations[*].path })' ${{ steps.anchore-scan-action.outputs.json }}
+          jq '.matches | map(.artifact | { name, version, locations: .locations[].path })' ${{ steps.anchore-scan-action.outputs.json }}
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           {
             echo '```json'
-            cat ${{ steps.anchore-scan-action.outputs.json }}
+            cat ${{ steps.anchore-scan-action.outputs.json }} | jq ".matches | map(.artifact | { name, version, "location": .e[0].path })"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq 'keys' < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
+          jq '.matches | map(.artifact | { name, version, "location": .e[0].path })' ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, "location": .e[0].path })' ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
+          jq . ${{ steps.anchore-scan-action.outputs.json }}
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -147,12 +147,9 @@ jobs:
         id: anchore-scan-action
         with:
           image: ${{ needs.build-and-cache.outputs.image }}
-          output-format: table
+          output-format: json
           fail-build: true
           severity-cutoff: medium
-
-      - name: Inspect action SARIF report
-        run: cat ${{ steps.anchore-scan-action.outputs.sarif }}
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,11 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-action.outputs.json }}
+          {
+            echo '```json'
+            jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-action.outputs.json }}
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, locations: .locations[].path })' ${{ steps.anchore-scan-action.outputs.json }}
+          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-action.outputs.json }}
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -144,11 +144,15 @@ jobs:
 
       - name: Run Anchore vulnerability scan
         uses: anchore/scan-action@v4
+        id: anchore-scan-action
         with:
           image: ${{ needs.build-and-cache.outputs.image }}
           output-format: table
           fail-build: true
           severity-cutoff: medium
+
+      - name: Inspect action SARIF report
+        run: cat ${{ steps.anchore-scan-action.outputs.sarif }}
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -151,10 +151,13 @@ jobs:
           fail-build: true
           severity-cutoff: medium
 
+      - name: Inspect action JSON report
+        run: cat ${{ steps.anchore-scan-action.outputs.json }}
+
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          echo "View results in GitHub Action logs" >> "$GITHUB_STEP_SUMMARY"
+          cat ${{ steps.anchore-scan-action.outputs.json }} | jq '.matches | map(.artifact | { name, version, "location": .e[0].path })' >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches' < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
+          jq 'keys' < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, "location": .e[0].path })' < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
+          jq '.matches' < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,11 +154,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          {
-            echo '```json'
-            jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-action.outputs.json }}
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-action.outputs.json }}
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -153,7 +153,12 @@ jobs:
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
-        run: 'jq ".matches | map(.artifact | { name, version, "location": .e[0].path })" < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"'
+        run: |
+          {
+            echo '```json'
+            cat ${{ steps.anchore-scan-action.outputs.json }}
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -154,7 +154,11 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq . ${{ steps.anchore-scan-action.outputs.json }}
+          {
+            echo '```json'
+            jq '.' ${{ steps.anchore-scan-action.outputs.json }}
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -151,13 +151,9 @@ jobs:
           fail-build: true
           severity-cutoff: medium
 
-      - name: Inspect action JSON report
-        run: cat ${{ steps.anchore-scan-action.outputs.json }}
-
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
-        run: |
-          cat ${{ steps.anchore-scan-action.outputs.json }} | jq '.matches | map(.artifact | { name, version, "location": .e[0].path })' >> "$GITHUB_STEP_SUMMARY"
+        run: 'jq ".matches | map(.artifact | { name, version, "location": .e[0].path })" < ${{ steps.anchore-scan-action.outputs.json }} >> "$GITHUB_STEP_SUMMARY"'
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           {
             echo '```json'
-            cat ${{ steps.anchore-scan-action.outputs.json }} | jq ".matches | map(.artifact | { name, version, "location": .e[0].path })"
+            jq ".matches | map(.artifact | { name, version, "location": .e[0].path })" < ${{ steps.anchore-scan-action.outputs.json }}
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,3 +1,5 @@
+trigger build
+
 # Simpler Grants Analytics
 
 ## Introduction

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,5 +1,3 @@
-trigger build
-
 # Simpler Grants Analytics
 
 ## Introduction


### PR DESCRIPTION
## Summary
Fixes https://github.com/HHS/simpler-grants-gov/issues/2538

### Time to review: __1 mins__

## Changes proposed

Changes the grype output from a table (which redacts critical information) to json output that shows the path the vulnerability is coming from. This, for example, pins down the location of a golang vulnerability inside of the analytics docker image.

## Context for reviewers

I decided to spend some time on this because we burned so much time hunting down the golang vulnerability the other day. Also I'm kind of procrastinating my other work, sorry 😓

## Testing

https://github.com/HHS/simpler-grants-gov/actions/runs/11467321173/job/31910027111

The analytics vulnerability is in the `gh` CLI

<img width="631" alt="image" src="https://github.com/user-attachments/assets/08c999b6-d004-4377-b524-59024c527362">
