### PR TITLE
[Unticketed] do not lint during e2e tests

### DIFF
--- a/.github/workflows/ci-frontend-a11y.yml
+++ b/.github/workflows/ci-frontend-a11y.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build Site
         run: |
           cat .env.development >> .env.local
-          npm run build
+          npm run build -- --no-lint
 
       - name: Run Server
         run: npm run start &

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build a prod version of the site
         run: |
           cat .env.development >> .env.local
-          npm run build
+          npm run build -- --no-lint
 
       - name: Run e2e tests (Shard ${{ matrix.shard }}/${{ matrix.total_shards }})
         env:


### PR DESCRIPTION
## Summary
Unticketed

### Time to review: __2 mins__

## Changes proposed
Remove linting from e2e and pa11y tests, as that's duplicative with linting already happening in a separate part of ci process

## Context for reviewers
### Test steps
1. _VERIFY_: output for e2e and pa11y runs on this branch do not include the output `Linting and checking validity of types ...`

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

