### PR TITLE
[unticketed] frontend package updates to work around axios vulnerability

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@opentelemetry/api": "^1.8.0",
         "@trussworks/react-uswds": "github:trussworks/react-uswds#58f3089739ac5ee415c11cfbe179daad7a62597",
         "@uswds/uswds": "^3.7.1",
+        "axios": "^1.8.2",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
         "focus-trap-react": "^10.2.3",
@@ -5002,10 +5003,12 @@
       }
     },
     "node_modules/@newrelic/security-agent": {
-      "version": "2.2.0",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/security-agent/-/security-agent-2.3.1.tgz",
+      "integrity": "sha512-ixJhVuFECYDVvBlSIWMn6jjbvk+46ag69anpvW7F72wz38tVUtN0EfabzPuZJx/dvR9ya509qIlFs+p4FQHjQQ==",
       "license": "New Relic Software License v1.0",
       "dependencies": {
-        "axios": "^1.7.4",
+        "axios": "^1.7.9",
         "check-disk-space": "^3.4.0",
         "content-type": "^1.0.5",
         "cron": "^3.1.7",
@@ -5221,6 +5224,63 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
@@ -6378,6 +6438,8 @@
     },
     "node_modules/@types/concat-stream": {
       "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.1.tgz",
+      "integrity": "sha512-eHE4cQPoj6ngxBZMvVf6Hw7Mh4jMW4U9lpGmS5GBPB9RYxlFg+CHaVN7ErNY4W9XfLIEn20b4VDYaIrbq0q4uA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6415,6 +6477,8 @@
     },
     "node_modules/@types/form-data": {
       "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "integrity": "sha512-8BSvG1kGm83cyJITQMZSulnl6QV8jqAGreJsc5tPu1Jq0vTSOiY/k24Wx82JRpWwZSqrala6sd5rWi6aNXvqcw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6535,6 +6599,8 @@
     },
     "node_modules/@types/luxon": {
       "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "license": "MIT"
     },
     "node_modules/@types/mdx": {
@@ -6581,6 +6647,8 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -7119,6 +7187,8 @@
     },
     "node_modules/acorn-import-attributes": {
       "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8"
@@ -7484,6 +7554,8 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
     "node_modules/asn1.js": {
@@ -7610,7 +7682,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -8369,6 +8443,8 @@
     },
     "node_modules/caseless": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "license": "Apache-2.0"
     },
     "node_modules/chai": {
@@ -8411,6 +8487,8 @@
     },
     "node_modules/check-disk-space": {
       "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz",
+      "integrity": "sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -8739,6 +8817,8 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8853,6 +8933,8 @@
     },
     "node_modules/cron": {
       "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-3.5.0.tgz",
+      "integrity": "sha512-0eYZqCnapmxYcV06uktql93wNWdlTmmBFP2iYz+JPVcQqlyFYcn1lFuIk4R54pkOmE7mcldTAPZv6X5XA4Q46A==",
       "license": "MIT",
       "dependencies": {
         "@types/luxon": "~3.4.0",
@@ -9169,6 +9251,8 @@
     },
     "node_modules/date-format": {
       "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -9732,7 +9816,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10734,6 +10817,8 @@
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -10825,6 +10910,8 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -10936,6 +11023,8 @@
     },
     "node_modules/find-package-json": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+      "integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
       "license": "MIT"
     },
     "node_modules/find-up": {
@@ -10992,6 +11081,8 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
@@ -11213,6 +11304,8 @@
     },
     "node_modules/get-port": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -11419,7 +11512,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -11601,6 +11693,8 @@
     },
     "node_modules/http-basic": {
       "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+      "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
       "license": "MIT",
       "dependencies": {
         "caseless": "^0.12.0",
@@ -11614,6 +11708,8 @@
     },
     "node_modules/http-basic/node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "engines": [
         "node >= 0.8"
       ],
