### PR TITLE
[Issue #2440] Update Header.tsx for index link

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -84,6 +84,8 @@ const Header = ({ logoPath, locale }: Props) => {
     setIsMobileNavExpanded(!isMobileNavExpanded);
   };
   const language = locale && locale.match("/^es/") ? "spanish" : "english";
+  const title =
+    usePathname() === "/" ? t("title") : <Link href="/">{t("title")}</Link>;
 
   return (
     <>
@@ -105,7 +107,7 @@ const Header = ({ logoPath, locale }: Props) => {
                     />
                   </span>
                 )}
-                <span className="font-sans-lg flex-fill">{t("title")}</span>
+                <span className="font-sans-lg flex-fill">{title}</span>
               </div>
             </Title>
             <NavMenuButton

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -74,4 +74,21 @@ describe("Header", () => {
     expect(searchLink).toBeInTheDocument();
     expect(searchLink).toHaveAttribute("href", "/search?refresh=true");
   });
+
+  it("displays a home link if not on home page", () => {
+    render(<Header />);
+
+    const homeLink = screen.getByRole("link", { name: "Simpler.Grants.gov" });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  it("display text without a home link if on home page", () => {
+    mockedPath = "/";
+    render(<Header />);
+
+    const homeText = screen.getByText("Simpler.Grants.gov");
+    expect(homeText).toBeInTheDocument();
+    expect(homeText).not.toHaveAttribute("href", "/");
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #2440

### Time to review: __5 mins__

## Changes proposed
Add link to site name in the header. Removes link if you are on the homepage. I don't love the user experience of sites that don't do that with their logo.

I looked at testing the link change but couldn't get it working timeboxing myself https://github.com/vercel/next.js/discussions/42527 . 