### PR TITLE
[Issue #4368] Respect HHS session timeout requirements

### DIFF
--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -94,7 +94,7 @@ def create_jwt_for_user(
         "iss": config.issuer,
         "email": email,
         "user_id": str(user.user_id),
-        "session_duration_minutes": config.token_expiration_minutes
+        "session_duration_minutes": config.token_expiration_minutes,
     }
 
     logger.info(

--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -94,6 +94,7 @@ def create_jwt_for_user(
         "iss": config.issuer,
         "email": email,
         "user_id": str(user.user_id),
+        "session_duration_minutes": config.token_expiration_minutes
     }
 
     logger.info(

--- a/frontend/src/services/auth/types.tsx
+++ b/frontend/src/services/auth/types.tsx
@@ -46,6 +46,7 @@ export interface UserProfile {
 // represents client JWT payload
 export interface SimplerJwtPayload extends JWTPayload {
   token: string;
+  session_duration_minutes: number;
 }
 // represents API JWT payload
 export type UserSession = UserProfile & SimplerJwtPayload;

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -13,15 +13,16 @@ locals {
     # Login.gov OAuth
     # Default values point to the IDP integration environment
     # which all non-prod environments should use
-    ENABLE_AUTH_ENDPOINT      = 0
-    LOGIN_GOV_CLIENT_ID       = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-${var.environment}-simpler-grants-gov"
-    LOGIN_GOV_ENDPOINT        = "https://idp.int.identitysandbox.gov/"
-    LOGIN_GOV_JWK_ENDPOINT    = "https://idp.int.identitysandbox.gov/api/openid_connect/certs"
-    LOGIN_GOV_AUTH_ENDPOINT   = "https://idp.int.identitysandbox.gov/openid_connect/authorize"
-    LOGIN_GOV_TOKEN_ENDPOINT  = "https://idp.int.identitysandbox.gov/api/openid_connect/token"
-    LOGIN_GOV_REDIRECT_SCHEME = var.enable_https ? "https" : "http"
-    API_JWT_ISSUER            = "simpler-grants-api-${var.environment}"
-    API_JWT_AUDIENCE          = "simpler-grants-api-${var.environment}"
+    ENABLE_AUTH_ENDPOINT             = 0
+    LOGIN_GOV_CLIENT_ID              = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-${var.environment}-simpler-grants-gov"
+    LOGIN_GOV_ENDPOINT               = "https://idp.int.identitysandbox.gov/"
+    LOGIN_GOV_JWK_ENDPOINT           = "https://idp.int.identitysandbox.gov/api/openid_connect/certs"
+    LOGIN_GOV_AUTH_ENDPOINT          = "https://idp.int.identitysandbox.gov/openid_connect/authorize"
+    LOGIN_GOV_TOKEN_ENDPOINT         = "https://idp.int.identitysandbox.gov/api/openid_connect/token"
+    LOGIN_GOV_REDIRECT_SCHEME        = var.enable_https ? "https" : "http"
+    API_JWT_ISSUER                   = "simpler-grants-api-${var.environment}"
+    API_JWT_AUDIENCE                 = "simpler-grants-api-${var.environment}"
+    API_JWT_TOKEN_EXPIRATION_MINUTES = 15
 
     TEST_AGENCY_PREFIXES = "GDIT,IVV,IVPDF,0001,FGLT,NGMS,NGMS-Sub1,SECSCAN"
   }


### PR DESCRIPTION
## Summary
Fixes #4368

### Time to review: __2 mins__

## Changes proposed
Set a default session timeout for all deployed environments that meets HHS' 15 minute requirement.
Pass the active session duration to the FE via the JWT so it can behave in concert with the BE
