### PR TITLE
[Issue #3830] send saved search id down in response payload

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -2248,6 +2248,29 @@ components:
           - $ref: '#/components/schemas/OpportunitySearchRequestV1'
       required:
       - name
+    SavedSearchResponse:
+      type: object
+      properties:
+        saved_search_id:
+          type: string
+          format: uuid
+          description: The ID of the saved search
+          example: 123e4567-e89b-12d3-a456-426614174000
+        name:
+          type: string
+          description: Name of the saved search
+          example: Grant opportunities in California
+        search_query:
+          description: The saved search query parameters
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/OpportunitySearchRequestV1'
+        created_at:
+          type: string
+          format: date-time
+          description: When the search was saved
+          example: '2024-01-01T00:00:00Z'
     UserSaveSearchResponse:
       type: object
       properties:
@@ -2256,7 +2279,10 @@ components:
           description: The message to return
           example: Success
         data:
-          example: null
+          type:
+          - object
+          allOf:
+          - $ref: '#/components/schemas/SavedSearchResponse'
         status_code:
           type: integer
           description: The HTTP status code
@@ -2341,29 +2367,6 @@ components:
           - $ref: '#/components/schemas/UserGetSavedSearchPaginationV1'
       required:
       - pagination
-    SavedSearchResponse:
-      type: object
-      properties:
-        saved_search_id:
-          type: string
-          format: uuid
-          description: The ID of the saved search
-          example: 123e4567-e89b-12d3-a456-426614174000
-        name:
-          type: string
-          description: Name of the saved search
-          example: Grant opportunities in California
-        search_query:
-          description: The saved search query parameters
-          type:
-          - object
-          allOf:
-          - $ref: '#/components/schemas/OpportunitySearchRequestV1'
-        created_at:
-          type: string
-          format: date-time
-          description: When the search was saved
-          example: '2024-01-01T00:00:00Z'
     UserSavedSearchesResponse:
       type: object
       properties:

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -282,7 +282,7 @@ def user_save_search(
         },
     )
 
-    return response.ApiResponse(message="Success")
+    return response.ApiResponse(message="Success", data=saved_search)
 
 
 @user_blueprint.delete("/<uuid:user_id>/saved-searches/<uuid:saved_search_id>")

--- a/api/src/api/users/user_schemas.py
+++ b/api/src/api/users/user_schemas.py
@@ -112,10 +112,6 @@ class UserSaveSearchRequestSchema(Schema):
     search_query = search_query = fields.Nested(OpportunitySearchRequestV1Schema)
 
 
-class UserSaveSearchResponseSchema(AbstractResponseSchema):
-    data = fields.MixinField(metadata={"example": None})
-
-
 class SavedSearchResponseSchema(Schema):
     saved_search_id = fields.UUID(
         metadata={
@@ -136,6 +132,10 @@ class SavedSearchResponseSchema(Schema):
     created_at = fields.DateTime(
         metadata={"description": "When the search was saved", "example": "2024-01-01T00:00:00Z"}
     )
+
+
+class UserSaveSearchResponseSchema(AbstractResponseSchema):
+    data = fields.Nested(SavedSearchResponseSchema)
 
 
 class UserSavedSearchesRequestSchema(Schema):


### PR DESCRIPTION
## Summary
Support for issue #3830 

### Time to review: __10 mins__

## Changes proposed
Send id of saved search down in payload on successful save request

## Context for reviewers
This id will be used by the frontend to trigger a refetch of a user's saved search list

See https://github.com/HHS/simpler-grants-gov/pull/4170

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

