### PR TITLE
[no ticket] remove lock timeout stuff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,12 +15,6 @@ on:
 
 concurrency: cd-${{inputs.app_name}}-${{ inputs.environment }}
 
-env:
-  # Set a timeout of two minutes for all terraform commands in the workflow
-  # to account for parallel jobs working in the same environment with the same
-  # terraform state files.
-  TF_CLI_ARGS: "-lock-timeout=120s"
-
 jobs:
   build-and-publish:
     name: Build


### PR DESCRIPTION
## Why?

```
  2024-10-30T18:48:37.855Z [INFO]  CLI command args: []string{"version", "-lock-timeout=120s", "--version"}
  Usage: terraform [global options] version [options]
  
    Displays the version of Terraform and all installed plugins
  
  Options:
  
    -json       Output the version information as a JSON object.
  Error parsing command-line flags: flag provided but not defined: -lock-timeout
```

https://github.com/HHS/simpler-grants-gov/actions/runs/11598939885/job/32298507568

:(