### PR TITLE
[Issue #4000]: Add new tone and voice page content for storybook

### DIFF
--- a/frontend/stories/brand/tone.mdx
+++ b/frontend/stories/brand/tone.mdx
@@ -1,0 +1,465 @@
+import { Meta } from "@storybook/blocks";
+
+import { Alert } from "@trussworks/react-uswds";
+
+<Meta
+  title="Guidance/Voice and Tone Guide"
+  description="Guidance for writing content and communications in the Grants.gov brand voice"
+/>
+
+<style>
+  {`
+  /* Higher specificity selectors */
+  .sbdocs.sbdocs-content p {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  
+  .sbdocs.sbdocs-content ul, 
+  .sbdocs.sbdocs-content ol {
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+  
+  .sbdocs.sbdocs-content h1, 
+  .sbdocs.sbdocs-content h2, 
+  .sbdocs.sbdocs-content h3, 
+  .sbdocs.sbdocs-content h4, 
+  .sbdocs.sbdocs-content h5 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+  }
+  
+  /* Target Alert component content */
+  .sbdocs.sbdocs-content .usa-alert p {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+  
+  /* Add some spacing between list items */
+  .sbdocs.sbdocs-content li {
+    margin-bottom: 0.25rem;
+  }
+`}
+</style>
+
+# Voice and Tone
+
+## I. Introduction and Definitions
+
+The purpose of this voice and tone guide is to help you write for Grants.gov so that we sound like the same organization everywhere people encounter our content. Consider these definitions to understand the difference between voice and tone:
+
+- Our **voice** is our unique personality. It's grounded in our brand identity, particularly our brand characters. It should be a consistent thread through everything we write and say.
+- Our **tone** adapts to the situation. For example, we may adjust our tone for the audience or the context in which our audiences need our information.
+
+## II. Our Voice
+
+Our brand characters serve as the foundation of our voice (and everything else about Grants.gov, from our visual identity to the product experience). This section details how we bring the four brand characters most relevant to our voice and tone to life in what we write and say:
+
+- Approachable
+- Trustworthy
+- Straightforward
+- Purposeful
+
+### Approachable
+
+We are responsive, warm, and open.
+
+#### **How we achieve this:**
+
+- Our writing positions us as a helpful concierge:
+
+<Alert type="warning" slim>
+  The Grants Learning Center is your gateway to the federal grants world.
+</Alert>
+
+<br />
+
+<Alert type="success" slim>
+  Get your federal grants questions answered in the Grants Learning Center.
+</Alert>
+
+- We focus on the positive and specify a next step when appropriate.
+
+<Alert type="warning" slim>
+  Grantors may register and log on to Grants.gov, but they will not be able to
+  perform agency-related actions until they are affiliated with the agency and
+  assigned role(s).
+</Alert>
+
+<br />
+
+<Alert type="success" slim>
+  Once your Point of Contact (POC) links you to the agency and assigns you the
+  appropriate roles, you'll be able to complete tasks in Grants.gov. Let your
+  agency POC know after you register.
+</Alert>
+
+### Trustworthy
+
+We are an indispensable, credible source of knowledge, information, and expertise.
+
+#### How we achieve this:
+
+- We are transparent and clear about our role in the federal grantmaking process.
+
+<Alert type="warning" slim>
+  The Grants.gov program management office was established, in 2002, as a part of the President's Management Agenda. Managed by the Department of Health and Human Services, Grants.gov is an E-Government initiative operating under the governance of the Office of Management and Budget.
+
+Under the President's Management Agenda, the office was chartered to deliver a system that provides a centralized location for grant seekers to find and apply for federal funding opportunities. Today, the Grants.gov system houses information on over 1,000 grant programs and vets grant applications for federal grant-making agencies.
+
+</Alert>
+
+<br />
+
+<Alert type="success" slim>
+  Grants.gov is a website from the U.S. government that pulls together grants offered by federal agencies in one place. Your organization can apply for many federal grants using the Grants.gov Workspace.
+
+For grants you can apply for using Grants.gov, you'll be able to track when it is delivered to the granting agency. After that hand-off, the granting agency will take over.
+
+</Alert>
+
+- We anticipate what our audiences want or need to know and pull out the information that impacts them most.
+
+<Alert type="warning" slim>
+  <em>
+    In this example from the Grants.Gov Release Notes page, a user has to open a
+    PDF to understand the changes and whether they affect them.
+  </em>{" "}
+  <img
+    data-testid="zoom-image"
+    alt=""
+    loading="lazy"
+    fetchpriority="low"
+    style={{ display: "inline" }}
+    className="inline ZoomImage_zoomImg__teSyL"
+    src="https://wiki.simpler.grants.gov/~gitbook/image?url=https%3A%2F%2F4039545949-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FPm7UEzeiS1tbLCV1SFRu%252Fuploads%252FTKItiVoQxxoDgP6Q7ZQ8%252FGrants.gov%2520Release%2520Notes%2520Example.png%3Falt%3Dmedia%26token%3Dec7212d8-c21e-4719-99d2-10010ffa3411&amp;width=300&amp;dpr=4&amp;quality=100&amp;sign=58fac58&amp;sv=2"
+    srcSet="https://wiki.simpler.grants.gov/~gitbook/image?url=https%3A%2F%2F4039545949-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FPm7UEzeiS1tbLCV1SFRu%252Fuploads%252FTKItiVoQxxoDgP6Q7ZQ8%252FGrants.gov%2520Release%2520Notes%2520Example.png%3Falt%3Dmedia%26token%3Dec7212d8-c21e-4719-99d2-10010ffa3411&amp;width=300&amp;dpr=1&amp;quality=100&amp;sign=58fac58&amp;sv=2 300w, https://wiki.simpler.grants.gov/~gitbook/image?url=https%3A%2F%2F4039545949-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FPm7UEzeiS1tbLCV1SFRu%252Fuploads%252FTKItiVoQxxoDgP6Q7ZQ8%252FGrants.gov%2520Release%2520Notes%2520Example.png%3Falt%3Dmedia%26token%3Dec7212d8-c21e-4719-99d2-10010ffa3411&amp;width=300&amp;dpr=2&amp;quality=100&amp;sign=58fac58&amp;sv=2 600w, https://wiki.simpler.grants.gov/~gitbook/image?url=https%3A%2F%2F4039545949-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FPm7UEzeiS1tbLCV1SFRu%252Fuploads%252FTKItiVoQxxoDgP6Q7ZQ8%252FGrants.gov%2520Release%2520Notes%2520Example.png%3Falt%3Dmedia%26token%3Dec7212d8-c21e-4719-99d2-10010ffa3411&amp;width=300&amp;dpr=3&amp;quality=100&amp;sign=58fac58&amp;sv=2 900w, https://wiki.simpler.grants.gov/~gitbook/image?url=https%3A%2F%2F4039545949-files.gitbook.io%2F%7E%2Ffiles%2Fv0%2Fb%2Fgitbook-x-prod.appspot.com%2Fo%2Fspaces%252FPm7UEzeiS1tbLCV1SFRu%252Fuploads%252FTKItiVoQxxoDgP6Q7ZQ8%252FGrants.gov%2520Release%2520Notes%2520Example.png%3Falt%3Dmedia%26token%3Dec7212d8-c21e-4719-99d2-10010ffa3411&amp;width=300&amp;dpr=4&amp;quality=100&amp;sign=58fac58&amp;sv=2 1200w"
+    sizes="300px"
+    width="1258"
+    height="86"
+  />
+</Alert>
+<br />
+
+<Alert type="success" slim>
+  <em>Adding a short summary of the key changes and why they are important suggests transparency. For example:</em> <br /><br />
+  <strong>What you should know</strong>
+
+These changes were made to ensure Grants.gov data – yours and ours – is as secure as possible:
+
+  <ul>
+    <li>You'll need to create a login.gov account or link your login.gov account to use Grants.gov.</li>
+    <li>It's now a requirement to add another way to verify your account (multi-factor authentication or MFA).</li>
+  </ul>
+</Alert>
+
+### Straightforward
+
+We prioritize efficient, streamlined interactions.
+
+#### **How we achieve this:**
+
+- We get straight to the point.
+
+<Alert type="warning" slim>
+  Determining whether you are eligible to apply for and receive a federal grant is very important. If you are not legally eligible for a specific funding opportunity, you would waste a lot of time and money completing the application process when you cannot actually receive the grant.
+
+When considering eligibility, the first step is to know what type of organization you represent (or whether you are applying as an individual). If you already know whether you will apply on behalf of your organization or as an individual, then you are ready to check your eligibility.
+
+There are many types of organizations generally eligible to apply for funding opportunities on Grants.gov. Each type of organization listed in the categories below is a specific search criterion in Search Grants. Individual applicants are welcome too!
+
+</Alert>
+ <br />
+
+<Alert type="success" slim>
+  Organizations who are eligible to apply for federal grants tend to fall into one of these categories:
+
+{" "}
+
+<ul>
+  <li>Local government</li>
+  <li>Schools, colleges, and universities</li>
+  <li>Public housing organizations</li>
+  <li>Nonprofit organizations</li>
+  <li>Businesses</li>
+</ul>
+
+Some grants are also open to individuals (like fellowships) and foreign organizations. Be sure to read the eligibility requirements carefully to make sure you're eligible before you apply.
+
+</Alert>
+
+- We write like people talk and use plain language. For example, we use the second-person you, embrace contractions, avoid jargon, and choose the simplest, most precise words.
+
+<Alert type="warning" slim>
+  <strong>How many grantors can register under an agency?</strong>
+
+An unlimited number of grantors can be registered under an agency.
+
+</Alert>
+ <br />
+
+<Alert type="success" slim>
+  <strong>How many grantors can register under an agency?</strong>
+
+You can register as many grantors as you need to manage your agency's grants.
+
+</Alert>
+
+### Purposeful
+
+We constantly seek new opportunities to bring value to our users and those we serve.
+
+#### **How we achieve this:**
+
+- We prioritize what our audiences want and need to know over self-promotion or lengthy background information.
+
+<Alert type="warning" slim>
+  Customize your Grants.gov opportunity subscriptions, including expanded
+  criteria for saved searches and the ability to view and manage existing
+  subscriptions. To subscribe to Grants.gov email notifications, users must
+  first create a Grants.gov account.
+</Alert>
+
+{" "}
+
+<br />
+
+<Alert type="success" slim>
+  You're in charge of what information you get from Grants.gov. Log in or create
+  your account to choose which email notifications you want in your inbox.
+</Alert>
+
+- We bring clarity to complex topics.
+
+<Alert type="warning" slim>
+  <strong>Understanding the Reporting and Oversight Process</strong> In 2006, the Federal Funding Accountability and Transparency Act (FFATA) set in motion a government-wide reporting procedure that has continued to evolve.
+
+The law requires that information about entities and organizations receiving federal funds be disclosed to the public via a central website, USAspending.gov. This information currently includes the entity's name, amount of the grant, funding agency, and location – among other requirements – and is published by the grant-making agency on USASpending.gov.
+
+</Alert>
+ <br />
+
+<Alert type="success" slim>
+  <strong>Grant Reporting and Oversight</strong>
+
+Grant reporting and oversight accomplishes two things:
+
+<ol>
+  <li>Gives the public access to information about who gets federal grant money on USASpending.com (as required by the Federal Funding Accountability and Transparency Act (FFATA)).</li>
+  <li>Helps granting agencies understand the impact of their grants.</li>
+</ol>
+</Alert>
+
+## III. Tone
+
+Along with a reminder of how we define tone, we can talk about the contexts for varying the tone, such as by audience and archetype, by channel, by content type, and situation. The following tone matrix provides some considerations for tone for five content purposes. Keep in mind that:
+
+- Choosing a tone and writing in that tone is not an exact science.
+- Our content doesn't always fit neatly in these categories, but they provide a container for thinking through tone.
+
+### Tone Matrix
+
+<table data-full-width="true">
+  <thead>
+    <tr>
+      <th> </th>
+      <th>Inform</th>
+      <th>Educate</th>
+      <th>Facilitate</th>
+      <th>Support</th>
+      <th>Promote</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <strong>Description</strong>
+      </td>
+      <td>Content that provides matter-of-fact details about Grants.gov</td>
+      <td>
+        Content that helps people understand how to use Grants.gov to publish
+        grant opportunities or find grants to apply for
+      </td>
+      <td>
+        Content that helps people complete their tasks related to Grants.gov
+      </td>
+      <td>
+        Content that helps people troubleshoot an issue with Grants.gov or
+        administer their Grants.gov account
+      </td>
+      <td>
+        Content that shares new information or drives people to content in other
+        content purpose categories
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Examples</strong>
+      </td>
+      <td>
+        <ul>
+          <li>Planned maintenance alert (distributed in various channels)</li>
+          <li>About Grants.gov content</li>
+          <li>Release notes</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>Grants 101 content</li>
+          <li>How-to content</li>
+          <li>Tips and Did you Know content</li>
+          <li>Eligibility details</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>User interface copy (including success messages)</li>
+          <li>Confirmation emails</li>
+          <li>Content for media professionals (e.g., press release)</li>
+          <li>
+            Content for elected officials (e.g., constituent presentation)
+          </li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>User interface copy (including error messages)</li>
+          <li>
+            How-to content for people responsible for agency administration and
+            technical implementation (there is likely overlap with Educate
+            content)
+          </li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>Tweet promoting a blog post on a how-to topic</li>
+          <li>
+            Information about a new feature in the newsletter or release note
+            summary/overview
+          </li>
+          <li>Email introducing Grants.gov to community organizations</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Tone Attributes</strong>
+      </td>
+      <td>
+        <ul>
+          <li>Matter-of-fact</li>
+          <li>Precise</li>
+          <li>Transparent</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>Helpful</li>
+          <li>Encouraging</li>
+          <li>Instructive</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>Reassuring</li>
+          <li>Empathetic</li>
+          <li>Anticipatory</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>Constructive</li>
+          <li>Instructive</li>
+          <li>Actionable</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>Value-focused</li>
+          <li>Upbeat</li>
+          <li>Inviting</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>Considerations</strong>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Be as clear and concise as possible while maintaining accuracy.
+          </li>
+          <li>
+            Use neutral language to avoid ascribing emotion to the content.
+          </li>
+          <li>
+            Only include historical information that your audiences need to know
+            to understand the information.
+          </li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Use the language your users are most likely to recognize and
+            understand, even if it may be considered jargon to people outside
+            your audience.
+          </li>
+          <li>Use a guiding tone without being patronizing.</li>
+          <li>Write applicant content for the novice archetype.</li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Write in a way that suggests you are attuned to the needs of the
+            audience, e.g., knowing what a reporter needs to write an unbiased,
+            factual story.
+          </li>
+          <li>
+            Anticipate what questions the audience may have and answer them in
+            language that makes sense to them.
+          </li>
+          <li>
+            Be realistic about the effort and time a task may involve, while
+            decomplicating the information.
+          </li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Use the language your users are most likely to recognize and
+            understand, even if it may be considered jargon to people outside
+            your audience.
+          </li>
+          <li>
+            Guide people to the next logical step or steps for their situation;
+            e.g. error messages should tell people how to fix the error.
+          </li>
+        </ul>
+      </td>
+      <td>
+        <ul>
+          <li>
+            Focus on the benefit of what you're promoting to the intended
+            audience.
+          </li>
+          <li>Avoid crossing the line between upbeat and cheesy.</li>
+          <li>
+            Keep an eye out for alienating language, e.g., phrases like "It's
+            simple and fast" could alienate someone who processes information
+            more slowly or uses accessibility tools to do their work.
+          </li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## IV. In Practice
+
+This section will be continually updated to show examples of content that is written in accordance with our voice and tone guidance.


### PR DESCRIPTION
## Summary
Fixes #4000

### Time to review: __5 mins__

## Changes proposed
> Adding the content from [Tone and Voice Guide](https://wiki.simpler.grants.gov/design-and-research/content-guidelines/voice-and-tone-guide) into Storybook

## Context for reviewers
> The Gitbook styling of the wiki page wasn't the most straightforward thing to replicate without creating custom components, which seemed like overkill for something that would only exist to service Storybook. Instead, I opted to utilize the [USWDS components](https://designsystem.digital.gov/components/overview/) directly since it is already a dependency of the project. 

## Additional information
![voice-and-tone-page-storybook](https://github.com/user-attachments/assets/8dee4471-c0fd-4b39-950e-947ef7437d4d)

![voice-and-tone-page-full](https://github.com/user-attachments/assets/19c6ce34-a25e-4f88-b376-73af6bf60db1)

