### PR TITLE
[Issue #4273] Stop APM New Relic logs, add New Relic metadata to logs manually

### DIFF
--- a/api/newrelic.ini
+++ b/api/newrelic.ini
@@ -223,9 +223,11 @@ distributed_tracing.enabled = true
 # no PII data is captured in messages of new relic.
 strip_exception_messages.enabled = true
 
-# Tell New Relic to include the full JSON / extra info from our logs
-# https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#application_logging.forwarding.context_data.enabled
-application_logging.forwarding.context_data.enabled = true
+# We don't enable application logging, but do decorate the logs with New Relic metadata
+# Instead of forwarding the logs using New Relic, we use a fluentbit sidecar to do that.
+application_logging.enabled = false
+application_logging.forwarding.enabled = false
+application_logging.local_decorating.enabled = false
 
 # ---------------------------------------------------------------------------
 
@@ -254,10 +256,6 @@ app_name = api-local
 developer_mode = true
 monitor_mode = false
 license_key=replace_me
-
-application_logging.enabled = false
-application_logging.forwarding.enabled = false
-application_logging.local_decorating.enabled = false
 
 [newrelic:staging]
 app_name = api-staging


### PR DESCRIPTION
## Summary
Fixes #4273

### Time to review: __3 mins__

## Changes proposed
Removed configuration that emits logs to New Relic directly from our API - we'll rely on the new fluentbit sidecar to forward them

Added metadata to our logs that New Relic wants for tracing/etc.

## Additional information
An example of this working locally - note that we actually hide these fields from our local log messages, you'll have to comment out these fields from https://github.com/HHS/simpler-grants-gov/blob/main/api/src/logging/decodelog.py#L121 in order to see them (which I did for this screenshot).
![Screenshot 2025-03-25 at 4 31 51 PM](https://github.com/user-attachments/assets/6a56582a-be97-42b3-97c0-14a69c283896)


