### PR TITLE
[Issue #2697] Enable agency data load in ELT process

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -37,7 +37,7 @@ TABLES_TO_LOAD = [
     "tfundinstr_forecast_hist",
     "tfundinstr_synopsis",
     "tfundinstr_synopsis_hist",
-    # tgroups,  # Want to hold on this until we have permissions
+    "tgroups",
 ]
 
 

--- a/api/src/data_migration/transformation/transform_oracle_data_task.py
+++ b/api/src/data_migration/transformation/transform_oracle_data_task.py
@@ -41,7 +41,7 @@ class TransformOracleDataTaskConfig(PydanticBaseEnvConfig):
     enable_applicant_type: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_APPLICANT_TYPE
     enable_funding_category: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_FUNDING_CATEGORY
     enable_funding_instrument: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_FUNDING_INSTRUMENT
-    enable_agency: bool = False  # TRANSFORM_ORACLE_DATA_ENABLE_AGENCY
+    enable_agency: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_AGENCY
 
 
 class TransformOracleDataTask(Task):


### PR DESCRIPTION
## Summary
Fixes #2697

### Time to review: __5 mins__

## Changes proposed
Enable the extract-load process on the TGROUPS table (agency data)

Enable the Agency transform steps

## Context for reviewers
I've tested this in the lower environments and prod by manually configuring the job to load the data, so all of the agency data is there already. This just gets updates from here on out.

The extract-load process has a set of tables it is configured to load, and the transformation process has specific classes for transforming tables that are handled via env vars, so the configuration change is minor.

The unit test changes I made show that the agency transforms are happening now when running the "full" job.

