### PR TITLE
[Issue #2943] markup split typo bugfix

### DIFF
--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -102,10 +102,6 @@ def _build_opportunities(db_session: db.Session, iterations: int, include_histor
             size=2, is_posted_summary=True, has_long_descriptions=True
         )
 
-        factories.OpportunityFactory.create_batch(
-            size=3, is_posted_summary=True, has_markup_descriptions=True
-        )
-
         if include_history:
             _add_history(forecasted_opps, add_forecast_hist=True)
             _add_history(

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -102,6 +102,10 @@ def _build_opportunities(db_session: db.Session, iterations: int, include_histor
             size=2, is_posted_summary=True, has_long_descriptions=True
         )
 
+        factories.OpportunityFactory.create_batch(
+            size=3, is_posted_summary=True, has_markup_descriptions=True
+        )
+
         if include_history:
             _add_history(forecasted_opps, add_forecast_hist=True)
             _add_history(

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -157,6 +157,8 @@ class CustomProvider(BaseProvider):
         "s3://local-opportunities/test_file_5.pdf",
     ]
 
+    MARKUP_STRING = "<div>{{paragraph}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph}}</div><div>{{paragraph}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph}}</div>"
+
     def agency_code(self) -> str:
         return self.random_element(self.AGENCIES)
 
@@ -200,6 +202,10 @@ class CustomProvider(BaseProvider):
 
     def s3_file_location(self) -> str:
         return self.random_element(self.OPPORTUNITY_ATTACHMENT_S3_PATHS)
+
+    def complex_markup_string(self) -> str:
+        return self.generator.parse(self.MARKUP_STRING)
+
 
 
 fake = faker.Faker()
@@ -342,6 +348,10 @@ class OpportunityFactory(BaseFactory):
 
         has_long_descriptions = factory.Trait(
             current_opportunity_summary__has_long_descriptions=True
+        )
+
+        has_markup_descriptions = factory.Trait(
+            current_opportunity_summary__has_markup_descriptions=True
         )
 
         # Set all nullable fields to null
@@ -582,6 +592,10 @@ class OpportunitySummaryFactory(BaseFactory):
             close_date_description=factory.Faker("paragraph", nb_sentences=30),
         )
 
+        has_markup_descriptions = factory.Trait(
+            summary_description=factory.Faker("complex_markup_string"),
+        )
+
 
 class CurrentOpportunitySummaryFactory(BaseFactory):
     class Meta:
@@ -621,6 +635,10 @@ class CurrentOpportunitySummaryFactory(BaseFactory):
 
         has_long_descriptions = factory.Trait(
             opportunity_summary__has_long_descriptions=True,
+        )
+
+        has_markup_descriptions = factory.Trait(
+            opportunity_summary__has_markup_descriptions=True,
         )
 
 

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -134,7 +134,7 @@ class CustomProvider(BaseProvider):
         "{{agency_code}} is looking to further investigate this topic. {{paragraph}}",
         "<p>{{paragraph}}</p><p><br></p><p>{{paragraph}}</p>",
         "The purpose of this Notice of Funding Opportunity (NOFO) is to support research into {{job}} and how we might {{catch_phrase}}.",
-        "<div>{{paragraph:long}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph:long}}</div> <div>{{paragraph:long}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph:long}}</div>"
+        "<div>{{paragraph:long}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph:long}}</div> <div>{{paragraph:long}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph:long}}</div>",
     ]
 
     # In the formatting, ? becomes a random letter, # becomes a random digit
@@ -157,7 +157,6 @@ class CustomProvider(BaseProvider):
         "s3://local-opportunities/test_file_4.pdf",
         "s3://local-opportunities/test_file_5.pdf",
     ]
-
 
     def agency_code(self) -> str:
         return self.random_element(self.AGENCIES)
@@ -191,7 +190,7 @@ class CustomProvider(BaseProvider):
         return self.generator.parse(pattern)
 
     def summary_description(self) -> str:
-        self.generator.set_arguments("long", { "nb_sentences": 25 })
+        self.generator.set_arguments("long", {"nb_sentences": 25})
         pattern = self.random_element(self.SUMMARY_DESCRIPTION_FORMATS)
         return self.generator.parse(pattern)
 
@@ -585,6 +584,7 @@ class OpportunitySummaryFactory(BaseFactory):
             close_date_description=factory.Faker("paragraph", nb_sentences=30),
         )
 
