### PR TITLE
[Issue 2709] add opportunity number to breadcrumb

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -100,8 +100,8 @@ async function OpportunityListing({ params }: { params: { id: string } }) {
     : emptySummary();
 
   breadcrumbs.push({
-    title: opportunityData.opportunity_title,
-    path: `/opportunity/${opportunityData.opportunity_id}/`,
+    title: `${opportunityData.opportunity_title}: ${opportunityData.opportunity_number}`,
+    path: `/opportunity/${opportunityData.opportunity_id}/`, // unused but required in breadcrumb implementation
   });
 
   return (

--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -16,22 +16,22 @@ type Props = {
   breadcrumbList: BreadcrumbList;
 };
 
-const Breadcrumbs = ({ breadcrumbList }: Props) => {
-  const rdfaMetadata = {
-    ol: {
-      vocab: "http://schema.org/",
-      typeof: "BreadcrumbList",
-    },
-    li: {
-      property: "itemListElement",
-      typeof: "ListItem",
-    },
-    a: {
-      property: "item",
-      typeof: "WebPage",
-    },
-  };
+const rdfaMetadata = {
+  ol: {
+    vocab: "http://schema.org/",
+    typeof: "BreadcrumbList",
+  },
+  li: {
+    property: "itemListElement",
+    typeof: "ListItem",
+  },
+  a: {
+    property: "item",
+    typeof: "WebPage",
+  },
+};
 
+const Breadcrumbs = ({ breadcrumbList }: Props) => {
   const breadcrumArray = breadcrumbList.map((breadcrumbInfo, i) => {
     return (
       <Breadcrumb

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -516,7 +516,7 @@ export const messages = {
         opportunity_number_desc: "Opportunity number (Ascending)",
         default: "Most relevant (Default)",
       },
-      label: "Sort By",
+      label: "Sort by",
     },
     filterToggleAll: {
       select: "Select All",


### PR DESCRIPTION
## Summary
Fixes #2709

### Time to review: __2 mins__

## Changes proposed
Added the opportunity number to the end of the breadcrumb text on the opportunity listing page. Also fixed the casing on the search "sort by" label as per request from design (requirement not in the attached ticket)

## Context for reviewers

### Test steps
1. visit the search page
2. _VERIFY_: sort by text reads "Sort by" and not "Sort By"
3. visit an opportunity pate
4. _VERIFY_: the opportunity number is visible at the end of the breadcrumb, ex `Home > Search > Walters PLC 1973 award: ROP-941-FY1996-350`

## Additional information


![Screenshot 2024-11-05 at 11 03 01 AM](https://github.com/user-attachments/assets/d069b8aa-83be-4ff2-a6b7-a4e1ef398f3d)
![Screenshot 2024-11-05 at 11 02 43 AM](https://github.com/user-attachments/assets/93d02e14-3bc0-4c74-97af-9e66b07593ee)

