### PR TITLE
[Issue #4010] Enable attachment load+transform by default

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -22,22 +22,15 @@ TABLES_TO_LOAD = [
     "topportunity",
     "topportunity_cfda",
     "tsynopsis",
-    "tsynopsis_hist",
     "tforecast",
-    "tforecast_hist",
     "tapplicanttypes_forecast",
-    "tapplicanttypes_forecast_hist",
     "tapplicanttypes_synopsis",
-    "tapplicanttypes_synopsis_hist",
     "tfundactcat_forecast",
-    "tfundactcat_forecast_hist",
     "tfundactcat_synopsis",
-    "tfundactcat_synopsis_hist",
     "tfundinstr_forecast",
-    "tfundinstr_forecast_hist",
     "tfundinstr_synopsis",
-    "tfundinstr_synopsis_hist",
     "tgroups",
+    "tsynopsisattachment",
 ]
 
 

--- a/api/src/data_migration/transformation/transform_oracle_data_task.py
+++ b/api/src/data_migration/transformation/transform_oracle_data_task.py
@@ -47,7 +47,7 @@ class TransformOracleDataTaskConfig(PydanticBaseEnvConfig):
     enable_funding_instrument: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_FUNDING_INSTRUMENT
     enable_agency: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_AGENCY
     enable_opportunity_attachment: bool = (
-        False  # TRANSFORM_ORACLE_DATA_ENABLE_OPPORTUNITY_ATTACHMENT
+        True  # TRANSFORM_ORACLE_DATA_ENABLE_OPPORTUNITY_ATTACHMENT
     )
 
 

--- a/api/tests/src/data_migration/transformation/test_transform_oracle_data_task.py
+++ b/api/tests/src/data_migration/transformation/test_transform_oracle_data_task.py
@@ -11,6 +11,7 @@ from tests.src.data_migration.transformation.conftest import (
     setup_agency,
     setup_cfda,
     setup_opportunity,
+    setup_opportunity_attachment,
     setup_synopsis_forecast,
     validate_agency,
     validate_applicant_type,
@@ -18,6 +19,7 @@ from tests.src.data_migration.transformation.conftest import (
     validate_funding_category,
     validate_funding_instrument,
     validate_opportunity,
+    validate_opportunity_attachment,
     validate_opportunity_summary,
     validate_summary_and_nested,
 )
@@ -45,7 +47,7 @@ class TestTransformFullRunTask(BaseTestClass):
     ) -> TransformOracleDataTask:
         return TransformOracleDataTask(db_session)
 
-    def test_all_inserts(self, db_session, transform_oracle_data_task):
+    def test_all_inserts(self, db_session, transform_oracle_data_task, s3_config):
         # Test that we're fully capable of processing inserts across an entire opportunity record
         parent_agency = setup_agency("INSERTAGENCY", create_existing=False)
         subagency = setup_agency("INSERTAGENCY-ABC", create_existing=False)
@@ -56,6 +58,14 @@ class TestTransformFullRunTask(BaseTestClass):
 
         cfda1 = setup_cfda(create_existing=False, opportunity=opportunity)
         cfda2 = setup_cfda(create_existing=False, opportunity=opportunity)
+
+        # Attachments
+        attachment1 = setup_opportunity_attachment(
+            create_existing=False, opportunity=opportunity, config=s3_config
+        )
+        attachment2 = setup_opportunity_attachment(
+            create_existing=False, opportunity=opportunity, config=s3_config
+        )
 
         ### Forecast
         forecast = setup_synopsis_forecast(
@@ -112,6 +122,10 @@ class TestTransformFullRunTask(BaseTestClass):
 
         assert len(created_opportunity.all_opportunity_summaries) == 2
 
+        assert len(created_opportunity.opportunity_attachments) == 2
+        validate_opportunity_attachment(db_session, attachment1)
+        validate_opportunity_attachment(db_session, attachment2)
+
         created_forecast = get_summary_from_source(db_session, forecast)
         assert created_forecast is not None
         validate_summary_and_nested(
@@ -137,8 +151,8 @@ class TestTransformFullRunTask(BaseTestClass):
         validate_agency(db_session, subagency)
 
         assert {
-            transform_oracle_data_task.Metrics.TOTAL_RECORDS_PROCESSED: 24,
-            transform_oracle_data_task.Metrics.TOTAL_RECORDS_INSERTED: 18,
+            transform_oracle_data_task.Metrics.TOTAL_RECORDS_PROCESSED: 26,
+            transform_oracle_data_task.Metrics.TOTAL_RECORDS_INSERTED: 20,
             transform_oracle_data_task.Metrics.TOTAL_RECORDS_UPDATED: 0,
             transform_oracle_data_task.Metrics.TOTAL_RECORDS_DELETED: 0,
             transform_oracle_data_task.Metrics.TOTAL_DUPLICATE_RECORDS_SKIPPED: 3,
@@ -146,7 +160,9 @@ class TestTransformFullRunTask(BaseTestClass):
             transform_oracle_data_task.Metrics.TOTAL_ERROR_COUNT: 3,
         }.items() <= transform_oracle_data_task.metrics.items()
 
-    def test_mix_of_inserts_updates_deletes(self, db_session, transform_oracle_data_task):
+    def test_mix_of_inserts_updates_deletes(
+        self, db_session, transform_oracle_data_task, s3_config
+    ):
         parent_agency = setup_agency("UPDATEAGENCY", create_existing=True)
         subagency = setup_agency(
             "UPDATEAGENCY-XYZ",
@@ -159,6 +175,17 @@ class TestTransformFullRunTask(BaseTestClass):
         )
         opportunity = f.StagingTopportunityFactory(
             opportunity_id=existing_opportunity.opportunity_id, cfdas=[]
+        )
+
+        # Attachments
+        attachment_insert = setup_opportunity_attachment(
+            create_existing=False, opportunity=existing_opportunity, config=s3_config
+        )
+        attachment_update = setup_opportunity_attachment(
+            create_existing=True, opportunity=existing_opportunity, config=s3_config
+        )
+        attachment_delete = setup_opportunity_attachment(
+            create_existing=True, opportunity=existing_opportunity, config=s3_config, is_delete=True
         )
 
         cfda_insert = setup_cfda(create_existing=False, opportunity=existing_opportunity)
@@ -355,6 +382,11 @@ class TestTransformFullRunTask(BaseTestClass):
             for al in updated_opportunity.opportunity_assistance_listings
         } == {cfda_insert.opp_cfda_id, cfda_update.opp_cfda_id}
 
+        assert len(updated_opportunity.opportunity_attachments) == 2
+        validate_opportunity_attachment(db_session, attachment_insert)
+        validate_opportunity_attachment(db_session, attachment_update)
+        validate_opportunity_attachment(db_session, attachment_delete, expect_in_db=False)
+
         validate_summary_and_nested(
             db_session,
             forecast_update,
@@ -380,21 +412,23 @@ class TestTransformFullRunTask(BaseTestClass):
         validate_agency(db_session, subagency, deleted_fields={"ldapGp", "description"})
 
         assert {
-            transform_oracle_data_task.Metrics.TOTAL_RECORDS_PROCESSED: 41,
-            transform_oracle_data_task.Metrics.TOTAL_RECORDS_INSERTED: 7,
-            transform_oracle_data_task.Metrics.TOTAL_RECORDS_UPDATED: 11,
-            transform_oracle_data_task.Metrics.TOTAL_RECORDS_DELETED: 7,
+            transform_oracle_data_task.Metrics.TOTAL_RECORDS_PROCESSED: 44,
+            transform_oracle_data_task.Metrics.TOTAL_RECORDS_INSERTED: 8,
+            transform_oracle_data_task.Metrics.TOTAL_RECORDS_UPDATED: 12,
+            transform_oracle_data_task.Metrics.TOTAL_RECORDS_DELETED: 8,
             transform_oracle_data_task.Metrics.TOTAL_DUPLICATE_RECORDS_SKIPPED: 15,
             transform_oracle_data_task.Metrics.TOTAL_RECORDS_ORPHANED: 0,
             transform_oracle_data_task.Metrics.TOTAL_DELETE_ORPHANS_SKIPPED: 1,
         }.items() <= transform_oracle_data_task.metrics.items()
 
-    def test_delete_opportunity_with_deleted_children(self, db_session, transform_oracle_data_task):
+    def test_delete_opportunity_with_deleted_children(
+        self, db_session, transform_oracle_data_task, s3_config
+    ):
         agency = setup_agency("AGENCYXYZ", create_existing=True)
 
         # We create an opportunity with a synopsis/forecast record, and various other child values
         # We then delete all of them at once. Deleting the opportunity will recursively delete the others
-        # but we'll still have delete events for the others - this verfies how we handle that.
+        # but we'll still have delete events for the others - this verifies how we handle that.
 
         existing_opportunity = f.OpportunityFactory(
             no_current_summary=True,
@@ -407,6 +441,10 @@ class TestTransformFullRunTask(BaseTestClass):
         )
 
         cfda = setup_cfda(create_existing=True, is_delete=True, opportunity=existing_opportunity)
+
+        attachment = setup_opportunity_attachment(
+            create_existing=True, opportunity=existing_opportunity, config=s3_config, is_delete=True
+        )
 
         ### Forecast - has several children that will be deleted
         summary_forecast = f.OpportunitySummaryFactory(
@@ -476,6 +514,7 @@ class TestTransformFullRunTask(BaseTestClass):
         # verify everything is not in the DB
         validate_opportunity(db_session, opportunity, expect_in_db=False)
         validate_assistance_listing(db_session, cfda, expect_in_db=False)
+        validate_opportunity_attachment(db_session, attachment, expect_in_db=False)
         validate_opportunity_summary(db_session, forecast, expect_in_db=False)
         validate_opportunity_summary(db_session, synopsis, expect_in_db=False)
 
@@ -491,11 +530,11 @@ class TestTransformFullRunTask(BaseTestClass):
         validate_agency(db_session, agency)
 
         assert {
-            transform_oracle_data_task.Metrics.TOTAL_RECORDS_PROCESSED: 11,
+            transform_oracle_data_task.Metrics.TOTAL_RECORDS_PROCESSED: 12,
             # Despite processing 11 records, only the opportunity is actually deleted directly
             transform_oracle_data_task.Metrics.TOTAL_RECORDS_DELETED: 1,
             f"opportunity.{transform_oracle_data_task.Metrics.TOTAL_RECORDS_DELETED}": 1,
-            transform_oracle_data_task.Metrics.TOTAL_DELETE_ORPHANS_SKIPPED: 9,
+            transform_oracle_data_task.Metrics.TOTAL_DELETE_ORPHANS_SKIPPED: 10,
         }.items() <= transform_oracle_data_task.metrics.items()
 
     def test_delete_opportunity_summary_with_deleted_children(

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -1333,10 +1333,10 @@ class TsynopsisAttachmentFactory(BaseFactory):
     class Meta:
         abstract = True
 
-    syn_att_id: factory.Sequence(lambda n: n)
-    opportunity_id: factory.Sequence(lambda n: n)
+    syn_att_id = factory.Sequence(lambda n: n)
+    opportunity_id = factory.Sequence(lambda n: n)
     att_revision_number = factory.Faker("random_int", min=1000, max=10000000)
-    att_type: factory.Faker("att_type")
+    att_type = factory.Faker("word")
     mime_type = factory.Faker("mime_type")
     link_url = factory.Faker("relevant_url")
     file_name = factory.Faker("file_name", category="text")
@@ -1722,6 +1722,14 @@ class StagingTgroupsFactory(AbstractStagingFactory):
 class StagingTsynopsisAttachmentFactory(TsynopsisAttachmentFactory, AbstractStagingFactory):
     class Meta:
         model = staging.attachment.TsynopsisAttachment
+
+    @classmethod
+    def _setup_next_sequence(cls):
+        # Force this to start at a large number
+        # so it doesn't cause weird ID conflicts with
+        # tests that create records in the actual attachment
+        # table directly (which starts counting at 1)
+        return 100000
 
     opportunity = factory.SubFactory(StagingTopportunityFactory)
     opportunity_id = factory.LazyAttribute(lambda o: o.opportunity.opportunity_id)


### PR DESCRIPTION
## Summary
Fixes #4010

### Time to review: __5 mins__

## Changes proposed
Make the attachment load (Oracle -> our staging table) and transform (staging -> API table) processes on by default

Remove Oracle data copy for tables we no longer use in transformations (historical tables)

## Context for reviewers
Enabling the load + transform is just two config options, one to add the table to the load config, and the other to set the default env var for attachments.

I also cleaned up copy the historical tables over at all as we no longer transform those tables and that's just a waste to continue to copy data we don't plan to use (we should clean those up even more like removing the tables, but that's definitely a much bigger change).

Otherwise just some test additions and fixes.


