### PR TITLE
[Issue #2327] Move WAF and Opensearch logs policies to the account level

### DIFF
--- a/infra/accounts/logs.tf
+++ b/infra/accounts/logs.tf
@@ -1,5 +1,8 @@
+# docs: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutResourcePolicy.html
+# only 10 of these are allowed per region, so we deploy 1 per account
+
 resource "aws_cloudwatch_log_resource_policy" "policy" {
-  policy_name     = "cloudwatch_log_resource_policy"
+  policy_name     = "account-level-logs"
   policy_document = data.aws_iam_policy_document.policy.json
 }
 
@@ -8,7 +11,9 @@ data "aws_iam_policy_document" "policy" {
     effect = "Allow"
     principals {
       identifiers = [
+        # docs: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createdomain-configure-slow-logs.html
         "es.amazonaws.com",
+        # docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html
         "delivery.logs.amazonaws.com"
       ]
       type = "Service"

--- a/infra/accounts/logs.tf
+++ b/infra/accounts/logs.tf
@@ -1,0 +1,33 @@
+resource "aws_cloudwatch_log_resource_policy" "policy" {
+  policy_name     = "cloudwatch_log_resource_policy"
+  policy_document = data.aws_iam_policy_document.policy.json
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "es.amazonaws.com",
+        "delivery.logs.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    actions = [
+      "logs:PutLogEvents",
+      "logs:PutLogEventsBatch",
+      "logs:CreateLogStream",
+    ]
+    resources = ["arn:aws:logs:*"]
+    condition {
+      test     = "ArnLike"
+      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      variable = "aws:SourceArn"
+    }
+    condition {
+      test     = "StringEquals"
+      values   = [tostring(data.aws_caller_identity.current.account_id)]
+      variable = "aws:SourceAccount"
+    }
+  }
+}

--- a/infra/modules/search/authentication.tf
+++ b/infra/modules/search/authentication.tf
@@ -151,22 +151,6 @@ data "aws_iam_policy_document" "opensearch_access" {
   }
 }
 
-data "aws_iam_policy_document" "opensearch_cloudwatch" {
-  statement {
-    effect = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["es.amazonaws.com"]
-    }
-    actions = [
-      "logs:PutLogEvents",
-      "logs:PutLogEventsBatch",
-      "logs:CreateLogStream",
-    ]
-    resources = ["arn:aws:logs:*"]
-  }
-}
-
 data "aws_iam_policy_document" "allow_all_aws_access" {
   # checkov:skip=CKV_AWS_109: TODO: https://github.com/HHS/simpler-grants-gov/issues/2472
   # checkov:skip=CKV_AWS_111: TODO: https://github.com/HHS/simpler-grants-gov/issues/2472

--- a/infra/modules/search/main.tf
+++ b/infra/modules/search/main.tf
@@ -8,11 +8,6 @@ resource "aws_cloudwatch_log_group" "opensearch" {
   kms_key_id        = aws_kms_key.opensearch.arn
 }
 
-resource "aws_cloudwatch_log_resource_policy" "opensearch" {
-  policy_name     = "opensearch-${var.service_name}"
-  policy_document = data.aws_iam_policy_document.opensearch_cloudwatch.json
-}
-
 resource "aws_opensearch_domain" "opensearch" {
   domain_name     = var.service_name
   engine_version  = var.engine_version

--- a/infra/modules/service/waf.tf
+++ b/infra/modules/service/waf.tf
@@ -205,36 +205,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "WafWebAclLogging" {
   ]
 }
 
-resource "aws_cloudwatch_log_resource_policy" "WafWebAclLoggingPolicy" {
-  count           = var.enable_load_balancer ? 1 : 0
-  policy_document = data.aws_iam_policy_document.WafWebAclLoggingDoc[0].json
-  policy_name     = "service-${var.service_name}-webacl-policy"
-}
-
 # Policy from terraform docs
-data "aws_iam_policy_document" "WafWebAclLoggingDoc" {
-  count = var.enable_load_balancer ? 1 : 0
-  statement {
-    effect = "Allow"
-    principals {
-      identifiers = ["delivery.logs.amazonaws.com"]
-      type        = "Service"
-    }
-    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
-    resources = ["${aws_cloudwatch_log_group.WafWebAclLoggroup[0].arn}:*"]
-    condition {
-      test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
-      variable = "aws:SourceArn"
-    }
-    condition {
-      test     = "StringEquals"
-      values   = [tostring(data.aws_caller_identity.current.account_id)]
-      variable = "aws:SourceAccount"
-    }
-  }
-}
-
 # Associate WAF with load balancer
 resource "aws_wafv2_web_acl_association" "WafWebAclAssociation" {
   count        = var.enable_load_balancer ? 1 : 0


### PR DESCRIPTION
## Summary

Fixes https://github.com/HHS/simpler-grants-gov/issues/2327

### Time to review: __1 mins__

## Context for reviewers

<img width="930" alt="image" src="https://github.com/user-attachments/assets/a5e14dcc-8ab9-4283-83aa-850526a1a4ce">

^ I ran into the resource limit above when deploying prod opensearch

So I have changed it so there is only 1 `aws_cloudwatch_log_resource_policy` resource

## Testing

I've already deployed this to dev, and to the account level. The diff applied just fine.