### PR TITLE
[Isssue 3060] Split acceptance criteria metric into 2 metrics

### DIFF
--- a/analytics/src/analytics/integrations/etldb/deliverable_model.py
+++ b/analytics/src/analytics/integrations/etldb/deliverable_model.py
@@ -119,18 +119,28 @@ class EtlDeliverableModel:
             text(
                 "insert into gh_deliverable_history"
                 "(deliverable_id, status, d_effective, "
-                "accept_criteria_total, accept_criteria_done) "
-                "values (:deliverable_id, :status, :effective, :ac_total, :ac_done) "
-                "on conflict(deliverable_id, d_effective) do update "
-                "set (status, t_modified, accept_criteria_total, accept_criteria_done) = "
-                "(:status, current_timestamp, :ac_total, :ac_done) returning id",
+                "accept_criteria_total, accept_criteria_done, "
+                "accept_metrics_total, accept_metrics_done) "
+                "values "
+                "(:deliverable_id, :status, :effective, "
+                ":criteria_total, :criteria_done, "
+                ":metrics_total, :metrics_done) "
+                "on conflict(deliverable_id, d_effective) "
+                "do update set (status, t_modified, "
+                "accept_criteria_total, accept_criteria_done, "
+                "accept_metrics_total, accept_metrics_done) = "
+                "(:status, current_timestamp, "
+                ":criteria_total, :criteria_done, "
+                ":metrics_total, :metrics_done) returning id",
             ),
             {
                 "deliverable_id": deliverable_id,
                 "status": deliverable_df["deliverable_status"],
                 "effective": self.dbh.effective_date,
-                "ac_total": ac_total.criteria,
-                "ac_done": ac_total.done,
+                "criteria_total": ac_total.criteria_total,
+                "criteria_done": ac_total.criteria_done,
+                "metrics_total": ac_total.metrics_total,
+                "metrics_done": ac_total.metrics_done,
             },
         )
         row = result.fetchone()

--- a/analytics/src/analytics/integrations/etldb/main.py
+++ b/analytics/src/analytics/integrations/etldb/main.py
@@ -11,7 +11,6 @@ from analytics.datasets.acceptance_criteria import (
     AcceptanceCriteriaDataset,
     AcceptanceCriteriaNestLevel,
     AcceptanceCriteriaTotal,
-    AcceptanceCriteriaType,
 )
 from analytics.datasets.etl_dataset import EtlDataset, EtlEntityType
 from analytics.integrations.etldb.deliverable_model import EtlDeliverableModel
