### PR TITLE
[Issue #1884] Finishes a load test (finally)

### DIFF
--- a/frontend/artillery-load-test.yml
+++ b/frontend/artillery-load-test.yml
@@ -5,13 +5,16 @@ config:
   http:
     timeout: 10
   phases:
-    - arrivalRate: 10
+    - duration: 300
+      arrivalRate: 10
       maxVusers: 100
       name: Warm up phase
-    - arrivalRate: 50
+    - duration: 300
+      arrivalRate: 50
       maxVusers: 500
       name: Ramp up load
-    - arrivalRate: 100
+    - duration: 300
+      arrivalRate: 100
       maxVusers: 2000
       name: Spike phase
   environments:


### PR DESCRIPTION
## Summary

Fixes https://github.com/HHS/simpler-grants-gov/issues/1884

### Time to review: __1 mins__

## Changes

Adds durations to all the artillery stages. I added durations before, and it didn't seem like they were being respected. But I added these ones, and now they are, I think? I dunno. I hate Artillery's documentation.

## Results

```
--------------------------------
Summary report @ 00:05:09(-0800)
--------------------------------

apdex.frustrated: .............................................................. 537
apdex.satisfied: ............................................................... 1087
apdex.tolerated: ............................................................... 853
errors.ETIMEDOUT: .............................................................. 45428
http.codes.200: ................................................................ 2193
http.codes.404: ................................................................ 633
http.codes.502: ................................................................ 4
http.downloaded_bytes: ......................................................... 0
http.request_rate: ............................................................. 50/sec
http.requests: ................................................................. 47905
http.response_time:
  min: ......................................................................... 82
  max: ......................................................................... 9913
  mean: ........................................................................ 1798.2
  median: ...................................................................... 383.8
  p95: ......................................................................... 8024.5
  p99: ......................................................................... 9607.1
http.response_time.2xx:
  min: ......................................................................... 84
  max: ......................................................................... 9913
  mean: ........................................................................ 1831.1
  median: ...................................................................... 407.5
  p95: ......................................................................... 8024.5
  p99: ......................................................................... 9607.1
http.response_time.4xx:
  min: ......................................................................... 82
  max: ......................................................................... 9874
  mean: ........................................................................ 1694
  median: ...................................................................... 267.8
  p95: ......................................................................... 8352
  p99: ......................................................................... 9801.2
http.response_time.5xx:
  min: ......................................................................... 102
  max: ......................................................................... 515
  mean: ........................................................................ 294
  median: ...................................................................... 186.8
  p95: ......................................................................... 368.8
  p99: ......................................................................... 368.8
http.responses: ................................................................ 2830
plugins.metrics-by-endpoint./opportunity/{{ id }}.codes.200: ................... 665
plugins.metrics-by-endpoint./opportunity/{{ id }}.codes.502: ................... 2
plugins.metrics-by-endpoint./opportunity/{{ id }}.errors.ETIMEDOUT: ............ 11409
plugins.metrics-by-endpoint./search?{{ query }}.codes.200: ..................... 495
plugins.metrics-by-endpoint./search?{{ query }}.codes.502: ..................... 1
plugins.metrics-by-endpoint./search?{{ query }}.errors.ETIMEDOUT: .............. 11449
plugins.metrics-by-endpoint./{{ route }}.codes.200: ............................ 760
plugins.metrics-by-endpoint./{{ route }}.codes.404: ............................ 553
plugins.metrics-by-endpoint./{{ route }}.codes.502: ............................ 1
plugins.metrics-by-endpoint./{{ route }}.errors.ETIMEDOUT: ..................... 22570
plugins.metrics-by-endpoint.response_time./opportunity/{{ id }}:
  min: ......................................................................... 91
  max: ......................................................................... 9816
  mean: ........................................................................ 2065
  median: ...................................................................... 596
  p95: ......................................................................... 7557.1
  p99: ......................................................................... 8520.7
plugins.metrics-by-endpoint.response_time./search?{{ query }}:
  min: ......................................................................... 102
  max: ......................................................................... 3151
  mean: ........................................................................ 467.3
  median: ...................................................................... 278.7
  p95: ......................................................................... 1652.8
  p99: ......................................................................... 2725
plugins.metrics-by-endpoint.response_time./{{ route }}:
  min: ......................................................................... 82
  max: ......................................................................... 9739
  mean: ........................................................................ 1156.9
  median: ...................................................................... 179.5
  p95: ......................................................................... 7407.5
  p99: ......................................................................... 8868.4
vusers.completed: .............................................................. 2477
vusers.created: ................................................................ 47905
vusers.created_by_name.404 Pages: .............................................. 11920
vusers.created_by_name.Opportunity Pages: ...................................... 12076
vusers.created_by_name.Searches: ............................................... 11945
vusers.created_by_name.Static Pages: ........................................... 11964
vusers.failed: ................................................................. 45428
vusers.session_length:
  min: ......................................................................... 162.9
  max: ......................................................................... 9999.2
  mean: ........................................................................ 1844.7
  median: ...................................................................... 584.2
  p95: ......................................................................... 8352
  p99: ......................................................................... 9607.1
vusers.skipped: ................................................................ 95
```