### PR TITLE
[Issue #3050] Make sure we escape single quotes

### DIFF
--- a/api/tests/src/data_migration/test_copy_oracle_data.py
+++ b/api/tests/src/data_migration/test_copy_oracle_data.py
@@ -30,7 +30,7 @@ def convert_value_for_insert(value) -> str:
     if isinstance(value, int):
         return str(value)
     if isinstance(value, str):
-        return f"'{value}'"  # noqa: B907
+        return f"'{value.replace("'", "''")}'"  # noqa: B907
     if isinstance(value, date):
         return f"'{value.isoformat()}'"  # noqa: B907
 


### PR DESCRIPTION
## Summary
Fixes #3050 

### Time to review: __2 mins__

## Changes proposed
Make sure we're escaping single quotes in our DB strings

## Context for reviewers
Tests started failing due to a string with "children's" in it
All tests are now passing locally
