### PR TITLE
[Issue #3387] remove opportunity contact telephone number

### DIFF
--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -107,23 +107,12 @@ const SummaryDescriptionDisplay = ({
 
 const OpportunityDescription = ({ summary, nofoPath }: Props) => {
   const t = useTranslations("OpportunityListing.description");
-  const agency_phone_number_stripped = summary?.agency_phone_number
-    ? summary.agency_phone_number.replace(/-/g, "")
-    : "";
 
   const additionalInformationOnEligibility =
     summary.applicant_eligibility_description ?? "--";
   const agencyEmailLink = summary?.agency_email_address ? (
     <a href={`mailto:${summary.agency_email_address}`}>
       {summary.agency_email_address}
-    </a>
-  ) : (
-    "--"
-  );
-
-  const telephoneLink = summary?.agency_phone_number ? (
-    <a href={`tel:${agency_phone_number_stripped}`}>
-      {summary.agency_phone_number}
     </a>
   ) : (
     "--"
@@ -161,8 +150,6 @@ const OpportunityDescription = ({ summary, nofoPath }: Props) => {
           <p>{summary.agency_email_address_description}</p>
         )}
         <p>{agencyEmailLink}</p>
-        <h4>{t("telephone")}</h4>
-        <p>{telephoneLink}</p>
       </div>
     </>
   );

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -22,7 +22,6 @@ export const messages = {
       contact_info: "Grantor contact information",
       description: "Description",
       email: "Email",
-      telephone: "Phone",
       show_summary: "Show full summary",
       show_description: "Show full description",
       hide_summary_description: "Hide full description",

--- a/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
@@ -43,7 +43,6 @@ const mockSummaryData: Summary = {
   agency_contact_description: "<p>Contact Description</p>",
   agency_email_address: "contact@example.com",
   agency_email_address_description: "Contact Email Description",
-  agency_phone_number: "123-456-7890",
 } as Summary;
 
 describe("OpportunityDescription", () => {
@@ -140,19 +139,12 @@ describe("OpportunityDescription", () => {
 
     expect(screen.getByText("contact@example.com")).toBeInTheDocument();
     expect(screen.getByText("Contact Email Description")).toBeInTheDocument();
-    expect(screen.getByText("123-456-7890")).toBeInTheDocument();
 
     const mailtoLink = screen.getByRole("link", {
       name: "contact@example.com",
     });
     const agency_email = "contact@example.com";
     expect(mailtoLink).toHaveAttribute("href", `mailto:${agency_email}`);
-
-    const telLink = screen.getByRole("link", {
-      name: "123-456-7890",
-    });
-    const number = "1234567890";
-    expect(telLink).toHaveAttribute("href", `tel:${number}`);
   });
 
   it("renders information correctly when null values are present", () => {
@@ -165,7 +157,6 @@ describe("OpportunityDescription", () => {
           agency_contact_description: null,
           agency_email_address: null,
           agency_email_address_description: null,
-          agency_phone_number: null,
           summary_description: null,
         }}
         nofoPath=""
@@ -187,9 +178,5 @@ describe("OpportunityDescription", () => {
     const emailHeading = screen.getByText("email");
     expect(emailHeading).toBeInTheDocument();
     expect(emailHeading.nextElementSibling).toHaveTextContent("--");
-
-    const telephoneHeading = screen.getByText("telephone");
-    expect(telephoneHeading).toBeInTheDocument();
-    expect(telephoneHeading.nextElementSibling).toHaveTextContent("--");
   });
 });


### PR DESCRIPTION
## Summary
Issue #3387

### Time to review: __5 mins__

## Changes proposed
Removes grantor phone info from opportunity listing

## Context for reviewers
Requested by Julius

### Test Steps

1. start server on this branch and visit an opportunity detail
2. _VERIFY_: no phone information is shown on the page

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

