### PR TITLE
[Unticketed] Adjust describe-log-streams command to not use query

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -144,7 +144,7 @@ while true; do
     echo "Timing out task $ecs_task_id waiting for logs"
     exit 1
   fi
-  is_log_stream_created=$(aws logs describe-log-streams --no-cli-pager --log-group-name "$log_group" --query "length(logStreams[?logStreamName==\`$log_stream\`])")
+  is_log_stream_created=$(aws logs describe-log-streams --no-cli-pager --log-group-name "$log_group" --log-stream-name-prefix "$log_stream" | jq -r '.logStreams | length')
   if [ "$is_log_stream_created" == "1" ]; then
     break
   fi


### PR DESCRIPTION
## Summary

### Time to review: __3 mins__

## Changes proposed
Change the run-command script we use for running ECS tasks to filter the log stream using `--log-stream-name-prefix` instead of `--query`

## Context for reviewers
We were seeing two issues that this hopefully resolves:
* This command was taking 7+ minutes to resolve
* This command frequently was getting rate limited and failing deployments (likely due to a lot of internal queries)

Testing this change to run an ECS task locally, it takes 1~2 seconds to run now

## Additional information
Was able to successfully use the script to run the transform script (setup to no-op), and did not need to wait long for logs to start flowing.

