### PR TITLE
[Issue #3247] login header follow up fixes

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -24,11 +24,12 @@ type PrimaryLink = {
 };
 
 type Props = {
-  logoPath?: string;
   locale?: string;
 };
 
 const homeRegexp = /^\/(?:e[ns])?$/;
+
+const logoPath = "./img/grants-logo.svg";
 
 const NavLinks = ({
   mobileExpanded,
@@ -120,8 +121,7 @@ const NavLinks = ({
   );
 };
 
-const Header = ({ logoPath, locale }: Props) => {
-  logoPath = "./img/grants-logo.svg";
+const Header = ({ locale }: Props) => {
   const t = useTranslations("Header");
   const [isMobileNavExpanded, setIsMobileNavExpanded] =
     useState<boolean>(false);

--- a/frontend/src/components/user/UserControl.tsx
+++ b/frontend/src/components/user/UserControl.tsx
@@ -113,7 +113,7 @@ const UserDropdown = ({
         menuId="user-control"
       />
       <Menu
-        className="position-absolute desktop:width-full z-top"
+        className="position-absolute desktop:width-full z-200"
         id="user-control"
         items={[
           <UserEmailItem key="email" isSubnav={true} email={user.email} />,

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -408,6 +408,11 @@ button.usa-pagination__button.usa-button {
           linear-gradient(transparent, transparent);
       }
     }
+    button[aria-expanded] {
+      span:after {
+        right: 0.75rem;
+      }
+    }
     .usa-nav__submenu-item {
       background-color: color("mint-60");
       a {
@@ -419,7 +424,7 @@ button.usa-pagination__button.usa-button {
       }
     }
     .usa-nav__submenu {
-      right: 3.6em;
+      right: 3.7em;
     }
   }
 }

--- a/frontend/tests/components/Header.test.tsx
+++ b/frontend/tests/components/Header.test.tsx
@@ -7,7 +7,6 @@ import { ReadonlyURLSearchParams } from "next/navigation";
 import Header from "src/components/Header";
 
 const props = {
-  logoPath: "/img/logo.svg",
   locale: "en",
 };
 


### PR DESCRIPTION
## Summary
Fixes #3247

### Time to review: __5 mins__

## Changes proposed
- fix bug where mobile login dropdown appeared on top of mobile menu
- improve spacing on mobile login dropdown

## Context for reviewers
### Test Steps
1. run the app on main
2. visit http://localhost:3000 on mobile
3. _VERIFY_: looks like "before" screenshots below
4. restart app on this branch and refresh
3. _VERIFY_: looks like "after" screenshots below

## Additional information

### Before
![Screenshot 2025-01-09 at 4 26 05 PM](https://github.com/user-attachments/assets/e6515a06-0cd7-4c62-9501-7bdee1f54d6f)
![Screenshot 2025-01-09 at 4 25 58 PM](https://github.com/user-attachments/assets/86cb697e-56cf-4dfc-a8df-9bf1c2545f44)

### After
![Screenshot 2025-01-09 at 4 23 01 PM](https://github.com/user-attachments/assets/d832277f-0eb8-4d63-821b-2268cc2319b3)

![Screenshot 2025-01-09 at 4 22 52 PM](https://github.com/user-attachments/assets/a7b6e9e4-6af7-4dd3-b2ef-827c6f652e50)

> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

