### PR TITLE
[Issue #3218] add custom button styles

### DIFF
--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -30,3 +30,196 @@ i.e.
     @include u-shadow(4);
   }
 }
+
+// Button
+.usa-button {
+  &,
+  &:visited {
+    background-color: color("mint-50");
+    color: white;
+    border-bottom: 5px solid color("mint-cool-40v");
+  }
+
+  &:hover,
+  &.usa-button--hover {
+    background-color: color("mint-60");
+    border-bottom: 5px solid color("mint-cool-50v");
+  }
+
+  &:active,
+  &.usa-button--active {
+    background-color: color("mint-70");
+    border-bottom: 5px solid color("mint-cool-50v");
+  }
+
+  &:disabled,
+  &[aria-disabled="true"] {
+    color: color("gray-60");
+    background-color: color("gray-20");
+    border-bottom: 5px solid color("gray-10");
+  }
+}
+
+// Button: Base
+.usa-button--base {
+  &,
+  &:visited {
+    background-color: color("gray-warm-50");
+    color: white;
+    border-bottom: 5px solid color("gray-warm-30");
+  }
+
+  &:hover,
+  &.usa-button--hover {
+    background-color: color("gray-warm-60");
+    border-bottom: 5px solid color("gray-warm-40");
+  }
+
+  &:active,
+  &.usa-button--active {
+    background-color: color("gray-warm-70");
+    border-bottom: 5px solid color("gray-warm-50");
+  }
+}
+
+// Button: Secondary
+.usa-button--secondary {
+  &,
+  &:visited {
+    background-color: color("mint-5");
+    color: color("mint-60");
+    border-bottom: 5px solid color("mint-cool-40v");
+  }
+
+  &:hover,
+  &.usa-button--hover {
+    background-color: color("mint-10");
+    color: color("mint-70");
+    border-bottom: 5px solid color("mint-cool-50v");
+  }
+
+  &:active,
+  &.usa-button--active {
+    background-color: color("mint-20");
+    color: color("mint-80");
+    border-bottom: 5px solid color("mint-cool-60v");
+  }
+}
+
+// Button: Accent Cool
+.usa-button--accent-cool {
+  &,
+  &:visited {
+    background-color: color("violet-30");
+    color: color("violet-80");
+    border-bottom: 5px solid color("violet-40");
+  }
+
+  &:hover,
+  &.usa-button--hover {
+    background-color: color("violet-20");
+    color: color("violet-70");
+    border-bottom: 5px solid color("violet-30");
+  }
+
+  &:active,
+  &.usa-button--active {
+    background-color: color("violet-10");
+    color: color("violet-60");
+    border-bottom: 5px solid color("violet-20");
+  }
+}
+
+// Button: Accent Warm
+.usa-button--accent-warm {
+  &,
+  &:visited {
+    background-color: color("yellow-20v");
+    color: color("gray-warm-80");
+    border-bottom: 5px solid color("orange-30v");
+  }
+
+  &:hover,
+  &.usa-button--hover {
+    background-color: color("yellow-10v");
+    border-bottom: 5px solid color("gold-20v");
+  }
+
+  &:active,
+  &.usa-button--active {
+    background-color: color("yellow-5v");
+    border-bottom: 5px solid color("yellow-20v");
+  }
+}
+
+// Button: Outline
+.usa-button--outline {
+  &,
+  &:visited {
+    background-color: color("transparent");
+    box-shadow: inset 0 0 0 2px color("mint-50");
+    color: color("mint-50");
+    border-bottom: 5px solid color("mint-50");
+  }
+
+  &:hover,
+  &.usa-button--hover {
+    background-color: color("transparent");
+    box-shadow: inset 0 0 0 2px color("mint-60");
+    color: color("mint-60");
+    border-bottom-color: color("mint-60");
+  }
+
+  &:active,
+  &.usa-button--active {
+    background-color: color("transparent");
+    box-shadow: inset 0 0 0 2px color("mint-70");
+    color: color("mint-70");
+    border-bottom-color: color("mint-70");
+  }
+
+  &.usa-button--inverse {
+    &,
+    &:visited {
+      box-shadow: inset 0 0 0 2px color("mint-10");
+      color: color("mint-10");
+      border-bottom-color: color("mint-10");
+    }
+
+    &:hover,
+    &.usa-button--hover {
+      box-shadow: inset 0 0 0 2px color("mint-5");
+      color: color("mint-5");
+      border-bottom-color: color("mint-5");
+    }
+
+    &:active,
+    &.usa-button--active {
+      box-shadow: inset 0 0 0 2px white;
+      color: white;
+      border-bottom-color: white;
+    }
+  }
+}
+
+// Button: Outline Disabled
+.usa-button--outline:disabled,
+.usa-button--outline[aria-disabled="true"],
+.usa-button--outline-inverse:disabled,
+.usa-button--outline-inverse[aria-disabled="true"] {
+  &,
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: color("transparent");
+    box-shadow: inset 0 0 0 2px color("gray-20");
+    color: color("gray-60");
+    border-bottom: 5px solid color("gray-20");
+  }
+}
+
+// Button: Unstyled
+.usa-button--unstyled {
+  @include button-unstyled;
+  border-bottom: 0 !important;
+}

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -177,11 +177,11 @@ in the form $setting: value,
   // $theme-color-emergency-dark: "red-warm-80",
 
   // Body colors
