### PR TITLE
[Unticketed] Fix s3 client checksum error

### DIFF
--- a/api/src/adapters/aws/s3_adapter.py
+++ b/api/src/adapters/aws/s3_adapter.py
@@ -36,7 +36,11 @@ def get_s3_client(
         params["endpoint_url"] = s3_config.s3_endpoint_url
 
     if boto_config is None:
-        boto_config = botocore.config.Config(signature_version="s3v4")
+        boto_config = botocore.config.Config(
+            signature_version="s3v4",
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+        )
 
     params["config"] = boto_config
 


### PR DESCRIPTION
## Summary

### Time to review: __3 mins__

## Changes proposed
Configure s3 client checksum behavior after recent library update

## Context for reviewers
Botocore (the python AWS library) recently modified how checksums behave with s3:
https://github.com/boto/botocore/blob/develop/CHANGELOG.rst#L377
(the relevant bits)
```
* api-change:``s3``: This change enhances integrity protections for new SDK requests to S3. S3 SDKs now support the CRC64NVME checksum algorithm, full object checksums for multipart S3 objects, and new default integrity protections for S3 requests.
* feature:``s3``: The S3 client attempts to validate response checksums for all S3 API operations that support checksums. However, if the SDK has not implemented the specified checksum algorithm then this validation is skipped. Checksum validation behavior can be configured using the ``when_supported`` and ``when_required`` options - in code using the ``response_checksum_validation`` parameter for ``botocore.config.Config``, in the shared AWS config file using ``response_checksum_validation``, or as an env variable using ``AWS_RESPONSE_CHECKSUM_VALIDATION``.
* feature:``s3``: Added support for the CRC64NVME checksum algorithm in the S3 client through the optional AWS CRT (``awscrt``) dependency.
* feature:``s3``: S3 client behavior is updated to always calculate a CRC32 checksum by default for operations that support it (such as PutObject or UploadPart), or require it (such as DeleteObjects). Checksum behavior can be configured using ``when_supported`` and ``when_required`` options - in code using the ``request_checksum_calculation`` parameter for ``botocore.config.Config``, in the shared AWS config file using ``request_checksum_calculation``, or as an env variable using ``AWS_REQUEST_CHECKSUM_CALCULATION``. Note: Botocore will no longer automatically compute and populate the Content-MD5 header.
```

This was causing an issue with us uploading files to our local s3 with a checksum error:
```
botocore.errorfactory.InvalidRequest: An error occurred (InvalidRequest) when calling the UploadPart operation: Checksum Type mismatch occurred, expected checksum Type: null, actual checksum Type: crc32
```

Effectively, I just disabled checksum validation unless it's required which should be the prior behavior if I'm following things correctly. I'm guessing localstack needs an update to s3 to return the right checksum codes?

