### PR TITLE
[Issue #3585] update search beta alert messaging

### DIFF
--- a/frontend/src/app/[locale]/search/layout.tsx
+++ b/frontend/src/app/[locale]/search/layout.tsx
@@ -1,5 +1,6 @@
 import { SEARCH_CRUMBS } from "src/constants/breadcrumbs";
 
+import { useTranslations } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
 import { use } from "react";
 
@@ -19,9 +20,29 @@ export default function SearchLayout({
   const { locale } = use(params);
   setRequestLocale(locale);
 
+  const t = useTranslations("Search.beta_alert");
+
   return (
     <>
-      <BetaAlert containerClasses="margin-top-5" />
+      <BetaAlert
+        containerClasses="margin-top-5"
+        heading={t("alert_title")}
+        alertMessage={t.rich("alert", {
+          mailToGrants: (chunks) => (
+            <a href="mailto:simpler@grants.gov">{chunks}</a>
+          ),
+          bugReport: (chunks) => (
+            <a href="https://github.com/HHS/simpler-grants-gov/issues/new?template=1_bug_report.yml">
+              {chunks}
+            </a>
+          ),
+          featureRequest: (chunks) => (
+            <a href="https://github.com/HHS/simpler-grants-gov/issues/new?template=2_feature_request.yml">
+              {chunks}
+            </a>
+          ),
+        })}
+      />
       <Breadcrumbs breadcrumbList={SEARCH_CRUMBS} />
       <SearchCallToAction />
       {children}

--- a/frontend/src/components/BetaAlert.tsx
+++ b/frontend/src/components/BetaAlert.tsx
@@ -1,13 +1,20 @@
 import { useTranslations } from "next-intl";
+import { ReactNode } from "react";
 import { GridContainer, Alert as USWDSAlert } from "@trussworks/react-uswds";
 
-type Props = {
+type BetaAlertProps = {
   containerClasses?: string;
+  heading?: string;
+  alertMessage?: string | ReactNode;
 };
 
-const BetaAlert = ({ containerClasses }: Props) => {
+const BetaAlert = ({
+  containerClasses,
+  heading,
+  alertMessage,
+}: BetaAlertProps) => {
   const t = useTranslations("Beta_alert");
-  const alert = t.rich("alert", {
+  const defaultAlertMessage = t.rich("alert", {
     LinkToGrants: (content) => <a href="https://www.grants.gov">{content}</a>,
   });
 
@@ -17,10 +24,10 @@ const BetaAlert = ({ containerClasses }: Props) => {
         <USWDSAlert
           type="warning"
           headingLevel="h2"
-          heading={t("alert_title")}
+          heading={heading || t("alert_title")}
           noIcon
         >
-          {alert}
+          {alertMessage || defaultAlertMessage}
         </USWDSAlert>
       </GridContainer>
     </div>

--- a/frontend/src/components/search/SearchCallToAction.tsx
+++ b/frontend/src/components/search/SearchCallToAction.tsx
@@ -7,7 +7,6 @@ const SearchCallToAction: React.FC = () => {
 
   return (
     <>
-      {/* <BetaAlert /> */}
       <GridContainer>
         <h1 className="margin-0 tablet-lg:font-sans-xl desktop-lg:font-sans-2xl">
           {t("callToAction.title")}

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -624,6 +624,12 @@ export const messages = {
     exportButton: {
       title: "Export results",
     },
+    beta_alert: {
+      alert_title:
+        "We’re actively building this search experience. Help us improve!",
+      alert:
+        "Send your feedback to <mailToGrants>simpler@grants.gov</mailToGrants>. GitHub users can file tickets to <bugReport>report a bug</bugReport> or <featureRequest>request a feature</featureRequest>.",
+    },
   },
   Maintenance: {
     heading: "Simpler.Grants.gov Is Currently Undergoing Maintenance",

--- a/frontend/tests/components/BetaAlert.test.tsx
+++ b/frontend/tests/components/BetaAlert.test.tsx
@@ -8,4 +8,21 @@ describe("BetaAlert", () => {
     const hero = screen.getByTestId("beta-alert");
     expect(hero).toBeInTheDocument();
   });
+
+  it("overrides default messaging when specified", () => {
+    render(
+      <BetaAlert
+        heading="THIS HEADERING"
+        alertMessage="please display my beta alert message"
+      />,
+    );
+
+    const heading = screen.getByRole("heading");
+    expect(heading).toHaveTextContent("THIS HEADERING");
+
+    const alertMessage = screen.getByRole("paragraph");
+    expect(alertMessage).toHaveTextContent(
+      "please display my beta alert message",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #3585

### Time to review: __5 mins__

## Changes proposed
Updates the beta alert copy for only the search page. Since the beta alert messaging was previously static across the app this includes functionality to allow passing in override values.

## Context for reviewers
### Test steps

1. start a server on this branch with `npm run dev`
2. visit http://localhost:3000
3. _VERIFY_: home page beta alert still matches prod
4. visit http://localhost:3000/search
5. _VERIFY_: beta alert content matches requirements

## Additional information


<img width="1258" alt="Screenshot 2025-02-03 at 11 50 50 AM" src="https://github.com/user-attachments/assets/b1eb196c-d6ac-4e87-b728-4af1b4581fe8" />
