### PR TITLE
[Issue #3584] Remove references to the attachment type that we're no longer using

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -124,11 +124,9 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
   });
 
   const nofoPath =
-    opportunityData.attachments.filter(
-      (document) =>
-        document.opportunity_attachment_type ===
-        "notice_of_funding_opportunity",
-    )[0]?.download_path || "";
+    opportunityData.attachments.length === 1
+      ? opportunityData.attachments[0]?.download_path
+      : "";
 
   return (
     <div>

--- a/frontend/src/components/opportunity/OpportunityDocuments.tsx
+++ b/frontend/src/components/opportunity/OpportunityDocuments.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from "next-intl";
 import { Link, Table } from "@trussworks/react-uswds";
 
 interface OpportunityDocument {
-  opportunity_attachment_type: string;
   file_name: string;
   download_path: string;
   updated_at: string;
@@ -26,7 +25,6 @@ const DocumentTable = ({ documents }: OpportunityDocumentsProps) => {
     <>
       <thead>
         <tr>
-          <th scope="col">{t("table_col_category")}</th>
           <th scope="col">{t("table_col_file_name")}</th>
           <th scope="col">{t("table_col_last_updated")}</th>
         </tr>
@@ -34,12 +32,6 @@ const DocumentTable = ({ documents }: OpportunityDocumentsProps) => {
       <tbody>
         {documents.map((document, index) => (
           <tr key={index}>
-            <th data-label={t("table_col_category")} scope="row">
-              {document.opportunity_attachment_type ===
-              "notice_of_funding_opportunity"
-                ? t("type.funding_details")
-                : t("type.other")}
-            </th>
             <td data-label={t("table_col_file_name")}>
               <Link target="_blank" href={document.download_path}>
                 {document.file_name}

--- a/frontend/stories/components/opportunity/OpportunityDocuments.stories.tsx
+++ b/frontend/stories/components/opportunity/OpportunityDocuments.stories.tsx
@@ -12,13 +12,11 @@ export const Default = {
   args: {
     documents: [
       {
-        opportunity_attachment_type: "notice_of_funding_opportunity",
         file_name: "FundingInformation.pdf",
         download_path: "https://example.com",
         updated_at: "2021-10-01T00:00:00Z",
       },
       {
-        opportunity_attachment_type: "other",
         file_name: "File2_ExhibitB.pdf",
         download_path: "https://example.com",
         updated_at: "2021-10-01T00:00:00Z",

--- a/frontend/tests/components/opportunity/OpportunityDocuments.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDocuments.test.tsx
@@ -9,13 +9,11 @@ jest.mock("next-intl", () => ({
 
 const mockData = [
   {
-    opportunity_attachment_type: "notice_of_funding_opportunity",
     file_name: "FundingInformation.pdf",
     download_path: "https://example.com",
     updated_at: "2021-10-01T00:00:00Z",
   },
   {
-    opportunity_attachment_type: "other",
     file_name: "File2_ExhibitB.pdf",
     download_path: "https://example.com",
     updated_at: "2021-10-01T00:00:00Z",


### PR DESCRIPTION
## Summary
Fixes #3584

### Time to review: __3 mins__

## Changes proposed
Remove references to the attachment_type which is depreciated on the backend. 

## Context for reviewers
Testing is limited locally, so I was able to verify that some of this works, but real test will be in Dev:
✅ One attachment: http://localhost:3000/opportunity/155
<img width="839" alt="image" src="https://github.com/user-attachments/assets/bc2a5e18-5f9b-417d-84d7-84cb99f01d22" />
<img width="790" alt="image" src="https://github.com/user-attachments/assets/3232bb2d-e373-4114-87c9-f23f0bbdfed0" />

✅ Two attachments: http://localhost:3000/opportunity/152 
<img width="837" alt="image" src="https://github.com/user-attachments/assets/08d6282c-82c9-41a1-9566-87148f965425" />


