### PR TITLE
[Issue #3003] Get deploy metabase from shell commande

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,4 @@ jobs:
       - name: Deploy release
         run: make release-deploy \
           APP_NAME=${{ inputs.app_name }} \
-          ENVIRONMENT=${{ inputs.environment }} \
-          DEPLOY_GITHUB_REF=${{ github.ref_name }} \
-          DEPLOY_GITHUB_SHA=${{ github.sha }}
+          ENVIRONMENT=${{ inputs.environment }}

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ infra-update-app-service: ## Create or update $APP_NAME's web service module
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "staging")
 	terraform -chdir="infra/$(APP_NAME)/service" init -input=false -reconfigure -backend-config="$(ENVIRONMENT).s3.tfbackend"
-	terraform -chdir="infra/$(APP_NAME)/service" apply -var="environment_name=$(ENVIRONMENT)" -var="deploy_github_ref=$(DEPLOY_GITHUB_REF)" -var="deploy_github_sha=$(DEPLOY_GITHUB_SHA)"
+	terraform -chdir="infra/$(APP_NAME)/service" apply -var="environment_name=$(ENVIRONMENT)"
 
 infra-update-metabase-service: ## Create or update $APP_NAME's web service module
 	# APP_NAME has a default value defined above, but check anyways in case the default is ever removed
@@ -201,7 +201,7 @@ release-run-database-migrations: ## Run $APP_NAME's database migrations in $ENVI
 release-deploy: ## Deploy release to $APP_NAME's web service in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)
 	@:$(call check_defined, ENVIRONMENT, the name of the application environment e.g. "prod" or "dev")
-	./bin/deploy-release.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT) $(DEPLOY_GITHUB_REF) $(DEPLOY_GITHUB_SHA)
+	./bin/deploy-release.sh $(APP_NAME) $(IMAGE_TAG) $(ENVIRONMENT)
 
 metabase-deploy: ## Deploy metabase to $APP_NAME's web service in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)

--- a/bin/deploy-release.sh
+++ b/bin/deploy-release.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 APP_NAME=$1
 IMAGE_TAG=$2
 ENVIRONMENT=$3
-DEPLOY_GITHUB_REF=$4
-DEPLOY_GITHUB_SHA=$5
 
 echo "--------------"
 echo "Deploy release"
@@ -14,11 +12,9 @@ echo "Input parameters:"
 echo "  APP_NAME=$APP_NAME"
 echo "  IMAGE_TAG=$IMAGE_TAG"
 echo "  ENVIRONMENT=$ENVIRONMENT"
-echo "  DEPLOY_GITHUB_REF=$DEPLOY_GITHUB_REF"
-echo "  DEPLOY_GITHUB_SHA=$DEPLOY_GITHUB_SHA"
 echo
 echo "Starting $APP_NAME deploy of $IMAGE_TAG to $ENVIRONMENT"
 
-TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$IMAGE_TAG" make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT" DEPLOY_GITHUB_REF="$DEPLOY_GITHUB_REF" DEPLOY_GITHUB_SHA="$DEPLOY_GITHUB_SHA"
+TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=$IMAGE_TAG" make infra-update-app-service APP_NAME="$APP_NAME" ENVIRONMENT="$ENVIRONMENT"
 
 echo "Completed $APP_NAME deploy of $IMAGE_TAG to $ENVIRONMENT"

--- a/infra/analytics/service/variables.tf
+++ b/infra/analytics/service/variables.tf
@@ -8,15 +8,3 @@ variable "image_tag" {
   description = "image tag to deploy to the environment"
   default     = null
 }
-
-variable "deploy_github_ref" {
-  type        = string
-  description = "github ref to deploy"
-  default     = null
-}
-
-variable "deploy_github_sha" {
-  type        = string
-  description = "github sha to deploy"
-  default     = null
-}

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -145,7 +145,7 @@ module "service" {
     }
   } : null
 
