### PR TITLE
[Issue #2770] deduplicate search requests

### DIFF
--- a/frontend/src/components/search/SearchPaginationFetch.tsx
+++ b/frontend/src/components/search/SearchPaginationFetch.tsx
@@ -1,23 +1,25 @@
 "use server";
 
-import fetchers from "src/app/api/Fetchers";
-import { QueryParamData } from "src/types/search/searchRequestTypes";
+import { SearchAPIResponse } from "src/types/search/searchResponseTypes";
 
 import SearchPagination from "src/components/search/SearchPagination";
 
 interface SearchPaginationProps {
-  searchParams: QueryParamData;
+  searchResultsPromise: Promise<SearchAPIResponse>;
   // Determines whether clicking on pager items causes a scroll to the top of the search
   // results. Created so the bottom pager can scroll.
   scroll: boolean;
+  page: number;
+  query?: string | null;
 }
 
 export default async function SearchPaginationFetch({
-  searchParams,
+  page,
+  query,
+  searchResultsPromise,
   scroll,
 }: SearchPaginationProps) {
-  const searchResults =
-    await fetchers.searchOpportunityFetcher.searchOpportunities(searchParams);
+  const searchResults = await searchResultsPromise;
   const totalPages = searchResults.pagination_info?.total_pages;
   const totalResults = searchResults.pagination_info?.total_records;
 
@@ -25,8 +27,8 @@ export default async function SearchPaginationFetch({
     <>
       <SearchPagination
         total={totalPages}
-        page={searchParams.page}
-        query={searchParams.query}
+        page={page}
+        query={query}
         scroll={scroll}
         totalResults={String(totalResults)}
       />

--- a/frontend/src/components/search/SearchResults.tsx
+++ b/frontend/src/components/search/SearchResults.tsx
@@ -1,4 +1,5 @@
 import Loading from "src/app/[locale]/search/loading";
+import fetchers from "src/app/api/Fetchers";
 import { QueryParamData } from "src/types/search/searchRequestTypes";
 
 import { Suspense } from "react";
@@ -20,19 +21,19 @@ export default function SearchResults({
 }) {
   const { page, sortby } = searchParams;
 
+  const searchResultsPromise =
+    fetchers.searchOpportunityFetcher.searchOpportunities(searchParams);
+
   const key = Object.entries(searchParams).join(",");
   const pager1key = Object.entries(searchParams).join("-") + "pager1";
   const pager2key = Object.entries(searchParams).join("-") + "pager2";
   return (
     <>
-      <Suspense
-        key={key}
-        fallback={<SearchResultsHeader sortby={sortby} loading={false} />}
-      >
+      <Suspense key={key} fallback={<SearchResultsHeader sortby={sortby} />}>
         <SearchResultsHeaderFetch
           sortby={sortby}
           queryTerm={query}
-          searchParams={searchParams}
+          searchResultsPromise={searchResultsPromise}
         />
       </Suspense>
       <div className="usa-prose">
@@ -42,10 +43,15 @@ export default function SearchResults({
             <SearchPagination loading={true} page={page} query={query} />
           }
         >
-          <SearchPaginationFetch searchParams={searchParams} scroll={false} />
+          <SearchPaginationFetch
+            page={page}
+            query={query}
+            searchResultsPromise={searchResultsPromise}
+            scroll={false}
+          />
         </Suspense>
         <Suspense key={key} fallback={<Loading message={loadingMessage} />}>
-          <SearchResultsListFetch searchParams={searchParams} />
+          <SearchResultsListFetch searchResultsPromise={searchResultsPromise} />
         </Suspense>
         <Suspense
           key={pager2key}
@@ -53,7 +59,12 @@ export default function SearchResults({
             <SearchPagination loading={true} page={page} query={query} />
           }
         >
-          <SearchPaginationFetch searchParams={searchParams} scroll={true} />
+          <SearchPaginationFetch
+            page={page}
+            query={query}
+            searchResultsPromise={searchResultsPromise}
+            scroll={true}
+          />
         </Suspense>
       </div>
     </>

--- a/frontend/src/components/search/SearchResultsHeaderFetch.tsx
+++ b/frontend/src/components/search/SearchResultsHeaderFetch.tsx
@@ -1,21 +1,19 @@
 "use server";
 
-import fetchers from "src/app/api/Fetchers";
-import { QueryParamData } from "src/types/search/searchRequestTypes";
+import { SearchAPIResponse } from "src/types/search/searchResponseTypes";
 
 import SearchResultsHeader from "./SearchResultsHeader";
 
 export default async function SearchResultsHeaderFetch({
-  searchParams,
+  searchResultsPromise,
   sortby,
   queryTerm,
 }: {
-  searchParams: QueryParamData;
+  searchResultsPromise: Promise<SearchAPIResponse>;
   sortby: string | null;
   queryTerm: string | null | undefined;
 }) {
-  const searchResults =
-    await fetchers.searchOpportunityFetcher.searchOpportunities(searchParams);
+  const searchResults = await searchResultsPromise;
   const totalResults = searchResults.pagination_info?.total_records;
 
   return (

--- a/frontend/src/components/search/SearchResultsListFetch.tsx
+++ b/frontend/src/components/search/SearchResultsListFetch.tsx
@@ -1,5 +1,4 @@
-import fetchers from "src/app/api/Fetchers";
-import { QueryParamData } from "src/types/search/searchRequestTypes";
+import { SearchAPIResponse } from "src/types/search/searchResponseTypes";
 
 import { getTranslations } from "next-intl/server";
 
@@ -7,14 +6,13 @@ import SearchResultsListItem from "src/components/search/SearchResultsListItem";
 import ServerErrorAlert from "src/components/ServerErrorAlert";
 
 interface ServerPageProps {
-  searchParams: QueryParamData;
+  searchResultsPromise: Promise<SearchAPIResponse>;
 }
 
 export default async function SearchResultsListFetch({
-  searchParams,
+  searchResultsPromise,
 }: ServerPageProps) {
-  const searchResults =
-    await fetchers.searchOpportunityFetcher.searchOpportunities(searchParams);
+  const searchResults = await searchResultsPromise;
   const maxPaginationError = null;
   const t = await getTranslations("Search");
 

--- a/frontend/tests/components/search/SearchResults.test.tsx
+++ b/frontend/tests/components/search/SearchResults.test.tsx
@@ -33,6 +33,12 @@ jest.mock("react", () => ({
   Suspense: ({ fallback }: { fallback: React.Component }) => fallback,
 }));
 
+jest.mock("src/app/api/Fetchers", () => ({
+  searchOpportunityFetcher: {
+    searchOpportunities: jest.fn(() => Promise.resolve()),
+  },
+}));
+
 describe("SearchResults", () => {
   it("Renders without errors", () => {
     render(

--- a/frontend/tests/pages/search/page.test.tsx
+++ b/frontend/tests/pages/search/page.test.tsx
@@ -47,7 +47,23 @@ jest.mock("react", () => ({
   Suspense: ({ fallback }: { fallback: React.Component }) => fallback,
 }));
 
+const fetchMock = jest.fn().mockResolvedValue({
+  json: jest.fn().mockResolvedValue({ data: [], errors: [], warnings: [] }),
+  ok: true,
+  status: 200,
+});
+
 describe("Search Route", () => {
+  let originalFetch: typeof global.fetch;
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+  beforeEach(() => {
+    global.fetch = fetchMock;
+  });
   it("renders the search page with expected checkboxes checked", async () => {
     const mockSearchParams = {
       status: "forecasted,posted",


### PR DESCRIPTION
## Summary
Fixes #2770

### Time to review: __10 mins__

## Changes proposed

The task here was to fix the current situation in which the search page is making 4 identical requests to the API on each page load.

To do this, instead of making individual requests in each of the search components that require search result data, we make one request in the top level component, and pass the unresolved Promise down to each child component, where it can resolve and provide data upon resolution.

Note that Next / React's request memoization does not work in this case because our search call is "POST" request and memoization only works on "GET"s.

## Context for reviewers

### Test steps

1. visit an search page on main while tailing API docker logs `docker logs grants-api -f`
2. _VERIFY_: 4 separate "start request" logs are visible
1. visit a search page on this branch while tailing API docker logs `docker logs grants-api -f`
2. _VERIFY_: one "start request" log is visible

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

