### PR TITLE
Let Flask pick HTTPS correctly based on if the service is configured …

### DIFF
--- a/api/src/auth/login_gov_jwt_auth.py
+++ b/api/src/auth/login_gov_jwt_auth.py
@@ -54,6 +54,8 @@ class LoginGovConfig(PydanticBaseEnvConfig):
         alias="LOGIN_GOV_CLIENT_ASSERTION_PRIVATE_KEY"
     )
 
+    login_gov_redirect_scheme: str = Field(alias="LOGIN_GOV_REDIRECT_SCHEME", default="http")
+
 
 # Initialize a config at startup
 _config: LoginGovConfig | None = None
@@ -131,7 +133,9 @@ def get_login_gov_redirect_uri(db_session: db.Session, config: LoginGovConfig | 
 
     # Ask Flask for its own URI - specifying we want the callback route
     # .user_login_callback points to the function itself defined in user_routes.py
-    redirect_uri = flask.url_for(".user_login_callback", _external=True)
+    redirect_uri = flask.url_for(
+        ".user_login_callback", _external=True, _scheme=config.login_gov_redirect_scheme
+    )
 
     # We want to redirect to the authorization endpoint of login.gov
     # See: https://developers.login.gov/oidc/authorization/

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -19,7 +19,7 @@ locals {
     LOGIN_GOV_JWK_ENDPOINT    = "https://idp.int.identitysandbox.gov/api/openid_connect/certs"
     LOGIN_GOV_AUTH_ENDPOINT   = "https://idp.int.identitysandbox.gov/openid_connect/authorize"
     LOGIN_GOV_TOKEN_ENDPOINT  = "https://idp.int.identitysandbox.gov/api/openid_connect/token"
-    LOGIN_GOV_REDIRECT_SCHEMA = var.enable_https ? "https" : "http"
+    LOGIN_GOV_REDIRECT_SCHEME = var.enable_https ? "https" : "http"
     API_JWT_ISSUER            = "simpler-grants-api-${var.environment}"
     API_JWT_AUDIENCE          = "simpler-grants-api-${var.environment}"
 

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -13,14 +13,15 @@ locals {
     # Login.gov OAuth
     # Default values point to the IDP integration environment
     # which all non-prod environments should use
-    ENABLE_AUTH_ENDPOINT     = 0
-    LOGIN_GOV_CLIENT_ID      = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-${var.environment}-simpler-grants-gov"
-    LOGIN_GOV_ENDPOINT       = "https://idp.int.identitysandbox.gov/"
-    LOGIN_GOV_JWK_ENDPOINT   = "https://idp.int.identitysandbox.gov/api/openid_connect/certs"
-    LOGIN_GOV_AUTH_ENDPOINT  = "https://idp.int.identitysandbox.gov/openid_connect/authorize"
-    LOGIN_GOV_TOKEN_ENDPOINT = "https://idp.int.identitysandbox.gov/api/openid_connect/token"
-    API_JWT_ISSUER           = "simpler-grants-api-${var.environment}"
-    API_JWT_AUDIENCE         = "simpler-grants-api-${var.environment}"
+    ENABLE_AUTH_ENDPOINT      = 0
+    LOGIN_GOV_CLIENT_ID       = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-${var.environment}-simpler-grants-gov"
+    LOGIN_GOV_ENDPOINT        = "https://idp.int.identitysandbox.gov/"
+    LOGIN_GOV_JWK_ENDPOINT    = "https://idp.int.identitysandbox.gov/api/openid_connect/certs"
+    LOGIN_GOV_AUTH_ENDPOINT   = "https://idp.int.identitysandbox.gov/openid_connect/authorize"
+    LOGIN_GOV_TOKEN_ENDPOINT  = "https://idp.int.identitysandbox.gov/api/openid_connect/token"
+    LOGIN_GOV_REDIRECT_SCHEMA = var.enable_https ? "https" : "http"
+    API_JWT_ISSUER            = "simpler-grants-api-${var.environment}"
+    API_JWT_AUDIENCE          = "simpler-grants-api-${var.environment}"
 
     TEST_AGENCY_PREFIXES = "GDIT,IVV,IVPDF,0001,FGLT,NGMS,NGMS-Sub1,SECSCAN"
   }


### PR DESCRIPTION
## Summary
Fixes #4263 

### Time to review: __5 mins__

## Changes proposed
Our Login.gov integration has to craft a redirect URL that Login.gov will send the user back to after login. This allows for control of the scheme for that URL to account for environments where we have HTTPS in front of the API vs not.

## Context for reviewers
If you set `LOGIN_GOV_REDIRECT_SCHEME=https` in `api/override.env` and run through the Login process you'll get redirected to a failed HTTPS://localhost:3000 URL 


