### PR TITLE
[Unticketed] fix auth bug - allow non ssl cookies in non-prod

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "node": ">=22.13.0"
   },
   "scripts": {
-    "all-checks": "npm run lint && npm run ts:check && npm run test && npm run build",
+    "all-checks": "npm run lint && npm run ts:check && npm run test && npm run build -- --no-lint",
     "build": "next build",
     "dev": "NEW_RELIC_ENABLED=false next dev",
     "dev:nr": "NODE_OPTIONS='-r @newrelic/next' next dev",

--- a/frontend/src/services/auth/session.ts
+++ b/frontend/src/services/auth/session.ts
@@ -56,8 +56,6 @@ const decryptLoginGovToken = async (
 
 // sets client token on cookie
 export const createSession = async (token: string) => {
-  // eslint-disable-next-line
-  console.log(`Creating session in ${environment.ENVIRONMENT}`);
   if (!clientJwtKey) {
     initializeSessionSecrets();
   }

--- a/frontend/src/services/auth/session.ts
+++ b/frontend/src/services/auth/session.ts
@@ -56,6 +56,8 @@ const decryptLoginGovToken = async (
 
 // sets client token on cookie
 export const createSession = async (token: string) => {
+  // eslint-disable-next-line
+  console.log(`Creating session in ${environment.ENVIRONMENT}`);
   if (!clientJwtKey) {
     initializeSessionSecrets();
   }
@@ -63,7 +65,7 @@ export const createSession = async (token: string) => {
   const session = await encrypt(token, expiresAt, clientJwtKey);
   cookies().set("session", session, {
     httpOnly: true,
-    secure: true,
+    secure: environment.ENVIRONMENT === "prod",
     expires: expiresAt,
     sameSite: "lax",
     path: "/",

--- a/frontend/src/services/auth/sessionUtils.ts
+++ b/frontend/src/services/auth/sessionUtils.ts
@@ -22,7 +22,7 @@ export const decrypt = async (
     });
     return payload;
   } catch (error) {
-    console.error("Failed to decrypt session cookie", error);
+    console.error(`Failed to decrypt session cookie with ${algorithm}`, error);
     return null;
   }
 };

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -90,7 +90,7 @@ export const splitMarkup = (
 export const findFirstWhitespace = (content: string, startAt: number): number =>
   content.substring(startAt).search(/\s/) + startAt;
 
-export const encodeText = (valueToEncode: string) =>
+export const encodeText = (valueToEncode: string): Uint8Array =>
   new TextEncoder().encode(valueToEncode);
 
 export const stringToBoolean = (

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -90,7 +90,7 @@ export const splitMarkup = (
 export const findFirstWhitespace = (content: string, startAt: number): number =>
   content.substring(startAt).search(/\s/) + startAt;
 
-export const encodeText = (valueToEncode: string): Uint8Array =>
+export const encodeText = (valueToEncode: string) =>
   new TextEncoder().encode(valueToEncode);
 
 export const stringToBoolean = (

--- a/frontend/tests/services/auth/session.test.ts
+++ b/frontend/tests/services/auth/session.test.ts
@@ -115,7 +115,7 @@ describe("createSession", () => {
       "encrypted session",
       {
         httpOnly: true,
-        secure: true,
+        secure: false, // true only in prod for now
         expires: new Date(0),
         sameSite: "lax",
         path: "/",


### PR DESCRIPTION
## Summary
Unticketed

### Time to review: __3 mins__

## Changes proposed
* Only set the "secure" parameter on the session cookie to `true` in prod for now, as our lower environments are not set up with SSL yet
* Also adds some logging for future debugging

## Context for reviewers
### Test steps
1. deploy to DEV if necessary 
2. log in
3. _VERIFY_: logged in header state is reflected after successful login

## Additional information
It's pretty clear we need better logging on the NextJS app, creating tickets to deal with that now.

