### PR TITLE
[Issue 4348] Update metabase query backups

### DIFF
--- a/analytics/src/analytics/integrations/metabase/sql/data-availability/newest.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/data-availability/newest.sql
@@ -1,3 +1,3 @@
 select
-max(gh_issue_history.d_effective)
+max(gh_issue_history.d_effective) as maximum_date
 from gh_issue_history

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-issue.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-issue.sql
@@ -127,6 +127,7 @@ WITH RECURSIVE
 
 SELECT
   (SELECT deliverable_title FROM deliverable_info) AS deliverable_title,
+  (SELECT CONCAT('https://github.com/', deliverable_ghid) FROM constants) as deliverable_url,
   issue_day,
   total_opened,
   total_closed,

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-points.sql
@@ -127,6 +127,7 @@ WITH RECURSIVE
 
 SELECT
   (SELECT deliverable_title FROM deliverable_info) AS deliverable_title,
+  (SELECT CONCAT('https://github.com/', deliverable_ghid) FROM constants) as deliverable_url,
   issue_day,
   total_opened,
   total_closed,

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-excluding-done.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-excluding-done.sql
@@ -1,77 +1,86 @@
-WITH  
-  -- Get deliverables  
-  deliverable AS (  
-    SELECT  
-      id AS deliverable_id,  
-      title,  
-      ghid  
-    FROM  
-      gh_deliverable  
+WITH
+  -- Get deliverables
+  deliverable AS (
+    SELECT
+      d.id AS deliverable_id,
+      d.title,
+      d.ghid
+    FROM
+      gh_deliverable d
     WHERE
-      ghid not in ('HHS/simpler-grants-gov/issues/3174')
-  ),  
+      NOT EXISTS (
+        SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid AND e.t_modified > d.t_modified AND CAST(e.t_modified AS DATE) != DATE '2025-02-04'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid AND i.t_modified > d.t_modified AND CAST(i.t_modified AS DATE) != DATE '2025-02-04'
+     )
+  ),
 
-  -- Get latest state snapshot for each deliverable  
-  deliverable_state AS (  
-    SELECT *  
-    FROM (  
-      SELECT  
-        h.deliverable_id,  
-        h.status,  
-        h.d_effective,  
-        ROW_NUMBER() OVER (  
-          PARTITION BY h.deliverable_id  
-          ORDER BY h.d_effective DESC  
-        ) AS ranked_order,  
-        d.title,  
-        d.ghid  
-      FROM  
-        gh_deliverable_history h  
-        JOIN deliverable d ON h.deliverable_id = d.deliverable_id  
-    ) history  
-    WHERE history.ranked_order = 1  
-  ),  
+  -- Get latest state snapshot for each deliverable
+  deliverable_state AS (
+    SELECT *
+    FROM (
+      SELECT
+        h.deliverable_id,
+        h.status,
+        h.d_effective,
+        ROW_NUMBER() OVER (
+          PARTITION BY h.deliverable_id
+          ORDER BY h.d_effective DESC
+        ) AS ranked_order,
+        d.title,
+        d.ghid
+      FROM
+        gh_deliverable_history h
+        JOIN deliverable d ON h.deliverable_id = d.deliverable_id
+    ) history
+    WHERE history.ranked_order = 1
+  ),
 
-  -- Get latest quad mapping per deliverable  
-  latest_deliverable_quad AS (  
-    SELECT *  
-    FROM (  
-      SELECT  
-        dm.deliverable_id,  
-        dm.quad_id,  
-        dm.d_effective,  
-        ROW_NUMBER() OVER (  
-          PARTITION BY dm.deliverable_id  
-          ORDER BY dm.d_effective DESC  
-        ) AS ranked_order  
-      FROM  
-        gh_deliverable_quad_map dm  
-    ) quad_history  
-    WHERE quad_history.ranked_order = 1  
-  ),  
+  -- Get latest quad mapping per deliverable
+  latest_deliverable_quad AS (
+    SELECT *
+    FROM (
+      SELECT
+        dm.deliverable_id,
+        dm.quad_id,
+        dm.d_effective,
+        ROW_NUMBER() OVER (
+          PARTITION BY dm.deliverable_id
+          ORDER BY dm.d_effective DESC
+        ) AS ranked_order
+      FROM
+        gh_deliverable_quad_map dm
+    ) quad_history
+    WHERE quad_history.ranked_order = 1
+  ),
 
