### PR TITLE
[Issue #3504] Return user to their original page after login

### DIFF
--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -3,33 +3,28 @@
 import SessionStorage from "src/utils/sessionStorage";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 export default function Login() {
-  const redirecting = useRef<boolean>(false);
   const router = useRouter();
 
-  useEffect((): void => {
+  useEffect(() => {
     if (typeof window !== "undefined") {
-      // without this check, even wrapped in a useEffect this would fire twice and the second time redirect to / because sessionStorage was empty.
-      if (!redirecting.current) {
-        redirecting.current = true;
-        const redirectURL = SessionStorage.getItem("login-redirect");
-        SessionStorage.removeItem("login-redirect");
+      const redirectURL = SessionStorage.getItem("login-redirect");
+      SessionStorage.removeItem("login-redirect");
 
-        if (
-          redirectURL === null ||
-          redirectURL === "" ||
-          redirectURL.substring(0, 1) !== "/"
-        ) {
-          router.push("/");
-          return;
-        }
-
-        router.push(redirectURL);
+      if (
+        redirectURL === null ||
+        redirectURL === "" ||
+        redirectURL.substring(0, 1) !== "/"
+      ) {
+        router.push("/");
       }
+      router.push(redirectURL || "/");
+      return () => SessionStorage.removeItem("login-redirect");
+    } else {
+      console.error("window is undefined");
     }
   }, [router]);
-
   return <>Redirecting...</>;
 }

--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -12,7 +12,11 @@ export default function Login() {
       const redirectURL = window?.sessionStorage?.getItem("login-redirect");
       window?.sessionStorage?.removeItem("login-redirect");
 
-      if (redirectURL === null || redirectURL === "") {
+      if (
+        redirectURL === null ||
+        redirectURL === "" ||
+        redirectURL.substring(0, 1) !== "/"
+      ) {
         window.location.assign("/");
         return;
       }

--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import SessionStorage from "src/utils/sessionStorage";
+
 import { useRef } from "react";
 
 export default function Login() {
@@ -9,8 +11,8 @@ export default function Login() {
     // without this check, even wrapped in a useEffect this would fire twice and the second time redirect to / because sessionStorage was empty.
     if (!redirecting.current) {
       redirecting.current = true;
-      const redirectURL = window?.sessionStorage?.getItem("login-redirect");
-      window?.sessionStorage?.removeItem("login-redirect");
+      const redirectURL = SessionStorage.getItem("login-redirect");
+      SessionStorage.removeItem("login-redirect");
 
       if (
         redirectURL === null ||

--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 export default function Login() {
   const redirecting = useRef<boolean>(false);

--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export default function Login() {
+  const redirecting = useRef<boolean>(false);
+
+  if (typeof window !== "undefined") {
+    // without this check, even wrapped in a useEffect this would fire twice and the second time redirect to / because sessionStorage was empty.
+    if (!redirecting.current) {
+      redirecting.current = true;
+      const redirectURL = window?.sessionStorage?.getItem("login-redirect");
+      window?.sessionStorage?.removeItem("login-redirect");
+
+      if (redirectURL === null || redirectURL === "") {
+        window.location.assign("/");
+        return;
+      }
+
+      window.location.assign(redirectURL);
+
+      return <>Redirecting...</>;
+    }
+  }
+}

--- a/frontend/src/app/[locale]/login/page.tsx
+++ b/frontend/src/app/[locale]/login/page.tsx
@@ -2,30 +2,34 @@
 
 import SessionStorage from "src/utils/sessionStorage";
 
-import { useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef } from "react";
 
 export default function Login() {
   const redirecting = useRef<boolean>(false);
+  const router = useRouter();
 
-  if (typeof window !== "undefined") {
-    // without this check, even wrapped in a useEffect this would fire twice and the second time redirect to / because sessionStorage was empty.
-    if (!redirecting.current) {
-      redirecting.current = true;
-      const redirectURL = SessionStorage.getItem("login-redirect");
-      SessionStorage.removeItem("login-redirect");
+  useEffect((): void => {
+    if (typeof window !== "undefined") {
+      // without this check, even wrapped in a useEffect this would fire twice and the second time redirect to / because sessionStorage was empty.
+      if (!redirecting.current) {
+        redirecting.current = true;
+        const redirectURL = SessionStorage.getItem("login-redirect");
+        SessionStorage.removeItem("login-redirect");
 
-      if (
-        redirectURL === null ||
-        redirectURL === "" ||
-        redirectURL.substring(0, 1) !== "/"
-      ) {
-        window.location.assign("/");
-        return;
+        if (
+          redirectURL === null ||
+          redirectURL === "" ||
+          redirectURL.substring(0, 1) !== "/"
+        ) {
+          router.push("/");
+          return;
+        }
+
+        router.push(redirectURL);
       }
-
-      window.location.assign(redirectURL);
-
-      return <>Redirecting...</>;
     }
-  }
+  }, [router]);
+
+  return <>Redirecting...</>;
 }

--- a/frontend/src/app/api/auth/callback/route.ts
+++ b/frontend/src/app/api/auth/callback/route.ts
@@ -11,7 +11,9 @@ export async function GET(request: NextRequest) {
   try {
     await createSession(token);
   } catch (_e) {
+    console.error("Error creating session for token", { token });
+    console.error(_e);
     return redirect("/error");
   }
-  return redirect("/");
+  return redirect("/login");
 }

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -47,7 +47,17 @@ export const LoginModal = ({
       </div>
       <ModalFooter>
         <ButtonGroup>
-          <a href={LOGIN_URL} key="login-link" className="usa-button">
+          <a
+            href={LOGIN_URL}
+            key="login-link"
+            className="usa-button"
+            onClick={(e) => {
+              const startURL = `${location.pathname}${location.search}`;
+              if (startURL !== "") {
+                window?.sessionStorage?.setItem("login-redirect", startURL);
+              }
+            }}
+          >
             {buttonText}
             <USWDSIcon
               className="usa-icon margin-right-05 margin-left-neg-05"

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -1,5 +1,7 @@
 "use-client";
 
+import SessionStorage from "src/utils/sessionStorage";
+
 import { RefObject } from "react";
 import {
   ButtonGroup,
@@ -51,10 +53,10 @@ export const LoginModal = ({
             href={LOGIN_URL}
             key="login-link"
             className="usa-button"
-            onClick={(e) => {
+            onClick={() => {
               const startURL = `${location.pathname}${location.search}`;
               if (startURL !== "") {
-                window?.sessionStorage?.setItem("login-redirect", startURL);
+                SessionStorage.setItem("login-redirect", startURL);
               }
             }}
           >

--- a/frontend/src/utils/sessionStorage.ts
+++ b/frontend/src/utils/sessionStorage.ts
@@ -1,0 +1,52 @@
+class SessionStorage {
+  static isSessionStorageAvailable(): boolean {
+    try {
+      return (
+        typeof window !== "undefined" &&
+        typeof window.sessionStorage !== "undefined"
+      );
+    } catch (error) {
+      console.error(`sessionStorage is not available:`, error);
+      return false;
+    }
+  }
+
+  static setItem(key: string, value: string): void {
+    if (!this.isSessionStorageAvailable()) return;
+    try {
+      sessionStorage.setItem(key, value);
+    } catch (error) {
+      console.error(`Error setting sessionStorage item:`, error);
+    }
+  }
+
+  static getItem(key: string): string | null {
+    if (!this.isSessionStorageAvailable()) return null;
+    try {
+      return sessionStorage.getItem(key);
+    } catch (error) {
+      console.error(`Error getting sessionStorage item:`, error);
+      return null;
+    }
+  }
+
+  static removeItem(key: string): void {
+    if (!this.isSessionStorageAvailable()) return;
+    try {
+      sessionStorage.removeItem(key);
+    } catch (error) {
+      console.error(`Error removing sessionStorage item:`, error);
+    }
+  }
+
+  static clear(): void {
+    if (!this.isSessionStorageAvailable()) return;
+    try {
+      sessionStorage.clear();
+    } catch (error) {
+      console.error(`Error clearing sessionStorage:`, error);
+    }
+  }
+}
+
+export default SessionStorage;

--- a/frontend/tests/api/auth/callback/route.test.ts
+++ b/frontend/tests/api/auth/callback/route.test.ts
@@ -24,7 +24,7 @@ describe("/api/auth/callback GET handler", () => {
 
     expect(createSessionMock).toHaveBeenCalledTimes(1);
     expect(createSessionMock).toHaveBeenCalledWith("fakeToken");
-    expect(redirectError.digest).toContain(";/;");
+    expect(redirectError.digest).toContain(";/login;");
   });
 
   it("if no token exists on query param, does not call createSession and redirects to unauthorized page", async () => {

--- a/frontend/tests/utils/getRoutes.test.ts
+++ b/frontend/tests/utils/getRoutes.test.ts
@@ -29,6 +29,7 @@ describe("getNextRoutes", () => {
       "/dev/feature-flags",
       "/error",
       "/health",
+      "/login",
       "/maintenance",
       "/opportunity/1",
       "/",


### PR DESCRIPTION
## Summary
Fixes #3504 

### Time to review: __5 mins__

## Changes proposed
* When the user clicks "Sign in," before sending them to the API to redirect the user on to Login.gov we record the current path and query string to session storage.
* Upon returning from Login.gov we have the Nest Server page that gets redirected to by the API in turn send the user to /login a client side route where we can read the session storage and redirect the user to their original page where they clicked to "Sign in"

## Context for reviewers
1. Sign out if Signed in
2. You can go to any page on the site, and click Sign in
3. After returning from Login.gov you should find yourself back on the original page
4. Sign out again
5. Add some query params to the URL
6. Click Sign in
7. After returning from Login.gov you should find yourself back on the original page with the query params intact.
