### PR TITLE
[Issue #1930] Ensure Action Workflows are possible and honor the provided environment

### DIFF
--- a/.github/workflows/cd-analytics-infra.yml
+++ b/.github/workflows/cd-analytics-infra.yml
@@ -9,7 +9,17 @@ on:
       - "infra/analytics/**"
   release:
     types: [published]
-
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "target environment"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
 jobs:
   build-repository:
     name: Build Repository
@@ -42,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         directory: ["database", "service"]
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || fromJSON('["dev", "staging"]') }} # deploy prod on releases, otherwise deploy staging and dev
+        envs: ${{ inputs.environment || github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
 
     permissions:
       contents: read

--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   analytics-checks:
-    name: Run Analyics Checks
+    name: Run Analytics Checks
     uses: ./.github/workflows/ci-analytics.yml
     secrets: inherit
 
@@ -41,7 +41,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
+        envs: ${{ inputs.environment || github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
     with:
       app_name: "analytics"
       environment: ${{ matrix.envs }}

--- a/.github/workflows/cd-api-infra.yml
+++ b/.github/workflows/cd-api-infra.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         directory: ["database", "service"]
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || fromJSON('["dev", "staging"]') }} # deploy prod on releases, otherwise deploy staging and dev
+        envs: ${{ inputs.environment || github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
 
     permissions:
       contents: read

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
+        envs: ${{ inputs.environment || github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
     with:
       app_name: "api"
       environment: ${{ matrix.envs }}

--- a/.github/workflows/cd-frontend-infra.yml
+++ b/.github/workflows/cd-frontend-infra.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         directory: ["service"]
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
+        envs: ${{ inputs.environment || github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
 
     permissions:
       contents: read

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
+        envs: ${{ inputs.environment || github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
     with:
       app_name: "frontend"
       environment: ${{ matrix.envs }}

--- a/.github/workflows/cd-metabase.yml
+++ b/.github/workflows/cd-metabase.yml
@@ -26,7 +26,7 @@ jobs:
       max-parallel: 1
       fail-fast: false
       matrix:
-        envs: ${{ github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
+        envs: ${{ inputs.environment || github.event_name == 'release' && fromJSON('["prod"]') || github.ref_name == 'main' && fromJSON('["dev", "staging"]') || fromJSON('["dev"]') }}
     with:
       version: ${{ inputs.image-tag }}
       environment: ${{ matrix.envs }}


### PR DESCRIPTION
## Summary
Fixes #1930

### Time to review: __2 mins__

## Changes proposed
Ensure all CD Actions are able to be triggered as a workflow manually and that the target environment is actually used for the deploy.

## Context for reviewers
A few CD actions didn't have workflows, those that did ignored the environment specified and instead picked deploy targets based on the branch we were deploying.

