### PR TITLE
Move "Saved grants" to far right of the header links

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -63,7 +63,7 @@ const NavLinks = ({
       return anonymousNavLinks;
     }
 
-    return anonymousNavLinks.toSpliced(2, 0, {
+    return anonymousNavLinks.toSpliced(anonymousNavLinks.length, 0, {
       text: t("nav_link_saved_grants"),
       href: "/saved-grants",
     });


### PR DESCRIPTION
## Summary
Fixes #{ISSUE}

### Time to review: __5 mins__

## Changes proposed
Moves "saved grants" to end of header links:

<img width="1188" alt="image" src="https://github.com/user-attachments/assets/551fee8a-952b-468a-b618-59010b48952e" />


## Testing

1. Login locally
2. See "Saved Grants" is to the far right, same as the screenshot above.
