### PR TITLE
[Issue #3500] Handle opportunity attachments when opp deleted or is published

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_opportunity.py
+++ b/api/src/data_migration/transformation/subtask/transform_opportunity.py
@@ -3,16 +3,29 @@ from typing import Tuple
 
 import src.data_migration.transformation.transform_constants as transform_constants
 import src.data_migration.transformation.transform_util as transform_util
+from src.adapters.aws import S3Config
 from src.data_migration.transformation.subtask.abstract_transform_subtask import (
     AbstractTransformSubTask,
 )
 from src.db.models.opportunity_models import Opportunity
 from src.db.models.staging.opportunity import Topportunity
+from src.services.opportunity_attachments import attachment_util
+from src.task.task import Task
+from src.util import file_util
 
 logger = logging.getLogger(__name__)
 
 
 class TransformOpportunity(AbstractTransformSubTask):
+
+    def __init__(self, task: Task, s3_config: S3Config | None = None):
+        super().__init__(task)
+
+        if s3_config is None:
+            s3_config = S3Config()
+
+        self.s3_config = s3_config
+
     def transform_records(self) -> None:
         # Fetch all opportunities that were modified
         # Alongside that, grab the existing opportunity record
@@ -53,10 +66,17 @@ class TransformOpportunity(AbstractTransformSubTask):
                 extra,
             )
 
+            # Cleanup the attachments from s3
+            if target_opportunity is not None:
+                for attachment in target_opportunity.opportunity_attachments:
+                    file_util.delete_file(attachment.file_location)
+
         else:
             # To avoid incrementing metrics for records we fail to transform, record
             # here whether it's an insert/update and we'll increment after transforming
             is_insert = target_opportunity is None
+
+            was_draft = target_opportunity.is_draft if target_opportunity else None
 
             logger.info("Transforming and upserting opportunity", extra=extra)
             transformed_opportunity = transform_util.transform_opportunity(
@@ -75,6 +95,24 @@ class TransformOpportunity(AbstractTransformSubTask):
                     prefix=transform_constants.OPPORTUNITY,
                 )
                 self.db_session.merge(transformed_opportunity)
+
+                # If an opportunity went from being a draft to not a draft (published)
+                # then we need to move all of its attachments to the public bucket
+                # from the draft s3 bucket.
+                if was_draft and transformed_opportunity.is_draft is False:
+                    for attachment in transformed_opportunity.opportunity_attachments:
+                        # Determine the new path
+                        file_name = attachment_util.adjust_legacy_file_name(attachment.file_name)
+                        s3_path = attachment_util.get_s3_attachment_path(
+                            file_name,
+                            attachment.attachment_id,
+                            transformed_opportunity,
+                            self.s3_config,
+                        )
+
+                        # Move the file
+                        file_util.move_file(attachment.file_location, s3_path)
+                        attachment.file_location = s3_path
 
         logger.info("Processed opportunity", extra=extra)
         source_opportunity.transformed_at = self.transform_time

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -18,6 +18,7 @@ import src.app as app_entry
 import src.auth.login_gov_jwt_auth as login_gov_jwt_auth
 import tests.src.db.models.factories as factories
 from src.adapters import search
+from src.adapters.aws import S3Config
 from src.adapters.oauth.login_gov.mock_login_gov_oauth_client import MockLoginGovOauthClient
 from src.constants.schema import Schemas
 from src.db import models
@@ -377,6 +378,14 @@ def other_mock_s3_bucket_resource(mock_s3):
 @pytest.fixture
 def other_mock_s3_bucket(other_mock_s3_bucket_resource):
     yield other_mock_s3_bucket_resource.name
+
+
+@pytest.fixture
+def s3_config(mock_s3_bucket, other_mock_s3_bucket):
+    return S3Config(
+        PUBLIC_FILES_BUCKET=f"s3://{mock_s3_bucket}",
+        DRAFT_FILES_BUCKET=f"s3://{other_mock_s3_bucket}",
+    )
 
 
 ####################

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
@@ -2,11 +2,14 @@ import pytest
 
 import src.data_migration.transformation.transform_constants as transform_constants
 from src.data_migration.transformation.subtask.transform_opportunity import TransformOpportunity
+from src.services.opportunity_attachments import attachment_util
+from src.util import file_util
 from tests.src.data_migration.transformation.conftest import (
     BaseTransformTestClass,
     setup_opportunity,
     validate_opportunity,
 )
