### PR TITLE
[Issue #3184] Switch from RDFa to Microdata as meta property tags weren't making it to the client

### DIFF
--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -16,18 +16,20 @@ type Props = {
   breadcrumbList: BreadcrumbList;
 };
 
-const rdfaMetadata = {
+const microdata = {
   ol: {
-    vocab: "http://schema.org/",
-    typeof: "BreadcrumbList",
+    itemScope: true,
+    itemType: "https://schema.org/BreadcrumbList",
   },
   li: {
-    property: "itemListElement",
-    typeof: "ListItem",
+    itemScope: true,
+    itemProp: "itemListElement",
+    itemType: "https://schema.org/ListItem",
   },
   a: {
-    property: "item",
-    typeof: "WebPage",
+    itemScope: true,
+    itemProp: "item",
+    itemType: "https://schema.org/WebPage",
   },
 };
 
@@ -37,17 +39,21 @@ const Breadcrumbs = ({ breadcrumbList }: Props) => {
       <Breadcrumb
         key={breadcrumbInfo.title + "-crumb"}
         current={i + 1 === breadcrumbList.length}
-        {...rdfaMetadata.li}
+        {...microdata.li}
       >
         {i + 1 !== breadcrumbList.length ? (
-          <BreadcrumbLink href={breadcrumbInfo.path} {...rdfaMetadata.a}>
+          <BreadcrumbLink
+            href={breadcrumbInfo.path}
+            itemID={breadcrumbInfo.path}
+            {...microdata.a}
+          >
             {}
-            <span property="name">{breadcrumbInfo.title}</span>
+            <span itemProp="name">{breadcrumbInfo.title}</span>
           </BreadcrumbLink>
         ) : (
-          <span property="name">{breadcrumbInfo.title}</span>
+          <span itemProp="name">{breadcrumbInfo.title}</span>
         )}
-        <meta property="position" content={(i + 1).toString()} />
+        <meta itemProp="position" content={(i + 1).toString()} />
       </Breadcrumb>
     );
   });
@@ -57,7 +63,7 @@ const Breadcrumbs = ({ breadcrumbList }: Props) => {
       className="padding-top-1 tablet:padding-top-3 desktop-lg:padding-top-4"
       data-testid="breadcrumb"
     >
-      <BreadcrumbBar listProps={{ ...rdfaMetadata.ol }}>
+      <BreadcrumbBar listProps={{ ...microdata.ol }}>
         {breadcrumArray}
       </BreadcrumbBar>
     </GridContainer>


### PR DESCRIPTION
## Summary
Fixes #3184 

### Time to review: __10 mins__

## Changes proposed
Use Microdata syntax within the Breadcrumb component

## Context for reviewers
RDFa style metadata was being flagged as missing by Google (position field, specifically). In testing, that seems to be because `<meta property` tags are stripped out by Next's page metadata handling to ensure that the more typical page level header meta tags work as expected via Next's layer for controlling them.

## Additional information
You could see in the existing code that we were setting `<meta property="position" content="{i+1}"/>` however but Google was flagging that property as missing on our Breadcrumbs. In testing, those tags were not showing in the Element Inspector nor when curling the pages directly. So something between our JSX code and the client was stripping the necessary tag. Microdata uses `itemprop` instead of `property` and that seems to evade the tag removal Next seems to be doing. We could have jumped all the way to JSOND, but this felt like a smaller, easier step since we already were doing in via markup, just in a way that wasn't fully translating to the browser.

