### PR TITLE
[unticketed] add aria label to fix broken tooltip accessibility test

### DIFF
--- a/frontend/src/components/TooltipWrapper.tsx
+++ b/frontend/src/components/TooltipWrapper.tsx
@@ -13,7 +13,7 @@ type TooltipProps = {
 };
 
 export const TooltipWrapper = (props: TooltipProps) => {
-  return <Tooltip {...props} />;
+  return <Tooltip aria-label={props.title} {...props} />;
 };
 
 export default TooltipWrapper;

--- a/frontend/src/components/search/SaveSearchPanel.tsx
+++ b/frontend/src/components/search/SaveSearchPanel.tsx
@@ -17,12 +17,19 @@ const TooltipWrapper = dynamic(() => import("src/components/TooltipWrapper"), {
   loading: () => <USWDSIcon className="margin-left-1" name="info_outline" />,
 });
 
-const SaveSearchTooltip = ({ text }: { text: string }) => {
+const SaveSearchTooltip = ({
+  text,
+  title,
+}: {
+  text: string;
+  title: string;
+}) => {
   return (
     <TooltipWrapper
       className="margin-left-1 usa-button--unstyled"
       label={<div className="width-card-lg text-wrap">{text}</div>}
       position="top"
+      title={title}
     >
       <USWDSIcon className="text-secondary-darker" name="info_outline" />
     </TooltipWrapper>
@@ -61,7 +68,10 @@ export function SaveSearchPanel() {
       {showSavedSearchUI && (
         <div className="margin-bottom-2 display-flex">
           <span className="text-bold">{t("heading")}</span>
-          <SaveSearchTooltip text={t("help.noSavedQueries")} />
+          <SaveSearchTooltip
+            text={t("help.noSavedQueries")}
+            title={t("help.general")}
+          />
         </div>
       )}
       <div className="display-flex flex-align-start text-underline">
@@ -74,7 +84,10 @@ export function SaveSearchPanel() {
           snackbarMessage={t("copySearch.snackbar")}
         >
           {!showSavedSearchUI && (
-            <SaveSearchTooltip text={t("help.unauthenticated")} />
+            <SaveSearchTooltip
+              text={t("help.unauthenticated")}
+              title={t("help.general")}
+            />
           )}
         </SearchQueryCopyButton>
       </div>

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -669,6 +669,7 @@ export const messages = {
           "Save this frequently used search query to your account. Apply it again later to save time when searching for opportunities.",
         authenticated:
           "Manage your saved search queries in your <strong>Workspace</strong>.",
+        general: "About saved searches",
       },
       modal: {
         title: "Save search query",


### PR DESCRIPTION
## Summary
unticketed

### Time to review: __5 mins__

## Changes proposed
Adding aria-label attribute to tooltip button to fix accessibility issue flagged in pa11y testing.

## Context for reviewers

Note that this is covering for a seeming deficiency in the Truss Tooltip component, as it uses a button under the hood but does not account for adding labeling or text to satisfy this axe rule:

https://dequeuniversity.com/rules/axe/4.2/button-name?application=axeAPI

### Test steps

1. `npm run dev` on this branch
2. `npm run test:pa11y-desktop`
3. _VERIFY_: all tests pass

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