+
 class CurrentOpportunitySummaryFactory(BaseFactory):
     class Meta:
         model = opportunity_models.CurrentOpportunitySummary
@@ -624,6 +624,7 @@ class CurrentOpportunitySummaryFactory(BaseFactory):
         has_long_descriptions = factory.Trait(
             opportunity_summary__has_long_descriptions=True,
         )
+
 
 class OpportunityAssistanceListingFactory(BaseFactory):
     class Meta:

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -134,6 +134,7 @@ class CustomProvider(BaseProvider):
         "{{agency_code}} is looking to further investigate this topic. {{paragraph}}",
         "<p>{{paragraph}}</p><p><br></p><p>{{paragraph}}</p>",
         "The purpose of this Notice of Funding Opportunity (NOFO) is to support research into {{job}} and how we might {{catch_phrase}}.",
+        "<div>{{paragraph:long}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph:long}}</div> <div>{{paragraph:long}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph:long}}</div>"
     ]
 
     # In the formatting, ? becomes a random letter, # becomes a random digit
@@ -157,7 +158,6 @@ class CustomProvider(BaseProvider):
         "s3://local-opportunities/test_file_5.pdf",
     ]
 
-    MARKUP_STRING = "<div>{{paragraph}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph}}</div><div>{{paragraph}} <a href='{{relevant_url}}'>{{sentence}}</a> {{paragraph}}</div>"
 
     def agency_code(self) -> str:
         return self.random_element(self.AGENCIES)
@@ -191,6 +191,7 @@ class CustomProvider(BaseProvider):
         return self.generator.parse(pattern)
 
     def summary_description(self) -> str:
+        self.generator.set_arguments("long", { "nb_sentences": 25 })
         pattern = self.random_element(self.SUMMARY_DESCRIPTION_FORMATS)
         return self.generator.parse(pattern)
 
@@ -202,9 +203,6 @@ class CustomProvider(BaseProvider):
 
     def s3_file_location(self) -> str:
         return self.random_element(self.OPPORTUNITY_ATTACHMENT_S3_PATHS)
-
-    def complex_markup_string(self) -> str:
-        return self.generator.parse(self.MARKUP_STRING)
 
 
 fake = faker.Faker()
@@ -347,10 +345,6 @@ class OpportunityFactory(BaseFactory):
 
         has_long_descriptions = factory.Trait(
             current_opportunity_summary__has_long_descriptions=True
-        )
-
-        has_markup_descriptions = factory.Trait(
-            current_opportunity_summary__has_markup_descriptions=True
         )
 
         # Set all nullable fields to null
@@ -591,11 +585,6 @@ class OpportunitySummaryFactory(BaseFactory):
             close_date_description=factory.Faker("paragraph", nb_sentences=30),
         )
 
-        has_markup_descriptions = factory.Trait(
-            summary_description=factory.Faker("complex_markup_string"),
-        )
-
-
 class CurrentOpportunitySummaryFactory(BaseFactory):
     class Meta:
         model = opportunity_models.CurrentOpportunitySummary
@@ -635,11 +624,6 @@ class CurrentOpportunitySummaryFactory(BaseFactory):
         has_long_descriptions = factory.Trait(
             opportunity_summary__has_long_descriptions=True,
         )
-
-        has_markup_descriptions = factory.Trait(
-            opportunity_summary__has_markup_descriptions=True,
-        )
-
 
 class OpportunityAssistanceListingFactory(BaseFactory):
     class Meta:

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -207,7 +207,6 @@ class CustomProvider(BaseProvider):
         return self.generator.parse(self.MARKUP_STRING)
 
 
-
 fake = faker.Faker()
 fake.add_provider(CustomProvider)
 factory.Faker.add_provider(CustomProvider)

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -31,8 +31,8 @@ export const splitMarkup = (
       }
       // handle things like urls within tag params that need to be ignored
       if (
-        (tracker.openTagIndicator && character === `"`) ||
-        character === `'`
+        tracker.openTagIndicator &&
+        (character === `"` || character === `'`)
       ) {
         tracker.inQuotes = !tracker.inQuotes;
       }


### PR DESCRIPTION
## Summary
Fixes #2943

### Time to review: __10 mins__

## Changes proposed
Fixes a bug in the markup split logic that could result in markup containing quotation marks to not be properly evaluated

## Context for reviewers

### Test steps

1. `make db-seed` on this branch
2. visit the opportunity page for a seeded record containing markup in the description
3. _VALIDATE_: description content is collapsed at the correct point and markup is not broken

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