@@ -11627,10 +11723,14 @@
     },
     "node_modules/http-basic/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/http-basic/node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -11644,10 +11744,14 @@
     },
     "node_modules/http-basic/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/http-basic/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -11666,6 +11770,8 @@
     },
     "node_modules/http-response-object": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^10.0.3"
@@ -11673,6 +11779,8 @@
     },
     "node_modules/http-response-object/node_modules/@types/node": {
       "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
       "license": "MIT"
     },
     "node_modules/https-browserify": {
@@ -11786,10 +11894,12 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.12.0",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.13.1.tgz",
+      "integrity": "sha512-k2V9wNm9B+ysuelDTHjI9d5KPc4l8zAZTGqj+pcynvWkypZd857ryzN8jNC7Pg2YZXNMJcHRPpaDyCBbNyVRpA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.8.2",
+        "acorn": "^8.14.0",
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
@@ -12047,6 +12157,8 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12119,6 +12231,8 @@
     },
     "node_modules/is-invalid-path": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-1.0.2.tgz",
+      "integrity": "sha512-6KLcFrPCEP3AFXMfnWrIFkZpYNBVzZAoBJJDEZKtI3LXkaDjM3uFMJQjxiizUuZTZ9Oh9FNv/soXbx5TcpaDmA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
@@ -13701,6 +13815,8 @@
     },
     "node_modules/jsonschema": {
       "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -13831,6 +13947,8 @@
     },
     "node_modules/log4js": {
       "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
+      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "date-format": "^4.0.14",
@@ -13897,6 +14015,8 @@
     },
     "node_modules/luxon": {
       "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -14173,16 +14293,22 @@
       "license": "MIT"
     },
     "node_modules/newrelic": {
-      "version": "12.10.0",
+      "version": "12.15.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-12.15.0.tgz",
+      "integrity": "sha512-9lseiusfKfXIitnHq4GzPAhLYDkvp/7mwXdw3i8Epg31sVl3/kuvg4TH7gYJw6na6LtcPz3A/lukasu6ubdGyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.2",
         "@grpc/proto-loader": "^0.7.5",
-        "@newrelic/security-agent": "^2.2.0",
+        "@newrelic/security-agent": "^2.3.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.0",
+        "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-trace-base": "^1.30.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "concat-stream": "^2.0.0",
         "https-proxy-agent": "^7.0.1",
-        "import-in-the-middle": "^1.11.2",
+        "import-in-the-middle": "^1.13.0",
         "json-bigint": "^1.0.0",
         "json-stringify-safe": "^5.0.0",
         "module-details-from-path": "^1.0.3",
@@ -14914,7 +15040,9 @@
       }
     },
     "node_modules/parse-cache-control": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -16447,6 +16575,8 @@
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16512,6 +16642,8 @@
     },
     "node_modules/promise": {
       "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "license": "MIT",
       "dependencies": {
         "asap": "~2.0.6"
@@ -17212,6 +17344,8 @@
     },
     "node_modules/request-ip": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==",
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -17371,6 +17505,8 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
     "node_modules/rimraf": {
@@ -17389,6 +17525,8 @@
     },
     "node_modules/ringbufferjs": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ringbufferjs/-/ringbufferjs-2.0.0.tgz",
+      "integrity": "sha512-GCOqTzUsTHF7nrqcgtNGAFotXztLgiePpIDpyWZ7R5I02tmfJWV+/yuJc//Hlsd8G+WzI1t/dc2y/w2imDZdog==",
       "license": "MIT"
     },
     "node_modules/ripemd160": {
@@ -17976,6 +18114,8 @@
     },
     "node_modules/streamroller": {
       "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
       "license": "MIT",
       "dependencies": {
         "date-format": "^4.0.14",
@@ -17988,6 +18128,8 @@
     },
     "node_modules/streamroller/node_modules/fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -18000,6 +18142,8 @@
     },
     "node_modules/streamroller/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -18007,6 +18151,8 @@
     },
     "node_modules/streamroller/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -18075,7 +18221,9 @@
       }
     },
     "node_modules/string.fromcodepoint": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
