### PR TITLE
[Issue #3003] Add deployment info

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,4 +52,8 @@ jobs:
           environment: ${{ inputs.environment }}
 
       - name: Deploy release
-        run: make release-deploy APP_NAME=${{ inputs.app_name }} ENVIRONMENT=${{ inputs.environment }}
+        run: make release-deploy \
+          APP_NAME=${{ inputs.app_name }} \
+          ENVIRONMENT=${{ inputs.environment }} \
+          DEPLOY_GITHUB_REF=${{ github.ref }} \
+          DEPLOY_GITHUB_SHA=${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,5 +55,5 @@ jobs:
         run: make release-deploy \
           APP_NAME=${{ inputs.app_name }} \
           ENVIRONMENT=${{ inputs.environment }} \
-          DEPLOY_GITHUB_REF=${{ github.ref }} \
+          DEPLOY_GITHUB_REF=${{ github.ref_name }} \
           DEPLOY_GITHUB_SHA=${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ infra-update-app-service: ## Create or update $APP_NAME's web service module
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	terraform -chdir="infra/$(APP_NAME)/service" init -input=false -reconfigure -backend-config="$(ENVIRONMENT).s3.tfbackend"
-	terraform -chdir="infra/$(APP_NAME)/service" apply -var="environment_name=$(ENVIRONMENT)"
+	terraform -chdir="infra/$(APP_NAME)/service" apply -var="environment_name=$(ENVIRONMENT)" -var="deploy_github_ref=$(DEPLOY_GITHUB_REF)" -var="deploy_github_sha=$(DEPLOY_GITHUB_SHA)"
 
 infra-update-metabase-service: ## Create or update $APP_NAME's web service module
 	# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
@@ -201,12 +201,12 @@ release-run-database-migrations: ## Run $APP_NAME's database migrations in $ENVI
 release-deploy: ## Deploy release to $APP_NAME's web service in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
-	./bin/deploy-release.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
+	./bin/deploy-release.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT) $(DEPLOY_GITHUB_REF) $(DEPLOY_GITHUB_SHA)
 
 metabase-deploy: ## Deploy metabase to $APP_NAME's web service in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
-	./bin/deploy-metabase.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)	
+	./bin/deploy-metabase.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
 
 release-image-name: ## Prints the image name of the release image
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 APP_NAME=$1
 IMAGE_TAG=$2
 ENVIRONMENT=$3
+DEPLOY_GITHUB_REF=$4
+DEPLOY_GITHUB_SHA=$5
 
 echo "--------------"
 echo "Deploy release"
@@ -12,9 +14,11 @@ echo "Input parameters:"
 echo "  APP_NAME=$APP_NAME"
 echo "  IMAGE_TAG=$IMAGE_TAG"
 echo "  ENVIRONMENT=$ENVIRONMENT"
+echo "  DEPLOY_GITHUB_REF=$DEPLOY_GITHUB_REF"
+echo "  DEPLOY_GITHUB_SHA=$DEPLOY_GITHUB_SHA"
 echo
 echo "Starting $APP_NAME deploy of $IMAGE_TAG to $ENVIRONMENT"
 
-TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$IMAGE_TAG" make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT"
+TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$IMAGE_TAG" make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT" DEPLOY_GITHUB_REF="$DEPLOY_GITHUB_REF" DEPLOY_GITHUB_SHA="$DEPLOY_GITHUB_SHA"
 
 echo "Completed $APP_NAME deploy of $IMAGE_TAG to $ENVIRONMENT"

--- a/infra/analytics/service/variables.tf
+++ b/infra/analytics/service/variables.tf
@@ -8,3 +8,15 @@ variable "image_tag" {
   description = "image tag to deploy to the environment"
   default     = null
 }
+
+variable "deploy_github_ref" {
+  type        = string
+  description = "github ref to deploy"
+  default     = null
+}
+
+variable "deploy_github_sha" {
+  type        = string
+  description = "github sha to deploy"
+  default     = null
+}

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -147,6 +147,9 @@ module "service" {
   extra_environment_variables = merge(
     local.service_config.extra_environment_variables,
     { "ENVIRONMENT" : var.environment_name },
+    { "DEPLOY_TIMESTAMP" : timestamp() },
+    deploy_github_sha != null ? { "DEPLOY_GITHUB_SHA" : var.deploy_github_sha } : {},
+    deploy_github_ref != null ? { "DEPLOY_GITHUB_REF" : var.deploy_github_ref } : {}
   )
 
   secrets = concat(

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -148,8 +148,8 @@ module "service" {
     local.service_config.extra_environment_variables,
     { "ENVIRONMENT" : var.environment_name },
     { "DEPLOY_TIMESTAMP" : timestamp() },
-    deploy_github_sha != null ? { "DEPLOY_GITHUB_SHA" : var.deploy_github_sha } : {},
-    deploy_github_ref != null ? { "DEPLOY_GITHUB_REF" : var.deploy_github_ref } : {}
+    var.deploy_github_sha != null ? { "DEPLOY_GITHUB_SHA" : var.deploy_github_sha } : {},
+    var.deploy_github_ref != null ? { "DEPLOY_GITHUB_REF" : var.deploy_github_ref } : {}
   )
 
   secrets = concat(

--- a/infra/api/service/variables.tf
+++ b/infra/api/service/variables.tf
@@ -8,3 +8,15 @@ variable "image_tag" {
   description = "image tag to deploy to the environment"
   default     = null
 }
+
+variable "deploy_github_ref" {
+  type        = string
+  description = "github ref to deploy"
+  default     = null
+}
+
+variable "deploy_github_sha" {
+  type        = string
+  description = "github sha to deploy"
+  default     = null
+}

--- a/infra/frontend/service/variables.tf
+++ b/infra/frontend/service/variables.tf
@@ -14,3 +14,15 @@ variable "domain" {
   description = "DNS domain of the website managed by HHS"
   default     = null
 }
+
+variable "deploy_github_ref" {
+  type        = string
+  description = "github ref to deploy"
+  default     = null
+}
+
+variable "deploy_github_sha" {
+  type        = string
+  description = "github sha to deploy"
+  default     = null
+}


### PR DESCRIPTION
## Summary

Relates #3003

### Time to review: __5 mins__

## Changes proposed

Adds the following environment variables to API deployments:

- DEPLOY_GITHUB_REF
- DEPLOY_GITHUB_SHA
- DEPLOY_TIMESTAMP

You can find the definitions for these values here: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables

## Testing

https://us-east-1.console.aws.amazon.com/ecs/v2/task-definitions/api-dev/288/json?region=us-east-1

<img width="465" alt="image" src="https://github.com/user-attachments/assets/4d015e6e-a70c-4e3a-ac8c-be1a93c32730">

<img width="331" alt="image" src="https://github.com/user-attachments/assets/5beb17e7-e016-4b62-979d-7680d50a5db0">

<img width="342" alt="image" src="https://github.com/user-attachments/assets/a5d67fff-def3-470e-8b2a-874971fb119e">

^ note that terraform doesn't provide a UNIX timestamp, which I'm a bit bummed about. But maybe we only put the timestamp into the healthcheck, and keep it as is?

