### PR TITLE
[Issue #3084] update email subscription error message (and related fixes and changes)

### DIFF
--- a/frontend/src/components/subscribe/SubscriptionForm.tsx
+++ b/frontend/src/components/subscribe/SubscriptionForm.tsx
@@ -81,7 +81,7 @@ export default function SubscriptionForm() {
         <TextInput type="text" name="hp" id="hp" />
       </div>
       <SubscriptionSubmitButton />
-      {state?.errorMessage?.length > 0 ? (
+      {state?.errorMessage ? (
         <ErrorMessage className="maxw-mobile-lg">
           {state?.errorMessage}
         </ErrorMessage>

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -432,7 +432,7 @@ export const messages = {
       invalid_email:
         "Enter an email address in the correct format, like name@example.com.",
       server:
-        "Failed to subscribe, due to a server error. Please try again later.",
+        "An error occurred when trying to save your subscription. If this continues to happen, email <email-link>simpler@grants.gov</email-link>.",
       already_subscribed: "This email address has already been subscribed.",
     },
   },


### PR DESCRIPTION
## Summary
Fixes #3084

### Time to review: __10 mins__

## Changes proposed
Update text for error message on subscribe page

All other changes were made in support of this change, but some notes are potentially helpful here:
- since we're introducing JSX into the actions file it now needs a tsx extension
- it seems like the actions file was not being linted before? There were some typos and linting errors to clean up that were unrelated to the change
- in testing the change it looks like an API key is actually not necessary to get a successful request through to Sendy, which is troubling.


## Context for reviewers
### Test Steps

1. start a server with `npm run build && npm start`, and make sure that the `SENDY_API_KEY`, `SENDY_API_URL`, and `SENDY_LIST_ID` env vars are not set anywhere in your system
2. visit http://localhost:3000/subscribe
3. attempt to subscribe
4. _VERIFY_: since you haven't set any of the Sendy credential env vars, you receive an error message that states `An error occurred when trying to save your subscription. If this continues to happen, email [simpler@grants.gov](mailto:simpler@grants.gov).`
5. 
#### Bonus
1. repeat the steps above, but while setting the `SENDY_API_URL` and `SENDY_LIST_ID` env vars correctly (values are stored in 1password)
2. _VERIFY_: even without an API key, the request goes through and does not show the expected error

## Additional information

<img width="1358" alt="Screenshot 2025-01-13 at 11 17 52 AM" src="https://github.com/user-attachments/assets/9bceb21e-94a1-4621-a5fe-f54e4b682195" />


