### PR TITLE
[Issue #3246] Put the users email address in the token returned by our auth logic

### DIFF
--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -67,7 +67,7 @@ def get_config() -> ApiJwtConfig:
 
 
 def create_jwt_for_user(
-    user: User, db_session: db.Session, config: ApiJwtConfig | None = None
+    user: User, db_session: db.Session, config: ApiJwtConfig | None = None, email: str | None = None
 ) -> Tuple[str, UserTokenSession]:
     if config is None:
         config = get_config()
@@ -90,6 +90,7 @@ def create_jwt_for_user(
         "iat": current_time,
         "aud": config.audience,
         "iss": config.issuer,
+        "email": email,
         "user_id": str(user.user_id),
     }
 

--- a/api/src/services/users/login_gov_callback_handler.py
+++ b/api/src/services/users/login_gov_callback_handler.py
@@ -149,7 +149,9 @@ def _process_token(db_session: db.Session, token: str, nonce: str) -> LoginGovCa
     # NOTE: This doesn't commit yet - but effectively moves the cache from memory to the DB transaction
     db_session.flush()
 
-    token, user_token_session = create_jwt_for_user(external_user.user, db_session)
+    token, user_token_session = create_jwt_for_user(
+        external_user.user, db_session, email=external_user.email
+    )
 
     logger.info(
         "Generated token for user",

--- a/api/tests/src/auth/test_api_jwt_auth.py
+++ b/api/tests/src/auth/test_api_jwt_auth.py
@@ -14,7 +14,7 @@ from src.auth.api_jwt_auth import (
     parse_jwt_for_user,
 )
 from src.db.models.user_models import UserTokenSession
-from tests.src.db.models.factories import UserFactory
+from tests.src.db.models.factories import LinkExternalUserFactory, UserFactory
 
 
 @pytest.fixture
@@ -57,6 +57,7 @@ def mini_app(monkeypatch_module):
 @freeze_time("2024-11-14 12:00:00", tz_offset=0)
 def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
     user = UserFactory.create()
+    linked_external_user = LinkExternalUserFactory.create(user=user)
     token, token_session = create_jwt_for_user(user, db_session, jwt_config)
     decoded_token = jwt.decode(
         token, algorithms=[jwt_config.algorithm], options={"verify_signature": False}
@@ -68,8 +69,17 @@ def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
         datetime.fromisoformat("2024-11-14 12:00:00+00:00").utctimetuple()
     )
     assert decoded_token["user_id"] == str(user.user_id)
+    assert decoded_token["email"] is None
     assert decoded_token["iss"] == jwt_config.issuer
     assert decoded_token["aud"] == jwt_config.audience
+
+    token_with_email, _ = create_jwt_for_user(
+        user, db_session, jwt_config, email=linked_external_user.email
+    )
+    decoded_token_with_email = jwt.decode(
+        token_with_email, algorithms=[jwt_config.algorithm], options={"verify_signature": False}
+    )
+    assert decoded_token_with_email["email"] == linked_external_user.email
 
     # Verify that the sub_id returned can be used to fetch a UserTokenSession object
     token_session = (


### PR DESCRIPTION
## Summary
Fixes #3246

### Time to review: 10 mins

## Changes proposed
Add email address to JWT token if exists.

## Context for reviewers
A user can have multiple linked external user records, but for now we'll assume they have a single one (the Login.gov one) where the email is stored.

## Additional information
See addition to unit test covering scenarios where emails exists and does not exist.

