### PR TITLE
[Issue #3017] fix the postgres vulnerability

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -23,9 +23,3 @@ ignore:
   - vulnerability: CVE-2024-34158
   - vulnerability: CVE-2024-34156
   - vulnerability: CVE-2024-34155
-
-  # https://github.com/HHS/simpler-grants-gov/issues/3015
-  - vulnerability: CVE-2024-10979
-  - vulnerability: CVE-2024-10978
-  - vulnerability: CVE-2024-10976
-  - vulnerability: CVE-2024-10977

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,8 +13,8 @@ FROM python:3.13-slim AS base
 RUN pip install --no-cache-dir poetry==1.5
 
 RUN apt-get update \
-    # Uninstall existing packages before installing their never versions
-    && apt-get uninstall --yes \
+    # Remove existing packages before installing their never versions
+    && apt-get remove --yes \
         build-essential \
         libpq-dev \
         postgresql \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -13,6 +13,12 @@ FROM python:3.13-slim AS base
 RUN pip install --no-cache-dir poetry==1.5
 
 RUN apt-get update \
+    # Uninstall existing packages before installing their never versions
+    && apt-get uninstall --yes \
+        build-essential \
+        libpq-dev \
+        postgresql \
+        wget \
     # Install security updates
     # https://pythonspeed.com/articles/security-updates-in-docker/
     && apt-get upgrade --yes \


### PR DESCRIPTION
## Summary

Fixes #3017

### Time to review: __1 mins__

## Context for reviewers

I figured this out overnight. If you uninstall first, it removes all the files, then a re-install is totally fresh. This fixes our postgres vuln problem.

The vuln scans are still failing... on two totally totally different problems (libc and tornado)