### PR TITLE
[Issue #3852] Initialize background task app properly for New Relic

### DIFF
--- a/api/src/task/ecs_background_task.py
+++ b/api/src/task/ecs_background_task.py
@@ -48,11 +48,13 @@ def ecs_background_task(task_name: str) -> Callable[[Callable[P, T]], Callable[P
     def decorator(f: Callable[P, T]) -> Callable[P, T]:
         @wraps(f)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            with _ecs_background_task_impl(task_name):
-                # Finally execute the function with New Relic instrumentation
-                return newrelic.agent.background_task(name=task_name, group="Python/ECSTask")(f)(
-                    *args, **kwargs
-                )
+            # Wrap with New Relic instrumentation
+            application = newrelic.agent.register_application(timeout=10.0)
+            with newrelic.agent.BackgroundTask(application, name=task_name, group="Python/ECSTask"):
+                # Wrap with our own logging (timing/general logs)
+                with _ecs_background_task_impl(task_name):
+                    # Finally actually run the task
+                    return f(*args, **kwargs)
 
         return wrapper
 


### PR DESCRIPTION
## Summary
Fixes #3852

### Time to review: __2 mins__

## Changes proposed
Initialize an "application" for New Relic before starting the New Relic background task

## Context for reviewers
From reading the docs, initializing the application is necessary when running outside of our normal API approach (which initializes automatically on first request). The whole background app thing is to separate our API metrics from the backend ECS task metrics (for example, slow DB queries are much more impactful in an API call than some ECS task).

## Additional information
I set the newrelic key locally, and ran some of our scripts, they now appear as "transactions" under the non-web transcation type:
![Screenshot 2025-02-13 at 12 32 10 PM](https://github.com/user-attachments/assets/cdac74e8-afd2-476d-90eb-423e51aeefc9)

