### PR TITLE
[Issues #2662 and #2663] Turn on Sprinty McBurndown

### DIFF
--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -1,3 +1,5 @@
+# NOTE(2024-11-15): This should be turned off once we fully migrate to Metabase
+# we're only running this temporarily as quality control for the new dashboard
 name: Analytics Checks
 
 on:

--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -39,12 +39,12 @@ jobs:
       - name: Run linting
         run: make lint
 
+      # The following tasks require github and slack tokens set in env secrets
       - name: Run tests
         run: make test-audit
 
-      # Both of these tasks are looking for github and slack auth
-      # - name: Export GitHub data
-      #   run: make gh-data-export
+      - name: Export GitHub data
+        run: make gh-data-export
 
-      # - name: Run reports
-      #   run: make sprint-reports
+      - name: Run reports
+        run: make sprint-reports

--- a/.github/workflows/run-analytics.yml
+++ b/.github/workflows/run-analytics.yml
@@ -20,8 +20,8 @@ jobs:
       ACTION: post-results # post results to slack
     steps:
       # set up python
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/run-analytics.yml
+++ b/.github/workflows/run-analytics.yml
@@ -1,0 +1,38 @@
+name: Run sprint reports
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 5 * * 1-5"
+
+defaults:
+  run:
+    working-directory: ./analytics # ensures that this job runs from the analytics sub-directory
+
+jobs:
+  run-reports:
+    name: Run sprint reports and deliverable reports
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN_PROJECT_ACCESS }}
+      ANALYTICS_SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      ANALYTICS_REPORTING_CHANNEL_ID: ${{ secrets.REPORTING_CHANNEL_ID }}
+      ACTION: post-results # post results to slack
+    steps:
+      # set up python
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      # install poetry
+      - uses: Gr1N/setup-poetry@v8
+
+      - name: Install analytics package using poetry
+        run: make install
+
+      - name: Export GitHub data
+        run: make gh-data-export
+
+      - name: Run reports
+        run: make sprint-reports

--- a/analytics/Makefile
+++ b/analytics/Makefile
@@ -26,7 +26,7 @@ SHELL = /bin/bash -o pipefail
 ifdef CI
  DOCKER_EXEC_ARGS := -T -e CI -e GH_TOKEN -e ANALYTICS_SLACK_BOT_TOKEN -e ANALYTICS_REPORTING_CHANNEL_ID
 else
- DOCKER_EXEC_ARGS := -e GH_TOKEN
+ DOCKER_EXEC_ARGS := -e GH_TOKEN -e ANALYTICS_SLACK_BOT_TOKEN -e ANALYTICS_REPORTING_CHANNEL_ID
 endif
 
 # By default, all python/poetry commands will run inside of the docker container
@@ -105,7 +105,10 @@ unit-test:
 e2e-test:
 	@echo "=> Running end-to-end tests"
 	@echo "============================="
-	$(POETRY) pytest tests/integrations --cov=src --cov-append
+	$(POETRY) pytest tests/integrations \
+		--slack-token-set \
+		--cov=src \
+		--cov-append
 
 test-audit: unit-test e2e-test
 	@echo "=> Running test coverage report"


### PR DESCRIPTION
## Summary

Turns on sprint reporting to Slack.

- Fixes #2662 
- Fixes #2663 

### Time to review: __5 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Enables Slack integration tests in `make e2e-test`
- Adds a step that runs the full ETL pipeline to `ci-analytics.yml` to prevent future PRs from breaking it
- Creates a GitHub action to run the sprint reports on a nightly basis

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We'll likely only re-enable sprint reporting through Slack for 1-2 sprints to serve as a QA check against the dashboards we're building in Metabase. Then once we have the Metabase dashboards set up, we'll turn this off again.

Also I set up the reporting in GitHub Actions (rather than AWS step functions) because we're not reading from or writing to anything in the simpler environment boundaries (e.g. Postgres) and it provides slightly tighter iteration loops without having to worry about deploying to dev, staging, etc.

If folks feel strongly about us running this in AWS though, I can adjust the PR to follow that pattern instead.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Here are the output messages in slack:
- [Sprint burndown HHS/13 (Nava board)](https://betagrantsgov.slack.com/archives/C06L7JGT9M0/p1731684072486029)
- [Sprint burndown HHS/17 (P&D board)](https://betagrantsgov.slack.com/archives/C06L7JGT9M0/p1731684081767849)
- [Percent complete by deliverable](https://betagrantsgov.slack.com/archives/C06L7JGT9M0/p1731684090063679)

Here's the exports and reporting step from the CI checks:

<img width="1043" alt="Screenshot 2024-11-15 at 10 14 47 AM" src="https://github.com/user-attachments/assets/fc4b11d5-7bf0-4423-a6de-f6dcf7c20057">
<img width="1056" alt="Screenshot 2024-11-15 at 10 15 05 AM" src="https://github.com/user-attachments/assets/02ac92b4-ec83-4eeb-859c-d1ba56f3d17b">
<img width="1046" alt="Screenshot 2024-11-15 at 10 15 18 AM" src="https://github.com/user-attachments/assets/eadef180-e88d-4469-89a7-896d6b2cee12">
<img width="1047" alt="Screenshot 2024-11-15 at 10 15 31 AM" src="https://github.com/user-attachments/assets/86879148-966a-4eeb-af70-fd230ffd4573">
