### PR TITLE
[Issue #3097] Fix analytics deploy not having a CDN

### DIFF
--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -17,7 +17,7 @@ locals {
   #   - If the origin is an S3 bucket, and the S3 bucket's desired domain name is null,
   #     then return null
   cdn_domain_name         = var.enable_alb_cdn && var.domain != null ? var.domain : var.enable_s3_cdn && var.s3_cdn_domain_name != null ? var.s3_cdn_domain_name : null
-  cdn_domain_name_env_var = local.cdn_domain_name != null ? local.cdn_domain_name : aws_cloudfront_distribution.cdn[0].domain_name
+  cdn_domain_name_env_var = local.cdn_domain_name != null ? local.cdn_domain_name : length(aws_cloudfront_distribution.cdn) != 0 ? aws_cloudfront_distribution.cdn[0].domain_name : null
 
   # The domain name of the origin, ie. where the content is being served from.
   #   - If the origin is an ALB, this is the DNS name of the ALB


### PR DESCRIPTION
## Summary

Accidentally caused by work on #3097

### Time to review: __1 mins__

## Changes proposed

Gaurds against the cause where a given service doesn't have a CDN to deploy _(which is only analytics right now)_

## Testing

Analytics deploy was broken before this change, and now it's not. I haven't tested API and frontend, but I'm hoping this doesn't break them.
