### PR TITLE
[Issue #2630] Enable search load to run hourly

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -46,5 +46,11 @@ locals {
       schedule_expression = "cron(0 * * * ? *)"
       state               = "ENABLED"
     }
+    populate-search-index = {
+      task_command = ["poetry", "run", "flask", "load-search-data", "load-opportunity-data"]
+      # Every hour at the half hour
+      schedule_expression = "cron(30 * * * ? *)"
+      state               = "ENABLED"
+    }
   }
 }

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -24,5 +24,8 @@ module "prod_config" {
   search_engine_version = "OpenSearch_2.15"
 
   service_override_extra_environment_variables = {
+    # Set the opportunity search index to have more shards/replicas in prod
+    LOAD_OPP_SEARCH_SHARD_COUNT   = 3
+    LOAD_OPP_SEARCH_REPLICA_COUNT = 2
   }
 }


### PR DESCRIPTION
## Summary
Fixes #2630

### Time to review: __3 mins__

## Changes proposed
Schedule the DB -> search index load job to run every hour

Set the shard/replica count for prod as it needs to be higher as we have more nodes.

## Context for reviewers
In the future we may want to coordinate the ELT process with this (put them in the same flow?), but for now I've setup the job to run 30 minutes after the start of the hour. The job in prod takes ~9 minutes at the moment.

The ELT process takes 4-5 minutes and runs at the top of the hour - the jobs overlapping wouldn't be a big deal other than search having staler data.

