### PR TITLE
[Issue #3097] S3 CDN Permissions

### DIFF
--- a/infra/modules/service/cdn-logs.tf
+++ b/infra/modules/service/cdn-logs.tf
@@ -49,17 +49,18 @@ data "aws_iam_policy_document" "cdn" {
   count = local.enable_cdn ? 1 : 0
 
   statement {
-    actions = [
-      "s3:GetObject",
-    ]
-
-    resources = [
-      "${aws_s3_bucket.cdn[0].arn}/*",
-    ]
-
+    sid       = "AllowCloudFrontIngress"
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.cdn[0].arn}/*"]
+    actions   = ["s3:GetObject"]
     principals {
-      type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.cdn[0].iam_arn]
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.cdn[0].arn]
     }
   }
 }

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -25,10 +25,13 @@ locals {
   origin_domain_name = var.enable_alb_cdn ? aws_lb.alb[0].dns_name : var.enable_s3_cdn ? aws_s3_bucket.s3_buckets[var.s3_cdn_bucket_name].bucket_regional_domain_name : null
 }
 
-resource "aws_cloudfront_origin_access_identity" "cdn" {
+resource "aws_cloudfront_origin_access_control" "cdn" {
   count = local.enable_cdn ? 1 : 0
 
-  comment = "Origin Access Identity for CloudFront to access S3 bucket"
+  name                              = var.service_name
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
 }
 
 resource "aws_cloudfront_cache_policy" "default" {
@@ -63,16 +66,19 @@ resource "aws_cloudfront_distribution" "cdn" {
   aliases = local.cdn_domain_name == null ? null : [local.cdn_domain_name]
 
   origin {
-    domain_name = local.origin_domain_name
-    origin_id   = local.default_origin_id
-    custom_origin_config {
-      http_port              = 80
-      https_port             = 443
-      origin_protocol_policy = var.cert_arn == null ? "http-only" : "https-only"
+    domain_name              = local.origin_domain_name
+    origin_id                = local.default_origin_id
+    origin_access_control_id = aws_cloudfront_origin_access_control.cdn[0].id
 
-      # See possible values here:
-      # https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_OriginSslProtocols.html
-      origin_ssl_protocols = local.ssl_protocols
+    dynamic "custom_origin_config" {
+      for_each = var.enable_alb_cdn ? [1] : []
+      content {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        # https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_OriginSslProtocols.html
+        origin_ssl_protocols = local.ssl_protocols
+      }
     }
     # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html
     dynamic "origin_shield" {
@@ -120,7 +126,6 @@ resource "aws_cloudfront_distribution" "cdn" {
   depends_on = [
     aws_s3_bucket_public_access_block.cdn[0],
     aws_s3_bucket_acl.cdn[0],
-    aws_s3_bucket_policy.cdn[0],
     aws_s3_bucket.cdn[0],
   ]
 


### PR DESCRIPTION
### Time to review: __4 mins__

## Context

I thought the S3 CDN would "just work" the way the ALB CDN did. This was a very incorrect assumption. The S3 CDN requires a large web of permissions 

## Changes proposed

Adds a bunch of IAM policies that roll up to: CDN can now access S3

## Testing

https://d3e8vod9uic4zv.cloudfront.net/bg.svg _(link will only work until the next time someone merges)_

<img width="1334" alt="image" src="https://github.com/user-attachments/assets/d983150b-879a-42ac-9228-b601c7e546e0" />
