### PR TITLE
[Issue #3134] Add schedule for `export-opportunity-data`

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -54,7 +54,7 @@ locals {
     }
     export-opportunity-data = {
       task_command = ["poetry", "run", "flask", "task", "export-opportunity-data"]
-      # Every day at 4am Eastern Time (9am UTC to ensure it runs at 4am ET even during DST)
+      # Every day at 4am Eastern Time during DST. 5am during non-DST.
       schedule_expression = "cron(0 9 * * ? *)"
       state               = "ENABLED"
     }

--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -52,5 +52,11 @@ locals {
       schedule_expression = "cron(30 * * * ? *)"
       state               = "ENABLED"
     }
+    export-opportunity-data = {
+      task_command = ["poetry", "run", "flask", "task", "export-opportunity-data"]
+      # Every day at 4am Eastern Time (9am UTC to ensure it runs at 4am ET even during DST)
+      schedule_expression = "cron(0 9 * * ? *)"
+      state               = "ENABLED"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #3134

### Time to review: 5 mins

## Changes proposed
Add a scheduler to run this task.

## Context for reviewers
Last bit of work for the export to run nightly.

