### PR TITLE
[Issue #4201] hide copy tooltip until saved searches feature flag is on

### DIFF
--- a/frontend/src/components/search/SaveSearchPanel.tsx
+++ b/frontend/src/components/search/SaveSearchPanel.tsx
@@ -107,7 +107,7 @@ export function SaveSearchPanel() {
           url={url}
           snackbarMessage={t("copySearch.snackbar")}
         >
-          {!showSavedSearchUI && (
+          {checkFeatureFlag("savedSearchesOn") && !user?.token && (
             <SaveSearchTooltip
               text={t("help.unauthenticated")}
               title={t("help.general")}


### PR DESCRIPTION
## Summary
Fixes #4201

### Time to review: __5 mins__

## Changes proposed
If `savedSearchesOn` feature flag is off, do not show tooltip next to copy url link

## Context for reviewers
### Testing steps

1. start a server on this branch with `npm run dev`
2. visit http://localhost:3000/search
3. _VERIFY_: there is no tooltip next to "Copy this search query"
4. visit http://localhost:3000/search?_ff=savedSearchesOn:true
3. _VERIFY_: there is a tooltip next to "Copy this search query"

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

