### PR TITLE
[no ticket] Fix codeowners ordering probably

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 
 * @mdragon # project lead
 
+/documentation/  @acouch @andycochran @btabaska @chouinar @coilysiren @doug-s-nava @mdragon @widal001 # everyone
+
 /analytics/               @acouch @coilysiren @widal001
 /documentation/analytics/ @acouch @coilysiren @widal001
 
@@ -15,5 +17,3 @@
 /documentation/infra/ @acouch @coilysiren @mdragon
 /.github/             @acouch @coilysiren @mdragon
 /bin/                 @acouch @coilysiren @mdragon
-
-/documentation/  @acouch @andycochran @btabaska @chouinar @coilysiren @doug-s-nava @mdragon @widal001 # everyone


### PR DESCRIPTION
## Context

Recently I've noticed that too many people have been getting tagged on documentation PRs. I wondered why this is. Well! Turns out codeowners files are evaluated top to bottom. So the more generic paths should come first.