### PR TITLE
[Issue #2923] Reduce false positive alert triggering

### DIFF
--- a/infra/modules/monitoring/main.tf
+++ b/infra/modules/monitoring/main.tf
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_metric_alarm" "high_app_response_time" {
   namespace           = "AWS/ApplicationELB"
   period              = 60
   statistic           = "Average"
-  threshold           = 0.2
+  threshold           = 0.5
   alarm_description   = "High target latency alert"
   treat_missing_data  = "ignore"
   alarm_actions       = [aws_sns_topic.this.arn]


### PR DESCRIPTION
## Summary
Fixes #2923 

### Time to review: __1 mins__

## Changes proposed
Raise the alert threshold for "slow" API requests to something at is closer to the threshold at which we'd start to care how long the request is taking.

## Context for reviewers
We were getting a lot of noise from this alert firing basically every time the site got traffic, this should help avoid the noise but keep the intent of telling us if things are getting slow.

