### PR TITLE
[Issue #4021] Create a task that validates agency data

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_agency.py
+++ b/api/src/data_migration/transformation/subtask/transform_agency.py
@@ -334,7 +334,9 @@ class ValidateAgencyData(AbstractTransformSubTask):
         PARENT_WITH_PARENT_AGENCY_COUNT = "parent_with_parent_agency_count"
 
     def transform_records(self) -> None:
-        agencies = self.db_session.scalars(select(Agency).options(selectinload(Agency.top_level_agency))).all()
+        agencies = self.db_session.scalars(
+            select(Agency).options(selectinload(Agency.top_level_agency))
+        ).all()
 
         for agency in agencies:
             self.validate_agency(agency)
@@ -349,6 +351,7 @@ class ValidateAgencyData(AbstractTransformSubTask):
             "top_level_agency_code": top_level_agency.agency_code if top_level_agency else None,
             "is_parent_test_agency": top_level_agency.is_test_agency if top_level_agency else None,
         }
+        logger.info("Validating agency", extra=log_extra)
 
         # If an agency has a dash in it, we would expect it to have a parent agency
         if top_level_agency is None and is_child_agency(agency):

--- a/api/src/data_migration/transformation/subtask/transform_agency.py
+++ b/api/src/data_migration/transformation/subtask/transform_agency.py
@@ -329,6 +329,7 @@ class ValidateAgencyData(AbstractTransformSubTask):
 
     class Metrics(StrEnum):
         AGENCY_VALIDATED_COUNT = "agency_validated_count"
+        TEST_AGENCY_COUNT = "test_agency_count"
         ORPHANED_CHILD_AGENCY_COUNT = "orphaned_child_agency_count"
         UNEXPECTED_TOP_LEVEL_AGENCY_COUNT = "unexpected_top_level_agency_count"
         PARENT_WITH_PARENT_AGENCY_COUNT = "parent_with_parent_agency_count"
@@ -352,6 +353,9 @@ class ValidateAgencyData(AbstractTransformSubTask):
             "is_parent_test_agency": top_level_agency.is_test_agency if top_level_agency else None,
         }
         logger.info("Validating agency", extra=log_extra)
+
+        if agency.is_test_agency:
+            self.increment(self.Metrics.TEST_AGENCY_COUNT)
 
         # If an agency has a dash in it, we would expect it to have a parent agency
         if top_level_agency is None and is_child_agency(agency):

--- a/api/src/data_migration/transformation/transform_oracle_data_task.py
+++ b/api/src/data_migration/transformation/transform_oracle_data_task.py
@@ -7,7 +7,7 @@ import src.data_migration.transformation.transform_constants as transform_consta
 from src.adapters import db
 from src.data_migration.transformation.subtask.transform_agency import (
     TransformAgency,
-    TransformAgencyHierarchy,
+    TransformAgencyHierarchy, ValidateAgencyData,
 )
 from src.data_migration.transformation.subtask.transform_applicant_type import (
     TransformApplicantType,
@@ -91,6 +91,7 @@ class TransformOracleDataTask(Task):
         if self.transform_config.enable_agency:
             TransformAgency(self).run()
             TransformAgencyHierarchy(self).run()
+            ValidateAgencyData(self).run()
 
         if self.transform_config.enable_opportunity_attachment:
             TransformOpportunityAttachment(self).run()

--- a/api/src/data_migration/transformation/transform_oracle_data_task.py
+++ b/api/src/data_migration/transformation/transform_oracle_data_task.py
@@ -7,7 +7,8 @@ import src.data_migration.transformation.transform_constants as transform_consta
 from src.adapters import db
 from src.data_migration.transformation.subtask.transform_agency import (
     TransformAgency,
-    TransformAgencyHierarchy, ValidateAgencyData,
+    TransformAgencyHierarchy,
+    ValidateAgencyData,
 )
 from src.data_migration.transformation.subtask.transform_applicant_type import (
     TransformApplicantType,

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -21,6 +21,7 @@ from src.adapters.oauth.login_gov.mock_login_gov_oauth_client import MockLoginGo
 from src.auth.api_jwt_auth import create_jwt_for_user
 from src.constants.schema import Schemas
 from src.db import models
+from src.db.models.agency_models import Agency
 from src.db.models.foreign import metadata as foreign_metadata
 from src.db.models.lookup.sync_lookup_values import sync_lookup_values
 from src.db.models.opportunity_models import Opportunity
@@ -450,6 +451,17 @@ class BaseTestClass:
             db_session.delete(opp)
 
         # Force the deletes to the DB
+        db_session.commit()
+
+    @pytest.fixture(scope="class")
+    def truncate_agencies(self, db_session):
+        with db_session.no_autoflush:
+            # Fetch all agencies
+            agencies = db_session.query(Agency).all()
+            # Delete each agency
+            for agency in agencies:
+                db_session.delete(agency)
+
         db_session.commit()
 
     @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary
Fixes #4021

### Time to review: __5 mins__

## Changes proposed
Created a task that validates agency data for a few known scenarios we've encountered

## Context for reviewers
This work is a follow-up to a discussion we had about oddities we've seen with agency data, and mainly aims for us to better be aware of data ending up in a weird state. While we've fixed some issues with the data, and fixed processes that build it, we know there are a few issues still present somewhere in the logic, and want to use this as a mechanism to help detect it.

