### PR TITLE
[Issue #3788] Include protocol when defining CDN_URL

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -46,7 +46,7 @@ locals {
     { name : "DB_SCHEMA", value : var.db_vars.connection_info.schema_name },
   ]
   cdn_environment_variables = local.enable_cdn ? [
-    { name : "CDN_URL", value : local.cdn_domain_name_env_var },
+    { name : "CDN_URL", value : "https://${local.cdn_domain_name_env_var}" },
   ] : []
   environment_variables = concat(
     local.base_environment_variables,


### PR DESCRIPTION
## Summary
Fixes #3788 

### Time to review: __1 mins__

## Changes proposed
The links in the API need to include the protocol, at the terraform level we transition from domain name to URL without adding the protocol, so injecting it there seems like the most logical place.

## Context for reviewers
URLs were missing a protocol, so the browser interprets them as a relative URL in the FE and other API consumers would have needed to know to add an https://

