### PR TITLE
[Issue #3129] Validate that the nonce matches in login gov token response

### DIFF
--- a/api/tests/src/auth/test_login_gov_jwt_auth.py
+++ b/api/tests/src/auth/test_login_gov_jwt_auth.py
@@ -10,6 +10,7 @@ from src.auth.login_gov_jwt_auth import JwtValidationError, LoginGovConfig, vali
 
 DEFAULT_CLIENT_ID = "urn:gov:unit-test"
 DEFAULT_ISSUER = "http://localhost:3000"
+DEFAULT_NONCE = "abc123"
 
 
 @pytest.fixture
@@ -35,6 +36,7 @@ def create_jwt(
     issuer: str = DEFAULT_ISSUER,
     audience: str = DEFAULT_CLIENT_ID,
     acr: str = "urn:acr.login.gov:auth-only",
+    nonce: str = DEFAULT_NONCE,
 ):
     payload = {
         "sub": user_id,
@@ -42,6 +44,7 @@ def create_jwt(
         "acr": acr,
         "aud": audience,
         "email": email,
+        "nonce": nonce,
         # The jwt encode function automatically turns these datetime
         # objects into a UTC timestamp integer
         "exp": expires_at,
@@ -50,7 +53,6 @@ def create_jwt(
         # These values aren't checked by anything at the moment
         # but are a part of the token from login.gov
         "jti": "abc123",
-        "nonce": "abc123",
         "at_hash": "abc123",
         "c_hash": "abc123",
     }
@@ -71,7 +73,7 @@ def test_validate_token_happy_path(login_gov_config, private_rsa_key):
         not_before=datetime.now(tz=timezone.utc) - timedelta(days=1),
     )
 
-    login_gov_user = validate_token(token, login_gov_config)
+    login_gov_user = validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
     assert login_gov_user.user_id == user_id
     assert login_gov_user.email == email
@@ -88,7 +90,7 @@ def test_validate_token_expired(login_gov_config, private_rsa_key):
     )
 
     with pytest.raises(JwtValidationError, match="Expired Token"):
-        validate_token(token, login_gov_config)
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 def test_validate_token_issued_at_future(login_gov_config, private_rsa_key):
@@ -102,7 +104,7 @@ def test_validate_token_issued_at_future(login_gov_config, private_rsa_key):
     )
 
     with pytest.raises(JwtValidationError, match="Token not yet valid"):
-        validate_token(token, login_gov_config)
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 def test_validate_token_not_before_future(login_gov_config, private_rsa_key):
@@ -116,7 +118,7 @@ def test_validate_token_not_before_future(login_gov_config, private_rsa_key):
     )
 
     with pytest.raises(JwtValidationError, match="Token not yet valid"):
-        validate_token(token, login_gov_config)
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 def test_validate_token_unknown_issuer(login_gov_config, private_rsa_key):
@@ -131,7 +133,7 @@ def test_validate_token_unknown_issuer(login_gov_config, private_rsa_key):
     )
 
     with pytest.raises(JwtValidationError, match="Unknown Issuer"):
-        validate_token(token, login_gov_config)
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 def test_validate_token_unknown_audience(login_gov_config, private_rsa_key):
@@ -146,7 +148,7 @@ def test_validate_token_unknown_audience(login_gov_config, private_rsa_key):
     )
 
     with pytest.raises(JwtValidationError, match="Unknown Audience"):
-        validate_token(token, login_gov_config)
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 def test_validate_token_invalid_signature(login_gov_config, other_rsa_key_pair, monkeypatch):
@@ -170,10 +172,10 @@ def test_validate_token_invalid_signature(login_gov_config, other_rsa_key_pair, 
         JwtValidationError,
         match="Token could not be validated against any public keys from login.gov",
     ):
-        validate_token(token, login_gov_config)
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
-def test_something_with_the_refresh(login_gov_config, other_rsa_key_pair, monkeypatch):
+def test_validate_token_key_found_on_refresh(login_gov_config, other_rsa_key_pair, monkeypatch):
     token = create_jwt(
         user_id="abc123",
         email="mail@fake.com",
@@ -188,7 +190,7 @@ def test_something_with_the_refresh(login_gov_config, other_rsa_key_pair, monkey
 
     monkeypatch.setattr(login_gov_jwt_auth, "_refresh_keys", override_method)
 
-    validate_token(token, login_gov_config)
+    validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 @freezegun.freeze_time("2024-11-14 12:00:00", tz_offset=0)
@@ -213,3 +215,18 @@ def test_get_login_gov_client_assertion(login_gov_config, public_rsa_key):
     assert decoded_jwt["exp"] == timegm(
         datetime.fromisoformat("2024-11-14 12:05:00+00:00").utctimetuple()
     )
+
+
+def test_validate_token_invalid_nonce(login_gov_config, private_rsa_key):
+    token = create_jwt(
+        user_id="abc123",
+        email="mail@fake.com",
+        nonce="something_else",
+        private_key=private_rsa_key,
+        expires_at=datetime.now(tz=timezone.utc) + timedelta(days=30),
+        issued_at=datetime.now(tz=timezone.utc) - timedelta(days=1),
+        not_before=datetime.now(tz=timezone.utc) - timedelta(days=1),
+    )
+
+    with pytest.raises(JwtValidationError, match="Nonce does not match expected"):
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)


### PR DESCRIPTION
## Summary
Fixes #3129

### Time to review: __10 mins__

## Changes proposed
Validate the nonce value when receiving the token back from login.gov

Delete the login gov state value after we've used it once

Some restructuring to handle the multi-commit approach required here

## Context for reviewers
We delete the state object after processing a response that uses it to prevent any sort of replay attack (ie. that state should be used for a single session of logging in, it shouldn't ever be used again). If a user navigates to the login page again later, we'd make a new state anyways, so the data isn't needed anyways.

As for the nonce, this is a UUID we generated when we first redirected someone to login.gov - login.gov doesn't echo it back to us until we are parsing the response from the token endpoint. In short, by checking for this, we protect ourselves from replay attacks.

## Additional information
See: https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes for more details on the nonce
https://en.wikipedia.org/wiki/Replay_attack

