### PR TITLE
[Issue #2475] Scale Out the ASGs more aggresively

### DIFF
--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -24,8 +24,8 @@ resource "aws_appautoscaling_policy" "ecs_scale_policy_memory" {
       predefined_metric_type = "ECSServiceAverageMemoryUtilization"
     }
     scale_in_cooldown  = 300
-    scale_out_cooldown = 60
-    target_value       = 75
+    scale_out_cooldown = 5
+    target_value       = 50
   }
 }
 
@@ -41,7 +41,7 @@ resource "aws_appautoscaling_policy" "ecs_scale_policy_cpu" {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
     scale_in_cooldown  = 300
-    scale_out_cooldown = 60
-    target_value       = 75
+    scale_out_cooldown = 5
+    target_value       = 50
   }
 }


### PR DESCRIPTION
## Summary

Fixes #2475

### Time to review: __2 mins__

## Changes proposed

- Changes the ASGs to evaluate scale-out potential every 5 seconds
- Changes to ASGs to target 50% maximum CPU and memory when performing scaling actions

## Context for reviewers

During load tests, I found that the frontend wasn't scaling up quickly enough to meet demand. I'm hoping that this auto-scaling configuration will help alleviate that.