### PR TITLE
[Issue #3628] allow error page to be interactive without refresh

### DIFF
--- a/frontend/src/app/[locale]/search/error.tsx
+++ b/frontend/src/app/[locale]/search/error.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import QueryProvider from "src/app/[locale]/search/QueryProvider";
+import { usePrevious } from "src/hooks/usePrevious";
 import { FrontendErrorDetails } from "src/types/apiResponseTypes";
 import { ServerSideSearchParams } from "src/types/searchRequestURLTypes";
 import { Breakpoints, ErrorProps } from "src/types/uiTypes";
 import { convertSearchParamsToProperTypes } from "src/utils/search/convertSearchParamsToProperTypes";
 
 import { useTranslations } from "next-intl";
+import { ReadonlyURLSearchParams, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { Alert } from "@trussworks/react-uswds";
 
@@ -51,8 +53,25 @@ function createBlankParsedError(): ParsedError {
   };
 }
 
-export default function SearchError({ error }: ErrorProps) {
+export default function SearchError({ error, reset }: ErrorProps) {
   const t = useTranslations("Search");
+  const searchParams = useSearchParams();
+  const previousSearchParams =
+    usePrevious<ReadonlyURLSearchParams>(searchParams);
+
+  useEffect(() => {
+    if (
+      reset &&
+      previousSearchParams &&
+      searchParams.toString() !== previousSearchParams?.toString()
+    ) {
+      reset();
+    }
+  }, [searchParams, reset]);
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
 
   // The error message is passed as an object that's been stringified.
   // Parse it here.

--- a/frontend/src/hooks/usePrevious.ts
+++ b/frontend/src/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from "react";
+
+export const usePrevious = <T>(value: T) => {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};

--- a/frontend/src/types/uiTypes.ts
+++ b/frontend/src/types/uiTypes.ts
@@ -20,4 +20,5 @@ export interface ErrorProps {
   // Next's error boundary also includes a reset function as a prop for retries,
   // but it was not needed as users can retry with new inputs in the normal page flow.
   error: Error & { digest?: string };
+  reset?: () => unknown;
 }

--- a/frontend/tests/e2e/search/search-error.spec.ts
+++ b/frontend/tests/e2e/search/search-error.spec.ts
@@ -1,18 +1,9 @@
-import { expect, Page, test } from "@playwright/test";
-import { BrowserContextOptions } from "playwright-core";
+import { expect, test } from "@playwright/test";
 
 import { toggleCheckbox, toggleMobileSearchFilters } from "./searchSpecUtil";
 
-interface PageProps {
-  page: Page;
-  browserName?: string;
-  contextOptions?: BrowserContextOptions;
-}
-
 test.describe("Search error page", () => {
-  test("should return an error page when expected", async ({
-    page,
-  }: PageProps) => {
+  test("should return an error page when expected", async ({ page }) => {
     // trigger error by providing an invalid status value
     await page.goto("/search?status=not_a_status");
 
@@ -30,7 +21,7 @@ test.describe("Search error page", () => {
 
     await toggleCheckbox(page, "status-closed");
 
-    await page.waitForURL(/status\=forecasted\,posted\,closed/, {
+    await page.waitForURL(/status=forecasted,posted,closed/, {
       timeout: 5000,
     });
   });

--- a/frontend/tests/e2e/search/search-error.spec.ts
+++ b/frontend/tests/e2e/search/search-error.spec.ts
@@ -1,0 +1,37 @@
+import { expect, Page, test } from "@playwright/test";
+import { BrowserContextOptions } from "playwright-core";
+
+import { toggleCheckbox, toggleMobileSearchFilters } from "./searchSpecUtil";
+
+interface PageProps {
+  page: Page;
+  browserName?: string;
+  contextOptions?: BrowserContextOptions;
+}
+
+test.describe("Search error page", () => {
+  test("should return an error page when expected", async ({
+    page,
+  }: PageProps) => {
+    // trigger error by providing an invalid status value
+    await page.goto("/search?status=not_a_status");
+
+    expect(page.locator(".usa-alert--error")).toBeTruthy();
+  });
+
+  test("should allow for performing a new search from error state", async ({
+    page,
+  }, { project }) => {
+    await page.goto("/search?status=not_a_status");
+
+    if (project.name.match(/[Mm]obile/)) {
+      await toggleMobileSearchFilters(page);
+    }
+
+    await toggleCheckbox(page, "status-closed");
+
+    await page.waitForURL(/status\=forecasted\,posted\,closed/, {
+      timeout: 5000,
+    });
+  });
+});

--- a/frontend/tests/hooks/usePrevious.test.ts
+++ b/frontend/tests/hooks/usePrevious.test.ts
@@ -1,0 +1,27 @@
+import { renderHook } from "@testing-library/react";
+import { usePrevious } from "src/hooks/usePrevious";
+
+// note that these tests come from https://github.com/streamich/react-use/blob/master/tests/usePrevious.test.ts
+const setUp = () =>
+  renderHook(({ state }) => usePrevious(state), { initialProps: { state: 0 } });
+
+describe("usePrevious", () => {
+  it("should return undefined on initial render", () => {
+    const { result } = setUp();
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("should always return previous state after each update", () => {
+    const { result, rerender } = setUp();
+
+    rerender({ state: 2 });
+    expect(result.current).toBe(0);
+
+    rerender({ state: 4 });
+    expect(result.current).toBe(2);
+
+    rerender({ state: 6 });
+    expect(result.current).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #3628

### Time to review: __10 mins__

## Changes proposed
Fixes bug where search error page had an unusable UI

Also introduces a usePrevious hook as pulled from https://www.developerway.com/posts/implementing-advanced-use-previous-hook (I think this hook implementation used to be in the React docs themselves, but I don't see it there anymore)

## Context for reviewers

This was fixed by correctly using NextJs's `reset` method which is not well documented https://nextjs.org/docs/app/api-reference/file-conventions/error#reset

Because NextJS's error handling uses React error boundaries under the hood, which are basically designed to set an error state and take action based on that state, it makes sense that something explicit must be done to tell the error boundary that the app is no longer in an error state. That's what reset is for, so by calling reset whenever a user interaction occurs on the error page, the problem disappears.

### Test steps

1. start on main with `npm run dev`
2. visit http://localhost:3000/search?status=fake
3. _VERIFY_: you're on the error page
4. click a filter or attempt to do a query based search
5. _VERIFY_: url updates but UI does not update
6. restart on this branch
2. visit http://localhost:3000/search?status=fake
3. _VERIFY_: you're on the error page
4. click a filter or attempt to do a query based search
5. _VERIFY_: the page performs the search and updates the UI

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