+      "integrity": "sha512-n69H31OnxSGSZyZbgBlvYIXlrMhJQ0dQAX1js1QDhpaUH6zmU3QYlj07bCwCNlPOu3oRXIubGPl2gDGnHsiCqg=="
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
@@ -18309,6 +18457,8 @@
     },
     "node_modules/sync-request": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
       "license": "MIT",
       "dependencies": {
         "http-response-object": "^3.0.1",
@@ -18321,6 +18471,8 @@
     },
     "node_modules/sync-rpc": {
       "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
       "license": "MIT",
       "dependencies": {
         "get-port": "^3.1.0"
@@ -18483,6 +18635,8 @@
     },
     "node_modules/then-request": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
       "license": "MIT",
       "dependencies": {
         "@types/concat-stream": "^1.6.0",
@@ -18503,10 +18657,14 @@
     },
     "node_modules/then-request/node_modules/@types/node": {
       "version": "8.10.66",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+      "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
       "license": "MIT"
     },
     "node_modules/then-request/node_modules/concat-stream": {
       "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "engines": [
         "node >= 0.8"
       ],
@@ -18519,12 +18677,15 @@
       }
     },
     "node_modules/then-request/node_modules/form-data": {
-      "version": "2.5.2",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
+      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
       "engines": {
@@ -18533,10 +18694,14 @@
     },
     "node_modules/then-request/node_modules/isarray": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/then-request/node_modules/readable-stream": {
       "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -18550,10 +18715,14 @@
     },
     "node_modules/then-request/node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/then-request/node_modules/string_decoder": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -18561,6 +18730,8 @@
     },
     "node_modules/then-request/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/third-party-capital": {
@@ -18934,6 +19105,8 @@
     },
     "node_modules/unescape": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unescape/-/unescape-1.0.1.tgz",
+      "integrity": "sha512-O0+af1Gs50lyH1nUu3ZyYS1cRh01Q/kUKatTOkSs7jukXE6/NebucDVxyiDsA9AQ4JC1V1jUH9EO8JX2nMDgGQ==",
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1"
@@ -18944,6 +19117,8 @@
     },
     "node_modules/unescape-js": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unescape-js/-/unescape-js-1.1.4.tgz",
+      "integrity": "sha512-42SD8NOQEhdYntEiUQdYq/1V/YHwr1HLwlHuTJB5InVVdOSbgI6xu8jK5q65yIzuFCfczzyDF/7hbGzVbyCw0g==",
       "license": "MIT",
       "dependencies": {
         "string.fromcodepoint": "^0.2.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
+    "axios": "^1.8.2",
     "@newrelic/next": "^0.10.0",
     "@next/third-parties": "^15.1.4",
     "@opentelemetry/api": "^1.8.0",


### PR DESCRIPTION
## Summary
unticketed

### Time to review: __10 mins__

## Changes proposed
* updates new relic security agent to latest version
* includes Axios as explicit dependency at latest version in order to remediate vulnerability

## Context for reviewers
CVE-2025-27152 appeared recently, and is causing our frontend code to (sometimes) not pass vulnerability scans

https://osv.dev/vulnerability/GHSA-jr5f-v2jv-69x6

Axios is a subdependency of the New Relic Node security agent package, but the package has not been updated to bring in the latest version of Axios yet. See https://github.com/newrelic/node-newrelic/releases

As a result this update includes a bump to the New Relic security agent, as well as an explicit bump to Axios, which we can remove from our package.json once New Relic updates to the latest Axios. See this ticket for that work https://github.com/HHS/simpler-grants-gov/issues/4096

Also worth noting is that Axios seems to declared their latest version (1.8.2) to represent a fix for this vulnerability, but an open issue suggests that it may not actually patch the issue, so this issue may pop up again. See https://github.com/axios/axios/issues/6816

### Testing

1. _VERIFY_: ci passes
2. _VERIFY_: app starts up locally and passes basic manual smoke test

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

