### PR TITLE
[Issue #2144] e2e tests for clear/select all filters and fix nested filter bug

### DIFF
--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { camelCase } from "lodash";
 import { QueryContext } from "src/app/[locale]/search/QueryProvider";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { QueryParamKey } from "src/types/search/searchResponseTypes";
@@ -43,6 +44,20 @@ export interface FilterOptionWithChildren {
   children: FilterOption[];
 }
 
+const isSectionAllSelected = (
+  allSelected: Set<string>,
+  query: Set<string>,
+): boolean => {
+  return areSetsEqual(allSelected, query);
+};
+
+const isSectionNoneSelected = (query: Set<string>): boolean => {
+  return query.size === 0;
+};
+
+const areSetsEqual = (a: Set<string>, b: Set<string>) =>
+  a.size === b.size && [...a].every((value) => b.has(value));
+
 export function SearchFilterAccordion({
   filterOptions,
   title,
@@ -50,13 +65,21 @@ export function SearchFilterAccordion({
   query,
 }: SearchFilterAccordionProps) {
   const { queryTerm } = useContext(QueryContext);
-  const { updateQueryParams } = useSearchParamUpdater();
+  const { updateQueryParams, searchParams } = useSearchParamUpdater();
+  console.log("###", title, searchParams);
   const totalCheckedCount = query.size;
-  // These are all of the available selectedable options.
-  const allOptionValues = filterOptions.map((options) => options.value);
-  // This is the setting if all are selected.
+  // all top level selectable filter options
+  const allOptionValues = filterOptions.reduce((values: string[], option) => {
+    if (option.children) {
+      return values;
+    }
+    values.push(option.value);
+    return values;
+  }, []);
+
   const allSelected = new Set(allOptionValues);
 
+  // SPLIT ME INTO MY OWN COMPONENT
   const getAccordionTitle = () => (
     <>
       {title}
@@ -77,19 +100,20 @@ export function SearchFilterAccordion({
     }
   };
 
-  const isSectionAllSelected = (
+  // need to add any existing relevant search params to the passed in set
+  const toggleSelectAllSection = (
+    all: boolean,
     allSelected: Set<string>,
-    query: Set<string>,
-  ): boolean => {
-    return areSetsEqual(allSelected, query);
-  };
+  ): void => {
+    // get existing current selected options for this accordion from url
+    const currentSelected = new Set(
+      searchParams.get(camelCase(title))?.split(","),
+    );
 
-  const isSectionNoneSelected = (query: Set<string>): boolean => {
-    return query.size === 0;
+    // add existing to newly selected section
+    const sectionPlusCurrent = new Set([...currentSelected, ...allSelected]);
+    toggleSelectAll(all, sectionPlusCurrent);
   };
-
-  const areSetsEqual = (a: Set<string>, b: Set<string>) =>
-    a.size === b.size && [...a].every((value) => b.has(value));
 
   const toggleOptionChecked = (value: string, isChecked: boolean) => {
     const updated = new Set(query);
@@ -99,6 +123,7 @@ export function SearchFilterAccordion({
 
   const isExpanded = !!query.size;
 
+  // SPLIT ME INTO MY OWN COMPONENT
   const getAccordionContent = () => (
     <>
       <SearchFilterToggleAll
@@ -119,7 +144,7 @@ export function SearchFilterAccordion({
                 value={option.value}
                 query={query}
                 updateCheckedOption={toggleOptionChecked}
-                toggleSelectAll={toggleSelectAll}
+                toggleSelectAll={toggleSelectAllSection}
                 accordionTitle={title}
                 isSectionAllSelected={isSectionAllSelected}
                 isSectionNoneSelected={isSectionNoneSelected}
@@ -138,6 +163,7 @@ export function SearchFilterAccordion({
     </>
   );
 
+  // MEMOIZE ME
   const accordionOptions: AccordionItemProps[] = [
     {
       title: getAccordionTitle(),

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -143,7 +143,7 @@ export function SearchFilterAccordion({
       title: getAccordionTitle(),
       content: getAccordionContent(),
       expanded: isExpanded,
-      id: `funding-instrument-filter-${queryParamKey}`,
+      id: `opportunity-filter-${queryParamKey}`,
       headingLevel: "h2",
     },
   ];

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -66,7 +66,7 @@ export function SearchFilterAccordion({
 }: SearchFilterAccordionProps) {
   const { queryTerm } = useContext(QueryContext);
   const { updateQueryParams, searchParams } = useSearchParamUpdater();
-  console.log("###", title, searchParams);
+
   const totalCheckedCount = query.size;
   // all top level selectable filter options
   const allOptionValues = filterOptions.reduce((values: string[], option) => {
@@ -91,28 +91,23 @@ export function SearchFilterAccordion({
     </>
   );
 
-  const toggleSelectAll = (all: boolean, allSelected: Set<string>): void => {
-    if (all) {
-      updateQueryParams(allSelected, queryParamKey, queryTerm);
-    } else {
-      const noneSelected = new Set<string>();
-      updateQueryParams(noneSelected, queryParamKey, queryTerm);
-    }
-  };
-
   // need to add any existing relevant search params to the passed in set
-  const toggleSelectAllSection = (
-    all: boolean,
-    allSelected: Set<string>,
-  ): void => {
-    // get existing current selected options for this accordion from url
-    const currentSelected = new Set(
-      searchParams.get(camelCase(title))?.split(","),
-    );
-
-    // add existing to newly selected section
-    const sectionPlusCurrent = new Set([...currentSelected, ...allSelected]);
-    toggleSelectAll(all, sectionPlusCurrent);
+  const toggleSelectAll = (all: boolean, newSelections?: Set<string>): void => {
+    if (all && newSelections) {
+      // get existing current selected options for this accordion from url
+      const currentSelections = new Set(
+        searchParams.get(camelCase(title))?.split(","),
+      );
+      // add existing to newly selected section
+      const sectionPlusCurrent = new Set([
+        ...currentSelections,
+        ...newSelections,
+      ]);
+      updateQueryParams(sectionPlusCurrent, queryParamKey, queryTerm);
+    } else {
+      const clearedSelections = newSelections || new Set<string>();
+      updateQueryParams(clearedSelections, queryParamKey, queryTerm);
+    }
   };
 
   const toggleOptionChecked = (value: string, isChecked: boolean) => {
@@ -128,7 +123,7 @@ export function SearchFilterAccordion({
     <>
       <SearchFilterToggleAll
         onSelectAll={() => toggleSelectAll(true, allSelected)}
-        onClearAll={() => toggleSelectAll(false, allSelected)}
+        onClearAll={() => toggleSelectAll(false)}
         isAllSelected={isSectionAllSelected(allSelected, query)}
         isNoneSelected={isSectionNoneSelected(query)}
       />
@@ -144,7 +139,7 @@ export function SearchFilterAccordion({
                 value={option.value}
                 query={query}
                 updateCheckedOption={toggleOptionChecked}
-                toggleSelectAll={toggleSelectAllSection}
+                toggleSelectAll={toggleSelectAll}
                 accordionTitle={title}
                 isSectionAllSelected={isSectionAllSelected}
                 isSectionNoneSelected={isSectionNoneSelected}

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
@@ -119,10 +119,10 @@ describe("SearchFilterAccordion", () => {
     );
 
     const accordionToggleButton = screen.getByTestId(
-      "accordionButton_funding-instrument-filter-status",
+      "accordionButton_opportunity-filter-status",
     );
     const contentDiv = screen.getByTestId(
-      "accordionItem_funding-instrument-filter-status",
+      "accordionItem_opportunity-filter-status",
     );
     expect(contentDiv).toHaveAttribute("hidden");
 

--- a/frontend/tests/e2e/search/search-no-results.spec.ts
+++ b/frontend/tests/e2e/search/search-no-results.spec.ts
@@ -2,7 +2,7 @@ import { expect, Page, test } from "@playwright/test";
 import { BrowserContextOptions } from "playwright-core";
 
 import {
-  expectURLContainsQueryParam,
+  expectURLContainsQueryParamValue,
   fillSearchInputAndSubmit,
   generateRandomString,
 } from "./searchSpecUtil";
@@ -23,7 +23,7 @@ test.describe("Search page tests", () => {
 
     await fillSearchInputAndSubmit(searchTerm, page);
     await new Promise((resolve) => setTimeout(resolve, 3250));
-    expectURLContainsQueryParam(page, "query", searchTerm);
+    expectURLContainsQueryParamValue(page, "query", searchTerm);
 
     // eslint-disable-next-line testing-library/prefer-screen-queries
     const resultsHeading = page.getByRole("heading", {

--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "@playwright/test";
 import { camelCase } from "lodash";
-import { toDashCase } from "src/utils/generalUtils";
 import { PageProps } from "tests/e2e/playwrightUtils";
 import {
   clickAccordionWithTitle,

--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -225,9 +225,10 @@ test.describe("Search page tests", () => {
         await clickAccordionWithTitle(page, filterType);
 
         // gather number of (top level) filter options for filter type
-
         const numberOfFilterOptions = await page
-          .locator(`#opportunity-filter-${camelCaseFilterType} input`)
+          .locator(
+            `#opportunity-filter-${camelCaseFilterType} > ul > li > div > input`,
+          )
           .count();
 
         // click select all for filter type
@@ -248,7 +249,9 @@ test.describe("Search page tests", () => {
 
         // validate that checkboxes are checked
         let checkboxes = await page
-          .locator(`#opportunity-filter-${camelCaseFilterType} input`)
+          .locator(
+            `#opportunity-filter-${camelCaseFilterType} > ul > li > div > input`,
+          )
           .all();
 
         await Promise.all(
@@ -283,7 +286,9 @@ test.describe("Search page tests", () => {
 
         // validate that checkboxes are not checked
         checkboxes = await page
-          .locator(`#opportunity-filter-${camelCaseFilterType} input`)
+          .locator(
+            `#opportunity-filter-${camelCaseFilterType} > ul > li > div > input`,
+          )
           .all();
 
         await Promise.all(

--- a/frontend/tests/e2e/search/searchUtil.ts
+++ b/frontend/tests/e2e/search/searchUtil.ts
@@ -12,10 +12,10 @@ export async function fillSearchInputAndSubmit(term: string, page: Page) {
   const searchInput = getSearchInput(page);
   await searchInput.fill(term);
   await page.click(".usa-search >> button[type='submit']");
-  expectURLContainsQueryParam(page, "query", term);
+  expectURLContainsQueryParamValue(page, "query", term);
 }
 
-export function expectURLContainsQueryParam(
+export function expectURLContainsQueryParamValue(
   page: Page,
   queryParamName: string,
   queryParamValue: string,
@@ -24,7 +24,7 @@ export function expectURLContainsQueryParam(
   expect(currentURL).toContain(`${queryParamName}=${queryParamValue}`);
 }
 
-export async function waitForURLContainsQueryParam(
+export async function waitForURLContainsQueryParamValue(
   page: Page,
   queryParamName: string,
   queryParamValue: string,
@@ -85,7 +85,7 @@ export async function toggleCheckboxes(
     runningQueryParams += runningQueryParams
       ? `,${queryParamValue}`
       : queryParamValue;
-    await waitForURLContainsQueryParam(
+    await waitForURLContainsQueryParamValue(
       page,
       queryParamName,
       runningQueryParams,

--- a/frontend/tests/utils/generalUtils.test.ts
+++ b/frontend/tests/utils/generalUtils.test.ts
@@ -1,4 +1,8 @@
-import { findFirstWhitespace, splitMarkup } from "src/utils/generalUtils";
+import {
+  findFirstWhitespace,
+  splitMarkup,
+  toDashCase,
+} from "src/utils/generalUtils";
 
 describe("splitMarkup", () => {
   it("handles case where markdown string is shorter than split point", () => {

--- a/frontend/tests/utils/generalUtils.test.ts
+++ b/frontend/tests/utils/generalUtils.test.ts
@@ -1,8 +1,4 @@
-import {
-  findFirstWhitespace,
-  splitMarkup,
-  toDashCase,
-} from "src/utils/generalUtils";
+import { findFirstWhitespace, splitMarkup } from "src/utils/generalUtils";
 
 describe("splitMarkup", () => {
   it("handles case where markdown string is shorter than split point", () => {


### PR DESCRIPTION
## Summary
Fixes #2144

### Time to review: __15 mins__

## Changes proposed

* adds e2e tests for "select all" and "clear all" filter functionality, including for agencies / nested filters
* fixes bugs with nested filters that showed incorrect selected filter counts and did not correctly clear selected filters

## Context for reviewers
### Test steps

#### Observe bug
1. start the app on main
2. from the search page, click "select all" at the top level of the agencies filter
3. _VALIDATE_: the ui suggests that 39 items are selected, when only 21 are
4. open an expander to show nested filter options
5. click "select all" for the nested options
6. _VALIDATE_: top level search options are cleared when nested ones are selected
7. select a top level option
8. click "clear all" under nested section
9. _VALIDATE_: all options are cleared, not just nested ones

#### Validate fix

1. start the app on this branch
2. from the search page, click "select all" at the top level of the agencies filter
3. _VALIDATE_: the ui states that 21 items are selected
4. open an expander to show nested filter options
5. click "select all" for the nested options
6. _VALIDATE_: top level search options are not cleared
7. select a top level option
8. click "clear all" under nested section
9. _VALIDATE_: only nested options are cleared

## Additional information
The filter components are still a bit of a mess, made a follow up ticket for some more cleanup work. https://github.com/HHS/simpler-grants-gov/issues/3331

