### PR TITLE
[Issue #2847] Hide v0/v0.1 opportunity endpoints from swagger

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -21,8 +21,6 @@ info:
   version: v0
 tags:
 - name: Health
-- name: Opportunity v0
-- name: Opportunity v0.1
 - name: Opportunity v1
 servers: .
 paths:
@@ -45,60 +43,6 @@ paths:
       tags:
       - Health
       summary: Health
-  /v0/opportunities/search:
-    post:
-      parameters:
-      - in: header
-        name: FF-Enable-Opportunity-Log-Msg
-        description: Whether to log a message in the opportunity endpoint
-        schema:
-          type: boolean
-        required: false
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OpportunitySearchResponseV0'
-          description: Successful response
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Validation error
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Authentication error
-      tags:
-      - Opportunity v0
-      summary: Opportunity Search
-      description: '
-
-        __ALPHA VERSION__
-
-
-        This endpoint in its current form is primarily for testing and feedback.
-
-
-        Features in this endpoint are still under heavy development, and subject to
-        change. Not for production use.
-
-
-        See [Release Phases](https://github.com/github/roadmap?tab=readme-ov-file#release-phases)
-        for further details.
-
-        '
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OpportunitySearch'
-      security:
-      - ApiKeyAuth: []
   /v1/opportunities/search:
     post:
       parameters: []
@@ -253,143 +197,6 @@ paths:
                     sort_direction: descending
       security:
       - ApiKeyAuth: []
-  /v0.1/opportunities/search:
-    post:
-      parameters: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OpportunitySearchResponseV01'
-          description: Successful response
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Validation error
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Authentication error
-      tags:
-      - Opportunity v0.1
-      summary: Opportunity Search
-      description: '
-
-        __ALPHA VERSION__
-
-
-        This endpoint in its current form is primarily for testing and feedback.
-
-
-        Features in this endpoint are still under heavy development, and subject to
-        change. Not for production use.
-
-
-        See [Release Phases](https://github.com/github/roadmap?tab=readme-ov-file#release-phases)
-        for further details.
-
-        '
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OpportunitySearchRequestV01'
-            examples:
-              example1:
-                summary: No filters
-                value:
-                  pagination:
-                    order_by: opportunity_id
-                    page_offset: 1
-                    page_size: 25
-                    sort_direction: ascending
-              example2:
-                summary: All filters
-                value:
-                  query: research
-                  filters:
-                    agency:
-                      one_of:
-                      - US-ABC
-                      - HHS
-                    applicant_type:
-                      one_of:
-                      - state_governments
-                      - county_governments
-                      - individuals
-                    funding_category:
-                      one_of:
-                      - recovery_act
-                      - arts
-                      - natural_resources
-                    funding_instrument:
-                      one_of:
-                      - cooperative_agreement
-                      - grant
-                    opportunity_status:
-                      one_of:
-                      - forecasted
-                      - posted
-                  pagination:
-                    order_by: opportunity_id
-                    page_offset: 1
-                    page_size: 25
-                    sort_direction: descending
-      security:
-      - ApiKeyAuth: []
-  /v0/opportunities/{opportunity_id}:
-    get:
-      parameters:
-      - in: path
-        name: opportunity_id
-        schema:
-          type: integer
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OpportunityGetResponseV0'
-          description: Successful response
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Authentication error
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-      tags:
-      - Opportunity v0
-      summary: Opportunity Get
-      description: '
-
-        __ALPHA VERSION__
-
-
-        This endpoint in its current form is primarily for testing and feedback.
-
-
-        Features in this endpoint are still under heavy development, and subject to
-        change. Not for production use.
-
-
-        See [Release Phases](https://github.com/github/roadmap?tab=readme-ov-file#release-phases)
-        for further details.
-
-        '
-      security:
-      - ApiKeyAuth: []
   /v1/opportunities/{opportunity_id}:
     get:
       parameters:
@@ -419,54 +226,6 @@ paths:
           description: Not found
       tags:
       - Opportunity v1
-      summary: Opportunity Get
-      description: '
-
-        __ALPHA VERSION__
-
-
-        This endpoint in its current form is primarily for testing and feedback.
-
-
-        Features in this endpoint are still under heavy development, and subject to
-        change. Not for production use.
-
-
-        See [Release Phases](https://github.com/github/roadmap?tab=readme-ov-file#release-phases)
-        for further details.
-
-        '
-      security:
-      - ApiKeyAuth: []
-  /v0.1/opportunities/{opportunity_id}:
-    get:
-      parameters:
-      - in: path
-        name: opportunity_id
-        schema:
-          type: integer
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/OpportunityGetResponseV01'
-          description: Successful response
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Authentication error
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: Not found
-      tags:
-      - Opportunity v0.1
       summary: Opportunity Get
       description: '
 
@@ -591,180 +350,6 @@ components:
           type: string
           description: An internal tracking ID
           example: 550e8400-e29b-41d4-a716-446655440000
-    OpportunitySorting:
-      type: object
-      properties:
-        order_by:
-          type: string
-          enum:
-          - opportunity_id
-          - agency
-          - opportunity_number
-          - created_at
-          - updated_at
-          description: The field to sort the response by
-        sort_direction:
-          description: Whether to sort the response ascending or descending
-          enum:
-          - ascending
-          - descending
-          type:
-          - string
-      required:
-      - order_by
-      - sort_direction
-    Pagination:
-      type: object
-      properties:
-        page_size:
-          type: integer
-          minimum: 1
-          description: The size of the page to fetch
-          example: 25
-        page_offset:
-          type: integer
-          minimum: 1
-          description: The page number to fetch, starts counting from 1
-          example: 1
-      required:
-      - page_offset
-      - page_size
-    OpportunitySearch:
-      type: object
-      properties:
-        opportunity_title:
-          type: string
-          description: The title of the opportunity to search for
-          example: research
-        category:
-          description: The opportunity category to search for
-          example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategoryLegacy
-          - D
-          enum:
-          - D
-          - M
-          - C
-          - E
-          - O
-          type:
-          - string
-        sorting:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunitySorting'
-        paging:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/Pagination'
-      required:
-      - paging
-      - sorting
-    PaginationInfo:
-      type: object
-      properties:
-        page_offset:
-          type: integer
-          description: The page number that was fetched
-          example: 1
-        page_size:
-          type: integer
-          description: The size of the page fetched
-          example: 25
-        total_records:
-          type: integer
-          description: The total number of records fetchable
-          example: 42
-        total_pages:
-          type: integer
-          description: The total number of pages that can be fetched
-          example: 2
-        order_by:
-          type: string
-          description: The field that the records were sorted by
-          example: id
-        sort_direction:
-          description: The direction the records are sorted
-          enum:
-          - ascending
-          - descending
-          type:
-          - string
-    OpportunityV0:
-      type: object
-      properties:
-        opportunity_id:
-          type: integer
-          readOnly: true
-          description: The internal ID of the opportunity
-          example: 12345
-        opportunity_number:
-          type: string
-          description: The funding opportunity number
-          example: ABC-123-XYZ-001
-        opportunity_title:
-          type: string
-          description: The title of the opportunity
-          example: Research into conservation techniques
-        agency:
-          type: string
-          description: The agency who created the opportunity
-          example: US-ABC
-        category:
-          description: The opportunity category
-          example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategoryLegacy
-          - D
-          enum:
-          - D
-          - M
-          - C
-          - E
-          - O
-          type:
-          - string
-        category_explanation:
-          type: string
-          description: Explanation of the category when the category is 'O' (other)
-          example: null
-        revision_number:
-          type: integer
-          description: The current revision number of the opportunity, counting starts
-            at 0
-          example: 0
-        modified_comments:
-          type: string
-          description: Details regarding what modification was last made
-          example: null
-        created_at:
-          type: string
-          format: date-time
-          readOnly: true
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
-    OpportunitySearchResponseV0:
-      type: object
-      properties:
-        pagination_info:
-          description: The pagination information for paginated endpoints
-          type: &id001
-          - object
-          allOf:
-          - $ref: '#/components/schemas/PaginationInfo'
-        message:
-          type: string
-          description: The message to return
-          example: Success
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpportunityV0'
-        status_code:
-          type: integer
-          description: The HTTP status code
-          example: 200
     FundingInstrumentFilterV1:
       type: object
       properties:
@@ -1124,6 +709,36 @@ components:
           - string
       required:
       - pagination
+    PaginationInfo:
+      type: object
+      properties:
+        page_offset:
+          type: integer
+          description: The page number that was fetched
+          example: 1
+        page_size:
+          type: integer
+          description: The size of the page fetched
+          example: 25
+        total_records:
+          type: integer
+          description: The total number of records fetchable
+          example: 42
+        total_pages:
+          type: integer
+          description: The total number of pages that can be fetched
+          example: 2
+        order_by:
+          type: string
+          description: The field that the records were sorted by
+          example: id
+        sort_direction:
+          description: The direction the records are sorted
+          enum:
+          - ascending
+          - descending
+          type:
+          - string
     OpportunityAssistanceListingV1:
       type: object
       properties:
@@ -1424,7 +1039,7 @@ components:
           description: The opportunity category
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategory
           - discretionary
-          enum: &id002
+          enum: &id001
           - discretionary
           - mandatory
           - continuation
@@ -1443,12 +1058,12 @@ components:
         opportunity_assistance_listings:
           type: array
           items:
-            type: &id003
+            type: &id002
             - object
             allOf:
             - $ref: '#/components/schemas/OpportunityAssistanceListingV1'
         summary:
-          type: &id004
+          type: &id003
           - object
           allOf:
           - $ref: '#/components/schemas/OpportunitySummaryV1'
@@ -1456,12 +1071,12 @@ components:
           description: The current status of the opportunity
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityStatus
           - posted
-          enum: &id005
+          enum: &id004
           - forecasted
           - posted
           - closed
           - archived
-          type: &id006
+          type: &id005
           - string
         created_at:
           type: string
@@ -1521,7 +1136,8 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id001
+          type:
+          - object
           allOf:
           - $ref: '#/components/schemas/PaginationInfo'
         message:
@@ -1542,495 +1158,6 @@ components:
           - object
           allOf:
           - $ref: '#/components/schemas/OpportunityFacetV1'
-    FundingInstrumentFilterV01:
-      type: object
-      properties:
-        one_of:
-          type: array
-          minItems: 1
-          items:
-            enum:
-            - cooperative_agreement
-            - grant
-            - procurement_contract
-            - other
-            type:
-            - string
-    FundingCategoryFilterV01:
-      type: object
-      properties:
-        one_of:
-          type: array
-          minItems: 1
-          items:
-            enum:
-            - recovery_act
-            - agriculture
-            - arts
-            - business_and_commerce
-            - community_development
-            - consumer_protection
-            - disaster_prevention_and_relief
-            - education
-            - employment_labor_and_training
-            - energy
-            - environment
-            - food_and_nutrition
-            - health
-            - housing
-            - humanities
-            - infrastructure_investment_and_jobs_act
-            - information_and_statistics
-            - income_security_and_social_services
-            - law_justice_and_legal_services
-            - natural_resources
-            - opportunity_zone_benefits
-            - regional_development
-            - science_technology_and_other_research_and_development
-            - transportation
-            - affordable_care_act
-            - other
-            type:
-            - string
-    ApplicantTypeFilterV01:
-      type: object
-      properties:
-        one_of:
-          type: array
-          minItems: 1
-          items:
-            enum:
-            - state_governments
-            - county_governments
-            - city_or_township_governments
-            - special_district_governments
-            - independent_school_districts
-            - public_and_state_institutions_of_higher_education
-            - private_institutions_of_higher_education
-            - federally_recognized_native_american_tribal_governments
-            - other_native_american_tribal_organizations
-            - public_and_indian_housing_authorities
-            - nonprofits_non_higher_education_with_501c3
-            - nonprofits_non_higher_education_without_501c3
-            - individuals
-            - for_profit_organizations_other_than_small_businesses
-            - small_businesses
-            - other
-            - unrestricted
-            type:
-            - string
-    OpportunityStatusFilterV01:
-      type: object
-      properties:
-        one_of:
-          type: array
-          minItems: 1
-          items:
-            enum:
-            - forecasted
-            - posted
-            - closed
-            - archived
-            type:
-            - string
-    AgencyFilterV01:
-      type: object
-      properties:
-        one_of:
-          type: array
-          minItems: 1
-          items:
-            type: string
-            minLength: 2
-            example: US-ABC
-    OpportunitySearchFilterV01:
-      type: object
-      properties:
-        funding_instrument:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/FundingInstrumentFilterV01'
-        funding_category:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/FundingCategoryFilterV01'
-        applicant_type:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/ApplicantTypeFilterV01'
-        opportunity_status:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunityStatusFilterV01'
-        agency:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/AgencyFilterV01'
-    OpportunityPagination:
-      type: object
-      properties:
-        order_by:
-          type: string
-          enum:
-          - opportunity_id
-          - opportunity_number
-          - opportunity_title
-          - post_date
-          - close_date
-          - agency_code
-          description: The field to sort the response by
-        sort_direction:
-          description: Whether to sort the response ascending or descending
-          enum:
-          - ascending
-          - descending
-          type:
-          - string
-        page_size:
-          type: integer
-          minimum: 1
-          description: The size of the page to fetch
-          example: 25
-        page_offset:
-          type: integer
-          minimum: 1
-          description: The page number to fetch, starts counting from 1
-          example: 1
-      required:
-      - order_by
-      - page_offset
-      - page_size
-      - sort_direction
-    OpportunitySearchRequestV01:
-      type: object
-      properties:
-        query:
-          type: string
-          minLength: 1
-          maxLength: 100
-          description: Query string which searches against several text fields
-          example: research
-        filters:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunitySearchFilterV01'
-        pagination:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunityPagination'
-      required:
-      - pagination
-    OpportunityAssistanceListingV01:
-      type: object
-      properties:
-        program_title:
-          type: string
-          description: The name of the program, see https://sam.gov/content/assistance-listings
-            for more detail
-          example: Space Technology
-        assistance_listing_number:
-          type: string
-          description: The assistance listing number, see https://sam.gov/content/assistance-listings
-            for more detail
-          example: '43.012'
-    OpportunitySummaryV01:
-      type: object
-      properties:
-        summary_description:
-          type: string
-          description: The summary of the opportunity
-          example: This opportunity aims to unravel the mysteries of the universe.
-        is_cost_sharing:
-          type: boolean
-          description: Whether or not the opportunity has a cost sharing/matching
-            requirement
-        is_forecast:
-          type: boolean
-          description: Whether the opportunity is forecasted, that is, the information
-            is only an estimate and not yet official
-          example: false
-        close_date:
-          type: string
-          format: date
-          description: The date that the opportunity will close - only set if is_forecast=False
-        close_date_description:
-          type: string
-          description: Optional details regarding the close date
-          example: Proposals are due earlier than usual.
-        post_date:
-          type: string
-          format: date
-          description: The date the opportunity was posted
-        archive_date:
-          type: string
-          format: date
-          description: When the opportunity will be archived
-        expected_number_of_awards:
-          type: integer
-          description: The number of awards the opportunity is expected to award
-          example: 10
-        estimated_total_program_funding:
-          type: integer
-          description: The total program funding of the opportunity in US Dollars
-          example: 10000000
-        award_floor:
-          type: integer
-          description: The minimum amount an opportunity would award
-          example: 10000
-        award_ceiling:
-          type: integer
-          description: The maximum amount an opportunity would award
-          example: 100000
-        additional_info_url:
-          type: string
-          description: A URL to a website that can provide additional information
-            about the opportunity
-          example: grants.gov
-        additional_info_url_description:
-          type: string
-          description: The text to display for the additional_info_url link
-          example: Click me for more info
-        forecasted_post_date:
-          type: string
-          format: date
-          description: Forecasted opportunity only. The date the opportunity is expected
-            to be posted, and transition out of being a forecast
-        forecasted_close_date:
-          type: string
-          format: date
-          description: Forecasted opportunity only. The date the opportunity is expected
-            to be close once posted.
-        forecasted_close_date_description:
-          type: string
-          description: Forecasted opportunity only. Optional details regarding the
-            forecasted closed date.
-          example: Proposals will probably be due on this date
-        forecasted_award_date:
-          type: string
-          format: date
-          description: Forecasted opportunity only. The date the grantor plans to
-            award the opportunity.
-        forecasted_project_start_date:
-          type: string
-          format: date
-          description: Forecasted opportunity only. The date the grantor expects the
-            award recipient should start their project
-        fiscal_year:
-          type: integer
-          description: Forecasted opportunity only. The fiscal year the project is
-            expected to be funded and launched
-        funding_category_description:
-          type: string
-          description: Additional information about the funding category
-          example: Economic Support
-        applicant_eligibility_description:
-          type: string
-          description: Additional information about the types of applicants that are
-            eligible
-          example: All types of domestic applicants are eligible to apply
-        agency_code:
-          type: string
-          description: The agency who owns the opportunity
-          example: US-ABC
-        agency_name:
-          type: string
-          description: The name of the agency who owns the opportunity
-          example: US Alphabetical Basic Corp
-        agency_phone_number:
-          type: string
-          description: The phone number of the agency who owns the opportunity
-          example: 123-456-7890
-        agency_contact_description:
-          type: string
-          description: Information regarding contacting the agency who owns the opportunity
-          example: For more information, reach out to Jane Smith at agency US-ABC
-        agency_email_address:
-          type: string
-          description: The contact email of the agency who owns the opportunity
-          example: fake_email@grants.gov
-        agency_email_address_description:
-          type: string
-          description: The text for the link to the agency email address
-          example: Click me to email the agency
-        funding_instruments:
-          type: array
-          items:
-            enum:
-            - cooperative_agreement
-            - grant
-            - procurement_contract
-            - other
-            type:
-            - string
-        funding_categories:
-          type: array
-          items:
-            enum:
-            - recovery_act
-            - agriculture
-            - arts
-            - business_and_commerce
-            - community_development
-            - consumer_protection
-            - disaster_prevention_and_relief
-            - education
-            - employment_labor_and_training
-            - energy
-            - environment
-            - food_and_nutrition
-            - health
-            - housing
-            - humanities
-            - infrastructure_investment_and_jobs_act
-            - information_and_statistics
-            - income_security_and_social_services
-            - law_justice_and_legal_services
-            - natural_resources
-            - opportunity_zone_benefits
-            - regional_development
-            - science_technology_and_other_research_and_development
-            - transportation
-            - affordable_care_act
-            - other
-            type:
-            - string
-        applicant_types:
-          type: array
-          items:
-            enum:
-            - state_governments
-            - county_governments
-            - city_or_township_governments
-            - special_district_governments
-            - independent_school_districts
-            - public_and_state_institutions_of_higher_education
-            - private_institutions_of_higher_education
-            - federally_recognized_native_american_tribal_governments
-            - other_native_american_tribal_organizations
-            - public_and_indian_housing_authorities
-            - nonprofits_non_higher_education_with_501c3
-            - nonprofits_non_higher_education_without_501c3
-            - individuals
-            - for_profit_organizations_other_than_small_businesses
-            - small_businesses
-            - other
-            - unrestricted
-            type:
-            - string
-    OpportunityV01:
-      type: object
-      properties:
-        opportunity_id:
-          type: integer
-          readOnly: true
-          description: The internal ID of the opportunity
-          example: 12345
-        opportunity_number:
-          type: string
-          description: The funding opportunity number
-          example: ABC-123-XYZ-001
-        opportunity_title:
-          type: string
-          description: The title of the opportunity
-          example: Research into conservation techniques
-        agency:
-          type: string
-          description: The agency who created the opportunity
-          example: US-ABC
-        agency_code:
-          type: string
-          description: The agency who created the opportunity
-          example: US-ABC
-        category:
-          description: The opportunity category
-          example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategory
-          - discretionary
-          enum:
-          - discretionary
-          - mandatory
-          - continuation
-          - earmark
-          - other
-          type:
-          - string
-        category_explanation:
-          type: string
-          description: Explanation of the category when the category is 'O' (other)
-          example: null
-        opportunity_assistance_listings:
-          type: array
-          items:
-            type:
-            - object
-            allOf:
-            - $ref: '#/components/schemas/OpportunityAssistanceListingV01'
-        summary:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunitySummaryV01'
-        opportunity_status:
-          description: The current status of the opportunity
-          example: !!python/object/apply:src.constants.lookup_constants.OpportunityStatus
-          - posted
-          enum:
-          - forecasted
-          - posted
-          - closed
-          - archived
-          type:
-          - string
-        created_at:
-          type: string
-          format: date-time
-          readOnly: true
-        updated_at:
-          type: string
-          format: date-time
-          readOnly: true
-    OpportunitySearchResponseV01:
-      type: object
-      properties:
-        pagination_info:
-          description: The pagination information for paginated endpoints
-          type: *id001
-          allOf:
-          - $ref: '#/components/schemas/PaginationInfo'
-        message:
-          type: string
-          description: The message to return
-          example: Success
-        data:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpportunityV01'
-        status_code:
-          type: integer
-          description: The HTTP status code
-          example: 200
-    OpportunityGetResponseV0:
-      type: object
-      properties:
-        message:
-          type: string
-          description: The message to return
-          example: Success
-        data:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunityV0'
-        status_code:
-          type: integer
-          description: The HTTP status code
-          example: 200
     OpportunityAttachmentV1:
       type: object
       properties:
@@ -2118,7 +1245,7 @@ components:
           description: The opportunity category
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategory
           - discretionary
-          enum: *id002
+          enum: *id001
           type:
           - string
           - 'null'
@@ -2132,19 +1259,19 @@ components:
         opportunity_assistance_listings:
           type: array
           items:
-            type: *id003
+            type: *id002
             allOf:
             - $ref: '#/components/schemas/OpportunityAssistanceListingV1'
         summary:
-          type: *id004
+          type: *id003
           allOf:
           - $ref: '#/components/schemas/OpportunitySummaryV1'
         opportunity_status:
           description: The current status of the opportunity
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityStatus
           - posted
-          enum: *id005
-          type: *id006
+          enum: *id004
+          type: *id005
         created_at:
           type: string
           format: date-time
@@ -2173,22 +1300,6 @@ components:
           - object
           allOf:
           - $ref: '#/components/schemas/OpportunityWithAttachmentsV1'
-        status_code:
-          type: integer
-          description: The HTTP status code
-          example: 200
-    OpportunityGetResponseV01:
-      type: object
-      properties:
-        message:
-          type: string
-          description: The message to return
-          example: Success
-        data:
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunityV01'
         status_code:
           type: integer
           description: The HTTP status code
@@ -2230,4 +1341,3 @@ components:
       type: apiKey
       in: header
       name: X-Auth
-

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -1341,3 +1341,4 @@ components:
       type: apiKey
       in: header
       name: X-Auth
+

--- a/api/src/api/opportunities_v0/opportunity_blueprint.py
+++ b/api/src/api/opportunities_v0/opportunity_blueprint.py
@@ -1,5 +1,12 @@
 from apiflask import APIBlueprint
 
 opportunity_blueprint = APIBlueprint(
-    "opportunity_v0", __name__, tag="Opportunity v0", cli_group="opportunity_v0", url_prefix="/v0"
+    "opportunity_v0",
+    __name__,
+    tag="Opportunity v0",
+    cli_group="opportunity_v0",
+    url_prefix="/v0",
+    # Before we fully deprecate the v0 endpoints
+    # we want to hide them from Swagger/OpenAPI
+    enable_openapi=False,
 )

--- a/api/src/api/opportunities_v0_1/opportunity_blueprint.py
+++ b/api/src/api/opportunities_v0_1/opportunity_blueprint.py
@@ -6,4 +6,7 @@ opportunity_blueprint = APIBlueprint(
     tag="Opportunity v0.1",
     cli_group="opportunity_v0_1",
     url_prefix="/v0.1",
+    # Before we fully deprecate the v0.1 endpoints
+    # we want to hide them from Swagger/OpenAPI
+    enable_openapi=False,
 )


### PR DESCRIPTION
## Summary
Fixes #2847

### Time to review: __3 mins__

## Changes proposed
Hide the v0/v0.1 endpoints from the OpenAPI docs

## Context for reviewers
The endpoints will continue to function, we just tell the processes that APIFlask uses to generate the OpenAPI spec to skip these endpoints. The endpoints continue to work uneventfully.

Note: we use these already for a few things, as we also use blueprints to define backend API tasks with this flag set.

## Additional information
What things look like now:
![Screenshot 2024-11-13 at 4 40 21 PM](https://github.com/user-attachments/assets/27505e2c-8ee5-4233-b146-ebb8aeafb389)

