### PR TITLE
[Unticketed] Enable context data logging in New Relic

### DIFF
--- a/api/newrelic.ini
+++ b/api/newrelic.ini
@@ -166,7 +166,7 @@ error_collector.enabled = true
 #
 # Note that most of these except for UnsupportedMediaTypeProblem are 400 responses.
 #
-error_collector.ignore_classes = 
+error_collector.ignore_classes =
 
 # Expected errors are reported to the UI but will not affect the
 # Apdex or error rate. To mark specific errors as expected, set this
@@ -186,7 +186,7 @@ error_collector.expected_classes =
 # 503: Service Unavailable - Temporary service unavailability. High volume should trigger a New Relic alarm.
 #
 # Status codes that we may want to ignore in the future:
-# 
+#
 # - 400: Bad Request - Validation and extra parameter errors. Unclear if we want to catch pydantic ValidationErrors here so we're keeping them for now. Instead, selectively ignore specific error classes above.
 # - 422: Unprocessable Entity - Haven't seen these yet so we'll report them.
 # - 504: Gateway Timeout - We do not expect any 504s to be thrown from the API server itself. This should come from the API Gateway that sits in front of it.
@@ -223,6 +223,10 @@ distributed_tracing.enabled = true
 # no PII data is captured in messages of new relic.
 strip_exception_messages.enabled = true
 
+# Tell New Relic to include the full JSON / extra info from our logs
+# https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#application_logging.forwarding.context_data.enabled
+application_logging.forwarding.context_data.enabled = true
+
 # ---------------------------------------------------------------------------
 
 #
@@ -233,7 +237,7 @@ strip_exception_messages.enabled = true
 # "local", "stage", "performance", "training", "prod", or "uat".
 #
 
-[newrelic:local] 
+[newrelic:local]
 # Don't turn on data reporting by default when running the API locally.
 #
 # To enable New Relic locally, set the following variables:


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Enable https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#application_logging.forwarding.context_data.enabled

## Context for reviewers
If I'm reading docs right, this should make it so New Relic automatically includes the `extra` we add to our logs. It already is getting the logs from the API and backend tasks successfully, but only includes the message. This should fix that?


