### PR TITLE
[Issue #3193] Use the KID value in login gov token validation

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -275,7 +275,7 @@ def setup_login_gov_auth(monkeypatch_session, public_rsa_key):
     """Setup login.gov JWK endpoint to be stubbed out"""
 
     def override_method(config):
-        config.public_keys = [public_rsa_key]
+        config.public_key_map = {"test-key-id": public_rsa_key}
 
     monkeypatch_session.setattr(login_gov_jwt_auth, "_refresh_keys", override_method)
 

--- a/api/tests/lib/auth_test_utils.py
+++ b/api/tests/lib/auth_test_utils.py
@@ -57,7 +57,7 @@ def create_jwt(
         "acr": "urn:acr.login.gov:auth-only",
     }
 
-    return jwt.encode(payload, private_key, algorithm="RS256")
+    return jwt.encode(payload, private_key, algorithm="RS256", headers={"kid": "test-key-id"})
 
 
 def oauth_param_override():

--- a/api/tests/src/api/opportunities_v0/test_opportunity_route.py
+++ b/api/tests/src/api/opportunities_v0/test_opportunity_route.py
@@ -328,7 +328,6 @@ def test_opportunity_search_invalid_request_422(
     )
     assert resp.status_code == 422
 
-    print(resp.get_json())
     response_data = resp.get_json()["errors"]
     assert response_data == expected_response_data
 

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_get.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_get.py
@@ -126,7 +126,6 @@ def test_get_opportunity_s3_endpoint_url_200(
     # Check the response
     assert resp.status_code == 200
     response_data = resp.get_json()["data"]
-    print("response_data", response_data)
     presigned_url = response_data["attachments"][0]["download_path"]
 
     # Validate pre-signed url

--- a/api/tests/src/api/users/test_user_route_login.py
+++ b/api/tests/src/api/users/test_user_route_login.py
@@ -50,8 +50,6 @@ def test_user_login_flow_happy_path_302(client, db_session):
     login_gov_config = login_gov_jwt_auth.get_config()
     resp = client.get("/v1/users/login", follow_redirects=True)
 
-    print(resp.history)
-
     # The final endpoint returns a 200
     # and dumps the params it was called with
     assert resp.status_code == 200
@@ -459,7 +457,7 @@ def test_user_callback_token_fails_validation_bad_token_302(
     assert resp.status_code == 200
     resp_json = resp.get_json()
     assert resp_json["message"] == "error"
-    assert resp_json["error_description"] == "Unable to process token"
+    assert resp_json["error_description"] == "Unable to parse token - invalid format"
 
     # Make sure the login gov state was deleted even though it errored
     db_state = (
@@ -498,10 +496,7 @@ def test_user_callback_token_fails_validation_no_valid_key_302(
     assert resp.status_code == 200
     resp_json = resp.get_json()
     assert resp_json["message"] == "error"
-    assert (
-        resp_json["error_description"]
-        == "Token could not be validated against any public keys from login.gov"
-    )
+    assert resp_json["error_description"] == "Invalid Signature"
 
     # Make sure the login gov state was deleted even though it errored
     db_state = (

--- a/api/tests/src/auth/test_login_gov_jwt_auth.py
+++ b/api/tests/src/auth/test_login_gov_jwt_auth.py
@@ -18,7 +18,7 @@ def login_gov_config(public_rsa_key, private_rsa_key):
     # Note this isn't session scoped so it gets remade
     # for every test in the event of changes to it
     return LoginGovConfig(
-        LOGIN_GOV_PUBLIC_KEYS=[public_rsa_key],
+        LOGIN_GOV_PUBLIC_KEY_MAP={"test-key-id": public_rsa_key},
         LOGIN_GOV_JWK_ENDPOINT="not_used",
         LOGIN_GOV_ENDPOINT=DEFAULT_ISSUER,
         LOGIN_GOV_CLIENT_ID=DEFAULT_CLIENT_ID,
@@ -37,6 +37,7 @@ def create_jwt(
     audience: str = DEFAULT_CLIENT_ID,
     acr: str = "urn:acr.login.gov:auth-only",
     nonce: str = DEFAULT_NONCE,
+    kid: str = "test-key-id",
 ):
     payload = {
         "sub": user_id,
@@ -57,7 +58,7 @@ def create_jwt(
         "c_hash": "abc123",
     }
 
-    return jwt.encode(payload, private_key, algorithm="RS256")
+    return jwt.encode(payload, private_key, algorithm="RS256", headers={"kid": kid})
 
 
 def test_validate_token_happy_path(login_gov_config, private_rsa_key):
@@ -170,27 +171,61 @@ def test_validate_token_invalid_signature(login_gov_config, other_rsa_key_pair, 
 
     with pytest.raises(
         JwtValidationError,
-        match="Token could not be validated against any public keys from login.gov",
+        match="Invalid Signature",
     ):
         validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 def test_validate_token_key_found_on_refresh(login_gov_config, other_rsa_key_pair, monkeypatch):
+    user_id = "12345678-abcxyz"
+    email = "xfake@mail.com"
+
     token = create_jwt(
-        user_id="abc123",
-        email="mail@fake.com",
+        user_id=user_id,
+        email=email,
         private_key=other_rsa_key_pair[0],  # Create it with a different key
         expires_at=datetime.now(tz=timezone.utc) + timedelta(days=30),
         issued_at=datetime.now(tz=timezone.utc) - timedelta(days=1),
         not_before=datetime.now(tz=timezone.utc) - timedelta(days=1),
+        kid="a-different-key",
     )
 
     def override_method(config):
-        config.public_keys = [other_rsa_key_pair[1]]
+        config.public_key_map = {"a-different-key": other_rsa_key_pair[1]}
 
     monkeypatch.setattr(login_gov_jwt_auth, "_refresh_keys", override_method)
 
-    validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
+    login_gov_user = validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
+
+    assert login_gov_user.user_id == user_id
+    assert login_gov_user.email == email
+
+
+def test_validate_token_kid_not_found(login_gov_config, other_rsa_key_pair, monkeypatch):
+    user_id = "12345678-abc"
+    email = "fake@mail.com"
+
+    token = create_jwt(
+        user_id=user_id,
+        email=email,
+        private_key=other_rsa_key_pair[0],  # Create it with a different key
+        expires_at=datetime.now(tz=timezone.utc) + timedelta(days=30),
+        issued_at=datetime.now(tz=timezone.utc) - timedelta(days=1),
+        not_before=datetime.now(tz=timezone.utc) - timedelta(days=1),
+        kid="a-different-key",
+    )
+
+    # Override it so nothing is found
+    def override_method(config):
+        config.public_key_map = {}
+
+    monkeypatch.setattr(login_gov_jwt_auth, "_refresh_keys", override_method)
+
+    with pytest.raises(
+        JwtValidationError,
+        match="No public key could be found for token",
+    ):
+        validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
 
 
 @freezegun.freeze_time("2024-11-14 12:00:00", tz_offset=0)


### PR DESCRIPTION
## Summary
Fixes #3193 

### Time to review: __5 mins__

## Changes proposed
Rather than iterate over all public keys from login.gov - instead directly use the one with the same KID (key ID)

## Context for reviewers
The KID is the Key ID, in the public endpoint from an OAuth server that gives you a list of keys the ID should be present there, and the header for a given token will have the KID as well. However these weren't guaranteed in the OAuth spec so I waited to assume they existed until I tested with real login.gov - they do exist.

Quite a bit of structure needed to be reorganized with this as the way we also structure the public keys went from a list to a dict. There was a lot of assumed failure cases if no key was found that worked that were removed and now the logic is a bit more directly:
* If a public key can't be found refresh the public keys
* If a public key is found, validate with it
* Otherwise error

We also no longer need to account for the "failed validation, but assume we used the wrong key" scenario since we'll have the exact key.

## Additional information
Everything continues to work uneventfully locally, the KID is set (always `issuer1`) in both places.

