### PR TITLE
[no ticket] Use higher ASG targets

### DIFF
--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -25,7 +25,7 @@ resource "aws_appautoscaling_policy" "ecs_scale_policy_memory" {
     }
     scale_in_cooldown  = 300
     scale_out_cooldown = 5
-    target_value       = 75
+    target_value       = 99
   }
 }
 

--- a/infra/modules/service/autoscaling.tf
+++ b/infra/modules/service/autoscaling.tf
@@ -25,7 +25,7 @@ resource "aws_appautoscaling_policy" "ecs_scale_policy_memory" {
     }
     scale_in_cooldown  = 300
     scale_out_cooldown = 5
-    target_value       = 50
+    target_value       = 75
   }
 }
 
@@ -42,6 +42,6 @@ resource "aws_appautoscaling_policy" "ecs_scale_policy_cpu" {
     }
     scale_in_cooldown  = 300
     scale_out_cooldown = 5
-    target_value       = 50
+    target_value       = 75
   }
 }


### PR DESCRIPTION
## Context

At 50% memory, the frontend hits that memory cap easily and immediately gets cycled out. I wasn't really expecting this behavior, but you live and you learn.

## Changes proposed

Increases the memory target to 99%, so nextjs only spins up new containers when after containers max out their cache. This won't meaningfully impact the backend, because the because the backend doesn't have an infinitely* scaling cache.

\* There's not significant indication that the nextjs cache is infinitely scaling. It might just scale higher than our current memory numbers.

I also increased the CPU target to 75%, which may come back to bite me I dunno. We'll see.