### PR TITLE
[Issue #3199] Add the user_id to the token returned by our login flow

### DIFF
--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -90,6 +90,7 @@ def create_jwt_for_user(
         "iat": current_time,
         "aud": config.audience,
         "iss": config.issuer,
+        "user_id": str(user.user_id),
     }
 
     logger.info(

--- a/api/tests/src/auth/test_api_jwt_auth.py
+++ b/api/tests/src/auth/test_api_jwt_auth.py
@@ -67,6 +67,7 @@ def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
     assert decoded_token["iat"] == timegm(
         datetime.fromisoformat("2024-11-14 12:00:00+00:00").utctimetuple()
     )
+    assert decoded_token["user_id"] == str(user.user_id)
     assert decoded_token["iss"] == jwt_config.issuer
     assert decoded_token["aud"] == jwt_config.audience
 


### PR DESCRIPTION
## Summary
Fixes #3199

### Time to review: 5 mins

## Changes proposed
Adds `user_id` to token. Updates tests.