-  // $theme-body-background-color: "white" !default;
+  // $theme-body-background-color: "white",
 
   // Text
-  // $theme-text-color: "ink" !default;
-  // $theme-text-reverse-color: "white" !default;
+  // $theme-text-color: "ink",
+  // $theme-text-reverse-color: "white",
 
   // Links
   $theme-link-color: "mint-50",
@@ -190,5 +190,12 @@ in the form $setting: value,
   $theme-link-active-color: "mint-70",
   $theme-link-reverse-color: "mint-5",
   $theme-link-reverse-hover-color: "mint-10",
-  $theme-link-reverse-active-color: "white"
+  $theme-link-reverse-active-color: "white", 
+
+  // Button
+  $theme-button-border-radius: 2px,
+  // $theme-button-font-family: "ui",
+  // $theme-button-icon-gap: 1,
+  // $theme-button-small-width: 6,
+  // $theme-button-stroke-width: 2px,
 );

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -139,7 +139,7 @@ in the form $setting: value,
   // $theme-color-error: "red-warm-50v",
   // $theme-color-error-dark: "red-60v",
   // $theme-color-error-darker: "red-70",
-
+  
   // Warning colors
   // $theme-color-warning-family: "gold",
   // $theme-color-warning-lighter: "yellow-5",
@@ -147,7 +147,7 @@ in the form $setting: value,
   // $theme-color-warning: "gold-20v",
   // $theme-color-warning-dark: "gold-30v",
   // $theme-color-warning-darker: "gold-50v",
-
+  
   // Success colors
   // $theme-color-success-family: "green-cool",
   // $theme-color-success-lighter: "green-cool-5",
@@ -155,7 +155,7 @@ in the form $setting: value,
   // $theme-color-success: "green-cool-40v",
   // $theme-color-success-dark: "green-cool-50v",
   // $theme-color-success-darker: "green-cool-60v",
-
+  
   // Info colors
   // $theme-color-info-family: "cyan",
   // $theme-color-info-lighter: "cyan-5",
@@ -163,7 +163,7 @@ in the form $setting: value,
   // $theme-color-info: "cyan-30v",
   // $theme-color-info-dark: "cyan-40v",
   // $theme-color-info-darker: "blue-cool-60",
-
+  
   // Disabled colors
   // $theme-color-disabled-family: "gray",
   // $theme-color-disabled-lighter: "gray-20",
@@ -171,18 +171,17 @@ in the form $setting: value,
   // $theme-color-disabled: "gray-50",
   // $theme-color-disabled-dark: "gray-70",
   // $theme-color-disabled-darker: "gray-90",
-
+  
   // Emergency colors
   // $theme-color-emergency: "red-warm-60v",
   // $theme-color-emergency-dark: "red-warm-80",
-
   // Body colors
   // $theme-body-background-color: "white",
-
+  
   // Text
   // $theme-text-color: "ink",
   // $theme-text-reverse-color: "white",
-
+  
   // Links
   $theme-link-color: "mint-50",
   $theme-link-visited-color: "violet-60",
@@ -190,7 +189,7 @@ in the form $setting: value,
   $theme-link-active-color: "mint-70",
   $theme-link-reverse-color: "mint-5",
   $theme-link-reverse-hover-color: "mint-10",
