### PR TITLE
[Unticketed] Allow for null deploy metadata

### DIFF
--- a/api/tests/src/util/test_deploy_metadata.py
+++ b/api/tests/src/util/test_deploy_metadata.py
@@ -1,3 +1,5 @@
+from freezegun import freeze_time
+
 from src.util.deploy_metadata import DeployMetadataConfig
 
 
@@ -30,3 +32,17 @@ def test_deploy_metadata_with_non_release_ref(monkeypatch):
     assert config.release_notes == "https://github.com/HHS/simpler-grants-gov/releases"
     assert config.deploy_commit == f"https://github.com/HHS/simpler-grants-gov/commit/{sha}"
     assert config.deploy_datetime_est.isoformat() == "2024-05-31T23:13:11-04:00"
+
+
+@freeze_time("2024-11-14 12:00:00", tz_offset=0)
+def test_deploy_metadata_all_none(monkeypatch):
+    monkeypatch.delenv("DEPLOY_GITHUB_REF")
+    monkeypatch.delenv("DEPLOY_GITHUB_SHA")
+    monkeypatch.delenv("DEPLOY_TIMESTAMP")
+
+    config = DeployMetadataConfig()
+
+    # Verify the calculated values are there
+    assert config.release_notes == "https://github.com/HHS/simpler-grants-gov/releases"
+    assert config.deploy_commit == "https://github.com/HHS/simpler-grants-gov"
+    assert config.deploy_datetime_est.isoformat() == "2024-11-14T07:00:00-05:00"


### PR DESCRIPTION
## Summary

### Time to review: __3 mins__

## Changes proposed
For our deploy metadata, allow the value to be null (however unlikely) to avoid breaking our jobs

## Context for reviewers
This shouldn't ever be null, but we did hit a weird case where it was due to manual testing which broke our ECS tasks in dev for a few days. This just makes a non-required field, actually non-required. Very useful, but not required.

