### PR TITLE
[Issue #3973] Fix null mime_type while transforming opportunity attachment

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
+++ b/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
@@ -196,6 +196,10 @@ def transform_opportunity_attachment(
         raise ValueError("Opportunity attachment does not have a file name, cannot process.")
     file_name = attachment_util.adjust_legacy_file_name(source_attachment.file_name)
 
+    # We should always have a mime type. Raise an error if we don't
+    if source_attachment.mime_type is None:
+        raise ValueError("Opportunity attachment does not have a mime type, cannot process.")
+
     file_location = attachment_util.get_s3_attachment_path(
         file_name, source_attachment.syn_att_id, opportunity, s3_config
     )

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity_attachment.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity_attachment.py
@@ -251,3 +251,23 @@ class TestTransformOpportunitySummary(BaseTransformTestClass):
             )
 
         assert insert.transformed_at is None
+
+    def test_transform_opportunity_attachment_null_mime_type(
+        self, db_session, transform_opportunity_attachment, s3_config
+    ):
+        opportunity = f.OpportunityFactory.create(opportunity_attachments=[])
+        insert = setup_opportunity_attachment(
+            create_existing=False,
+            opportunity=opportunity,
+            config=s3_config,
+            source_values={"mime_type": None},
+        )
+
+        with pytest.raises(
+            ValueError, match="Opportunity attachment does not have a mime type, cannot process"
+        ):
+            transform_opportunity_attachment.process_opportunity_attachment(
+                insert, None, opportunity
+            )
+
+        assert insert.transformed_at is None


### PR DESCRIPTION
## Summary
Fixes #3973

### Time to review: 5 mins

## Changes proposed
Guard against null mime_type. Add test

## Context for reviewers
Discovered while loading / transforming attachment data in dev.

## Additional information
See attached unit test