-  $theme-link-reverse-active-color: "white", 
+  $theme-link-reverse-active-color: "white",
 
   // Button
   $theme-button-border-radius: 2px,

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -175,6 +175,7 @@ in the form $setting: value,
   // Emergency colors
   // $theme-color-emergency: "red-warm-60v",
   // $theme-color-emergency-dark: "red-warm-80",
+
   // Body colors
   // $theme-body-background-color: "white",
 

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -139,7 +139,7 @@ in the form $setting: value,
   // $theme-color-error: "red-warm-50v",
   // $theme-color-error-dark: "red-60v",
   // $theme-color-error-darker: "red-70",
-  
+
   // Warning colors
   // $theme-color-warning-family: "gold",
   // $theme-color-warning-lighter: "yellow-5",
@@ -147,7 +147,7 @@ in the form $setting: value,
   // $theme-color-warning: "gold-20v",
   // $theme-color-warning-dark: "gold-30v",
   // $theme-color-warning-darker: "gold-50v",
-  
+
   // Success colors
   // $theme-color-success-family: "green-cool",
   // $theme-color-success-lighter: "green-cool-5",
@@ -155,7 +155,7 @@ in the form $setting: value,
   // $theme-color-success: "green-cool-40v",
   // $theme-color-success-dark: "green-cool-50v",
   // $theme-color-success-darker: "green-cool-60v",
-  
+
   // Info colors
   // $theme-color-info-family: "cyan",
   // $theme-color-info-lighter: "cyan-5",
@@ -163,7 +163,7 @@ in the form $setting: value,
   // $theme-color-info: "cyan-30v",
   // $theme-color-info-dark: "cyan-40v",
   // $theme-color-info-darker: "blue-cool-60",
-  
+
   // Disabled colors
   // $theme-color-disabled-family: "gray",
   // $theme-color-disabled-lighter: "gray-20",
@@ -171,17 +171,17 @@ in the form $setting: value,
   // $theme-color-disabled: "gray-50",
   // $theme-color-disabled-dark: "gray-70",
   // $theme-color-disabled-darker: "gray-90",
-  
+
   // Emergency colors
   // $theme-color-emergency: "red-warm-60v",
   // $theme-color-emergency-dark: "red-warm-80",
   // Body colors
   // $theme-body-background-color: "white",
-  
+
   // Text
   // $theme-text-color: "ink",
   // $theme-text-reverse-color: "white",
-  
+
   // Links
   $theme-link-color: "mint-50",
   $theme-link-visited-color: "violet-60",

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -139,6 +139,7 @@ in the form $setting: value,
   // $theme-color-error: "red-warm-50v",
   // $theme-color-error-dark: "red-60v",
   // $theme-color-error-darker: "red-70",
+
   // Warning colors
   // $theme-color-warning-family: "gold",
   // $theme-color-warning-lighter: "yellow-5",
@@ -146,6 +147,7 @@ in the form $setting: value,
   // $theme-color-warning: "gold-20v",
   // $theme-color-warning-dark: "gold-30v",
   // $theme-color-warning-darker: "gold-50v",
+
   // Success colors
   // $theme-color-success-family: "green-cool",
   // $theme-color-success-lighter: "green-cool-5",
@@ -153,6 +155,7 @@ in the form $setting: value,
   // $theme-color-success: "green-cool-40v",
   // $theme-color-success-dark: "green-cool-50v",
   // $theme-color-success-darker: "green-cool-60v",
+
   // Info colors
   // $theme-color-info-family: "cyan",
   // $theme-color-info-lighter: "cyan-5",
@@ -160,6 +163,7 @@ in the form $setting: value,
   // $theme-color-info: "cyan-30v",
   // $theme-color-info-dark: "cyan-40v",
   // $theme-color-info-darker: "blue-cool-60",
+
   // Disabled colors
   // $theme-color-disabled-family: "gray",
   // $theme-color-disabled-lighter: "gray-20",
@@ -167,14 +171,18 @@ in the form $setting: value,
   // $theme-color-disabled: "gray-50",
   // $theme-color-disabled-dark: "gray-70",
   // $theme-color-disabled-darker: "gray-90",
+
   // Emergency colors
   // $theme-color-emergency: "red-warm-60v",
   // $theme-color-emergency-dark: "red-warm-80",
