### PR TITLE
[Issue #2776] fix broken markup parsing when links are present

### DIFF
--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -69,6 +69,18 @@ const SummaryDescriptionDisplay = ({
   const purifiedSummary = DOMPurify.sanitize(summaryDescription);
 
   const { preSplit, postSplit } = splitMarkup(purifiedSummary, 600);
+
+  if (!postSplit) {
+    return (
+      <div
+        dangerouslySetInnerHTML={{
+          __html: summaryDescription
+            ? DOMPurify.sanitize(summaryDescription)
+            : "--",
+        }}
+      />
+    );
+  }
   return (
     <>
       <div

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -35,7 +35,14 @@ export const splitMarkup = (
         }
         tracker.openTagIndicator = true;
       }
-      if (tracker.openTagIndicator && character === "/") {
+      // handle things like urls within tag params that need to be ignored
+      if (
+        (tracker.openTagIndicator && character === `"`) ||
+        character === `'`
+      ) {
+        tracker.inQuotes = !tracker.inQuotes;
+      }
+      if (tracker.openTagIndicator && character === "/" && !tracker.inQuotes) {
         if (tracker.closeTagIndicator) {
           throw new Error("Malformed markup: improperly closed tag");
         }
@@ -64,6 +71,8 @@ export const splitMarkup = (
       openTagIndicator: false,
       closeTagIndicator: false,
       splitComplete: false,
+      tagCharacters: "",
+      inQuotes: false,
     },
   );
   return {

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -29,12 +29,6 @@ export const splitMarkup = (
         tracker.postSplit += character;
         return tracker;
       }
-      if (character === "<") {
-        if (tracker.openTagIndicator) {
-          throw new Error("Malformed markup: unclosed tag");
-        }
-        tracker.openTagIndicator = true;
-      }
       // handle things like urls within tag params that need to be ignored
       if (
         (tracker.openTagIndicator && character === `"`) ||
@@ -42,7 +36,17 @@ export const splitMarkup = (
       ) {
         tracker.inQuotes = !tracker.inQuotes;
       }
-      if (tracker.openTagIndicator && character === "/" && !tracker.inQuotes) {
+      if (tracker.inQuotes) {
+        tracker.preSplit += character;
+        return tracker;
+      }
+      if (character === "<") {
+        if (tracker.openTagIndicator) {
+          throw new Error("Malformed markup: unclosed tag");
+        }
+        tracker.openTagIndicator = true;
+      }
+      if (tracker.openTagIndicator && character === "/") {
         if (tracker.closeTagIndicator) {
           throw new Error("Malformed markup: improperly closed tag");
         }

--- a/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
@@ -8,6 +8,13 @@ import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import OpportunityDescription from "src/components/opportunity/OpportunityDescription";
 
+const splitMarkupMock = jest
+  .fn()
+  .mockImplementation((content: string, index: number) => ({
+    preSplit: content.substring(0, index),
+    postSplit: content.substring(index),
+  }));
+
 jest.mock("isomorphic-dompurify", () => ({
   sanitize: jest.fn((input: string) => input),
 }));
@@ -15,6 +22,15 @@ jest.mock("isomorphic-dompurify", () => ({
 jest.mock("next-intl", () => ({
   useTranslations: () => useTranslationsMock(),
 }));
+
+jest.mock("src/utils/generalUtils", () => ({
+  splitMarkup: (content: string, index: number) =>
+    // eslint-disable-next-line
+    splitMarkupMock(content, index),
+}));
+
+const longDescription =
+  "Its young really risk. College call month identify out east. Defense writer ahead trip smile. Picture data area system manager hour none. Doctor pay visit save test. Again feeling little throughout. Improve drug play remain face word somebody. Baby miss may drive treat letter. Laugh message as car position team. Want build last. Model or base within bag manager brother. How still teacher son fish pay until. Debate doctor visit because success. Message will white risk. Follow sell nearly individual family crime particularly understand. Police street federal six really major owner. Should friend minute team material trade special. Example above government usually deal fill few. Kid middle our sometimes appear. Ready share century nor take let. Water sort choice beat design she sport commercial. Nature if natural feel. Yes door cold realize. Receive trade central good realize number woman them. Actually there common order purpose within. Enough trouble develop station almost read. Who attack include company.";
 
 const mockSummaryData: Summary = {
   summary_description: "<p>Summary Description</p>",
@@ -44,6 +60,44 @@ describe("OpportunityDescription", () => {
     expect(DOMPurify.sanitize).toHaveBeenCalledWith(
       sanitizedSummaryDescription,
     );
+  });
+
+  it("splits opportunity description after 600 characters if description is longer than 750 characters", () => {
+    render(
+      <OpportunityDescription
+        summary={{ ...mockSummaryData, summary_description: longDescription }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Its young really risk. College call month identify out east. Defense writer ahead trip smile. Picture data area system manager hour none. Doctor pay visit save test. Again feeling little throughout. Improve drug play remain face word somebody. Baby miss may drive treat letter. Laugh message as car position team. Want build last. Model or base within bag manager brother. How still teacher son fish pay until. Debate doctor visit because success. Message will white risk. Follow sell nearly individual family crime particularly understand. Police street federal six really major owner. Should friend...",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryAllByText(
+        " minute team material trade special. Example above government usually deal fill few. Kid middle our sometimes appear. Ready share century nor take let. Water sort choice beat design she sport commercial. Nature if natural feel. Yes door cold realize. Receive trade central good realize number woman them. Actually there common order purpose within. Enough trouble develop station almost read. Who attack include company.",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("shows all description if parsed mark up comes out with no content to hide", () => {
+    splitMarkupMock.mockImplementation((content: string) => ({
+      preSplit: content,
+      postSplit: "",
+    }));
+
+    render(
+      <OpportunityDescription
+        summary={{ ...mockSummaryData, summary_description: longDescription }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Its young really risk. College call month identify out east. Defense writer ahead trip smile. Picture data area system manager hour none. Doctor pay visit save test. Again feeling little throughout. Improve drug play remain face word somebody. Baby miss may drive treat letter. Laugh message as car position team. Want build last. Model or base within bag manager brother. How still teacher son fish pay until. Debate doctor visit because success. Message will white risk. Follow sell nearly individual family crime particularly understand. Police street federal six really major owner. Should friend minute team material trade special. Example above government usually deal fill few. Kid middle our sometimes appear. Ready share century nor take let. Water sort choice beat design she sport commercial. Nature if natural feel. Yes door cold realize. Receive trade central good realize number woman them. Actually there common order purpose within. Enough trouble develop station almost read. Who attack include company.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders the eligible applicants with mapped values", () => {

--- a/frontend/tests/utils/generalUtils.test.ts
+++ b/frontend/tests/utils/generalUtils.test.ts
@@ -69,6 +69,17 @@ describe("splitMarkup", () => {
       " <div>that I've been turning over <strong>in</strong> my mind ever since.</div>",
     );
   });
+  it("ignores anything that is within quotes within a tag and allows it to pass through", () => {
+    const exampleMarkup =
+      "<div>In <a href='http://things' fake='<<>>>><<//'>my younger</a> and more <p>vulnerable <strong>years my<ul><li>father</li><li>gave</li></ul>me</strong> some </p>advice</div> <div>that I've been turning over <strong>in</strong> my mind ever since.</div>";
+    const { preSplit, postSplit } = splitMarkup(exampleMarkup, 75);
+    expect(preSplit).toEqual(
+      "<div>In <a href='http://things' fake='<<>>>><<//'>my younger</a> and more <p>vulnerable <strong>years my<ul><li>father</li><li>gave</li></ul>me</strong> some </p>advice</div>",
+    );
+    expect(postSplit).toEqual(
+      " <div>that I've been turning over <strong>in</strong> my mind ever since.</div>",
+    );
+  });
 });
 
 describe("findFirstWhitespace", () => {


### PR DESCRIPTION
## Summary
Fixes #2776

### Time to review: __10 mins__

## Changes proposed

A bug exists in the markup parsing functionality that splits opportunity description strings, such that when content is provided that contains forward slashes within a tag that are not closing tag indicators, the parsing breaks. This means anything with a link tag likely will break, ex. `<a href="http://google.com">`.

This adds functionality to the parsing to ignore anything that is contained in quotes within a tag.

Along with this, the example opportunities that exhibited the bug also exhibited cases where the majority of the description is wrapped in a single tag, creating a case where the parser is essentially unable to split the content without breaking the markup. In this case, I'm assuming we'd want to hide the "show more" link, as it doesn't do anything, so I implemented that as well.

## Context for reviewers

### Examples of problematic opportunities
* 356878
* 356877
* 356876
* 309362 

### Test steps

1. obtain creds to connect to the PROD API and add them to your .env.development file
2. on this branch, visit the detail page for each opportunity
3. _VERIFY_: the page loads with no 500 or 404
4. _VERIFY_: description content is either collapsed after a reasonable amount of characters, or if not collapsed, does not show a "show more" button


## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

