### PR TITLE
[Issue #3160] Configure analytics extract jobs

### DIFF
--- a/analytics/local.env
+++ b/analytics/local.env
@@ -57,4 +57,4 @@ LOG_FORMAT=human-readable
 # S3
 ############################
 
-LOAD_OPPORTUNITY_DATA_FILE_PATH=S3://local-opportunities/public-extracts
+API_ANALYTICS_DB_EXTRACTS_PATH=/tmp

--- a/analytics/src/analytics/integrations/extracts/load_opportunity_data.py
+++ b/analytics/src/analytics/integrations/extracts/load_opportunity_data.py
@@ -24,7 +24,7 @@ class LoadOpportunityDataFileConfig(BaseSettings):
 
     load_opportunity_data_file_path: str | None = Field(
         default=None,
-        alias="LOAD_OPPORTUNITY_DATA_FILE_PATH",
+        alias="API_ANALYTICS_DB_EXTRACTS_PATH",
     )
 
 

--- a/analytics/tests/integrations/extracts/test_load_opportunity_data.py
+++ b/analytics/tests/integrations/extracts/test_load_opportunity_data.py
@@ -49,7 +49,7 @@ def test_extract_copy_opportunity_data(
     """Test files are uploaded to mocks3 and all records are in test schema."""
     monkeypatch.setenv("DB_SCHEMA", test_schema)
     monkeypatch_session.setenv(
-        "LOAD_OPPORTUNITY_DATA_FILE_PATH",
+        "API_ANALYTICS_DB_EXTRACTS_PATH",
         f"S3://{mock_s3_bucket}/public-extracts",
     )
     test_db_conn = create_test_db

--- a/api/local.env
+++ b/api/local.env
@@ -131,7 +131,7 @@ IS_LOCAL_FOREIGN_TABLE=true
 PUBLIC_FILES_OPPORTUNITY_DATA_EXTRACTS_PATH=/tmp
 
 # File path for the create-analytics-db-csvs task
-ANALYTICS_DB_CSV_FILE_PATH=/tmp
+API_ANALYTICS_DB_EXTRACTS_PATH=/tmp
 
 ############################
 # Deploy Metadata

--- a/api/src/task/analytics/create_analytics_db_csvs.py
+++ b/api/src/task/analytics/create_analytics_db_csvs.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 
 import click
 import sqlalchemy
-from pydantic_settings import SettingsConfigDict
+from pydantic import Field
 
 import src.adapters.db as db
 import src.adapters.db.flask_db as flask_db
@@ -40,14 +40,12 @@ def create_analytics_db_csvs(db_session: db.Session, tables_to_extract: list[str
 
 
 class CreateAnalyticsDbCsvsConfig(PydanticBaseEnvConfig):
-    model_config = SettingsConfigDict(env_prefix="ANALYTICS_DB_CSV_")
-
-    # ANALYTICS_DB_CSV_FILE_PATH
-    file_path: str
+    # API_ANALYTICS_DB_EXTRACTS_PATH
+    file_path: str = Field(alias="API_ANALYTICS_DB_EXTRACTS_PATH")
 
     # Override the schema for where the tables exist, only needed
     # for testing right now
-    db_schema: str | None = None
+    db_schema: str | None = Field(None, alias="API_ANALYTICS_DB_SCHEMA")
 
 
 class CreateAnalyticsDbCsvsTask(Task):

--- a/api/tests/src/task/analytics/test_create_analytics_db_csvs.py
+++ b/api/tests/src/task/analytics/test_create_analytics_db_csvs.py
@@ -38,7 +38,7 @@ class TestCreateAnalyticsDbCsvsTask(BaseTestClass):
     @pytest.fixture()
     def task(self, db_session, mock_s3_bucket, test_api_schema):
         config = CreateAnalyticsDbCsvsConfig(
-            file_path=f"s3://{mock_s3_bucket}/table-extracts", db_schema=test_api_schema
+            API_ANALYTICS_DB_EXTRACTS_PATH=f"s3://{mock_s3_bucket}/table-extracts", API_ANALYTICS_DB_SCHEMA=test_api_schema
         )
         return CreateAnalyticsDbCsvsTask(db_session, config=config)
 

--- a/infra/analytics/app-config/env-config/scheduled_jobs.tf
+++ b/infra/analytics/app-config/env-config/scheduled_jobs.tf
@@ -11,5 +11,11 @@ locals {
       schedule_expression = "rate(1 days)"
       state               = "ENABLED"
     }
+    opportunity-load-csvs = {
+      task_command = ["poetry", "run", "analytics", "etl", "opportunity-load"]
+      # Every day at 6am Eastern Time during DST. 7am during non-DST.
+      schedule_expression = "cron(0 11 * * ? *)"
+      state               = "ENABLED"
+    }
   }
 }

--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -58,5 +58,11 @@ locals {
       schedule_expression = "cron(0 9 * * ? *)"
       state               = "ENABLED"
     }
+    create-analytics-db-csvs = {
+      task_command = ["poetry", "run", "flask", "task", "create-analytics-db-csvs"]
+      # Every day at 5am Eastern Time during DST. 6am during non-DST.
+      schedule_expression = "cron(0 10 * * ? *)"
+      state               = "ENABLED"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #3160

### Time to review: __5 mins__

## Changes proposed
Configures an API job to create a CSV DB extract to run daily

Configure an Analytics job to parse the CSV DB extract to run daily

Env var renames to match what is configured in terraform

## Context for reviewers
Jobs are pretty simple, just set them up to run 60 minutes apart for now. From testing, the first job took less than a minute to run in dev, so no concern with it finishing in time.

## Additional information
Reran the jobs locally to verify every env var is connected properly