### PR TITLE
[unticketed] send opportunity id in body of post request

### DIFF
--- a/frontend/src/app/api/user/saved-opportunities/route.ts
+++ b/frontend/src/app/api/user/saved-opportunities/route.ts
@@ -11,8 +11,6 @@ export const DELETE = async (request: Request) => {
 };
 
 const handleRequest = async (request: Request) => {
-  const headers = request.headers;
-  const opportunityId = headers.get("opportunityId");
   if (request.method !== "POST" && request.method !== "DELETE") {
     return Response.json(
       { message: `Method ${request.method} not allowed` },
@@ -22,6 +20,9 @@ const handleRequest = async (request: Request) => {
   const action = request.method === "POST" ? "save" : "delete";
 
   try {
+    const { opportunityId } = (await request.json()) as {
+      opportunityId: string;
+    };
     const session = await getSession();
     if (!session || !session.token) {
       throw new UnauthorizedError("No active session to save opportunity");

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -38,9 +38,7 @@ export const OpportunitySaveUserControl = () => {
     try {
       const res = await fetch("/api/user/saved-opportunities", {
         method,
-        headers: {
-          opportunityId,
-        },
+        body: JSON.stringify({ opportunityId }),
       });
       if (res.ok && res.status === 200) {
         const data = (await res.json()) as { type: string };

--- a/frontend/tests/api/user/saved-opportunities/route.test.ts
+++ b/frontend/tests/api/user/saved-opportunities/route.test.ts
@@ -30,11 +30,11 @@ jest.mock("src/services/fetch/fetchers/savedOpportunityFetcher", () => ({
 
 const fakeRequestForSavedOpps = (success = true, method: string) => {
   return {
-    headers: {
-      get: jest.fn(() => {
-        return success ? 1 : null;
-      }),
-    },
+    json: jest.fn(() => {
+      return success
+        ? Promise.resolve({ opportunityId: "1" })
+        : Promise.resolve({ opportunityId: null });
+    }),
     method,
   } as unknown as NextRequest;
 };


### PR DESCRIPTION
## Summary
unticketed

### Time to review: __5 mins__

## Changes proposed
For consistency, change client side request to save opportunity to use POST body rather than header

## Context for reviewers
### Test steps

1. see https://github.com/HHS/simpler-grants-gov/pull/3677

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

