### PR TITLE
[Issue #3773] Fix task logic when an error occurs when attempting to write to the DB

### DIFF
--- a/api/src/task/task.py
+++ b/api/src/task/task.py
@@ -3,7 +3,6 @@ import logging
 import time
 from enum import StrEnum
 from typing import Any
-from sqlalchemy import exc
 
 import src.adapters.db as db
 from src.db.models.task_models import JobLog, JobStatus

--- a/api/src/task/task.py
+++ b/api/src/task/task.py
@@ -3,6 +3,7 @@ import logging
 import time
 from enum import StrEnum
 from typing import Any
+from sqlalchemy import exc
 
 import src.adapters.db as db
 from src.db.models.task_models import JobLog, JobStatus
@@ -40,11 +41,6 @@ class Task(abc.ABC, metaclass=abc.ABCMeta):
             self.db_session.add(self.job)
             self.db_session.commit()
 
-            # Create initial job record
-            self.job = JobLog(job_type=self.cls_name(), job_status=JobStatus.STARTED)
-            self.db_session.add(self.job)
-            self.db_session.commit()
-
             # Initialize the metrics
             self.initialize_metrics()
 
@@ -65,13 +61,12 @@ class Task(abc.ABC, metaclass=abc.ABCMeta):
             raise
         finally:
             job_status = JobStatus.COMPLETED if job_succeeded else JobStatus.FAILED
-            # If the session is active, we can commit the job update
-            if job_succeeded:
-                self.update_job(job_status, metrics=self.metrics)
-            else:
-                # If the session is not active due to an error upstream, we need to begin a new transaction
-                with self.db_session.begin():
-                    self.update_job(job_status, metrics=self.metrics)
+
+            # Rollback if the session is not active due to error above
+            if not self.db_session.is_active:
+                self.db_session.rollback()
+
+            self.update_job(job_status, metrics=self.metrics)
 
     def initialize_metrics(self) -> None:
         zero_metrics_dict: dict[str, Any] = {metric: 0 for metric in self.Metrics}

--- a/api/tests/src/task/test_task.py
+++ b/api/tests/src/task/test_task.py
@@ -1,5 +1,5 @@
 import pytest
-from sqlalchemy.exc import InvalidRequestError, IntegrityError
+from sqlalchemy.exc import IntegrityError, InvalidRequestError
 
 from src.db.models.extract_models import ExtractMetadata
 from src.db.models.task_models import JobLog, JobStatus

--- a/api/tests/src/task/test_task.py
+++ b/api/tests/src/task/test_task.py
@@ -91,6 +91,10 @@ def test_successful_task_completion(db_session):
 
 def test_task_handles_duplicate_key_error(db_session, enable_factory_create):
     """Test that task properly handles SQLAlchemy errors e.g. integrity errors"""
+    # Clear any existing ExtractMetadata records
+    db_session.query(ExtractMetadata).delete()
+    db_session.commit()
+
     task = DuplicateKeyTask(db_session)
 
     with pytest.raises(IntegrityError):


### PR DESCRIPTION
## Summary
Fixes #3773

### Time to review: 10 mins

## Changes proposed
Update task runner to handle SQLAlchemy db errors, including rolling back if needed before committing the `JobLog` record.

## Context for reviewers
When we hit an error in one of our tasks, if the error is due to a database issue (let's say a unique constraint being violated) an error will be thrown, but the transaction is still active. When we go to update the job table, we run into an issue as the transaction is still "begun" and we get an error saying we can't start a new transaction.

## Additional information
See unit test to cover db failing scenario

