### PR TITLE
[no ticket] Adds a command for running step functions

### DIFF
--- a/bin/run-step-function.sh
+++ b/bin/run-step-function.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# -----------------------------------------------------------------------------
+# Starts a step function execution for the given application and environment.
+#
+# Positional parameters:
+#   APP – the name of subdirectory of /infra that holds the application's code
+#   ENVIRONMENT (required) – the name of the application environment (e.g. dev, staging, prod)
+#   STEP_FUNCTION (required) – the name of the step function to execute
+#
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+APP="$1"
+ENVIRONMENT="$2"
+STEP_FUNCTION="$3"
+
+ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+REGION=$(aws configure get region)
+USER=$(whoami)
+DATE=$(date +%s)
+STEP_FUNCTION_ARN="arn:aws:states:$REGION:$ACCOUNT:stateMachine:$APP-$ENVIRONMENT-$STEP_FUNCTION"
+EXECUTION_ARN="arn:aws:states:$REGION:$ACCOUNT:execution:$APP-$ENVIRONMENT-$STEP_FUNCTION"
+EXECUTION_URL="https://$REGION.console.aws.amazon.com/states/home?region=$REGION#/v2/executions/details/$EXECUTION_ARN:$USER-$DATE"
+
+echo "aws stepfunctions start-execution"
+echo "  --state-machine-arn $STEP_FUNCTION_ARN"
+echo "  --name $USER-$DATE"
+
+aws stepfunctions start-execution \
+  --state-machine-arn "$STEP_FUNCTION_ARN" \
+  --name "$USER-$DATE" \
+  >/dev/null 2>&1
+
+echo ""
+echo "View the step function execution in the AWS console:"
+echo "  $EXECUTION_URL"


### PR DESCRIPTION
### Time to review: __2 mins__

## Context for reviewers

Functionally procrastination on my part, I wrote this so I could test step functions without having to drop into / out of the AWS console

## Testing

```bash
$ ./bin/run-step-function.sh analytics prod opportunity-load-csvs
aws stepfunctions start-execution
  --state-machine-arn arn:aws:states:us-east-1:315341936575:stateMachine:analytics-prod-opportunity-load-csvs
  --name kai-1737665796

View the step function execution in the AWS console:
  https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:315341936575:execution:analytics-prod-opportunity-load-csvs:kai-1737665796
```