### PR TITLE
[Unticketed] Add cryptopgraphy dependency so RS256 is available

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1574,6 +1574,9 @@ files = [
     {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
 ]
 
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
 dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
@@ -2308,4 +2311,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.13"
-content-hash = "8c5dbac2265a7099755476c829c2bcb200fe27b230a41f8c3d737caacb73bba1"
+content-hash = "19d743f8994ec28e627395943e010795f42022e01184c4fedd4ee9e0630eedf4"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -26,7 +26,7 @@ psycopg = { extras = ["binary"], version = "^3.1.19" }
 pydantic-settings = "^2.0.3"
 flask-cors = "^5.0.0"
 opensearch-py = "^2.5.0"
-pyjwt = "^2.9.0"
+pyjwt = { extras = ["crypto"], version = "^2.9.0" }
 newrelic = "10.4.0"
 jinja2 = ">=3.1.5"
 tenacity = "^8.0"


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Add dependency on crypto library so other digital signature approaches are available

## Context for reviewers
We use RS256 encryption which requires crypto to be installed: https://pyjwt.readthedocs.io/en/latest/installation.html

Locally this wasn't an issue, but getting an error non-locally. We setup dependencies differently locally, so some test dependency probably brings the library in.

