### PR TITLE
[Issue #3121] Verify site ownership with Google

### DIFF
--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -85,6 +85,10 @@ export default async function LocaleLayout({ children, params }: Props) {
     <html lang={locale} suppressHydrationWarning>
       <head>
         <GoogleAnalytics gaId={environment.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID} />
+        <meta
+          name="google-site-verification"
+          content="jFShzxCTiLzv8gvEW4ft7fCaQkluH229-B-tJKteYJY"
+        />
       </head>
       <body>
         <NextIntlClientProvider messages={messages}>


### PR DESCRIPTION
## Summary
Fixes #3121 

### Time to review: __1 mins__

## Changes proposed
To gain access to Google Search Console Tools we need to verify we control the simpler.grants.gov site

## Context for reviewers
The Google Tools in question allow us to see the crawl data from Google for our site, be alerted to and troubleshoot problems with our site's content, structured metadata, and crawlability. It will also let us better understand the Google Search queries that include us as a result as well as what gets us clicked on.

