### PR TITLE
[Issue #3183] Make search facets for agencies return more than 25 agencies

### DIFF
--- a/api/src/services/opportunities_v1/search_opportunities.py
+++ b/api/src/services/opportunities_v1/search_opportunities.py
@@ -137,7 +137,7 @@ def _add_aggregations(builder: search.SearchQueryBuilder) -> None:
     builder.aggregation_terms("applicant_type", _adjust_field_name("applicant_type"))
     builder.aggregation_terms("funding_instrument", _adjust_field_name("funding_instrument"))
     builder.aggregation_terms("funding_category", _adjust_field_name("funding_category"))
-    builder.aggregation_terms("agency", _adjust_field_name("agency_code"))
+    builder.aggregation_terms("agency", _adjust_field_name("agency_code"), size=1000)
 
 
 def _get_search_request(params: SearchOpportunityParams) -> dict:


### PR DESCRIPTION
## Summary
Fixes #3183

### Time to review: __3 mins__

## Changes proposed
Modify the search facet count logic to allow up to 1000 unique agencies in response

## Context for reviewers
By default we configured the size to be 25 arbitrarily. There are about 700 agencies with opportunities in prod, so configured a number a bit above that for now.

We might want to consider allowing the user of the API to specify the facets they want in the future.

## Additional information
I loaded a lot of opportunities into the search index, and the response for facet counts now has all of the agencies we have configured locally with is about 80.

