### PR TITLE
[Issue ##2798] Break up e2e tests

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -1,5 +1,4 @@
 name: Frontend E2E Tests
-
 on:
   workflow_call:
   pull_request:
@@ -25,6 +24,11 @@ jobs:
     name: Run E2E Tests
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        shard: [1, 2, 3]
+        total_shards: [3]
+
     steps:
       - uses: actions/checkout@v4
 
@@ -35,10 +39,9 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
-      - run: npm ci
-
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - run: |
+          npm ci
+          npx playwright install --with-deps
 
       - name: Start API Server for e2e tests
         run: |
@@ -50,15 +53,75 @@ jobs:
           ../api/bin/wait-for-api.sh
         shell: bash
 
-      - name: Run E2E Tests
+      - name: Build a prod version of the site
         run: |
-          npm run build
           cat .env.development >> .env.local
-          npm run test:e2e
+          npm run build
 
-      - uses: actions/upload-artifact@v4
+      - name: Run e2e tests (Shard ${{ matrix.shard }}/${{ matrix.total_shards }})
+        env:
+          CI: true
+          TOTAL_SHARDS: ${{ matrix.total_shards }}
+          CURRENT_SHARD: ${{ matrix.shard }}
+        run: npm run test:e2e
+
+      - name: Verify Blob Report Directory
+        run: |
+          echo "Contents of blob-report directory:"
+          ls -R blob-report || echo "blob-report directory not found"
+
+      - name: Upload Blob Report
         if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: ./frontend/playwright-report/
+          name: blob-report-shard-${{ matrix.shard }}
+          path: /home/runner/work/simpler-grants-gov/simpler-grants-gov/frontend/blob-report
+          retention-days: 1
+
+  create-report:
+    name: Create Merged Test Report
+    if: ${{ !cancelled() }}
+    needs: [e2e-tests]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: ${{ env.PACKAGE_MANAGER }}
+          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
+
+      - run: |
+          npm ci
+          npx playwright install --with-deps
+
+      - name: Download All Blob Reports
+        uses: actions/download-artifact@v4
+        with:
+          path: frontend/all-blob-reports
+          pattern: blob-report-shard-*
+          merge-multiple: true
+
+      - name: Verify Downloaded Artifacts
+        run: |
+          echo "Contents of all-blob-reports after download:"
+          ls -R all-blob-reports*
+
+      - name: Merge Blob Reports into HTML
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Verify Downloaded Artifacts
+        run: |
+          echo "Contents of all-blob-reports after download:"
+          ls -R playwright*
+
+      - name: Upload Merged HTML Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: merged-html-report
+          path: frontend/playwright-report
           retention-days: 30

--- a/frontend/docker-compose-release.yml
+++ b/frontend/docker-compose-release.yml
@@ -1,0 +1,23 @@
+# Docker compose file for testing the release version of the frontend.
+services:
+  nextjs:
+    container_name: next-dev
+    platform: linux/amd64
+    build:
+      context: .
+      target: release
+    env_file:
+      - ./.env.local
+    volumes:
+      - ./src:/frontend/src
+      - ./public:/frontend/public
+    restart: always
+    ports:
+      - 3000:3000
+    networks:
+      - default
+      - api_grants_backend
+
+networks:
+  api_grants_backend:
+    external: true

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  // Use 'blob' for CI to allow merging of reports. See https://playwright.dev/docs/test-reporters
+  reporter: process.env.CI ? "blob" : "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -32,7 +32,12 @@ export default defineConfig({
     screenshot: "on",
     video: "on-first-retry",
   },
-
+  shard: {
+    // Total number of shards
+    total: parseInt(process.env.TOTAL_SHARDS || "1"),
+    // Specifies which shard this job should execute
+    current: parseInt(process.env.CURRENT_SHARD || "1"),
+  },
   /* Configure projects for major browsers */
   projects: [
     {


### PR DESCRIPTION
## Summary
Fixes #2798

### Time to review: __5 mins__

## Changes proposed
Update e2e tests so they are sharded across 3 processes that run in parallel. Time per test reduced by a couple of mins. More importantly the tests seem less flaky. This not as big a deal now but the tests should scale as we grow.

