### PR TITLE
[Issue #3203] Update GitHub API validation

### DIFF
--- a/analytics/src/analytics/integrations/github/main.py
+++ b/analytics/src/analytics/integrations/github/main.py
@@ -6,31 +6,17 @@ we disable writing to disk in https://github.com/HHS/simpler-grants-gov/issues/3
 """
 
 import json
-from datetime import datetime, timedelta
+import logging
 from pathlib import Path
-from typing import Any
+
+from pydantic import ValidationError
 
 from analytics.integrations.github.client import GitHubGraphqlClient
+from analytics.integrations.github.validation import CombinedProjectItem
+
+logger = logging.getLogger(__name__)
 
 PARENT_DIR = Path(__file__).resolve().parent
-
-
-def safe_pluck(data: dict, keys: str) -> Any:  # noqa: ANN401
-    """
-    Safely pluck a value from a nested dictionary using a string of dot-separated keys.
-
-    Example:
-        data = {"content": {"parent": {"url": "example.com"}}}
-        safe_pluck(data, "content.parent.url") # returns "example.com"
-        safe_pluck(data, "content.missing") # returns None
-
-    """
-    current = data
-    for key in keys.split("."):
-        if not isinstance(current, dict) or key not in current:
-            return None
-        current = current[key]
-    return current
 
 
 def transform_project_data(
@@ -40,54 +26,53 @@ def transform_project_data(
     excluded_types: tuple = (),  # By default include everything
 ) -> list[dict]:
     """Pluck and reformat relevant fields for each item in the raw data."""
-    return [
-        {
-            # project metadata
-            "project_owner": owner,
-            "project_number": project,
-            # issue metadata
-            "issue_title": safe_pluck(item, "content.title"),
-            "issue_url": safe_pluck(item, "content.url"),
-            "issue_parent": safe_pluck(item, "content.parent.url"),
-            "issue_type": safe_pluck(item, "content.issueType.name"),
-            "issue_status": safe_pluck(item, "status.name"),
-            "issue_is_closed": safe_pluck(item, "content.closed"),
-            "issue_opened_at": safe_pluck(item, "content.createdAt"),
-            "issue_closed_at": safe_pluck(item, "content.closedAt"),
-            "issue_points": safe_pluck(item, "points.number"),
-            # sprint metadata
-            "sprint_id": safe_pluck(item, "sprint.iterationId"),
-            "sprint_name": safe_pluck(item, "sprint.title"),
-            "sprint_start": safe_pluck(item, "sprint.startDate"),
-            "sprint_length": safe_pluck(item, "sprint.duration"),
-            "sprint_end": compute_end_date(
-                safe_pluck(item, "sprint.startDate"),
-                safe_pluck(item, "sprint.duration"),
-            ),
-            # roadmap metadata
-            "deliverable_pillar": safe_pluck(item, "pillar.name"),
-            "quad_id": safe_pluck(item, "quad.id"),
-            "quad_name": safe_pluck(item, "quad.name"),
-            "quad_start": safe_pluck(item, "quad.startDate"),
-            "quad_length": safe_pluck(item, "quad.duration"),
-            "quad_end": compute_end_date(
-                safe_pluck(item, "quad.startDate"),
-                safe_pluck(item, "quad.duration"),
-            ),
-        }
-        for item in raw_data
-        if safe_pluck(item, "content.issueType.name") not in excluded_types
-    ]
+    transformed_data = []
 
+    for i, item in enumerate(raw_data):
+        try:
+            # Validate and parse the raw item
+            validated_item = CombinedProjectItem.model_validate(item)
 
-def compute_end_date(start_date: str | None, duration: int | None) -> str | None:
-    """Compute the end date based on start date and duration."""
-    if not start_date or not duration:
-        return None
+            # Skip excluded issue types
+            if validated_item.content.issue_type.name in excluded_types:
+                continue
 
-    start = datetime.strptime(start_date, "%Y-%m-%d")  # noqa: DTZ007
-    end = start + timedelta(days=duration)
-    return end.strftime("%Y-%m-%d")
+            # Transform into flattened format
+            transformed = {
+                # project metadata
+                "project_owner": owner,
+                "project_number": project,
+                # issue metadata
+                "issue_title": validated_item.content.title,
+                "issue_url": validated_item.content.url,
+                "issue_parent": validated_item.content.parent.url,
+                "issue_type": validated_item.content.issue_type.name,
+                "issue_status": validated_item.status.name,
+                "issue_is_closed": validated_item.content.closed,
+                "issue_opened_at": validated_item.content.created_at,
+                "issue_closed_at": validated_item.content.closed_at,
+                "issue_points": validated_item.points.number,
+                # sprint metadata
+                "sprint_id": validated_item.sprint.iteration_id,
+                "sprint_name": validated_item.sprint.title,
+                "sprint_start": validated_item.sprint.start_date,
+                "sprint_length": validated_item.sprint.duration,
+                "sprint_end": validated_item.sprint.end_date,
+                # roadmap metadata
+                "deliverable_pillar": validated_item.pillar.name,
+                "quad_id": validated_item.quad.iteration_id,
+                "quad_name": validated_item.quad.title,
+                "quad_start": validated_item.quad.start_date,
+                "quad_length": validated_item.quad.duration,
+                "quad_end": validated_item.quad.end_date,
+            }
+            transformed_data.append(transformed)
+        except ValidationError as err:
+            logger.error("Error parsing row %d, skipped.", i)  # noqa: TRY400
+            logger.debug("Error: %s", err)
+            continue
+
+    return transformed_data
 
 
 def export_sprint_data(

--- a/analytics/src/analytics/integrations/github/main.py
+++ b/analytics/src/analytics/integrations/github/main.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from analytics.integrations.github.client import GitHubGraphqlClient
-from analytics.integrations.github.validation import CombinedProjectItem
+from analytics.integrations.github.validation import ProjectItem
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def transform_project_data(
     for i, item in enumerate(raw_data):
         try:
             # Validate and parse the raw item
-            validated_item = CombinedProjectItem.model_validate(item)
+            validated_item = ProjectItem.model_validate(item)
 
             # Skip excluded issue types
             if validated_item.content.issue_type.name in excluded_types:

--- a/analytics/src/analytics/integrations/github/validation.py
+++ b/analytics/src/analytics/integrations/github/validation.py
@@ -1,0 +1,85 @@
+"""Pydantic schemas for validating GitHub API responses."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# #############################################
+# Issue content sub-schemas
+# #############################################
+
+
+class IssueParent(BaseModel):
+    """Schema for the parent issue of a sub-issue."""
+
+    title: str | None = None
+    url: str | None = None
+
+
+class IssueType(BaseModel):
+    """Schema for the type of an issue."""
+
+    name: str | None = None
+
+
+class IssueContent(BaseModel):
+    """Schema for core issue metadata."""
+
+    title: str
+    url: str
+    closed: bool
+    created_at: datetime = Field(alias="createdAt")
+    closed_at: datetime | None = Field(alias="closedAt", default=None)
+
+
+# #############################################
+# Project field sub-schemas
+# #############################################
+
+
+class IterationValue(BaseModel):
+    """Schema for iteration field values like Sprint or Quad."""
+
+    iteration_id: str | None = Field(alias="iterationId", default=None)
+    title: str | None = None
+    start_date: str | None = Field(alias="startDate", default=None)
+    duration: int | None = None
+
+
+class SingleSelectValue(BaseModel):
+    """Schema for single select field values like Status or Pillar."""
+
+    option_id: str | None = Field(alias="optionId", default=None)
+    name: str | None = None
+
+
+class NumberValue(BaseModel):
+    """Schema for number field values like Points."""
+
+    number: int | None = None
+
+
+# #############################################
+# Top-level project item schemas
+# #############################################
+
+
+class ProjectItem(BaseModel):
+    """Schema for a project board item."""
+
+    content: IssueContent
+    status: SingleSelectValue | None = None
+
+
+class RoadmapItem(ProjectItem):
+    """Schema for an item on the roadmap board."""
+
+    quad: IterationValue | None = None
+    pillar: SingleSelectValue | None = None
+
+
+class SprintItem(ProjectItem):
+    """Schema for an item on the sprint board."""
+
+    sprint: IterationValue | None = None
+    points: NumberValue | None = None

--- a/analytics/src/analytics/integrations/github/validation.py
+++ b/analytics/src/analytics/integrations/github/validation.py
@@ -1,5 +1,6 @@
 """Pydantic schemas for validating GitHub API responses."""
 
+# pylint: disable=no-self-argument
 from datetime import datetime, timedelta
 
 from pydantic import BaseModel, Field, computed_field, model_validator

--- a/analytics/src/analytics/integrations/github/validation.py
+++ b/analytics/src/analytics/integrations/github/validation.py
@@ -97,47 +97,11 @@ class NumberValue(BaseModel):
 
 
 class ProjectItem(BaseModel):
-    """Schema for a project board item."""
-
-    content: IssueContent
-    status: SingleSelectValue = Field(default_factory=SingleSelectValue)
-
-    @model_validator(mode="before")
-    def replace_none_with_defaults(cls, values) -> dict:  # noqa: ANN001, N805
-        """Replace None with default_factory instances."""
-        # Replace None with default_factory instances
-        return safe_default_factory(values, ["status"])
-
-
-class RoadmapItem(ProjectItem):
-    """Schema for an item on the roadmap board."""
-
-    quad: IterationValue = Field(default_factory=IterationValue)
-    pillar: SingleSelectValue = Field(default_factory=SingleSelectValue)
-
-    @model_validator(mode="before")
-    def replace_none_with_defaults(cls, values) -> dict:  # noqa: ANN001, N805
-        """Replace None with default_factory instances."""
-        # Replace None with default_factory instances
-        return safe_default_factory(values, ["quad", "pillar", "status"])
-
-
-class SprintItem(ProjectItem):
-    """Schema for an item on the sprint board."""
-
-    sprint: IterationValue = Field(default_factory=IterationValue)
-    points: NumberValue = Field(default_factory=NumberValue)
-
-    @model_validator(mode="before")
-    def replace_none_with_defaults(cls, values) -> dict:  # noqa: ANN001, N805
-        """Replace None with default_factory instances."""
-        # Replace None with default_factory instances
-        return safe_default_factory(values, ["sprint", "points", "status"])
-
-
-class CombinedProjectItem(ProjectItem):
     """Schema that combines fields from both RoadmapItem and SprintItem."""
 
+    # Issue fields
+    content: IssueContent
+    status: SingleSelectValue = Field(default_factory=SingleSelectValue)
     # Sprint fields
     sprint: IterationValue = Field(default_factory=IterationValue)
     points: NumberValue = Field(default_factory=NumberValue)

--- a/analytics/tests/integrations/github/test_validation.py
+++ b/analytics/tests/integrations/github/test_validation.py
@@ -1,6 +1,7 @@
 """Test the validation schemas for GitHub API responses."""
 
-import pytest
+import pytest  # noqa: I001
+from pydantic import ValidationError
 from analytics.integrations.github.validation import (
     IssueContent,
     IterationValue,
@@ -8,7 +9,6 @@ from analytics.integrations.github.validation import (
     ProjectItem,
     SingleSelectValue,
 )
-from pydantic import ValidationError
 
 # #############################################
 # Test data constants

--- a/analytics/tests/integrations/github/test_validation.py
+++ b/analytics/tests/integrations/github/test_validation.py
@@ -5,8 +5,6 @@ from datetime import datetime
 import pytest
 from analytics.integrations.github.validation import (
     IssueContent,
-    IssueParent,
-    IssueType,
     IterationValue,
     NumberValue,
     ProjectItem,
@@ -16,123 +14,165 @@ from analytics.integrations.github.validation import (
 )
 from pydantic import ValidationError
 
+# #############################################
+# Test data constants
+# #############################################
 
-@pytest.fixture
-def valid_issue_content() -> dict:
-    """Fixture for a fully populated issue content."""
-    return {
-        "title": "Test Issue",
-        "url": "https://github.com/test/repo/issues/1",
-        "closed": True,
-        "createdAt": "2024-01-01T00:00:00Z",
-        "closedAt": "2024-01-02T00:00:00Z",
-    }
+VALID_ISSUE_CONTENT = {
+    "title": "Test Issue",
+    "url": "https://github.com/test/repo/issues/1",
+    "closed": True,
+    "createdAt": "2024-01-01T00:00:00Z",
+    "closedAt": "2024-01-02T00:00:00Z",
+    "parent": {
+        "title": "Test Parent",
+        "url": "https://github.com/test/repo/issues/2",
+    },
+    "type": {
+        "name": "Bug",
+    },
+}
+
+VALID_ITERATION_VALUE = {
+    "iterationId": "123",
+    "title": "Sprint 1",
+    "startDate": "2024-01-01",
+    "duration": 14,
+}
+
+VALID_SINGLE_SELECT = {
+    "optionId": "456",
+    "name": "In Progress",
+}
 
 
-@pytest.fixture
-def valid_iteration_value() -> dict:
-    """Fixture for a fully populated iteration value."""
-    return {
-        "iterationId": "123",
-        "title": "Sprint 1",
-        "startDate": "2024-01-01",
-        "duration": 14,
-    }
-
-
-@pytest.fixture
-def valid_single_select() -> dict:
-    """Fixture for a fully populated single select value."""
-    return {
-        "optionId": "456",
-        "name": "In Progress",
-    }
+# #############################################
+# Project items tests
+# #############################################
 
 
 class TestProjectItems:
     """Test cases for top-level project item schemas."""
 
-    def test_project_item_fully_populated(
-        self,
-        valid_issue_content: dict,
-        valid_single_select: dict,
-    ) -> None:
+    def test_project_item_fully_populated(self) -> None:
         """Test validating a fully populated project item."""
         data = {
-            "content": valid_issue_content,
-            "status": valid_single_select,
+            "content": VALID_ISSUE_CONTENT,
+            "status": VALID_SINGLE_SELECT,
         }
         item = ProjectItem.model_validate(data)
-        assert isinstance(item.content, IssueContent)
-        assert isinstance(item.status, SingleSelectValue)
+        assert item.content.title == "Test Issue"
+        assert item.status.name == "In Progress"
 
-    def test_project_item_minimal(self, valid_issue_content: dict) -> None:
+    def test_project_item_minimal(self) -> None:
         """Test validating a project item with only required fields."""
         data = {
-            "content": valid_issue_content,
+            "content": VALID_ISSUE_CONTENT,
         }
         item = ProjectItem.model_validate(data)
-        assert item.status is None
+        assert item.status.name is None
+        assert item.status.option_id is None
 
-    def test_roadmap_item_fully_populated(
-        self,
-        valid_issue_content: dict,
-        valid_single_select: dict,
-        valid_iteration_value: dict,
-    ) -> None:
+
+class TestRoadmapItems:
+    """Test cases for roadmap item schemas."""
+
+    def test_fully_populated(self) -> None:
         """Test validating a fully populated roadmap item."""
         data = {
-            "content": valid_issue_content,
-            "status": valid_single_select,
-            "quad": valid_iteration_value,
-            "pillar": valid_single_select,
+            "content": VALID_ISSUE_CONTENT,
+            "status": VALID_SINGLE_SELECT,
+            "quad": VALID_ITERATION_VALUE,
+            "pillar": VALID_SINGLE_SELECT,
         }
         item = RoadmapItem.model_validate(data)
-        assert isinstance(item.quad, IterationValue)
-        assert isinstance(item.pillar, SingleSelectValue)
+        assert item.quad.title == "Sprint 1"
+        assert item.pillar.name == "In Progress"
 
-    def test_sprint_item_fully_populated(
-        self,
-        valid_issue_content: dict,
-        valid_single_select: dict,
-        valid_iteration_value: dict,
-    ) -> None:
+    def test_with_nulls(self) -> None:
+        """Test validating a roadmap item with null values."""
+        data = {
+            "content": {
+                "title": "Test Issue",
+                "url": "https://github.com/test/repo/issues/1",
+                "closed": True,
+                "createdAt": "2024-01-01T00:00:00Z",
+                "closedAt": "2024-01-02T00:00:00Z",
+                "type": None,
+                "parent": None,
+            },
+            "quad": None,
+            "pillar": None,
+            "status": None,
+        }
+        item = RoadmapItem.model_validate(data)
+        assert item.quad.title is None
+        assert item.quad.iteration_id is None
+        assert item.pillar.name is None
+        assert item.pillar.option_id is None
+        assert item.status.name is None
+        assert item.status.option_id is None
+
+
+class TestSprintItem:
+    """Test cases for sprint item schemas."""
+
+    def test_fully_populated(self) -> None:
         """Test validating a fully populated sprint item."""
         data = {
-            "content": valid_issue_content,
-            "status": valid_single_select,
-            "sprint": valid_iteration_value,
+            "content": VALID_ISSUE_CONTENT,
+            "status": VALID_SINGLE_SELECT,
+            "sprint": VALID_ITERATION_VALUE,
             "points": {"number": 5},
         }
         item = SprintItem.model_validate(data)
-        assert isinstance(item.sprint, IterationValue)
-        assert isinstance(item.points, NumberValue)
+        assert item.sprint.title == "Sprint 1"
         assert item.points.number == 5
 
-    def test_sprint_item_minimal(self, valid_issue_content: dict) -> None:
-        """Test validating a sprint item with only required fields."""
+    def test_with_nulls(self) -> None:
+        """Test validating a sprint item with null values."""
         data = {
-            "content": valid_issue_content,
+            "content": {
+                "title": "Test Issue",
+                "url": "https://github.com/test/repo/issues/1",
+                "closed": True,
+                "createdAt": "2024-01-01T00:00:00Z",
+                "closedAt": "2024-01-02T00:00:00Z",
+                "type": None,
+                "parent": None,
+            },
+            "sprint": None,
+            "points": None,
+            "status": None,
         }
-        item = SprintItem.model_validate(data)
-        assert item.sprint is None
-        assert item.points is None
-        assert item.status is None
+        item = SprintItem(**data)
+        assert item.sprint.title is None
+        assert item.sprint.iteration_id is None
+        assert item.points.number is None
+        assert item.status.name is None
+        assert item.status.option_id is None
+
+
+# #############################################
+# Issue content tests
+# #############################################
 
 
 class TestIssueContent:
     """Test cases for issue content schemas."""
 
-    def test_issue_content_fully_populated(self, valid_issue_content: dict) -> None:
+    def test_fully_populated(self) -> None:
         """Test validating a fully populated issue content."""
-        issue = IssueContent.model_validate(valid_issue_content)
+        issue = IssueContent.model_validate(VALID_ISSUE_CONTENT)
         assert issue.title == "Test Issue"
         assert issue.url == "https://github.com/test/repo/issues/1"
         assert issue.closed is True
         assert isinstance(issue.created_at, datetime)
         assert isinstance(issue.closed_at, datetime)
+        assert issue.parent.title == "Test Parent"
+        assert issue.issue_type.name == "Bug"
 
-    def test_issue_content_minimal(self) -> None:
+    def test_minimal(self) -> None:
         """Test validating an issue content with only required fields."""
         minimal_content = {
             "title": "Test Issue",
@@ -142,6 +182,27 @@ class TestIssueContent:
         }
         issue = IssueContent.model_validate(minimal_content)
         assert issue.closed_at is None
+        assert issue.parent.title is None
+        assert issue.parent.url is None
+        assert issue.issue_type.name is None
+
+    def test_with_nulls(self) -> None:
+        """Test validating an issue content with null values."""
+        data = {
+            "title": "Test Issue",
+            "url": "https://github.com/test/repo/issues/1",
+            "closed": True,
+            "createdAt": "2024-01-01T00:00:00Z",
+            "closedAt": None,
+            "type": None,
+            "parent": None,
+        }
+        issue = IssueContent.model_validate(data)
+        assert issue.title == "Test Issue"
+        assert issue.closed_at is None
+        assert issue.issue_type.name is None
+        assert issue.parent.title is None
+        assert issue.parent.url is None
 
     def test_missing_title_raises_error(self) -> None:
         """Test that validation fails when title is missing."""
@@ -187,29 +248,18 @@ class TestIssueContent:
                 },
             )
 
-    def test_issue_parent_with_empty_data(self) -> None:
-        """Test validating issue parent with empty data."""
-        parent = IssueParent.model_validate({})
-        assert parent.title is None
-        assert parent.url is None
 
-    def test_issue_type_with_name(self) -> None:
-        """Test validating issue type with a name value."""
-        type_with_value = IssueType.model_validate({"name": "Bug"})
-        assert type_with_value.name == "Bug"
-
-    def test_issue_type_with_empty_data(self) -> None:
-        """Test validating issue type with empty data."""
-        type_without_value = IssueType.model_validate({})
-        assert type_without_value.name is None
+# #############################################
+# Project field tests
+# #############################################
 
 
 class TestProjectFields:
     """Test cases for project field schemas."""
 
-    def test_iteration_value_fully_populated(self, valid_iteration_value: dict) -> None:
+    def test_iteration_value_fully_populated(self) -> None:
         """Test validating a fully populated iteration value."""
-        iteration = IterationValue.model_validate(valid_iteration_value)
+        iteration = IterationValue.model_validate(VALID_ITERATION_VALUE)
         assert iteration.iteration_id == "123"
         assert iteration.title == "Sprint 1"
         assert iteration.start_date == "2024-01-01"
@@ -223,12 +273,9 @@ class TestProjectFields:
         assert iteration.start_date is None
         assert iteration.duration is None
 
-    def test_single_select_value_fully_populated(
-        self,
-        valid_single_select: dict,
-    ) -> None:
+    def test_single_select_value_fully_populated(self) -> None:
         """Test validating a fully populated single select value."""
-        select = SingleSelectValue.model_validate(valid_single_select)
+        select = SingleSelectValue.model_validate(VALID_SINGLE_SELECT)
         assert select.option_id == "456"
         assert select.name == "In Progress"
 

--- a/analytics/tests/integrations/github/test_validation.py
+++ b/analytics/tests/integrations/github/test_validation.py
@@ -1,0 +1,243 @@
+"""Test the validation schemas for GitHub API responses."""
+
+from datetime import datetime
+
+import pytest
+from analytics.integrations.github.validation import (
+    IssueContent,
+    IssueParent,
+    IssueType,
+    IterationValue,
+    NumberValue,
+    ProjectItem,
+    RoadmapItem,
+    SingleSelectValue,
+    SprintItem,
+)
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def valid_issue_content() -> dict:
+    """Fixture for a fully populated issue content."""
+    return {
+        "title": "Test Issue",
+        "url": "https://github.com/test/repo/issues/1",
+        "closed": True,
+        "createdAt": "2024-01-01T00:00:00Z",
+        "closedAt": "2024-01-02T00:00:00Z",
+    }
+
+
+@pytest.fixture
+def valid_iteration_value() -> dict:
+    """Fixture for a fully populated iteration value."""
+    return {
+        "iterationId": "123",
+        "title": "Sprint 1",
+        "startDate": "2024-01-01",
+        "duration": 14,
+    }
+
+
+@pytest.fixture
+def valid_single_select() -> dict:
+    """Fixture for a fully populated single select value."""
+    return {
+        "optionId": "456",
+        "name": "In Progress",
+    }
+
+
+class TestProjectItems:
+    """Test cases for top-level project item schemas."""
+
+    def test_project_item_fully_populated(
+        self,
+        valid_issue_content: dict,
+        valid_single_select: dict,
+    ) -> None:
+        """Test validating a fully populated project item."""
+        data = {
+            "content": valid_issue_content,
+            "status": valid_single_select,
+        }
+        item = ProjectItem.model_validate(data)
+        assert isinstance(item.content, IssueContent)
+        assert isinstance(item.status, SingleSelectValue)
+
+    def test_project_item_minimal(self, valid_issue_content: dict) -> None:
+        """Test validating a project item with only required fields."""
+        data = {
+            "content": valid_issue_content,
+        }
+        item = ProjectItem.model_validate(data)
+        assert item.status is None
+
+    def test_roadmap_item_fully_populated(
+        self,
+        valid_issue_content: dict,
+        valid_single_select: dict,
+        valid_iteration_value: dict,
+    ) -> None:
+        """Test validating a fully populated roadmap item."""
+        data = {
+            "content": valid_issue_content,
+            "status": valid_single_select,
+            "quad": valid_iteration_value,
+            "pillar": valid_single_select,
+        }
+        item = RoadmapItem.model_validate(data)
+        assert isinstance(item.quad, IterationValue)
+        assert isinstance(item.pillar, SingleSelectValue)
+
+    def test_sprint_item_fully_populated(
+        self,
+        valid_issue_content: dict,
+        valid_single_select: dict,
+        valid_iteration_value: dict,
+    ) -> None:
+        """Test validating a fully populated sprint item."""
+        data = {
+            "content": valid_issue_content,
+            "status": valid_single_select,
+            "sprint": valid_iteration_value,
+            "points": {"number": 5},
+        }
+        item = SprintItem.model_validate(data)
+        assert isinstance(item.sprint, IterationValue)
+        assert isinstance(item.points, NumberValue)
+        assert item.points.number == 5
+
+    def test_sprint_item_minimal(self, valid_issue_content: dict) -> None:
+        """Test validating a sprint item with only required fields."""
+        data = {
+            "content": valid_issue_content,
+        }
+        item = SprintItem.model_validate(data)
+        assert item.sprint is None
+        assert item.points is None
+        assert item.status is None
+
+
+class TestIssueContent:
+    """Test cases for issue content schemas."""
+
+    def test_issue_content_fully_populated(self, valid_issue_content: dict) -> None:
+        """Test validating a fully populated issue content."""
+        issue = IssueContent.model_validate(valid_issue_content)
+        assert issue.title == "Test Issue"
+        assert issue.url == "https://github.com/test/repo/issues/1"
+        assert issue.closed is True
+        assert isinstance(issue.created_at, datetime)
+        assert isinstance(issue.closed_at, datetime)
+
+    def test_issue_content_minimal(self) -> None:
+        """Test validating an issue content with only required fields."""
+        minimal_content = {
+            "title": "Test Issue",
+            "url": "https://github.com/test/repo/issues/1",
+            "closed": False,
+            "createdAt": "2024-01-01T00:00:00Z",
+        }
+        issue = IssueContent.model_validate(minimal_content)
+        assert issue.closed_at is None
+
+    def test_missing_title_raises_error(self) -> None:
+        """Test that validation fails when title is missing."""
+        with pytest.raises(ValidationError):
+            IssueContent.model_validate(
+                {
+                    "url": "https://github.com/test/repo/issues/1",
+                    "closed": True,
+                    "createdAt": "2024-01-01T00:00:00Z",
+                },
+            )
+
+    def test_missing_url_raises_error(self) -> None:
+        """Test that validation fails when url is missing."""
+        with pytest.raises(ValidationError):
+            IssueContent.model_validate(
+                {
+                    "title": "Test Issue",
+                    "closed": True,
+                    "createdAt": "2024-01-01T00:00:00Z",
+                },
+            )
+
+    def test_missing_closed_raises_error(self) -> None:
+        """Test that validation fails when closed is missing."""
+        with pytest.raises(ValidationError):
+            IssueContent.model_validate(
+                {
+                    "title": "Test Issue",
+                    "url": "https://github.com/test/repo/issues/1",
+                    "createdAt": "2024-01-01T00:00:00Z",
+                },
+            )
+
+    def test_missing_created_at_raises_error(self) -> None:
+        """Test that validation fails when createdAt is missing."""
+        with pytest.raises(ValidationError):
+            IssueContent.model_validate(
+                {
+                    "title": "Test Issue",
+                    "url": "https://github.com/test/repo/issues/1",
+                    "closed": True,
+                },
+            )
+
+    def test_issue_parent_with_empty_data(self) -> None:
+        """Test validating issue parent with empty data."""
+        parent = IssueParent.model_validate({})
+        assert parent.title is None
+        assert parent.url is None
+
+    def test_issue_type_with_name(self) -> None:
+        """Test validating issue type with a name value."""
+        type_with_value = IssueType.model_validate({"name": "Bug"})
+        assert type_with_value.name == "Bug"
+
+    def test_issue_type_with_empty_data(self) -> None:
+        """Test validating issue type with empty data."""
+        type_without_value = IssueType.model_validate({})
+        assert type_without_value.name is None
+
+
+class TestProjectFields:
+    """Test cases for project field schemas."""
+
+    def test_iteration_value_fully_populated(self, valid_iteration_value: dict) -> None:
+        """Test validating a fully populated iteration value."""
+        iteration = IterationValue.model_validate(valid_iteration_value)
+        assert iteration.iteration_id == "123"
+        assert iteration.title == "Sprint 1"
+        assert iteration.start_date == "2024-01-01"
+        assert iteration.duration == 14
+
+    def test_iteration_value_with_empty_data(self) -> None:
+        """Test validating an iteration value with empty data."""
+        iteration = IterationValue.model_validate({})
+        assert iteration.iteration_id is None
+        assert iteration.title is None
+        assert iteration.start_date is None
+        assert iteration.duration is None
+
+    def test_single_select_value_fully_populated(
+        self,
+        valid_single_select: dict,
+    ) -> None:
+        """Test validating a fully populated single select value."""
+        select = SingleSelectValue.model_validate(valid_single_select)
+        assert select.option_id == "456"
+        assert select.name == "In Progress"
+
+    def test_number_value_with_number(self) -> None:
+        """Test validating number value with a number."""
+        with_value = NumberValue.model_validate({"number": 5})
+        assert with_value.number == 5
+
+    def test_number_value_with_empty_data(self) -> None:
+        """Test validating number value with empty data."""
+        without_value = NumberValue.model_validate({})
+        assert without_value.number is None

--- a/analytics/tests/integrations/github/test_validation.py
+++ b/analytics/tests/integrations/github/test_validation.py
@@ -167,8 +167,6 @@ class TestIssueContent:
         assert issue.title == "Test Issue"
         assert issue.url == "https://github.com/test/repo/issues/1"
         assert issue.closed is True
-        assert isinstance(issue.created_at, datetime)
-        assert isinstance(issue.closed_at, datetime)
         assert issue.parent.title == "Test Parent"
         assert issue.issue_type.name == "Bug"
 
@@ -264,6 +262,7 @@ class TestProjectFields:
         assert iteration.title == "Sprint 1"
         assert iteration.start_date == "2024-01-01"
         assert iteration.duration == 14
+        assert iteration.end_date == "2024-01-15"
 
     def test_iteration_value_with_empty_data(self) -> None:
         """Test validating an iteration value with empty data."""
@@ -272,6 +271,7 @@ class TestProjectFields:
         assert iteration.title is None
         assert iteration.start_date is None
         assert iteration.duration is None
+        assert iteration.end_date is None
 
     def test_single_select_value_fully_populated(self) -> None:
         """Test validating a fully populated single select value."""


### PR DESCRIPTION
## Summary

Changes how we validate the response data from the GitHub API.

Fixes #3203 

### Time to review: __5 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Adds new schemas to validate the GitHub output
- Uses those schemas to modify the `transform_project_data()` method

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This PR is stacked on top of #3393 

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

