### PR TITLE
[Issue 1890] add GA beacon for filter use on search

### DIFF
--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from "next";
+import QueryProvider from "src/app/[locale]/search/QueryProvider";
 import withFeatureFlag from "src/hoc/search/withFeatureFlag";
+import { SearchParamsTypes } from "src/types/search/searchRequestTypes";
 import { Breakpoints } from "src/types/uiTypes";
 import { convertSearchParamsToProperTypes } from "src/utils/search/convertSearchParamsToProperTypes";
 
@@ -7,10 +9,10 @@ import { useTranslations } from "next-intl";
 import { getTranslations, unstable_setRequestLocale } from "next-intl/server";
 
 import ContentDisplayToggle from "src/components/ContentDisplayToggle";
+import SearchAnalytics from "src/components/search/SearchAnalytics";
 import SearchBar from "src/components/search/SearchBar";
 import SearchFilters from "src/components/search/SearchFilters";
 import SearchResults from "src/components/search/SearchResults";
-import QueryProvider from "./QueryProvider";
 
 export async function generateMetadata() {
   const t = await getTranslations({ locale: "en" });
@@ -20,22 +22,10 @@ export async function generateMetadata() {
   };
   return meta;
 }
-
-interface searchParamsTypes {
-  agency?: string;
-  category?: string;
-  eligibility?: string;
-  fundingInstrument?: string;
-  page?: string;
-  query?: string;
-  sortby?: string;
-  status?: string;
-  [key: string]: string | undefined;
-}
-
-function Search({ searchParams }: { searchParams: searchParamsTypes }) {
+function Search({ searchParams }: { searchParams: SearchParamsTypes }) {
   unstable_setRequestLocale("en");
   const t = useTranslations("Search");
+
   const convertedSearchParams = convertSearchParamsToProperTypes(searchParams);
   const { agency, category, eligibility, fundingInstrument, query, status } =
     convertedSearchParams;
@@ -46,6 +36,7 @@ function Search({ searchParams }: { searchParams: searchParamsTypes }) {
 
   return (
     <>
+      <SearchAnalytics params={searchParams} />
       <QueryProvider>
         <div className="grid-container">
           <div className="search-bar">

--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { sendGAEvent } from "@next/third-parties/google";
+import { omit } from "lodash";
+import { SearchParamsTypes } from "src/types/search/searchRequestTypes";
+
+import { useEffect } from "react";
+
+const getCurrentFilters = (params: SearchParamsTypes): string => {
+  return JSON.stringify(omit(params, "query", "page"));
+};
+
+function SearchAnalytics({ params }: { params: SearchParamsTypes }) {
+  useEffect(() => {
+    sendGAEvent("event", "search_attempt", {
+      search_filters: getCurrentFilters(params),
+    });
+  }, [params]);
+  return <></>;
+}
+
+export default SearchAnalytics;

--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -12,6 +12,7 @@ const getCurrentFilters = (params: SearchParamsTypes): string => {
 
 function SearchAnalytics({ params }: { params: SearchParamsTypes }) {
   useEffect(() => {
+    // send list of filters defined in page query params on each page load
     sendGAEvent("event", "search_attempt", {
       search_filters: getCurrentFilters(params),
     });

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -64,3 +64,15 @@ export interface QueryParamData {
   actionType?: SearchFetcherActionType;
   fieldChanged?: string;
 }
+
+export interface SearchParamsTypes {
+  agency?: string;
+  category?: string;
+  eligibility?: string;
+  fundingInstrument?: string;
+  page?: string;
+  query?: string;
+  sortby?: string;
+  status?: string;
+  [key: string]: string | undefined;
+}

--- a/frontend/tests/components/search/SearchAnalytics.test.tsx
+++ b/frontend/tests/components/search/SearchAnalytics.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react";
+
+import SearchAnalytics from "src/components/search/SearchAnalytics";
+
+const sendGAEventMock = jest.fn();
+
+jest.mock("@next/third-parties/google", () => ({
+  /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
+  sendGAEvent: (...args: unknown[]) => sendGAEventMock(...args),
+}));
+
+describe("SearchAnalytics", () => {
+  it("calls sendGAEvent with expected params on render", () => {
+    const { rerender } = render(
+      <SearchAnalytics
+        params={{
+          fundingInstrument: "cooperative_agreement",
+          status: "posted, archived",
+          agency: "AC,PAMS-SC",
+          page: "1",
+          query: "a random search term",
+        }}
+      />,
+    );
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "search_attempt", {
+      search_filters:
+        '{"fundingInstrument":"cooperative_agreement","status":"posted, archived","agency":"AC,PAMS-SC"}',
+    });
+
+    rerender(
+      <SearchAnalytics
+        params={{
+          status: "posted, archived, closed",
+          agency: "AC",
+          category: "recovery_act",
+          page: "1",
+          query: "a random search term",
+        }}
+      />,
+    );
+    expect(sendGAEventMock).toHaveBeenCalledWith("event", "search_attempt", {
+      search_filters:
+        '{"status":"posted, archived, closed","agency":"AC","category":"recovery_act"}',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1890

### Time to review: __15 mins__

## Changes proposed
Added a GA event beacon "search_attempt" to track each load of the search results page and pass along a list of filters in place.

## Context for reviewers

Note that in React strict mode, which is on for us and by default when running a DEV Next server, components basically mount, unmount, then mount again, in order to test out expected behavior around maintaining state between page loads, or something. This means that out of the box on a local server you may see multiple beacons being fired when the page is first loaded, but if you turn off strict mode here, you should see only one:
https://github.com/HHS/simpler-grants-gov/blob/fa3aabddd9d34feaa0c358888e7c5008970e7033/frontend/next.config.js#L19

For more see https://legacy.reactjs.org/docs/strict-mode.html#ensuring-reusable-state

Also these test steps will assume you've got omnibug or something similar installed for testing this PR, otherwise you can look at your network console and parse out requests being made to GA that way. https://chromewebstore.google.com/detail/omnibug/bknpehncffejahipecakbfkomebjmokl

### Test steps
1. visit a search page
2. _VERIFY_: omnibug console shows a beacon going out withe event type set to "search_attempt" and search_filters data set to "{"status":"forecasted,posted"}"
3. update filters
4. _VERIFY_: omnibug console shows a search_attempt event with search_filters reflecting the new filter selection
5. enter a search term
6. _VERIFY_: omnibug console shows a search_attempt beacon but event data does not include the search term (or any other non-filter related information)

## Additional information
We're currently firing a "search_term" event whenever a filter or search keyword is updated, however, this event is not fired on the initial search / page load, and only contains the information about the filter or keyword that is actively being updated. I'm not sure if we want to keep this around, or if we want to fold it into the new event by adding some dimensions there. See https://github.com/HHS/simpler-grants-gov/blob/fa3aabddd9d34feaa0c358888e7c5008970e7033/frontend/src/hooks/useSearchParamUpdater.ts#L44

Note that as far as a GA report, that's inconclusive as of 10/29, will need to check back to see if the data is coming in as expected and that we can actually report back on it. https://analytics.google.com/analytics/web/#/analysis/p439528520/edit/bFNLNRQKRN2eUYMJAZshfg

### Omnibug example
![Screenshot 2024-10-29 at 11 46 17 AM](https://github.com/user-attachments/assets/5ae12bb6-ecd7-4d51-a7de-30a2ed095c2e)


