### PR TITLE
[Issue #2699] Skip assistance listing transform processing with empty fields

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
+++ b/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
@@ -87,6 +87,27 @@ class TransformAssistanceListing(AbstractTransformSubTask):
             source_assistance_listing.transformation_notes = transform_constants.ORPHANED_CFDA
 
         else:
+            # Check if assistance listing has empty required fields
+            if (
+                not source_assistance_listing.programtitle
+                or not source_assistance_listing.cfdanumber
+            ):
+                self.increment(
+                    transform_constants.Metrics.TOTAL_RECORDS_SKIPPED,
+                    prefix=transform_constants.ASSISTANCE_LISTING,
+                )
+                logger.info(
+                    "Skipping assistance listing with empty required fields",
+                    extra={
+                        **extra,
+                        "programtitle": source_assistance_listing.programtitle,
+                        "cfdanumber": source_assistance_listing.cfdanumber,
+                    },
+                )
+                source_assistance_listing.transformation_notes = "empty_assistance_listing"
+                source_assistance_listing.transformed_at = self.transform_time
+                return
+
             # To avoid incrementing metrics for records we fail to transform, record
             # here whether it's an insert/update and we'll increment after transforming
             is_insert = target_assistance_listing is None

--- a/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
+++ b/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
@@ -86,12 +86,11 @@ class TransformAssistanceListing(AbstractTransformSubTask):
             )
             source_assistance_listing.transformation_notes = transform_constants.ORPHANED_CFDA
 
+        elif not source_assistance_listing.programtitle or not source_assistance_listing.cfdanumber:
+               self.increment(...)
+               logger.info(...)
+               source_assistance_listing.transformation_notes = "empty_assistance_listing"
         else:
-            # Check if assistance listing has empty required fields
-            if (
-                not source_assistance_listing.programtitle
-                or not source_assistance_listing.cfdanumber
-            ):
                 self.increment(
                     transform_constants.Metrics.TOTAL_RECORDS_SKIPPED,
                     prefix=transform_constants.ASSISTANCE_LISTING,

--- a/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
+++ b/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
@@ -87,26 +87,22 @@ class TransformAssistanceListing(AbstractTransformSubTask):
             source_assistance_listing.transformation_notes = transform_constants.ORPHANED_CFDA
 
         elif not source_assistance_listing.programtitle or not source_assistance_listing.cfdanumber:
-               self.increment(...)
-               logger.info(...)
-               source_assistance_listing.transformation_notes = "empty_assistance_listing"
-        else:
-                self.increment(
-                    transform_constants.Metrics.TOTAL_RECORDS_SKIPPED,
-                    prefix=transform_constants.ASSISTANCE_LISTING,
-                )
-                logger.info(
-                    "Skipping assistance listing with empty required fields",
-                    extra={
-                        **extra,
-                        "programtitle": source_assistance_listing.programtitle,
-                        "cfdanumber": source_assistance_listing.cfdanumber,
-                    },
-                )
-                source_assistance_listing.transformation_notes = "empty_assistance_listing"
-                source_assistance_listing.transformed_at = self.transform_time
-                return
+            self.increment(
+                transform_constants.Metrics.TOTAL_RECORDS_SKIPPED,
+                prefix=transform_constants.ASSISTANCE_LISTING,
+            )
+            logger.info(
+                "Skipping assistance listing with empty required fields",
+                extra={
+                    **extra,
+                    "programtitle": source_assistance_listing.programtitle,
+                    "cfdanumber": source_assistance_listing.cfdanumber,
+                },
+            )
+            source_assistance_listing.transformation_notes = "empty_assistance_listing"
+            source_assistance_listing.transformed_at = self.transform_time
 
+        else:
             # To avoid incrementing metrics for records we fail to transform, record
             # here whether it's an insert/update and we'll increment after transforming
             is_insert = target_assistance_listing is None

--- a/api/src/data_migration/transformation/transform_constants.py
+++ b/api/src/data_migration/transformation/transform_constants.py
@@ -42,6 +42,7 @@ class Metrics(StrEnum):
     TOTAL_RECORDS_DELETED = "total_records_deleted"
     TOTAL_RECORDS_INSERTED = "total_records_inserted"
     TOTAL_RECORDS_UPDATED = "total_records_updated"
+    TOTAL_RECORDS_SKIPPED = "total_records_skipped"
     TOTAL_RECORDS_ORPHANED = "total_records_orphaned"
     TOTAL_DUPLICATE_RECORDS_SKIPPED = "total_duplicate_records_skipped"
     TOTAL_HISTORICAL_ORPHANS_SKIPPED = "total_historical_orphans_skipped"


### PR DESCRIPTION
## Summary
Fixes #2699

### Time to review: 30 mins

## Changes proposed
Modify `transform_assistance_listings` to skip listings with empty or null values for `programtitle` or `cfdanumber` values.

## Context for reviewers
We want to modify the process that transforms assistance listings from the legacy system to not create a record in our assistance listings table if the program_title/assistance_listing_number are null/empty. The legacy system has these "empty" records to handle connecting other pieces of data in a way that is confusing, and can be implemented differently when we get to it.

## Additional information
See attached unit tests

