### PR TITLE
[Issue #2475] Rescale frontend CPU and memory

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -23,6 +23,8 @@ Scaling is handled by configuring the following values:
 - instance desired instance count
 - instance scaling minimum capacity
 - instance scaling maximum capacity
+- instance CPU
+- instance memory
 
 Our ECS instances auto scale based on both memory and CPU. You can view the autoscaling configuration
 here: [infra/modules/service/autoscaling.tf](infra/modules/service/autoscaling.tf)

--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -32,6 +32,8 @@ output "service_config" {
     instance_desired_instance_count = var.instance_desired_instance_count
     instance_scaling_max_capacity   = var.instance_scaling_max_capacity
     instance_scaling_min_capacity   = var.instance_scaling_min_capacity
+    instance_cpu                    = var.instance_cpu
+    instance_memory                 = var.instance_memory
     extra_environment_variables = merge(
       local.default_extra_environment_variables,
       var.service_override_extra_environment_variables

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -72,6 +72,18 @@ variable "database_min_capacity" {
   type        = number
 }
 
+variable "instance_cpu" {
+  description = "CPU units for the ECS container instances"
+  type        = number
+  default     = 1024
+}
+
+variable "instance_memory" {
+  description = "Memory in MiB for the ECS container instances"
+  type        = number
+  default     = 2048
+}
+
 variable "instance_desired_instance_count" {
   description = "Number of desired ECS container instances for the service"
   type        = number

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -123,8 +123,8 @@ module "service" {
   max_capacity           = local.service_config.instance_scaling_max_capacity
   min_capacity           = local.service_config.instance_scaling_min_capacity
   enable_autoscaling     = true
-  cpu                    = 1024
-  memory                 = 2048
+  cpu                    = local.service_config.instance_cpu
+  memory                 = local.service_config.instance_memory
 
   cert_arn = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
 

--- a/infra/frontend/app-config/env-config/outputs.tf
+++ b/infra/frontend/app-config/env-config/outputs.tf
@@ -17,6 +17,8 @@ output "service_config" {
     instance_desired_instance_count = var.instance_desired_instance_count
     instance_scaling_max_capacity   = var.instance_scaling_max_capacity
     instance_scaling_min_capacity   = var.instance_scaling_min_capacity
+    instance_cpu                    = var.instance_cpu
+    instance_memory                 = var.instance_memory
     extra_environment_variables = merge(
       local.default_extra_environment_variables,
       var.service_override_extra_environment_variables

--- a/infra/frontend/app-config/env-config/variables.tf
+++ b/infra/frontend/app-config/env-config/variables.tf
@@ -20,6 +20,18 @@ variable "has_incident_management_service" {
   type = bool
 }
 
+variable "instance_cpu" {
+  description = "CPU units for the ECS container instances"
+  type        = number
+  default     = 256
+}
+
+variable "instance_memory" {
+  description = "Memory in MiB for the ECS container instances"
+  type        = number
+  default     = 512
+}
+
 variable "instance_desired_instance_count" {
   type    = number
   default = 1

--- a/infra/frontend/app-config/prod.tf
+++ b/infra/frontend/app-config/prod.tf
@@ -16,4 +16,7 @@ module "prod_config" {
   instance_scaling_min_capacity   = 4
   # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
   instance_scaling_max_capacity = 20
+
+  instance_cpu    = 1024
+  instance_memory = 2048
 }

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -128,8 +128,8 @@ module "service" {
   max_capacity           = local.service_config.instance_scaling_max_capacity
   min_capacity           = local.service_config.instance_scaling_min_capacity
   enable_autoscaling     = true
-  cpu                    = 256 // these are probably too small
-  memory                 = 512 // these are probably too small
+  cpu                    = local.service_config.instance_cpu
+  memory                 = local.service_config.instance_memory
 
   app_access_policy_arn      = null
   migrator_access_policy_arn = null


### PR DESCRIPTION
## Summary

Relates to https://github.com/HHS/simpler-grants-gov/issues/2475

### Time to review: __2 mins__

## Changes proposed

- Makes CPU and memory a variable
- Bumps the frontend's CPU and memory up to the numbers the API is using (they just seemed like a good set of numbers to use 🤷🏼‍♀️)

## Context for reviewers

This will help the frontend be more resilient!