### PR TITLE
[Unticketed] Fix test that was using incorrect name for agency field after rename

### DIFF
--- a/api/tests/src/data_migration/transformation/test_transform_oracle_data_task.py
+++ b/api/tests/src/data_migration/transformation/test_transform_oracle_data_task.py
@@ -207,7 +207,7 @@ class TestTransformFullRunTask(BaseTestClass):
         )
 
         existing_opportunity = f.OpportunityFactory(
-            no_current_summary=True, opportunity_assistance_listings=[], agency="UPDATEAGENCY"
+            no_current_summary=True, opportunity_assistance_listings=[], agency_code="UPDATEAGENCY"
         )
         opportunity = f.StagingTopportunityFactory(
             opportunity_id=existing_opportunity.opportunity_id, cfdas=[]
@@ -466,7 +466,7 @@ class TestTransformFullRunTask(BaseTestClass):
         # but we'll still have delete events for the others - this verfies how we handle that.
 
         existing_opportunity = f.OpportunityFactory(
-            no_current_summary=True, opportunity_assistance_listings=[], agency="AGENCYXYZ"
+            no_current_summary=True, opportunity_assistance_listings=[], agency_code="AGENCYXYZ"
         )
         opportunity = f.StagingTopportunityFactory(
             opportunity_id=existing_opportunity.opportunity_id, cfdas=[], is_deleted=True


### PR DESCRIPTION
## Summary
Fixes <Unticketed>

### Time to review: __2 mins__

## Changes proposed
Fixes unit tests that broke after a recent rename of agency fields

Changed the name in one PR, and adjusted tests in a separate, but forgot to reconcile them before merging both to main.

