### PR TITLE
[Unticketed] Ignore vulnerability for issue fixed in upcoming Python release

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -28,3 +28,6 @@ ignore:
   # Last Checked: Dec 19th, 2024
   - vulnerability: GHSA-v778-237x-gjrc
   - vulnerability: GHSA-w32m-9786-jp63
+  # Issue with asyncio library in Python, should be fixed
+  # in 3.13.2 (early February 2025)
+  - vulnerability: CVE-2024-12254


### PR DESCRIPTION
### Time to review: __1 mins__

## Changes proposed
Ignore vulnerability https://nvd.nist.gov/vuln/detail/CVE-2024-12254

## Context for reviewers
Grype is saying it wants us to upgrade to python 3.14a which releases in October and is not yet prod ready

The fix is also in 3.13, but not yet released (should be February)


