### PR TITLE
[Issue #680] Add basic CDN configuration

### DIFF
--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -123,6 +123,8 @@ module "service" {
   public_subnet_ids      = data.aws_subnets.public.ids
   private_subnet_ids     = data.aws_subnets.private.ids
   cert_arn               = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
+  domain                 = local.domain
+  environment_name       = var.environment_name
   hostname               = module.app_config.hostname
   desired_instance_count = local.service_config.instance_desired_instance_count
   max_capacity           = local.service_config.instance_scaling_max_capacity
@@ -130,6 +132,10 @@ module "service" {
   enable_autoscaling     = true
   cpu                    = local.service_config.instance_cpu
   memory                 = local.service_config.instance_memory
+
+  # Enable the CDN for production and staging environments, disable it for dev.
+  # This allows us to test the impact of the CDN by diffing staging and dev.
+  enable_cdn = contains(["production", "staging"], var.environment_name) ? true : false
 
   app_access_policy_arn      = null
   migrator_access_policy_arn = null

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -124,7 +124,6 @@ module "service" {
   private_subnet_ids     = data.aws_subnets.private.ids
   cert_arn               = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
   domain                 = local.domain
-  environment_name       = var.environment_name
   hostname               = module.app_config.hostname
   desired_instance_count = local.service_config.instance_desired_instance_count
   max_capacity           = local.service_config.instance_scaling_max_capacity

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -42,7 +42,6 @@ resource "aws_cloudfront_distribution" "cdn" {
   enabled         = true
   is_ipv6_enabled = true
   aliases         = var.domain != null ? [var.domain] : []
-  staging         = var.environment_name == "prod" ? true : false
 
   origin {
     domain_name = "http://${aws_lb.alb[0].dns_name}"

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -1,0 +1,89 @@
+locals {
+  # We have the option to route the CDN to multiple origins based on the origin id.
+  # We do not currently do this, though.
+  default_origin_id = "default"
+}
+
+resource "aws_s3_bucket" "cdn" {
+  count = var.enable_cdn ? 1 : 0
+
+  bucket_prefix = "${var.service_name}-cdn-access-logs"
+  force_destroy = false
+  # checkov:skip=CKV2_AWS_62:Event notification not necessary for this bucket especially due to likely use of lifecycle rules
+  # checkov:skip=CKV_AWS_18:Access logging was not considered necessary for this bucket
+  # checkov:skip=CKV_AWS_144:Not considered critical to the point of cross region replication
+  # checkov:skip=CKV_AWS_300:Known issue where Checkov gets confused by multiple rules
+  # checkov:skip=CKV_AWS_21:Bucket versioning is not worth it in this use case
+}
+
+resource "aws_cloudfront_cache_policy" "default" {
+  name = "default"
+
+  # These are the default values
+  min_ttl     = 0
+  default_ttl = 3600
+  max_ttl     = 86400
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "all"
+    }
+    headers_config {
+      header_behavior = "all"
+    }
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+  }
+}
+
+resource "aws_cloudfront_distribution" "cdn" {
+  count           = var.enable_cdn ? 1 : 0
+  enabled         = true
+  is_ipv6_enabled = true
+  aliases         = var.domain != null ? [var.domain] : []
+  staging         = var.environment_name == "prod" ? true : false
+
+  origin {
+    domain_name = "http://${aws_lb.alb[0].dns_name}"
+    origin_id   = local.default_origin_id
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cdn[0].bucket_domain_name
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id       = local.default_origin_id
+    cache_policy_id        = aws_cloudfront_cache_policy.default.id
+    compress               = true
+    viewer_protocol_policy = "allow-all"
+
+    # Default to caching for 1 hour, with a minimum of 1 minute.
+    # The default TTL can be overriden by the `Cache-Control max-age` or `Expires` headers
+    # There's also a `max_ttl` option, which can be used to override the above headers.
+    min_ttl     = 60
+    default_ttl = 3600
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = var.cert_arn
+  }
+}

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -186,11 +186,6 @@ variable "enable_cdn" {
   default     = false
 }
 
-variable "environment_name" {
-  description = "The name of the environment"
-  type        = string
-}
-
 variable "healthcheck_command" {
   description = "The command to run to check the health of the container, used on the container health check"
   type        = list(string)

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -162,6 +162,12 @@ variable "readonly_root_filesystem" {
   default     = true
 }
 
+variable "domain" {
+  description = "The domain name for the service"
+  type        = string
+  default     = null
+}
+
 variable "drop_linux_capabilities" {
   description = "Whether to drop linux parameters"
   type        = bool
@@ -172,6 +178,17 @@ variable "enable_load_balancer" {
   description = "Whether to enable a load balancer for the service"
   type        = bool
   default     = true
+}
+
+variable "enable_cdn" {
+  description = "Whether to enable a CDN for the service"
+  type        = bool
+  default     = false
+}
+
+variable "environment_name" {
+  description = "The name of the environment"
+  type        = string
 }
 
 variable "healthcheck_command" {


### PR DESCRIPTION
## Summary

Relates to #680

### Time to review: __20 mins__

## Changes proposed

- Adds a Cloudfront CDN
- The CDN caches everything at 1 hour by default
- It is only active in staging and prod
- It logs to a (newly created) S3 bucket
- It forward to the frontend ALB
- It only caches GET, HEAD, OPTIONS

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

