### PR TITLE
Add E2E tests for opportunity details page

### DIFF
--- a/frontend/tests/e2e/opportunity.spec.ts
+++ b/frontend/tests/e2e/opportunity.spec.ts
@@ -2,7 +2,7 @@
 import { expect, test } from "@playwright/test";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/opportunity/1");
+  await page.goto("/opportunity/32");
 });
 
 test.afterEach(async ({ context }) => {
@@ -14,5 +14,45 @@ test("has title", async ({ page }) => {
 });
 
 test("has page attributes", async ({ page }) => {
-  await expect(page.getByText("Forecasted")).toBeVisible();
+  await expect(page.getByText("Application process")).toBeVisible();
+});
+
+test("can expand and collapse summary", async ({ page }) => {
+  await expect(page.getByText("Show full summary")).toBeVisible();
+  await expect(page.getByText(/.*From single present little building.*/)).not.toBeVisible();
+  await expect(page.getByText("Hide full description")).not.toBeVisible();
+
+  await page.getByRole("button", { name: /^Show full summary$/ }).click();
+
+  // validate that summary has been expanded
+  await expect(page.getByText("Show full summary")).not.toBeVisible();
+  await expect(page.getByText(/.*From single present little building.*/)).toBeVisible();
+  await expect(page.getByText("Hide full description")).toBeVisible();
+
+  await page.getByRole("button", { name: /^Hide full description$/ }).click();
+
+  // validate that summary has been collapsed
+  await expect(page.getByText("Show full summary")).toBeVisible();
+  await expect(page.getByText(/.*From single present little building.*/)).not.toBeVisible();
+  await expect(page.getByText("Hide full description")).not.toBeVisible();
+});
+
+test("can expand and collapse description", async ({ page }) => {
+  await expect(page.getByText("Show full description")).toBeVisible();
+  await expect(page.getByText(/.*Year section value bag none clear.*/)).not.toBeVisible();
+  await expect(page.getByText("Hide full description")).not.toBeVisible();
+
+  await page.getByRole("button", { name: /^Show full description$/ }).click();
+
+  // validate that description has been expanded
+  await expect(page.getByText("Show full description")).not.toBeVisible();
+  await expect(page.getByText(/.*Year section value bag none clear.*/)).toBeVisible();
+  await expect(page.getByText("Hide full description")).toBeVisible();
+
+  await page.getByRole("button", { name: /^Hide full description$/ }).click();
+
+  // validate that description has been collapsed
+  await expect(page.getByText("Show full description")).toBeVisible();
+  await expect(page.getByText(/.*Year section value bag none clear.*/)).not.toBeVisible();
+  await expect(page.getByText("Hide full description")).not.toBeVisible();
 });


### PR DESCRIPTION
## Summary
Fixes #2715

### Time to review: __5 mins__

## Changes proposed
> Added E2E test cases for opportunity details page

## Context for reviewers
> Added tests that validate that expandable sections can be expanded and collapsed. 

## Additional information
> 
![image](https://github.com/user-attachments/assets/a56656d8-4755-46b3-9df9-ee199ccc13fa)

