### PR TITLE
[Issue #3356] Upgrade Jinja2 to 3.1.5

### DIFF
--- a/analytics/poetry.lock
+++ b/analytics/poetry.lock
@@ -1503,13 +1503,13 @@ testing = ["Django", "attrs", "colorama", "docopt", "pytest (<9.0.0)"]
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
-    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
+    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
 ]
 
 [package.dependencies]
@@ -4038,4 +4038,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.13"
-content-hash = "bf6073ede1c2274e5d4335beb49fba237ef2a4dd7add0585469d293a8dfb4dab"
+content-hash = "adb763cdaeec5edebd8427314e182c6aab113271ee1c16d52bd7f2d241dfc98b"

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -12,6 +12,7 @@ db-migrate = "analytics.cli:migrate_database"
 
 [tool.poetry.dependencies]
 dynaconf = "^3.2.4"
+jinja2 = ">=3.1.5"
 kaleido = "0.2.1"
 notebook = "^7.0.0"                               # Goal is to replace this with another method of presenting charts
 pandas = "^2.0.3"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -826,13 +826,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
-    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
+    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
 ]
 
 [package.dependencies]
@@ -2293,4 +2293,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.13"
-content-hash = "e967e5a513ccfa475e80592e446c7b07dc8eaa7bdf76bf3c23378f81c1638fdf"
+content-hash = "3ec709ec920bfe19fe679376457e2ddc70c84129541051b8dab330d108cec184"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -28,6 +28,7 @@ flask-cors = "^5.0.0"
 opensearch-py = "^2.5.0"
 pyjwt = "^2.9.0"
 newrelic = "10.3.1"
+jinja2 = ">=3.1.5"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"


### PR DESCRIPTION
## Summary
Fixes #3356 

### Time to review: 5 mins

## Changes proposed
Upgrade Jinja2 to 3.1.5 in API and Analytics projects

## Context for reviewers
The currently installed Jinja version was flagged for a medium vulnerability in CI

## Additional information
More info on the run here: https://github.com/HHS/simpler-grants-gov/actions/runs/12481427243/job/34833926210#step:6:17

