### PR TITLE
[no ticket] frontend has no database

### DIFF
--- a/infra/frontend/app-config/main.tf
+++ b/infra/frontend/app-config/main.tf
@@ -10,7 +10,7 @@ locals {
   # 2. Each environment's config will have a database_config property that is used to
   #    pass db_vars into the infra/modules/service module, which provides the necessary
   #    configuration for the service to access the database
-  has_database = true
+  has_database = false
 
   # Whether or not the application depends on external non-AWS services.
   # If enabled, the networks associated with this application's environments

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -145,9 +145,6 @@ module "service" {
 
   enable_alb_cdn = true
 
-  app_access_policy_arn      = null
-  migrator_access_policy_arn = null
-
   extra_environment_variables = merge({
     # FEATURE_FLAGS_PROJECT = module.feature_flags.evidently_project_name
     # BUCKET_NAME           = local.storage_config.bucket_name


### PR DESCRIPTION
## Context

followup from: https://github.com/HHS/simpler-grants-gov/commit/9eca4df4f71f403c07165a5a3e71b02888daa529

The infra template changed the default value of "has database" from false to true, which resulted in the frontend trying to deploy a database