+from tests.src.db.models.factories import OpportunityAttachmentFactory, OpportunityFactory
 
 
 class TestTransformOpportunity(BaseTransformTestClass):
@@ -97,3 +100,72 @@ class TestTransformOpportunity(BaseTransformTestClass):
             transform_opportunity.process_opportunity(insert_that_will_fail, None)
 
         validate_opportunity(db_session, insert_that_will_fail, expect_in_db=False)
+
+    def test_process_opportunity_delete_with_attachments(
+        self, db_session, transform_opportunity, s3_config
+    ):
+
+        source_opportunity = setup_opportunity(create_existing=False, is_delete=True)
+
+        target_opportunity = OpportunityFactory.create(
+            opportunity_id=source_opportunity.opportunity_id, opportunity_attachments=[]
+        )
+
+        attachments = []
+        for i in range(10):
+            s3_path = attachment_util.get_s3_attachment_path(
+                f"my_file{i}.txt", i, target_opportunity, s3_config
+            )
+
+            with file_util.open_stream(s3_path, "w") as outfile:
+                outfile.write(f"This is the {i}th file")
+
+            attachment = OpportunityAttachmentFactory.create(
+                opportunity=target_opportunity, file_location=s3_path
+            )
+            attachments.append(attachment)
+
+        transform_opportunity.process_opportunity(source_opportunity, target_opportunity)
+
+        validate_opportunity(db_session, source_opportunity, expect_in_db=False)
+
+        # Verify all of the files were deleted
+        for attachment in attachments:
+            assert file_util.file_exists(attachment.file_location) is False
+
+    def test_process_opportunity_update_to_non_draft_with_attachments(
+        self, db_session, transform_opportunity, s3_config
+    ):
+
+        source_opportunity = setup_opportunity(
+            create_existing=False, source_values={"is_draft": "N"}
+        )
+
+        target_opportunity = OpportunityFactory.create(
+            opportunity_id=source_opportunity.opportunity_id,
+            is_draft=True,
+            opportunity_attachments=[],
+        )
+
+        attachments = []
+        for i in range(10):
+            s3_path = attachment_util.get_s3_attachment_path(
+                f"my_file{i}.txt", i, target_opportunity, s3_config
+            )
+            assert s3_path.startswith(s3_config.draft_files_bucket_path) is True
+
+            with file_util.open_stream(s3_path, "w") as outfile:
+                outfile.write(f"This is the {i}th file")
+
+            attachment = OpportunityAttachmentFactory.create(
+                opportunity=target_opportunity, file_location=s3_path
+            )
+            attachments.append(attachment)
+
+        transform_opportunity.process_opportunity(source_opportunity, target_opportunity)
+
+        validate_opportunity(db_session, source_opportunity)
+
+        # Verify all of the files were moved to the public bucket
+        for attachment in attachments:
+            assert attachment.file_location.startswith(s3_config.public_files_bucket_path) is True

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity_attachment.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity_attachment.py
@@ -1,7 +1,6 @@
 import pytest
 
 import tests.src.db.models.factories as f
-from src.adapters.aws import S3Config
 from src.data_migration.transformation import transform_constants
 from src.data_migration.transformation.subtask.transform_opportunity_attachment import (
     TransformOpportunityAttachment,
@@ -16,13 +15,6 @@ from tests.src.data_migration.transformation.conftest import (
 
 
 class TestTransformOpportunitySummary(BaseTransformTestClass):
-
-    @pytest.fixture
-    def s3_config(self, mock_s3_bucket, other_mock_s3_bucket):
-        return S3Config(
-            PUBLIC_FILES_BUCKET=f"s3://{mock_s3_bucket}",
-            DRAFT_FILES_BUCKET=f"s3://{other_mock_s3_bucket}",
-        )
 
     @pytest.fixture()
     def transform_opportunity_attachment(self, transform_oracle_data_task, s3_config):


### PR DESCRIPTION
## Summary
Fixes #3500

### Time to review: __10 mins__

## Changes proposed
Handle the following two cases during the transformation process
* Opportunity deleted - clean up attachments from s3
* Opportunity stops being a draft - move all the attachments to the other s3 bucket

## Context for reviewers
Mostly just some additional file utils for moving files to handle the above scenarios. Only noteworthy callout is that there isn't really a concept of "moving" a file on s3, it's just a copy+delete.

