### PR TITLE
Return notFound if opportunity not found

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -6,6 +6,7 @@ import withFeatureFlag from "src/hoc/search/withFeatureFlag";
 import { Opportunity } from "src/types/opportunity/opportunityResponseTypes";
 
 import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
 import { GridContainer } from "@trussworks/react-uswds";
 
 import BetaAlert from "src/components/BetaAlert";
@@ -26,6 +27,7 @@ export async function generateMetadata({ params }: { params: { id: string } }) {
     title = `${t("OpportunityListing.page_title")} - ${opportunityData.opportunity_title}`;
   } catch (error) {
     console.error("Failed to render title");
+    return notFound();
   }
   const meta: Metadata = {
     title,


### PR DESCRIPTION
## Summary
Fixes #2337

### Time to review: 5 mins

## Changes proposed
Return notFound() if opportunity API returns a 404 error code.

## Context for reviewers
See screen capture to demonstrate local env returning 'Oops! Page Not Found' title vs current dev showing 'Opportunity Listing' title:
https://github.com/user-attachments/assets/31a6ba1b-8e9f-4df7-9a79-bd72ac7ca8e1



