### PR TITLE
[no ticket] fix silly infinite redirect issue

### DIFF
--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -107,4 +107,5 @@ resource "aws_cloudfront_distribution" "cdn" {
   #checkov:skip=CKV2_AWS_47:Configure WAF in future work
   #checkov:skip=CKV2_AWS_32:Configure response headers policy in future work
   #checkov:skip=CKV_AWS_374:Ignore the geo restriction
+  #checkov:skip=CKV_AWS_305:We don't need a default root object... we don't need to redirect / to index.html.
 }

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -38,9 +38,8 @@ resource "aws_cloudfront_cache_policy" "default" {
 resource "aws_cloudfront_distribution" "cdn" {
   count = var.enable_cdn ? 1 : 0
 
-  enabled             = var.enable_cdn ? true : false
-  aliases             = var.domain == null ? null : [var.domain]
-  default_root_object = "/"
+  enabled = var.enable_cdn ? true : false
+  aliases = var.domain == null ? null : [var.domain]
 
   origin {
     domain_name = aws_lb.alb[0].dns_name


### PR DESCRIPTION
## Context

`default_root_object` does the following:

> [default_root_object](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#default_root_object-1) (Optional) - Object that you want CloudFront to return (for example, index.html) when an end user requests the root URL.

It sends the user somewhere when they request `/`, like for example to the literal route `index.html`. Well we don't have an `index.html`. So I figured, `/` should just go to `/`, right? Wrong. When you tell `/` to go to `/` what you end up with is an infinite redirect loop. This me an undue amount of time to debug 😅 

I have no idea why AWS allows you to shoot yourself in the foot like this. Pointing `default_root_object` to `/` should return a validation error on AWS's end...