### PR TITLE
[Issue 3487] Remove legacy sprint reports from scheduled jobs

### DIFF
--- a/infra/analytics/app-config/env-config/scheduled_jobs.tf
+++ b/infra/analytics/app-config/env-config/scheduled_jobs.tf
@@ -7,7 +7,7 @@ locals {
 
   scheduled_jobs = {
     sprint-reports = {
-      task_command        = ["make", "gh-data-export", "sprint-reports", "gh-transform-and-load"]
+      task_command        = ["make", "gh-data-export", "gh-transform-and-load"]
       schedule_expression = "rate(1 days)"
       state               = "ENABLED"
     }


### PR DESCRIPTION
## Summary
Fixes #3487

### Time to review: __1 min__

## Changes proposed
> What was added, updated, or removed in this PR.

Update scheduled jobs to remove daily generation of sprint and delivery reports. Those reports are now generated in Metabase.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

