### PR TITLE
[Issue #3822] Modify our PII logging mask to allow long floats

### DIFF
--- a/api/src/logging/pii.py
+++ b/api/src/logging/pii.py
@@ -56,12 +56,12 @@ def mask_pii(record: logging.LogRecord) -> bool:
 # Regular expression to match a tax identifier (SSN), 9 digits with optional dashes.
 # Matches between word boundaries (\b), except when:
 #  - Preceded by word character and dash (e.g. "ip-10-11-12-134")
-#  - Followed by a dot and digit, for decimal numbers (e.g. 999000000.5)
-# See https://docs.python.org/3/library/re.html#regular-expression-syntax
+#  - Preceded by or followed by a decimal point (for floating point numbers)
 TIN_RE = re.compile(
     r"""
         \b          # word boundary
         (?<!\w-)    # not preceded by word character and dash
+        (?<!\.)     # not preceded by decimal point
         (\d-?){8}   # digit then optional dash, 8 times
         \d          # last digit
         \b          # word boundary

--- a/api/tests/src/logging/test_pii.py
+++ b/api/tests/src/logging/test_pii.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 import src.logging.pii as pii
@@ -26,3 +28,40 @@ import src.logging.pii as pii
 )
 def test_mask_pii(input, expected):
     assert pii._mask_pii(input) == expected
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_output",
+    [
+        # Basic SSN patterns that should be masked
+        ("123456789", "*********"),
+        ("123-45-6789", "*********"),
+        # IP addresses that should not be masked
+        ("ip-10-11-12-134", "ip-10-11-12-134"),
+        # Floating point numbers that should not be masked
+        ("5.999000000", "5.999000000"),
+        ("999000000.5", "999000000.5"),
+        ("0.999000000", "0.999000000"),
+        ("999.000000", "999.000000"),
+        # Mixed content
+        ("SSN: 123456789 Amount: 999000000.5", "SSN: ********* Amount: 999000000.5"),
+        ("IP: ip-10-11-12-134 SSN: 123-45-6789", "IP: ip-10-11-12-134 SSN: *********"),
+    ],
+)
+def test_mask_pii_logging_floats(input_value, expected_output):
+    # Create a LogRecord with the test value
+    record = logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg=input_value,
+        args=(),
+        exc_info=None,
+    )
+
+    # Apply PII masking
+    pii.mask_pii(record)
+
+    # Check that the message was properly masked
+    assert record.msg == expected_output


### PR DESCRIPTION
## Summary
Fixes #3822 

### Time to review: 5 mins

## Changes proposed
Modify our PII logging mask
Add unit test

## Context for reviewers
We've encountered an odd bug that causes random errors with our logic to mask PII from logs: https://github.com/HHS/simpler-grants-gov/actions/runs/13246291300/job/36973529031

The error is ultimately due to our process that masks PII information replacing a float/timestamp with ********* and then the formatting in the logger breaking.

https://github.com/HHS/simpler-grants-gov/blob/main/api/src/logging/pii.py

This masking process happens on every log record, and it checks every part of the log message if it contains a certain regex that looks like an SSN (9 digits in a row, optionally separated by dashes) and replaces it with *********. There are already some rules built into this to not replace if we think it's a floating point number, but it only handles the integer half (eg. 999000000.5 is unmodified, but not 5.999000000). We should fix that

## Additional information
See unit test

