### PR TITLE
[Issue #2500] Remove duplicate restrictive search access policy

### DIFF
--- a/infra/modules/search/authentication.tf
+++ b/infra/modules/search/authentication.tf
@@ -139,18 +139,6 @@ resource "aws_ssm_parameter" "opensearch_endpoint" {
   key_id      = aws_kms_key.opensearch.arn
 }
 
-data "aws_iam_policy_document" "opensearch_access" {
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::315341936575:root"]
-    }
-    effect    = "Allow"
-    actions   = ["es:*"]
-    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.service_name}/*"]
-  }
-}
-
 data "aws_iam_policy_document" "allow_all_aws_access" {
   # checkov:skip=CKV_AWS_109: TODO: https://github.com/HHS/simpler-grants-gov/issues/2472
   # checkov:skip=CKV_AWS_111: TODO: https://github.com/HHS/simpler-grants-gov/issues/2472

--- a/infra/modules/search/main.tf
+++ b/infra/modules/search/main.tf
@@ -9,9 +9,8 @@ resource "aws_cloudwatch_log_group" "opensearch" {
 }
 
 resource "aws_opensearch_domain" "opensearch" {
-  domain_name     = var.service_name
-  engine_version  = var.engine_version
-  access_policies = data.aws_iam_policy_document.opensearch_access.json
+  domain_name    = var.service_name
+  engine_version = var.engine_version
 
   encrypt_at_rest {
     enabled    = true


### PR DESCRIPTION
## Summary

Relates to #2500

### Time to review: __1 mins__

## Changes proposed

@chouinar discovered that the opensearch policy might be "flip flopping" between two versions because we technically define it twice. So this PR removes one of those policies.