### PR TITLE
[Unticketed] Adjust how cascade-deletes are done in tests

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -29,6 +29,7 @@ from src.db.models.staging import metadata as staging_metadata
 from src.util.local import load_local_env_vars
 from tests.lib import db_testing
 from tests.lib.auth_test_utils import mock_oauth_endpoint
+from tests.lib.db_testing import cascade_delete_from_db_table
 
 logger = logging.getLogger(__name__)
 
@@ -445,24 +446,11 @@ class BaseTestClass:
         As this is at the class scope, this will only run once for a given
         class implementation.
         """
-
-        opportunities = db_session.query(Opportunity).all()
-        for opp in opportunities:
-            db_session.delete(opp)
-
-        # Force the deletes to the DB
-        db_session.commit()
+        cascade_delete_from_db_table(db_session, Opportunity)
 
     @pytest.fixture(scope="class")
     def truncate_agencies(self, db_session):
-        with db_session.no_autoflush:
-            # Fetch all agencies
-            agencies = db_session.query(Agency).all()
-            # Delete each agency
-            for agency in agencies:
-                db_session.delete(agency)
-
-        db_session.commit()
+        cascade_delete_from_db_table(db_session, Agency)
 
     @pytest.fixture(scope="class")
     def truncate_staging_tables(self, db_session, test_staging_schema):

--- a/api/tests/lib/db_testing.py
+++ b/api/tests/lib/db_testing.py
@@ -3,7 +3,8 @@
 import contextlib
 import logging
 
-from sqlalchemy import text
+from sqlalchemy import select, text
+from sqlalchemy.orm import selectinload
 
 import src.adapters.db as db
 from src.adapters.db.clients.postgres_config import get_db_config
@@ -58,3 +59,23 @@ def _drop_schema(conn: db.Connection, schema_name: str):
     with conn.begin():
         conn.execute(text(f"DROP SCHEMA {schema_name} CASCADE;"))
     logger.info("drop schema %s", schema_name)
+
+
+def cascade_delete_from_db_table(db_session: db.Session, table_model) -> None:
+    """Delete all records in a table in a way that cascade-deletes any records configured to do so
+
+    Normally if you were to try to do a "delete all" query against a table which has foreign keys referencing it
+    you'd get an error. SQLAlchemy's cascade deletes handle recursively cleaning up anything that would still reference it.
+
+    Note that these types of queries are much slower as it needs to first fetch and then iterate over A LOT
+    of models potentially. Before you use this, please make sure you can't write your test in a way that is fine
+    with whatever data might exist in a given table.
+    """
+
+    with db_session.no_autoflush:
+        records = db_session.scalars(select(table_model).options(selectinload("*")))
+
+        for record in records:
+            db_session.delete(record)
+
+        db_session.commit()

--- a/api/tests/src/api/agencies_v1/test_agencies_routes.py
+++ b/api/tests/src/api/agencies_v1/test_agencies_routes.py
@@ -2,6 +2,7 @@ import pytest
 
 from src.db.models.agency_models import Agency
 from tests.conftest import BaseTestClass
+from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.db.models.factories import AgencyFactory
 
 
@@ -9,16 +10,7 @@ class TestAgenciesRoutes(BaseTestClass):
     @pytest.fixture(autouse=True)
     def cleanup_agencies(self, db_session):
         yield
-
-        # Use no_autoflush to prevent premature flushes
-        with db_session.no_autoflush:
-            # Fetch all agencies
-            agencies = db_session.query(Agency).all()
-            # Delete each agency
-            for agency in agencies:
-                db_session.delete(agency)
-
-        db_session.commit()
+        cascade_delete_from_db_table(db_session, Agency)
 
     def test_agencies_get_default_dates(
         self, client, api_auth_token, enable_factory_create, db_session

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -4,15 +4,13 @@ import pytest
 from sqlalchemy import select
 
 from src.db.models.competition_models import Application, Competition
+from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.db.models.factories import CompetitionFactory, OpportunityFactory
 
 
 @pytest.fixture(autouse=True)
 def clear_competitions(db_session):
-    competitions = db_session.query(Competition).all()
-    for competition in competitions:
-        db_session.delete(competition)
-    db_session.commit()
+    cascade_delete_from_db_table(db_session, Competition)
 
 
 def test_application_start_success(client, api_auth_token, enable_factory_create, db_session):

--- a/api/tests/src/search/backend/test_load_opportunities_to_index.py
+++ b/api/tests/src/search/backend/test_load_opportunities_to_index.py
@@ -15,6 +15,7 @@ from src.search.backend.load_opportunities_to_index import (
 from src.util import file_util
 from src.util.datetime_util import get_now_us_eastern_datetime
 from tests.conftest import BaseTestClass
+from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.db.models.factories import (
     AgencyFactory,
     OpportunityAttachmentFactory,
@@ -406,9 +407,7 @@ class TestLoadOpportunitiesToIndexPartialRefresh(BaseTestClass):
     def test_opportunities_to_process_query(
         self, db_session, load_opportunities_to_index, enable_factory_create
     ):
-        opportunities = db_session.query(Opportunity).all()
-        for opp in opportunities:
-            db_session.delete(opp)
+        cascade_delete_from_db_table(db_session, Opportunity)
 
         # Add new opportunities
         oca_1 = OpportunityChangeAuditFactory.create()


### PR DESCRIPTION
## Summary
Fixes #{ISSUE}

### Time to review: __1 mins__

## Changes proposed
Adjust the way we cleanup tables between unit tests

## Context for reviewers
A recent test failure prompted this change: https://github.com/HHS/simpler-grants-gov/actions/runs/13930349741/job/38985691135 - likely this was just a random failure, but it meant it was worth looking into how we do cleanup between individual unit tests. I made it so all deletes now use the same utility which does two things:
* Does everything in a no_autoflush block to prevent any weird flush in the middle of a delete
* Adds `selectinload` to fetch all relationships up front to improve performance (locally I got things to run in about 75% of the previous time).

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

