### PR TITLE
[Issue #3066] Expose analytics CLI entry point in Docker

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -118,7 +118,8 @@ RUN poetry install --no-root --only main
 # include section in pyproject.toml. Also note that if you change the name or
 # version section in pyproject.toml, you will need to change the dist/... to match
 # or the application will not build
-RUN poetry build --format wheel && pip install 'dist/simpler_grants_gov_analytics-0.1.0-py3-none-any.whl'
+RUN poetry build --format wheel && \
+  pip install --no-cache-dir 'dist/simpler_grants_gov_analytics-0.1.0-py3-none-any.whl'
 
 # Add project's virtual env to the PATH so we can directly run poetry scripts
 # defiend in pyproject.toml

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -115,12 +115,9 @@ RUN poetry install --no-root --only main
 
 # Build the application binary (python wheel) defined in pyproject.toml
 # Note that this will only copy over python files, and files stated in the
-# include section in pyproject.toml. Also note that if you change the name or
-# version section in pyproject.toml, you will need to change the dist/... to match
-# or the application will not build
-# RUN poetry build --format wheel && \
-#   pip install --no-cache-dir 'dist/simpler_grants_gov_analytics-0.1.0-py3-none-any.whl'
-RUN poetry install --only-root
+# include section in pyproject.toml.
+RUN poetry build --format wheel && \
+  poetry run pip install --no-cache-dir dist/*.whl
 
 # Add project's virtual env to the PATH so we can directly run poetry scripts
 # defiend in pyproject.toml

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -13,22 +13,22 @@ RUN pip install --no-cache-dir poetry==1.8.2 --upgrade
 RUN apt-get update \
   # Remove existing packages before installing their never versions
   && apt-get remove --yes \
-    build-essential \
-    libc-dev \
-    libpq-dev \
-    postgresql \
-    wget \
-    jq \
+  build-essential \
+  libc-dev \
+  libpq-dev \
+  postgresql \
+  wget \
+  jq \
   # Install security updates
   # https://pythonspeed.com/articles/security-updates-in-docker/
   && apt-get upgrade --yes \
   && apt-get install --no-install-recommends --yes \
-    build-essential \
-    libc-dev \
-    libpq-dev \
-    postgresql \
-    wget \
-    jq \
+  build-essential \
+  libc-dev \
+  libpq-dev \
+  postgresql \
+  wget \
+  jq \
   # Reduce the image size by clear apt cached lists
   # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
   && rm -fr /var/lib/apt/lists/* \
@@ -118,7 +118,7 @@ RUN poetry install --no-root --only main
 # include section in pyproject.toml. Also note that if you change the name or
 # version section in pyproject.toml, you will need to change the dist/... to match
 # or the application will not build
-RUN poetry build --format wheel && poetry run pip install 'dist/simpler_grants_gov_analytics-0.1.0-py3-none-any.whl'
+RUN poetry build --format wheel && pip install 'dist/simpler_grants_gov_analytics-0.1.0-py3-none-any.whl'
 
 # Add project's virtual env to the PATH so we can directly run poetry scripts
 # defiend in pyproject.toml
@@ -126,3 +126,8 @@ ENV PATH="/analytics/.venv/bin:$PATH"
 
 
 USER ${RUN_USER}
+
+# The entrypoint for the container that exposes the `analytics` CLI
+# You can call this entry point with `docker run <image> <analytics-sub-command>`
+# For example `docker run <image> etl db_migrate`
+ENTRYPOINT ["analytics"]

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -118,8 +118,9 @@ RUN poetry install --no-root --only main
 # include section in pyproject.toml. Also note that if you change the name or
 # version section in pyproject.toml, you will need to change the dist/... to match
 # or the application will not build
-RUN poetry build --format wheel && \
-  pip install --no-cache-dir 'dist/simpler_grants_gov_analytics-0.1.0-py3-none-any.whl'
+# RUN poetry build --format wheel && \
+#   pip install --no-cache-dir 'dist/simpler_grants_gov_analytics-0.1.0-py3-none-any.whl'
+RUN poetry install --only-root
 
 # Add project's virtual env to the PATH so we can directly run poetry scripts
 # defiend in pyproject.toml

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -13,22 +13,22 @@ RUN pip install --no-cache-dir poetry==1.8.2 --upgrade
 RUN apt-get update \
   # Remove existing packages before installing their never versions
   && apt-get remove --yes \
-  build-essential \
-  libc-dev \
-  libpq-dev \
-  postgresql \
-  wget \
-  jq \
+    build-essential \
+    libc-dev \
+    libpq-dev \
+    postgresql \
+    wget \
+    jq \
   # Install security updates
   # https://pythonspeed.com/articles/security-updates-in-docker/
   && apt-get upgrade --yes \
   && apt-get install --no-install-recommends --yes \
-  build-essential \
-  libc-dev \
-  libpq-dev \
-  postgresql \
-  wget \
-  jq \
+    build-essential \
+    libc-dev \
+    libpq-dev \
+    postgresql \
+    wget \
+    jq \
   # Reduce the image size by clear apt cached lists
   # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
   && rm -fr /var/lib/apt/lists/* \

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -125,8 +125,3 @@ ENV PATH="/analytics/.venv/bin:$PATH"
 
 
 USER ${RUN_USER}
-
-# The entrypoint for the container that exposes the `analytics` CLI
-# You can call this entry point with `docker run <image> <analytics-sub-command>`
-# For example `docker run <image> etl db_migrate`
-ENTRYPOINT ["analytics"]

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 
 [tool.poetry.scripts]
 analytics = "analytics.cli:app"
-db-migrate = "src.analytics.cli:migrate_database"
 
 [tool.poetry.dependencies]
 dynaconf = "^3.2.4"

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 
 [tool.poetry.scripts]
 analytics = "analytics.cli:app"
+db-migrate = "analytics.cli:migrate_database"
 
 [tool.poetry.dependencies]
 dynaconf = "^3.2.4"


### PR DESCRIPTION
## Summary

Exposes the `analytics` CLI entry point for the Docker image that allows us to run `docker run <image> etl db_migrate` as part of the CI/CD pipeline. 

Fixes #3066 

### Time to review: __2 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Edits the `poetry run pip install` to use `--no-cache-dir` and use a wildcard for the `dist/*.whl` so that users don't have to change that line if we bump the version.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

To prove that the entry point is available to run from the Docker container (without `poetry run`) do the following steps:

1. Checkout the current PR
2. Run `make release-build` from the root of the `/analytics/` sub-directory
3. Copy the `sha256:<image-hash>` from the resulting docker logs:
   ```
   => exporting to image                                                                                                      0.0s
   => => exporting layers                                                                                                     0.0s
   => => writing image sha256:14939cf59d75e1465ae5fd8030715d79ae33168bf0007346b571654a73914040                                0.0s
   ```
4. Use that image hash to run the following command `docker run <image-hash> analytics etl --help` and it should print out:
<img width="1072" alt="Screenshot 2024-12-03 at 1 55 21 PM" src="https://github.com/user-attachments/assets/4916f321-ce11-4467-85d5-40625cbfa553">

**Note:** Trying to run the actual DB migration with this method will fail because the migration depends on interacting with a live Postgres instance, which is what we use `docker compose` for but the current `docker-compose.yml` has the target set to `dev` based on [this Slack thread](https://betagrantsgov.slack.com/archives/C05TSL64VUH/p1733259136748469?thread_ts=1733253723.080049&cid=C05TSL64VUH) testing it with `docker compose run` may not be necessary.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

There are two main strategies for installing the package and exposing the CLI entry point:

- `poetry install --only-root` Not chosen because it installs an editable version of the python package (equivalent to doing `pip install . -e`) which is usually reserved for development
- `poetry build ... && poetry run pip install ...` Chosen because it first builds a stable version of the package and installs it