### PR TITLE
[Issue #3097] Adds configuration for S3 CDN

### DIFF
--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -123,6 +123,8 @@ module "service" {
   max_capacity           = local.service_config.instance_scaling_max_capacity
   min_capacity           = local.service_config.instance_scaling_min_capacity
   enable_autoscaling     = true
+  enable_s3_cdn          = true
+  s3_cdn_bucket_name     = "public-files"
   cpu                    = local.service_config.instance_cpu
   memory                 = local.service_config.instance_memory
   environment_name       = var.environment_name

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -131,7 +131,7 @@ module "service" {
   cpu                    = local.service_config.instance_cpu
   memory                 = local.service_config.instance_memory
   enable_autoscaling     = true
-  enable_cdn             = true
+  enable_alb_cdn         = true
 
   app_access_policy_arn      = null
   migrator_access_policy_arn = null

--- a/infra/modules/service/cdn-logs.tf
+++ b/infra/modules/service/cdn-logs.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "cdn" {
-  count = var.enable_cdn ? 1 : 0
+  count = local.enable_cdn ? 1 : 0
 
   bucket_prefix = "${var.service_name}-cdn-access-logs"
   force_destroy = false
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "cdn" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "cdn" {
-  count = var.enable_cdn ? 1 : 0
+  count = local.enable_cdn ? 1 : 0
 
   bucket = aws_s3_bucket.cdn[0].id
   rule {
@@ -25,7 +25,7 @@ resource "aws_s3_bucket_ownership_controls" "cdn" {
 }
 
 resource "aws_s3_bucket_acl" "cdn" {
-  count = var.enable_cdn ? 1 : 0
+  count = local.enable_cdn ? 1 : 0
 
   bucket = aws_s3_bucket.cdn[0].id
 
@@ -35,7 +35,7 @@ resource "aws_s3_bucket_acl" "cdn" {
 }
 
 resource "aws_s3_bucket_public_access_block" "cdn" {
-  count = var.enable_cdn ? 1 : 0
+  count = local.enable_cdn ? 1 : 0
 
   bucket = aws_s3_bucket.cdn[0].id
 
@@ -46,7 +46,7 @@ resource "aws_s3_bucket_public_access_block" "cdn" {
 }
 
 data "aws_iam_policy_document" "cdn" {
-  count = var.enable_cdn ? 1 : 0
+  count = local.enable_cdn ? 1 : 0
 
   statement {
     actions = [
@@ -65,14 +65,14 @@ data "aws_iam_policy_document" "cdn" {
 }
 
 resource "aws_s3_bucket_policy" "cdn" {
-  count = var.enable_cdn ? 1 : 0
+  count = local.enable_cdn ? 1 : 0
 
   bucket = aws_s3_bucket.cdn[0].id
   policy = data.aws_iam_policy_document.cdn[0].json
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "cdn" {
-  count = var.enable_cdn ? 1 : 0
+  count = local.enable_cdn ? 1 : 0
 
   bucket = aws_s3_bucket.cdn[0].id
 

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -5,6 +5,19 @@ locals {
   ssl_protocols            = ["TLSv1.2"]
   minimum_protocol_version = "TLSv1.2_2021"
   enable_cdn               = var.enable_alb_cdn || var.enable_s3_cdn
+
+  # The domain name of the CDN, ie. URL people use in order to access the CDN.
+  # Null outputs here result in the CDN content being served from the CDN's default domain name.
+  #   - If the origin is an ALB, and the ALB's domain name is not null, this is the domain name of the ALB
+  #   - If the origin is an ALB, and the ALB's domain name is null, then return null
+  #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is not null, this is the domain name of the S3 bucket
+  #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is null, then return null
+  cdn_domain_name = var.enable_alb_cdn && var.domain != null ? var.domain : var.enable_s3_cdn && var.s3_cdn_domain_name != null ? var.s3_cdn_domain_name : null
+
+  # The domain name of the origin, ie. where the content is being served from.
+  #   - If the origin is an ALB, this is the DNS name of the ALB
+  #   - If the origin is an S3 bucket, this is the regional domain name of the S3 bucket.
+  origin_domain_name = var.enable_alb_cdn ? aws_lb.alb[0].dns_name : var.enable_s3_cdn ? aws_s3_bucket.s3_buckets[var.s3_cdn_bucket_name].bucket_regional_domain_name : null
 }
 
 resource "aws_cloudfront_origin_access_identity" "cdn" {
@@ -42,10 +55,10 @@ resource "aws_cloudfront_distribution" "cdn" {
   count = local.enable_cdn ? 1 : 0
 
   enabled = local.enable_cdn ? true : false
-  aliases = var.domain == null ? null : [var.domain]
+  aliases = local.cdn_domain_name == null ? null : [local.cdn_domain_name]
 
   origin {
-    domain_name = var.enable_alb_cdn ? aws_lb.alb[0].dns_name : aws_s3_bucket.s3_buckets[var.s3_cdn_bucket_name].bucket_regional_domain_name
+    domain_name = local.origin_domain_name
     origin_id   = local.default_origin_id
     custom_origin_config {
       http_port              = 80
@@ -105,7 +118,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     aws_s3_bucket.cdn[0],
   ]
 
-  #checkov:skip=CKV2_AWS_46:We sometimes us a ALB origin
+  #checkov:skip=CKV2_AWS_46:We sometimes use a ALB origin
   #checkov:skip=CKV_AWS_174:False positive
   #checkov:skip=CKV_AWS_310:Configure a failover in future work
   #checkov:skip=CKV_AWS_68:Configure WAF in future work

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -8,10 +8,14 @@ locals {
 
   # The domain name of the CDN, ie. URL people use in order to access the CDN.
   # Null outputs here result in the CDN content being served from the CDN's default domain name.
-  #   - If the origin is an ALB, and the ALB's domain name is not null, this is the domain name of the ALB
-  #   - If the origin is an ALB, and the ALB's domain name is null, then return null
-  #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is not null, this is the domain name of the S3 bucket
-  #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is null, then return null
+  #   - If the origin is an ALB, and the ALB's domain name is not null,
+  #     then use the domain name of the ALB
+  #   - If the origin is an ALB, and the ALB's domain name is null,
+  #     then return null
+  #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is not null,
+  #     then use the domain name of the S3 bucket
+  #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is null,
+  #     then return null
   cdn_domain_name = var.enable_alb_cdn && var.domain != null ? var.domain : var.enable_s3_cdn && var.s3_cdn_domain_name != null ? var.s3_cdn_domain_name : null
 
   # The domain name of the origin, ie. where the content is being served from.

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -16,7 +16,8 @@ locals {
   #     then use the domain name of the S3 bucket
   #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is null,
   #     then return null
-  cdn_domain_name = var.enable_alb_cdn && var.domain != null ? var.domain : var.enable_s3_cdn && var.s3_cdn_domain_name != null ? var.s3_cdn_domain_name : null
+  cdn_domain_name         = var.enable_alb_cdn && var.domain != null ? var.domain : var.enable_s3_cdn && var.s3_cdn_domain_name != null ? var.s3_cdn_domain_name : null
+  cdn_domain_name_env_var = local.cdn_domain_name != null ? local.cdn_domain_name : aws_cloudfront_distribution.cdn[0].domain_name
 
   # The domain name of the origin, ie. where the content is being served from.
   #   - If the origin is an ALB, this is the DNS name of the ALB

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -45,9 +45,13 @@ locals {
     { name : "DB_NAME", value : var.db_vars.connection_info.db_name },
     { name : "DB_SCHEMA", value : var.db_vars.connection_info.schema_name },
   ]
+  cdn_environment_variables = local.enable_cdn ? [
+    { name : "CDN_URL", value : local.cdn_domain_name_env_var },
+  ] : []
   environment_variables = concat(
     local.base_environment_variables,
     local.db_environment_variables,
+    local.cdn_environment_variables,
     [
       for name, value in var.extra_environment_variables :
       { name : name, value : value }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -204,10 +204,22 @@ variable "enable_load_balancer" {
   default     = true
 }
 
-variable "enable_cdn" {
-  description = "Whether to enable a CDN for the service"
+variable "enable_alb_cdn" {
+  description = "Whether to enable an ALB origin CDN for the service"
   type        = bool
   default     = false
+}
+
+variable "enable_s3_cdn" {
+  description = "Whether to enable a S3 origin CDN for the service"
+  type        = bool
+  default     = false
+}
+
+variable "s3_cdn_bucket_name" {
+  description = "The name of the S3 bucket to use for the S3 CDN"
+  type        = string
+  default     = null
 }
 
 variable "healthcheck_command" {

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -205,19 +205,25 @@ variable "enable_load_balancer" {
 }
 
 variable "enable_alb_cdn" {
-  description = "Whether to enable an ALB origin CDN for the service"
+  description = "Whether to enable an ALB origin CDN for the service. Cannot be enabled at the same time as the S3 CDN."
   type        = bool
   default     = false
 }
 
 variable "enable_s3_cdn" {
-  description = "Whether to enable a S3 origin CDN for the service"
+  description = "Whether to enable a S3 origin CDN for the service. Cannot be enabled at the same time as the ALB CDN."
   type        = bool
   default     = false
 }
 
 variable "s3_cdn_bucket_name" {
-  description = "The name of the S3 bucket to use for the S3 CDN"
+  description = "The name of the S3 bucket to use for the S3 CDN."
+  type        = string
+  default     = null
+}
+
+variable "s3_cdn_domain_name" {
+  description = "The domain name of the S3 bucket to use for the S3 CDN"
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Summary

Probably finishes #3097

### Time to review: __5 mins__

## Changes proposed

Adds configuration to the CDN that allows it to operate in 4 modes:

1. With no fronting domain name, and an ALB origin (eg. frontend dev)
2. With a fronting domain name, and an ALB origin (eg. frontend prod)
3. With no fronting domain name, and a S3 origin (eg. API dev)
4. With a fronting domain name, and a S3 origin (eg. API prod)

## Context for reviewers

It's complicated in here 😅 

## Testing

I tested by deploying to API dev and frontend dev