### PR TITLE
[no ticket] Dont run migrations inside of the sidecar

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -76,7 +76,7 @@ network_config=$(aws ecs describe-services --no-cli-pager --cluster "${cluster_n
 current_region=$(./bin/current-region)
 aws_user_id=$(aws sts get-caller-identity --no-cli-pager --query UserId --output text)
 
-container_name=$(aws ecs describe-task-definition --task-definition "${task_definition_family}" --query "taskDefinition.containerDefinitions[0].name" --output text)
+container_name=$(aws ecs describe-task-definition --task-definition "${task_definition_family}" --query "taskDefinition.containerDefinitions[?name == '${service_name}'].name" --output text)
 
 overrides=$(
   cat <<EOF

--- a/infra/api/app-config/.terraform.lock.hcl
+++ b/infra/api/app-config/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.4"
+  hashes = [
+    "h1:cCabxnWQ5fX1lS7ZqgUzsvWmKZw9FA7NRxAZ94vcTcc=",
+    "zh:037fd82cd86227359bc010672cd174235e2d337601d4686f526d0f53c87447cb",
+    "zh:0ea1db63d6173d01f2fa8eb8989f0809a55135a0d8d424b08ba5dabad73095fa",
+    "zh:17a4d0a306566f2e45778fbac48744b6fd9c958aaa359e79f144c6358cb93af0",
+    "zh:298e5408ab17fd2e90d2cd6d406c6d02344fe610de5b7dae943a58b958e76691",
+    "zh:38ecfd29ee0785fd93164812dcbe0664ebbe5417473f3b2658087ca5a0286ecb",
+    "zh:59f6a6f31acf66f4ea3667a555a70eba5d406c6e6d93c2c641b81d63261eeace",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:ad0279dfd09d713db0c18469f585e58d04748ca72d9ada83883492e0dd13bd58",
+    "zh:c69f66fd21f5e2c8ecf7ca68d9091c40f19ad913aef21e3ce23836e91b8cbb5f",
+    "zh:d4a56f8c48aa86fc8e0c233d56850f5783f322d6336f3bf1916e293246b6b5d4",
+    "zh:f2b394ebd4af33f343835517e80fc876f79361f4688220833bc3c77655dd2202",
+    "zh:f31982f29f12834e5d21e010856eddd19d59cd8f449adf470655bfd19354377e",
+  ]
+}

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -122,27 +122,6 @@ resource "aws_ecs_task_definition" "app" {
 
   container_definitions = jsonencode([
     {
-      name                   = "${local.container_name}-fluent-bit"
-      image                  = local.new_relic_fluent_bit_version,
-      memory                 = 256,
-      cpu                    = 1024,
-      networkMode            = "awsvpc",
-      essential              = true,
-      readonlyRootFilesystem = false,
-      firelensConfiguration = {
-        type = "fluentbit",
-        options = {
-          enable-ecs-log-metadata = "true"
-        }
-      }
-      secrets = [
-        {
-          name      = "apiKey",
-          valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/api/${var.environment_name}/new-relic-license-key"
-        }
-      ]
-    },
-    {
       name                   = local.container_name,
       image                  = local.image_url,
       memory                 = var.memory,
@@ -189,7 +168,28 @@ resource "aws_ecs_task_definition" "app" {
       mountPoints    = []
       systemControls = []
       volumesFrom    = []
-    }
+    },
+    {
+      name                   = "${local.container_name}-fluent-bit"
+      image                  = local.new_relic_fluent_bit_version,
+      memory                 = 256,
+      cpu                    = 1024,
+      networkMode            = "awsvpc",
+      essential              = true,
+      readonlyRootFilesystem = false,
+      firelensConfiguration = {
+        type = "fluentbit",
+        options = {
+          enable-ecs-log-metadata = "true"
+        }
+      }
+      secrets = [
+        {
+          name      = "apiKey",
+          valueFrom = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/api/${var.environment_name}/new-relic-license-key"
+        }
+      ]
+    },
   ])
 
   # Variable input values for the primary container, plus extra for the firelense sidecar


### PR DESCRIPTION
## Context

Currently the migrations run in the first container in the list, instead of trying to get the primary application container