-  -- Get quad names for each deliverable using latest mapping  
-  deliverable_quad AS (  
-    SELECT  
-      lq.deliverable_id,  
-      q.name AS quad_name  
-    FROM  
-      latest_deliverable_quad lq  
-      JOIN gh_quad q ON lq.quad_id = q.id  
-  )  
+  -- Get quad names for each deliverable using latest mapping
+  deliverable_quad AS (
+    SELECT
+      lq.deliverable_id,
+      q.name AS quad_name
+    FROM
+      latest_deliverable_quad lq
+      JOIN gh_quad q ON lq.quad_id = q.id
+  )
 
-SELECT  
-  ds.deliverable_id,  
-  ds.title,  
-  ds.status,  
-  ds.d_effective,  
-  ds.ghid,  
-  dq.quad_name,  
-  CONCAT('https://github.com/', ds.ghid) AS url  
-FROM  
-  deliverable_state ds  
-  LEFT JOIN deliverable_quad dq ON ds.deliverable_id = dq.deliverable_id  
-WHERE  
-  ds.status != 'Done'  
-ORDER BY  
+SELECT
+  ds.deliverable_id,
+  ds.title,
+  ds.status,
+  ds.d_effective,
+  ds.ghid,
+  dq.quad_name,
+  CONCAT('https://github.com/', ds.ghid) AS url
+FROM
+  deliverable_state ds
+  LEFT JOIN deliverable_quad dq ON ds.deliverable_id = dq.deliverable_id
+WHERE
+  ds.status != 'Done'
+ORDER BY
   ds.title asc;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-excluding-done.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-excluding-done.sql
@@ -7,6 +7,8 @@ WITH
       ghid  
     FROM  
       gh_deliverable  
+    WHERE
+      ghid not in ('HHS/simpler-grants-gov/issues/3174')
   ),  
 
   -- Get latest state snapshot for each deliverable  

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-including-done-only.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-including-done-only.sql
@@ -1,75 +1,86 @@
-WITH  
-  -- Get deliverables  
-  deliverable AS (  
-    SELECT  
-      id AS deliverable_id,  
-      title,  
-      ghid  
-    FROM  
-      gh_deliverable  
-  ),  
+WITH
+  -- Get deliverables
+  deliverable AS (
+    SELECT
+      id AS deliverable_id,
+      title,
+      ghid
+    FROM
+      gh_deliverable d
+    WHERE
+      NOT EXISTS (
+        SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid AND e.t_modified > d.t_modified AND CAST(e.t_modified AS DATE) != DATE '2025-02-04'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid AND i.t_modified > d.t_modified AND CAST(i.t_modified AS DATE) != DATE '2025-02-04'
+     )
+  ),
 
-  -- Get latest state snapshot for each deliverable  
-  deliverable_state AS (  
-    SELECT *  
-    FROM (  
-      SELECT  
-        h.deliverable_id,  
-        h.status,  
-        h.d_effective,  
-        ROW_NUMBER() OVER (  
-          PARTITION BY h.deliverable_id  
-          ORDER BY h.d_effective DESC  
-        ) AS ranked_order,  
-        d.title,  
-        d.ghid  
-      FROM  
-        gh_deliverable_history h  
-        JOIN deliverable d ON h.deliverable_id = d.deliverable_id  
-    ) history  
-    WHERE history.ranked_order = 1  
-  ),  
+  -- Get latest state snapshot for each deliverable
+  deliverable_state AS (
+    SELECT *
+    FROM (
+      SELECT
+        h.deliverable_id,
+        h.status,
+        h.d_effective,
+        ROW_NUMBER() OVER (
+          PARTITION BY h.deliverable_id
+          ORDER BY h.d_effective DESC
+        ) AS ranked_order,
+        d.title,
+        d.ghid
+      FROM
+        gh_deliverable_history h
+        JOIN deliverable d ON h.deliverable_id = d.deliverable_id
+    ) history
+    WHERE history.ranked_order = 1
+  ),
 
-  -- Get latest quad mapping per deliverable  
-  latest_deliverable_quad AS (  
-    SELECT *  
-    FROM (  
-      SELECT  
-        dm.deliverable_id,  
-        dm.quad_id,  
-        dm.d_effective,  
-        ROW_NUMBER() OVER (  
-          PARTITION BY dm.deliverable_id  
-          ORDER BY dm.d_effective DESC  
-        ) AS ranked_order  
-      FROM  
-        gh_deliverable_quad_map dm  
-    ) quad_history  
-    WHERE quad_history.ranked_order = 1  
-  ),  
+  -- Get latest quad mapping per deliverable
+  latest_deliverable_quad AS (
+    SELECT *
+    FROM (
+      SELECT
+        dm.deliverable_id,
+        dm.quad_id,
+        dm.d_effective,
+        ROW_NUMBER() OVER (
+          PARTITION BY dm.deliverable_id
+          ORDER BY dm.d_effective DESC
+        ) AS ranked_order
+      FROM
+        gh_deliverable_quad_map dm
+    ) quad_history
+    WHERE quad_history.ranked_order = 1
+  ),
 
