### PR TITLE
[Issue #3401] Use brand color for page section backgrounds

### DIFF
--- a/frontend/src/app/[locale]/process/page.tsx
+++ b/frontend/src/app/[locale]/process/page.tsx
@@ -29,10 +29,10 @@ export default function Process({ params: { locale } }: LocalizedPageProps) {
       <BetaAlert containerClasses="margin-top-5" />
       <Breadcrumbs breadcrumbList={PROCESS_CRUMBS} />
       <ProcessIntro />
-      <div className="padding-top-4 bg-gray-5">
+      <div className="padding-top-4 bg-base-lightest">
         <ProcessProgress />
       </div>
-      <div className="padding-top-4 bg-gray-5">
+      <div className="padding-top-4 bg-base-lightest">
         <ProcessNext />
       </div>
       <ProcessInvolved />

--- a/frontend/src/app/[locale]/research/page.tsx
+++ b/frontend/src/app/[locale]/research/page.tsx
@@ -31,7 +31,7 @@ export default function Research({ params: { locale } }: LocalizedPageProps) {
       <Breadcrumbs breadcrumbList={RESEARCH_CRUMBS} />
       <ResearchIntro />
       <ResearchMethodology />
-      <div className="padding-top-4 bg-gray-5">
+      <div className="padding-top-4 bg-base-lightest">
         <ResearchArchetypes />
         <ResearchThemes />
       </div>


### PR DESCRIPTION
## Summary
Fixes #3401 

### Time to review: __1 mins__

## Changes proposed
- Use the `.bg-base-lightest` utility class (which is the brand's `gray-warm-5`) instead of `. bg-gray-5` 

## Context for reviewers
This is a very subtle color difference that might be hard for some to notice

## Additional information
![image](https://github.com/user-attachments/assets/f4b95e62-8526-4b65-9c60-4fa0d6696cc5)
