### PR TITLE
[no ticket] Double analytics memory

### DIFF
--- a/infra/analytics/service/main.tf
+++ b/infra/analytics/service/main.tf
@@ -113,7 +113,7 @@ module "service" {
   public_subnet_ids     = data.aws_subnets.public.ids
   private_subnet_ids    = data.aws_subnets.private.ids
   cpu                   = 1024
-  memory                = 2048
+  memory                = 4096
 
   readonly_root_filesystem = false
 


### PR DESCRIPTION
### Time to review: __1 mins__

## Context for reviewers

The prod analytics container is currently OOM'ing on the load csvs job
