### PR TITLE
[Issue #3214] update fonts to Public Sans, Newsreader

### DIFF
--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -22,6 +22,8 @@ i.e.
 
 @use "uswds-core" as *;
 
+@import url("https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&display=swap");
+
 .pdf-card {
   transition: transform 0.2s;
   @include u-shadow(2);

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -58,6 +58,15 @@ in the form $setting: value,
   ),
 
   // Typography settings
+  $theme-font-type-sans: "public-sans",
+  $theme-typeface-tokens: (
+    newsreader: (
+      display-name: "Newsreader",
+      cap-height: 364px,
+      stack: "Georgia, serif",
+    )
+  ),
+  $theme-font-type-serif: "newsreader",
   $theme-global-link-styles: true,
   $theme-body-font-size: "md",
   $theme-type-scale-3xs: 2,


### PR DESCRIPTION
## Summary
Fixes #3124 

### Time to review: __2 mins__

## Changes proposed
This change adds the Newsreader font from the Google Fonts hosting service, sets the sans serf font to Public Sans, defines a USWDS type token for Newsreader, and sets the serif font to Newsreader (with the fallback set to Georgia, per brand guidelines). 

## Context for reviewers
When you view the site, all type should be Public Sans or Newsreader. You should no longer see Source Sans Pro or Merriweather. This change just changes the fonts. There will be subsequent PRs to use the right fonts in the right places so that the design looks better. 

## Additional information

Before (left) & after (right)
![image](https://github.com/user-attachments/assets/29925790-4233-466d-929d-7869f87ef973)
