### PR TITLE
[Issue #2770] cache opportunity requests

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -25,8 +25,7 @@ export async function generateMetadata({ params }: { params: { id: string } }) {
   const id = Number(params.id);
   let title = `${t("OpportunityListing.page_title")}`;
   try {
-    const { data: opportunityData } =
-      await fetchers.opportunityFetcher.getOpportunityById(id);
+    const { data: opportunityData } = await fetchers.opportunityFetcher(id);
     title = `${t("OpportunityListing.page_title")} - ${opportunityData.opportunity_title}`;
   } catch (error) {
     console.error("Failed to render page title due to API error", error);
@@ -87,7 +86,7 @@ async function OpportunityListing({ params }: { params: { id: string } }) {
 
   let opportunityData = {} as Opportunity;
   try {
-    const response = await fetchers.opportunityFetcher.getOpportunityById(id);
+    const response = await fetchers.opportunityFetcher(id);
     opportunityData = response.data;
   } catch (error) {
     if (parseErrorStatus(error as ApiRequestError) === 404) {

--- a/frontend/src/app/api/Fetchers.ts
+++ b/frontend/src/app/api/Fetchers.ts
@@ -1,9 +1,16 @@
 import OpportunityListingAPI from "src/app/api//OpportunityListingAPI";
 import SearchOpportunityAPI from "src/app/api/SearchOpportunityAPI";
 
+import { cache } from "react";
+
+const searchApi = new SearchOpportunityAPI();
+const opportunityListingApi = new OpportunityListingAPI();
+
 const fetchers = {
-  searchOpportunityFetcher: new SearchOpportunityAPI(),
-  opportunityFetcher: new OpportunityListingAPI(),
+  searchOpportunityFetcher: searchApi.searchOpportunities.bind(searchApi),
+  opportunityFetcher: cache(
+    opportunityListingApi.getOpportunityById.bind(opportunityListingApi),
+  ),
 };
 
 export default fetchers;

--- a/frontend/src/components/search/SearchPaginationFetch.tsx
+++ b/frontend/src/components/search/SearchPaginationFetch.tsx
@@ -16,8 +16,7 @@ export default async function SearchPaginationFetch({
   searchParams,
   scroll,
 }: SearchPaginationProps) {
-  const searchResults =
-    await fetchers.searchOpportunityFetcher.searchOpportunities(searchParams);
+  const searchResults = await fetchers.searchOpportunityFetcher(searchParams);
   const totalPages = searchResults.pagination_info?.total_pages;
   const totalResults = searchResults.pagination_info?.total_records;
 

--- a/frontend/src/components/search/SearchResultsHeaderFetch.tsx
+++ b/frontend/src/components/search/SearchResultsHeaderFetch.tsx
@@ -14,8 +14,7 @@ export default async function SearchResultsHeaderFetch({
   sortby: string | null;
   queryTerm: string | null | undefined;
 }) {
-  const searchResults =
-    await fetchers.searchOpportunityFetcher.searchOpportunities(searchParams);
+  const searchResults = await fetchers.searchOpportunityFetcher(searchParams);
   const totalResults = searchResults.pagination_info?.total_records;
 
   return (

--- a/frontend/src/components/search/SearchResultsListFetch.tsx
+++ b/frontend/src/components/search/SearchResultsListFetch.tsx
@@ -13,8 +13,7 @@ interface ServerPageProps {
 export default async function SearchResultsListFetch({
   searchParams,
 }: ServerPageProps) {
-  const searchResults =
-    await fetchers.searchOpportunityFetcher.searchOpportunities(searchParams);
+  const searchResults = await fetchers.searchOpportunityFetcher(searchParams);
   const maxPaginationError = null;
   const t = await getTranslations("Search");
 

--- a/frontend/tests/components/search/SearchResults.test.tsx
+++ b/frontend/tests/components/search/SearchResults.test.tsx
@@ -31,6 +31,7 @@ jest.mock("next-intl", () => ({
 jest.mock("react", () => ({
   ...jest.requireActual<typeof import("react")>("react"),
   Suspense: ({ fallback }: { fallback: React.Component }) => fallback,
+  cache: (fn: unknown) => fn,
 }));
 
 describe("SearchResults", () => {

--- a/frontend/tests/pages/search/page.test.tsx
+++ b/frontend/tests/pages/search/page.test.tsx
@@ -45,6 +45,7 @@ jest.mock("next/navigation", () => ({
 jest.mock("react", () => ({
   ...jest.requireActual<typeof import("react")>("react"),
   Suspense: ({ fallback }: { fallback: React.Component }) => fallback,
+  cache: (fn: unknown) => fn,
 }));
 
 describe("Search Route", () => {


### PR DESCRIPTION
## Summary
Fixes #2770

Note that https://github.com/HHS/simpler-grants-gov/pull/2790 also solves this issue, we only need to take one or the other


### Time to review: __ 15 mins__

## Changes proposed

Currently two requests to the API's opportunity endpoint on each opportunity detail page load. This is because the page is making two calls to the opportunity fetch function and for reasons that are still not entirely clear Next's fetch memoization functionality is not deduplicating the calls, and allowing both requests to pass through.

This change wraps call to opportunity fetch function in a React "cache" call to get desired memoization behavior and eliminate the duplicate call.

Also included is a slight change to the "fetcher" definition behavior and pattern, which necessitates adding a `.bind()` call in order to maintain the use of "this" in the underlying API classes.

## Context for reviewers
So far I have not been able to track down why the React / Next memoization is not happening, but in the interest of time this seems like a good solution at least temporarily. Follow up can be found here https://github.com/HHS/simpler-grants-gov/issues/2789

### Test steps

1. visit an opportunity detail on main while tailing API docker logs `docker logs grants-api -f`
2. _VERIFY_: two separate "start request" logs are visible
1. visit an opportunity detail on this branch while tailing API docker logs `docker logs grants-api -f`
2. _VERIFY_: one "start request" log is visible

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

