### PR TITLE
[Unticketed] Modify agency transform to ignore a new field

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_agency.py
+++ b/api/src/data_migration/transformation/subtask/transform_agency.py
@@ -73,6 +73,8 @@ NOT_MAPPED_FIELDS = {
     # These fields were only found in the test environment
     "ASSISTCompatible",
     "SAMValidation",
+    # This was added in Jan 2025 in Grants.gov, we aren't using it yet
+    "AllowSubmitWithExpSAM",
 }
 
 REQUIRED_FIELDS = {


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Adds a filter to the transform agency task to skip a new field

## Context for reviewers
grants.gov added a new type of field to the TGroups table (the key-value table that stores agency info) which is causing the following error: `Unknown tgroups agency field AllowSubmitWithExpSAM`.

While I'm not sure what this field does exactly (something to do with allowing users to submit even if their SAM validation isn't done), I know we don't need to worry about it for a while as we don't yet handle anything with apply. So for now, ignoring the field so we stop erroring on these fields. We can always pick it back up later.
