### PR TITLE
[Issue 2968] Add execution timers to ETL workflow logging

### DIFF
--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -2,9 +2,9 @@
 # pylint: disable=C0415
 """Expose a series of CLI entrypoints for the analytics package."""
 
-import time
 import logging
 import logging.config
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated
@@ -89,7 +89,7 @@ def export_github_data(
     start_time = time.perf_counter()
     GitHubProjectETL(config).run()
     end_time = time.perf_counter()
-    logger.info("extract workflow executed in %.5f seconds", end_time-start_time)
+    logger.info("extract workflow executed in %.5f seconds", end_time - start_time)
 
 
 # ===========================================================
@@ -154,7 +154,7 @@ def transform_and_load(
     # sync data to db
     etldb.sync_data(dataset, datestamp)
     end_time = time.perf_counter()
-    logger.info("transform and load executed in %.5f seconds", end_time-start_time)
+    logger.info("transform and load executed in %.5f seconds", end_time - start_time)
 
 
 @etl_app.command(name="extract_transform_and_load")
@@ -183,7 +183,7 @@ def extract_transform_and_load(
     start_time = time.perf_counter()
     extracted_json = GitHubProjectETL(config).extract_and_transform_in_memory()
     end_time = time.perf_counter()
-    logger.info("extract executed in %.5f seconds", end_time-start_time)
+    logger.info("extract executed in %.5f seconds", end_time - start_time)
 
     # hydrate a dataset instance from the input data
     logger.info("transforming and loading data")
@@ -192,7 +192,7 @@ def extract_transform_and_load(
     # sync dataset to db
     etldb.sync_data(dataset, datestamp)
     end_time = time.perf_counter()
-    logger.info("transform and load executed in %.5f seconds", end_time-start_time)
+    logger.info("transform and load executed in %.5f seconds", end_time - start_time)
 
     logger.info("ETL workflow is done")
 

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -2,6 +2,7 @@
 # pylint: disable=C0415
 """Expose a series of CLI entrypoints for the analytics package."""
 
+import time
 import logging
 import logging.config
 from datetime import datetime
@@ -82,8 +83,13 @@ def export_github_data(
     config = load_config(config_path, GitHubProjectConfig)
     config.temp_dir = temp_dir
     config.output_file = output_file
+
     # Run ETL pipeline
+    logger.info("running extract workflow")
+    start_time = time.perf_counter()
     GitHubProjectETL(config).run()
+    end_time = time.perf_counter()
+    logger.info("extract workflow executed in %.5f seconds", end_time-start_time)
 
 
 # ===========================================================
@@ -140,16 +146,15 @@ def transform_and_load(
             "FATAL ERROR: malformed effective date, expected YYYY-MM-DD format",
         )
         return
-    logger.info("running transform and load with effective date %s", datestamp)
+    logger.info("running transform and load workflow with effective date %s", datestamp)
 
     # hydrate a dataset instance from the input data
+    start_time = time.perf_counter()
     dataset = EtlDataset.load_from_json_file(file_path=issue_file)
-
     # sync data to db
     etldb.sync_data(dataset, datestamp)
-
-    # finish
-    logger.info("transform and load is done")
+    end_time = time.perf_counter()
+    logger.info("transform and load executed in %.5f seconds", end_time-start_time)
 
 
 @etl_app.command(name="extract_transform_and_load")
@@ -171,20 +176,25 @@ def extract_transform_and_load(
             "FATAL ERROR: malformed effective date, expected YYYY-MM-DD format",
         )
         return
-    logger.info("running extract transform and load with effective date %s", datestamp)
+    logger.info("running ETL workflow with effective date %s", datestamp)
 
     # extract data from GitHub
     logger.info("extracting data from GitHub")
+    start_time = time.perf_counter()
     extracted_json = GitHubProjectETL(config).extract_and_transform_in_memory()
+    end_time = time.perf_counter()
+    logger.info("extract executed in %.5f seconds", end_time-start_time)
+
     # hydrate a dataset instance from the input data
-    logger.info("transforming data")
+    logger.info("transforming and loading data")
+    start_time = time.perf_counter()
     dataset = EtlDataset.load_from_json_object(json_data=extracted_json)
-
     # sync dataset to db
-    logger.info("writing to database")
     etldb.sync_data(dataset, datestamp)
+    end_time = time.perf_counter()
+    logger.info("transform and load executed in %.5f seconds", end_time-start_time)
 
-    logger.info("workflow is done!")
+    logger.info("ETL workflow is done")
 
 
 def validate_effective_date(effective_date: str) -> str | None:

--- a/analytics/src/analytics/cli.py
+++ b/analytics/src/analytics/cli.py
@@ -146,7 +146,7 @@ def transform_and_load(
             "FATAL ERROR: malformed effective date, expected YYYY-MM-DD format",
         )
         return
-    logger.info("running transform and load workflow with effective date %s", datestamp)
+    logger.info("running transform and load with effective date %s", datestamp)
 
     # hydrate a dataset instance from the input data
     start_time = time.perf_counter()
@@ -154,7 +154,7 @@ def transform_and_load(
     # sync data to db
     etldb.sync_data(dataset, datestamp)
     end_time = time.perf_counter()
-    logger.info("transform and load executed in %.5f seconds", end_time - start_time)
+    logger.info("transform and load is done after %.5f seconds", end_time - start_time)
 
 
 @etl_app.command(name="extract_transform_and_load")
@@ -176,7 +176,7 @@ def extract_transform_and_load(
             "FATAL ERROR: malformed effective date, expected YYYY-MM-DD format",
         )
         return
-    logger.info("running ETL workflow with effective date %s", datestamp)
+    logger.info("running extract transform and load with effective date %s", datestamp)
 
     # extract data from GitHub
     logger.info("extracting data from GitHub")


### PR DESCRIPTION
## Summary
Fixes #2968 

### Time to review: __2 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

Adds a few simple execution timers so we can easily measure and inspect how long the ETL workflow takes to execute.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

It was suggested that we optimize the ETL workflow insert pattern. A precursor to any optimization is measuring the baseline performance. This PR introduces simple execution timers to measure baseline performance. 

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

