### PR TITLE
[Unticketed] Add the task class to the final completion log

### DIFF
--- a/api/src/task/task.py
+++ b/api/src/task/task.py
@@ -70,6 +70,7 @@ class Task(abc.ABC, metaclass=abc.ABCMeta):
 
     def initialize_metrics(self) -> None:
         zero_metrics_dict: dict[str, Any] = {metric: 0 for metric in self.Metrics}
+        zero_metrics_dict["task_class"] = self.cls_name()
         self.set_metrics(zero_metrics_dict)
 
     def set_metrics(self, metrics: dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary

### Time to review: __1 mins__

## Changes proposed
Adds `task_class` to the logs wherever we log the task metrics


## Context for reviewers
During various backend tasks we collect metrics (counts of various scenarios) that at the end we log out. These are really useful for making dashboards and/or alerts (here's how many records we processed each hour).

There isn't a good way in the current data to target a specific tasks log statement, this just adds an easy `where task_class = 'LoadOracleDataTask'` to those queries in New Relic. Note that the `cls_name` function resolves to the actual instantiated class, not `Task` - we already use that in log messages and a few other places.

## Additional information
Running locally, that value now appears where I expect:

![Screenshot 2025-03-26 at 3 31 43 PM](https://github.com/user-attachments/assets/5c49e87c-d425-4707-bd28-f88d64877d20)
