### PR TITLE
[Issue #3828] Update copy button to support non-https

### DIFF
--- a/frontend/src/components/search/SearchQueryCopyButton.tsx
+++ b/frontend/src/components/search/SearchQueryCopyButton.tsx
@@ -14,7 +14,7 @@ const TooltipWrapper = dynamic(() => import("src/components/TooltipWrapper"), {
   loading: () => <USWDSIcon className="margin-left-1" name="info_outline" />,
 });
 
-const SNACKBAR_VISIBLE_TIME = 60000;
+const SNACKBAR_VISIBLE_TIME = 6000;
 
 type SearchQueryCopyButtonProps = {
   copyText: string;
@@ -49,7 +49,7 @@ const SearchQueryCopyButton = ({
               showSnackbar(SNACKBAR_VISIBLE_TIME);
             })
             .catch((error) => {
-              console.error("Error copying to clipboard:", error);
+              console.error(error);
             });
         }}
       >

--- a/frontend/src/components/user/SaveSearchPanel.tsx
+++ b/frontend/src/components/user/SaveSearchPanel.tsx
@@ -2,15 +2,20 @@
 
 import { useTranslations } from "next-intl";
 import { usePathname, useSearchParams } from "next/navigation";
+import { useMemo } from "react";
 
 import SearchQueryCopyButton from "src/components/search/SearchQueryCopyButton";
 
 export const SaveSearchPanel = () => {
   const path = usePathname();
   const searchParams = useSearchParams();
-  const query = searchParams?.toString() ? `?${searchParams.toString()}` : "";
-  const origin = typeof window !== "undefined" ? window.location.origin : "";
-  const url = `${origin}${path}${query}`;
+
+  const url = useMemo(() => {
+    const query = searchParams?.toString() ? `?${searchParams.toString()}` : "";
+    const origin = typeof window !== "undefined" ? window.location.origin : "";
+    return `${origin}${path}${query}`;
+  }, [searchParams, path]);
+
   const t = useTranslations("Search.savedQuery");
   return (
     <div className="border-base-lighter border-1px padding-2 flex-align-start text-primary-darker text-underline display-flex">

--- a/frontend/src/components/user/SaveSearchPanel.tsx
+++ b/frontend/src/components/user/SaveSearchPanel.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { environment } from "src/constants/environments";
-
 import { useTranslations } from "next-intl";
 import { usePathname, useSearchParams } from "next/navigation";
 
@@ -11,7 +9,8 @@ export const SaveSearchPanel = () => {
   const path = usePathname();
   const searchParams = useSearchParams();
   const query = searchParams?.toString() ? `?${searchParams.toString()}` : "";
-  const url = `${environment.NEXT_PUBLIC_BASE_URL}${path}${query}`;
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const url = `${origin}${path}${query}`;
   const t = useTranslations("Search.savedQuery");
   return (
     <div className="border-base-lighter border-1px padding-2 flex-align-start text-primary-darker text-underline display-flex">

--- a/frontend/src/hooks/useCopyToClipboard.ts
+++ b/frontend/src/hooks/useCopyToClipboard.ts
@@ -6,16 +6,42 @@ export const useCopyToClipboard = () => {
   const [copied, setCopied] = useState(false);
   const [copying, setCopying] = useState(false);
 
+  // Provides https fallback to clipboard API
+  // credit to: https://stackoverflow.com/a/65996386
+  const copyWithFallback = async (content: string) => {
+    // Use fallback if https is not supported
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(content);
+    } else {
+      const textArea = document.createElement("textarea");
+      textArea.value = content;
+      textArea.style.position = "absolute";
+      textArea.style.left = "-999999px";
+      document.body.prepend(textArea);
+      textArea.select();
+      try {
+        // This is identified as deprecated https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+        // though no standard has replaced it and the "copy" command is supported
+        // in all browsers.
+        document.execCommand("copy");
+      } catch (error) {
+        console.error(error);
+      } finally {
+        textArea.remove();
+      }
+    }
+  };
+
   const copyToClipboard = async (content: string, contentTime: number) => {
     try {
       setCopying(true);
-      await navigator.clipboard.writeText(content);
+      await copyWithFallback(content);
       setCopied(true);
       setCopying(false);
     } catch (error) {
       setCopied(false);
       setCopying(false);
-      console.error(`Error copying to clipboard: ${content}`, error);
+      throw new Error(`Error copying to clipboard: ${error as string}`);
     } finally {
       setTimeout(() => {
         setCopied(false);


### PR DESCRIPTION
## Summary
Fixes #3828

### Time to review: __5 mins__

## Changes proposed
The clipboard property of the Navigator interface [requires https](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard) or localhost, which was not discovered until testing in dev.

This PR fixes that, throws an error in the clipboard component so the tooltip is not shown if it fails, and updates the content URL.

### Testing locally

1. Run `npm run dev` on `main`. 

```bash
   ▲ Next.js 15.1.4
   - Local:        http://localhost:3000
   - Network:      http://192.168.1.66:3000
   - Environments: .env.local, .env.development
```  
Use the `Network` URL, go to /search and see that the copy function errors.

2. Checkout this branch. Repeat the process, see that it works.

