### PR TITLE
[no ticket] Adds cert arn back

### DIFF
--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -144,6 +144,7 @@ module "service" {
   public_subnet_ids  = data.aws_subnets.public.ids
   private_subnet_ids = data.aws_subnets.private.ids
 
+  cert_arn       = local.service_config.domain_name != null ? data.aws_acm_certificate.cert[0].arn : null
   domain_name    = local.service_config.domain_name
   hosted_zone_id = null
   # hosted_zone_id  = local.service_config.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -127,6 +127,7 @@ module "service" {
   public_subnet_ids  = data.aws_subnets.public.ids
   private_subnet_ids = data.aws_subnets.private.ids
 
+  cert_arn       = local.service_config.domain_name != null ? data.aws_acm_certificate.cert[0].arn : null
   domain_name    = local.service_config.domain_name
   hosted_zone_id = null
   # hosted_zone_id  = local.service_config.domain_name != null ? data.aws_route53_zone.zone[0].zone_id : null


### PR DESCRIPTION
## Context

I accidentally removed the cert arn inputs here: https://github.com/HHS/simpler-grants-gov/commit/9eca4df4f71f403c07165a5a3e71b02888daa529#diff-cab9e585e98c92c0a043f3c83f786a614183055ee52f403d90634a6287cd0f74L134

## Testing

<img width="597" alt="image" src="https://github.com/user-attachments/assets/0632f4c4-5454-4ee9-a9f6-798a1b06da28" />

## Caution

The terraform deploy will probably deploy (safely) because the HTTPS ingress already exists. I'll do a safe update to fix that issue once it happens.