-  -- Get quad names for each deliverable using latest mapping  
-  deliverable_quad AS (  
-    SELECT  
-      lq.deliverable_id,  
-      q.name AS quad_name  
-    FROM  
-      latest_deliverable_quad lq  
-      JOIN gh_quad q ON lq.quad_id = q.id  
-  )  
+  -- Get quad names for each deliverable using latest mapping
+  deliverable_quad AS (
+    SELECT
+      lq.deliverable_id,
+      q.name AS quad_name
+    FROM
+      latest_deliverable_quad lq
+      JOIN gh_quad q ON lq.quad_id = q.id
+  )
 
-SELECT  
-  ds.deliverable_id,  
-  ds.title,  
-  ds.status,  
-  ds.d_effective,  
-  ds.ghid,  
-  dq.quad_name,  
-  CONCAT('https://github.com/', ds.ghid) AS url  
-FROM  
-  deliverable_state ds  
-  LEFT JOIN deliverable_quad dq ON ds.deliverable_id = dq.deliverable_id  
-WHERE  
-  ds.status = 'Done'  
-ORDER BY  
+SELECT
+  ds.deliverable_id,
+  ds.title,
+  ds.status,
+  ds.d_effective,
+  ds.ghid,
+  dq.quad_name,
+  CONCAT('https://github.com/', ds.ghid) AS url
+FROM
+  deliverable_state ds
+  LEFT JOIN deliverable_quad dq ON ds.deliverable_id = dq.deliverable_id
+WHERE
+  ds.status = 'Done'
+ORDER BY
   ds.title asc;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-including-done.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-including-done.sql
@@ -5,5 +5,7 @@ SELECT
   concat('https://github.com/', ghid) as url 
 FROM
   gh_deliverable
+WHERE
+  ghid not in ('HHS/simpler-grants-gov/issues/3174')
 ORDER BY
   title

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-including-done.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-titles-including-done.sql
@@ -2,10 +2,19 @@ SELECT
   id AS deliverable_id,
   title,
   ghid,
-  concat('https://github.com/', ghid) as url 
+  concat('https://github.com/', ghid) as url
 FROM
-  gh_deliverable
-WHERE
-  ghid not in ('HHS/simpler-grants-gov/issues/3174')
+  gh_deliverable d
+    WHERE
+      NOT EXISTS (
+        SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid AND e.t_modified > d.t_modified AND CAST(e.t_modified AS DATE) != DATE '2025-02-04'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid AND i.t_modified > d.t_modified AND CAST(i.t_modified AS DATE) != DATE '2025-02-04'
+     )
 ORDER BY
   title

--- a/analytics/src/analytics/integrations/metabase/sql/sprint-metrics/sprint-issues-pointed.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/sprint-metrics/sprint-issues-pointed.sql
@@ -55,7 +55,7 @@ WITH
         )
         OR (
           -- ...otherwise use yesterday
-          h.d_effective = data_availability.max
+          h.d_effective = data_availability.maximum_date
           AND sprint_data.end_date >= CURRENT_DATE
         )
       )

--- a/analytics/src/analytics/integrations/metabase/sql/sprint-metrics/sprints-with-scd-data.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/sprint-metrics/sprints-with-scd-data.sql
@@ -1,16 +1,18 @@
 WITH
   project_data AS {{#168-project-data}},
-  availability_data as {{#159-data-availability-oldest}},
+  oldest_data as {{#159-data-availability-oldest}},
+  newest_data as {{#160-data-availability-newest}},
   sprint_data AS (
     SELECT
       gh_sprint.name AS sprint_name,
       gh_sprint.start_date,
       gh_sprint.id AS sprint_id
     FROM
-      gh_sprint, availability_data
+      gh_sprint, oldest_data, newest_data
     WHERE
       {{project_id}}
-      AND gh_sprint.start_date >= availability_data.minimum_date
+      AND gh_sprint.start_date >= oldest_data.minimum_date
+      AND gh_sprint.start_date <= newest_data.maximum_date
     ORDER BY
       sprint_name
   )
@@ -18,3 +20,4 @@ SELECT
   *
 FROM
   sprint_data
+ORDER BY start_date desc


### PR DESCRIPTION
## Summary
Fixes #4348

### Time to review: __2 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

Changes to sprint, deliverable, and burndown queries to (1) exclude future sprints from sprint filter, (2) exclude issues that changed type from deliverable to epic or issue, and (3) include url in result set to enable click behavior on dashboards.
 
## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We do not have automated backups or source control for queries in Metabase. So every time we change a query in Metabase, we have to manually update these backups  :( 

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

