### PR TITLE
[Issue #1884] 4x the max number of potential containers

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -55,3 +55,6 @@ npm-debug.log*
 # pa11y
 screenshots-output/*
 pa11y_output.txt
+
+# Artilery
+tests/artillery/params.json

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -13,10 +13,10 @@ module "prod_config" {
   # instance_desired_instance_count and instance_scaling_min_capacity are scaled for 5x the average CPU and Memory
   # seen over 12 months, as of November 2024 exlucing an outlier range around February 2024.
   # The math is: 5 * max(average CPU or average Memory) * 1.3. The 1.3 is for a buffer.
-  instance_desired_instance_count = 2
-  instance_scaling_min_capacity   = 2
+  instance_desired_instance_count = 4
+  instance_scaling_min_capacity   = 4
   # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
-  instance_scaling_max_capacity = 10
+  instance_scaling_max_capacity = 40
 
   # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html
   # https://us-east-1.console.aws.amazon.com/rds/home?region=us-east-1#database:id=api-prod;is-cluster=true;tab=monitoring

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -28,7 +28,7 @@ module "staging_config" {
   # Temporarily scale staging to the same numbers as prod for the load test
   instance_desired_instance_count = 2
   instance_scaling_min_capacity   = 2
-  instance_scaling_max_capacity   = 10
+  instance_scaling_max_capacity   = 40
   database_min_capacity           = 20
   database_max_capacity           = 128
   database_instance_count         = 2

--- a/infra/frontend/app-config/prod.tf
+++ b/infra/frontend/app-config/prod.tf
@@ -15,7 +15,7 @@ module "prod_config" {
   instance_desired_instance_count = 4
   instance_scaling_min_capacity   = 4
   # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
-  instance_scaling_max_capacity = 20
+  instance_scaling_max_capacity = 80
 
   instance_cpu    = 1024
   instance_memory = 2048

--- a/infra/frontend/app-config/staging.tf
+++ b/infra/frontend/app-config/staging.tf
@@ -19,5 +19,5 @@ module "staging_config" {
   # Temporarily scale staging to the same numbers as prod for the load test
   instance_desired_instance_count = 4
   instance_scaling_min_capacity   = 4
-  instance_scaling_max_capacity   = 20
+  instance_scaling_max_capacity   = 80
 }

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -24,7 +24,7 @@ resource "aws_appautoscaling_policy" "ecs_scale_policy_memory" {
       predefined_metric_type = "ECSServiceAverageMemoryUtilization"
     }
     scale_in_cooldown  = 300
-    scale_out_cooldown = 5
+    scale_out_cooldown = 30
     target_value       = 50
   }
 }
@@ -41,7 +41,7 @@ resource "aws_appautoscaling_policy" "ecs_scale_policy_cpu" {
       predefined_metric_type = "ECSServiceAverageCPUUtilization"
     }
     scale_in_cooldown  = 300
-    scale_out_cooldown = 5
+    scale_out_cooldown = 30
     target_value       = 50
   }
 }


### PR DESCRIPTION
## Summary

Realtes to https://github.com/HHS/simpler-grants-gov/issues/1884

### Time to review: __5 mins__

## Changes proposed

Throws even more containers at our frontend performance problem

## Context for reviewers

I tested "level 1" of https://github.com/HHS/simpler-grants-gov/issues/1884 with the following configuration

```yaml
  phases:
    - arrivalRate: 10
      maxVusers: 50
      name: Warm up phase
    - arrivalRate: 100
      maxVusers: 1000
      name: Ramp up load
    - arrivalRate: 200
      maxVusers: 2000
      name: Spike phase
```

This is a low amount of spike load (IMO) and it caused -alot- of 500 errors. But once the containers has scaled up sufficiently, the 500 errors died down. So I'm yet again adjusting the scaling, in hopes that these new numbers don't "fail" the level 1 load test again.
