### PR TITLE
docs: small updates to docs to optimize dev setup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -30,8 +30,6 @@
 
 ### Running the app locally
 
-Before running the server, duplicate the `/frontend/env.development` file and name the copy `/frontend/.env.local`, in order to avoid checking in any sensitive data to Github.
-
 From the `/frontend` directory:
 
 1. Install dependencies
@@ -41,6 +39,10 @@ From the `/frontend` directory:
 1. Optionally, disable [telemetry data collection](https://nextjs.org/telemetry)
    ```bash
    npx next telemetry disable
+   ```
+1. Create local environment file
+   ```bash
+   cp .env.development .env.local
    ```
 1. Run the local development server
    ```bash


### PR DESCRIPTION
## Summary
Fixes N/A

### Time to review: 2 mins

## Changes proposed
As a new contributor, I noticed during my frontend dev setup that I missed the "step" for copying over the `.env.development` to `.env.local`. I believe this happened due to a small typo in the original documentation (`/frontend/env.development` instead of `/frontend/.env.development` - notice the **dot** in front of env). So I just created the actual step of copying the environment variable file in the numbered list of steps.

## Context for reviewers
I wanted to get some thoughts about this change. I'm hoping it can optimize the speed of the local environment setup for new contributors. Thank you!

## Additional information
N/A

