### PR TITLE
[Issue #2515] use CodeOwners to assign reviewers and don't try to upgrade Python

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,13 +14,7 @@
     "dependencies"
   ],
   "branchPrefix": "renovate/",
-  "reviewers": [
-    "sammysteiner",
-    "acouch",
-    "jamesbursa",
-    "coilysiren",
-    "aplybeah"
-  ],
+  "reviewersFromCodeOwners": true,
   "rangeStrategy": "update-lockfile",
   "timezone": "America/New_York",
   "vulnerabilityAlerts": {
@@ -136,6 +130,15 @@
         "analytics/poetry.lock"
       ],
       "matchPackagePatterns": ["kaleido"]
+    },
+    {
+      "description": "Don't upgrade Python itself as annual releases reflect as minor version bumps",
+      "enabled": false,
+      "matchFileNames": [
+        "analytics/pyproject.toml",
+        "api/pyproject.toml"
+      ],
+      "matchPackagePatterns": ["python"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fixes #2515

### Time to review: __2 mins__

## Changes proposed
Update Renovate's config to use CodeOwners to assign reviewers and ignore Python releases since we need to evaluate those releases more deeply before allowing.

[Renovate Config Docs](https://docs.renovatebot.com/configuration-options/#matchpackagenames)
