### PR TITLE
[Issue #2781] Only run vuln scans if the relevant files have changed

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -27,9 +27,15 @@ jobs:
     uses: ./.github/workflows/ci-analytics.yml
     secrets: inherit
 
+  vulnerability-scans:
+    name: Vulnerability Scans
+    uses: ./.github/workflows/vulnerability-scans.yml
+    with:
+      app_name: analytics
+
   deploy:
     name: Deploy
-    needs: analytics-checks
+    needs: [analytics-checks, vulnerability-scans]
     uses: ./.github/workflows/deploy.yml
     strategy:
       max-parallel: 1

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -26,9 +26,15 @@ jobs:
     name: Run API Checks
     uses: ./.github/workflows/ci-api.yml
 
+  vulnerability-scans:
+    name: Vulnerability Scans
+    uses: ./.github/workflows/vulnerability-scans.yml
+    with:
+      app_name: api
+
   deploy:
     name: Deploy
-    needs: api-checks
+    needs: [api-checks, vulnerability-scans]
     uses: ./.github/workflows/deploy.yml
     strategy:
       max-parallel: 1

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -26,9 +26,15 @@ jobs:
     name: Run Frontend Checks
     uses: ./.github/workflows/ci-frontend.yml
 
+  vulnerability-scans:
+    name: Vulnerability Scans
+    uses: ./.github/workflows/vulnerability-scans.yml
+    with:
+      app_name: frontend
+
   deploy:
     name: Deploy
-    needs: frontend-checks
+    needs: [frontend-checks, vulnerability-scans]
     uses: ./.github/workflows/deploy.yml
     strategy:
       max-parallel: 1

--- a/.github/workflows/ci-analytics-vulnerability-scans.yml
+++ b/.github/workflows/ci-analytics-vulnerability-scans.yml
@@ -10,13 +10,13 @@ on:
       - .hadolint.yaml
       - .trivyignore
       - .github/workflows/ci-vulnerability-scans.yml
+      - analytics/Dockerfile
+      - analytics/pyproject.toml
+      - analytics/poetry.lock
 
 jobs:
   vulnerability-scans:
     name: Vulnerability Scans
-    strategy:
-      matrix:
-        app_name: ["frontend", "api", "analytics"]
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
-      app_name: ${{ matrix.app_name }}
+      app_name: analytics

--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -48,9 +48,3 @@ jobs:
 
       # - name: Run reports
       #   run: make sprint-reports
-
-  vulnerability-scans:
-    name: Run Analytics Vulnerability Scans
-    uses: ./.github/workflows/vulnerability-scans.yml
-    with:
-      app_name: "analytics"

--- a/.github/workflows/ci-api-vulnerability-scans.yml
+++ b/.github/workflows/ci-api-vulnerability-scans.yml
@@ -1,0 +1,22 @@
+# GitHub Actions CI workflow that runs vulnerability scans on the application's Docker image
+# to ensure images built are secure before they are deployed.
+
+name: CI Vulnerability Scans
+
+on:
+  pull_request:
+    paths:
+      - .grype.yml
+      - .hadolint.yaml
+      - .trivyignore
+      - .github/workflows/ci-vulnerability-scans.yml
+      - api/Dockerfile
+      - api/pyproject.toml
+      - api/poetry.lock
+
+jobs:
+  vulnerability-scans:
+    name: Vulnerability Scans
+    uses: ./.github/workflows/vulnerability-scans.yml
+    with:
+      app_name: api

--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -35,9 +35,3 @@ jobs:
 
       - name: Start tests
         run: make test-coverage
-
-  vulnerability-scans:
-    name: Run API Vulnerability Scans
-    uses: ./.github/workflows/vulnerability-scans.yml
-    with:
-      app_name: "api"

--- a/.github/workflows/ci-frontend-vulnerability-scans.yml
+++ b/.github/workflows/ci-frontend-vulnerability-scans.yml
@@ -1,0 +1,22 @@
+# GitHub Actions CI workflow that runs vulnerability scans on the application's Docker image
+# to ensure images built are secure before they are deployed.
+
+name: CI Vulnerability Scans
+
+on:
+  pull_request:
+    paths:
+      - .grype.yml
+      - .hadolint.yaml
+      - .trivyignore
+      - .github/workflows/ci-vulnerability-scans.yml
+      - frontend/Dockerfile
+      - frontendpi/package.json
+      - frontend/package-lock.json
+
+jobs:
+  vulnerability-scans:
+    name: Vulnerability Scans
+    uses: ./.github/workflows/vulnerability-scans.yml
+    with:
+      app_name: frontend

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -46,14 +46,14 @@ jobs:
       - run: npm run test -- --testLocationInResults --json --outputFile=coverage/report.json
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-            coverage-file: coverage/report.json
-            test-script: npm test
-            working-directory: ./frontend
-            annotations: ${{ github.event.pull_request.head.repo.full_name == github.event.repository.name && 'failed-tests' || 'none' }}
-            package-manager: npm
-            icons: emoji
-            skip-step: none
-            output: ${{ github.event.pull_request.head.repo.full_name == github.event.repository.name && 'comment' || 'report-markdown' }}
+          coverage-file: coverage/report.json
+          test-script: npm test
+          working-directory: ./frontend
+          annotations: ${{ github.event.pull_request.head.repo.full_name == github.event.repository.name && 'failed-tests' || 'none' }}
+          package-manager: npm
+          icons: emoji
+          skip-step: none
+          output: ${{ github.event.pull_request.head.repo.full_name == github.event.repository.name && 'comment' || 'report-markdown' }}
 
   # Confirms the front end still builds successfully
   check-frontend-builds:
@@ -97,9 +97,3 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
       - run: npm ci
       - run: npm run storybook-build
-
-  vulnerability-scans:
-    name: Run Frontend Vulnerability Scans
-    uses: ./.github/workflows/vulnerability-scans.yml
-    with:
-      app_name: 'frontend'


### PR DESCRIPTION
## Summary

Fixes #2781

### Time to review: __2 mins__

## Changes proposed

- PRs only run vuln scans if relevant files have changed
- Deploys still run vuln scans

I tried to sneak "skip vuln scans for dev deploys" but that's a little bit more involved so it'll come in another package

## Testing

I haven't! So hopefully it's not fully of typos