### PR TITLE
[Issue 2665] Add new job to initialize EtlDb

### DIFF
--- a/infra/analytics/app-config/env-config/scheduled_jobs.tf
+++ b/infra/analytics/app-config/env-config/scheduled_jobs.tf
@@ -11,5 +11,10 @@ locals {
       schedule_expression = "rate(1 days)"
       state               = "ENABLED"
     }
+    init-etldb = {
+      task_command        = ["make", "init-db"]
+      schedule_expression = "rate(1 days)"
+      state               = "ENABLED"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #2665 

### Time to review: __1 min__

## Changes proposed
> What was added, updated, or removed in this PR.
Added scheduled job to run `make init-db` 

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The GitHub data export, transform, and load job (see https://github.com/HHS/simpler-grants-gov/pull/2759) depends on a certain schema existing in Postgres. This PR creates a job to ensure the schema exists. 

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

