### PR TITLE
[Unticketed] Fix backend task timer

### DIFF
--- a/api/src/task/task.py
+++ b/api/src/task/task.py
@@ -43,11 +43,12 @@ class Task(abc.ABC, metaclass=abc.ABCMeta):
             # Initialize the metrics
             self.initialize_metrics()
 
-            # Run the actual task
-            self.run_task()
-
+            # Start the timer
             logger.info("Starting %s", self.cls_name())
             start = time.perf_counter()
+
+            # Run the actual task
+            self.run_task()
 
             # Calculate and set a duration
             end = time.perf_counter()


### PR DESCRIPTION
## Summary

### Time to review: __1 mins__

## Changes proposed
Fix the timer for our ECS tasks to actually wrap the code that they run in

## Context for reviewers
The actual implementation of a task is in the `run_task` method, the timer somehow got moved to be after the job ran, so all the metrics were 0 seconds. This fixes that
