### PR TITLE
[Issue #2580] Run vulnerability scans twice

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-action.outputs.json }}
+          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-json.outputs.json }}
 
   dockle-scan:
     name: Dockle Scan

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -142,9 +142,18 @@ jobs:
         run: |
           docker load < /tmp/docker-image.tar
 
-      - name: Run Anchore vulnerability scan
+     - name: Run Anchore vulnerability scan
         uses: anchore/scan-action@v4
-        id: anchore-scan-action
+        with:
+          image: ${{ needs.build-and-cache.outputs.image }}
+          output-format: table
+          fail-build: true
+          severity-cutoff: medium
+
+      - name: Run Anchore vulnerability scan
+        if: always() # Runs even if there is a failure
+        uses: anchore/scan-action@v4
+        id: anchore-scan-json
         with:
           image: ${{ needs.build-and-cache.outputs.image }}
           output-format: json

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           docker load < /tmp/docker-image.tar
 
-     - name: Run Anchore vulnerability scan
+      - name: Run Anchore vulnerability scan
         uses: anchore/scan-action@v4
         with:
           image: ${{ needs.build-and-cache.outputs.image }}


### PR DESCRIPTION
## Changes

Runs vulnerability scans twice so we can get both the version fixes and CVE locations

## Context 

This is a patchwork fix for #2580. I would rather fix this upstream, so I'm not making this PR as resolving #2580