### PR TITLE
[Issue #4263] Need to know if the service is HTTPS not the local container

### DIFF
--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -13,13 +13,14 @@ locals {
     # Login.gov OAuth
     # Default values point to the IDP integration environment
     # which all non-prod environments should use
+    # local.service_config not var because we want if the service is HTTPS not if this endpoint is HTTPS
     ENABLE_AUTH_ENDPOINT      = 0
     LOGIN_GOV_CLIENT_ID       = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-${var.environment}-simpler-grants-gov"
     LOGIN_GOV_ENDPOINT        = "https://idp.int.identitysandbox.gov/"
     LOGIN_GOV_JWK_ENDPOINT    = "https://idp.int.identitysandbox.gov/api/openid_connect/certs"
     LOGIN_GOV_AUTH_ENDPOINT   = "https://idp.int.identitysandbox.gov/openid_connect/authorize"
     LOGIN_GOV_TOKEN_ENDPOINT  = "https://idp.int.identitysandbox.gov/api/openid_connect/token"
-    LOGIN_GOV_REDIRECT_SCHEME = var.enable_https ? "https" : "http"
+    LOGIN_GOV_REDIRECT_SCHEME = local.service_config.enable_https ? "https" : "http"
     API_JWT_ISSUER            = "simpler-grants-api-${var.environment}"
     API_JWT_AUDIENCE          = "simpler-grants-api-${var.environment}"
 


### PR DESCRIPTION
## Summary
Fixes #4263

I'm inferring that var.enable_https is if the local container server should be running HTTPS (false in our apps). So I think I might have found the right higher level config that we should really be checking local.service_config.enable_https

### Time to review: __3 mins__

## Changes proposed
Check the correct enable_https
