### PR TITLE
[no ticket] Fix ordering of CDN deploy operations

### DIFF
--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -119,6 +119,7 @@ resource "aws_cloudfront_distribution" "cdn" {
 
   depends_on = [
     aws_s3_bucket_public_access_block.cdn[0],
+    aws_s3_bucket_acl.cdn[0],
     aws_s3_bucket_policy.cdn[0],
     aws_s3_bucket.cdn[0],
   ]


### PR DESCRIPTION
## Summary

Fixes https://github.com/HHS/simpler-grants-gov/actions/runs/12815925972/job/35736051716

### Time to review: __1 mins__

## Changes proposed

When deploying from scratch, as opposed to the iterative deploy you would do during testing, you often find small quirks where the order to operations for the deploy are slightly incorrect. This is one of those cases.