### PR TITLE
[Issue #3390] Remove agency_phone_number from Opportunity/Search API responses

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -1496,12 +1496,6 @@ components:
           description: Additional information about the types of applicants that are
             eligible
           example: All types of domestic applicants are eligible to apply
-        agency_phone_number:
-          type:
-          - string
-          - 'null'
-          description: The phone number of the agency who owns the opportunity
-          example: 123-456-7890
         agency_contact_description:
           type:
           - string

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -174,14 +174,6 @@ class OpportunitySummaryV1Schema(Schema):
             "example": "All types of domestic applicants are eligible to apply",
         },
     )
-
-    agency_phone_number = fields.String(
-        allow_none=True,
-        metadata={
-            "description": "The phone number of the agency who owns the opportunity",
-            "example": "123-456-7890",
-        },
-    )
     agency_contact_description = fields.String(
         allow_none=True,
         metadata={

--- a/api/tests/src/api/opportunities_v1/conftest.py
+++ b/api/tests/src/api/opportunities_v1/conftest.py
@@ -208,7 +208,7 @@ def validate_opportunity_summary(db_summary: OpportunitySummary, resp_summary: d
         == resp_summary["applicant_eligibility_description"]
     )
 
-    assert db_summary.agency_phone_number == resp_summary["agency_phone_number"]
+    assert "agency_phone_number" not in resp_summary
     assert db_summary.agency_contact_description == resp_summary["agency_contact_description"]
     assert db_summary.agency_email_address == resp_summary["agency_email_address"]
     assert (

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_search.py
@@ -42,6 +42,10 @@ def validate_search_response(
 
     response_ids = [int(opp["opportunity_id"]) for opp in opportunities]
 
+    for opp in opportunities:
+        if "summary" in opp:
+            assert "agency_phone_number" not in opp["summary"]
+
     assert (
         response_ids == expected_ids
     ), f"Actual opportunities:\n {'\n'.join([opp['opportunity_title'] for opp in opportunities])}"
@@ -77,6 +81,7 @@ def build_opp(
     award_floor: int | None,
     award_ceiling: int | None,
     estimated_total_program_funding: int | None,
+    agency_phone_number: str | None = "123-456-7890",
 ) -> Opportunity:
     opportunity = OpportunityFactory.build(
         opportunity_title=opportunity_title,
@@ -108,6 +113,7 @@ def build_opp(
         award_floor=award_floor,
         award_ceiling=award_ceiling,
         estimated_total_program_funding=estimated_total_program_funding,
+        agency_phone_number=agency_phone_number,
     )
 
     opportunity.current_opportunity_summary = CurrentOpportunitySummaryFactory.build(
@@ -150,6 +156,7 @@ NASA_SPACE_FELLOWSHIP = build_opp(
     award_floor=50_000,
     award_ceiling=5_000_000,
     estimated_total_program_funding=15_000_000,
+    agency_phone_number="123-456-7890",
 )
 
 NASA_INNOVATIONS = build_opp(


### PR DESCRIPTION
## Summary
Fixes #3390 

### Time to review: 10 mins

## Changes proposed
Remove `agency_phone_number` from opportunity GET and search API responses.

## Context for reviewers
Additional context in #3390 and associated ticket.

## Additional information
See updated unit tests.

