### PR TITLE
[no ticket] Fix infinite state locks

### DIFF
--- a/.github/workflows/cd-analytics-infra.yml
+++ b/.github/workflows/cd-analytics-infra.yml
@@ -39,6 +39,7 @@ jobs:
     name: Deploy Infrastructure
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         directory: ["database", "service"]
         envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || fromJSON('["dev", "staging"]') }} # deploy prod on releases, otherwise deploy staging and dev

--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -33,6 +33,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     strategy:
       max-parallel: 1
+      fail-fast: false
       matrix:
         envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
     with:

--- a/.github/workflows/cd-api-infra.yml
+++ b/.github/workflows/cd-api-infra.yml
@@ -38,6 +38,7 @@ jobs:
     name: Deploy Infrastructure
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         directory: ["database", "service"]
         envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || fromJSON('["dev", "staging"]') }} # deploy prod on releases, otherwise deploy staging and dev

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -32,6 +32,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     strategy:
       max-parallel: 1
+      fail-fast: false
       matrix:
         envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
     with:

--- a/.github/workflows/cd-frontend-infra.yml
+++ b/.github/workflows/cd-frontend-infra.yml
@@ -38,6 +38,7 @@ jobs:
     name: Deploy Infrastructure
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         directory: ["service"]
         envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || fromJSON('["dev", "staging"]') }} # deploy prod on releases, otherwise deploy staging and dev

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -32,6 +32,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     strategy:
       max-parallel: 1
+      fail-fast: false
       matrix:
         envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
     with:


### PR DESCRIPTION
### Time to review: __1 mins__

## Context for reviewers

Platform's assertion is this: whenever a deploy fails for any reason, it cancels the deploy, which locks the other 3 jobs. Those 3 jobs remain locked indefinitely. On the next deploy, every job but 1 is locked, but the other 3 jobs fail because they were locked prior, which causes 1 first job to be canceled, and thusly all 4 jobs are locked. It's an avalanche effect. Whenever 1 deploy fails, all 4 fail that point onwards.