### PR TITLE
[Issue 2487] relevant uswds and trussworks upgrades

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,9 +11,10 @@
       "dependencies": {
         "@next/third-parties": "^14.3.0-canary.59",
         "@opentelemetry/api": "^1.8.0",
-        "@trussworks/react-uswds": "^7.0.0",
-        "@uswds/uswds": "^3.6.0",
+        "@trussworks/react-uswds": "^9.1.0",
+        "@uswds/uswds": "^3.7.1",
         "clsx": "^2.1.1",
+        "focus-trap-react": "^10.2.3",
         "isomorphic-dompurify": "^2.15.0",
         "js-cookie": "^3.0.5",
         "lodash": "^4.17.21",
@@ -8422,14 +8423,16 @@
       }
     },
     "node_modules/@trussworks/react-uswds": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@trussworks/react-uswds/-/react-uswds-7.0.0.tgz",
-      "integrity": "sha512-N3O0BRuhyLoZKjYM0Mq+XIXJ3ShvCEh6uhqwRstIde6E9m0Au6JLy1YEv9A8eapBxDvyqZW3jiVTGzW/JqS+eA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@trussworks/react-uswds/-/react-uswds-9.1.0.tgz",
+      "integrity": "sha512-vQsr73oMtDIzLHVtkgD81tL7YxzygTyH9e1P3Lv/C1tGlqoNEUmUgVEmUVzo/IwOvMN0XxxSkNkOpnM9rDzRMg==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">= 16.20.0"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "@uswds/uswds": "^3.7.1",
+        "focus-trap-react": "^10.2.3",
         "react": "^16.x || ^17.x || ^18.x",
         "react-dom": "^16.x || ^17.x || ^18.x"
       }
@@ -14945,6 +14948,30 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
+      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.0.tgz",
+      "integrity": "sha512-XrCTj44uNE0clTA47y1AbIb7tM7w6+zi6WrJzb4RxRe3uAIIivkBCwlsCqe7R3vPRT/LCQzfe4+N/KjtJMQMgw==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^7.6.0",
+        "tabbable": "^6.2.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.8.1",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
       }
     },
     "node_modules/for-each": {
@@ -22528,7 +22555,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -23141,8 +23167,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -25061,6 +25086,12 @@
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
       "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
       "dev": true
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,9 +28,10 @@
   "dependencies": {
     "@next/third-parties": "^14.3.0-canary.59",
     "@opentelemetry/api": "^1.8.0",
-    "@trussworks/react-uswds": "^7.0.0",
-    "@uswds/uswds": "^3.6.0",
+    "@trussworks/react-uswds": "^9.1.0",
+    "@uswds/uswds": "^3.7.1",
     "clsx": "^2.1.1",
+    "focus-trap-react": "^10.2.3",
     "isomorphic-dompurify": "^2.15.0",
     "js-cookie": "^3.0.5",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Summary
Fixes #2487

### Time to review: __20 mins__

## Changes proposed

Upgrade Trussworks to latest version, upgrade USWDS to latest version supported by Trussworks.

## Context for reviewers

See notes here: https://github.com/HHS/simpler-grants-gov/issues/2487#issuecomment-2432512375

### Test steps

**Note:** it's probably too early to implementing anything, but how do we feel about visual diffing tools like Percy?

These test steps are what I did, in order to allow an easy-ish side by side comparison of main vs this branch, but you could take screenshots of the main branch pages and compare to screenshots of this branch, or there are probably other options as well. The point is, do a visual diff of the site.

1. _VERIFY_ all CI build stuff passes
2. create an alternate simpler repo either by re-cloning into a new directory, or running a `cp` into a new directory
3. ensure that your alternate directory is on main and your regular directory is on this branch, or vice versa, and `npm ci` in both directories
4. start servers from both directories, these will start on locahost:3000 and localhost:3001
5. run the apps side by side and do a rough visual diff check on every page to make sure nothing is different
6. run some searches and look at opportunities as well, to make sure functionality is the same

## Additional information



