### PR TITLE
[Issue #2732] clear search input when clicking search nav link

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "all-checks": "npm run test && npm run lint && npm run ts:check && npm run build",
     "build": "next build",
     "dev": "next dev",
     "debug": "NODE_OPTIONS='--inspect' next dev",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useFeatureFlags } from "src/hooks/useFeatureFlags";
 import { assetPath } from "src/utils/assetPath";
 
 import { useTranslations } from "next-intl";
@@ -33,14 +32,10 @@ const NavLinks = ({
   onToggleMobileNav: () => unknown;
 }) => {
   const t = useTranslations("Header");
-  const { featureFlagsManager } = useFeatureFlags();
   const path = usePathname();
 
   const getSearchLink = useCallback(
-    (onSearch: boolean, enabled: boolean) => {
-      if (!enabled) {
-        return {};
-      }
+    (onSearch: boolean) => {
       return {
         text: t("nav_link_search"),
         href: onSearch ? "/search?refresh=true" : "/search",
@@ -52,15 +47,12 @@ const NavLinks = ({
   const navLinkList = useMemo(() => {
     return [
       { text: t("nav_link_home"), href: "/" },
-      getSearchLink(
-        path.includes("/search"),
-        featureFlagsManager.isFeatureEnabled("showSearchV0"),
-      ),
+      getSearchLink(path.includes("/search")),
       { text: t("nav_link_process"), href: "/process" },
       { text: t("nav_link_research"), href: "/research" },
       { text: t("nav_link_subscribe"), href: "/subscribe" },
     ];
-  }, [t, path, featureFlagsManager, getSearchLink]);
+  }, [t, path, getSearchLink]);
 
   const navItems = useMemo(() => {
     return navLinkList.map((link: PrimaryLink) => {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,8 +5,8 @@ import { assetPath } from "src/utils/assetPath";
 
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
+import { useCallback, useMemo, useState } from "react";
 import {
   GovBanner,
   NavMenuButton,
@@ -15,63 +15,84 @@ import {
   Header as USWDSHeader,
 } from "@trussworks/react-uswds";
 
-type PrimaryLinks = {
-  i18nKey: string;
-  href: string;
-}[];
+type PrimaryLink = {
+  text?: string;
+  href?: string;
+};
 
 type Props = {
   logoPath?: string;
   locale?: string;
 };
 
+const NavLinks = ({
+  mobileExpanded,
+  onToggleMobileNav,
+}: {
+  mobileExpanded: boolean;
+  onToggleMobileNav: () => unknown;
+}) => {
+  const t = useTranslations("Header");
+  const { featureFlagsManager } = useFeatureFlags();
+  const path = usePathname();
+
+  const getSearchLink = useCallback(
+    (onSearch: boolean, enabled: boolean) => {
+      if (!enabled) {
+        return {};
+      }
+      return {
+        text: t("nav_link_search"),
+        href: onSearch ? "/search?refresh=true" : "/search",
+      };
+    },
+    [t],
+  );
+
+  const navLinkList = useMemo(() => {
+    return [
+      { text: t("nav_link_home"), href: "/" },
+      getSearchLink(
+        path.includes("/search"),
+        featureFlagsManager.isFeatureEnabled("showSearchV0"),
+      ),
+      { text: t("nav_link_process"), href: "/process" },
+      { text: t("nav_link_research"), href: "/research" },
+      { text: t("nav_link_subscribe"), href: "/subscribe" },
+    ];
+  }, [t, path, featureFlagsManager, getSearchLink]);
+
+  const navItems = useMemo(() => {
+    return navLinkList.map((link: PrimaryLink) => {
+      if (!link.text || !link.href) {
+        return <></>;
+      }
+      return (
+        <Link href={link.href} key={link.href}>
+          {link.text}
+        </Link>
+      );
+    });
+  }, [navLinkList]);
+
+  return (
+    <PrimaryNav
+      items={navItems}
+      mobileExpanded={mobileExpanded}
+      onToggleMobileNav={onToggleMobileNav}
+    ></PrimaryNav>
+  );
+};
+
 const Header = ({ logoPath, locale }: Props) => {
   const t = useTranslations("Header");
-  const [isMobileNavExpanded, setIsMobileNavExpanded] = useState(false);
+  const [isMobileNavExpanded, setIsMobileNavExpanded] =
+    useState<boolean>(false);
   const handleMobileNavToggle = () => {
     setIsMobileNavExpanded(!isMobileNavExpanded);
   };
-
-  const primaryLinksRef = useRef<PrimaryLinks>([]);
-  const { featureFlagsManager } = useFeatureFlags();
-  const router = useRouter();
-  const path = usePathname();
-  console.log("&&& path", path);
-
-  useEffect(() => {
-    console.log("&&& on search", path.includes("search"));
-    primaryLinksRef.current = [
-      { i18nKey: t("nav_link_home"), href: "/" },
-      { i18nKey: t("nav_link_process"), href: "/process" },
-      { i18nKey: t("nav_link_research"), href: "/research" },
-      { i18nKey: t("nav_link_subscribe"), href: "/subscribe" },
-    ];
-    const searchNavLink = {
-      i18nKey: t("nav_link_search"),
-      href: "/search",
-    };
-
-    if (featureFlagsManager.isFeatureEnabled("showSearchV0")) {
-      primaryLinksRef.current.splice(1, 0, searchNavLink);
-    }
-  }, [featureFlagsManager, t, path]);
-
-  const navItems = primaryLinksRef.current.map((link) => (
-    <Link
-      href={link.href}
-      key={link.href}
-      // onClick={() => {
-      //   if (path.includes("search") && link.href.includes("search")) {
-      //     return router.push("/search?refresh=true").then(() => undefined);
-      //   }
-      // }}
-    >
-      {link.i18nKey}
-    </Link>
-  ));
   const language = locale && locale.match("/^es/") ? "spanish" : "english";
 
-  console.log("&&& refresh nav items?", navItems);
   return (
     <>
       <div
@@ -100,11 +121,10 @@ const Header = ({ logoPath, locale }: Props) => {
               label={t("nav_menu_toggle")}
             />
           </div>
-          <PrimaryNav
-            items={navItems}
+          <NavLinks
             mobileExpanded={isMobileNavExpanded}
             onToggleMobileNav={handleMobileNavToggle}
-          ></PrimaryNav>
+          />
         </div>
       </USWDSHeader>
     </>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { assetPath } from "src/utils/assetPath";
 
 import { useTranslations } from "next-intl";
 import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import {
   GovBanner,
@@ -33,8 +34,12 @@ const Header = ({ logoPath, locale }: Props) => {
 
   const primaryLinksRef = useRef<PrimaryLinks>([]);
   const { featureFlagsManager } = useFeatureFlags();
+  const router = useRouter();
+  const path = usePathname();
+  console.log("&&& path", path);
 
   useEffect(() => {
+    console.log("&&& on search", path.includes("search"));
     primaryLinksRef.current = [
       { i18nKey: t("nav_link_home"), href: "/" },
       { i18nKey: t("nav_link_process"), href: "/process" },
@@ -45,18 +50,28 @@ const Header = ({ logoPath, locale }: Props) => {
       i18nKey: t("nav_link_search"),
       href: "/search",
     };
+
     if (featureFlagsManager.isFeatureEnabled("showSearchV0")) {
       primaryLinksRef.current.splice(1, 0, searchNavLink);
     }
-  }, [featureFlagsManager, t]);
+  }, [featureFlagsManager, t, path]);
 
   const navItems = primaryLinksRef.current.map((link) => (
-    <Link href={link.href} key={link.href}>
+    <Link
+      href={link.href}
+      key={link.href}
+      // onClick={() => {
+      //   if (path.includes("search") && link.href.includes("search")) {
+      //     return router.push("/search?refresh=true").then(() => undefined);
+      //   }
+      // }}
+    >
       {link.i18nKey}
     </Link>
   ));
   const language = locale && locale.match("/^es/") ? "spanish" : "english";
 
+  console.log("&&& refresh nav items?", navItems);
   return (
     <>
       <div

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -21,6 +21,8 @@ export default function SearchBar({ query }: SearchBarProps) {
     updateQueryParams("", "query", queryTerm, false);
   };
 
+  // if we have "refresh=true" query param, clear the input
+  // this supports the expected refresh of the input if the user clicks the search link while on the search page
   useEffect(() => {
     if (searchParams.get("refresh") && inputRef.current) {
       updateQueryTerm("");
@@ -28,11 +30,12 @@ export default function SearchBar({ query }: SearchBarProps) {
     }
   }, [searchParams, updateQueryTerm]);
 
+  // removes the "refresh" param once a user has dirtied the input
   useEffect(() => {
-    if (searchParams.get("refresh") && queryTerm) {
+    if (searchParams.get("refresh") && inputRef.current?.value) {
       updateQueryParams("", "refresh");
     }
-  }, [queryTerm, searchParams, updateQueryParams]);
+  }, [searchParams, updateQueryParams]);
 
   return (
     <div className="margin-top-5 margin-bottom-2">

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -4,22 +4,37 @@ import { QueryContext } from "src/app/[locale]/search/QueryProvider";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 
 import { useTranslations } from "next-intl";
-import { useContext } from "react";
+import { useSearchParams } from "next/navigation";
+import { useContext, useEffect } from "react";
 import { Icon } from "@trussworks/react-uswds";
 
 interface SearchBarProps {
   query: string | null | undefined;
 }
 
+// what can we look at to determine if there is a page refresh so we can clear the queryTerm
+// let's try making the nav take you to like "search-opportunities?navLink=true" which redirects to '/search" but we've already captured the state to know to reset the form????
 export default function SearchBar({ query }: SearchBarProps) {
   const { queryTerm, updateQueryTerm } = useContext(QueryContext);
-  const { updateQueryParams } = useSearchParamUpdater();
+  const { updateQueryParams, searchParams } = useSearchParamUpdater();
+  const t = useTranslations("Search");
 
   const handleSubmit = () => {
     updateQueryParams("", "query", queryTerm, false);
   };
 
-  const t = useTranslations("Search");
+  console.log("!!! search bar render query", query);
+  console.log("!!! search bar render queryTerm", queryTerm);
+
+  // useEffect(() => {
+  //   console.log("CHECKING", searchParams.get("refresh"));
+  //   if (searchParams.get("refresh")) {
+  //     console.log("UPDATDIHNG");
+  //     updateQueryTerm("");
+  //   }
+  // }, [searchParams, updateQueryTerm]);
+
+  // useEffect(() => console.log("***"), []);
 
   return (
     <div className="margin-top-5 margin-bottom-2">

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -4,17 +4,15 @@ import { QueryContext } from "src/app/[locale]/search/QueryProvider";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 
 import { useTranslations } from "next-intl";
-import { useSearchParams } from "next/navigation";
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useRef } from "react";
 import { Icon } from "@trussworks/react-uswds";
 
 interface SearchBarProps {
   query: string | null | undefined;
 }
 
-// what can we look at to determine if there is a page refresh so we can clear the queryTerm
-// let's try making the nav take you to like "search-opportunities?navLink=true" which redirects to '/search" but we've already captured the state to know to reset the form????
 export default function SearchBar({ query }: SearchBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const { queryTerm, updateQueryTerm } = useContext(QueryContext);
   const { updateQueryParams, searchParams } = useSearchParamUpdater();
   const t = useTranslations("Search");
@@ -23,18 +21,18 @@ export default function SearchBar({ query }: SearchBarProps) {
     updateQueryParams("", "query", queryTerm, false);
   };
 
-  console.log("!!! search bar render query", query);
-  console.log("!!! search bar render queryTerm", queryTerm);
+  useEffect(() => {
+    if (searchParams.get("refresh") && inputRef.current) {
+      updateQueryTerm("");
+      inputRef.current.value = "";
+    }
+  }, [searchParams, updateQueryTerm]);
 
-  // useEffect(() => {
-  //   console.log("CHECKING", searchParams.get("refresh"));
-  //   if (searchParams.get("refresh")) {
-  //     console.log("UPDATDIHNG");
-  //     updateQueryTerm("");
-  //   }
-  // }, [searchParams, updateQueryTerm]);
-
-  // useEffect(() => console.log("***"), []);
+  useEffect(() => {
+    if (searchParams.get("refresh") && queryTerm) {
+      updateQueryParams("", "refresh");
+    }
+  }, [queryTerm, searchParams, updateQueryParams]);
 
   return (
     <div className="margin-top-5 margin-bottom-2">
@@ -51,6 +49,7 @@ export default function SearchBar({ query }: SearchBarProps) {
       </label>
       <div className="usa-search usa-search--big" role="search">
         <input
+          ref={inputRef}
           className="usa-input maxw-none"
           id="query"
           type="search"

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -49,6 +49,7 @@ export function useSearchParamUpdater() {
   };
 
   return {
+    searchParams,
     updateQueryParams,
   };
 }

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -10,6 +10,7 @@ export function useSearchParamUpdater() {
   const router = useRouter();
   const params = new URLSearchParams(searchParams);
 
+  // note that providing an empty string as `queryParamValue` will remove the param
   const updateQueryParams = (
     // The parameter value that is not the query term. Query term is treated
     // separately because updates to it are captured, ie if a user updates the
@@ -17,7 +18,7 @@ export function useSearchParamUpdater() {
     queryParamValue: string | Set<string>,
     // Key of the parameter.
     key: string,
-    queryTerm: string | null | undefined,
+    queryTerm?: string | null,
     // Determines whether the state update scrolls the user to the top. This
     // is useful for components that are expected to be "under the fold."
     scroll = false,

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -1,6 +1,8 @@
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "tests/react-utils";
 
+import { ReadonlyURLSearchParams, usePathname } from "next/navigation";
+
 import Header from "src/components/Header";
 
 const props = {
@@ -16,6 +18,20 @@ const props = {
     },
   ],
 };
+
+const mockedPath = "/fakepath";
+
+const getMockedPath = () => mockedPath;
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    searchParams: new ReadonlyURLSearchParams(),
+  }),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => getMockedPath(),
+}));
 
 describe("Header", () => {
   it("toggles the mobile nav menu", async () => {

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "tests/react-utils";
 
-import { ReadonlyURLSearchParams, usePathname } from "next/navigation";
+import { ReadonlyURLSearchParams } from "next/navigation";
 
 import Header from "src/components/Header";
 

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -7,19 +7,10 @@ import Header from "src/components/Header";
 
 const props = {
   logoPath: "/img/logo.svg",
-  primaryLinks: [
-    {
-      i18nKey: "nav_link_home",
-      href: "/",
-    },
-    {
-      i18nKey: "nav_link_health",
-      href: "/health",
-    },
-  ],
+  locale: "en",
 };
 
-const mockedPath = "/fakepath";
+let mockedPath = "/fakepath";
 
 const getMockedPath = () => mockedPath;
 
@@ -65,5 +56,22 @@ describe("Header", () => {
     await userEvent.click(govBanner);
 
     expect(govBanner).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("displays a search link without refresh param if not currently on search page", () => {
+    render(<Header />);
+
+    const searchLink = screen.getByRole("link", { name: "Search" });
+    expect(searchLink).toBeInTheDocument();
+    expect(searchLink).toHaveAttribute("href", "/search");
+  });
+
+  it("displays a search link with refresh param if currently on search page", () => {
+    mockedPath = "/search";
+    render(<Header />);
+
+    const searchLink = screen.getByRole("link", { name: "Search" });
+    expect(searchLink).toBeInTheDocument();
+    expect(searchLink).toHaveAttribute("href", "/search?refresh=true");
   });
 });

--- a/frontend/tests/components/search/SearchBar.test.tsx
+++ b/frontend/tests/components/search/SearchBar.test.tsx
@@ -5,6 +5,7 @@ import { axe } from "jest-axe";
 import QueryProvider from "src/app/[locale]/search/QueryProvider";
 import { render, screen } from "tests/react-utils";
 
+import { ReadonlyURLSearchParams } from "next/navigation";
 import React from "react";
 
 import SearchBar from "src/components/search/SearchBar";
@@ -15,6 +16,7 @@ const mockUpdateQueryParams = jest.fn();
 jest.mock("src/hooks/useSearchParamUpdater", () => ({
   useSearchParamUpdater: () => ({
     updateQueryParams: mockUpdateQueryParams,
+    searchParams: new ReadonlyURLSearchParams(),
   }),
 }));
 

--- a/frontend/tests/pages/search/page.test.tsx
+++ b/frontend/tests/pages/search/page.test.tsx
@@ -4,6 +4,8 @@ import Search from "src/app/[locale]/search/page";
 import { SEARCH_NO_STATUS_VALUE } from "src/constants/search";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
+import { ReadonlyURLSearchParams } from "next/navigation";
+
 // test without feature flag functionality
 jest.mock("src/hoc/search/withFeatureFlag", () =>
   jest.fn((Component: React.Component) => Component),
@@ -16,6 +18,12 @@ jest.mock("next-intl/server", () => ({
 
 jest.mock("next-intl", () => ({
   useTranslations: () => useTranslationsMock(),
+}));
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    searchParams: new ReadonlyURLSearchParams(),
+  }),
 }));
 
 // // currently, with Suspense mocked out below to always show fallback content,


### PR DESCRIPTION
## Summary
Fixes #2732

### Time to review: __10 mins__

## Changes proposed
Fixes a bug where the search bar does not clear when clicking "search" on the nav while on the search page.

The solution I came up with was to append a query param to the search nav item when on the search page, whose presence is a signal to the page to clear the search bar.

The approach is not ideal, but a fix requires knowing when a navigation has occurred, and Next does not provide a simple way to know that without relying on something like global state.

## Context for reviewers

### Test steps

1. on this branch, visit the search page
2. enter text in the search bar
3. click the "search" nav item
4. _VERIFY_ the search bar is cleared when the page refreshes

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

