### PR TITLE
[Issue #2619] hide mobile nav under correct conditions

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import clsx from "clsx";
 import { assetPath } from "src/utils/assetPath";
 
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   GovBanner,
   NavMenuButton,
@@ -29,7 +30,7 @@ const NavLinks = ({
   onToggleMobileNav,
 }: {
   mobileExpanded: boolean;
-  onToggleMobileNav: () => unknown;
+  onToggleMobileNav: () => void;
 }) => {
   const t = useTranslations("Header");
   const path = usePathname();
@@ -61,17 +62,26 @@ const NavLinks = ({
       }
       return (
         <Link href={link.href} key={link.href}>
-          {link.text}
+          {" "}
+          <span
+            onClick={() => {
+              if (mobileExpanded) {
+                onToggleMobileNav();
+              }
+            }}
+          >
+            {link.text}
+          </span>
         </Link>
       );
     });
-  }, [navLinkList]);
+  }, [navLinkList, mobileExpanded, onToggleMobileNav]);
 
   return (
     <PrimaryNav
       items={navItems}
       mobileExpanded={mobileExpanded}
-      onToggleMobileNav={onToggleMobileNav}
+      onToggleMobileNav={() => onToggleMobileNav()}
     ></PrimaryNav>
   );
 };
@@ -83,12 +93,38 @@ const Header = ({ logoPath, locale }: Props) => {
   const handleMobileNavToggle = () => {
     setIsMobileNavExpanded(!isMobileNavExpanded);
   };
+
+  const closeMenuOnEscape = useCallback((event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      setIsMobileNavExpanded(false);
+    }
+  }, []);
+
   const language = locale && locale.match("/^es/") ? "spanish" : "english";
+
+  // does this work? if so, need to fix up the typing
+  useEffect(() => {
+    if (isMobileNavExpanded) {
+      document.addEventListener("keyup", closeMenuOnEscape);
+    }
+    return () => {
+      document.removeEventListener("keyup", closeMenuOnEscape);
+    };
+  }, [isMobileNavExpanded, closeMenuOnEscape]);
 
   return (
     <>
       <div
-        className={`usa-overlay ${isMobileNavExpanded ? "is-visible" : ""}`}
+        className={clsx({
+          "usa-overlay": true,
+          "desktop:display-none": true,
+          "is-visible": isMobileNavExpanded,
+        })}
+        onClick={() => {
+          if (isMobileNavExpanded) {
+            setIsMobileNavExpanded(false);
+          }
+        }}
       />
       <GovBanner language={language} />
       <USWDSHeader basic={true}>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -90,9 +90,6 @@ const Header = ({ logoPath, locale }: Props) => {
   const t = useTranslations("Header");
   const [isMobileNavExpanded, setIsMobileNavExpanded] =
     useState<boolean>(false);
-  const handleMobileNavToggle = () => {
-    setIsMobileNavExpanded(!isMobileNavExpanded);
-  };
 
   const closeMenuOnEscape = useCallback((event: KeyboardEvent) => {
     if (event.key === "Escape") {
@@ -100,9 +97,6 @@ const Header = ({ logoPath, locale }: Props) => {
     }
   }, []);
 
-  const language = locale && locale.match("/^es/") ? "spanish" : "english";
-
-  // does this work? if so, need to fix up the typing
   useEffect(() => {
     if (isMobileNavExpanded) {
       document.addEventListener("keyup", closeMenuOnEscape);
@@ -111,6 +105,12 @@ const Header = ({ logoPath, locale }: Props) => {
       document.removeEventListener("keyup", closeMenuOnEscape);
     };
   }, [isMobileNavExpanded, closeMenuOnEscape]);
+
+  const language = locale && locale.match("/^es/") ? "spanish" : "english";
+
+  const handleMobileNavToggle = () => {
+    setIsMobileNavExpanded(!isMobileNavExpanded);
+  };
 
   return (
     <>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -62,8 +62,7 @@ const NavLinks = ({
       }
       return (
         <Link href={link.href} key={link.href}>
-          {" "}
-          <span
+          <div
             onClick={() => {
               if (mobileExpanded) {
                 onToggleMobileNav();
@@ -71,7 +70,7 @@ const NavLinks = ({
             }}
           >
             {link.text}
-          </span>
+          </div>
         </Link>
       );
     });
@@ -81,7 +80,7 @@ const NavLinks = ({
     <PrimaryNav
       items={navItems}
       mobileExpanded={mobileExpanded}
-      onToggleMobileNav={() => onToggleMobileNav()}
+      onToggleMobileNav={onToggleMobileNav}
     ></PrimaryNav>
   );
 };

--- a/frontend/tests/e2e/index.spec.ts
+++ b/frontend/tests/e2e/index.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable testing-library/prefer-screen-queries */
 import { expect, test } from "@playwright/test";
-import { PageProps } from "tests/e2e/playwrightUtils";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");

--- a/frontend/tests/e2e/playwrightUtils.ts
+++ b/frontend/tests/e2e/playwrightUtils.ts
@@ -1,0 +1,7 @@
+import { BrowserContextOptions, Page } from "@playwright/test";
+
+export interface PageProps {
+  page: Page;
+  browserName?: string;
+  contextOptions?: BrowserContextOptions;
+}

--- a/frontend/tests/e2e/search/search-loading.spec.ts
+++ b/frontend/tests/e2e/search/search-loading.spec.ts
@@ -14,7 +14,9 @@ test.describe("Search page tests", () => {
 
     const page = await browser.newPage();
     await page.goto("/search");
-    const loadingIndicator = page.getByTestId("loading-message");
+    const loadingIndicator = page.locator(
+      'span[data-testid="loading-message"]',
+    );
 
     await fillSearchInputAndSubmit(searchTerm, page);
     await expect(loadingIndicator).toBeVisible();

--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -1,6 +1,5 @@
-import { expect, Page, test } from "@playwright/test";
-import { BrowserContextOptions } from "playwright-core";
-
+import { expect, test } from "@playwright/test";
+import { PageProps } from "tests/e2e/playwrightUtils";
 import {
   clickAccordionWithTitle,
   clickLastPaginationPage,
@@ -18,13 +17,7 @@ import {
   toggleCheckboxes,
   toggleMobileSearchFilters,
   waitForSearchResultsInitialLoad,
-} from "./searchSpecUtil";
-
-interface PageProps {
-  page: Page;
-  browserName?: string;
-  contextOptions?: BrowserContextOptions;
-}
+} from "tests/e2e/search/searchSpecUtil";
 
 test.describe("Search page tests", () => {
   test("should refresh and retain filters in a new tab", async ({ page }, {


### PR DESCRIPTION
## Summary
Fixes #2619

### Time to review: __15 mins__

## Changes proposed

Handles 4 conditions where we are not currently hiding the mobile nav but should be

## Context for reviewers
### Test steps

1. on this branch, open up the app in a tablet or mobile sized viewport (less than 1024px wide)
2. open the mobile menu by clicking "menu"
3. click a menu option
4. _VERIFY_: the menu closes
5. reopen the menu
6. click somewhere in the app other than the menu
4. _VERIFY_: the menu closes
5. reopen the menu
6. press the escape key on your keyboard
4. _VERIFY_: the menu closes
5. reopen the menu
6. resize your viewport above 1024px
4. _VERIFY_: the menu closes
9. resize your menu back below 1024px
10. _VERIFY_: the menu automatically reopens (since it was not explicitly closed - not sure if this is desired behavior but it's what we've got right now without introducing JS media queries, which I think we should try to avoid)

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

