### PR TITLE
[Unticketed] Fix scenario where opp attachment is null

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
+++ b/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
@@ -188,5 +188,9 @@ def transform_opportunity_attachment(
 def write_file(
     source_attachment: TsynopsisAttachment, destination_attachment: OpportunityAttachment
 ) -> None:
+
+    if source_attachment.file_lob is None:
+        raise ValueError("Attachment is null, cannot copy")
+
     with file_util.open_stream(destination_attachment.file_location, "wb") as outfile:
         outfile.write(source_attachment.file_lob)

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity_attachment.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity_attachment.py
@@ -233,3 +233,21 @@ class TestTransformOpportunitySummary(BaseTransformTestClass):
         )
 
         validate_opportunity_attachment(db_session, synopsis_attachment, expect_in_db=False)
+
+    def test_transform_opportunity_attachment_null_file_lob(
+        self, db_session, transform_opportunity_attachment, s3_config
+    ):
+        opportunity = f.OpportunityFactory.create(opportunity_attachments=[])
+        insert = setup_opportunity_attachment(
+            create_existing=False,
+            opportunity=opportunity,
+            config=s3_config,
+            source_values={"file_lob": None},
+        )
+
+        with pytest.raises(ValueError, match="Attachment is null, cannot copy"):
+            transform_opportunity_attachment.process_opportunity_attachment(
+                insert, None, opportunity
+            )
+
+        assert insert.transformed_at is None

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -1009,7 +1009,7 @@ class TsynopsisAttachmentFactory(BaseFactory):
     file_name = factory.Faker("file_name", category="text")
     file_desc = factory.Faker("sentence")
     file_lob = factory.LazyFunction(lambda: fake.sentence(25).encode())
-    file_lob_size = factory.LazyAttribute(lambda x: len(x.file_lob))
+    file_lob_size = factory.LazyAttribute(lambda x: len(x.file_lob) if x.file_lob else 0)
     create_date = factory.Faker("date_time_between", start_date="-1y", end_date="now")
     created_date = factory.LazyAttribute(
         lambda o: fake.date_time_between(start_date=o.create_date, end_date="now")


### PR DESCRIPTION
## Summary

### Time to review: __3 mins__

## Changes proposed
Handle case (by erroring) if an opportunity attachment is null from legacy data

## Context for reviewers
Note that by erroring like this, processing on other attachments will continue.

Hit this issue when testing in dev, forgot that the `file_lob` column that contains the opportunity attachments from the legacy data is a nullable field. Easy enough fix to throw a value error so processing continues and we skip that record.

