### PR TITLE
[Unticketed] Fix a noisy log from New Relic in tests

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -55,6 +55,12 @@ def env_vars():
     load_local_env_vars()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def set_logging_defaults(monkeypatch_session):
+    # Some loggers are noisy/buggy in our tests, so adjust them
+    monkeypatch_session.setenv("LOG_LEVEL_OVERRIDES", "newrelic.core.agent=ERROR")
+
+
 ### Uploads test files
 @pytest.fixture
 def upload_opportunity_attachment_s3(reset_aws_env_vars, mock_s3_bucket):


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Add the ability to adjust log level in env var

Use that env var to make a log message from New Relic stop appearing in unit tests

## Context for reviewers
You can configure the log level of any logger, which we already have static defaults for many in our logging config. In this case, I didn't want a default as there was an errant log message propagating from New Relic every time we ran our unit tests.

Easiest fix was just to hide the log message, and figured I'd add some flexibility for it while I was at it, borrowing some code from past projects.

## Additional information

Before this change, if you ran `make test` it would run successfully, but always dump out this annoying error message.

The error is likely just the app closing before New Relic does and while we could try to rework something to make that not happen, it's happening when the tests are done / we don't care about New Relic at all in tests.
```sh
--- Logging error ---
Traceback (most recent call last):
  File "/Users/michaelchouinard/.pyenv/versions/3.13.0/lib/python3.13/logging/__init__.py", line 1153, in emit
    stream.write(msg + self.terminator)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
ValueError: I/O operation on closed file.
Call stack:
  File "/Users/michaelchouinard/workspace/grants-equity/api/.venv/lib/python3.13/site-packages/newrelic/core/agent.py", line 731, in _atexit_shutdown
    self.shutdown_agent()
  File "/Users/michaelchouinard/workspace/grants-equity/api/.venv/lib/python3.13/site-packages/newrelic/core/agent.py", line 740, in shutdown_agent
    _logger.info("New Relic Python Agent Shutdown")
  File "/Users/michaelchouinard/.pyenv/versions/3.13.0/lib/python3.13/logging/__init__.py", line 1519, in info
    self._log(INFO, msg, args, **kwargs)
  File "/Users/michaelchouinard/.pyenv/versions/3.13.0/lib/python3.13/logging/__init__.py", line 1664, in _log
    self.handle(record)
  File "/Users/michaelchouinard/.pyenv/versions/3.13.0/lib/python3.13/logging/__init__.py", line 1680, in handle
    self.callHandlers(record)
  File "/Users/michaelchouinard/workspace/grants-equity/api/.venv/lib/python3.13/site-packages/newrelic/hooks/logger_logging.py", line 55, in wrap_callHandlers
    return wrapped(*args, **kwargs)
Message: 'New Relic Python Agent Shutdown'
Arguments: ()
```

