### PR TITLE
[Issue #3696] Update get agencies endpoint to remove extra queries

### DIFF
--- a/api/src/db/models/user_models.py
+++ b/api/src/db/models/user_models.py
@@ -85,7 +85,7 @@ class UserSavedOpportunity(ApiSchemaTable, TimestampMixin):
     )
 
     last_notified_at: Mapped[datetime] = mapped_column(
-        default=datetime.utcnow, server_default="NOW()", nullable=False
+        default=datetime_util.utcnow, server_default="NOW()", nullable=False
     )
 
     user: Mapped[User] = relationship(User, back_populates="saved_opportunities")

--- a/api/src/services/agencies_v1/get_agencies.py
+++ b/api/src/services/agencies_v1/get_agencies.py
@@ -2,7 +2,7 @@ import logging
 from typing import Sequence, Tuple
 
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import asc, select
 from sqlalchemy.orm import joinedload
 
 import src.adapters.db as db
@@ -27,29 +27,19 @@ class AgencyListParams(BaseModel):
 def get_agencies(
     db_session: db.Session, list_params: AgencyListParams
 ) -> Tuple[Sequence[Agency], PaginationInfo]:
-    stmt = select(Agency).options(joinedload(Agency.top_level_agency), joinedload("*"))
+    stmt = (
+        select(Agency).options(joinedload(Agency.top_level_agency), joinedload("*"))
+        # Exclude test agencies
+        .where(Agency.is_test_agency.isnot(True))
+    )
 
-    # Exclude test agencies
-    stmt = stmt.where(Agency.is_test_agency != True)  # noqa: E712
+    # TODO https://github.com/HHS/simpler-grants-gov/issues/3697
+    # use the sorting parameters from the request
+    stmt.order_by(asc("agency_code"))
 
     if list_params.filters:
         if list_params.filters.agency_name:
             stmt = stmt.where(Agency.agency_name == list_params.filters.agency_name)
-
-    # Execute the query and fetch all agencies
-    agencies = db_session.execute(stmt).unique().scalars().all()
-
-    # Create a dictionary to map agency names to agency instances
-    agency_dict = {agency.agency_name: agency for agency in agencies}
-
-    # Process top-level agencies
-    for agency in agencies:
-        if "-" in agency.agency_name:
-            top_level_name = agency.agency_name.split("-")[0].strip()
-            # Find the top-level agency using the dictionary
-            top_level_agency = agency_dict.get(top_level_name)
-            if top_level_agency:
-                agency.top_level_agency = top_level_agency
 
     # Apply pagination after processing
     paginator: Paginator[Agency] = Paginator(


### PR DESCRIPTION
## Summary
Fixes #3696

### Time to review: __5 mins__

## Changes proposed
Cleanup the way we setup get agencies queries to remove extra/unused logic

## Context for reviewers
It looks like two separate queries were setup to do the same thing, but only one is used, trim out the extra one that might actually cause issues because it's setting the top level agency in its loop.
