### PR TITLE
[Issue #3764] add search query params to new relic

### DIFF
--- a/documentation/frontend/analytics.md
+++ b/documentation/frontend/analytics.md
@@ -34,11 +34,13 @@ Admin users will have full access to the features available in New Relic's UI. N
 
 ## Usage
 
-TBD - what are important features to know about, and how do we use them?
+### Custom Attributes / Events
 
-## Dashboards
+New Relic does not collect search params on URLs by default for security reasons. We have implemented custom attributes on search page events to capture approved query param values. These custom attributes will all be prefixed with `search_param_`.
 
-TBD
+### Dashboards
+
+Since non-admin users will only be able to consume metrics via dashboards, it is important for any important information to be surfaced in dashboards.
 
 ## Integration
 
@@ -46,6 +48,12 @@ Note that all integrations will require access to two pieces of information:
 
 - `NEW_RELIC_APP_NAME`
 - `NEW_RELIC_LICENSE_KEY`
+
+### Browser
+
+The browser monitoring code is added via the New Relic NPM package from the main Next JS layout file. Client side code and browser monitoring will work as long as the code is injected correctly by the Next backend into the client. From the client, `window.newrelic` can be accessed to perform any necessary customization.
+
+Note that the `window.newrelic` object may not be available immediately upon page load, so timing needs to be considered whenever this object is referenced.
 
 ### Local
 
@@ -58,8 +66,6 @@ npm run build -- --no-lint && NEW_RELIC_APP_NAME="Simpler Grants Next DEV" NEW_R
 For testing locally in order to more closely emulate the deployed environment, see the considerations mentioned in the `deployed` section below.
 
 ### Deployed
-
-**Note:** This section is TBD as we work through some issues with our New Relic implementation for the Next client.
 
 Integration of New Relic into the client and Node processes will be handled by the New Relic Node package. The Node library is able to generate the necessary scripts for the client code to report back to New Relic. [See the layout file](https://github.com/HHS/simpler-grants-gov/blob/a2ce07dc15b65c9fa27ecbbe7a9566c84542b554/frontend/src/app/%5Blocale%5D/layout.tsx#L77) to see how this is being done.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,6 +44,7 @@
         "@types/jest-axe": "^3.5.5",
         "@types/js-cookie": "^3.0.6",
         "@types/lodash": "^4.17.13",
+        "@types/new-relic-browser": "^1.230.5",
         "@types/newrelic": "^9.14.6",
         "@types/node": "^22.10.5",
         "@types/node-fetch": "^2.6.11",
@@ -6540,6 +6541,13 @@
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
       "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/new-relic-browser": {
+      "version": "1.230.5",
+      "resolved": "https://registry.npmjs.org/@types/new-relic-browser/-/new-relic-browser-1.230.5.tgz",
+      "integrity": "sha512-+CD0Z/R0G1BEBb3MagvpfD2tNtn11PXION1zHsSqyiEEGvNB+Xzf19GU10bmM2FLDoKCSbSsKgu7MxPbTNmA2w==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "lint": "next lint",
     "lint-fix": "npm run lint -- --fix",
     "postinstall": "node ./scripts/postinstall.js",
-    "start:nr": "NODE_OPTIONS='-r @newrelic/next' next start -p ${PORT:-3000}",
+    "start:nr": "NEW_RELIC_ENABLED=true NODE_OPTIONS='-r @newrelic/next' next start -p ${PORT:-3000}",
     "start": "next start -p ${PORT:-3000}",
     "storybook": "storybook dev -p 6006",
     "storybook-build": "storybook build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "@types/js-cookie": "^3.0.6",
     "@types/lodash": "^4.17.13",
     "@types/newrelic": "^9.14.6",
+    "@types/new-relic-browser": "^1.230.5",
     "@types/node": "^22.10.5",
     "@types/node-fetch": "^2.6.11",
     "@types/react": "^19",

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import * as newrelic from "newrelic";
  */
 import { Metadata } from "next";
 import { environment } from "src/constants/environments";
+import { NewRelicWithCorrectTypes } from "src/types/newRelic";
 
 import Script from "next/script";
 
@@ -18,35 +19,13 @@ import { getMessages, setRequestLocale } from "next-intl/server";
 
 import Layout from "src/components/Layout";
 
+const typedNewRelic = newrelic as NewRelicWithCorrectTypes;
+
 export const metadata: Metadata = {
   icons: [`${environment.NEXT_PUBLIC_BASE_PATH}/img/favicon.ico`],
 };
 
-type NRType = typeof newrelic;
-
-// see https://github.com/newrelic/node-newrelic/blob/40aea36320d15b201800431268be2c3d4c794a7b/api.js#L752
-// types library does not expose a type for the options here, so building from scratch
-interface typedGetBrowserTimingHeaderOptions {
-  nonce?: string;
-  hasToRemoveScriptWrapper?: boolean;
-  allowTransactionlessInjection?: boolean; // tho jsdoc in nr code types this as "options"
-}
-
-interface NewRelicWithCorrectTypes extends NRType {
-  agent: {
-    collector: {
-      isConnected: () => boolean;
-    };
-    on: (event: string, callback: (value: unknown) => void) => void;
-  };
-  getBrowserTimingHeader: (
-    options?: typedGetBrowserTimingHeaderOptions,
-  ) => string;
-}
-
 const locales = ["en", "es"];
-
-const typedNewRelic = newrelic as NewRelicWithCorrectTypes;
 
 export function generateStaticParams() {
   return locales.map((locale) => ({ locale }));

--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import QueryProvider from "src/app/[locale]/search/QueryProvider";
+import { environment } from "src/constants/environments";
 import withFeatureFlag from "src/hoc/withFeatureFlag";
 import { LocalizedPageProps } from "src/types/intl";
 import { SearchParamsTypes } from "src/types/search/searchRequestTypes";
@@ -48,7 +49,10 @@ function Search({ searchParams, params }: SearchPageProps) {
 
   return (
     <>
-      <SearchAnalytics params={resolvedSearchParams} />
+      <SearchAnalytics
+        params={resolvedSearchParams}
+        newRelicEnabled={environment.NEW_RELIC_ENABLED === "true"}
+      />
       <QueryProvider>
         <div className="grid-container">
           <div className="search-bar">

--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -41,21 +41,16 @@ function SearchAnalytics({
       return () => {};
     }
     if (params) {
-      console.log(
-        "~~~ updating new relic search query param custom attributes",
-        params,
-      );
       Object.entries(params).forEach(([key, value]) => {
+        // only pass on valid query params to NR
         if ((validSearchQueryParamKeys as readonly string[]).includes(key)) {
-          console.log("$$$ setting new relic custom attribute", key, value);
           setNewRelicCustomAttribute(key, value || "");
         }
       });
     }
+    // note that this cleanup is not running quickly enough to prevent search query params
+    // being sent on route transition when navigating away from the search page
     return () => {
-      console.log(
-        "!!! unsetting new relic search query param custom attributes",
-      );
       unsetAllNewRelicQueryAttributes();
     };
   }, [params, newRelicEnabled, newRelicInitialized]);

--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -3,6 +3,7 @@
 import { sendGAEvent } from "@next/third-parties/google";
 import { omit } from "lodash";
 import { SearchParamsTypes } from "src/types/search/searchRequestTypes";
+import { validSearchQueryParamKeys } from "src/types/search/searchResponseTypes";
 
 import { useEffect } from "react";
 
@@ -10,7 +11,29 @@ const getCurrentFilters = (params: SearchParamsTypes): string => {
   return JSON.stringify(omit(params, "query", "page"));
 };
 
+// send custom New Relic and GA data for search pages
 function SearchAnalytics({ params }: { params: SearchParamsTypes }) {
+  // set new relic query param based custom attributes
+  useEffect(() => {
+    if (params) {
+      console.log(
+        "~~~ updating new relic search query param custom attributes",
+        params,
+      );
+      Object.entries(params).forEach(([key, value]) => {
+        if (key in validSearchQueryParamKeys) {
+          console.log("$$$ setting new relic custom attribute", key, value);
+        }
+      });
+    }
+    return () => {
+      console.log(
+        "!!! unsetting new relic search query param custom attributes",
+      );
+    };
+  }, [params]);
+
+  //
   useEffect(() => {
     // send list of filters defined in page query params on each page load
     sendGAEvent("event", "search_attempt", {

--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -41,7 +41,6 @@ function SearchAnalytics({
       return () => {};
     }
     if (params) {
-      // updateNewRelicSearchParams(params, newRelicInitialized);
       console.log(
         "~~~ updating new relic search query param custom attributes",
         params,

--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -30,8 +30,9 @@ function SearchAnalytics({
     if (!newRelicEnabled) {
       return;
     }
-    const ready = waitForNewRelic();
-    setNewRelicInitialized(!!ready);
+    waitForNewRelic()
+      .then((ready) => setNewRelicInitialized(!!ready))
+      .catch((e) => console.error("Error waiting for new relic", e));
   }, [newRelicEnabled]);
 
   // set new relic query param based custom attributes

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -3,7 +3,7 @@
 import { camelCase } from "lodash";
 import { QueryContext } from "src/app/[locale]/search/QueryProvider";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
-import { QueryParamKey } from "src/types/search/searchResponseTypes";
+import { ValidSearchQueryParam } from "src/types/search/searchResponseTypes";
 
 import { useContext } from "react";
 import { Accordion } from "@trussworks/react-uswds";
@@ -32,7 +32,7 @@ export interface FilterOption {
 export interface SearchFilterAccordionProps {
   filterOptions: FilterOption[];
   query: Set<string>;
-  queryParamKey: QueryParamKey; // Ex - In query params, search?{key}=first,second,third
+  queryParamKey: ValidSearchQueryParam; // Ex - In query params, search?{key}=first,second,third
   title: string; // Title in header of accordion
 }
 
@@ -164,7 +164,7 @@ export function SearchFilterAccordion({
       title: getAccordionTitle(),
       content: getAccordionContent(),
       expanded: isExpanded,
-      id: `opportunity-filter-${queryParamKey}`,
+      id: `opportunity-filter-${queryParamKey as string}`,
       headingLevel: "h2",
     },
   ];

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -18,6 +18,7 @@ const {
   FEATURE_SAVED_OPPORTUNITIES_ON,
   AUTH_LOGIN_URL,
   API_JWT_PUBLIC_KEY,
+  NEW_RELIC_ENABLED,
 } = process.env;
 
 export const featureFlags = {
@@ -45,4 +46,5 @@ export const environment: { [key: string]: string } = {
   SESSION_SECRET: SESSION_SECRET || "",
   NEXT_PUBLIC_BASE_URL: NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
   API_JWT_PUBLIC_KEY: API_JWT_PUBLIC_KEY || "",
+  NEW_RELIC_ENABLED: NEW_RELIC_ENABLED || "false",
 };

--- a/frontend/src/services/search/SearchFilterManager.ts
+++ b/frontend/src/services/search/SearchFilterManager.ts
@@ -1,10 +1,10 @@
-import { QueryParamKey } from "src/types/search/searchResponseTypes";
+import { ValidSearchQueryParam } from "src/types/search/searchResponseTypes";
 
 import { FilterOption } from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
 
 type UpdateQueryParamsFunction = (
   checkedSet: Set<string>,
-  queryParamKey: QueryParamKey,
+  queryParamKey: ValidSearchQueryParam,
 ) => void;
 
 // TODO (Issue #1491): explore setting up a more maintanable class to manage checked state

--- a/frontend/src/types/newRelic.ts
+++ b/frontend/src/types/newRelic.ts
@@ -1,0 +1,23 @@
+import * as newrelic from "newrelic";
+
+type NRType = typeof newrelic;
+
+// see https://github.com/newrelic/node-newrelic/blob/40aea36320d15b201800431268be2c3d4c794a7b/api.js#L752
+// types library does not expose a type for the options here, so building from scratch
+interface typedGetBrowserTimingHeaderOptions {
+  nonce?: string;
+  hasToRemoveScriptWrapper?: boolean;
+  allowTransactionlessInjection?: boolean; // tho jsdoc in nr code types this as "options"
+}
+
+export interface NewRelicWithCorrectTypes extends NRType {
+  agent: {
+    collector: {
+      isConnected: () => boolean;
+    };
+    on: (event: string, callback: (value: unknown) => void) => void;
+  };
+  getBrowserTimingHeader: (
+    options?: typedGetBrowserTimingHeaderOptions,
+  ) => string;
+}

--- a/frontend/src/types/search/searchResponseTypes.ts
+++ b/frontend/src/types/search/searchResponseTypes.ts
@@ -64,21 +64,33 @@ export interface SearchAPIResponse extends APIResponse {
   fieldChanged?: string;
 }
 
-export enum validSearchQueryParamKeys {
-  page = "page",
-  query = "query",
-  sortby = "sortby",
-  status = "status",
-  fundingInstrument = "fundingInstrument",
-  eligibility = "eligibility",
-  agency = "agency",
-  category = "category",
-}
+// export enum validSearchQueryParamKeys {
+//   page = "page",
+//   query = "query",
+//   sortby = "sortby",
+//   status = "status",
+//   fundingInstrument = "fundingInstrument",
+//   eligibility = "eligibility",
+//   agency = "agency",
+//   category = "category",
+// }
+
+export const validSearchQueryParamKeys = [
+  "page",
+  "query",
+  "sortby",
+  "status",
+  "fundingInstrument",
+  "eligibility",
+  "agency",
+  "category",
+] as const;
 
 // Only a few defined keys possible
 // URL example => ?query=abcd&status=closed,archived
-// export type ValidSearchQueryParam =
-//   (typeof validSearchQueryParamKeys)[keyof typeof validSearchQueryParamKeys];
+export type ValidSearchQueryParam = (typeof validSearchQueryParamKeys)[number];
 
-export type ValidSearchQueryParam = keyof typeof validSearchQueryParamKeys;
+// type Attempt = (typeof keysArray)[number];
+
+// export type ValidSearchQueryParam = keyof typeof validSearchQueryParamKeys;
 export type SearchResponseData = Opportunity[];

--- a/frontend/src/types/search/searchResponseTypes.ts
+++ b/frontend/src/types/search/searchResponseTypes.ts
@@ -64,16 +64,21 @@ export interface SearchAPIResponse extends APIResponse {
   fieldChanged?: string;
 }
 
+export enum validSearchQueryParamKeys {
+  page = "page",
+  query = "query",
+  sortby = "sortby",
+  status = "status",
+  fundingInstrument = "fundingInstrument",
+  eligibility = "eligibility",
+  agency = "agency",
+  category = "category",
+}
+
 // Only a few defined keys possible
 // URL example => ?query=abcd&status=closed,archived
-export type QueryParamKey =
-  | "page"
-  | "query"
-  | "sortby"
-  | "status"
-  | "fundingInstrument"
-  | "eligibility"
-  | "agency"
-  | "category";
+// export type ValidSearchQueryParam =
+//   (typeof validSearchQueryParamKeys)[keyof typeof validSearchQueryParamKeys];
 
+export type ValidSearchQueryParam = keyof typeof validSearchQueryParamKeys;
 export type SearchResponseData = Opportunity[];

--- a/frontend/src/types/search/searchResponseTypes.ts
+++ b/frontend/src/types/search/searchResponseTypes.ts
@@ -64,17 +64,6 @@ export interface SearchAPIResponse extends APIResponse {
   fieldChanged?: string;
 }
 
-// export enum validSearchQueryParamKeys {
-//   page = "page",
-//   query = "query",
-//   sortby = "sortby",
-//   status = "status",
-//   fundingInstrument = "fundingInstrument",
-//   eligibility = "eligibility",
-//   agency = "agency",
-//   category = "category",
-// }
-
 export const validSearchQueryParamKeys = [
   "page",
   "query",
@@ -90,7 +79,4 @@ export const validSearchQueryParamKeys = [
 // URL example => ?query=abcd&status=closed,archived
 export type ValidSearchQueryParam = (typeof validSearchQueryParamKeys)[number];
 
-// type Attempt = (typeof keysArray)[number];
-
-// export type ValidSearchQueryParam = keyof typeof validSearchQueryParamKeys;
 export type SearchResponseData = Opportunity[];

--- a/frontend/src/utils/analyticsUtil.ts
+++ b/frontend/src/utils/analyticsUtil.ts
@@ -1,22 +1,50 @@
-// // note that the `newrelic` referenced here is the newrelic object added to window when
-// // client side new relic scripts are loaded and run, rather than anything explicity imported
-// type NewRelicBrowser = typeof newrelic;
+import { validSearchQueryParamKeys } from "src/types/search/searchResponseTypes";
 
-// const getNewRelicBrowserInstance = (): NewRelicBrowser | null => {
-//   return window && window.newRelic
-//     ? (window.newRelic as NewRelicBrowser)
-//     : null;
-// };
+// note that the `newrelic` referenced here is the newrelic object added to window when
+// client side new relic scripts are loaded and run, rather than anything explicity imported
+type NewRelicBrowser = typeof newrelic;
 
-// const setNewRelicCustomAttribute = (key: string, value: string): undefined => {
-//   const newRelic = getNewRelicBrowserInstance();
-//   if (!newRelic) {
-//     return;
-//   }
-//   newRelic.setCustomAttribute(key, value);
-// };
+const NEW_RELIC_POLL_INTERVAL = 2;
+const NEW_RELIC_POLL_TIMEOUT = 2000;
 
-// // TODO does setting "" as the value effectively `unset` the attribute?
-// const unsetNewRelicCustomAttribute = (key: string) => {
-//   setNewRelicCustomAttribute(key, "");
-// };
+// taking less than 2 ms to intantiate locally but not ready on first run
+// this will wait until it's present on the window
+export const waitForNewRelic = (elapsed = 0) => {
+  const present = !!window.newrelic;
+  if (elapsed > NEW_RELIC_POLL_TIMEOUT) {
+    console.error("New Relic browser code not found");
+    return false;
+  }
+  console.debug("waiting for new relic: ", elapsed);
+  if (!present) {
+    return setTimeout(
+      () => waitForNewRelic(elapsed + NEW_RELIC_POLL_INTERVAL),
+      NEW_RELIC_POLL_INTERVAL,
+    );
+  }
+  return true;
+};
+
+const getNewRelicBrowserInstance = (): NewRelicBrowser | null => {
+  return window && window.newrelic ? window.newrelic : null;
+};
+
+export const setNewRelicCustomAttribute = (
+  key: string,
+  value: string,
+): undefined => {
+  const newRelic = getNewRelicBrowserInstance();
+  if (!newRelic) {
+    console.log("--- nr not defined");
+    return;
+  }
+  console.log("--- setting custom attribute", key, value);
+  newRelic.setCustomAttribute(key, value);
+};
+
+// TODO does setting "" as the value effectively `unset` the attribute?
+export const unsetAllNewRelicQueryAttributes = () => {
+  validSearchQueryParamKeys.forEach((key) => {
+    setNewRelicCustomAttribute(key, "");
+  });
+};

--- a/frontend/src/utils/analyticsUtil.ts
+++ b/frontend/src/utils/analyticsUtil.ts
@@ -15,7 +15,7 @@ export const waitForNewRelic = (elapsed = 0) => {
     console.error("New Relic browser code not found");
     return false;
   }
-  console.debug("waiting for new relic: ", elapsed);
+  console.debug("Waiting for new relic: ", elapsed);
   if (!present) {
     return setTimeout(
       () => waitForNewRelic(elapsed + NEW_RELIC_POLL_INTERVAL),
@@ -38,6 +38,7 @@ export const setNewRelicCustomAttribute = (
     console.error("New Relic not defined setting custom attribute");
     return;
   }
+  // using underscores since NR has problems with querying fields with dashes
   newRelic.setCustomAttribute(`search_param_${key}`, value);
 };
 

--- a/frontend/src/utils/analyticsUtil.ts
+++ b/frontend/src/utils/analyticsUtil.ts
@@ -1,0 +1,22 @@
+// // note that the `newrelic` referenced here is the newrelic object added to window when
+// // client side new relic scripts are loaded and run, rather than anything explicity imported
+// type NewRelicBrowser = typeof newrelic;
+
+// const getNewRelicBrowserInstance = (): NewRelicBrowser | null => {
+//   return window && window.newRelic
+//     ? (window.newRelic as NewRelicBrowser)
+//     : null;
+// };
+
+// const setNewRelicCustomAttribute = (key: string, value: string): undefined => {
+//   const newRelic = getNewRelicBrowserInstance();
+//   if (!newRelic) {
+//     return;
+//   }
+//   newRelic.setCustomAttribute(key, value);
+// };
+
+// // TODO does setting "" as the value effectively `unset` the attribute?
+// const unsetNewRelicCustomAttribute = (key: string) => {
+//   setNewRelicCustomAttribute(key, "");
+// };

--- a/frontend/src/utils/analyticsUtil.ts
+++ b/frontend/src/utils/analyticsUtil.ts
@@ -35,11 +35,10 @@ export const setNewRelicCustomAttribute = (
 ): undefined => {
   const newRelic = getNewRelicBrowserInstance();
   if (!newRelic) {
-    console.log("--- nr not defined");
+    console.error("New Relic not defined setting custom attribute");
     return;
   }
-  console.log("--- setting custom attribute", key, value);
-  newRelic.setCustomAttribute(key, value);
+  newRelic.setCustomAttribute(`search_param_${key}`, value);
 };
 
 // TODO does setting "" as the value effectively `unset` the attribute?

--- a/frontend/tests/components/search/SearchAnalytics.test.tsx
+++ b/frontend/tests/components/search/SearchAnalytics.test.tsx
@@ -13,10 +13,11 @@ jest.mock("@next/third-parties/google", () => ({
 }));
 
 jest.mock("src/utils/analyticsUtil", () => ({
-  waitForNewRelic: () => waitForNewRelicMock(),
-  setNewRelicCustomAttribute: (...args) =>
+  waitForNewRelic: () => waitForNewRelicMock() as unknown,
+  setNewRelicCustomAttribute: (...args: unknown[]): unknown =>
     setNewRelicCustomAttributeMock(...args),
-  unsetAllNewRelicQueryAttributes: () => unsetAllNewRelicQueryAttributesMock(),
+  unsetAllNewRelicQueryAttributes: () =>
+    unsetAllNewRelicQueryAttributesMock() as unknown,
 }));
 
 const basicParams = {

--- a/frontend/tests/components/search/SearchAnalytics.test.tsx
+++ b/frontend/tests/components/search/SearchAnalytics.test.tsx
@@ -3,24 +3,37 @@ import { render } from "@testing-library/react";
 import SearchAnalytics from "src/components/search/SearchAnalytics";
 
 const sendGAEventMock = jest.fn();
+const waitForNewRelicMock = jest.fn();
+const setNewRelicCustomAttributeMock = jest.fn();
+const unsetAllNewRelicQueryAttributesMock = jest.fn();
 
 jest.mock("@next/third-parties/google", () => ({
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-return */
   sendGAEvent: (...args: unknown[]) => sendGAEventMock(...args),
 }));
 
+jest.mock("src/utils/analyticsUtil", () => ({
+  waitForNewRelic: () => waitForNewRelicMock(),
+  setNewRelicCustomAttribute: (...args) =>
+    setNewRelicCustomAttributeMock(...args),
+  unsetAllNewRelicQueryAttributes: () => unsetAllNewRelicQueryAttributesMock(),
+}));
+
+const basicParams = {
+  fundingInstrument: "cooperative_agreement",
+  status: "posted, archived",
+  agency: "AC,PAMS-SC",
+  page: "1",
+  query: "a random search term",
+};
+
 describe("SearchAnalytics", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
   it("calls sendGAEvent with expected params on render", () => {
     const { rerender } = render(
-      <SearchAnalytics
-        params={{
-          fundingInstrument: "cooperative_agreement",
-          status: "posted, archived",
-          agency: "AC,PAMS-SC",
-          page: "1",
-          query: "a random search term",
-        }}
-      />,
+      <SearchAnalytics params={basicParams} newRelicEnabled={false} />,
     );
     expect(sendGAEventMock).toHaveBeenCalledWith("event", "search_attempt", {
       search_filters:
@@ -36,11 +49,93 @@ describe("SearchAnalytics", () => {
           page: "1",
           query: "a random search term",
         }}
+        newRelicEnabled={false}
       />,
     );
     expect(sendGAEventMock).toHaveBeenCalledWith("event", "search_attempt", {
       search_filters:
         '{"status":"posted, archived, closed","agency":"AC","category":"recovery_act"}',
     });
+  });
+
+  it("does not waitForNewRelic if New Relic is not enabled", () => {
+    render(<SearchAnalytics params={basicParams} newRelicEnabled={false} />);
+    expect(waitForNewRelicMock).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt to set custom attributes if New Relic is not enabled", () => {
+    const { rerender } = render(
+      <SearchAnalytics params={basicParams} newRelicEnabled={false} />,
+    );
+
+    rerender(
+      <SearchAnalytics
+        params={{
+          ...basicParams,
+          page: "2",
+        }}
+        newRelicEnabled={false}
+      />,
+    );
+    expect(setNewRelicCustomAttributeMock).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt to set custom attributes if New Relic is not initialized", () => {
+    waitForNewRelicMock.mockResolvedValue(false);
+    const { rerender } = render(
+      <SearchAnalytics params={basicParams} newRelicEnabled={true} />,
+    );
+
+    rerender(
+      <SearchAnalytics
+        params={{
+          ...basicParams,
+          page: "2",
+        }}
+        newRelicEnabled={true}
+      />,
+    );
+    expect(setNewRelicCustomAttributeMock).not.toHaveBeenCalled();
+  });
+
+  it("calls setNewRelicCustomAttribute for all search params when params change", async () => {
+    waitForNewRelicMock.mockImplementation(() => {
+      return Promise.resolve(true);
+    });
+    const { rerender } = render(
+      <SearchAnalytics params={basicParams} newRelicEnabled={true} />,
+    );
+
+    // have to wait a tick for the wait promise to resolve
+    const animationFramePromise = new Promise((resolve) => {
+      requestAnimationFrame(resolve);
+    });
+
+    await animationFramePromise;
+
+    rerender(
+      <SearchAnalytics
+        params={{
+          ...basicParams,
+          page: "2",
+        }}
+        newRelicEnabled={true}
+      />,
+    );
+    Object.entries({
+      ...basicParams,
+      page: "2",
+    }).forEach(([key, value]) => {
+      expect(setNewRelicCustomAttributeMock).toHaveBeenCalledWith(key, value);
+    });
+  });
+
+  it("calls unsetAllNewRelicQueryAttributes on cleanup", () => {
+    waitForNewRelicMock.mockImplementation(() => {
+      return Promise.resolve(true);
+    });
+    render(<SearchAnalytics params={basicParams} newRelicEnabled={true} />);
+
+    expect(unsetAllNewRelicQueryAttributesMock).toHaveBeenCalled();
   });
 });

--- a/frontend/tests/utils/analyticsUtils.test.ts
+++ b/frontend/tests/utils/analyticsUtils.test.ts
@@ -70,7 +70,7 @@ describe("unsetAllNewRelicQueryAttributes", () => {
     jest.resetAllMocks();
   });
   it("does not attempt to call new relic if new relic does not exist", () => {
-    unsetAllNewRelicQueryAttributes("key");
+    unsetAllNewRelicQueryAttributes();
     expect(mockSetCustomAttribute).not.toHaveBeenCalled();
   });
   it("calls new relic with passed values, with key properly prefixed", () => {

--- a/frontend/tests/utils/analyticsUtils.test.ts
+++ b/frontend/tests/utils/analyticsUtils.test.ts
@@ -1,0 +1,94 @@
+import { validSearchQueryParamKeys } from "src/types/search/searchResponseTypes";
+import {
+  setNewRelicCustomAttribute,
+  unsetAllNewRelicQueryAttributes,
+  waitForNewRelic,
+} from "src/utils/analyticsUtil";
+
+jest.useFakeTimers();
+const mockSetCustomAttribute = jest.fn();
+
+describe("waitForNewRelic", () => {
+  afterEach(() => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    window.newrelic = undefined;
+    jest.resetAllMocks();
+  });
+  it("returns true if new relic is found", async () => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    window.newrelic = {};
+    const result = await waitForNewRelic();
+    expect(result).toEqual(true);
+  });
+  it("when the timeout is reached returns false", async () => {
+    // eslint-disable-next-line
+    const resolution = new Promise<boolean>((resolve) =>
+      waitForNewRelic().then((result) => {
+        resolve(result);
+      }),
+    );
+    await jest.runAllTimersAsync();
+
+    const result = await resolution;
+    expect(result).toEqual(false);
+  });
+});
+
+describe("setNewRelicCustomAttribute", () => {
+  afterEach(() => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    window.newrelic = undefined;
+    jest.resetAllMocks();
+  });
+  it("does not attempt to call new relic if new relic does not exist", () => {
+    setNewRelicCustomAttribute("key", "value");
+    expect(mockSetCustomAttribute).not.toHaveBeenCalled();
+  });
+  it("calls new relic with passed values, with key properly prefixed", () => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    window.newrelic = {
+      setCustomAttribute: mockSetCustomAttribute,
+    };
+
+    setNewRelicCustomAttribute("key", "value");
+    expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+      "search_param_key",
+      "value",
+    );
+  });
+});
+
+describe("unsetAllNewRelicQueryAttributes", () => {
+  afterEach(() => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    window.newrelic = undefined;
+    jest.resetAllMocks();
+  });
+  it("does not attempt to call new relic if new relic does not exist", () => {
+    unsetAllNewRelicQueryAttributes("key");
+    expect(mockSetCustomAttribute).not.toHaveBeenCalled();
+  });
+  it("calls new relic with passed values, with key properly prefixed", () => {
+    // eslint-disable-next-line
+    // @ts-ignore
+    window.newrelic = {
+      setCustomAttribute: mockSetCustomAttribute,
+    };
+
+    unsetAllNewRelicQueryAttributes();
+    expect(mockSetCustomAttribute).toHaveBeenCalledTimes(
+      validSearchQueryParamKeys.length,
+    );
+    validSearchQueryParamKeys.forEach((key) => {
+      expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+        `search_param_${key}`,
+        "",
+      );
+    });
+  });
+});

--- a/infra/frontend/app-config/staging.tf
+++ b/infra/frontend/app-config/staging.tf
@@ -21,9 +21,6 @@ module "staging_config" {
   # instance_scaling_max_capacity is 5x the instance_scaling_min_capacity
   instance_scaling_max_capacity = 10
 
-  service_override_extra_environment_variables = {
-    NEW_RELIC_ENABLED = "false"
-  }
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
   # Defaults to `false`. Uncomment the next line to enable.


### PR DESCRIPTION
## Summary
Fixes #3764 

### Time to review: __15 mins__

## Changes proposed
* sends search page query params to new relic. This data is not collected out of the box by new relic because of security concerns.
* adds a typing package for the new relic client side object
* some moving around of new relic and query param related typing
* enables new relic in staging

## Context for reviewers

Note that custom attributes are being cleared when navigating away from the search page, but not quickly enough for them to not show up on the route transition events on navigation. Not sure if this is a deal breaker.

Also note that I've discovered that trying to run the app with new relic enabled but without an app name or license key results in the application hanging indefinitely. We should fix this in a future ticket.

Further note that given the somewhat vague requirements in the ticket I've just tried to make sure here that all the necessary data is making it into new relic, as much as possible. I created a basic dashboard view of a query to show the new parameters, but anything other work on this should probably go in another ticket. I attempted to make the query more flexible, by querying for all attributes with the `search_param` prefix, so far with no luck;.

Documentation updates are in order, but need to wait for https://github.com/HHS/simpler-grants-gov/pull/4005 with larger documentation updates to come in first

### Related docs
* https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setcustomattribute/

### Test steps

1. start a server on this branch with `npm run build -- --no-lint && NEW_RELIC_APP_NAME="Simpler Grants Next DEV" NEW_RELIC_LICENSE_KEY="<license key from 1password>" npm run start:nr`
2. load the app and navigate to the search page
3. click around to select filters, enter a search term, change sort options, and navigate between pages
4. visit the Search Parameters dashboard in the new relic ui https://one.newrelic.com/dashboards/detail/NTI0OTgwOXxWSVp8REFTSEJPQVJEfGRhOjgyNTU5NDg?account=5249809&state=90941f99-7f84-52ed-7197-f4fa625e85ab
5. _VERIFY_: your interactions show up in the table

## Additional information

![Screenshot 2025-02-27 at 10 12 21 AM](https://github.com/user-attachments/assets/a5e39925-2c17-43a4-bc05-74c46c5943c1)

