### PR TITLE
[Issue #2701] Set search FF to allow for anon users 

### DIFF
--- a/frontend/src/constants/featureFlags.ts
+++ b/frontend/src/constants/featureFlags.ts
@@ -4,5 +4,5 @@ import { FeatureFlags } from "src/services/FeatureFlagManager";
 export const featureFlags: FeatureFlags = {
   // This is for showing the search page as it is being developed and user tested
   // This should be removed when the search page goes live, before May 2024
-  showSearchV0: false,
+  showSearchV0: true,
 };


### PR DESCRIPTION
## Summary
Fixes #2701

### Time to review: __5 mins__

## Changes proposed
Flipping the search FF to allow anon users to see the search and opp pages.

We should have a follow-up to remove the FF manager implementations ie:

```javascript

export default withFeatureFlag(Search, "showSearchV0");

```
etc

I created an additional PR for this which we can keep until in DRAFT until we are ready.

