### PR TITLE
[Issue #4060] documents UI tuning

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -122,11 +122,6 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
     path: `/opportunity/${opportunityData.opportunity_id}/`, // unused but required in breadcrumb implementation
   });
 
-  const nofoPath =
-    opportunityData.attachments.length === 1
-      ? opportunityData.attachments[0]?.download_path
-      : "";
-
   return (
     <div>
       <BetaAlert />
@@ -144,7 +139,6 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
             <OpportunityIntro opportunityData={opportunityData} />
             <OpportunityDescription
               summary={opportunityData.summary}
-              opportunityId={opportunityData.opportunity_id}
               attachments={opportunityData.attachments}
             />
             <OpportunityDocuments

--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -144,8 +144,8 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
             <OpportunityIntro opportunityData={opportunityData} />
             <OpportunityDescription
               summary={opportunityData.summary}
-              nofoPath={nofoPath}
               opportunityId={opportunityData.opportunity_id}
+              attachments={opportunityData.attachments}
             />
             <OpportunityDocuments
               documents={opportunityData.attachments}

--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -1,5 +1,8 @@
 import DOMPurify from "isomorphic-dompurify";
-import { Summary } from "src/types/opportunity/opportunityResponseTypes";
+import {
+  OpportunityDocument,
+  Summary,
+} from "src/types/opportunity/opportunityResponseTypes";
 import { splitMarkup } from "src/utils/generalUtils";
 
 import { useTranslations } from "next-intl";
@@ -9,7 +12,7 @@ import OpportunityDownload from "src/components/opportunity/OpportunityDownload"
 
 type OpportunityDescriptionProps = {
   summary: Summary;
-  nofoPath: string;
+  attachments: OpportunityDocument[];
   opportunityId: number;
 };
 
@@ -108,7 +111,7 @@ const SummaryDescriptionDisplay = ({
 
 const OpportunityDescription = ({
   summary,
-  nofoPath,
+  attachments,
   opportunityId,
 }: OpportunityDescriptionProps) => {
   const t = useTranslations("OpportunityListing.description");
@@ -127,10 +130,7 @@ const OpportunityDescription = ({
     <>
       <div className="usa-prose margin-top-3">
         <h2>{t("title")}</h2>
-        <OpportunityDownload
-          nofoPath={nofoPath}
-          opportunityId={opportunityId}
-        />
+        <OpportunityDownload attachments={attachments} />
         <h3>{t("summary")}</h3>
         <SummaryDescriptionDisplay
           summaryDescription={summary.summary_description || ""}

--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -13,7 +13,6 @@ import OpportunityDownload from "src/components/opportunity/OpportunityDownload"
 type OpportunityDescriptionProps = {
   summary: Summary;
   attachments: OpportunityDocument[];
-  opportunityId: number;
 };
 
 enum ApplicantType {
@@ -112,7 +111,6 @@ const SummaryDescriptionDisplay = ({
 const OpportunityDescription = ({
   summary,
   attachments,
-  opportunityId,
 }: OpportunityDescriptionProps) => {
   const t = useTranslations("OpportunityListing.description");
 

--- a/frontend/src/components/opportunity/OpportunityDocuments.tsx
+++ b/frontend/src/components/opportunity/OpportunityDocuments.tsx
@@ -7,6 +7,7 @@ interface OpportunityDocument {
   file_name: string;
   download_path: string;
   updated_at: string;
+  file_description?: string;
 }
 
 interface OpportunityDocumentsProps {
@@ -25,6 +26,7 @@ const DocumentTable = ({
       <thead>
         <tr>
           <th scope="col">{t("table_col_file_name")}</th>
+          <th scope="col">{t("table_col_description")}</th>
           <th scope="col">{t("table_col_last_updated")}</th>
         </tr>
       </thead>
@@ -39,6 +41,9 @@ const DocumentTable = ({
               >
                 {document.file_name}
               </Link>
+            </td>
+            <td data-label={t("table_col_description")}>
+              <div>{document.file_description}</div>
             </td>
             <td data-label={t("table_col_last_updated")}>
               {/* https://day.js.org/docs/en/display/format */}

--- a/frontend/src/components/opportunity/OpportunityDocuments.tsx
+++ b/frontend/src/components/opportunity/OpportunityDocuments.tsx
@@ -68,7 +68,7 @@ const OpportunityDocuments = ({
     <>
       <h2 id="opportunity_documents">{t("title")}</h2>
       {documents.length > 0 ? (
-        <Table>
+        <Table className="width-full">
           <DocumentTable documents={documents} opportunityId={opportunityId} />
         </Table>
       ) : (

--- a/frontend/src/components/opportunity/OpportunityDocuments.tsx
+++ b/frontend/src/components/opportunity/OpportunityDocuments.tsx
@@ -1,14 +1,8 @@
+import { OpportunityDocument } from "src/types/opportunity/opportunityResponseTypes";
 import { getConfiguredDayJs } from "src/utils/dateUtil";
 
 import { useTranslations } from "next-intl";
 import { Link, Table } from "@trussworks/react-uswds";
-
-interface OpportunityDocument {
-  file_name: string;
-  download_path: string;
-  updated_at: string;
-  file_description?: string;
-}
 
 interface OpportunityDocumentsProps {
   documents: OpportunityDocument[];

--- a/frontend/src/components/opportunity/OpportunityDownload.tsx
+++ b/frontend/src/components/opportunity/OpportunityDownload.tsx
@@ -1,37 +1,21 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { Button, Link } from "@trussworks/react-uswds";
+import { OpportunityDocument } from "src/types/opportunity/opportunityResponseTypes";
 
-import { USWDSIcon } from "src/components/USWDSIcon";
+import { useTranslations } from "next-intl";
+import { Link } from "@trussworks/react-uswds";
 
 type OpportunityDownloadProps = {
-  nofoPath: string;
-  opportunityId: number;
+  attachments: OpportunityDocument[];
 };
 
-const downloadNOFO = (nofoPath: string) => {
-  window.open(nofoPath, "_blank");
-};
-
-const OpportunityDownload = ({
-  nofoPath,
-  opportunityId,
-}: OpportunityDownloadProps) => {
+const OpportunityDownload = ({ attachments }: OpportunityDownloadProps) => {
   const t = useTranslations("OpportunityListing.description");
 
   return (
     <>
-      {nofoPath.length > 0 ? (
+      {attachments.length > 0 ? (
         <div className="grid-row flex-justify">
-          <Button
-            onClick={() => downloadNOFO(nofoPath)}
-            type="button"
-            id={`opportunity-document-button-${opportunityId}`}
-          >
-            <span>{t("nofo_download")} </span>
-            <USWDSIcon name={"file_download"} className="usa-icon--size-4" />
-          </Button>
           <Link
             className="flex-align-self-center"
             href={"#opportunity_documents"}

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -50,7 +50,7 @@ export const messages = {
     },
     documents: {
       title: "Documents",
-      table_col_category: "Category",
+      table_col_description: "Description",
       table_col_file_name: "File name",
       table_col_last_updated: "Last updated",
       type: {

--- a/frontend/src/types/opportunity/opportunityResponseTypes.ts
+++ b/frontend/src/types/opportunity/opportunityResponseTypes.ts
@@ -7,7 +7,7 @@ export interface OpportunityAssistanceListing {
   program_title: string;
 }
 
-interface OpportunityDocument {
+export interface OpportunityDocument {
   opportunity_attachment_type: string;
   file_name: string;
   download_path: string;

--- a/frontend/src/types/opportunity/opportunityResponseTypes.ts
+++ b/frontend/src/types/opportunity/opportunityResponseTypes.ts
@@ -8,10 +8,10 @@ export interface OpportunityAssistanceListing {
 }
 
 export interface OpportunityDocument {
-  opportunity_attachment_type: string;
   file_name: string;
   download_path: string;
   updated_at: string;
+  file_description?: string;
 }
 
 interface MinimalSummary {

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -111,3 +111,10 @@ export const fakeSearchAPIResponse: SearchAPIResponse = {
   message: "anything",
   status_code: 200,
 };
+
+export const fakeOpportunityDocument = {
+  file_name: "your_file_thanks.mp3",
+  download_path: "http://big-website.net/your_file_again.mp4",
+  updated_at: Date.now().toString(),
+  file_description: "a description for your file",
+};

--- a/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDescription.test.tsx
@@ -48,11 +48,7 @@ const mockSummaryData: Summary = {
 describe("OpportunityDescription", () => {
   it("renders the opportunity description", () => {
     render(
-      <OpportunityDescription
-        opportunityId={1}
-        summary={mockSummaryData}
-        nofoPath=""
-      />,
+      <OpportunityDescription summary={mockSummaryData} attachments={[]} />,
     );
 
     const descriptionHeading = screen.getByText("description");
@@ -70,9 +66,8 @@ describe("OpportunityDescription", () => {
   it("splits opportunity description after 600 characters if description is longer than 750 characters", () => {
     render(
       <OpportunityDescription
-        opportunityId={1}
         summary={{ ...mockSummaryData, summary_description: longDescription }}
-        nofoPath=""
+        attachments={[]}
       />,
     );
 
@@ -96,9 +91,8 @@ describe("OpportunityDescription", () => {
 
     render(
       <OpportunityDescription
-        opportunityId={1}
         summary={{ ...mockSummaryData, summary_description: longDescription }}
-        nofoPath=""
+        attachments={[]}
       />,
     );
 
@@ -111,11 +105,7 @@ describe("OpportunityDescription", () => {
 
   it("renders the eligible applicants with mapped values", () => {
     render(
-      <OpportunityDescription
-        opportunityId={1}
-        summary={mockSummaryData}
-        nofoPath=""
-      />,
+      <OpportunityDescription summary={mockSummaryData} attachments={[]} />,
     );
 
     const eligibleApplicantsHeading = screen.getByText("eligible_applicants");
@@ -130,11 +120,7 @@ describe("OpportunityDescription", () => {
 
   it("renders additional information on eligibility", () => {
     render(
-      <OpportunityDescription
-        opportunityId={1}
-        summary={mockSummaryData}
-        nofoPath=""
-      />,
+      <OpportunityDescription summary={mockSummaryData} attachments={[]} />,
     );
 
     const additionalInfoHeading = screen.getByText("additional_info");
@@ -153,11 +139,7 @@ describe("OpportunityDescription", () => {
 
   it("renders agency contact information", () => {
     render(
-      <OpportunityDescription
-        opportunityId={1}
-        summary={mockSummaryData}
-        nofoPath=""
-      />,
+      <OpportunityDescription summary={mockSummaryData} attachments={[]} />,
     );
 
     const contactInfoHeading = screen.getByText("contact_info");
@@ -176,7 +158,6 @@ describe("OpportunityDescription", () => {
   it("renders information correctly when null values are present", () => {
     render(
       <OpportunityDescription
-        opportunityId={1}
         summary={{
           ...mockSummaryData,
           applicant_types: [],
@@ -186,7 +167,7 @@ describe("OpportunityDescription", () => {
           agency_email_address_description: null,
           summary_description: null,
         }}
-        nofoPath=""
+        attachments={[]}
       />,
     );
 

--- a/frontend/tests/components/opportunity/OpportunityDownload.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDownload.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { fakeOpportunityDocument } from "src/utils/testing/fixtures";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import OpportunityDownload from "src/components/opportunity/OpportunityDownload";
@@ -8,35 +9,16 @@ jest.mock("next-intl", () => ({
 }));
 
 describe("OpportunityDownload Component", () => {
-  const nofoPath = "http://example.com/nofo.pdf";
-
-  it("renders if nofoPath is present", () => {
-    render(<OpportunityDownload opportunityId={1} nofoPath={nofoPath} />);
-
-    expect(
-      screen.getByRole("button", { name: "nofo_download" }),
-    ).toBeInTheDocument();
+  it("renders link if at least one attachment is present", () => {
+    render(<OpportunityDownload attachments={[fakeOpportunityDocument]} />);
+    const link = screen.getByRole("link");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "#opportunity_documents");
   });
 
-  it("does not render if nofoPath is not present", () => {
-    render(<OpportunityDownload opportunityId={1} nofoPath="" />);
+  it("does not render link if no attachments are present", () => {
+    render(<OpportunityDownload attachments={[]} />);
 
-    expect(
-      screen.queryByRole("button", { name: "nofo_download" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("opens a new tab when download button is clicked", () => {
-    window.open = jest.fn();
-
-    render(<OpportunityDownload opportunityId={1} nofoPath={nofoPath} />);
-
-    const downloadButton = screen.getByRole("button", {
-      name: "nofo_download",
-    });
-
-    fireEvent.click(downloadButton);
-
-    expect(window.open).toHaveBeenCalledWith(nofoPath, "_blank");
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Fixes #4060

### Time to review: __10 mins__

## Changes proposed
* remove "nofo download" button
* add description column in opportunity detail page documents table
* make documents table full width

## Context for reviewers
### Test steps
1. start a server on this branch with `npm run dev`
2. visit an opportunity page with 1 attachment (should be 7) http://localhost:3000/opportunity/7
3. _VERIFY_: there is no download nofo button
4. _VERIFY_: documents table contains a description column

## Additional information

![Screenshot 2025-03-27 at 15-28-48 Opportunity Listing - Research into Jewellery designer industry](https://github.com/user-attachments/assets/67b7c37a-1974-4753-af67-89cd2a4e93c7)
