### PR TITLE
[Issue #1884] make artillery very aggressive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ dmypy.json
 
 # Python testing stuff
 *__pycache__*
+
+# Artilery
+frontend/tests/artillery/params.json

--- a/api/artillery-load-test.yml
+++ b/api/artillery-load-test.yml
@@ -5,17 +5,17 @@ config:
   http:
     timeout: 10
   phases:
-    - duration: 30
-      arrivalRate: 2
-      maxVusers: 50
-      name: Warm up phase
-    - duration: 30
-      arrivalRate: 28
-      maxVusers: 250
-      name: Ramp up load
-    - duration: 30
-      arrivalRate: 56
+    - duration: 600
+      arrivalRate: 1
       maxVusers: 1000
+      name: Warm up phase
+    - duration: 600
+      arrivalRate: 10
+      maxVusers: 5000
+      name: Ramp up load
+    - duration: 600
+      arrivalRate: 100
+      maxVusers: 10000
       name: Spike phase
   environments:
     prod:

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -72,7 +72,7 @@ load-test-dev: # Load test the dev environment in aws
 	artillery run -e dev artillery-load-test.yml
 
 load-test-staging: # Load test the staging environment in aws
-	artillery run -e staging artillery-load-test.yml
+	artillery run -e stage artillery-load-test.yml
 
 load-test-prod: # Load test the production environment in aws. Please test responsibly
 	artillery run -e prod artillery-load-test.yml

--- a/frontend/artillery-load-test.yml
+++ b/frontend/artillery-load-test.yml
@@ -5,17 +5,17 @@ config:
   http:
     timeout: 10
   phases:
-    - duration: 600
-      arrivalRate: 1
-      maxVusers: 1000
-      name: Warm up phase
-    - duration: 600
+    - duration: 3000
       arrivalRate: 10
       maxVusers: 5000
-      name: Ramp up load
-    - duration: 600
+      name: Warm up phase
+    - duration: 3000
       arrivalRate: 100
-      maxVusers: 10000
+      maxVusers: 25000
+      name: Ramp up load
+    - duration: 3000
+      arrivalRate: 1000
+      maxVusers: 50000
       name: Spike phase
   environments:
     local:
@@ -34,7 +34,7 @@ config:
           name: Spike phase
     prod:
       target: https://simpler.grants.gov
-    staging:
+    stage:
       target: http://frontend-staging-1506108424.us-east-1.elb.amazonaws.com
     dev:
       target: http://frontend-dev-1739892538.us-east-1.elb.amazonaws.com

--- a/frontend/artillery-load-test.yml
+++ b/frontend/artillery-load-test.yml
@@ -5,17 +5,17 @@ config:
   http:
     timeout: 10
   phases:
-    - duration: 30
-      arrivalRate: 2
-      maxVusers: 50
-      name: Warm up phase
-    - duration: 30
-      arrivalRate: 28
-      maxVusers: 250
-      name: Ramp up load
-    - duration: 30
-      arrivalRate: 56
+    - duration: 600
+      arrivalRate: 1
       maxVusers: 1000
+      name: Warm up phase
+    - duration: 600
+      arrivalRate: 10
+      maxVusers: 5000
+      name: Ramp up load
+    - duration: 600
+      arrivalRate: 100
+      maxVusers: 10000
       name: Spike phase
   environments:
     local:


### PR DESCRIPTION
## Summary

Relates to #1884

### Time to review: __2 mins__

## Changes proposed

Scales the artillery config up to "the site falls down" numbers, so that we can see exactly what the failure cases are for our website.

Unless we are testing for DDOS protection, we should never need to test artillery with higher numbers than this. These numbers are _**very**_ high.

## Context for reviewers

We tested this already in staging, and it does in fact break the site. Or at least, it does with 4 people running it.