-  extra_environment_variables = merge({})
+  extra_environment_variables = merge(local.service_config.extra_environment_variables)
 
   secrets = concat(
     [for secret_name in keys(local.service_config.secrets) : {

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -125,6 +125,7 @@ module "service" {
   enable_autoscaling     = true
   cpu                    = local.service_config.instance_cpu
   memory                 = local.service_config.instance_memory
+  environment_name       = var.environment_name
 
   cert_arn = local.domain != null ? data.aws_acm_certificate.cert[0].arn : null
 
@@ -144,13 +145,7 @@ module "service" {
     }
   } : null
 
-  extra_environment_variables = merge(
-    local.service_config.extra_environment_variables,
-    { "ENVIRONMENT" : var.environment_name },
-    { "DEPLOY_TIMESTAMP" : timestamp() },
-    var.deploy_github_sha != null ? { "DEPLOY_GITHUB_SHA" : var.deploy_github_sha } : {},
-    var.deploy_github_ref != null ? { "DEPLOY_GITHUB_REF" : var.deploy_github_ref } : {}
-  )
+  extra_environment_variables = merge({})
 
   secrets = concat(
     [for secret_name in keys(local.service_config.secrets) : {

--- a/infra/api/service/variables.tf
+++ b/infra/api/service/variables.tf
@@ -8,15 +8,3 @@ variable "image_tag" {
   description = "image tag to deploy to the environment"
   default     = null
 }
-
-variable "deploy_github_ref" {
-  type        = string
-  description = "github ref to deploy"
-  default     = null
-}
-
-variable "deploy_github_sha" {
-  type        = string
-  description = "github sha to deploy"
-  default     = null
-}

--- a/infra/frontend/service/variables.tf
+++ b/infra/frontend/service/variables.tf
@@ -14,15 +14,3 @@ variable "domain" {
   description = "DNS domain of the website managed by HHS"
   default     = null
 }
-
-variable "deploy_github_ref" {
-  type        = string
-  description = "github ref to deploy"
-  default     = null
-}
-
-variable "deploy_github_sha" {
-  type        = string
-  description = "github sha to deploy"
-  default     = null
-}

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -6,15 +6,15 @@ data "aws_ecr_repository" "app" {
 }
 
 data "external" "whoami" {
-  program = ["sh", "-c", "whoami | xargs -I {} echo '{\"result\": \"{}\"}'"]
+  program = ["sh", "-c", "whoami | xargs -I {} echo '{\"value\": \"{}\"}'"]
 }
 
 data "external" "deploy_github_ref" {
-  program = ["sh", "-c", "git branch --show-current | xargs -I {} echo '{\"result\": \"{}\"}'"]
+  program = ["sh", "-c", "git branch --show-current | xargs -I {} echo '{\"value\": \"{}\"}'"]
 }
 
 data "external" "deploy_github_sha" {
-  program = ["sh", "-c", "git rev-parse HEAD | xargs -I {} echo '{\"result\": \"{}\"}'"]
+  program = ["sh", "-c", "git rev-parse HEAD | xargs -I {} echo '{\"value\": \"{}\"}'"]
 }
 
 locals {
@@ -32,9 +32,9 @@ locals {
     { name : "S3_BUCKET_ARN", value : aws_s3_bucket.general_purpose.arn },
     { name : "ENVIRONMENT", value : var.environment_name },
     { name : "DEPLOY_TIMESTAMP", value : timestamp() },
-    { name : "DEPLOY_GITHUB_SHA", value : data.external.deploy_github_sha.result },
-    { name : "DEPLOY_GITHUB_REF", value : data.external.deploy_github_ref.result },
-    { name : "DEPLOY_WHOAMI", value : data.external.whoami.result }
+    { name : "DEPLOY_GITHUB_SHA", value : data.external.deploy_github_sha.result.value },
+    { name : "DEPLOY_GITHUB_REF", value : data.external.deploy_github_ref.result.value },
+    { name : "DEPLOY_WHOAMI", value : data.external.whoami.result.value }
   ], local.hostname)
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -6,15 +6,15 @@ data "aws_ecr_repository" "app" {
 }
 
 data "external" "whoami" {
-  program = ["whoami"]
+  program = ["sh", "-c", "whoami | jq -R -c '{\"result\": .}'"]
 }
 
 data "external" "deploy_github_ref" {
-  program = ["git branch --show-current"]
+  program = ["sh", "-c", "git branch --show-current | jq -R -c '{\"result\": .}'"]
 }
 
 data "external" "deploy_github_sha" {
-  program = ["git rev-parse HEAD"]
+  program = ["sh", "-c", "git rev-parse HEAD | jq -R -c '{\"result\": .}'"]
 }
 
 locals {

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -6,15 +6,15 @@ data "aws_ecr_repository" "app" {
 }
 
 data "external" "whoami" {
-  program = ["sh", "-c", "whoami | jq -R -c '{\"result\": .}'"]
+  program = ["sh", "-c", "whoami | xargs -I {} echo '{\"result\": \"{}\"}'"]
 }
 
 data "external" "deploy_github_ref" {
-  program = ["sh", "-c", "git branch --show-current | jq -R -c '{\"result\": .}'"]
+  program = ["sh", "-c", "git branch --show-current | xargs -I {} echo '{\"result\": \"{}\"}'"]
 }
 
 data "external" "deploy_github_sha" {
-  program = ["sh", "-c", "git rev-parse HEAD | jq -R -c '{\"result\": .}'"]
+  program = ["sh", "-c", "git rev-parse HEAD | xargs -I {} echo '{\"result\": \"{}\"}'"]
 }
 
 locals {

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -30,11 +30,11 @@ locals {
     { name : "PORT", value : tostring(var.container_port) },
     { name : "AWS_REGION", value : data.aws_region.current.name },
     { name : "S3_BUCKET_ARN", value : aws_s3_bucket.general_purpose.arn },
-    { "ENVIRONMENT" : var.environment_name },
-    { "DEPLOY_TIMESTAMP" : timestamp() },
-    { "DEPLOY_GITHUB_SHA" : data.external.deploy_github_sha.result },
-    { "DEPLOY_GITHUB_REF" : data.external.deploy_github_ref.result },
-    { "DEPLOY_WHOAMI" : data.external.whoami.result }
+    { name : "ENVIRONMENT", value : var.environment_name },
+    { name : "DEPLOY_TIMESTAMP", value : timestamp() },
+    { name : "DEPLOY_GITHUB_SHA", value : data.external.deploy_github_sha.result },
+    { name : "DEPLOY_GITHUB_REF", value : data.external.deploy_github_ref.result },
+    { name : "DEPLOY_WHOAMI", value : data.external.whoami.result }
   ], local.hostname)
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -48,6 +48,12 @@ variable "container_port" {
   default     = 8000
 }
 
+variable "environment_name" {
+  type        = string
+  description = "The name of the environment"
+  default     = ""
+}
+
 variable "hostname" {
   type        = string
   description = "The hostname to override the default AWS configuration"


### PR DESCRIPTION
## Summary

Relates to #3003, followup from https://github.com/HHS/simpler-grants-gov/pull/3072

Completes 50% of https://github.com/HHS/simpler-grants-gov/issues/3149

### Time to review: __2 mins__

## Changes proposed

- adds DEPLOY_WHOAMI to the deploy metadata environment variables
- adds them to the module layer so they're present on every service we deploy
- removes from the CLI inputs because they're being input by terraform shell commands now (which is something I should have thought about sooner!)

## Testing

From Github actions:

<img width="325" alt="image" src="https://github.com/user-attachments/assets/a9417006-5a00-4aea-98e7-8885995ccb1d">

Locally:

<img width="313" alt="image" src="https://github.com/user-attachments/assets/61972d42-eb2e-46ae-8857-acb9e5655782">
