### PR TITLE
[Unticketed] Fix a flaky test due to agency ID conflict

### DIFF
--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -796,16 +796,6 @@ class AgencyFactory(BaseFactory):
     class Meta:
         model = agency_models.Agency
 
-    @classmethod
-    def _setup_next_sequence(cls):
-        if _db_session is not None:
-            value = _db_session.query(func.max(agency_models.Agency.agency_id)).scalar()
-            if value is not None:
-                return value + 1
-
-        return 1
-
-    agency_id = factory.Sequence(lambda n: n)
     agency_name = factory.Faker("agency_name")
 
     agency_code = factory.Iterator(CustomProvider.AGENCIES)


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Remove ID setting in factories for agency to avoid issue where tests tried to create an ID that already was created by factory

## Context for reviewers
When our code runs and creates a record with an integer ID it uses a DB sequence to get the next value. However, the factory was managing its own sequence which meant that if a test tried to create an agency, it ran into an issue.

We don't need this sequence logic for anything and can rely on the DB to avoid any conflicts


