### PR TITLE
[Issue #3644] Allow longer querystring since our FE relies on that for search filters

### DIFF
--- a/infra/modules/service/waf.tf
+++ b/infra/modules/service/waf.tf
@@ -39,6 +39,14 @@ resource "aws_wafv2_web_acl" "waf" {
 
           name = "NoUserAgent_HEADER"
         }
+
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
+          name = "SizeRestrictions_QUERYSTRING"
+        }
       }
     }
     visibility_config {


### PR DESCRIPTION
## Summary
Fixes #3644 

### Time to review: __5 mins__

## Changes proposed
Stop blocking on long query strings, count instead

## Context for reviewers
Manually changed this setting in Dev and verified the search page no longer 403'd
