### PR TITLE
[Issue #3464] Better agency display/sort in search

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -1522,6 +1522,8 @@ components:
           - post_date
           - close_date
           - agency_code
+          - agency_name
+          - top_level_agency_name
           description: The field to sort the response by
         sort_direction:
           description: Whether to sort the response ascending or descending

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -489,6 +489,8 @@ class OpportunitySearchRequestV1Schema(Schema):
                 "post_date",
                 "close_date",
                 "agency_code",
+                "agency_name",
+                "top_level_agency_name",
             ],
             default_sort_order=[{"order_by": "opportunity_id", "sort_direction": "descending"}],
         ),

--- a/api/src/db/models/agency_models.py
+++ b/api/src/db/models/agency_models.py
@@ -98,7 +98,7 @@ class Agency(ApiSchemaTable, TimestampMixin):
         ForeignKey(agency_id),
         nullable=True,
     )
-    top_level_agency: Mapped["Agency"] = relationship(
+    top_level_agency: Mapped["Agency | None"] = relationship(
         lambda: Agency,
         remote_side=[agency_id],
     )

--- a/api/src/db/models/opportunity_models.py
+++ b/api/src/db/models/opportunity_models.py
@@ -97,8 +97,9 @@ class Opportunity(ApiSchemaTable, TimestampMixin):
     def top_level_agency_name(self) -> str | None:
         if self.agency_record is not None and self.agency_record.top_level_agency is not None:
             return self.agency_record.top_level_agency.agency_name
+ 
+        return self.agency_name
 
-        return None
 
     @property
     def agency_name(self) -> str | None:

--- a/api/src/db/models/opportunity_models.py
+++ b/api/src/db/models/opportunity_models.py
@@ -97,9 +97,8 @@ class Opportunity(ApiSchemaTable, TimestampMixin):
     def top_level_agency_name(self) -> str | None:
         if self.agency_record is not None and self.agency_record.top_level_agency is not None:
             return self.agency_record.top_level_agency.agency_name
- 
-        return self.agency_name
 
+        return self.agency_name
 
     @property
     def agency_name(self) -> str | None:

--- a/api/src/services/opportunities_v1/search_opportunities.py
+++ b/api/src/services/opportunities_v1/search_opportunities.py
@@ -42,6 +42,8 @@ REQUEST_FIELD_NAME_MAPPING = {
     "close_date": "summary.close_date",
     "agency_code": "agency_code.keyword",
     "agency": "agency_code.keyword",
+    "agency_name": "agency_name.keyword",
+    "top_level_agency_name": "top_level_agency_name.keyword",
     "opportunity_status": "opportunity_status.keyword",
     "funding_instrument": "summary.funding_instruments.keyword",
     "funding_category": "summary.funding_categories.keyword",

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -97,7 +97,7 @@ export default function SearchResultsListItem({
                   : "--"}
               </span>
             </div>
-            <div className="grid-col tablet:order-3 overflow-hidden font-body-xs">
+            <div className="grid-col tablet:order-2 overflow-hidden font-body-xs">
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.summary.agency")}</strong>
                 {opportunity?.top_level_agency_name &&
@@ -110,6 +110,8 @@ export default function SearchResultsListItem({
                         agencyNameLookup[opportunity?.summary?.agency_code]
                       : "--")}
               </span>
+            </div>
+            <div className="grid-col tablet:order-3 overflow-hidden font-body-xs">
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.opportunity_number")}</strong>
                 {opportunity?.opportunity_number}

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -100,13 +100,15 @@ export default function SearchResultsListItem({
             <div className="grid-col tablet:order-3 overflow-hidden font-body-xs">
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.summary.agency")}</strong>
-                {opportunity?.agency ||
-                  (opportunity?.summary?.agency_name &&
-                  opportunity?.summary?.agency_code &&
-                  agencyNameLookup
-                    ? // Use same exact label we're using for the agency filter list
-                      agencyNameLookup[opportunity?.summary?.agency_code]
-                    : "--")}
+                {opportunity?.top_level_agency_name &&
+                opportunity?.agency_name &&
+                opportunity?.top_level_agency_name !== opportunity?.agency_name
+                  ? `${opportunity?.top_level_agency_name} - ${opportunity?.agency_name}`
+                  : opportunity?.agency_name ||
+                    (agencyNameLookup && opportunity?.summary?.agency_code
+                      ? // Use same exact label we're using for the agency filter list
+                        agencyNameLookup[opportunity?.summary?.agency_code]
+                      : "--")}
               </span>
               <span className={metadataBorderClasses}>
                 <strong>{t("resultsListItem.opportunity_number")}</strong>

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -11,15 +11,19 @@ export type PaginationOrderBy =
   | "opportunity_id"
   | "opportunity_number"
   | "opportunity_title"
-  | "agency_code"
+  | "agency_name"
+  | "top_level_agency_code"
   | "post_date"
   | "close_date";
 export type PaginationSortDirection = "ascending" | "descending";
-export interface PaginationRequestBody {
+export type PaginationSortOrder = {
   order_by: PaginationOrderBy;
+  sort_direction: PaginationSortDirection;
+}[];
+export interface PaginationRequestBody {
   page_offset: number;
   page_size: number;
-  sort_direction: PaginationSortDirection;
+  sort_order: PaginationSortOrder;
 }
 
 export type SearchRequestBody = {

--- a/frontend/src/types/search/searchResponseTypes.ts
+++ b/frontend/src/types/search/searchResponseTypes.ts
@@ -43,6 +43,7 @@ export interface Summary {
 
 export interface Opportunity {
   agency: string | null;
+  agency_name: string | null;
   category: string | null;
   category_explanation: string | null;
   created_at: string;
@@ -52,6 +53,7 @@ export interface Opportunity {
   opportunity_status: OpportunityStatus;
   opportunity_title: string;
   summary: Summary;
+  top_level_agency_name: string | null;
   updated_at: string;
 }
 

--- a/frontend/tests/services/fetch/fetchers/SearchFetcher.test.ts
+++ b/frontend/tests/services/fetch/fetchers/SearchFetcher.test.ts
@@ -90,10 +90,14 @@ describe("downloadOpportunities", () => {
     expect(mockfetchOpportunitySearch).toHaveBeenCalledWith({
       body: {
         pagination: {
-          order_by: "opportunity_number", // This should be the actual value being used in the API method
+          sort_order: [
+            {
+              order_by: "opportunity_number", // This should be the actual value being used in the API method
+              sort_direction: "ascending", // or "descending" based on your sortby parameter
+            },
+          ],
           page_offset: 1,
           page_size: 5000,
-          sort_direction: "ascending", // or "descending" based on your sortby parameter
         },
         query: "research",
         filters: {

--- a/frontend/tests/services/fetch/fetchers/SearchFetcher.test.ts
+++ b/frontend/tests/services/fetch/fetchers/SearchFetcher.test.ts
@@ -51,10 +51,14 @@ describe("searchForOpportunities", () => {
     expect(mockfetchOpportunitySearch).toHaveBeenCalledWith({
       body: {
         pagination: {
-          order_by: "opportunity_number", // This should be the actual value being used in the API method
+          sort_order: [
+            {
+              order_by: "opportunity_number",
+              sort_direction: "ascending",
+            },
+          ], // This should be the actual value being used in the API method
           page_offset: 1,
           page_size: 25,
-          sort_direction: "ascending", // or "descending" based on your sortby parameter
         },
         query: "research",
         filters: {
@@ -157,9 +161,9 @@ describe("buildPagination", () => {
       ...{ page: 5, sortby: null },
     });
 
-    expect(pagination.order_by).toEqual("relevancy");
+    expect(pagination.sort_order[0].order_by).toEqual("relevancy");
     expect(pagination.page_offset).toEqual(5);
-    expect(pagination.sort_direction).toEqual("descending");
+    expect(pagination.sort_order[0].sort_direction).toEqual("descending");
   });
 
   it("builds correct offset based on action type and field changed", () => {
@@ -206,14 +210,14 @@ describe("buildPagination", () => {
       ...{ sortby: "closeDateAsc" },
     });
 
-    expect(pagination.order_by).toEqual("close_date");
+    expect(pagination.sort_order[0].order_by).toEqual("close_date");
 
     const secondPagination = buildPagination({
       ...searchProps,
       ...{ sortby: "postedDateAsc" },
     });
 
-    expect(secondPagination.order_by).toEqual("post_date");
+    expect(secondPagination.sort_order[0].order_by).toEqual("post_date");
   });
 
   it("builds correct sort_direction based on sortby", () => {
@@ -222,20 +226,20 @@ describe("buildPagination", () => {
       ...{ sortby: "opportunityNumberDesc" },
     });
 
-    expect(pagination.sort_direction).toEqual("descending");
+    expect(pagination.sort_order[0].sort_direction).toEqual("descending");
 
     const secondPagination = buildPagination({
       ...searchProps,
       ...{ sortby: "postedDateAsc" },
     });
 
-    expect(secondPagination.sort_direction).toEqual("ascending");
+    expect(secondPagination.sort_order[0].sort_direction).toEqual("ascending");
 
     const thirdPagination = buildPagination({
       ...searchProps,
       ...{ sortby: null },
     });
 
-    expect(thirdPagination.sort_direction).toEqual("descending");
+    expect(thirdPagination.sort_order[0].sort_direction).toEqual("descending");
   });
 });


### PR DESCRIPTION
## Summary
Fixes #3464 

### Time to review: __10 mins__
🚨🚨🚨 Diffing against Michael's API change branch for now to highlight the further changes I made, but we will probably merge direct to main not into his branch to go to main.

## Changes proposed
Added support for the API change that takes an array of sort criteria instead of individual arguments for filed and direction

## Additional information
With some logging in the API layer I was able to demonstrate we were getting the correct format passed in from the FE and results sorted as expected:
Default/relevancy sort:
``` sort_order: [SortOrderParams(order_by='relevancy', sort_direction=<SortDirection.DESCENDING: 'descending'>), SortOrderParams(order_by='post_date', sort_direction=<SortDirection.DESCENDING: 'descending'>)]```
Agency sort:
``` sort_order: [SortOrderParams(order_by='top_level_agency_name', sort_direction=<SortDirection.DESCENDING: 'descending'>), SortOrderParams(order_by='agency_name', sort_direction=<SortDirection.DESCENDING: 'descending'>)] ```