### PR TITLE
[no ticket] Scales staging costs back down

### DIFF
--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -7,31 +7,23 @@ module "staging_config" {
   database_enable_http_endpoint   = true
   has_incident_management_service = local.has_incident_management_service
 
-  # # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html
-  # # https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/api-staging/services/api-staging/health?region=us-east-1
-  # # instance_desired_instance_count and instance_scaling_min_capacity are scaled for the average CPU and Memory
-  # # seen over 12 months, as of November 2024 exlucing an outlier range around February 2024.
-  # # With a minimum of 2, so CPU doesn't spike to infinity on deploys.
-  # instance_desired_instance_count = 2
-  # instance_scaling_min_capacity   = 2
-  # # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
-  # instance_scaling_max_capacity = 10
-
-  # # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html
-  # # https://us-east-1.console.aws.amazon.com/rds/home?region=us-east-1#database:id=api-dev;is-cluster=true;tab=monitoring
-  # # database_min_capacity is average api-staging ServerlessDatabaseCapacity seen over 12 months, as of November 2024
-  # database_min_capacity = 2
-  # # database_max_capacity is 5x the database_min_capacity
-  # database_max_capacity   = 10
-  # database_instance_count = 2
-
-  # Temporarily scale staging to the same numbers as prod for the load test
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html
+  # https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/api-staging/services/api-staging/health?region=us-east-1
+  # instance_desired_instance_count and instance_scaling_min_capacity are scaled for the average CPU and Memory
+  # seen over 12 months, as of November 2024 exlucing an outlier range around February 2024.
+  # With a minimum of 2, so CPU doesn't spike to infinity on deploys.
   instance_desired_instance_count = 2
   instance_scaling_min_capacity   = 2
-  instance_scaling_max_capacity   = 10
-  database_min_capacity           = 20
-  database_max_capacity           = 128
-  database_instance_count         = 2
+  # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
+  instance_scaling_max_capacity = 10
+
+  # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.setting-capacity.html
+  # https://us-east-1.console.aws.amazon.com/rds/home?region=us-east-1#database:id=api-dev;is-cluster=true;tab=monitoring
+  # database_min_capacity is average api-staging ServerlessDatabaseCapacity seen over 12 months, as of November 2024
+  database_min_capacity = 2
+  # database_max_capacity is 5x the database_min_capacity
+  database_max_capacity   = 10
+  database_instance_count = 2
 
   has_search = true
   # https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version

--- a/infra/frontend/app-config/staging.tf
+++ b/infra/frontend/app-config/staging.tf
@@ -6,20 +6,15 @@ module "staging_config" {
   has_database                    = local.has_database
   has_incident_management_service = local.has_incident_management_service
 
-  # # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html
-  # # https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/frontend-dev/services/frontend-dev/health?region=us-east-1
-  # # instance_desired_instance_count and instance_scaling_min_capacity are scaled for the average CPU and Memory
-  # # seen over 12 months, as of November 2024 exlucing an outlier range around February 2024.
-  # # With a minimum of 2, so CPU doesn't spike to infinity on deploys.
-  # instance_desired_instance_count = 2
-  # instance_scaling_min_capacity   = 2
-  # # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
-  # instance_scaling_max_capacity = 10
-
-  # Temporarily scale staging to the same numbers as prod for the load test
-  instance_desired_instance_count = 4
-  instance_scaling_min_capacity   = 4
-  instance_scaling_max_capacity   = 20
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-auto-scaling.html
+  # https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/frontend-dev/services/frontend-dev/health?region=us-east-1
+  # instance_desired_instance_count and instance_scaling_min_capacity are scaled for the average CPU and Memory
+  # seen over 12 months, as of November 2024 exlucing an outlier range around February 2024.
+  # With a minimum of 2, so CPU doesn't spike to infinity on deploys.
+  instance_desired_instance_count = 2
+  instance_scaling_min_capacity   = 2
+  # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
+  instance_scaling_max_capacity = 10
 
   service_override_extra_environment_variables = {
     NEW_RELIC_ENABLED = "false"


### PR DESCRIPTION
### Time to review: __1 mins__

## Changes proposed

Sets staging scaling back down to devs numbers, rather than prods. This means that the absolute load test numbers are no longer useful to test in staging with.