### PR TITLE
[no ticket] Adds fluentbit itselfs logs into cloudwatch

### DIFF
--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -40,7 +40,10 @@ data "aws_iam_policy_document" "task_executor" {
       "logs:PutLogEvents",
       "logs:DescribeLogStreams"
     ]
-    resources = ["${aws_cloudwatch_log_group.service_logs.arn}:*"]
+    resources = [
+      "${aws_cloudwatch_log_group.service_logs.arn}:*",
+      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:service/${var.service_name}-fluentbit:log-stream:${var.service_name}/${var.service_name}-fluentbit/*"
+    ]
   }
 
   # Allow ECS to authenticate with ECR

--- a/infra/modules/service/application_logs.tf
+++ b/infra/modules/service/application_logs.tf
@@ -13,3 +13,14 @@ resource "aws_cloudwatch_log_group" "service_logs" {
   # TODO(https://github.com/navapbc/template-infra/issues/164) Encrypt with customer managed KMS key
   # checkov:skip=CKV_AWS_158:Encrypt service logs with customer key in future work
 }
+
+resource "aws_cloudwatch_log_group" "fluentbit" {
+  name = "${aws_cloudwatch_log_group.service_logs.name}-fluentbit"
+
+  # Conservatively retain logs for 5 years.
+  # Looser requirements may allow shorter retention periods
+  retention_in_days = 1827
+
+  # TODO(https://github.com/navapbc/template-infra/issues/164) Encrypt with customer managed KMS key
+  # checkov:skip=CKV_AWS_158:Encrypt service logs with customer key in future work
+}

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -184,6 +184,14 @@ resource "aws_ecs_task_definition" "app" {
         options = {
           enable-ecs-log-metadata = "true"
         }
+      },
+      logConfiguration = {
+        logDriver = "awslogs",
+        options = {
+          "awslogs-group"         = "${aws_cloudwatch_log_group.service_logs.name}-fluentbit",
+          "awslogs-region"        = data.aws_region.current.name,
+          "awslogs-stream-prefix" = local.log_stream_prefix
+        }
       }
       secrets = [
         {
@@ -207,6 +215,8 @@ resource "aws_ecs_task_definition" "app" {
   network_mode = "awsvpc"
 
   depends_on = [
+    aws_cloudwatch_log_group.service_logs,
+    aws_cloudwatch_log_group.fluentbit,
     aws_iam_role_policy.task_executor,
     aws_iam_role_policy_attachment.extra_policies,
   ]


### PR DESCRIPTION
## Context

This is a little confusing to bear with me.

Right now, AWS only allows a given container to allow logs to output to one location. And we set it up so that the primary application container logs => fluentbit => New Relic. Okay.

Well, guess what! fluentbit itself has logs as well! And those logs aren't being sent anywhere. So we can send those to cloudwatch.

## Testing

TODO