### PR TITLE
[Issue #2656] logout route

### DIFF
--- a/frontend/src/app/[locale]/user/LogoutButton.tsx
+++ b/frontend/src/app/[locale]/user/LogoutButton.tsx
@@ -8,10 +8,11 @@ Delete this file when we build an actual Users page
 import { useRouter } from "next/navigation";
 import { Button } from "@trussworks/react-uswds";
 
-const makeLogoutRequest = async (push) => {
+const makeLogoutRequest = async (push: (location: string) => void) => {
   const response = await fetch("/api/auth/logout", { method: "POST" });
   if (response.status === 200) {
-    return push("/user?message=logged out");
+    push("/user?message=logged out");
+    return;
   }
   push("/user?message=log out error");
 };
@@ -19,6 +20,7 @@ const makeLogoutRequest = async (push) => {
 export const LogoutButton = () => {
   const router = useRouter();
   return (
+    // eslint-disable-next-line
     <Button type="button" onClick={() => makeLogoutRequest(router.push)}>
       Logout
     </Button>

--- a/frontend/src/app/[locale]/user/LogoutButton.tsx
+++ b/frontend/src/app/[locale]/user/LogoutButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+/*
+
+Delete this file when we build an actual Users page
+
+*/
+import { useRouter } from "next/navigation";
+import { Button } from "@trussworks/react-uswds";
+
+const makeLogoutRequest = async (push) => {
+  const response = await fetch("/api/auth/logout", { method: "POST" });
+  if (response.status === 200) {
+    return push("/user?message=logged out");
+  }
+  push("/user?message=log out error");
+};
+
+export const LogoutButton = () => {
+  const router = useRouter();
+  return (
+    <Button type="button" onClick={() => makeLogoutRequest(router.push)}>
+      Logout
+    </Button>
+  );
+};

--- a/frontend/src/app/[locale]/user/page.tsx
+++ b/frontend/src/app/[locale]/user/page.tsx
@@ -4,6 +4,8 @@ import { LocalizedPageProps } from "src/types/intl";
 import { getTranslations } from "next-intl/server";
 import { GridContainer } from "@trussworks/react-uswds";
 
+import { LogoutButton } from "./LogoutButton";
+
 export async function generateMetadata({
   params: { locale },
 }: LocalizedPageProps) {
@@ -32,6 +34,7 @@ export default async function UserDisplay({
     <GridContainer>
       <h1>{t("heading")}</h1>
       {message && <div>{message}</div>}
+      <LogoutButton />
     </GridContainer>
   );
 }

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,7 +1,7 @@
 import { postLogout } from "src/app/api/userFetcher";
 import { deleteSession, getSession } from "src/services/auth/session";
 
-export async function GET() {
+export async function POST() {
   try {
     // logout on API via /v1/users/token/logout
     const session = await getSession();
@@ -17,6 +17,9 @@ export async function GET() {
     return Response.json({ message: "logout success" });
   } catch (e) {
     const error = e as Error;
-    return new Response(`Error logging out: ${error.message}`, { status: 500 });
+    return Response.json(
+      { message: `Error logging out: ${error.message}` },
+      { status: 500 },
+    );
   }
 }

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,22 @@
+import { postLogout } from "src/app/api/userFetcher";
+import { deleteSession, getSession } from "src/services/auth/session";
+
+export async function GET() {
+  try {
+    // logout on API via /v1/users/token/logout
+    const session = await getSession();
+    if (!session || !session.token) {
+      throw new Error("No active session to logout");
+    }
+    const response = await postLogout(session.token);
+    if (!response) {
+      throw new Error("No logout response from API");
+    }
+    // delete session from current cookies
+    deleteSession();
+    return Response.json({ message: "logout success" });
+  } catch (e) {
+    const error = e as Error;
+    return new Response(`Error logging out: ${error.message}`, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/clientUserFetcher.ts
+++ b/frontend/src/app/api/clientUserFetcher.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { ApiRequestError } from "src/errors";
+import { SessionPayload, UserFetcher } from "src/services/auth/types";
+
+// this fetcher is a one off for now, since the request is made from the client to the
+// NextJS Node server. We will need to build out a fetcher pattern to accomodate this usage in the future
+export const userFetcher: UserFetcher = async (url) => {
+  let response;
+  try {
+    response = await fetch(url);
+  } catch (e) {
+    console.error("User session fetch network error", e);
+    throw new ApiRequestError(0); // Network error
+  }
+  if (response.status === 204) return undefined;
+  if (response.ok) return (await response.json()) as SessionPayload;
+  throw new ApiRequestError(response.status);
+};

--- a/frontend/src/app/api/endpointConfigs.ts
+++ b/frontend/src/app/api/endpointConfigs.ts
@@ -21,3 +21,10 @@ export const fetchOpportunityEndpoint = {
   namespace: "opportunities",
   method: "GET" as ApiMethod,
 };
+
+export const userLogoutEndpoint = {
+  basePath: environment.API_URL,
+  version: "v1",
+  namespace: "users/token/logout",
+  method: "POST" as ApiMethod,
+};

--- a/frontend/src/app/api/fetchers.ts
+++ b/frontend/src/app/api/fetchers.ts
@@ -4,6 +4,7 @@ import {
   EndpointConfig,
   fetchOpportunityEndpoint,
   opportunitySearchEndpoint,
+  userLogoutEndpoint,
 } from "src/app/api/endpointConfigs";
 import {
   createRequestBody,
@@ -72,3 +73,6 @@ export const fetchOpportunity = cache(
 export const fetchOpportunitySearch = requesterForEndpoint<SearchAPIResponse>(
   opportunitySearchEndpoint,
 );
+
+export const postUserLogout =
+  requesterForEndpoint<APIResponse>(userLogoutEndpoint);

--- a/frontend/src/app/api/userFetcher.ts
+++ b/frontend/src/app/api/userFetcher.ts
@@ -1,19 +1,6 @@
-"use client";
+import { postUserLogout } from "src/app/api/fetchers";
 
-import { ApiRequestError } from "src/errors";
-import { SessionPayload, UserFetcher } from "src/services/auth/types";
-
-// this fetcher is a one off for now, since the request is made from the client to the
-// NextJS Node server. We will need to build out a fetcher pattern to accomodate this usage in the future
-export const userFetcher: UserFetcher = async (url) => {
-  let response;
-  try {
-    response = await fetch(url);
-  } catch (e) {
-    console.error("User session fetch network error", e);
-    throw new ApiRequestError(0); // Network error
-  }
-  if (response.status === 204) return undefined;
-  if (response.ok) return (await response.json()) as SessionPayload;
-  throw new ApiRequestError(response.status);
+export const postLogout = async (token: string) => {
+  const jwtAuthHeader = { "X-SGG-Token": token };
+  return postUserLogout({ additionalHeaders: jwtAuthHeader });
 };

--- a/frontend/src/hoc/withFeatureFlag.tsx
+++ b/frontend/src/hoc/withFeatureFlag.tsx
@@ -1,4 +1,4 @@
-dimport { environment } from "src/constants/environments";
+import { environment } from "src/constants/environments";
 import { FeatureFlagsManager } from "src/services/FeatureFlagManager";
 import { WithFeatureFlagProps } from "src/types/uiTypes";
 

--- a/frontend/src/hoc/withFeatureFlag.tsx
+++ b/frontend/src/hoc/withFeatureFlag.tsx
@@ -1,4 +1,4 @@
-import { environment } from "src/constants/environments";
+dimport { environment } from "src/constants/environments";
 import { FeatureFlagsManager } from "src/services/FeatureFlagManager";
 import { WithFeatureFlagProps } from "src/types/uiTypes";
 

--- a/frontend/src/services/auth/UserProvider.tsx
+++ b/frontend/src/services/auth/UserProvider.tsx
@@ -3,7 +3,7 @@
 // note that importing these individually allows us to mock them, otherwise mocks don't work :shrug:
 import debounce from "lodash/debounce";
 import noop from "lodash/noop";
-import { userFetcher } from "src/app/api/userFetcher";
+import { userFetcher } from "src/app/api/clientUserFetcher";
 import { UserSession } from "src/services/auth/types";
 import { UserContext } from "src/services/auth/useUser";
 import { isSessionExpired } from "src/utils/authUtil";

--- a/frontend/tests/api/auth/callback/route.test.ts
+++ b/frontend/tests/api/auth/callback/route.test.ts
@@ -17,7 +17,7 @@ jest.mock("src/services/auth/session", () => ({
 
 // note that all calls to the GET endpoint need to be caught here since the behavior of the Next redirect
 // is to throw an error
-describe("GET request", () => {
+describe("/api/auth/callback GET handler", () => {
   afterEach(() => jest.clearAllMocks());
   it("calls createSession with token set in header", async () => {
     getSessionMock.mockImplementation(() => ({

--- a/frontend/tests/api/auth/logout/route.test.ts
+++ b/frontend/tests/api/auth/logout/route.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST } from "src/app/api/auth/logout/route";
+import { wrapForExpectedError } from "src/utils/testing/commonTestUtils";
+
+const getSessionMock = jest.fn();
+const deleteSessionMock = jest.fn();
+const postLogoutMock = jest.fn();
+
+jest.mock("src/services/auth/session", () => ({
+  getSession: (): unknown => getSessionMock(),
+  deleteSession: (): unknown => deleteSessionMock(),
+}));
+
+jest.mock("src/app/api/userFetcher", () => ({
+  postLogout: (token: string) => postLogoutMock(token),
+}));
+
+// note that all calls to the GET endpoint need to be caught here since the behavior of the Next redirect
+// is to throw an error
+describe("/api/auth/logout POST handler", () => {
+  afterEach(() => jest.clearAllMocks());
+  it("errors if there is no current session token", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "",
+    }));
+    const response = await POST();
+
+    expect(postLogoutMock).toHaveBeenCalledTimes(0);
+    expect(response.status).toEqual(500);
+    const json = await response.json();
+    expect(json.message).toEqual(
+      "Error logging out: No active session to logout",
+    );
+  });
+  it("calls postLogout with token from session", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "fakeToken",
+    }));
+    await POST();
+
+    expect(postLogoutMock).toHaveBeenCalledTimes(1);
+    expect(postLogoutMock).toHaveBeenCalledWith("fakeToken");
+  });
+  it("errors if API logout call errors", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "fakeToken",
+    }));
+    postLogoutMock.mockImplementation(() => {
+      throw new Error("the API threw this error");
+    });
+    const response = await POST();
+
+    expect(postLogoutMock).toHaveBeenCalledTimes(1);
+    expect(postLogoutMock).toHaveBeenCalledWith("fakeToken");
+    expect(response.status).toEqual(500);
+    const json = await response.json();
+    expect(json.message).toEqual("Error logging out: the API threw this error");
+  });
+
+  it("errors if API logout call returns nothing", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "fakeToken",
+    }));
+    postLogoutMock.mockImplementation(() => null);
+    const response = await POST();
+
+    expect(postLogoutMock).toHaveBeenCalledTimes(1);
+    expect(postLogoutMock).toHaveBeenCalledWith("fakeToken");
+    expect(response.status).toEqual(500);
+    const json = await response.json();
+    expect(json.message).toEqual(
+      "Error logging out: No logout response from API",
+    );
+  });
+  it("calls deleteSession", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "fakeToken",
+    }));
+    postLogoutMock.mockImplementation(() => "success");
+    await POST();
+
+    expect(deleteSessionMock).toHaveBeenCalledTimes(1);
+  });
+  it("returns sucess message on success", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "fakeToken",
+    }));
+    postLogoutMock.mockImplementation(() => "success");
+    const response = await POST();
+
+    expect(response.status).toEqual(200);
+    const json = await response.json();
+    expect(json.message).toEqual("logout success");
+  });
+});

--- a/frontend/tests/api/auth/logout/route.test.ts
+++ b/frontend/tests/api/auth/logout/route.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { POST } from "src/app/api/auth/logout/route";
-import { wrapForExpectedError } from "src/utils/testing/commonTestUtils";
 
 const getSessionMock = jest.fn();
 const deleteSessionMock = jest.fn();
@@ -15,7 +14,7 @@ jest.mock("src/services/auth/session", () => ({
 }));
 
 jest.mock("src/app/api/userFetcher", () => ({
-  postLogout: (token: string) => postLogoutMock(token),
+  postLogout: (token: string): unknown => postLogoutMock(token),
 }));
 
 // note that all calls to the GET endpoint need to be caught here since the behavior of the Next redirect
@@ -30,7 +29,7 @@ describe("/api/auth/logout POST handler", () => {
 
     expect(postLogoutMock).toHaveBeenCalledTimes(0);
     expect(response.status).toEqual(500);
-    const json = await response.json();
+    const json = (await response.json()) as { message: string };
     expect(json.message).toEqual(
       "Error logging out: No active session to logout",
     );
@@ -56,7 +55,7 @@ describe("/api/auth/logout POST handler", () => {
     expect(postLogoutMock).toHaveBeenCalledTimes(1);
     expect(postLogoutMock).toHaveBeenCalledWith("fakeToken");
     expect(response.status).toEqual(500);
-    const json = await response.json();
+    const json = (await response.json()) as { message: string };
     expect(json.message).toEqual("Error logging out: the API threw this error");
   });
 
@@ -70,7 +69,7 @@ describe("/api/auth/logout POST handler", () => {
     expect(postLogoutMock).toHaveBeenCalledTimes(1);
     expect(postLogoutMock).toHaveBeenCalledWith("fakeToken");
     expect(response.status).toEqual(500);
-    const json = await response.json();
+    const json = (await response.json()) as { message: string };
     expect(json.message).toEqual(
       "Error logging out: No logout response from API",
     );
@@ -92,7 +91,7 @@ describe("/api/auth/logout POST handler", () => {
     const response = await POST();
 
     expect(response.status).toEqual(200);
-    const json = await response.json();
+    const json = (await response.json()) as { message: string };
     expect(json.message).toEqual("logout success");
   });
 });

--- a/frontend/tests/services/auth/useUser.test.tsx
+++ b/frontend/tests/services/auth/useUser.test.tsx
@@ -5,7 +5,7 @@ import { useUser } from "src/services/auth/useUser";
 
 const userFetcherMock = jest.fn();
 
-jest.mock("src/app/api/userFetcher", () => ({
+jest.mock("src/app/api/clientUserFetcher", () => ({
   userFetcher: () => userFetcherMock() as unknown,
 }));
 


### PR DESCRIPTION
## Summary
Fixes #2656

### Time to review: __15 mins__

## Changes proposed
Creates a Node route that can be used to log out a user

* calls the API logout endpoint
* removes client side cookie

Also adds fetch function to use to call the API logout route and a dummy logout button to use for testing

## Context for reviewers
### Test steps

1. set `LOGIN_FINAL_DESTINATION` in api env to "localhost:3000/api/auth/callback"
2. run `make setup-env-override-file` in api
3. in new private window visit http://localhost:8080/v1/users/login
4. enter something and click the button
5. _VALIDATE_: user page loads with "session created" message
6. _VALIDATE_: entries are created in the local user and user_token_session DB tables
7. _VALIDATE_: client side "session" cookie is present in browser
8. click logout button
9. _VALIDATE_: page shows "logged out" message
6. _VALIDATE_: entries are removed in the local user_token_session DB table
7. _VALIDATE_: client side "session" cookie is no longer present in browser 

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

