### PR TITLE
[Unticketed] Fix UUID default example to not randomize each time

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -2091,8 +2091,7 @@ components:
           type: string
           format: uuid
           description: The ID of the saved search
-          example: !!python/object:uuid.UUID
-            int: 82637552140693101888240202082641616217
+          example: 123e4567-e89b-12d3-a456-426614174001
         name:
           type: string
           description: Name of the saved search
@@ -2306,4 +2305,3 @@ components:
       type: apiKey
       in: header
       name: X-SGG-Token
-

--- a/api/src/api/schemas/extension/schema_fields.py
+++ b/api/src/api/schemas/extension/schema_fields.py
@@ -1,7 +1,6 @@
 import copy
 import enum
 import typing
-import uuid
 
 from apiflask import fields as original_fields
 from marshmallow import ValidationError
@@ -133,7 +132,12 @@ class UUID(original_fields.UUID, MixinField):
 
     def __init__(self, **kwargs: typing.Any):
         super().__init__(**kwargs)
-        self.metadata["example"] = uuid.uuid4()
+
+        # Set a default value for the UUID if none supplied
+        example_value = kwargs.get("metadata", {}).get(
+            "example", "123e4567-e89b-12d3-a456-426614174000"
+        )
+        self.metadata["example"] = example_value
 
 
 class Date(original_fields.Date, MixinField):


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Fix schema field logic for UUID to not default to a randomly generated UUID every time and either use a static value or whatever the user passed in

## Context for reviewers
Was seeing on recent PRs that after we added UUID params to the schemas, they were randomly generating each time.

## Additional information
Generated the file again myself a few times to verify it doesn't change each run now

