### PR TITLE
[Issue #3510] update page meta descriptions

### DIFF
--- a/frontend/src/app/[locale]/process/page.tsx
+++ b/frontend/src/app/[locale]/process/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale });
   const meta: Metadata = {
     title: t("Process.page_title"),
-    description: t("Process.meta_description"),
+    description: t("Index.meta_description"),
   };
   return meta;
 }

--- a/frontend/src/app/[locale]/research/page.tsx
+++ b/frontend/src/app/[locale]/research/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale });
   const meta: Metadata = {
     title: t("Research.page_title"),
-    description: t("Research.meta_description"),
+    description: t("Index.meta_description"),
   };
   return meta;
 }

--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale });
   const meta: Metadata = {
     title: t("Search.title"),
-    description: t("Index.meta_description"),
+    description: t("Search.meta_description"),
   };
   return meta;
 }

--- a/frontend/src/app/[locale]/subscribe/page.tsx
+++ b/frontend/src/app/[locale]/subscribe/page.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale });
   const meta: Metadata = {
     title: t("Subscribe.page_title"),
-    description: t("Index.meta_description"),
+    description: t("Subscribe.meta_description"),
   };
 
   return meta;

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -7,7 +7,8 @@ export const messages = {
   },
   OpportunityListing: {
     page_title: "Opportunity Listing",
-    meta_description: "Summary details for the specific opportunity listing.",
+    meta_description:
+      "Read detailed information about this funding opportunity.",
     intro: {
       agency: "Agency: ",
       assistance_listings: "Assistance Listings: ",
@@ -80,7 +81,7 @@ export const messages = {
   Index: {
     page_title: "Simpler.Grants.gov",
     meta_description:
-      "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
+      "Simpler.Grants.gov is improving how you discover, post, and apply for federal discretionary funding on Grants.gov.",
     goal: {
       paragraph_1:
         "Grants.gov should be extremely simple, accessible, and easy to use. Our mission is to increase access to federal financial assistance and continuously improve the grants experience for everyone.",
@@ -127,8 +128,6 @@ export const messages = {
   },
   Research: {
     page_title: "Research | Simpler.Grants.gov",
-    meta_description:
-      "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     intro: {
       title: "Our existing research",
       content:
@@ -269,8 +268,6 @@ export const messages = {
   },
   Process: {
     page_title: "Process | Simpler.Grants.gov",
-    meta_description:
-      "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
     intro: {
       title: "Our open process",
       content:
@@ -411,6 +408,8 @@ export const messages = {
   },
   Subscribe: {
     page_title: "Subscribe | Simpler.Grants.gov",
+    meta_description:
+      "Sign up for email updates from the Simpler.Grants.gov team.",
     title: "Subscribe to project updates",
     intro: "Subscribe to get Simpler.Grants.gov project updates in your inbox!",
     paragraph_1:
@@ -543,7 +542,7 @@ export const messages = {
   Search: {
     title: "Search Funding Opportunities | Simpler.Grants.gov",
     meta_description:
-      "A one‑stop shop for all federal discretionary funding to make it easy for you to discover, understand, and apply for opportunities.",
+      "Search for and discover relevant opportunities using our improved search.",
     description: "Try out our experimental search page.",
     accordion: {
       titles: {


### PR DESCRIPTION
## Summary
Fixes #3510

### Time to review: __10 mins__

## Changes proposed
Updating page meta description text as per ticket requirements

## Context for reviewers
### Test steps

These tests involve checking meta descriptions, which you an either do by inspecting the meta tags in the head of the page's HTML, or with a browser extension of some sort.

1. start a server on this branch with `npm run dev`
2. visit http://localhost:3000
3. _VERIFY_: meta description reads: "Simpler.Grants.gov is improving how you discover, post, and apply for federal discretionary funding on Grants.gov."
2. visit http://localhost:3000/search
3. _VERIFY_: meta description reads: "Search for and discover relevant opportunities using our improved search."
2. visit http://localhost:3000/process
3. _VERIFY_: meta description reads: "Simpler.Grants.gov is improving how you discover, post, and apply for federal discretionary funding on Grants.gov"
4. visit http://localhost:3000/research
3. _VERIFY_: meta description reads: "Simpler.Grants.gov is improving how you discover, post, and apply for federal discretionary funding on Grants.gov"
4. visit http://localhost:3000/subscribe
3. _VERIFY_: meta description reads: "Sign up for email updates from the Simpler.Grants.gov team."
4. visit http://localhost:3000/opportunity/1
3. _VERIFY_: meta description reads: "Read detailed information about this funding opportunity."



## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

