### PR TITLE
[Unticketed] Fix issue where opportunities aren't loaded to search index

### DIFF
--- a/api/src/search/backend/load_opportunities_to_index.py
+++ b/api/src/search/backend/load_opportunities_to_index.py
@@ -97,7 +97,7 @@ class LoadOpportunitiesToIndex(Task):
                                 "field": "_ingest._value.data",
                             }
                         },
-                        "ignore_missing": True
+                        "ignore_missing": True,
                     }
                 }
             ],

--- a/api/src/search/backend/load_opportunities_to_index.py
+++ b/api/src/search/backend/load_opportunities_to_index.py
@@ -336,6 +336,11 @@ class LoadOpportunitiesToIndex(Task):
                 json_record["attachments"] = self.get_attachment_json_for_opportunity(
                     record.opportunity_attachments
                 )
+            else:
+                # TODO: This shouldn't be needed, but with the pipeline enabled, if we don't
+                # include any attachments, then the opportunities don't get added.
+                # Need to further investigate the pipeline logic to see if we can reconfigure it.
+                json_record["attachments"] = []
 
             json_records.append(json_record)
             self.increment(self.Metrics.RECORDS_LOADED)

--- a/api/src/search/backend/load_opportunities_to_index.py
+++ b/api/src/search/backend/load_opportunities_to_index.py
@@ -97,6 +97,7 @@ class LoadOpportunitiesToIndex(Task):
                                 "field": "_ingest._value.data",
                             }
                         },
+                        "ignore_missing": True
                     }
                 }
             ],
@@ -336,11 +337,6 @@ class LoadOpportunitiesToIndex(Task):
                 json_record["attachments"] = self.get_attachment_json_for_opportunity(
                     record.opportunity_attachments
                 )
-            else:
-                # TODO: This shouldn't be needed, but with the pipeline enabled, if we don't
-                # include any attachments, then the opportunities don't get added.
-                # Need to further investigate the pipeline logic to see if we can reconfigure it.
-                json_record["attachments"] = []
 
             json_records.append(json_record)
             self.increment(self.Metrics.RECORDS_LOADED)


### PR DESCRIPTION
## Summary

### Time to review: __1 mins__

## Changes proposed
Tell processor to allow the record even if attachments are missing

## Context for reviewers
https://www.elastic.co/guide/en/elasticsearch/reference/current/foreach-processor.html

ignore_missing is defaulted to False. This means if the record has no attachments, it just drops it and moves on. This fix makes it not drop it, and just allow it.

## Additional information
Set `ENABLE_OPPORTUNITY_ATTACHMENT_PIPELINE=false` in the local.env

Run `make db-seed-local` and `make populate-search-opportunities`, without this fix, nothing ends up in the search index.

