### PR TITLE
[Unticketed] Ignore vulnerability for issue with pending fix

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -19,7 +19,7 @@ ignore:
   - fix-state: wont-fix
   - fix-state: unknown
 
-  # https://github.com/HHS/simpler-grants-gov/issues/2582
-  - vulnerability: CVE-2024-34158
-  - vulnerability: CVE-2024-34156
-  - vulnerability: CVE-2024-34155
+  # Issue due to crypto package pulled in by GitHub CLI
+  # Will be fixed in next GitHub CLI release
+  # Last Checked: Dec 19th, 2024
+  - vulnerability: GHSA-v778-237x-gjrc

--- a/.grype.yml
+++ b/.grype.yml
@@ -19,6 +19,10 @@ ignore:
   - fix-state: wont-fix
   - fix-state: unknown
 
+  # https://github.com/HHS/simpler-grants-gov/issues/2582
+  - vulnerability: CVE-2024-34158
+  - vulnerability: CVE-2024-34156
+  - vulnerability: CVE-2024-34155
   # Issue due to crypto package pulled in by GitHub CLI
   # Will be fixed in next GitHub CLI release
   # Last Checked: Dec 19th, 2024

--- a/.grype.yml
+++ b/.grype.yml
@@ -27,3 +27,4 @@ ignore:
   # Will be fixed in next GitHub CLI release
   # Last Checked: Dec 19th, 2024
   - vulnerability: GHSA-v778-237x-gjrc
+  - vulnerability: GHSA-w32m-9786-jp63


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Ignore [GHSA-v778-237x-gjrc](https://github.com/advisories/GHSA-v778-237x-gjrc)

Cleaned up old ignores that _should_ be fixed by now

## Context for reviewers
This vulnerability is in a dependency pulled in by the Github CLI. A [fix was made](https://github.com/cli/cli/commit/1af421012e5e7a648577e091e5a094a80b75d720) but no new release has occurred, likely due to the holidays. https://github.com/cli/cli/releases

As this vulnerability already would exist in our image, ignoring it for now seems uneventful, and the issue shouldn't persist beyond the holidays.


