### PR TITLE
[Issue #3953] Logout user if session is expired

### DIFF
--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -19,7 +19,6 @@ export async function POST() {
     return Response.json({ message: "logout success" });
   } catch (e) {
     const { message, status, cause } = readError(e as Error, 500);
-    console.log(status, message, cause);
     // if token expired, delete session and return 401
     if (status === 401 && cause?.message === "Token expired") {
       await deleteSession();

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -18,10 +18,20 @@ export async function POST() {
     await deleteSession();
     return Response.json({ message: "logout success" });
   } catch (e) {
-    const { message, status } = readError(e as Error, 500);
-    return Response.json(
-      { message: `Error logging out: ${message}` },
-      { status },
-    );
+    const { message, status, cause } = readError(e as Error, 500);
+    console.log(status, message, cause);
+    // if token expired, delete session and return 401
+    if (status === 401 && cause?.message === "Token expired") {
+      await deleteSession();
+      return Response.json(
+        { message: "session previously expired" },
+        { status },
+      );
+    } else {
+      return Response.json(
+        { message: `Error logging out: ${message}` },
+        { status },
+      );
+    }
   }
 }

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -199,6 +199,7 @@ export const readError = (e: Error, defaultStatus: number) => {
 
   return {
     status: Number(status),
-    message: cause ? JSON.stringify(cause) : message,
+    message,
+    cause: cause as FrontendErrorDetails,
   };
 };

--- a/frontend/tests/api/auth/logout/route.test.ts
+++ b/frontend/tests/api/auth/logout/route.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { POST } from "src/app/api/auth/logout/route";
+import { UnauthorizedError } from "src/errors";
 
 const getSessionMock = jest.fn();
 const deleteSessionMock = jest.fn();
@@ -34,7 +35,7 @@ describe("/api/auth/logout POST handler", () => {
     expect(response.status).toEqual(401);
     const json = (await response.json()) as { message: string };
     expect(json.message).toEqual(
-      'Error logging out: {"type":"UnauthorizedError","searchInputs":{},"message":"No active session to logout","status":401,"details":{}}',
+      "Error logging out: No active session to logout",
     );
   });
   it("calls postLogout with token from session", async () => {
@@ -61,7 +62,6 @@ describe("/api/auth/logout POST handler", () => {
     const json = (await response.json()) as { message: string };
     expect(json.message).toEqual("Error logging out: the API threw this error");
   });
-
   it("errors if API logout call returns nothing", async () => {
     getSessionMock.mockImplementation(() => ({
       token: "fakeToken",
@@ -75,7 +75,7 @@ describe("/api/auth/logout POST handler", () => {
     const json = (await response.json()) as { message: string };
     // const message = JSON.parse(json) as FrontendErrorDetails;
     expect(json.message).toEqual(
-      'Error logging out: {"type":"APIRequestError","searchInputs":{},"message":"No logout response from API","status":400,"details":{}}',
+      "Error logging out: No logout response from API",
     );
   });
   it("calls deleteSession", async () => {
@@ -86,6 +86,22 @@ describe("/api/auth/logout POST handler", () => {
     await POST();
 
     expect(deleteSessionMock).toHaveBeenCalledTimes(1);
+  });
+  it("calls deleteSession if token expired", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "fakeToken",
+    }));
+    postLogoutMock.mockImplementation(() => {
+      throw new UnauthorizedError("Token expired");
+    });
+    const response = await POST();
+
+    expect(postLogoutMock).toHaveBeenCalledTimes(1);
+    expect(postLogoutMock).toHaveBeenCalledWith("fakeToken");
+    expect(response.status).toEqual(401);
+    expect(deleteSessionMock).toHaveBeenCalledTimes(1);
+    const json = (await response.json()) as { message: string };
+    expect(json.message).toEqual("session previously expired");
   });
   it("returns sucess message on success", async () => {
     getSessionMock.mockImplementation(() => ({


### PR DESCRIPTION
## Summary
Fixes #3953

### Time to review: __10 mins__

## Changes proposed

Logs out user if expired. Updates `parseError()` so that message can be inspected separately if desired.


## Testing locally

1. start the API and frontend locally
2. login
3. click logout, see that the logout works correctly
4. login again
5. wait until the session has expired while you are still logged in
6. click logout, see that the logout works correctly
