### PR TITLE
[#3775] ETL Fix for broken project objects from private repos

### DIFF
--- a/analytics/src/analytics/integrations/github/main.py
+++ b/analytics/src/analytics/integrations/github/main.py
@@ -30,43 +30,46 @@ def transform_project_data(
 
     for i, item in enumerate(raw_data):
         try:
+            # Filter out invalid content from boards local user may not have permission to
+            if item["content"] is not None:
             # Validate and parse the raw item
-            validated_item = ProjectItem.model_validate(item)
+                validated_item = ProjectItem.model_validate(item)
+                # Skip excluded issue types
+                if validated_item.content.issue_type.name in excluded_types:
+                    continue
 
-            # Skip excluded issue types
-            if validated_item.content.issue_type.name in excluded_types:
-                continue
-
-            # Transform into flattened format
-            transformed = {
-                # project metadata
-                "project_owner": owner,
-                "project_number": project,
-                # issue metadata
-                "issue_title": validated_item.content.title,
-                "issue_url": validated_item.content.url,
-                "issue_parent": validated_item.content.parent.url,
-                "issue_type": validated_item.content.issue_type.name,
-                "issue_status": validated_item.status.name,
-                "issue_is_closed": validated_item.content.closed,
-                "issue_opened_at": validated_item.content.created_at,
-                "issue_closed_at": validated_item.content.closed_at,
-                "issue_points": validated_item.points.number,
-                # sprint metadata
-                "sprint_id": validated_item.sprint.iteration_id,
-                "sprint_name": validated_item.sprint.title,
-                "sprint_start": validated_item.sprint.start_date,
-                "sprint_length": validated_item.sprint.duration,
-                "sprint_end": validated_item.sprint.end_date,
-                # roadmap metadata
-                "deliverable_pillar": validated_item.pillar.name,
-                "quad_id": validated_item.quad.iteration_id,
-                "quad_name": validated_item.quad.title,
-                "quad_start": validated_item.quad.start_date,
-                "quad_length": validated_item.quad.duration,
-                "quad_end": validated_item.quad.end_date,
-            }
-            transformed_data.append(transformed)
+                # Transform into flattened format
+                transformed = {
+                    # project metadata
+                    "project_owner": owner,
+                    "project_number": project,
+                    # issue metadata
+                    "issue_title": validated_item.content.title,
+                    "issue_url": validated_item.content.url,
+                    "issue_parent": validated_item.content.parent.url,
+                    "issue_type": validated_item.content.issue_type.name,
+                    "issue_status": validated_item.status.name,
+                    "issue_is_closed": validated_item.content.closed,
+                    "issue_opened_at": validated_item.content.created_at,
+                    "issue_closed_at": validated_item.content.closed_at,
+                    "issue_points": validated_item.points.number,
+                    # sprint metadata
+                    "sprint_id": validated_item.sprint.iteration_id,
+                    "sprint_name": validated_item.sprint.title,
+                    "sprint_start": validated_item.sprint.start_date,
+                    "sprint_length": validated_item.sprint.duration,
+                    "sprint_end": validated_item.sprint.end_date,
+                    # roadmap metadata
+                    "deliverable_pillar": validated_item.pillar.name,
+                    "quad_id": validated_item.quad.iteration_id,
+                    "quad_name": validated_item.quad.title,
+                    "quad_start": validated_item.quad.start_date,
+                    "quad_length": validated_item.quad.duration,
+                    "quad_end": validated_item.quad.end_date,
+                }
+                transformed_data.append(transformed)
+            else:
+                logger.debug(f"skipped {item}")
         except ValidationError as err:
             logger.error("Error parsing row %d, skipped.", i)  # noqa: TRY400
             logger.debug("Error: %s", err)

--- a/analytics/src/analytics/integrations/github/main.py
+++ b/analytics/src/analytics/integrations/github/main.py
@@ -32,7 +32,7 @@ def transform_project_data(
         try:
             # Filter out invalid content from boards local user may not have permission to
             if item["content"] is not None:
-            # Validate and parse the raw item
+                # Validate and parse the raw item
                 validated_item = ProjectItem.model_validate(item)
                 # Skip excluded issue types
                 if validated_item.content.issue_type.name in excluded_types:
@@ -68,8 +68,7 @@ def transform_project_data(
                     "quad_end": validated_item.quad.end_date,
                 }
                 transformed_data.append(transformed)
-            else:
-                logger.debug(f"skipped {item}")
+
         except ValidationError as err:
             logger.error("Error parsing row %d, skipped.", i)  # noqa: TRY400
             logger.debug("Error: %s", err)

--- a/analytics/src/analytics/integrations/github/main.py
+++ b/analytics/src/analytics/integrations/github/main.py
@@ -31,43 +31,46 @@ def transform_project_data(
     for i, item in enumerate(raw_data):
         try:
             # Filter out invalid content from boards local user may not have permission to
-            if item["content"] is not None:
-                # Validate and parse the raw item
-                validated_item = ProjectItem.model_validate(item)
-                # Skip excluded issue types
-                if validated_item.content.issue_type.name in excluded_types:
-                    continue
+            if item.get("content") is None:
+                logger.info("Row %d is missing the 'content' key, skipping.", i)
+                continue
 
-                # Transform into flattened format
-                transformed = {
-                    # project metadata
-                    "project_owner": owner,
-                    "project_number": project,
-                    # issue metadata
-                    "issue_title": validated_item.content.title,
-                    "issue_url": validated_item.content.url,
-                    "issue_parent": validated_item.content.parent.url,
-                    "issue_type": validated_item.content.issue_type.name,
-                    "issue_status": validated_item.status.name,
-                    "issue_is_closed": validated_item.content.closed,
-                    "issue_opened_at": validated_item.content.created_at,
-                    "issue_closed_at": validated_item.content.closed_at,
-                    "issue_points": validated_item.points.number,
-                    # sprint metadata
-                    "sprint_id": validated_item.sprint.iteration_id,
-                    "sprint_name": validated_item.sprint.title,
-                    "sprint_start": validated_item.sprint.start_date,
-                    "sprint_length": validated_item.sprint.duration,
-                    "sprint_end": validated_item.sprint.end_date,
-                    # roadmap metadata
-                    "deliverable_pillar": validated_item.pillar.name,
-                    "quad_id": validated_item.quad.iteration_id,
-                    "quad_name": validated_item.quad.title,
-                    "quad_start": validated_item.quad.start_date,
-                    "quad_length": validated_item.quad.duration,
-                    "quad_end": validated_item.quad.end_date,
-                }
-                transformed_data.append(transformed)
+            # Validate and parse the raw item
+            validated_item = ProjectItem.model_validate(item)
+            # Skip excluded issue types
+            if validated_item.content.issue_type.name in excluded_types:
+                continue
+
+            # Transform into flattened format
+            transformed = {
+                # project metadata
+                "project_owner": owner,
+                "project_number": project,
+                # issue metadata
+                "issue_title": validated_item.content.title,
+                "issue_url": validated_item.content.url,
+                "issue_parent": validated_item.content.parent.url,
+                "issue_type": validated_item.content.issue_type.name,
+                "issue_status": validated_item.status.name,
+                "issue_is_closed": validated_item.content.closed,
+                "issue_opened_at": validated_item.content.created_at,
+                "issue_closed_at": validated_item.content.closed_at,
+                "issue_points": validated_item.points.number,
+                # sprint metadata
+                "sprint_id": validated_item.sprint.iteration_id,
+                "sprint_name": validated_item.sprint.title,
+                "sprint_start": validated_item.sprint.start_date,
+                "sprint_length": validated_item.sprint.duration,
+                "sprint_end": validated_item.sprint.end_date,
+                # roadmap metadata
+                "deliverable_pillar": validated_item.pillar.name,
+                "quad_id": validated_item.quad.iteration_id,
+                "quad_name": validated_item.quad.title,
+                "quad_start": validated_item.quad.start_date,
+                "quad_length": validated_item.quad.duration,
+                "quad_end": validated_item.quad.end_date,
+            }
+            transformed_data.append(transformed)
 
         except ValidationError as err:
             logger.error("Error parsing row %d, skipped.", i)  # noqa: TRY400

--- a/analytics/tests/dataquality/inputs/roadmap.py
+++ b/analytics/tests/dataquality/inputs/roadmap.py
@@ -676,4 +676,12 @@ def mock_graphql_roadmap_data(
             "pillar": None,
             "status": {"optionId": "f75ad846", "name": "Backlog"},
         },
+        {
+            "content": None,
+            "status": None,
+            "sprint": None,
+            "points": None,
+            "quad": None,
+            "pillar": None,
+        },
     ]

--- a/analytics/tests/integrations/github/test_validation.py
+++ b/analytics/tests/integrations/github/test_validation.py
@@ -2,6 +2,7 @@
 
 import pytest  # noqa: I001
 from pydantic import ValidationError
+from analytics.integrations.github.main import transform_project_data
 from analytics.integrations.github.validation import (
     IssueContent,
     IterationValue,
@@ -41,6 +42,35 @@ VALID_SINGLE_SELECT = {
     "name": "In Progress",
 }
 
+
+
+class TestTransformProjectData:
+    """Test cases for the entire transform function."""
+
+    def test_content_none(self) -> None:
+        """Test validating a project item that has none for it's content filters that item out."""
+        data = [{
+        "content": None,
+        "status": None,
+        "sprint": None,
+        "points": None,
+        "quad": None,
+        "pillar": None,
+        },
+        {
+            "content": VALID_ISSUE_CONTENT,
+            "status": VALID_SINGLE_SELECT,
+            "sprint": VALID_ITERATION_VALUE,
+            "points": {"number": 5},
+            "quad": VALID_ITERATION_VALUE,
+            "pillar": VALID_SINGLE_SELECT,
+        },
+        ]
+        result = transform_project_data(data, "test", project=17)
+
+        assert len(result) == 1
+        print(result[0])
+        assert result[0]["issue_title"] == "Test Issue"
 
 # #############################################
 # Project items tests

--- a/analytics/tests/integrations/github/test_validation.py
+++ b/analytics/tests/integrations/github/test_validation.py
@@ -43,34 +43,35 @@ VALID_SINGLE_SELECT = {
 }
 
 
-
 class TestTransformProjectData:
     """Test cases for the entire transform function."""
 
     def test_content_none(self) -> None:
         """Test validating a project item that has none for it's content filters that item out."""
-        data = [{
-        "content": None,
-        "status": None,
-        "sprint": None,
-        "points": None,
-        "quad": None,
-        "pillar": None,
-        },
-        {
-            "content": VALID_ISSUE_CONTENT,
-            "status": VALID_SINGLE_SELECT,
-            "sprint": VALID_ITERATION_VALUE,
-            "points": {"number": 5},
-            "quad": VALID_ITERATION_VALUE,
-            "pillar": VALID_SINGLE_SELECT,
-        },
+        data = [
+            {
+                "content": None,
+                "status": None,
+                "sprint": None,
+                "points": None,
+                "quad": None,
+                "pillar": None,
+            },
+            {
+                "content": VALID_ISSUE_CONTENT,
+                "status": VALID_SINGLE_SELECT,
+                "sprint": VALID_ITERATION_VALUE,
+                "points": {"number": 5},
+                "quad": VALID_ITERATION_VALUE,
+                "pillar": VALID_SINGLE_SELECT,
+            },
         ]
         result = transform_project_data(data, "test", project=17)
 
         assert len(result) == 1
         print(result[0])
         assert result[0]["issue_title"] == "Test Issue"
+
 
 # #############################################
 # Project items tests


### PR DESCRIPTION
## Summary
Fixes #3775 

### Time to review: __5 mins__

## Changes proposed
A check in the validation step to avoid empty objects since they were causing errors in the process.

## Context for reviewers
If an item from is added from a project to one of the ETL sprint boards that the GitHub token doesn't have access to the ETL process will fail instead of just omitting the bad data.

## Additional information
### Failure output
<img width="472" alt="image" src="https://github.com/user-attachments/assets/b3673564-bd27-4ecd-8574-fc57e628417e" />

### Fixed output
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/8b792be0-b7d5-485b-99a2-c25a9fcd7e94" />