+
   // Body colors
-  // $theme-body-background-color: "white",
+  // $theme-body-background-color: "white" !default;
+
   // Text
-  // $theme-text-color: "ink",
-  // $theme-text-reverse-color: "white",
+  // $theme-text-color: "ink" !default;
+  // $theme-text-reverse-color: "white" !default;
+
   // Links
   $theme-link-color: "mint-50",
   $theme-link-visited-color: "violet-60",

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -139,7 +139,6 @@ in the form $setting: value,
   // $theme-color-error: "red-warm-50v",
   // $theme-color-error-dark: "red-60v",
   // $theme-color-error-darker: "red-70",
-
   // Warning colors
   // $theme-color-warning-family: "gold",
   // $theme-color-warning-lighter: "yellow-5",
@@ -147,7 +146,6 @@ in the form $setting: value,
   // $theme-color-warning: "gold-20v",
   // $theme-color-warning-dark: "gold-30v",
   // $theme-color-warning-darker: "gold-50v",
-
   // Success colors
   // $theme-color-success-family: "green-cool",
   // $theme-color-success-lighter: "green-cool-5",
@@ -155,7 +153,6 @@ in the form $setting: value,
   // $theme-color-success: "green-cool-40v",
   // $theme-color-success-dark: "green-cool-50v",
   // $theme-color-success-darker: "green-cool-60v",
-
   // Info colors
   // $theme-color-info-family: "cyan",
   // $theme-color-info-lighter: "cyan-5",
@@ -163,7 +160,6 @@ in the form $setting: value,
   // $theme-color-info: "cyan-30v",
   // $theme-color-info-dark: "cyan-40v",
   // $theme-color-info-darker: "blue-cool-60",
-
   // Disabled colors
   // $theme-color-disabled-family: "gray",
   // $theme-color-disabled-lighter: "gray-20",
@@ -171,18 +167,14 @@ in the form $setting: value,
   // $theme-color-disabled: "gray-50",
   // $theme-color-disabled-dark: "gray-70",
   // $theme-color-disabled-darker: "gray-90",
-
   // Emergency colors
   // $theme-color-emergency: "red-warm-60v",
   // $theme-color-emergency-dark: "red-warm-80",
-
   // Body colors
   // $theme-body-background-color: "white",
-
   // Text
   // $theme-text-color: "ink",
   // $theme-text-reverse-color: "white",
-
   // Links
   $theme-link-color: "mint-50",
   $theme-link-visited-color: "violet-60",

--- a/frontend/src/styles/_uswds-theme.scss
+++ b/frontend/src/styles/_uswds-theme.scss
@@ -77,5 +77,118 @@ in the form $setting: value,
       "palette-color-system-yellow-light",
       "palette-color-system-green-cool",
       "palette-color-system-red-warm"
