### PR TITLE
temporarily hardcode prod GA id while we work out a better solution

### DIFF
--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -8,10 +8,6 @@ const {
   API_URL,
   API_AUTH_TOKEN = "",
   NEXT_PUBLIC_BASE_URL,
-  // for deployed envs it will come from ECS task def env var
-  // it will not be populated locally, or in Jest or E2E tests
-  // if it is needed locally or tests, add it in .env.local or command line
-  NEXT_PUBLIC_GOOGLE_ANALYTICS_ID = "",
 } = process.env;
 
 // home for all interpreted server side environment variables
@@ -28,5 +24,5 @@ export const environment: { [key: string]: string } = {
   API_URL: API_URL || "",
   API_AUTH_TOKEN,
   NEXT_PUBLIC_BASE_URL: NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
-  NEXT_PUBLIC_GOOGLE_ANALYTICS_ID,
+  NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: "G-6MDCC5EZW2",
 };


### PR DESCRIPTION
## Summary
Fixes UNTICKETED

### Time to review: __5 mins__

## Changes proposed
After bugs were found in https://github.com/HHS/simpler-grants-gov/pull/3001, this will allow prod deploys to go forward by pointing all GA data to the prod account while we work on a better fix.

## Context for reviewers
### Test steps

1. npm run build && npm start
2. open dev tools and search for `googletag`
3. _VERIFY_: tag includes prod GA id

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

