### PR TITLE
[Unticketed] Fix agency relationship loading in the GET opp endpoint

### DIFF
--- a/api/src/services/opportunities_v1/get_opportunity.py
+++ b/api/src/services/opportunities_v1/get_opportunity.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import noload, selectinload
 import src.adapters.db as db
 import src.util.datetime_util as datetime_util
 from src.api.route_utils import raise_flask_error
+from src.db.models.agency_models import Agency
 from src.db.models.opportunity_models import Opportunity, OpportunitySummary
 
 
@@ -17,6 +18,10 @@ def _fetch_opportunity(
         .where(Opportunity.opportunity_id == opportunity_id)
         .where(Opportunity.is_draft.is_(False))
         .options(selectinload("*"))
+        # To get the top_level_agency field set properly upfront,
+        # we need to explicitly join here as the "*" approach doesn't
+        # seem to work with the way our agency relationships are setup
+        .options(selectinload(Opportunity.agency_record).selectinload(Agency.top_level_agency))
     )
 
     if not load_all_opportunity_summaries:


### PR DESCRIPTION
### Time to review: __2 mins__

## Changes proposed
Explicitly load the agency relationships upfront in the GET /opportunity endpoint

## Context for reviewers
By default SQLAlchemy lazy-loads all relationships, we had configured the opportunity fetch to load `*` relationships, but the way our agency relationships are setup don't seem to work without explicitly defining it. So I did that.

Need to do some additional configuration to make this work with a unit test which I'll follow-up with, but testing locally it stopped erroring.

## Additional information
The original error: `"Parent instance <Agency at 0x7f498eee92b0> is not bound to a Session; lazy load operation of attribute 'top_level_agency' cannot proceed (Background on this error at: https://sqlalche.me/e/20/bhk3)",`

