### PR TITLE
[no ticket] fix cron vuln scan logic (hopefully)

### DIFF
--- a/.github/workflows/ci-cron-vulnerability-scans.yml
+++ b/.github/workflows/ci-cron-vulnerability-scans.yml
@@ -22,4 +22,5 @@ jobs:
 
   send-slack-notification:
     if: failure()
+    needs: vulnerability-scans
     uses: ./.github/workflows/send-slack-notification.yml

--- a/.github/workflows/ci-cron-vulnerability-scans.yml
+++ b/.github/workflows/ci-cron-vulnerability-scans.yml
@@ -13,6 +13,7 @@ jobs:
   vulnerability-scans:
     name: Vulnerability Scans
     strategy:
+      fail-fast: false
       matrix:
         app_name: ["frontend", "api", "analytics"]
     uses: ./.github/workflows/vulnerability-scans.yml


### PR DESCRIPTION
### Time to review: __1 mins__

## Changes proposed

Changes the vuln scan cronjob to both:

- have an explicit `needs` keyword
- always run every vuln scan on every app

## Context for reviewers

Right now the setup for the cron vuln scans is nonideal, this is shown here:

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/b84a7289-f0cc-485d-b05d-2afa78b7f0c7">

There are two problems here:

- the matrix fails fast, which means that if one scan fails, the other scans won't get a chance to cache
- there is a `needs` statement missing on the slack job, so it doesn't wait for the vuln scans to complete before it alerts slack. In practice this means that it will never alert slack (and in my experience, it never has)