### PR TITLE
[Issue #4260] Fix GET saved opportunity filter by user ID 

### DIFF
--- a/api/src/services/users/get_saved_opportunities.py
+++ b/api/src/services/users/get_saved_opportunities.py
@@ -3,7 +3,7 @@ from typing import Sequence, Tuple
 from uuid import UUID
 
 from pydantic import BaseModel
-from sqlalchemy import asc, desc, nulls_last, select, and_
+from sqlalchemy import and_, asc, desc, nulls_last, select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import Select
 
@@ -57,10 +57,11 @@ def get_saved_opportunities(
     stmt = (
         select(Opportunity)
         .join(
-            UserSavedOpportunity, and_(
+            UserSavedOpportunity,
+            and_(
                 UserSavedOpportunity.opportunity_id == Opportunity.opportunity_id,
-                UserSavedOpportunity.user_id == user_id
-            )
+                UserSavedOpportunity.user_id == user_id,
+            ),
         )
         .join(
             CurrentOpportunitySummary,

--- a/api/src/services/users/get_saved_opportunities.py
+++ b/api/src/services/users/get_saved_opportunities.py
@@ -3,7 +3,7 @@ from typing import Sequence, Tuple
 from uuid import UUID
 
 from pydantic import BaseModel
-from sqlalchemy import asc, desc, nulls_last, select
+from sqlalchemy import asc, desc, nulls_last, select, and_
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import Select
 
@@ -57,7 +57,10 @@ def get_saved_opportunities(
     stmt = (
         select(Opportunity)
         .join(
-            UserSavedOpportunity, UserSavedOpportunity.opportunity_id == Opportunity.opportunity_id
+            UserSavedOpportunity, and_(
+                UserSavedOpportunity.opportunity_id == Opportunity.opportunity_id,
+                UserSavedOpportunity.user_id == user_id
+            )
         )
         .join(
             CurrentOpportunitySummary,

--- a/api/tests/src/api/users/test_user_saved_opportunities_get.py
+++ b/api/tests/src/api/users/test_user_saved_opportunities_get.py
@@ -224,17 +224,17 @@ def test_user_get_only_own_saved_opportunities(
     # Create an opportunity and save it for the current user
     user_opportunity = OpportunityFactory.create(opportunity_title="User's Opportunity")
     UserSavedOpportunityFactory.create(user=user, opportunity=user_opportunity)
-    
+
     # Create another user with their own saved opportunity
     other_user = UserFactory.create()
     other_opportunity = OpportunityFactory.create(opportunity_title="Other User's Opportunity")
     UserSavedOpportunityFactory.create(user=other_user, opportunity=other_opportunity)
-    
+
     # Create a third opportunity saved by both users
     shared_opportunity = OpportunityFactory.create(opportunity_title="Shared Opportunity")
     UserSavedOpportunityFactory.create(user=user, opportunity=shared_opportunity)
     UserSavedOpportunityFactory.create(user=other_user, opportunity=shared_opportunity)
-    
+
     # Make the request for the current user
     response = client.post(
         f"/v1/users/{user.user_id}/saved-opportunities/list",
@@ -246,19 +246,19 @@ def test_user_get_only_own_saved_opportunities(
             }
         },
     )
-    
+
     # Verify the response
     assert response.status_code == 200
     assert len(response.json["data"]) == 2  # User should see only their 2 saved opportunities
-    
+
     # Get the opportunity IDs from the response
     opportunity_ids = [opp["opportunity_id"] for opp in response.json["data"]]
-    
+
     # Verify that the user sees their own opportunities but not the other user's
     assert user_opportunity.opportunity_id in opportunity_ids
     assert shared_opportunity.opportunity_id in opportunity_ids
     assert other_opportunity.opportunity_id not in opportunity_ids
-    
+
     # Verify the opportunity titles
     opportunity_titles = [opp["opportunity_title"] for opp in response.json["data"]]
     assert "User's Opportunity" in opportunity_titles

--- a/api/tests/src/api/users/test_user_saved_opportunities_get.py
+++ b/api/tests/src/api/users/test_user_saved_opportunities_get.py
@@ -215,3 +215,52 @@ def test_get_saved_opportunities_sorting(
     assert [opp["opportunity_id"] for opp in opportunities] == [
         opp.opportunity_id for opp in expected_result
     ]
+
+
+def test_user_get_only_own_saved_opportunities(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test that users only get their own saved opportunities, not those of other users"""
+    # Create an opportunity and save it for the current user
+    user_opportunity = OpportunityFactory.create(opportunity_title="User's Opportunity")
+    UserSavedOpportunityFactory.create(user=user, opportunity=user_opportunity)
+    
+    # Create another user with their own saved opportunity
+    other_user = UserFactory.create()
+    other_opportunity = OpportunityFactory.create(opportunity_title="Other User's Opportunity")
+    UserSavedOpportunityFactory.create(user=other_user, opportunity=other_opportunity)
+    
+    # Create a third opportunity saved by both users
+    shared_opportunity = OpportunityFactory.create(opportunity_title="Shared Opportunity")
+    UserSavedOpportunityFactory.create(user=user, opportunity=shared_opportunity)
+    UserSavedOpportunityFactory.create(user=other_user, opportunity=shared_opportunity)
+    
+    # Make the request for the current user
+    response = client.post(
+        f"/v1/users/{user.user_id}/saved-opportunities/list",
+        headers={"X-SGG-Token": user_auth_token},
+        json={
+            "pagination": {
+                "page_offset": 1,
+                "page_size": 25,
+            }
+        },
+    )
+    
+    # Verify the response
+    assert response.status_code == 200
+    assert len(response.json["data"]) == 2  # User should see only their 2 saved opportunities
+    
+    # Get the opportunity IDs from the response
+    opportunity_ids = [opp["opportunity_id"] for opp in response.json["data"]]
+    
+    # Verify that the user sees their own opportunities but not the other user's
+    assert user_opportunity.opportunity_id in opportunity_ids
+    assert shared_opportunity.opportunity_id in opportunity_ids
+    assert other_opportunity.opportunity_id not in opportunity_ids
+    
+    # Verify the opportunity titles
+    opportunity_titles = [opp["opportunity_title"] for opp in response.json["data"]]
+    assert "User's Opportunity" in opportunity_titles
+    assert "Shared Opportunity" in opportunity_titles
+    assert "Other User's Opportunity" not in opportunity_titles


### PR DESCRIPTION
## Summary
Fixes #4260

### Time to review: 5 mins

## Changes proposed
Update query to join on `user_id`

## Context for reviewers
Previously this was not added, resulting in a bug showing all user saved opportunities.

## Additional information
See attached unit test (which fails in `main`), passes here.
