### PR TITLE
[Issue #2471] Update `SprintBurndown` to use `GitHubIssues` dataset

### DIFF
--- a/analytics/Makefile
+++ b/analytics/Makefile
@@ -190,8 +190,7 @@ sprint-burndown:
 	@echo "=> Running sprint burndown report"
 	@echo "====================================================="
 	$(POETRY) analytics calculate sprint_burndown \
-	--sprint-file $(SPRINT_FILE) \
-	--issue-file $(ISSUE_FILE) \
+	--issue-file $(DELIVERY_FILE) \
 	--output-dir $(OUTPUT_DIR) \
 	--sprint  "$(SPRINT)" \
 	--unit $(UNIT) \

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -11,7 +11,6 @@ from sqlalchemy import text
 
 from analytics.datasets.deliverable_tasks import DeliverableTasks
 from analytics.datasets.issues import GitHubIssues
-from analytics.datasets.sprint_board import SprintBoard
 from analytics.integrations import db, github, slack
 from analytics.metrics.base import BaseMetric, Unit
 from analytics.metrics.burndown import SprintBurndown
@@ -156,7 +155,6 @@ def calculate_sprint_burndown(
 
 @metrics_app.command(name="sprint_burnup")
 def calculate_sprint_burnup(
-    sprint_file: Annotated[str, SPRINT_FILE_ARG],
     issue_file: Annotated[str, ISSUE_FILE_ARG],
     sprint: Annotated[str, SPRINT_ARG],
     unit: Annotated[Unit, UNIT_ARG] = Unit.points.value,  # type: ignore[assignment]
@@ -167,10 +165,7 @@ def calculate_sprint_burnup(
 ) -> None:
     """Calculate the burnup of a particular sprint."""
     # load the input data
-    sprint_data = SprintBoard.load_from_json_files(
-        sprint_file=sprint_file,
-        issue_file=issue_file,
-    )
+    sprint_data = GitHubIssues.from_json(issue_file)
     # calculate burnup
     burnup = SprintBurnup(sprint_data, sprint=sprint, unit=unit)
     show_and_or_post_results(

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -133,7 +133,6 @@ def export_github_data(
 
 @metrics_app.command(name="sprint_burndown")
 def calculate_sprint_burndown(
-    sprint_file: Annotated[str, SPRINT_FILE_ARG],
     issue_file: Annotated[str, ISSUE_FILE_ARG],
     sprint: Annotated[str, SPRINT_ARG],
     unit: Annotated[Unit, UNIT_ARG] = Unit.points.value,  # type: ignore[assignment]
@@ -144,10 +143,7 @@ def calculate_sprint_burndown(
 ) -> None:
     """Calculate the burndown for a particular sprint."""
     # load the input data
-    sprint_data = SprintBoard.load_from_json_files(
-        sprint_file=sprint_file,
-        issue_file=issue_file,
-    )
+    sprint_data = GitHubIssues.from_json(issue_file)
     # calculate burndown
     burndown = SprintBurndown(sprint_data, sprint=sprint, unit=unit)
     show_and_or_post_results(

--- a/analytics/src/analytics/metrics/burnup.py
+++ b/analytics/src/analytics/metrics/burnup.py
@@ -14,13 +14,7 @@ import plotly.express as px
 
 from analytics.datasets.issues import GitHubIssues
 from analytics.metrics.base import BaseMetric, Statistic, Unit
-from analytics.metrics.utils import (
-    Columns,
-    IssueState,
-    get_cum_sum_of_tix,
-    get_daily_tix_counts_by_status,
-    get_tix_date_range,
-)
+from analytics.metrics.utils import Columns, sum_tix_by_day
 
 if TYPE_CHECKING:
     from plotly.graph_objects import Figure
@@ -40,9 +34,6 @@ class SprintBurnup(BaseMetric[GitHubIssues]):
         self.sprint = self._get_and_validate_sprint_name(sprint)
         self.sprint_data = self._isolate_data_for_this_sprint()
         self.date_col = "date"
-        self.points_col = dataset.points_col
-        self.opened_col = dataset.opened_col  # type: ignore[attr-defined]
-        self.closed_col = dataset.closed_col  # type: ignore[attr-defined]
         self.columns = Columns(
             opened_at_col=dataset.opened_col,
             closed_at_col=dataset.closed_col,
@@ -53,46 +44,20 @@ class SprintBurnup(BaseMetric[GitHubIssues]):
         super().__init__(dataset)
 
     def calculate(self) -> pd.DataFrame:
-        """
-        Calculate the sprint burnup.
-
-        Notes
-        -----
-        Sprint burnup is calculated with the following algorithm:
-        1. Isolate Sprint records
-        2. Create data range for burnup
-        3. Group issues/points by date opened and date closed
-        4. Join on date
-
-        """
+        """Calculate the sprint burnup."""
         # make a copy of columns and rows we need to calculate burndown for this sprint
-        burnup_cols = [self.dataset.opened_col, self.closed_col, self.points_col]
+        burnup_cols = [
+            self.dataset.opened_col,
+            self.dataset.closed_col,
+            self.dataset.points_col,
+        ]
         df_sprint = self.sprint_data[burnup_cols].copy()
-        # get the date range over which tix were created and closed
-        df_tix_range = get_tix_date_range(
+        # Count the number of tickets opened, closed, and remaining by day
+        return sum_tix_by_day(
             df=df_sprint,
             cols=self.columns,
+            unit=self.unit,
             sprint_end=self.dataset.sprint_end(self.sprint),
-        )
-        # get the number of tix opened and closed each day
-        df_opened = get_daily_tix_counts_by_status(
-            df=df_sprint,
-            cols=self.columns,
-            state=IssueState.OPEN,
-            unit=self.unit,
-        )
-        df_closed = get_daily_tix_counts_by_status(
-            df=df_sprint,
-            cols=self.columns,
-            state=IssueState.CLOSED,
-            unit=self.unit,
-        )
-        # combine the daily opened and closed counts to get total open and closed per day
-        return get_cum_sum_of_tix(
-            cols=self.columns,
-            dates=df_tix_range,
-            opened=df_opened,
-            closed=df_closed,
         )
 
     def plot_results(self) -> Figure:
@@ -140,13 +105,13 @@ class SprintBurnup(BaseMetric[GitHubIssues]):
         sprint_start = self.dataset.sprint_start(self.sprint).strftime("%Y-%m-%d")
         sprint_end = self.dataset.sprint_end(self.sprint).strftime("%Y-%m-%d")
         # get open and closed counts and percentages
-        total_opened = int(df[self.columns.opened_count_col].sum())
-        total_closed = int(df[self.columns.closed_count_col].sum())
+        total_opened = int(df["opened"].sum())
+        total_closed = int(df["closed"].sum())
         pct_closed = round(total_closed / total_opened * 100, 2)
         # For burnup, we want to know at a glance the pct_remaining
         pct_remaining = round(100 - pct_closed, 2)
         # get the percentage of tickets that were ticketed
-        is_pointed = self.sprint_data[self.points_col] >= 1
+        is_pointed = self.sprint_data[self.dataset.points_col] >= 1
         issues_pointed = len(self.sprint_data[is_pointed])
         issues_total = len(self.sprint_data)
         pct_pointed = round(issues_pointed / issues_total * 100, 2)

--- a/analytics/src/analytics/metrics/utils.py
+++ b/analytics/src/analytics/metrics/utils.py
@@ -30,6 +30,22 @@ class IssueState(StrEnum):
     CLOSED = "closed"
 
 
+def sum_tix_by_day(
+    df: pd.DataFrame,
+    cols: Columns,
+    unit: Unit,
+    sprint_end: pd.Timestamp,
+) -> pd.DataFrame:
+    """Count the total number of tix opened, closed, and remaining by day."""
+    # Get the date range for burndown/burnup
+    df_tix_range = get_tix_date_range(df, cols, sprint_end)
+    # Get the number of tix opened and closed by day
+    df_opened = get_daily_tix_counts_by_status(df, cols, IssueState.OPEN, unit)
+    df_closed = get_daily_tix_counts_by_status(df, cols, IssueState.CLOSED, unit)
+    # combine the daily opened and closed counts to get total open and closed per day
+    return get_cum_sum_of_tix(cols, df_tix_range, df_opened, df_closed)
+
+
 def get_daily_tix_counts_by_status(
     df: pd.DataFrame,
     cols: Columns,

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 """
 Configure pytest settings and create reusable fixtures and functions.
 
@@ -204,7 +205,7 @@ def sprint_row(
     }
 
 
-def issue(
+def issue(  # pylint: disable=too-many-locals
     issue: int,
     kind: IssueType = IssueType.TASK,
     parent: str | None = None,

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
+from analytics.datasets.issues import IssueMetadata, IssueType
 
 # skips the integration tests in tests/integrations/
 # to run the integration tests, invoke them directly: pytest tests/integrations/
@@ -58,7 +59,7 @@ def mock_slackbot_fixture():
     return MockSlackbot()
 
 
-def write_test_data_to_file(data: dict | list[dict], output_file: str):
+def write_test_data_to_file(data: dict | list[dict], output_file: str | Path):
     """Write test JSON data to a file for use in a test."""
     parent_dir = Path(output_file).parent
     parent_dir.mkdir(exist_ok=True, parents=True)
@@ -201,3 +202,46 @@ def sprint_row(
         "created_date": created_date,
         "closed_date": closed_date,
     }
+
+
+def issue(
+    issue: int,
+    kind: IssueType = IssueType.TASK,
+    parent: str | None = None,
+    points: int | None = 1,
+    quad: str | None = None,
+    epic: str | None = None,
+    deliverable: str | None = None,
+    sprint: int = 1,
+    sprint_start: str = DAY_0,
+    sprint_length: int = 2,
+    created: str = DAY_0,
+    closed: str | None = None,
+) -> IssueMetadata:
+    """Create a new issue."""
+    # Create issue name
+    name = f"{kind.value}{issue}"
+    # Create sprint timestamp fields
+    sprint_name = f"Sprint {sprint}"
+    sprint_start_ts = pd.Timestamp(sprint_start)
+    sprint_duration = pd.Timedelta(days=sprint_length)
+    sprint_end_ts = sprint_start_ts + sprint_duration
+    return IssueMetadata(
+        issue_title=name,
+        issue_type=kind.value,
+        issue_url=name,
+        issue_is_closed=bool(closed),
+        issue_opened_at=created,
+        issue_closed_at=closed,
+        issue_parent=parent,
+        issue_points=points,
+        quad_name=quad,
+        epic_title=epic,
+        epic_url=epic,
+        deliverable_title=deliverable,
+        deliverable_url=deliverable,
+        sprint_id=sprint_name,
+        sprint_name=sprint_name,
+        sprint_start=sprint_start,
+        sprint_end=sprint_end_ts.strftime("%Y-%m-%d"),
+    )

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -168,7 +168,7 @@ def sprint_row(
     created: str = DAY_1,
     closed: str | None = None,
     status: str = "In Progress",
-    points: int = 1,
+    points: int | None = 1,
     sprint: int = 1,
     sprint_start: str = DAY_1,
     sprint_length: int = 2,

--- a/analytics/tests/datasets/test_issues.py
+++ b/analytics/tests/datasets/test_issues.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 from analytics.datasets.issues import (
     GitHubIssues,
     IssueMetadata,
@@ -11,7 +12,14 @@ from analytics.datasets.issues import (
 )
 from analytics.datasets.utils import dump_to_json
 
-from tests.conftest import DAY_0
+from tests.conftest import (
+    DAY_0,
+    DAY_1,
+    DAY_2,
+    DAY_3,
+    DAY_4,
+    DAY_5,
+)
 
 
 def issue(
@@ -30,12 +38,10 @@ def issue(
     # Create issue name
     name = f"{kind.value}{issue}"
     # create timestamp and time delta fields
-    sprint_name = f"Sprint{sprint}"
+    sprint_name = f"Sprint {sprint}"
     sprint_start_ts = pd.Timestamp(sprint_start)
     sprint_duration = pd.Timedelta(days=sprint_length)
     sprint_end_ts = sprint_start_ts + sprint_duration
-    sprint_end = sprint_end_ts.strftime("%Y-%m-%d")
-    print(f"Sprint End: {sprint_end}")
     return IssueMetadata(
         issue_title=name,
         issue_type=kind.value,
@@ -53,7 +59,7 @@ def issue(
         sprint_id=sprint_name,
         sprint_name=sprint_name,
         sprint_start=sprint_start,
-        sprint_end=sprint_end,
+        sprint_end=sprint_end_ts.strftime("%Y-%m-%d"),
     )
 
 
@@ -207,3 +213,64 @@ class TestGetParentWithType:
         )
         # Assert
         assert got == wanted
+
+
+class TestGetSprintNameFromDate:
+    """Test the GitHubIssues.get_sprint_name_from_date() method."""
+
+    @pytest.mark.parametrize(
+        ("date", "expected"),
+        [
+            (DAY_1, "Sprint 1"),
+            (DAY_2, "Sprint 1"),
+            (DAY_4, "Sprint 2"),
+            (DAY_5, "Sprint 2"),
+        ],
+    )
+    def test_return_name_if_matching_sprint_exists(self, date: str, expected: str):
+        """Test that correct sprint is returned if date exists in a sprint."""
+        # setup - create sample dataset
+        board_data = [
+            issue(issue=1, sprint=1, sprint_start=DAY_0, sprint_length=3),
+            issue(issue=2, sprint=1, sprint_start=DAY_0, sprint_length=3),
+            issue(issue=3, sprint=2, sprint_start=DAY_3, sprint_length=3),
+        ]
+        board_data = [i.__dict__ for i in board_data]
+        board = GitHubIssues.from_dict(board_data)
+        # validation
+        sprint_date = pd.Timestamp(date)
+        sprint_name = board.get_sprint_name_from_date(sprint_date)
+        assert sprint_name == expected
+
+    def test_return_none_if_no_matching_sprint(self):
+        """The method should return None if no sprint contains the date."""
+        # setup - create sample dataset
+        board_data = [
+            issue(issue=1, sprint=1, sprint_start=DAY_1),
+            issue(issue=2, sprint=2, sprint_start=DAY_4),
+        ]
+        board_data = [i.__dict__ for i in board_data]
+        board = GitHubIssues.from_dict(board_data)
+        # validation
+        bad_date = pd.Timestamp("1900-01-01")
+        sprint_name = board.get_sprint_name_from_date(bad_date)
+        assert sprint_name is None
+
+    def test_return_previous_sprint_if_date_is_start_of_next_sprint(self):
+        """
+        Test correct behavior for sprint end/start dates.
+
+        If date provided is both the the end of one sprint and the beginning of
+        another, then return the name of the sprint that just ended.
+        """
+        # setup - create sample dataset
+        board_data = [
+            issue(issue=1, sprint=1, sprint_start=DAY_1, sprint_length=2),
+            issue(issue=2, sprint=2, sprint_start=DAY_3, sprint_length=2),
+        ]
+        board_data = [i.__dict__ for i in board_data]
+        board = GitHubIssues.from_dict(board_data)
+        # execution
+        bad_date = pd.Timestamp(DAY_3)  # end of sprint 1 and start of sprint 2
+        sprint_name = board.get_sprint_name_from_date(bad_date)
+        assert sprint_name == "Sprint 1"

--- a/analytics/tests/datasets/test_issues.py
+++ b/analytics/tests/datasets/test_issues.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 from analytics.datasets.issues import (
     GitHubIssues,
-    IssueMetadata,
     IssueType,
     get_parent_with_type,
 )
@@ -19,48 +18,8 @@ from tests.conftest import (
     DAY_3,
     DAY_4,
     DAY_5,
+    issue,
 )
-
-
-def issue(
-    issue: int,
-    kind: IssueType = IssueType.TASK,
-    parent: str | None = None,
-    points: int | None = None,
-    quad: str | None = None,
-    epic: str | None = None,
-    deliverable: str | None = None,
-    sprint: int = 1,
-    sprint_start: str = DAY_0,
-    sprint_length: int = 2,
-) -> IssueMetadata:
-    """Create a new issue."""
-    # Create issue name
-    name = f"{kind.value}{issue}"
-    # create timestamp and time delta fields
-    sprint_name = f"Sprint {sprint}"
-    sprint_start_ts = pd.Timestamp(sprint_start)
-    sprint_duration = pd.Timedelta(days=sprint_length)
-    sprint_end_ts = sprint_start_ts + sprint_duration
-    return IssueMetadata(
-        issue_title=name,
-        issue_type=kind.value,
-        issue_url=name,
-        issue_is_closed=False,
-        issue_opened_at="2024-02-01",
-        issue_closed_at=None,
-        issue_parent=parent,
-        issue_points=points,
-        quad_name=quad,
-        epic_title=epic,
-        epic_url=epic,
-        deliverable_title=deliverable,
-        deliverable_url=deliverable,
-        sprint_id=sprint_name,
-        sprint_name=sprint_name,
-        sprint_start=sprint_start,
-        sprint_end=sprint_end_ts.strftime("%Y-%m-%d"),
-    )
 
 
 class TestGitHubIssues:

--- a/analytics/tests/datasets/test_issues.py
+++ b/analytics/tests/datasets/test_issues.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pandas as pd
 from analytics.datasets.issues import (
     GitHubIssues,
     IssueMetadata,
@@ -10,17 +11,31 @@ from analytics.datasets.issues import (
 )
 from analytics.datasets.utils import dump_to_json
 
+from tests.conftest import DAY_0
+
 
 def issue(
-    name: str,
+    issue: int,
     kind: IssueType = IssueType.TASK,
     parent: str | None = None,
     points: int | None = None,
     quad: str | None = None,
     epic: str | None = None,
     deliverable: str | None = None,
+    sprint: int = 1,
+    sprint_start: str = DAY_0,
+    sprint_length: int = 2,
 ) -> IssueMetadata:
     """Create a new issue."""
+    # Create issue name
+    name = f"{kind.value}{issue}"
+    # create timestamp and time delta fields
+    sprint_name = f"Sprint{sprint}"
+    sprint_start_ts = pd.Timestamp(sprint_start)
+    sprint_duration = pd.Timedelta(days=sprint_length)
+    sprint_end_ts = sprint_start_ts + sprint_duration
+    sprint_end = sprint_end_ts.strftime("%Y-%m-%d")
+    print(f"Sprint End: {sprint_end}")
     return IssueMetadata(
         issue_title=name,
         issue_type=kind.value,
@@ -35,6 +50,10 @@ def issue(
         epic_url=epic,
         deliverable_title=deliverable,
         deliverable_url=deliverable,
+        sprint_id=sprint_name,
+        sprint_name=sprint_name,
+        sprint_start=sprint_start,
+        sprint_end=sprint_end,
     )
 
 
@@ -46,37 +65,37 @@ class TestGitHubIssues:
         # Arrange - create dummy sprint data
         sprint_file = tmp_path / "sprint-data.json"
         sprint_data = [
-            issue(name="task1", kind=IssueType.TASK, parent="epic1", points=2),
-            issue(name="task2", kind=IssueType.TASK, parent="epic2", points=1),
+            issue(issue=1, kind=IssueType.TASK, parent="Epic3", points=2),
+            issue(issue=2, kind=IssueType.TASK, parent="Epic4", points=1),
         ]
         roadmap_data = [i.model_dump() for i in sprint_data]
         dump_to_json(str(sprint_file), roadmap_data)
         # Act - create dummy roadmap data
         roadmap_file = tmp_path / "roadmap-data.json"
         roadmap_data = [
-            issue(name="epic1", kind=IssueType.EPIC, parent="del1"),
-            issue(name="epic2", kind=IssueType.EPIC, parent="del2"),
-            issue(name="del1", kind=IssueType.DELIVERABLE, quad="quad1"),
+            issue(issue=3, kind=IssueType.EPIC, parent="Deliverable5"),
+            issue(issue=4, kind=IssueType.EPIC, parent="Deliverable6"),
+            issue(issue=5, kind=IssueType.DELIVERABLE, quad="quad1"),
         ]
         roadmap_data = [i.model_dump() for i in roadmap_data]
         dump_to_json(str(roadmap_file), roadmap_data)
         # Arrange
         output_data = [
             issue(
-                name="task1",
+                issue=1,
                 points=2,
-                parent="epic1",
-                deliverable="del1",
+                parent="Epic3",
+                deliverable="Deliverable5",
                 quad="quad1",
-                epic="epic1",
+                epic="Epic3",
             ),
             issue(
-                name="task2",
+                issue=2,
                 points=1,
-                parent="epic2",
+                parent="Epic4",
                 deliverable=None,
                 quad=None,
-                epic="epic2",
+                epic="Epic4",
             ),
         ]
         wanted = [i.model_dump() for i in output_data]
@@ -95,12 +114,13 @@ class TestGetParentWithType:
     def test_return_epic_that_is_direct_parent_of_issue(self):
         """Return the correct epic for an issue that is one level down."""
         # Arrange
-        task = "task"
+        task = "Task1"
+        epic = "Epic1"
         lookup = {
-            task: issue(name=task, kind=IssueType.TASK, parent="epic"),
-            "epic": issue(name=task, kind=IssueType.EPIC, parent=None),
+            task: issue(issue=1, kind=IssueType.TASK, parent=epic),
+            epic: issue(issue=2, kind=IssueType.EPIC, parent=None),
         }
-        wanted = lookup["epic"]
+        wanted = lookup[epic]
         # Act
         got = get_parent_with_type(
             child_url=task,
@@ -113,13 +133,15 @@ class TestGetParentWithType:
     def test_return_correct_deliverable_that_is_grandparent_of_issue(self):
         """Return the correct deliverable for an issue that is two levels down."""
         # Arrange
-        task = "task"
+        task = "Task1"
+        epic = "Epic2"
+        deliverable = "Deliverable3"
         lookup = {
-            task: issue(name=task, kind=IssueType.TASK, parent="epic"),
-            "epic": issue(name=task, kind=IssueType.EPIC, parent="deliverable"),
-            "deliverable": issue(name=task, kind=IssueType.DELIVERABLE, parent=None),
+            task: issue(issue=1, kind=IssueType.TASK, parent=epic),
+            epic: issue(issue=2, kind=IssueType.EPIC, parent=deliverable),
+            deliverable: issue(issue=3, kind=IssueType.DELIVERABLE, parent=None),
         }
-        wanted = lookup["deliverable"]
+        wanted = lookup[deliverable]
         # Act
         got = get_parent_with_type(
             child_url=task,
@@ -134,7 +156,7 @@ class TestGetParentWithType:
         # Arrange
         task = "task"
         lookup = {
-            task: issue(name=task, kind=IssueType.TASK, parent=None),
+            task: issue(issue=1, kind=IssueType.TASK, parent=None),
         }
         wanted = None
         # Act
@@ -149,10 +171,11 @@ class TestGetParentWithType:
     def test_return_none_if_parents_form_a_cycle(self):
         """Return None if the issue hierarchy forms a cycle."""
         # Arrange
-        task = "task"
+        task = "Task1"
+        parent = "Task2"
         lookup = {
-            task: issue(name=task, kind=IssueType.TASK, parent="parent"),
-            "parent": issue(name=task, kind=IssueType.TASK, parent=task),
+            task: issue(issue=1, kind=IssueType.TASK, parent="parent"),
+            parent: issue(issue=2, kind=IssueType.TASK, parent=task),
         }
         wanted = None
         # Act
@@ -167,11 +190,13 @@ class TestGetParentWithType:
     def test_return_none_if_deliverable_is_not_found_in_parents(self):
         """Return None if the desired type (e.g. epic) isn't found in the list of parents."""
         # Arrange
-        task = "task"
+        task = "Task1"
+        parent = "Task2"
+        epic = "Epic3"
         lookup = {
-            task: issue(name=task, kind=IssueType.TASK, parent="parent"),
-            "parent": issue(name=task, kind=IssueType.TASK, parent="epic"),
-            "epic": issue(name=task, kind=IssueType.EPIC, parent=task),
+            task: issue(issue=1, kind=IssueType.TASK, parent=parent),
+            parent: issue(issue=2, kind=IssueType.TASK, parent=epic),
+            epic: issue(issue=3, kind=IssueType.EPIC, parent=task),
         }
         wanted = None
         # Act

--- a/analytics/tests/metrics/test_burndown.py
+++ b/analytics/tests/metrics/test_burndown.py
@@ -25,6 +25,7 @@ def result_row(
     closed: int,
     delta: int,
     total: int,
+    closed_total: int,
 ) -> dict:
     """Create a sample result row."""
     return {
@@ -33,6 +34,7 @@ def result_row(
         "closed": closed,
         "delta": delta,
         "total_open": total,
+        "total_closed": closed_total,
     }
 
 
@@ -73,11 +75,13 @@ class TestSprintBurndownByTasks:
         assert df[output.date_col].min() == pd.Timestamp(DAY_1)
         assert df[output.date_col].max() == pd.Timestamp(DAY_3)
         # validation - check burndown output
+        # fmt: off
         expected = [
-            result_row(day=DAY_1, opened=1, closed=0, delta=1, total=1),
-            result_row(day=DAY_2, opened=0, closed=0, delta=0, total=1),
-            result_row(day=DAY_3, opened=0, closed=1, delta=-1, total=0),
+            result_row(day=DAY_1, opened=1, closed=0, delta=1, total=1, closed_total=0),
+            result_row(day=DAY_2, opened=0, closed=0, delta=0, total=1, closed_total=0),
+            result_row(day=DAY_3, opened=0, closed=1, delta=-1, total=0, closed_total=1),
         ]
+        # fmt: on
         assert df.to_dict("records") == expected
 
     def test_count_tix_created_before_sprint_start(self):
@@ -96,12 +100,14 @@ class TestSprintBurndownByTasks:
         assert df[output.date_col].min() == pd.Timestamp(DAY_0)
         assert df[output.date_col].max() == pd.Timestamp(DAY_3)
         # validation - check burndown output
+        # fmt: off
         expected = [
-            result_row(day=DAY_0, opened=2, closed=0, delta=2, total=2),
-            result_row(day=DAY_1, opened=0, closed=0, delta=0, total=2),
-            result_row(day=DAY_2, opened=0, closed=1, delta=-1, total=1),
-            result_row(day=DAY_3, opened=0, closed=1, delta=-1, total=0),
+            result_row(day=DAY_0, opened=2, closed=0, delta=2, total=2, closed_total=0),
+            result_row(day=DAY_1, opened=0, closed=0, delta=0, total=2, closed_total=0),
+            result_row(day=DAY_2, opened=0, closed=1, delta=-1, total=1, closed_total=1),
+            result_row(day=DAY_3, opened=0, closed=1, delta=-1, total=0, closed_total=2),
         ]
+        # fmt: on
         assert df.to_dict("records") == expected
 
     def test_count_tix_closed_after_sprint_start(self):
@@ -132,12 +138,14 @@ class TestSprintBurndownByTasks:
         assert df[output.date_col].min() == pd.Timestamp(DAY_1)
         assert df[output.date_col].max() == pd.Timestamp(DAY_4)
         # validation - check burndown output
+        # fmt: off
         expected = [
-            result_row(day=DAY_1, opened=2, closed=0, delta=2, total=2),
-            result_row(day=DAY_2, opened=0, closed=1, delta=-1, total=1),
-            result_row(day=DAY_3, opened=0, closed=0, delta=0, total=1),
-            result_row(day=DAY_4, opened=0, closed=1, delta=-1, total=0),
+            result_row(day=DAY_1, opened=2, closed=0, delta=2, total=2, closed_total=0),
+            result_row(day=DAY_2, opened=0, closed=1, delta=-1, total=1, closed_total=1),
+            result_row(day=DAY_3, opened=0, closed=0, delta=0, total=1, closed_total=1),
+            result_row(day=DAY_4, opened=0, closed=1, delta=-1, total=0, closed_total=2),
         ]
+        # fmt: on
         assert df.to_dict("records") == expected
 
     def test_count_tix_created_after_sprint_start(self):
@@ -153,12 +161,14 @@ class TestSprintBurndownByTasks:
         output = SprintBurndown(test_data, sprint="Sprint 1", unit=Unit.issues)
         df = output.results
         # validation - check burndown output
+        # fmt: off
         expected = [
-            result_row(day=DAY_0, opened=1, closed=0, delta=1, total=1),
-            result_row(day=DAY_1, opened=0, closed=0, delta=0, total=1),
-            result_row(day=DAY_2, opened=1, closed=1, delta=0, total=1),
-            result_row(day=DAY_3, opened=0, closed=1, delta=-1, total=0),
+            result_row(day=DAY_0, opened=1, closed=0, delta=1, total=1, closed_total=0),
+            result_row(day=DAY_1, opened=0, closed=0, delta=0, total=1, closed_total=0),
+            result_row(day=DAY_2, opened=1, closed=1, delta=0, total=1, closed_total=1),
+            result_row(day=DAY_3, opened=0, closed=1, delta=-1, total=0, closed_total=2),
         ]
+        # fmt: on
         assert df.to_dict("records") == expected
 
     def test_include_all_sprint_days_if_tix_closed_early(self):
@@ -209,11 +219,13 @@ class TestSprintBurndownByTasks:
         output = SprintBurndown(test_data, sprint="@current", unit=Unit.issues)
         df = output.results
         # validation - check burndown output
+        # fmt: off
         expected = [
-            result_row(day=day_1, opened=2, closed=0, delta=2, total=2),
-            result_row(day=day_2, opened=0, closed=1, delta=-1, total=1),
-            result_row(day=day_3, opened=0, closed=0, delta=0, total=1),
+            result_row(day=day_1, opened=2, closed=0, delta=2, total=2, closed_total=0),
+            result_row(day=day_2, opened=0, closed=1, delta=-1, total=1, closed_total=1),
+            result_row(day=day_3, opened=0, closed=0, delta=0, total=1, closed_total=1),
         ]
+        # fmt: on
         assert df.to_dict("records") == expected
 
 
@@ -233,12 +245,14 @@ class TestSprintBurndownByPoints:
         output = SprintBurndown(test_data, sprint="Sprint 1", unit=Unit.points)
         df = output.results
         # validation
+        # fmt: off
         expected = [
-            result_row(day=DAY_0, opened=2, closed=0, delta=2, total=2),
-            result_row(day=DAY_1, opened=0, closed=0, delta=0, total=2),
-            result_row(day=DAY_2, opened=3, closed=0, delta=3, total=5),
-            result_row(day=DAY_3, opened=0, closed=0, delta=0, total=5),
+            result_row(day=DAY_0, opened=2, closed=0, delta=2, total=2, closed_total=0),
+            result_row(day=DAY_1, opened=0, closed=0, delta=0, total=2, closed_total=0),
+            result_row(day=DAY_2, opened=3, closed=0, delta=3, total=5, closed_total=0),
+            result_row(day=DAY_3, opened=0, closed=0, delta=0, total=5, closed_total=0),
         ]
+        # fmt: on
         assert df.to_dict("records") == expected
 
     def test_burndown_excludes_tix_without_points(self):
@@ -255,11 +269,13 @@ class TestSprintBurndownByPoints:
         output = SprintBurndown(test_data, sprint="Sprint 1", unit=Unit.points)
         df = output.results
         # validation
+        # fmt: off
         expected = [
-            result_row(day=DAY_1, opened=2, closed=0, delta=2, total=2),
-            result_row(day=DAY_2, opened=0, closed=0, delta=0, total=2),
-            result_row(day=DAY_3, opened=0, closed=0, delta=0, total=2),
+            result_row(day=DAY_1, opened=2, closed=0, delta=2, total=2, closed_total=0),
+            result_row(day=DAY_2, opened=0, closed=0, delta=0, total=2, closed_total=0),
+            result_row(day=DAY_3, opened=0, closed=0, delta=0, total=2, closed_total=0),
         ]
+        # fmt: on
         assert df.to_dict("records") == expected
 
 

--- a/analytics/tests/metrics/test_burnup.py
+++ b/analytics/tests/metrics/test_burnup.py
@@ -451,8 +451,8 @@ class TestGetStats:
         points = SprintBurnup(test_data, sprint="Sprint 1", unit=Unit.points)
         issues = SprintBurnup(test_data, sprint="Sprint 1", unit=Unit.issues)
         # validation - check they're calculated correctly
-        assert points.stats.get(self.SPRINT_START).value == DAY_1
-        assert points.stats.get(self.SPRINT_END).value == DAY_3
+        assert points.stats[self.SPRINT_START].value == DAY_1
+        assert points.stats[self.SPRINT_END].value == DAY_3
         # validation - check that they are the same
         # fmt: off
         assert points.stats.get(self.SPRINT_START) == issues.stats.get(self.SPRINT_START)
@@ -473,13 +473,13 @@ class TestGetStats:
         output = SprintBurnup(test_data, sprint="Sprint 1", unit=Unit.issues)
         print(output.results)
         # validation - check that stats were calculated correctly
-        assert output.stats.get(self.TOTAL_CLOSED).value == 2
-        assert output.stats.get(self.TOTAL_OPENED).value == 4
-        assert output.stats.get(self.PCT_CLOSED).value == 50.0
+        assert output.stats[self.TOTAL_CLOSED].value == 2
+        assert output.stats[self.TOTAL_OPENED].value == 4
+        assert output.stats[self.PCT_CLOSED].value == 50.0
         # validation - check that message contains string value of Unit.issues
-        assert Unit.issues.value in output.stats.get(self.TOTAL_CLOSED).suffix
-        assert Unit.issues.value in output.stats.get(self.TOTAL_OPENED).suffix
-        assert "%" in output.stats.get(self.PCT_CLOSED).suffix
+        assert Unit.issues.value in output.stats[self.TOTAL_CLOSED].suffix
+        assert Unit.issues.value in output.stats[self.TOTAL_OPENED].suffix
+        assert "%" in output.stats[self.PCT_CLOSED].suffix
 
     def test_get_total_closed_and_opened_when_unit_is_points(self):
         """Test that total_closed is calculated correctly when unit is issues."""
@@ -494,13 +494,13 @@ class TestGetStats:
         # execution
         output = SprintBurnup(test_data, sprint="Sprint 1", unit=Unit.points)
         # validation
-        assert output.stats.get(self.TOTAL_CLOSED).value == 3
-        assert output.stats.get(self.TOTAL_OPENED).value == 9
-        assert output.stats.get(self.PCT_CLOSED).value == 33.33  # rounded to 2 places
+        assert output.stats[self.TOTAL_CLOSED].value == 3
+        assert output.stats[self.TOTAL_OPENED].value == 9
+        assert output.stats[self.PCT_CLOSED].value == 33.33  # rounded to 2 places
         # validation - check that message contains string value of Unit.points
-        assert Unit.points.value in output.stats.get(self.TOTAL_CLOSED).suffix
-        assert Unit.points.value in output.stats.get(self.TOTAL_OPENED).suffix
-        assert "%" in output.stats.get(self.PCT_CLOSED).suffix
+        assert Unit.points.value in output.stats[self.TOTAL_CLOSED].suffix
+        assert Unit.points.value in output.stats[self.TOTAL_OPENED].suffix
+        assert "%" in output.stats[self.PCT_CLOSED].suffix
 
     def test_include_issues_closed_after_sprint_end(self):
         """Issues that are closed after sprint ended should be included in closed count."""
@@ -531,9 +531,9 @@ class TestGetStats:
         # execution
         output = SprintBurnup(test_data, sprint="Sprint 1", unit=Unit.issues)
         # validation
-        assert output.stats.get(self.TOTAL_CLOSED).value == 2
-        assert output.stats.get(self.TOTAL_OPENED).value == 3
-        assert output.stats.get(self.PCT_CLOSED).value == 66.67  # rounded to 2 places
+        assert output.stats[self.TOTAL_CLOSED].value == 2
+        assert output.stats[self.TOTAL_OPENED].value == 3
+        assert output.stats[self.PCT_CLOSED].value == 66.67  # rounded to 2 places
 
     def test_get_percent_pointed(self):
         """Test that percent pointed is calculated correctly."""
@@ -548,12 +548,12 @@ class TestGetStats:
         # execution
         output = SprintBurnup(test_data, sprint="Sprint 1", unit=Unit.points)
         # validation
-        assert output.stats.get(self.TOTAL_CLOSED).value == 3
-        assert output.stats.get(self.TOTAL_OPENED).value == 3
-        assert output.stats.get(self.PCT_CLOSED).value == 100
-        assert output.stats.get(self.PCT_POINTED).value == 50
+        assert output.stats[self.TOTAL_CLOSED].value == 3
+        assert output.stats[self.TOTAL_OPENED].value == 3
+        assert output.stats[self.PCT_CLOSED].value == 100
+        assert output.stats[self.PCT_POINTED].value == 50
         # validation - check that stat contains '%' suffix
-        assert f"% of {Unit.issues.value}" in output.stats.get(self.PCT_POINTED).suffix
+        assert f"% of {Unit.issues.value}" in output.stats[self.PCT_POINTED].suffix
 
     def test_exclude_other_sprints_in_percent_pointed(self):
         """Only include issues in this sprint when calculating percent pointed."""
@@ -568,9 +568,9 @@ class TestGetStats:
         # execution
         output = SprintBurnup(test_data, sprint="Sprint 1", unit=Unit.issues)
         # validation
-        assert output.stats.get(self.TOTAL_CLOSED).value == 2
-        assert output.stats.get(self.TOTAL_OPENED).value == 3
-        assert output.stats.get(self.PCT_POINTED).value == 66.67  # exclude final row
+        assert output.stats[self.TOTAL_CLOSED].value == 2
+        assert output.stats[self.TOTAL_OPENED].value == 3
+        assert output.stats[self.PCT_POINTED].value == 66.67  # exclude final row
 
 
 class TestFormatSlackMessage:
@@ -708,7 +708,7 @@ def test_post_to_slack(
     """Test the steps required to post the results to slack, without actually posting."""
     # execution
     sample_burnup.post_results_to_slack(
-        mock_slackbot,
+        mock_slackbot,  # type: ignore[assignment]
         channel_id="test_channel",
         output_dir=tmp_path,
     )

--- a/analytics/tests/test_cli.py
+++ b/analytics/tests/test_cli.py
@@ -10,6 +10,7 @@ from analytics.cli import app
 from tests.conftest import (
     json_issue_row,
     json_sprint_row,
+    issue,
     write_test_data_to_file,
 )
 
@@ -22,6 +23,7 @@ class MockFiles:
 
     issue_file: Path
     sprint_file: Path
+    delivery_file: Path
 
 
 @pytest.fixture(name="mock_files")
@@ -30,15 +32,21 @@ def test_file_fixtures(tmp_path: Path) -> MockFiles:
     # set paths to test files
     issue_file = tmp_path / "data" / "issue-data.json"
     sprint_file = tmp_path / "data" / "sprint-data.json"
+    delivery_file = tmp_path / "data" / "delivery-data.json"
     # create test data
     sprint_data = [json_sprint_row(issue=1, parent_number=2)]
     issue_data = [
         json_issue_row(issue=1, labels=["task"]),
         json_issue_row(issue=2, labels=["deliverable: 30k ft"]),
     ]
+    delivery_data = [
+        issue(issue=1).__dict__,
+        issue(issue=2).__dict__,
+    ]
     # write test data to json files
     write_test_data_to_file(issue_data, issue_file)
     write_test_data_to_file({"items": sprint_data}, sprint_file)
+    write_test_data_to_file(delivery_data, delivery_file)
     # confirm the data was written
     assert issue_file.exists()
     assert sprint_file.exists()
@@ -46,6 +54,7 @@ def test_file_fixtures(tmp_path: Path) -> MockFiles:
     return MockFiles(
         issue_file=issue_file,
         sprint_file=sprint_file,
+        delivery_file=delivery_file,
     )
 
 
@@ -58,10 +67,8 @@ class TestCalculateSprintBurndown:
         command = [
             "calculate",
             "sprint_burndown",
-            "--sprint-file",
-            str(mock_files.sprint_file),
             "--issue-file",
-            str(mock_files.issue_file),
+            str(mock_files.delivery_file),
             "--sprint",
             "Sprint 1",
         ]
@@ -81,10 +88,8 @@ class TestCalculateSprintBurndown:
         command = [
             "calculate",
             "sprint_burndown",
-            "--sprint-file",
-            str(mock_files.sprint_file),
             "--issue-file",
-            str(mock_files.issue_file),
+            str(mock_files.delivery_file),
             "--sprint",
             "Sprint 1",
             "--show-results",
@@ -107,10 +112,8 @@ class TestCalculateSprintBurndown:
         command = [
             "calculate",
             "sprint_burndown",
-            "--sprint-file",
-            str(mock_files.sprint_file),
             "--issue-file",
-            str(mock_files.issue_file),
+            str(mock_files.delivery_file),
             "--sprint",
             "Sprint 1",
             "--unit",

--- a/analytics/tests/test_cli.py
+++ b/analytics/tests/test_cli.py
@@ -130,6 +130,78 @@ class TestCalculateSprintBurndown:
         assert "issues" in result.stdout
 
 
+class TestCalculateSprintBurnup:
+    """Test the calculate_sprint_burnup entry point with mock data."""
+
+    def test_without_showing_or_posting_results(self, mock_files: MockFiles):
+        """Entrypoint should run successfully but not print slack message to stdout."""
+        # setup - create command
+        command = [
+            "calculate",
+            "sprint_burnup",
+            "--issue-file",
+            str(mock_files.delivery_file),
+            "--sprint",
+            "Sprint 1",
+        ]
+        # execution
+        result = runner.invoke(app, command)
+        print(result.stdout)
+        # validation - check there wasn't an error
+        assert result.exit_code == 0
+        assert "Slack message" not in result.stdout
+
+    def test_stdout_message_includes_points_if_no_unit_is_set(
+        self,
+        mock_files: MockFiles,
+    ):
+        """CLI should uses 'points' as default unit and include it in stdout message."""
+        # setup - create command
+        command = [
+            "calculate",
+            "sprint_burnup",
+            "--issue-file",
+            str(mock_files.delivery_file),
+            "--sprint",
+            "Sprint 1",
+            "--show-results",
+        ]
+        # execution
+        result = runner.invoke(app, command)
+        print(result.stdout)
+        # validation - check there wasn't an error
+        assert result.exit_code == 0
+        # validation - check that slack message is printed and includes 'points'
+        assert "Slack message" in result.stdout
+        assert "points" in result.stdout
+
+    def test_stdout_message_includes_issues_if_unit_set_to_issues(
+        self,
+        mock_files: MockFiles,
+    ):
+        """CLI should use issues if set explicitly and include it in stdout."""
+        # setup - create command
+        command = [
+            "calculate",
+            "sprint_burnup",
+            "--issue-file",
+            str(mock_files.delivery_file),
+            "--sprint",
+            "Sprint 1",
+            "--unit",
+            "issues",
+            "--show-results",
+        ]
+        # execution
+        result = runner.invoke(app, command)
+        print(result.stdout)
+        # validation - check there wasn't an error
+        assert result.exit_code == 0
+        # validation - check that slack message is printed and includes 'points'
+        assert "Slack message" in result.stdout
+        assert "issues" in result.stdout
+
+
 class TestCalculateDeliverablePercentComplete:
     """Test the calculate_deliverable_percent_complete entry point with mock data."""
 


### PR DESCRIPTION
## Summary

Stacked PR that builds on #2539 to replace the `SprintBoard` dataset in `SprintBurndown` and `SprintBurnup` with the new `GitHubIssues` dataset. 

Fixes #2471

**Note:** ~Once we merge in #2539 I'll rebase this branch on `main` and change the base for the PR to `main`~ Rebased ✅ 

### Time to review: __10 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Replaces the `SprintBoard` dataset with `GitHubIssues` in the `SprintBurndown` and `SprintBurnup` metrics
- Reuses intermediate steps to calculate burnup/burndown across both `SprintBurnup` and `SprintBurndown`

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. Follow the instructions to run this code natively (in order to view the chart)
2. Export the data: `make delivery-data-export POINTS_FIELD="Story Points"`
3. Run burndown: `make sprint-burndown`

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

You should see a chart that looks like this:

<img width="1440" alt="Screenshot 2024-10-29 at 9 33 41 AM" src="https://github.com/user-attachments/assets/cc03a081-ffc8-46cd-b291-91b68e12b6d8">

And it should output the following stats:

<img width="1440" alt="Screenshot 2024-10-29 at 9 35 03 AM" src="https://github.com/user-attachments/assets/41feeda7-2712-481e-9304-15aee88eae54">
