### PR TITLE
[Issue #2938] Switch to Metabase Enterprise to allow us to enter a License

### DIFF
--- a/infra/analytics/metabase/main.tf
+++ b/infra/analytics/metabase/main.tf
@@ -84,7 +84,7 @@ module "service" {
   source       = "../../modules/service"
   service_name = local.service_name
   # https://hub.docker.com/r/metabase/metabase
-  image_repository_url     = "docker.io/metabase/metabase"
+  image_repository_url     = "docker.io/metabase/metabase-enterprise"
   image_tag                = local.image_tag
   vpc_id                   = data.aws_vpc.network.id
   public_subnet_ids        = data.aws_subnets.public.ids


### PR DESCRIPTION
## Summary
Fixes #2938 

### Time to review: __1 mins__

## Changes proposed
Switch to Metabase Enterprise image

## Context for reviewers
We need to run the Enterprise image to enter the details for our Pro license
