### PR TITLE
[Issue #773] add research participant cta

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "all-checks": "npm run test && npm run lint && npm run ts:check && npm run build",
     "build": "next build",
-    "dev": "next dev",
+    "dev": "NEW_RELIC_ENABLED=false next dev",
     "dev:nr": "NODE_OPTIONS='-r @newrelic/next' next dev",
     "debug": "NODE_OPTIONS='--inspect' next dev",
     "format": "prettier --write '**/*.{js,json,md,ts,tsx,scss,yaml,yml}'",

--- a/frontend/src/app/[locale]/research/ResearchMethodology.tsx
+++ b/frontend/src/app/[locale]/research/ResearchMethodology.tsx
@@ -1,9 +1,7 @@
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import { Button, Grid } from "@trussworks/react-uswds";
 
 import ContentLayout from "src/components/ContentLayout";
-import { USWDSIcon } from "src/components/USWDSIcon";
 
 const ResearchMethodology = () => {
   const t = useTranslations("Research");
@@ -38,18 +36,22 @@ const ResearchMethodology = () => {
           ),
           li: (chunks) => <li>{chunks}</li>,
         })}
-        <p className="font-sans-md line-height-sans-4 desktop-lg:line-height-sans-6">
+        <h3 className="tablet-lg:font-sans-lg tablet-lg:margin-bottom-05">
           {t("methodology.title_3")}
-        </p>
-        <Link href="/subscribe" passHref>
-          <Button className="margin-bottom-4" type="button" outline>
-            <span className="margin-right-4">{t("methodology.cta")}</span>
-            <USWDSIcon
-              className="usa-icon usa-icon--size-3 text-middle margin-left-neg-3"
-              name="arrow_forward"
-            />
+        </h3>
+        <a
+          href="https://ethn.io/screeners/113856/edit?step=design"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Button
+            className="margin-bottom-4 margin-top-2 padding-3"
+            type="button"
+            size="big"
+          >
+            {t("methodology.cta")}
           </Button>
-        </Link>
+        </a>
       </Grid>
     </ContentLayout>
   );

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -143,9 +143,8 @@ export const messages = {
       title_2: "Research objectives:",
       paragraph_2:
         "<ul><li>Examine existing user journeys and behaviors, identifying how Grants.gov fits into their overall approach</li><li>Learn from user experiences, roles, challenges</li><li>Identify barriers and how a simpler Grants.gov can create a more intuitive user experience, especially for new users</li></ul>",
-      title_3:
-        "Want to be notified when there are upcoming user research efforts?",
-      cta: "Sign up for project updates",
+      title_3: "Want to participate in user research?",
+      cta: "Sign up to join a usability study",
     },
     archetypes: {
       title: "Applicant archetypes",

--- a/frontend/tests/e2e/research.spec.ts
+++ b/frontend/tests/e2e/research.spec.ts
@@ -13,11 +13,13 @@ test("has title", async ({ page }) => {
   await expect(page).toHaveTitle("Research | Simpler.Grants.gov");
 });
 
-test("can navigate to /subscribe", async ({ page }) => {
+test("can navigate to ethnio in new tab", async ({ page, context }) => {
+  const newTabPromise = context.waitForEvent("page");
   await page
-    .getByRole("link", { name: /sign up for project updates/i })
+    .getByRole("link", { name: /Sign up to join a usability study/i })
     .getByTestId("button")
     .click();
 
-  await expect(page).toHaveURL(/subscribe/);
+  const newPage = await newTabPromise;
+  await expect(newPage).toHaveURL(/ethn\.io/g);
 });


### PR DESCRIPTION
## Summary
Fixes #773

### Time to review: __10 mins__

## Changes proposed
Adds a button linking to ethnio form for potential research participants, as matching the figma here:
https://www.figma.com/design/FGxWtAgToKhehLJCiuy1zL/Simpler.Grants.gov-Project?node-id=67-15381&node-type=frame&t=xufn7BqnxbENUmXq-0

## Context for reviewers
### Test Steps

1. open the research page on this branch
2. _VERIFY_: compare to figma, make sure it looks right
3. click on the "sign up to join a usability study" link
4. _VERIFY_: the ethnio link opens up in a new tab

## Additional information
<img width="1245" alt="Screenshot 2024-12-02 at 2 59 02 PM" src="https://github.com/user-attachments/assets/615296c5-6a29-497d-8d8d-1ade315fb73d">

