### PR TITLE
[External] Increase test coverage for dateUtil module in frontend.

### DIFF
--- a/frontend/tests/utils/dateUtil.test.ts
+++ b/frontend/tests/utils/dateUtil.test.ts
@@ -17,4 +17,10 @@ describe("formatDate", () => {
   it("returns a human readable string for properly formatted dates", () => {
     expect(formatDate("2024-10-10")).toBe("October 10, 2024");
   });
+
+  it("invokes console warn when date string does not contain 3 parts", () => {
+    const logSpy = jest.spyOn(global.console, "warn");
+    formatDate("10-1019999");
+    expect(logSpy).toHaveBeenCalledWith("invalid date string provided for parse");
+  });
 });

--- a/frontend/tests/utils/dateUtil.test.ts
+++ b/frontend/tests/utils/dateUtil.test.ts
@@ -21,6 +21,8 @@ describe("formatDate", () => {
   it("invokes console warn when date string does not contain 3 parts", () => {
     const logSpy = jest.spyOn(global.console, "warn");
     formatDate("10-1019999");
-    expect(logSpy).toHaveBeenCalledWith("invalid date string provided for parse");
+    expect(logSpy).toHaveBeenCalledWith(
+      "invalid date string provided for parse",
+    );
   });
 });


### PR DESCRIPTION
## Summary
There is currently a use case in the `dateUtil` module that is preventing full unit test coverage. This pull requests covers that use case to get this module to 100% coverage.

The use case is when a date string is passed into `formatDate` and does not have 3 parts delimited by a `-`. When this use case occurs, we expect to log a warning in the console and is tested by this pr.

### Time to review: 5m

## Changes proposed
> Add a unit test case in the dateUtil.test.ts test module to cover the use case mentioned above.

## Context for reviewers
> This change can be tested and verified by running `npm run test` within the ~/frontend directory of this repository.

## Additional information
> You should see the following results of the unit tests.
![Screenshot 2025-01-07 at 12 58 27 PM](https://github.com/user-attachments/assets/e3e11c23-5dfa-46e2-86cc-fd131f4773bb)


