### PR TITLE
[Unticketed] Adjust the batch size of the attachment job to be 100

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
+++ b/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
@@ -43,11 +43,9 @@ class TransformOpportunityAttachment(AbstractTransformSubTask):
             TsynopsisAttachment,
             OpportunityAttachment,
             [TsynopsisAttachment.syn_att_id == OpportunityAttachment.attachment_id],
-            batch_size=(
-                self.attachment_config.total_attachments_to_process
-                if self.attachment_config.total_attachments_to_process
-                else 1000
-            ),
+            # We load opportunity attachments into memory, so need to process very small batches
+            # to avoid running out of memory.
+            batch_size=100,
         )
 
         self.process_opportunity_attachment_group(records)


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Change the opportunity attachment job to process 100 attachments at a time

## Context for reviewers
This means we'll fetch 100 attachments at a time into memory - instead of 1000+ like we were previously doing

Doing this because I hit an out-of-memory error on the ECS task when running - not 100% certain this will work (depends on how the ORM cache works?) but want to test it.

