### PR TITLE
[Issue #2625] set max-ages for app pages

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -16,6 +16,40 @@ const appSassOptions = sassOptions(basePath);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        // Static pages are 6 hours.
+        source: "/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, s-maxage=21600, stale-while-revalidate",
+          },
+        ],
+      },
+      // Search page is 1 hour.
+      {
+        source: "/search",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, s-maxage=3600, stale-while-revalidate",
+          },
+        ],
+      },
+      // Opportunity pages are 10 minutes.
+      {
+        source: "/opportunity/:id(\\d{1,})",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, s-maxage=600, stale-while-revalidate",
+          },
+        ],
+      },
+    ];
+  },
   basePath,
   reactStrictMode: true,
   // Output only the necessary files for a deployment, excluding irrelevant node_modules

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -19,32 +19,37 @@ const nextConfig = {
   async headers() {
     return [
       {
-        // Static pages are 6 hours.
+        // static pages are stored for 6 hours, refreshed in the background for
+        // up to 10 minutes, and up to 12 hours if there is an error
         source: "/:path*",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, s-maxage=21600, stale-while-revalidate",
+            value: "s-maxage=21600, stale-while-revalidate=600, stale-if-error=43200",
+          },
+          {
+            key: "Vary",
+            value: "Accept-Language",
           },
         ],
       },
-      // Search page is 1 hour.
+      // search page is stored 1 hour, stale 1 min, stale if error 5 mins
       {
         source: "/search",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, s-maxage=3600, stale-while-revalidate",
+            value: "s-maxage=3600, stale-while-revalidate=60, stale-if-error=300",
           },
         ],
       },
-      // Opportunity pages are 10 minutes.
+      // opportunity pages are stored 10 mins, stale 1 min, stale if error 5 mins
       {
         source: "/opportunity/:id(\\d{1,})",
         headers: [
           {
             key: "Cache-Control",
-            value: "public, s-maxage=600, stale-while-revalidate",
+            value: "s-maxage=600, stale-while-revalidate=60, stale-if-error=300",
           },
         ],
       },

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -25,7 +25,8 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "s-maxage=21600, stale-while-revalidate=600, stale-if-error=43200",
+            value:
+              "s-maxage=21600, stale-while-revalidate=600, stale-if-error=43200",
           },
           {
             key: "Vary",
@@ -39,7 +40,8 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "s-maxage=3600, stale-while-revalidate=60, stale-if-error=300",
+            value:
+              "s-maxage=3600, stale-while-revalidate=60, stale-if-error=300",
           },
         ],
       },
@@ -49,7 +51,8 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "s-maxage=600, stale-while-revalidate=60, stale-if-error=300",
+            value:
+              "s-maxage=600, stale-while-revalidate=60, stale-if-error=300",
           },
         ],
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "all-checks": "npm run test && npm run lint && npm run ts:check && npm run build",
+    "all-checks": "npm run lint && npm run ts:check && npm run test && npm run build",
     "build": "next build",
     "dev": "next dev",
     "dev:nr": "NODE_OPTIONS='-r @newrelic/next' next dev",


### PR DESCRIPTION
## Summary
Fixes #2625

### Time to review: __5 mins__

## Changes proposed
Explicitly set the headers for different parts of the app so they are cached by clients and the CDN appropriately.