### PR TITLE
[Issue #3038] Ignore the PG false positives in trivy like we did in anchore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,9 @@
 #  Issue:         Why there is a finding and why this is here or not been removed
 #  Last checked:  Date last checked in scans
 #The-CVE-or-vuln-id # Remove comment at start of line
+
+# https://github.com/HHS/simpler-grants-gov/issues/3015
+CVE-2024-10979
+CVE-2024-10978
+CVE-2024-10976
+CVE-2024-10977


### PR DESCRIPTION
## Summary
Fixes #3038

### Time to review: __2 mins__

## Changes proposed
Ignore the PG 15 CVEs that we have already install a later version than those vulnerable, but the scan is getting tripped up on a seeming false positive