### PR TITLE
Agency e2e test flakiness

### DIFF
--- a/.github/workflows/ci-frontend-a11y.yml
+++ b/.github/workflows/ci-frontend-a11y.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Start API Server for search results
         run: |
           cd ../api
-          make init db-seed-local cover_all_agencies=true populate-search-opportunities start &
+          make init db-seed-local-with-agencies populate-search-opportunities start &
           cd ../frontend
           # ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh

--- a/.github/workflows/ci-frontend-a11y.yml
+++ b/.github/workflows/ci-frontend-a11y.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Start API Server for search results
         run: |
           cd ../api
-          make init db-seed-local populate-search-opportunities start &
+          make init db-seed-local cover_all_agencies=true populate-search-opportunities start &
           cd ../frontend
           # ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Start API Server for e2e tests
         run: |
           cd ../api
-          make init db-seed-local cover_all_agencies=true populate-search-opportunities start
+          make init db-seed-local-with-agencies populate-search-opportunities start
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
           echo "ENABLE_OPPORTUNITY_ATTACHMENT_PIPELINE=false" >> override.env
           cd ../frontend

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Start API Server for e2e tests
         run: |
           cd ../api
-          make init db-seed-local populate-search-opportunities start
+          make init db-seed-local cover_all_agencies=true populate-search-opportunities start
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
           echo "ENABLE_OPPORTUNITY_ATTACHMENT_PIPELINE=false" >> override.env
           cd ../frontend
@@ -60,7 +60,7 @@ jobs:
           sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env >> .env.local
           cat .env.development >> .env.local
           # Use the localhost url for tests
-          sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://localhost:3000|' .env.local 
+          sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://localhost:3000|' .env.local
           npm run build -- --no-lint
 
       - name: Run e2e tests (Shard ${{ matrix.shard }}/${{ matrix.total_shards }})

--- a/api/Makefile
+++ b/api/Makefile
@@ -173,6 +173,9 @@ db-migrate-heads: ## Show migrations marked as a head
 db-seed-local: ## Generate records into your local database
 	$(PY_RUN_CMD) db-seed-local $(args)
 
+db-seed-local-with-agencies: ## add an opportunity for each agency
+	$(PY_RUN_CMD) db-seed-local --cover_all_agencies=true
+
 db-check-migrations: ## Verify the DB schema matches the DB migrations generated
 	$(alembic_cmd) check || (echo -e "\n$(RED)Migrations are not up-to-date, make sure you generate migrations by running 'make db-migrate-create <msg>'$(NO_COLOR)"; exit 1)
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -171,7 +171,7 @@ db-migrate-heads: ## Show migrations marked as a head
 	$(alembic_cmd) heads $(args)
 
 db-seed-local: ## Generate records into your local database
-	$(PY_RUN_CMD) db-seed-local $(args)
+	$(PY_RUN_CMD) db-seed-local --cover_all_agencies=true $(args)
 
 db-check-migrations: ## Verify the DB schema matches the DB migrations generated
 	$(alembic_cmd) check || (echo -e "\n$(RED)Migrations are not up-to-date, make sure you generate migrations by running 'make db-migrate-create <msg>'$(NO_COLOR)"; exit 1)

--- a/api/Makefile
+++ b/api/Makefile
@@ -171,7 +171,7 @@ db-migrate-heads: ## Show migrations marked as a head
 	$(alembic_cmd) heads $(args)
 
 db-seed-local: ## Generate records into your local database
-	$(PY_RUN_CMD) db-seed-local --cover_all_agencies=true $(args)
+	$(PY_RUN_CMD) db-seed-local $(args)
 
 db-check-migrations: ## Verify the DB schema matches the DB migrations generated
 	$(alembic_cmd) check || (echo -e "\n$(RED)Migrations are not up-to-date, make sure you generate migrations by running 'make db-migrate-create <msg>'$(NO_COLOR)"; exit 1)

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -30,6 +30,8 @@ def _build_opportunities(db_session: db.Session, iterations: int) -> None:
         factories.OpportunityFactory.create_batch(
             size=2, is_posted_summary=True, has_long_descriptions=True
         )
+        for agency in factories.CustomProvider.AGENCIES:
+          factories.OpportunityFactory.create(agency_code=agency)
 
         # generate a few opportunities with mostly null values
         all_null_opportunities = factories.OpportunityFactory.create_batch(

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -31,7 +31,7 @@ def _build_opportunities(db_session: db.Session, iterations: int) -> None:
             size=2, is_posted_summary=True, has_long_descriptions=True
         )
         for agency in factories.CustomProvider.AGENCIES:
-          factories.OpportunityFactory.create(agency_code=agency)
+            factories.OpportunityFactory.create(agency_code=agency)
 
         # generate a few opportunities with mostly null values
         all_null_opportunities = factories.OpportunityFactory.create_batch(

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -60,7 +60,12 @@ def _build_opportunities(
     default=1,
     help="Number of sets of opportunities to create, note that several are created per iteration",
 )
-def seed_local_db(iterations: int, cover_all_agencies: bool = True) -> None:
+@click.option(
+    "--cover_all_agencies",
+    default="false",
+    help="Should the seed include an opportunity assigned to each agency?",
+)
+def seed_local_db(iterations: int, cover_all_agencies: bool) -> None:
     with src.logging.init("seed_local_db"):
         logger.info("Running seed script for local DB")
         error_if_not_local()

--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -28,7 +28,7 @@ import {
 
 test.describe("Search page tests", () => {
   // flaky
-  test.skip("should refresh and retain filters in a new tab", async ({ page }, {
+  test("should refresh and retain filters in a new tab", async ({ page }, {
     project,
   }) => {
     // Set all inputs, then refresh the page. Those same inputs should be
@@ -243,7 +243,7 @@ test.describe("Search page tests", () => {
       "Funding instrument",
       "Eligibility",
       "Category",
-      // "Agency", - agency test is flaky
+      "Agency",
     ];
 
     filterTypes.forEach((filterType) => {
@@ -339,7 +339,7 @@ test.describe("Search page tests", () => {
       - click clear all nested agency
     */
     // flaky
-    test.skip("selects and clears nested agency filters", async ({ page }, {
+    test("selects and clears nested agency filters", async ({ page }, {
       project,
     }) => {
       const nestedFilterCheckboxesSelector =


### PR DESCRIPTION
## Summary
unticketed, fixes e2e tests that were skipped for convenience in https://github.com/HHS/simpler-grants-gov/pull/4359

### Time to review: __5 mins__

## Changes proposed
Adds option to seed an open opportunity associated with each seeded agency.

This should ease some manual testing scenarios, as well as making e2e tests more robust when dealing with agencies.

## Context for reviewers
### Test steps

1. tests pass in ci

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

