### PR TITLE
[#2625] Update next.config.js for /subcribe caching

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -56,6 +56,16 @@ const nextConfig = {
           },
         ],
       },
+      // don't cache the form
+      {
+        source: "/subscribe/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, must-revalidate",
+          },
+        ],
+      },
     ];
   },
   basePath,


### PR DESCRIPTION
## Summary
Fixes #2625

### Time to review: __2 mins__

## Changes proposed
Keeps /subcribe from being cached so form still works with the CDN.