### PR TITLE
[Issue 3601] highlighting search terms

### DIFF
--- a/frontend/src/components/search/SearchResults.tsx
+++ b/frontend/src/components/search/SearchResults.tsx
@@ -84,7 +84,7 @@ const ResolvedSearchResults = async ({
             totalResults={totalResults}
           />
         </div>
-        <SearchResultsList searchResults={searchResults} />
+        <SearchResultsList searchResults={searchResults} queryTerm={query || ""} />
         <SearchPagination
           totalPages={totalPages}
           page={page}

--- a/frontend/src/components/search/SearchResultsList.tsx
+++ b/frontend/src/components/search/SearchResultsList.tsx
@@ -10,10 +10,12 @@ import ServerErrorAlert from "src/components/ServerErrorAlert";
 
 interface ServerPageProps {
   searchResults: SearchAPIResponse;
+  queryTerm: string
 }
 
 export default async function SearchResultsList({
   searchResults,
+  queryTerm
 }: ServerPageProps) {
   const t = await getTranslations("Search");
 
@@ -45,6 +47,7 @@ export default async function SearchResultsList({
         <li key={opportunity?.opportunity_id}>
           <SearchResultsListItem
             opportunity={opportunity}
+            queryTerm={queryTerm}
             saved={savedOpportunityIds.includes(opportunity?.opportunity_id)}
           />
         </li>

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -12,12 +12,14 @@ import SearchResultListItemStatus from "./SearchResultListItemStatus";
 
 interface SearchResultsListItemProps {
   opportunity: Opportunity;
+  queryTerm: string;
   agencyNameLookup?: AgencyNamyLookup;
   saved?: boolean;
 }
 
 export default function SearchResultsListItem({
   opportunity,
+  queryTerm,
   agencyNameLookup,
   saved = false,
 }: SearchResultsListItemProps) {
@@ -75,7 +77,8 @@ export default function SearchResultsListItem({
                   href={`/opportunity/${opportunity?.opportunity_id}`}
                   className="usa-link usa-link"
                 >
-                  {opportunity?.opportunity_title}
+                  {HighlightQueryTerms(opportunity?.opportunity_title)}
+                  
                 </Link>
               </h2>
             </div>

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -41,6 +41,29 @@ export default function SearchResultsListItem({
     text-base-darker
   `;
 
+  const HighlightQueryTerms = (title: string) => {
+    const queryItems = new Set<string>(queryTerm.split(" "));
+    const titleItems = title.split(" ");
+
+    const display = titleItems.map((word) => {
+      if(queryItems.has(word)) {
+        return {className: "bg-yellow", data: word}
+      }
+      return {className: "", data: word}
+    })
+
+    const displayFormat = display.map((item) => {
+      const styles = `display-inline ${item.className}`
+      return (
+        <>
+          {item.className === "bg-yellow" ? <span className={styles} key={Math.random()}>{item.data}</span> : ` ${item.data} `}
+        </>
+      )
+    })
+
+    return displayFormat
+  }
+
   return (
     <div className={resultBorderClasses}>
       <div className="grid-row grid-gap">

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -58,7 +58,7 @@ export default function SearchResultsListItem({
       const styles = `display-inline ${item.className}`
       return (
         <>
-          {item.className === "bg-yellow" ? <span className={styles} key={Math.random()}>{item.data}</span> : ` ${item.data} `}
+          {item.className === "bg-yellow" ? <span className={styles} key={Math.random()}> {item.data} </span> : ` ${item.data} `}
         </>
       )
     })

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -76,6 +76,7 @@ export default function SearchResultsListItem({
                 <Link
                   href={`/opportunity/${opportunity?.opportunity_id}`}
                   className="usa-link usa-link"
+                  key={opportunity?.opportunity_id}
                 >
                   {HighlightQueryTerms(opportunity?.opportunity_title)}
                   


### PR DESCRIPTION
## Summary
Fixes #3601 

### Time to review: 10 minutes

## Changes proposed
> What was added, updated, or removed in this PR.

The query search term has now been passed into `SearchResults.tsx` allowing to filter and highlight any terms mentioned in the query

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Changes were verified using the local development environment with the api server, database, and frontend running.

There currently is an extra piece of whitespace per highlighted term appended in front, which could present some minor difficulty in quickly seeing the highlighted term for some users.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

![image](https://github.com/user-attachments/assets/67f321dc-cb13-4a13-bc3b-8378fb57aa37)

![image](https://github.com/user-attachments/assets/2aa5e34f-631d-4cf4-9466-500b6598ab53)


