### PR TITLE
[Issues #2834 and #2561] Only lint issues closed by PR

### DIFF
--- a/.github/linters/queries/getItemMetadata.graphql
+++ b/.github/linters/queries/getItemMetadata.graphql
@@ -8,6 +8,10 @@ query (
       issueType {
         name
       }
+
+      # get list of pull requests that are linked to this issue
+      ...pullRequestMetadata
+
       # get all of the project items associated with this issue
       projectItems(first: 10) {
         nodes {
@@ -43,6 +47,23 @@ fragment projectMetadata on ProjectV2Item {
     owner {
       ... on Organization {
         login
+      }
+    }
+  }
+}
+
+fragment pullRequestMetadata on Issue {
+  pullRequests: closedByPullRequestsReferences(
+    first: 10
+    includeClosedPrs: true
+  ) {
+    nodes {
+      ... on PullRequest {
+        author {
+          ... on User {
+            login
+          }
+        }
       }
     }
   }

--- a/.github/linters/scripts/set-points-and-sprint.sh
+++ b/.github/linters/scripts/set-points-and-sprint.sh
@@ -106,6 +106,21 @@ jq ".data.resource.projectItems.nodes[] |
 # Get issue type
 issue_type=$(jq -r ".data.resource.issueType.name" $raw_data_file)
 
+# Get PR author (if PR is linked to issue)
+pr_author=$(
+  jq -r '.data.resource.pullRequests.nodes |
+  if length > 0 then .[0].author.login else null end' $raw_data_file
+)
+
+# #######################################################
+# Abort update if issue wasn't closed by a PR
+# #######################################################
+
+if [[ $pr_author == 'null' ]]; then
+  echo "Issue '$issue_url' wasn't closed by a PR. Skipping further updates."
+  exit 0
+fi
+
 # #######################################################
 # Fetch project metadata
 # #######################################################

--- a/.github/workflows/ci-project-linters.yml
+++ b/.github/workflows/ci-project-linters.yml
@@ -18,12 +18,15 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN_PROJECT_ACCESS }}
       # Test issue with points and sprint values unset
-      # to be used with set-points-and-sprint.sh test
+      # to be used with set-points-and-sprint.sh test to demonstrate update
       UNSET_ISSUE: "https://github.com/HHS/simpler-grants-gov/issues/1932"
+      # Test issue with points and sprint values unset, but no linked PR,
+      # to be used with set-points-and-sprint.sh test to demonstrate skipping
+      ISSUE_WITHOUT_PR: "https://github.com/HHS/grants-product-and-delivery/issues/261"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Dry run - Set points and sprint field
+      - name: Dry run - Set points and sprint field (update metadata)
         run: |
           ./scripts/set-points-and-sprint.sh \
             --url "${UNSET_ISSUE}" \
@@ -31,4 +34,14 @@ jobs:
             --project 13 \
             --sprint-field "Sprint" \
             --points-field "Story Points" \
+            --dry-run
+
+      - name: Dry run - Set points and sprint field (skip issue because no PR)
+        run: |
+          ./scripts/set-points-and-sprint.sh \
+            --url "${ISSUE_WITHOUT_PR}" \
+            --org "HHS" \
+            --project 17 \
+            --sprint-field "Sprint" \
+            --points-field "Points" \
             --dry-run


### PR DESCRIPTION
## Summary

Updates issue linter to only update assignee, story points, and sprint values if the issue is closed by a PR.

- Fixes #2834 
- Fixes #2561 

### Time to review: __3 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Adds linked PR details to GraphQL query
- Skips updates if issue has no linked PR
- Assigns PR author to issue

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. Checkout PR
2. Find an issue that _wasn't_ closed by a PR
3. Unset that issues Story Points or Sprint value in project HHS/13 (Simpler.Grants.gov product backlog)
4. Run the following command from the command line:
```
./scripts/set-points-and-sprint.sh \
 --url "<issue-url>" \
 --org "HHS" \
 --project 13 \
 --sprint-field "Sprint" \
 --points-field "Story Points" \
 --dry-run
```

You should see something like this:
```
Running in dry run mode
Issue '<issue-url>' wasn't closed by a PR. Skipping further action.
```

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Here are [examples](https://github.com/HHS/simpler-grants-gov/actions/runs/12245175931/job/34158514554?pr=3154) of when it _would_ and _wouldn't_ run:

<img width="1436" alt="Screenshot 2024-12-09 at 5 08 25 PM" src="https://github.com/user-attachments/assets/17166bea-1b48-440c-aba0-b5f0dbeba488">


