### PR TITLE
[Issue #2696] Allow frontend-infra to be kicked off manually

### DIFF
--- a/.github/workflows/cd-frontend-infra.yml
+++ b/.github/workflows/cd-frontend-infra.yml
@@ -9,6 +9,17 @@ on:
       - "infra/frontend/**"
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "target environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
 
 jobs:
   build-repository:
@@ -41,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         directory: ["service"]
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || fromJSON('["dev", "staging"]') }} # deploy prod on releases, otherwise deploy staging and dev
+        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Supports #2696

### Time to review: __1 mins__

## Changes proposed
Allow Frontend Infra to be deployed via the Action Workflow

