### PR TITLE
[Issue #3217] update color settings to match brand

### DIFF
--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -139,7 +139,6 @@ in the form $setting: value,
   // $theme-color-error: "red-warm-50v",
   // $theme-color-error-dark: "red-60v",
   // $theme-color-error-darker: "red-70",
-
   // Warning colors
   // $theme-color-warning-family: "gold",
   // $theme-color-warning-lighter: "yellow-5",
@@ -147,7 +146,6 @@ in the form $setting: value,
   // $theme-color-warning: "gold-20v",
   // $theme-color-warning-dark: "gold-30v",
   // $theme-color-warning-darker: "gold-50v",
-
   // Success colors
   // $theme-color-success-family: "green-cool",
   // $theme-color-success-lighter: "green-cool-5",
@@ -155,7 +153,6 @@ in the form $setting: value,
   // $theme-color-success: "green-cool-40v",
   // $theme-color-success-dark: "green-cool-50v",
   // $theme-color-success-darker: "green-cool-60v",
-
   // Info colors
   // $theme-color-info-family: "cyan",
   // $theme-color-info-lighter: "cyan-5",
@@ -163,7 +160,6 @@ in the form $setting: value,
   // $theme-color-info: "cyan-30v",
   // $theme-color-info-dark: "cyan-40v",
   // $theme-color-info-darker: "blue-cool-60",
-
   // Disabled colors
   // $theme-color-disabled-family: "gray",
   // $theme-color-disabled-lighter: "gray-20",
@@ -171,18 +167,14 @@ in the form $setting: value,
   // $theme-color-disabled: "gray-50",
   // $theme-color-disabled-dark: "gray-70",
   // $theme-color-disabled-darker: "gray-90",
-
   // Emergency colors
   // $theme-color-emergency: "red-warm-60v",
   // $theme-color-emergency-dark: "red-warm-80",
-
   // Body colors
   // $theme-body-background-color: "white" !default;
-
   // Text
   // $theme-text-color: "ink" !default;
   // $theme-text-reverse-color: "white" !default;
-
   // Links
   $theme-link-color: "mint-50",
   $theme-link-visited-color: "violet-60",

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -77,5 +77,118 @@ in the form $setting: value,
       "palette-color-system-yellow-light",
       "palette-color-system-green-cool",
       "palette-color-system-red-warm"
-    )
+    ),
+
+  // Base colors
+  $theme-color-base-family: "gray-warm",
+  $theme-color-base-lightest: "gray-warm-5",
+  $theme-color-base-lighter: "gray-warm-10",
+  $theme-color-base-light: "gray-warm-20",
+  $theme-color-base: "gray-warm-30",
+  $theme-color-base-dark: "gray-warm-50",
+  $theme-color-base-darker: "gray-warm-70",
+  $theme-color-base-darkest: "gray-warm-90",
+  $theme-color-base-ink: "gray-warm-90",
+
+  // Primary colors
+  $theme-color-primary-family: "mint",
+  $theme-color-primary-lightest: "mint-5",
+  $theme-color-primary-lighter: "mint-10",
+  $theme-color-primary-light: "mint-20",
+  $theme-color-primary: "mint-30",
+  $theme-color-primary-vivid: "mint-40",
+  $theme-color-primary-dark: "mint-50",
+  $theme-color-primary-darker: "mint-60",
+  $theme-color-primary-darkest: "mint-70",
+
+  // Secondary colors
+  $theme-color-secondary-family: "blue-cool-vivid",
+  $theme-color-secondary-lightest: "blue-cool-5v",
+  $theme-color-secondary-lighter: "blue-cool-10v",
+  $theme-color-secondary-light: "blue-cool-20v",
+  $theme-color-secondary: "blue-cool-30v",
+  $theme-color-secondary-vivid: "blue-cool-40v",
+  $theme-color-secondary-dark: "blue-cool-50v",
+  $theme-color-secondary-darker: "blue-cool-60v",
+  $theme-color-secondary-darkest: "blue-cool-70v",
+
+  // Accent warm colors
+  $theme-color-accent-warm-family: "yellow-vivid",
+  $theme-color-accent-warm-lightest: "yellow-5v",
+  $theme-color-accent-warm-lighter: "yellow-10v",
+  $theme-color-accent-warm-light: "yellow-20v",
+  $theme-color-accent-warm: "gold-20v",
+  $theme-color-accent-warm-dark: "orange-30v",
+  $theme-color-accent-warm-darker: "orange-warm-40v",
+  $theme-color-accent-warm-darkest: "orange-warm-50v",
+
+  // Accent cool colors
+  $theme-color-accent-cool-family: "violet",
+  $theme-color-accent-cool-lightest: "violet-10",
+  $theme-color-accent-cool-lighter: "violet-20",
+  $theme-color-accent-cool-light: "violet-30",
+  $theme-color-accent-cool: "violet-40",
+  $theme-color-accent-cool-dark: "violet-50",
+  $theme-color-accent-cool-darker: "violet-60",
+  $theme-color-accent-cool-darkest: "violet-70",
+
+  // Error colors
+  // $theme-color-error-family: "red-warm",
+  // $theme-color-error-lighter: "red-warm-10",
+  // $theme-color-error-light: "red-warm-30v",
+  // $theme-color-error: "red-warm-50v",
+  // $theme-color-error-dark: "red-60v",
+  // $theme-color-error-darker: "red-70",
+
+  // Warning colors
+  // $theme-color-warning-family: "gold",
+  // $theme-color-warning-lighter: "yellow-5",
+  // $theme-color-warning-light: "yellow-10v",
+  // $theme-color-warning: "gold-20v",
+  // $theme-color-warning-dark: "gold-30v",
+  // $theme-color-warning-darker: "gold-50v",
+
+  // Success colors
+  // $theme-color-success-family: "green-cool",
+  // $theme-color-success-lighter: "green-cool-5",
+  // $theme-color-success-light: "green-cool-20v",
+  // $theme-color-success: "green-cool-40v",
+  // $theme-color-success-dark: "green-cool-50v",
+  // $theme-color-success-darker: "green-cool-60v",
+
+  // Info colors
+  // $theme-color-info-family: "cyan",
+  // $theme-color-info-lighter: "cyan-5",
+  // $theme-color-info-light: "cyan-20",
+  // $theme-color-info: "cyan-30v",
+  // $theme-color-info-dark: "cyan-40v",
+  // $theme-color-info-darker: "blue-cool-60",
+
+  // Disabled colors
+  // $theme-color-disabled-family: "gray",
+  // $theme-color-disabled-lighter: "gray-20",
+  // $theme-color-disabled-light: "gray-40",
+  // $theme-color-disabled: "gray-50",
+  // $theme-color-disabled-dark: "gray-70",
+  // $theme-color-disabled-darker: "gray-90",
+
+  // Emergency colors
+  // $theme-color-emergency: "red-warm-60v",
+  // $theme-color-emergency-dark: "red-warm-80",
+
+  // Body colors
+  // $theme-body-background-color: "white" !default;
+
+  // Text
+  // $theme-text-color: "ink" !default;
+  // $theme-text-reverse-color: "white" !default;
+
+  // Links
+  $theme-link-color: "mint-50",
+  $theme-link-visited-color: "violet-60",
+  $theme-link-hover-color: "mint-60",
+  $theme-link-active-color: "mint-70",
+  $theme-link-reverse-color: "mint-5",
+  $theme-link-reverse-hover-color: "mint-10",
+  $theme-link-reverse-active-color: "white"
 );


### PR DESCRIPTION
## Summary
Fixes #3217 

### Time to review: __5 mins__

## Changes proposed
This change updates the USWDS theme file to use the brand color palette prescribed in the [Figma](https://www.figma.com/design/FGxWtAgToKhehLJCiuy1zL/Simpler.Grants.gov-Project?node-id=1503-695&node-type=frame&t=InZzQfGYsDVKfze4-0). 

## Context for reviewers
It's not easy to preview all these changes, as we're not using all the colors yet. But all the variables are defined to work with the brand colors now. You can view the site to confirm that the theme is applying the colors to the links, buttons, and background elements. 

#3227 should be merged into this before merging into `feature/brand`

## Additional information

Note the following in this before and after: 
- Link color changed from blue to green in the "An official website" banner at the top
- Visited link color changed to the right violet in the beta alert
- Hero background shows the change to the `primary` color (this will be fixed to use the right color in #3224) 
- The button color color uses the new `primary` color (#3218 will make this match the brand) 

![image](https://github.com/user-attachments/assets/035297c2-20e7-4bd6-90d5-06c9a8bd8e58)
