### PR TITLE
[Issue 4100] Increase analytics ETL frequency 

### DIFF
--- a/infra/analytics/app-config/env-config/scheduled_jobs.tf
+++ b/infra/analytics/app-config/env-config/scheduled_jobs.tf
@@ -8,7 +8,7 @@ locals {
   scheduled_jobs = {
     sprint-reports = {
       task_command        = ["make", "gh-extract-transform-and-load"]
-      schedule_expression = "rate(1 days)"
+      schedule_expression = "rate(8 hours)"
       state               = "ENABLED"
     }
     opportunity-load-csvs = {


### PR DESCRIPTION
## Summary
Fixes #4100 

### Time to review: __1 min__

## Changes proposed
> What was added, updated, or removed in this PR.

This PR increases the frequency of the automated ETL workflow from 1x to 3x per day.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The analytics ETL workflow currently runs once every 24 hours, which means stakeholders are often times viewing stale data (i.e. "yesterday's data").

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

