### PR TITLE
[Unticketed] Change s3 client to use s3v4 signature version

### DIFF
--- a/api/src/adapters/aws/s3_adapter.py
+++ b/api/src/adapters/aws/s3_adapter.py
@@ -1,5 +1,6 @@
 import boto3
 import botocore.client
+import botocore.config
 
 from src.util.env_config import PydanticBaseEnvConfig
 
@@ -21,7 +22,9 @@ class S3Config(PydanticBaseEnvConfig):
 
 
 def get_s3_client(
-    s3_config: S3Config | None = None, session: boto3.Session | None = None
+    s3_config: S3Config | None = None,
+    session: boto3.Session | None = None,
+    boto_config: botocore.config.Config | None = None,
 ) -> botocore.client.BaseClient:
     if s3_config is None:
         s3_config = S3Config()
@@ -29,6 +32,11 @@ def get_s3_client(
     params = {}
     if s3_config.s3_endpoint_url is not None:
         params["endpoint_url"] = s3_config.s3_endpoint_url
+
+    if boto_config is None:
+        boto_config = botocore.config.Config(signature_version="s3v4")
+
+    params["config"] = boto_config
 
     if session is not None:
         return session.client("s3", **params)


### PR DESCRIPTION
### Time to review: __3 mins__

## Changes proposed
Modified the configuration for our s3 client to use `s3v4` for the signature version

## Context for reviewers
Something with the way encryption works on s3 buckets requires setting a different signature version than the default that botocore uses.

Locally I was getting a URL like: `http://localhost:4566/local-opportunities/test_file_5.pdf?AWSAccessKeyId=NO_CREDS&Signature=Pg9ZyyoIkLKAawtsrCFOTwtjbF4%3D&Expires=1730319613` before and after the change I get `http://localhost:4566/local-opportunities/test_file_5.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=NO_CREDS%2F20241030%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20241030T195105Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=1e138f2b39305c711fa152a6504454db11f022c7644775d0b7a52dbeb339f809`

As a quick test, I went to the AWS s3 console and presigned a file directly there. The format was a lot closer to the second one, so this seems like the right fix.


