### PR TITLE
[no ticket] move drafts s3 bucket location

### DIFF
--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -147,7 +147,6 @@ module "service" {
   extra_environment_variables = merge(
     local.service_config.extra_environment_variables,
     { "ENVIRONMENT" : var.environment_name },
-    { "DRAFTS_S3_BUCKET_ARN" : aws_s3_bucket.draft_documents.arn }
   )
 
   secrets = concat(

--- a/infra/modules/service/draft_documents.tf
+++ b/infra/modules/service/draft_documents.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "draft_documents" {
-  bucket_prefix = "${local.service_name}-documents-draft"
+  bucket_prefix = "${var.service_name}-documents-draft"
   force_destroy = false
   # checkov:skip=CKV2_AWS_62:Event notification not necessary for this bucket especially due to likely use of lifecycle rules
   # checkov:skip=CKV_AWS_18:Access logging was not considered necessary for this bucket

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -29,6 +29,7 @@ locals {
   environment_variables = concat(
     local.base_environment_variables,
     local.db_environment_variables,
+    [{ name : "DRAFTS_S3_BUCKET_ARN", value : aws_s3_bucket.draft_documents.arn }],
     [
       for name, value in var.extra_environment_variables :
       { name : name, value : value }


### PR DESCRIPTION
## Summary

I really should have caught this in code review TBH ... but the s3 bucket needs to be defined inside of the module, because it uses variables only present inside of the module.

## Context

https://github.com/HHS/simpler-grants-gov/actions/runs/11898376420/job/33154738145

## Testing

```
  # module.service.aws_ecs_task_definition.app must be replaced
-/+ resource "aws_ecs_task_definition" "app" {
      ~ arn                      = "arn:aws:ecs:us-east-1:315341936575:task-definition/api-dev:272" -> (known after apply)
      ~ arn_without_revision     = "arn:aws:ecs:us-east-1:315341936575:task-definition/api-dev" -> (known after apply)
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                  ~ environment            = [
                        # (5 unchanged elements hidden)
                        {
                            name  = "DB_USER"
                            value = "app"
                        },
                      + {
                          + name  = "DRAFTS_S3_BUCKET_ARN"
                          + value = "arn:aws:s3:::api-dev-documents-draft20241118182345535400000001"
                        },
                        {
                            name  = "ENVIRONMENT"
                            value = "dev"
                        },
```