### PR TITLE
[Issue #3160] Give analytic access to the transfer bucket

### DIFF
--- a/infra/analytics/service/transfer_access.tf
+++ b/infra/analytics/service/transfer_access.tf
@@ -1,0 +1,28 @@
+data "aws_ssm_parameter" "transfer_bucket_arn" {
+  name = "/buckets/api-${var.environment_name}/api-analytics-transfer/arn"
+}
+
+data "aws_ssm_parameter" "transfer_bucket_id" {
+  name = "/buckets/api-${var.environment_name}/api-analytics-transfer/id"
+}
+
+data "aws_iam_policy_document" "transfer_bucket_access" {
+  statement {
+    effect = "Allow"
+    resources = [
+      data.aws_ssm_parameter.transfer_bucket_arn.value,
+      "${data.aws_ssm_parameter.transfer_bucket_arn.value}/*",
+    ]
+    actions = ["s3:Get*", "s3:List*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.service.app_service_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "transfer_bucket_access" {
+  bucket = data.aws_ssm_parameter.transfer_bucket_id.value
+  policy = data.aws_iam_policy_document.transfer_bucket_access.json
+}

--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -38,6 +38,10 @@ output "task_definition_arn" {
   value = aws_ecs_task_definition.app.arn
 }
 
+output "app_service_arn" {
+  value = aws_iam_role.app_service.arn
+}
+
 output "task_role_arn" {
   value = aws_iam_role.task_executor.arn
 }

--- a/infra/modules/service/s3_buckets.tf
+++ b/infra/modules/service/s3_buckets.tf
@@ -99,3 +99,19 @@ resource "aws_s3_bucket_policy" "s3_buckets" {
   bucket   = aws_s3_bucket.s3_buckets[each.key].id
   policy   = data.aws_iam_policy_document.s3_buckets_put_access[each.key].json
 }
+
+resource "aws_ssm_parameter" "s3_bucket_arns" {
+  for_each = var.s3_buckets
+
+  name  = "/buckets/${var.service_name}/${each.key}/arn"
+  type  = "String"
+  value = aws_s3_bucket.s3_buckets[each.key].arn
+}
+
+resource "aws_ssm_parameter" "s3_bucket_ids" {
+  for_each = var.s3_buckets
+
+  name  = "/buckets/${var.service_name}/${each.key}/id"
+  type  = "String"
+  value = aws_s3_bucket.s3_buckets[each.key].id
+}

--- a/infra/modules/service/s3_buckets.tf
+++ b/infra/modules/service/s3_buckets.tf
@@ -104,7 +104,7 @@ resource "aws_ssm_parameter" "s3_bucket_arns" {
   for_each = var.s3_buckets
 
   name  = "/buckets/${var.service_name}/${each.key}/arn"
-  type  = "String"
+  type  = "SecureString"
   value = aws_s3_bucket.s3_buckets[each.key].arn
 }
 
@@ -112,6 +112,6 @@ resource "aws_ssm_parameter" "s3_bucket_ids" {
   for_each = var.s3_buckets
 
   name  = "/buckets/${var.service_name}/${each.key}/id"
-  type  = "String"
+  type  = "SecureString"
   value = aws_s3_bucket.s3_buckets[each.key].id
 }

--- a/infra/modules/service/s3_buckets.tf
+++ b/infra/modules/service/s3_buckets.tf
@@ -106,6 +106,7 @@ resource "aws_ssm_parameter" "s3_bucket_arns" {
   name  = "/buckets/${var.service_name}/${each.key}/arn"
   type  = "SecureString"
   value = aws_s3_bucket.s3_buckets[each.key].arn
+  # checkov:skip=CKV_AWS_337: KMS encryption is overkill here
 }
 
 resource "aws_ssm_parameter" "s3_bucket_ids" {
@@ -114,4 +115,5 @@ resource "aws_ssm_parameter" "s3_bucket_ids" {
   name  = "/buckets/${var.service_name}/${each.key}/id"
   type  = "SecureString"
   value = aws_s3_bucket.s3_buckets[each.key].id
+  # checkov:skip=CKV_AWS_337: KMS encryption is overkill here
 }


### PR DESCRIPTION
## Summary

Relates to #3160

### Time to review: __2 mins__

## Changes proposed

- Writes the iterative s3 bucket ids and arns to ssm params
- Reads the api's variants of those ssm params into the analytics application
- Gives the analytics application access to the api's s3 buckets

## ⚠️ Deploy Warning ⚠️ 

This creates a dependency between the API infra and Analytics infra. Because of this, there will be a race condition between the two deployments. If a deploy is broken, then the fix is just to deploy again.
