### PR TITLE
[Issue 2665] Add gh-transform-and-load command to scheduled jobs

### DIFF
--- a/infra/analytics/app-config/env-config/scheduled_jobs.tf
+++ b/infra/analytics/app-config/env-config/scheduled_jobs.tf
@@ -7,7 +7,7 @@ locals {
 
   scheduled_jobs = {
     sprint-reports = {
-      task_command        = ["make", "gh-data-export", "sprint-reports"]
+      task_command        = ["make", "gh-data-export", "sprint-reports", "gh-transform-and-load"]
       schedule_expression = "rate(1 days)"
       state               = "ENABLED"
     }


### PR DESCRIPTION
## Summary
Fixes #2665 

### Time to review: __1 min__

## Changes proposed
> What was added, updated, or removed in this PR.

Added `gh-transform-and-load` command to existing `make gh-data-export` command. I'm not sure if this is sufficient or correct, but I'm taking a guess based on what I see in https://github.com/HHS/simpler-grants-gov/pull/2546 and https://github.com/HHS/simpler-grants-gov/pull/2506.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

In the analytics work stream, we have a new CLI command `make gh-transform-and-load` for transforming and loading (some) GitHub data. Per issue #2665, that command should be run daily, after the existing `gh-data-export` command which exports data from Github. 

I see that `scheduled_jobs.tf` seems to be the mechanism by which `make gh-data-export` runs daily. In this PR I'm taking and educated guess and attempting to add `gh-transform-and-load` to the existing job, and requesting feedback from @coilysiren as to whether this is the correct approach. 

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