@@ -149,7 +148,6 @@ def sync_deliverables(
         ac_total = (
             ac.get_totals(
                 ghid,
-                AcceptanceCriteriaType.MAIN,
                 AcceptanceCriteriaNestLevel.ALL,
             )
             if ac is not None

--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0009_add_accept_metrics_to_deliv_hist.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0009_add_accept_metrics_to_deliv_hist.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF EXISTS gh_deliverable_history ADD COLUMN IF NOT EXISTS accept_metrics_done INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE IF EXISTS gh_deliverable_history ADD COLUMN IF NOT EXISTS accept_metrics_total INTEGER NOT NULL DEFAULT 0;

--- a/analytics/tests/datasets/test_acceptance_criteria.py
+++ b/analytics/tests/datasets/test_acceptance_criteria.py
@@ -6,7 +6,6 @@ from analytics.datasets.acceptance_criteria import (
     AcceptanceCriteriaDataset,
     AcceptanceCriteriaNestLevel,
     AcceptanceCriteriaTotal,
-    AcceptanceCriteriaType,
 )
 
 
@@ -118,11 +117,12 @@ def test_checkboxes_in_unrelated_sections_ignored(
     """Ensure checkboxes in non-relevant sections are ignored."""
     totals = acceptance_criteria_dataset.get_totals(
         "org/repo/issues/789",
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
-    assert totals.criteria == 2  # Only the valid acceptance criteria should count
-    assert totals.done == 1  # One valid checkbox is checked
+    assert totals.criteria_total == 2  # Only the valid acceptance criteria should count
+    assert totals.criteria_done == 1  # One valid checkbox is checked
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_missing_criteria_section(
@@ -131,11 +131,12 @@ def test_missing_criteria_section(
     """Ensure an issue without an acceptance criteria section returns zero counts."""
     totals = acceptance_criteria_dataset.get_totals(
         "org/repo/issues/456",
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
-    assert totals.criteria == 0
-    assert totals.done == 0
+    assert totals.criteria_total == 0
+    assert totals.criteria_done == 0
+    assert totals.metrics_total == 2
+    assert totals.metrics_done == 1
 
 
 def test_malformed_checkboxes_ignored(
@@ -149,11 +150,12 @@ def test_malformed_checkboxes_ignored(
 """
     totals = acceptance_criteria_dataset.parse_body_content(
         malformed_body,
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
-    assert totals.criteria == 0
-    assert totals.done == 0
+    assert totals.criteria_total == 0
+    assert totals.criteria_done == 0
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_case_insensitive_section_headers(
@@ -167,11 +169,12 @@ def test_case_insensitive_section_headers(
 """
     totals = acceptance_criteria_dataset.parse_body_content(
         case_variation_body,
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
-    assert totals.criteria == 2
-    assert totals.done == 1
+    assert totals.criteria_total == 2
+    assert totals.criteria_done == 1
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_empty_body_content(
@@ -180,11 +183,12 @@ def test_empty_body_content(
     """Ensure an empty body content does not cause errors and returns zero counts."""
     totals = acceptance_criteria_dataset.parse_body_content(
         "",
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
-    assert totals.criteria == 0
-    assert totals.done == 0
+    assert totals.criteria_total == 0
+    assert totals.criteria_done == 0
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_whitespace_in_section_headers(
@@ -198,11 +202,12 @@ def test_whitespace_in_section_headers(
 """
     totals = acceptance_criteria_dataset.parse_body_content(
         whitespace_variation_body,
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
-    assert totals.criteria == 2
-    assert totals.done == 1
+    assert totals.criteria_total == 2
+    assert totals.criteria_done == 1
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_deeply_nested_checkboxes_all_levels(
@@ -219,12 +224,13 @@ def test_deeply_nested_checkboxes_all_levels(
 
     totals = acceptance_criteria_dataset.parse_body_content(
         deep_nesting_body,
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
 
-    assert totals.criteria == 4
-    assert totals.done == 1
+    assert totals.criteria_total == 4
+    assert totals.criteria_done == 1
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_h2_h4_headers_dont_break_parsing(
@@ -262,12 +268,13 @@ Some introductory text.
 
     totals = acceptance_criteria_dataset.parse_body_content(
         mixed_headers_body,
-        AcceptanceCriteriaType.ALL,
         AcceptanceCriteriaNestLevel.ALL,
     )
 
-    assert totals.criteria == 4
-    assert totals.done == 2
+    assert totals.criteria_total == 2
+    assert totals.criteria_done == 1
+    assert totals.metrics_total == 2
+    assert totals.metrics_done == 1
 
 
 def test_get_totals_with_no_data() -> None:
@@ -277,13 +284,14 @@ def test_get_totals_with_no_data() -> None:
 
     totals = dataset.get_totals(
         "org/repo/issues/123",
-        AcceptanceCriteriaType.ALL,
         AcceptanceCriteriaNestLevel.ALL,
     )
 
     assert isinstance(totals, AcceptanceCriteriaTotal)
-    assert totals.criteria == 0
-    assert totals.done == 0
+    assert totals.criteria_total == 0
+    assert totals.criteria_done == 0
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_get_totals_with_valid_data(
@@ -292,13 +300,14 @@ def test_get_totals_with_valid_data(
     """Test get_totals with a valid issue URL."""
     totals = acceptance_criteria_dataset.get_totals(
         "org/repo/issues/123",
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.ALL,
     )
 
     assert isinstance(totals, AcceptanceCriteriaTotal)
-    assert totals.criteria == 6
-    assert totals.done == 3
+    assert totals.criteria_total == 6
+    assert totals.criteria_done == 3
+    assert totals.metrics_total == 3
+    assert totals.metrics_done == 0
 
 
 def test_get_totals_nested_level_1(
@@ -307,12 +316,13 @@ def test_get_totals_nested_level_1(
     """Test get_totals filtering by Level 1 checkboxes only."""
     totals = acceptance_criteria_dataset.get_totals(
         "org/repo/issues/123",
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.LEVEL_1,
     )
 
-    assert totals.criteria == 3
-    assert totals.done == 0
+    assert totals.criteria_total == 3
+    assert totals.criteria_done == 0
+    assert totals.metrics_total == 3
+    assert totals.metrics_done == 0
 
 
 def test_get_totals_nested_level_2(
@@ -321,12 +331,13 @@ def test_get_totals_nested_level_2(
     """Test get_totals filtering by Level 2 checkboxes only."""
     totals = acceptance_criteria_dataset.get_totals(
         "org/repo/issues/123",
-        AcceptanceCriteriaType.MAIN,
         AcceptanceCriteriaNestLevel.LEVEL_2,
     )
 
-    assert totals.criteria == 3
-    assert totals.done == 3
+    assert totals.criteria_total == 3
+    assert totals.criteria_done == 3
+    assert totals.metrics_total == 0
+    assert totals.metrics_done == 0
 
 
 def test_get_totals_with_metrics_section(
@@ -335,9 +346,10 @@ def test_get_totals_with_metrics_section(
     """Test get_totals with a different section (Metrics)."""
     totals = acceptance_criteria_dataset.get_totals(
         "org/repo/issues/456",
-        AcceptanceCriteriaType.METRICS,
         AcceptanceCriteriaNestLevel.ALL,
     )
 
-    assert totals.criteria == 2
-    assert totals.done == 1
+    assert totals.criteria_total == 0
+    assert totals.criteria_done == 0
+    assert totals.metrics_total == 2
+    assert totals.metrics_done == 1


### PR DESCRIPTION
## Summary
Fixes #3063 

### Time to review: __2 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Extend ETL workflow to write 2 acceptance criteria metrics to DB instead of 1:
* percent of acceptance criteria done
* percent of acceptance metrics done

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

