### PR TITLE
[Issue #3955] Opportunity page returning 500 not 404 errors when Opp is not found

### DIFF
--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -8,11 +8,11 @@ import { QueryParamData } from "src/types/search/searchRequestTypes";
 
 export const parseErrorStatus = (error: ApiRequestError): number => {
   const { message } = error;
-  const cause = <FrontendErrorDetails>error.cause;
+  const cause = error.cause as FrontendErrorDetails;
 
   try {
     if (cause?.status) {
-      return cause?.status;
+      return cause.status;
     }
     const parsedMessage = JSON.parse(message) as { status: number };
     return parsedMessage.status;

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -8,11 +8,16 @@ import { QueryParamData } from "src/types/search/searchRequestTypes";
 
 export const parseErrorStatus = (error: ApiRequestError): number => {
   const { message } = error;
+  const cause = <FrontendErrorDetails>error.cause;
+
   try {
+    if (cause?.status) {
+      return cause?.status;
+    }
     const parsedMessage = JSON.parse(message) as { status: number };
     return parsedMessage.status;
   } catch (e) {
-    console.error("Malformed error object");
+    console.error("Malformed error object", e);
     return 500;
   }
 };


### PR DESCRIPTION
## Summary
Fixes #3955 

### Time to review: __5 mins__

## Changes proposed
Earlier changes had restructured the error object but the parsing function wasn't updated to adjust

## Context for reviewers
Steps to test:
1. Open Dev Tools
2. Ensure the Network tab is active
3. Go to any Opportunity page that doesn't exist, like: http://localhost:3000/1000000
4. Ensure that the page is returning a 404 status not a 500 status
5. Confirm there is no message about malformed error object in the NextJS console logs server side.
6. It is expected there will be NextJS console logs server side noting `Failed to render page title due to API error Error: Not Found` and the associated callstack.