-    )
+    ),
+
+  // Base colors
+  $theme-color-base-family: "gray-warm",
+  $theme-color-base-lightest: "gray-warm-5",
+  $theme-color-base-lighter: "gray-warm-10",
+  $theme-color-base-light: "gray-warm-20",
+  $theme-color-base: "gray-warm-30",
+  $theme-color-base-dark: "gray-warm-50",
+  $theme-color-base-darker: "gray-warm-70",
+  $theme-color-base-darkest: "gray-warm-90",
+  $theme-color-base-ink: "gray-warm-90",
+
+  // Primary colors
+  $theme-color-primary-family: "mint",
+  $theme-color-primary-lightest: "mint-5",
+  $theme-color-primary-lighter: "mint-10",
+  $theme-color-primary-light: "mint-20",
+  $theme-color-primary: "mint-30",
+  $theme-color-primary-vivid: "mint-40",
+  $theme-color-primary-dark: "mint-50",
+  $theme-color-primary-darker: "mint-60",
+  $theme-color-primary-darkest: "mint-70",
+
+  // Secondary colors
+  $theme-color-secondary-family: "blue-cool-vivid",
+  $theme-color-secondary-lightest: "blue-cool-5v",
+  $theme-color-secondary-lighter: "blue-cool-10v",
+  $theme-color-secondary-light: "blue-cool-20v",
+  $theme-color-secondary: "blue-cool-30v",
+  $theme-color-secondary-vivid: "blue-cool-40v",
+  $theme-color-secondary-dark: "blue-cool-50v",
+  $theme-color-secondary-darker: "blue-cool-60v",
+  $theme-color-secondary-darkest: "blue-cool-70v",
+
+  // Accent warm colors
+  $theme-color-accent-warm-family: "yellow-vivid",
+  $theme-color-accent-warm-lightest: "yellow-5v",
+  $theme-color-accent-warm-lighter: "yellow-10v",
+  $theme-color-accent-warm-light: "yellow-20v",
+  $theme-color-accent-warm: "gold-20v",
+  $theme-color-accent-warm-dark: "orange-30v",
+  $theme-color-accent-warm-darker: "orange-warm-40v",
+  $theme-color-accent-warm-darkest: "orange-warm-50v",
+
+  // Accent cool colors
+  $theme-color-accent-cool-family: "violet",
+  $theme-color-accent-cool-lightest: "violet-10",
+  $theme-color-accent-cool-lighter: "violet-20",
+  $theme-color-accent-cool-light: "violet-30",
+  $theme-color-accent-cool: "violet-40",
+  $theme-color-accent-cool-dark: "violet-50",
+  $theme-color-accent-cool-darker: "violet-60",
+  $theme-color-accent-cool-darkest: "violet-70",
+
+  // Error colors
+  // $theme-color-error-family: "red-warm",
+  // $theme-color-error-lighter: "red-warm-10",
+  // $theme-color-error-light: "red-warm-30v",
+  // $theme-color-error: "red-warm-50v",
+  // $theme-color-error-dark: "red-60v",
+  // $theme-color-error-darker: "red-70",
+
+  // Warning colors
+  // $theme-color-warning-family: "gold",
+  // $theme-color-warning-lighter: "yellow-5",
+  // $theme-color-warning-light: "yellow-10v",
+  // $theme-color-warning: "gold-20v",
+  // $theme-color-warning-dark: "gold-30v",
+  // $theme-color-warning-darker: "gold-50v",
+
+  // Success colors
+  // $theme-color-success-family: "green-cool",
+  // $theme-color-success-lighter: "green-cool-5",
+  // $theme-color-success-light: "green-cool-20v",
+  // $theme-color-success: "green-cool-40v",
+  // $theme-color-success-dark: "green-cool-50v",
+  // $theme-color-success-darker: "green-cool-60v",
+
+  // Info colors
+  // $theme-color-info-family: "cyan",
+  // $theme-color-info-lighter: "cyan-5",
+  // $theme-color-info-light: "cyan-20",
+  // $theme-color-info: "cyan-30v",
+  // $theme-color-info-dark: "cyan-40v",
+  // $theme-color-info-darker: "blue-cool-60",
+
+  // Disabled colors
+  // $theme-color-disabled-family: "gray",
+  // $theme-color-disabled-lighter: "gray-20",
+  // $theme-color-disabled-light: "gray-40",
+  // $theme-color-disabled: "gray-50",
+  // $theme-color-disabled-dark: "gray-70",
+  // $theme-color-disabled-darker: "gray-90",
+
+  // Emergency colors
+  // $theme-color-emergency: "red-warm-60v",
+  // $theme-color-emergency-dark: "red-warm-80",
+
+  // Body colors
+  // $theme-body-background-color: "white" !default;
+
+  // Text
+  // $theme-text-color: "ink" !default;
+  // $theme-text-reverse-color: "white" !default;
+
+  // Links
+  $theme-link-color: "mint-50",
+  $theme-link-visited-color: "violet-60",
+  $theme-link-hover-color: "mint-60",
+  $theme-link-active-color: "mint-70",
+  $theme-link-reverse-color: "mint-5",
+  $theme-link-reverse-hover-color: "mint-10",
+  $theme-link-reverse-active-color: "white"
 );


### PR DESCRIPTION
## Summary
Fixes #3218

### Time to review: __10 mins__

## Changes proposed
Adds custom CSS for all the button styles

## Context for reviewers
This is done w/ custom styles, not settings, because USWDS assume that you want to use specific colors from your theme palette. We also need to ad the custom bottom border. 

This should be merged into #3226 before it's merged into `feature/brand`

## Additional information

Here's a temp change (not committed) of the Subscribe page to include all the button variants: 

![image](https://github.com/user-attachments/assets/56b70909-cb99-4487-aaba-04dd2115fa22)
