### PR TITLE
[Issue #3204] Remove opportunities connected to test agencies from search results

### DIFF
--- a/api/src/search/backend/load_opportunities_to_index.py
+++ b/api/src/search/backend/load_opportunities_to_index.py
@@ -99,7 +99,7 @@ class LoadOpportunitiesToIndex(Task):
             .all()
         )
 
-        # Process updates and inserts, and skip test records
+        # Process updates and inserts
         processed_opportunity_ids = set()
         opportunities_to_index = []
 
@@ -116,7 +116,7 @@ class LoadOpportunitiesToIndex(Task):
                 },
             )
 
-            # Add to index batch if it's not associated with a test agency
+            # Add to index batch if it's indexable
             opportunities_to_index.append(opportunity)
             processed_opportunity_ids.add(opportunity.opportunity_id)
 


### PR DESCRIPTION
## Summary
Fixes #3204 

### Time to review: __5 mins__

## Changes proposed
If an opportunity is connected to a test agency, do not load it into the search index

Fixed a bug with how incremental updates/deletes worked that was deleting everything if it wasn't in an update

## Context for reviewers
Certain agencies are marked as test agencies, and will be excluded from appearing in the left-hand navigation already. However, that doesn't stop you from finding them in search results by other means. Even though the number of test records appearing in search is small (5 at the time of writing), we'll be cautious and just filter them all out, which lets us potentially do more in the future as well.

We also handle deleting anything that already exists in the incremental job - that likely won't matter in most cases, but if an agency is ever marked as a test that wasn't previously, we'll handle that.

## Additional information
In prod, there are only 5 opportunities this will actually filter out right now, some subagencies aren't included in the list yet, but we'll deal with that separately:
https://simpler.grants.gov/search?agency=GDIT,IVV,IVPDF,0001,FGLT,NGMS,NGMS-Sub1,SECSCAN&status=forecasted,posted,archived,closed
