### PR TITLE
[Issue #2851] always display cta button beneath text

### DIFF
--- a/frontend/src/components/opportunity/OpportunityCTA.tsx
+++ b/frontend/src/components/opportunity/OpportunityCTA.tsx
@@ -28,7 +28,12 @@ const OpportunityCTA = ({ id }: { id: number }) => {
   const content = (
     <>
       <span>{t("apply_content")}</span>
-      <a href={legacyOpportunityURL} target="_blank" rel="noopener noreferrer">
+      <a
+        href={legacyOpportunityURL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="display-block"
+      >
         <Button type="button" outline={true} className="margin-top-2">
           <span>{t("button_content")}</span>
           <USWDSIcon


### PR DESCRIPTION
## Summary
Fixes #2851

### Time to review: __3 mins__

## Changes proposed
Adds styling to ensure cta button sits beneath text at all viewport sizes

## Context for reviewers
### Test steps

1. load an opportunity detail page on this branch
2. resize viewport from desktop to mobile size
3. _VERIFY_: at all viewport sizes the cta button sits beneath the cta text 

## Additional information

Compare to screenshot in the ticket
<img width="843" alt="Screenshot 2024-12-02 at 1 31 43 PM" src="https://github.com/user-attachments/assets/53292fc2-d649-4f3b-be00-ea34b2053e44">
