### PR TITLE
[unticketed] fix webkit / chrome error with csv download filename

### DIFF
--- a/frontend/src/services/fetch/fetchers/clientSearchResultsDownloadFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientSearchResultsDownloadFetcher.ts
@@ -1,4 +1,7 @@
+"use client";
+
 import { getConfiguredDayJs } from "src/utils/dateUtil";
+import { saveBlobToFile } from "src/utils/generalUtils";
 
 import { ReadonlyURLSearchParams } from "next/navigation";
 
@@ -17,16 +20,9 @@ export const downloadSearchResultsCSV = async (
       throw new Error(`Unsuccessful csv download. ${response.status}`);
     }
     const csvBlob = await response.blob();
-    location.assign(
-      URL.createObjectURL(
-        new File(
-          [csvBlob],
-          `grants-search-${getConfiguredDayJs()(new Date()).format("YYYYMMDDHHmm")}.csv`,
-          {
-            type: "data:text/csv",
-          },
-        ),
-      ),
+    saveBlobToFile(
+      csvBlob,
+      `grants-search-${getConfiguredDayJs()(new Date()).format("YYYYMMDDHHmm")}.csv`,
     );
   } catch (e) {
     console.error(e);

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -96,3 +96,18 @@ export const encodeText = (valueToEncode: string) =>
 export const stringToBoolean = (
   mightRepresentABoolean: string | undefined,
 ): boolean => mightRepresentABoolean === "true";
+
+// a hack to get filenames to work on blob based downloads across all browsers
+// see https://stackoverflow.com/a/48968694
+export const saveBlobToFile = (blob: Blob, filename: string) => {
+  const temporaryLink = document.createElement("a");
+  document.body.appendChild(temporaryLink);
+  const url = window.URL.createObjectURL(blob);
+  temporaryLink.href = url;
+  temporaryLink.download = filename;
+  temporaryLink.click();
+  setTimeout(() => {
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(temporaryLink);
+  }, 0);
+};

--- a/frontend/tests/e2e/search/search-download.spec.ts
+++ b/frontend/tests/e2e/search/search-download.spec.ts
@@ -14,6 +14,6 @@ test.describe("Search results export", () => {
       .locator('div[data-testid="search-download-button-container"] > button')
       .click();
     const download = await downloadPromise;
-    expect(download.url()).toBeTruthy();
+    expect(download.suggestedFilename()).toMatch(/grants-search-\d+\.csv/);
   });
 });


### PR DESCRIPTION
## Summary
Unticketed

### Time to review: __10 mins__

## Changes proposed
https://github.com/HHS/simpler-grants-gov/pull/3689 introduced search results csv downloads but on all browsers other than Firefox, the files were not downloading with the proper file names. This fix is a bit of a hack, but one that was used by FileSaver.js, which people probably still use! https://github.com/eligrey/FileSaver.js/blob/master/src/FileSaver.js

## Context for reviewers
The new function here is not covered by unit tests, but I did improve the e2e test around the functionality.
### Test steps
1. `npm run dev` in this branch
2. visit http://localhost:3000/search
3. click "export results"
4. _VERIFY_: file downloads with filename matching `grants-search-<timestamp>.csv`
5. repeat steps 2 - 4 for every browser you have available


## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

