### PR TITLE
[Issue #2833] Turn off comment in sprint reporting linter

### DIFF
--- a/.github/linters/scripts/set-points-and-sprint.sh
+++ b/.github/linters/scripts/set-points-and-sprint.sh
@@ -200,19 +200,3 @@ if jq -e ".sprint == null" $item_data_file > /dev/null; then
 else
     echo "Sprint value already set for issue: ${issue_url}"
 fi
-
-# #######################################################
-# Set the sprint value, if empty
-# #######################################################
-
-comment="Beep boop: Automatically setting the point and sprint values for this issue "
-comment+="in project ${org}/${project} because they were unset when the issue was closed."
-
-# Skip actual posting in dry-run mode
-if [[ $dry_run == "YES" ]]; then
-  echo "Would post comment: ${comment}"
-# otherwise post the comment
-else
-  gh issue comment "${issue_url}" \
-    --body "${comment}"
-fi

--- a/.github/workflows/lint-set-points-and-sprint.yml
+++ b/.github/workflows/lint-set-points-and-sprint.yml
@@ -13,6 +13,10 @@ jobs:
   run-project-linters:
     name: Run set points and sprint values on close
     runs-on: ubuntu-latest
+    # Prevents duplicate runs of this linter for the same issue
+    concurrency:
+      group: issue-${{ github.event.issue.number }}
+      cancel-in-progress: true
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN_PROJECT_ACCESS }}
       ISSUE_URL: ${{ github.event.issue.html_url }}


### PR DESCRIPTION
## Summary

Removes the step in which a comment is posted to an issue that is closed without a sprint or story points. This was per @coilysiren and @mxk0 request to help reduce noise on tickets.

Fixes #2833 

### Time to review: __2 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Removes comment step - details are still being written to the action log
- Limits concurrency to 1 - which prevents this linter from running multiple times on the same issue when it's closed

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This is hard to test until we merge it, but once we do issue #2833 should get the sprint and points value set, without a comment being posted.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Dry-run no longer includes comment step:

<img width="895" alt="Screenshot 2024-11-14 at 10 13 14 AM" src="https://github.com/user-attachments/assets/6da5963d-4eca-4b66-b7f2-58a8e0fe51e5">
