### PR TITLE
[no ticket] Update IAM roles before running database migrations

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -155,6 +155,11 @@ resource "aws_ecs_task_definition" "app" {
 
   # Reference https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
   network_mode = "awsvpc"
+
+  depends_on = [
+    aws_iam_role_policy.task_executor,
+    aws_iam_role_policy_attachment.extra_policies,
+  ]
 }
 
 resource "aws_ecs_cluster" "cluster" {


### PR DESCRIPTION
### Time to review: __1 mins__

## Context for reviewers

Recently, Doug and Michael observed an issue where database migrations failed because a new task definition needed to update its IAM permissions. This happens because the database migrations deploy "targets" the task definition during the deployment and try to update just that. Then that task definition crashes on startup because it doesn't have the proper permissions.

My theoretical solve for that is: to require the task definition to depend on the IAM roles being updated first. That should prevent an updated task definition from rolling out without its associated permissions.

## Testing

I just tested this that deploys, setting up a real thorough test case would take too much time I think.