### PR TITLE
[Issue #2871] upgrade to node 22.13

### DIFF
--- a/.github/workflows/ci-frontend-a11y.yml
+++ b/.github/workflows/ci-frontend-a11y.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./frontend
 
     env:
-      NODE_VERSION: 20
+      NODE_VERSION: 22
       LOCKFILE_PATH: ./frontend/package-lock.json
       PACKAGE_MANAGER: npm
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -11,7 +11,7 @@ defaults:
     working-directory: ./frontend
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 22
   LOCKFILE_PATH: ./frontend/package-lock.json
   PACKAGE_MANAGER: npm
 

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -12,7 +12,7 @@ defaults:
     working-directory: ./frontend
 
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 22
   LOCKFILE_PATH: ./frontend/package-lock.json # or yarn.lock
   PACKAGE_MANAGER: npm # or yarn
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 # This file is largely based on the template-application-flask Dockerfile and
 # Next.js Docker example: https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose
 # =============================================================================
-FROM node:20-bookworm-slim AS base
+FROM node:22-bookworm-slim AS base
 WORKDIR /frontend
 
 # Install dependencies
@@ -54,7 +54,7 @@ RUN npm run build -- --no-lint
 # Run the Next.js server
 # =====================================
 # Use clean image for release, excluding any unnecessary files or dependencies
-FROM node:20-bullseye-slim AS release
+FROM node:22-bookworm-slim AS release
 WORKDIR /frontend
 
 # Update system and install security updates

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -81,6 +81,18 @@ const nextConfig = {
     nrExternals(config);
     return config;
   },
+  eslint: {
+    dirs: [
+      "src",
+      "stories",
+      ".storybook",
+      "tests",
+      "scripts",
+      "frontend",
+      "lib",
+      "types",
+    ],
+  },
 };
 
 module.exports = withNextIntl(nextConfig);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,7 +45,7 @@
         "@types/js-cookie": "^3.0.6",
         "@types/lodash": "^4.17.13",
         "@types/newrelic": "^9.14.6",
-        "@types/node": "^20.8.2",
+        "@types/node": "^22.10.5",
         "@types/node-fetch": "^2.6.11",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
@@ -75,7 +75,7 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5508,16 +5508,6 @@
         }
       }
     },
-    "node_modules/@storybook/builder-webpack5/node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.8"
-      }
-    },
     "node_modules/@storybook/components": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.4.2.tgz",
@@ -5581,23 +5571,6 @@
       "peerDependencies": {
         "storybook": "^8.4.7"
       }
-    },
-    "node_modules/@storybook/core-webpack/node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.20.0"
-      }
-    },
-    "node_modules/@storybook/core-webpack/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@storybook/csf": {
       "version": "0.1.11",
@@ -5925,16 +5898,6 @@
         "yarn": ">=1"
       }
     },
-    "node_modules/@storybook/nextjs/node_modules/@types/node": {
-      "version": "22.10.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
-      "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.20.0"
-      }
-    },
     "node_modules/@storybook/nextjs/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -6126,13 +6089,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@storybook/nextjs/node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@storybook/preset-react-webpack": {
       "version": "8.4.7",
@@ -6348,16 +6304,6 @@
         "node": ">=14",
         "npm": ">=6",
         "yarn": ">=1"
-      }
-    },
-    "node_modules/@storybook/preset-react-webpack/node_modules/@types/node": {
-      "version": "22.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@storybook/preset-react-webpack/node_modules/ansi-styles": {
@@ -7118,11 +7064,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.16.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.5.tgz",
-      "integrity": "sha512-VwYCweNo3ERajwy0IUlqqcyZ8/A7Zwa9ZP3MnENWcB11AejO+tLy3pu850goUW2FC/IJMdZUfKpX/yxL1gymCA==",
+      "version": "22.10.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
+      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -21531,9 +21478,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "license": "MIT"
     },
     "node_modules/unescape": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "all-checks": "npm run lint && npm run ts:check && npm run test && npm run build",
@@ -13,7 +13,7 @@
     "debug": "NODE_OPTIONS='--inspect' next dev",
     "format": "prettier --write '**/*.{js,json,md,ts,tsx,scss,yaml,yml}'",
     "format-check": "prettier --check '**/*.{js,json,md,ts,tsx,scss,yaml,yml}'",
-    "lint": "next lint --dir src --dir stories --dir .storybook --dir tests --dir scripts --dir frontend --dir lib --dir types",
+    "lint": "next lint",
     "lint-fix": "npm run lint -- --fix",
     "postinstall": "node ./scripts/postinstall.js",
     "start:nr": "NODE_OPTIONS= '-r @newrelic/next' next start -p ${PORT:-3000}",
@@ -66,7 +66,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/lodash": "^4.17.13",
     "@types/newrelic": "^9.14.6",
-    "@types/node": "^20.8.2",
+    "@types/node": "^22.10.5",
     "@types/node-fetch": "^2.6.11",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",


### PR DESCRIPTION
## Summary
Fixes #2871

### Time to review: __20 mins__

## Changes proposed
All usages of Node in the application upgraded to latest 22 minor version (22.13). This includes:
- github actions
- Dockerfile base image
- package.json engine (this will require local developers to be using the 22.13 <= in order to run npm installs)
- node types package (upgraded to latest available, the versions for this package do not seem to be totally in line with actual node versions)

This also:
- moves linting behavior into the next config from the package script (just for cleanliness)
- upgrades the release Dockerfile base to bookworm from bullseye. This was already done for the build image, I think it was just an oversight that the release image was not upgraded as well.

## Context for reviewers
### Test Steps
1. `npm run dev` and do a basic regression test
2. _VERIFY_: app works as normal
3. `npm run build && npm start` and do a basic regression test
4. _VERIFY_: app works as normal
5. update development.env to point to docker host and `docker compose -f ./docker-compose-release.yml up --build` and do a basic regression test
4. _VERIFY_: app works as normal

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

