### PR TITLE
[Issue #3849] Remove historical transforms from funding instrument [3/4] 

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_funding_instrument.py
+++ b/api/src/data_migration/transformation/subtask/transform_funding_instrument.py
@@ -10,8 +10,8 @@ from src.db.models.opportunity_models import (
     LinkOpportunitySummaryFundingInstrument,
     OpportunitySummary,
 )
-from src.db.models.staging.forecast import TfundinstrForecast, TfundinstrForecastHist
-from src.db.models.staging.synopsis import TfundinstrSynopsis, TfundinstrSynopsisHist
+from src.db.models.staging.forecast import TfundinstrForecast
+from src.db.models.staging.synopsis import TfundinstrSynopsis
 
 logger = logging.getLogger(__name__)
 
@@ -37,22 +37,6 @@ class TransformFundingInstrument(AbstractTransformSubTask):
         )
         self.process_link_funding_instruments_group(forecast_funding_instrument_records)
 
-        logger.info("Processing historical forecast funding instruments")
-        forecast_funding_instrument_hist_records = self.fetch_with_opportunity_summary(
-            TfundinstrForecastHist,
-            link_table,
-            [
-                TfundinstrForecastHist.fi_frcst_id
-                == LinkOpportunitySummaryFundingInstrument.legacy_funding_instrument_id,
-                OpportunitySummary.opportunity_summary_id
-                == LinkOpportunitySummaryFundingInstrument.opportunity_summary_id,
-            ],
-            is_forecast=True,
-            is_historical_table=True,
-            relationship_load_value=relationship_load_value,
-        )
-        self.process_link_funding_instruments_group(forecast_funding_instrument_hist_records)
-
         logger.info("Processing synopsis funding instruments")
         synopsis_funding_instrument_records = self.fetch_with_opportunity_summary(
             TfundinstrSynopsis,
@@ -68,22 +52,6 @@ class TransformFundingInstrument(AbstractTransformSubTask):
             relationship_load_value=relationship_load_value,
         )
         self.process_link_funding_instruments_group(synopsis_funding_instrument_records)
-
-        logger.info("Processing historical synopsis funding instruments")
-        synopsis_funding_instrument_hist_records = self.fetch_with_opportunity_summary(
-            TfundinstrSynopsisHist,
-            link_table,
-            [
-                TfundinstrSynopsisHist.fi_syn_id
-                == LinkOpportunitySummaryFundingInstrument.legacy_funding_instrument_id,
-                OpportunitySummary.opportunity_summary_id
-                == LinkOpportunitySummaryFundingInstrument.opportunity_summary_id,
-            ],
-            is_forecast=False,
-            is_historical_table=True,
-            relationship_load_value=relationship_load_value,
-        )
-        self.process_link_funding_instruments_group(synopsis_funding_instrument_hist_records)
 
     def process_link_funding_instruments_group(
         self,

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_funding_instrument.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_funding_instrument.py
@@ -126,12 +126,15 @@ class TestTransformFundingInstrument(BaseTransformTestClass):
         assert metrics[transform_constants.Metrics.TOTAL_RECORDS_UPDATED] == 1
         assert transform_constants.Metrics.TOTAL_ERROR_COUNT not in metrics
 
-    @pytest.mark.parametrize("is_forecast,revision_number", [(True, None), (False, None)])
+    @pytest.mark.parametrize("is_forecast", [True, False])
     def test_process_funding_instrument_but_current_missing(
-        self, db_session, transform_funding_instrument, is_forecast, revision_number
+        self,
+        db_session,
+        transform_funding_instrument,
+        is_forecast,
     ):
         opportunity_summary = f.OpportunitySummaryFactory.create(
-            is_forecast=is_forecast, revision_number=revision_number, no_link_values=True
+            is_forecast=is_forecast, no_link_values=True
         )
         delete_but_current_missing = setup_funding_instrument(
             create_existing=False,
@@ -149,19 +152,18 @@ class TestTransformFundingInstrument(BaseTransformTestClass):
         assert delete_but_current_missing.transformation_notes == "orphaned_delete_record"
 
     @pytest.mark.parametrize(
-        "is_forecast,revision_number,legacy_lookup_value",
-        [(True, None, "X"), (False, None, "4"), (True, 5, "Y"), (False, 10, "A")],
+        "is_forecast,legacy_lookup_value",
+        [(True, "X"), (False, "4"), (True, "Y"), (False, "A")],
     )
     def test_process_funding_instrument_but_invalid_lookup_value(
         self,
         db_session,
         transform_funding_instrument,
         is_forecast,
-        revision_number,
         legacy_lookup_value,
     ):
         opportunity_summary = f.OpportunitySummaryFactory.create(
-            is_forecast=is_forecast, revision_number=revision_number, no_link_values=True
+            is_forecast=is_forecast, no_link_values=True
         )
         insert_but_invalid_value = setup_funding_instrument(
             create_existing=False,


### PR DESCRIPTION
## Summary
Partially fixes #3849

### Time to review: 15 mins

## Changes proposed
Modify funding instrument transforms and tests to remove legacy history table processing.

## Context for reviewers
This is PR 3/4

## Additional information
See updated unit tests

