### PR TITLE
[Issue #3730] Fix parsing `issueType` bug

### DIFF
--- a/analytics/src/analytics/integrations/github/validation.py
+++ b/analytics/src/analytics/integrations/github/validation.py
@@ -5,6 +5,12 @@ from datetime import datetime, timedelta
 
 from pydantic import BaseModel, Field, computed_field, model_validator
 
+# Declares class level constants for the fields that need to be aliased
+ISSUE_TYPE = "issueType"
+CLOSED_AT = "closedAt"
+CREATED_AT = "createdAt"
+PARENT = "parent"
+
 
 def safe_default_factory(data: dict, keys_to_replace: list[str]) -> dict:
     """
@@ -40,19 +46,20 @@ class IssueType(BaseModel):
 class IssueContent(BaseModel):
     """Schema for core issue metadata."""
 
+    # The fields that we're parsing from the raw GitHub output
     title: str
     url: str
     closed: bool
-    created_at: str = Field(alias="createdAt")
-    closed_at: str | None = Field(alias="closedAt", default=None)
-    issue_type: IssueType = Field(alias="type", default_factory=IssueType)
+    created_at: str = Field(alias=CREATED_AT)
+    closed_at: str | None = Field(alias=CLOSED_AT, default=None)
+    issue_type: IssueType = Field(alias=ISSUE_TYPE, default_factory=IssueType)
     parent: IssueParent = Field(default_factory=IssueParent)
 
     @model_validator(mode="before")
     def replace_none_with_defaults(cls, values) -> dict:  # noqa: ANN001, N805
         """Replace None with default_factory instances."""
         # Replace None with default_factory instances
-        return safe_default_factory(values, ["type", "parent"])
+        return safe_default_factory(values, [ISSUE_TYPE, PARENT])
 
 
 # #############################################

--- a/analytics/src/analytics/integrations/github/validation.py
+++ b/analytics/src/analytics/integrations/github/validation.py
@@ -1,15 +1,29 @@
 """Pydantic schemas for validating GitHub API responses."""
 
 # pylint: disable=no-self-argument
+# mypy: disable-error-code="literal-required"
+# This mypy disable is needed so we can use constants for field aliases
+
 from datetime import datetime, timedelta
 
 from pydantic import BaseModel, Field, computed_field, model_validator
 
-# Declares class level constants for the fields that need to be aliased
+# Declare constants for the fields that need to be aliased from the GitHub data
+# so that we only have to change these values in one place.
+#
+# We need to declare them at the module-level instead of class-level
+# because pydantic throws an error when using class level constants.
+
+# Issue content aliases
 ISSUE_TYPE = "issueType"
 CLOSED_AT = "closedAt"
 CREATED_AT = "createdAt"
 PARENT = "parent"
+# Iteration aliases
+ITERATION_ID = "iterationId"
+START_DATE = "startDate"
+# Single select aliases
+OPTION_ID = "optionId"
 
 
 def safe_default_factory(data: dict, keys_to_replace: list[str]) -> dict:
@@ -57,7 +71,7 @@ class IssueContent(BaseModel):
 
     @model_validator(mode="before")
     def replace_none_with_defaults(cls, values) -> dict:  # noqa: ANN001, N805
-        """Replace None with default_factory instances."""
+        """Replace keys that are set to None with default_factory instances."""
         # Replace None with default_factory instances
         return safe_default_factory(values, [ISSUE_TYPE, PARENT])
 
@@ -70,9 +84,9 @@ class IssueContent(BaseModel):
 class IterationValue(BaseModel):
     """Schema for iteration field values like Sprint or Quad."""
 
-    iteration_id: str | None = Field(alias="iterationId", default=None)
+    iteration_id: str | None = Field(alias=ITERATION_ID, default=None)
     title: str | None = None
-    start_date: str | None = Field(alias="startDate", default=None)
+    start_date: str | None = Field(alias=START_DATE, default=None)
     duration: int | None = None
 
     @computed_field
@@ -89,7 +103,7 @@ class IterationValue(BaseModel):
 class SingleSelectValue(BaseModel):
     """Schema for single select field values like Status or Pillar."""
 
-    option_id: str | None = Field(alias="optionId", default=None)
+    option_id: str | None = Field(alias=OPTION_ID, default=None)
     name: str | None = None
 
 
@@ -119,7 +133,7 @@ class ProjectItem(BaseModel):
 
     @model_validator(mode="before")
     def replace_none_with_defaults(cls, values) -> dict:  # noqa: ANN001, N805
-        """Replace None with default_factory instances."""
+        """Replace keys that are set to None with default_factory instances."""
         return safe_default_factory(
             values,
             ["sprint", "points", "quad", "pillar", "status"],

--- a/analytics/tests/integrations/github/test_validation.py
+++ b/analytics/tests/integrations/github/test_validation.py
@@ -24,7 +24,7 @@ VALID_ISSUE_CONTENT = {
         "title": "Test Parent",
         "url": "https://github.com/test/repo/issues/2",
     },
-    "type": {
+    "issueType": {
         "name": "Bug",
     },
 }


### PR DESCRIPTION
## Summary

Fixes the type in the `IssueType` pydantic model that was causing `issueType` to be parsed incorrectly.

Fixes #3730 

### Time to review: __5 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

- Fixes typo in `IssueType` field alias (it was incorrectly aliased as `"type"` instead of `"issueType"`)
- Replaces the string literal field aliases with module level constants to make it easier to update and monitor field aliases.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. Checkout the PR locally
2. Run `make gh-data-export` to export the data from GitHub
3. Run the following command to check the percentage of issues that have `null` value for issue type:
    ```bash
    jq '[.[] | select(.issue_type == null)] | length' data/delivery-data.json
    ```
4. The output should be around 691
5. Spot check values in `data/delivery-data.json` where `"issue_type"` is `null` each issue that you check, should be missing a "Type" in GitHub (see screenshot below)
<img width="411" alt="Screenshot 2025-01-30 at 5 02 46 PM" src="https://github.com/user-attachments/assets/78b3f96b-0046-4cbe-b4d4-d22a54037031" />

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

A major goal for Sprint 2.3 will be to set up some automated data quality checks in both Metabase and the ETL pipeline to prevent or at least catch similar regressions earlier.
