### PR TITLE
[Issue #3404] use brand green for process page icons

### DIFF
--- a/frontend/src/app/[locale]/process/ProcessProgress.tsx
+++ b/frontend/src/app/[locale]/process/ProcessProgress.tsx
@@ -54,7 +54,7 @@ const ProcessProgress = () => {
                 >
                   <IconListIcon>
                     <USWDSIcon
-                      className="usa-icon text-green"
+                      className="usa-icon text-primary-darker"
                       name="check_circle"
                     />
                   </IconListIcon>


### PR DESCRIPTION
## Summary
Fixes #3404

### Time to review: __1 mins__

## Changes proposed
- Switch the utility class of the green checkmark icons in the IconList component on the process page 

## Context for reviewers
This uses a brand green instead of the default `green` token

## Additional information
![image](https://github.com/user-attachments/assets/16c57331-f37e-4235-85f4-7d9fed15f68e)
