### PR TITLE
Ds/renovate i18next http backend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,7 +60,7 @@
         "eslint-plugin-storybook": "^0.9.0",
         "eslint-plugin-testing-library": "^5.11.0",
         "i18next-browser-languagedetector": "^7.0.2",
-        "i18next-http-backend": "^2.2.1",
+        "i18next-http-backend": "^3.0.1",
         "jest": "^29.5.0",
         "jest-axe": "^7.0.0",
         "jest-cli": "^29.5.0",
@@ -13429,9 +13429,9 @@
       }
     },
     "node_modules/i18next-http-backend": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.7.1.tgz",
-      "integrity": "sha512-vPksHIckysGgykCD8JwCr2YsJEml9Cyw+Yu2wtb4fQ7xIn9RH/hkUDh5UkwnIzb0kSL4SJ30Ab/sCInhQxbCgg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.1.tgz",
+      "integrity": "sha512-XT2lYSkbAtDE55c6m7CtKxxrsfuRQO3rUfHzj8ZyRtY9CkIX3aRGwXGTkUhpGWce+J8n7sfu3J0f2wTzo7Lw0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13419,19 +13419,21 @@
       }
     },
     "node_modules/i18next-browser-languagedetector": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.1.tgz",
-      "integrity": "sha512-h/pM34bcH6tbz8WgGXcmWauNpQupCGr25XPp9cZwZInR9XHSjIFDYp1SIok7zSPsTOMxdvuLyu86V+g2Kycnfw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.2.tgz",
+      "integrity": "sha512-6b7r75uIJDWCcCflmbof+sJ94k9UQO4X0YR62oUfqGI/GjCLVzlCwu8TFdRZIqVLzWbzNcmkmhfqKEr4TLz4HQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/i18next-http-backend": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.6.1.tgz",
-      "integrity": "sha512-rCilMAnlEQNeKOZY1+x8wLM5IpYOj10guGvEpeC59tNjj6MMreLIjIW8D1RclhD3ifLwn6d/Y9HEM1RUE6DSog==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.7.1.tgz",
+      "integrity": "sha512-vPksHIckysGgykCD8JwCr2YsJEml9Cyw+Yu2wtb4fQ7xIn9RH/hkUDh5UkwnIzb0kSL4SJ30Ab/sCInhQxbCgg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-fetch": "4.0.0"
       }
@@ -20456,9 +20458,9 @@
       "license": "MIT"
     },
     "node_modules/storybook-react-i18next": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/storybook-react-i18next/-/storybook-react-i18next-3.1.7.tgz",
-      "integrity": "sha512-y5wwZ2ROtKxESoiDw1Ct4yOdAQxsRh4mYqsCqV9rvcPzUsQExsTsxEUkEc1GCeITrQPYWdAZtI1sCXC3NzMD8A==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/storybook-react-i18next/-/storybook-react-i18next-3.1.8.tgz",
+      "integrity": "sha512-v5WN0ra5Bwn4+IwDZ5Uc7jKCMy2NICe9zyUCuGabeQPfd+b76/4oDkPmVGoYsVqOORpm2uHtDJM1lYN4cWEtRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-storybook": "^0.9.0",
     "eslint-plugin-testing-library": "^5.11.0",
     "i18next-browser-languagedetector": "^7.0.2",
-    "i18next-http-backend": "^2.2.1",
+    "i18next-http-backend": "^3.0.1",
     "jest": "^29.5.0",
     "jest-axe": "^7.0.0",
     "jest-cli": "^29.5.0",
@@ -97,5 +97,8 @@
     "storybook-react-i18next": "^3.1.7",
     "style-loader": "^3.3.2",
     "typescript": "^5.0.0"
+  },
+  "overrides": {
+    "i18next-http-backend": "^3.0.1"
   }
 }


### PR DESCRIPTION
## Summary
Fixes unticketed

### Time to review: __15 mins__

## Changes proposed
This is an update to the renovate PR to update i18n-next https://github.com/HHS/simpler-grants-gov/pull/2595

The renovate PR pushes i18next-http-backend to 2.7, which has been deprecated by the maintainer. As 2.7 contained a breaking change and introduced a possible bug, we should be pointing at the latest version, 3.0.1 instead

see https://github.com/i18next/i18next-http-backend/issues/161

## Context for reviewers
Test steps can be found in gitbook, but I can't find them at the moment. Did the private gitbook go away?

In general, make sure you can build the app, and run the app and storybook locally

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

