### PR TITLE
[unticketed] add padding on first date in search result

### DIFF
--- a/frontend/src/components/search/SearchResultListItemStatus.tsx
+++ b/frontend/src/components/search/SearchResultListItemStatus.tsx
@@ -32,7 +32,7 @@ const StatusItem = ({
       >
         <strong>{description}</strong>
         {showDate && (
-          <span className="text-no-uppercase">
+          <span className="text-no-uppercase padding-left-05">
             {date ? formatDate(date) : "--"}
           </span>
         )}


### PR DESCRIPTION
## Summary
unticketed

### Time to review: __1 mins__

## Changes proposed
adds padding after color, before date on first date item in search results. I think this is a recent regression.

## Context for reviewers
### Test steps
1. run `npm run dev` on this branch
2. visit a search page
3. compare to prod
4. _VALIDATE_: the date isn't scrunched. Also compare screenshots below

## Additional information
### Prod

![Screenshot 2025-02-26 at 12 50 44 PM](https://github.com/user-attachments/assets/4d96138f-271c-4618-b537-3d736f351043)


### This branch
![Screenshot 2025-02-26 at 1 09 24 PM](https://github.com/user-attachments/assets/27bafc69-3315-447a-839d-1354bc0a93d8)

