### PR TITLE
[Issue #4355] Adjust logging in LoadOracleDataTask to use less metrics

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -103,7 +103,7 @@ start-debug:
 run-logs: start ## Start the API and follow the logs
 	docker compose logs --follow --no-color $(APP_NAME)
 
-init: setup-env-override-file build init-db init-opensearch init-localstack
+init: setup-env-override-file build init-db init-opensearch init-localstack init-mock-soap-services
 
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes
@@ -328,5 +328,7 @@ load-test-prod: # Load test the production environment in aws. Please test respo
 #########################
 # Mock SOAP services
 #########################
-start-mock-soap-services:
-	docker compose up --detach mock-applicants-soap-api 	# start applicants soap api
+init-mock-soap-services: start-mock-soap-services ## Initialize the applicants soap api
+
+start-mock-soap-services: ## start applicants soap api
+	docker compose up --detach mock-applicants-soap-api

--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -122,7 +122,7 @@ class LoadOracleDataTask(src.task.task.Task):
 
     def do_insert(self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table) -> int:
         """Determine new rows by primary key, and copy them into the staging table."""
-        log_extra = {"table": foreign_table.name}
+        log_extra: dict = {"table": foreign_table.name}
 
         logger.info("Fetching records to be inserted", extra=log_extra)
         select_sql = sql.build_select_new_rows_sql(foreign_table, staging_table)
@@ -154,19 +154,19 @@ class LoadOracleDataTask(src.task.task.Task):
         t1 = time.monotonic()
         total_insert_count = sum(insert_chunk_count)
         self.increment("count.insert.total", total_insert_count)
-        self.increment(f"count.insert.{staging_table.name}", total_insert_count)
-        self.set_metrics(
-            {
-                f"count.insert.chunk.{staging_table.name}": ",".join(map(str, insert_chunk_count)),
-                f"time.insert.{staging_table.name}": round(t1 - t0, 3),
-            }
-        )
+
+        log_extra |= {
+            f"count.insert.{staging_table.name}": total_insert_count,
+            f"count.insert.chunk.{staging_table.name}": ",".join(map(str, insert_chunk_count)),
+            f"time.insert.{staging_table.name}": round(t1 - t0, 3),
+        }
+        logger.info("Processed records to be inserted", extra=log_extra)
 
         return total_insert_count
 
     def do_update(self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table) -> int:
         """Find updated rows using last_upd_date, copy them, and reset transformed_at to NULL."""
-        log_extra = {"table": foreign_table.name}
+        log_extra: dict = {"table": foreign_table.name}
 
         logger.info("Fetching records to be updated", extra=log_extra)
         select_sql = sql.build_select_updated_rows_sql(foreign_table, staging_table)
@@ -195,13 +195,13 @@ class LoadOracleDataTask(src.task.task.Task):
         t1 = time.monotonic()
         total_update_count = sum(update_chunk_count)
         self.increment("count.update.total", total_update_count)
-        self.increment(f"count.update.{staging_table.name}", total_update_count)
-        self.set_metrics(
-            {
-                f"count.update.chunk.{staging_table.name}": ",".join(map(str, update_chunk_count)),
-                f"time.update.{staging_table.name}": round(t1 - t0, 3),
-            }
-        )
+
+        log_extra |= {
+            f"count.update.{staging_table.name}": total_update_count,
+            f"count.update.chunk.{staging_table.name}": ",".join(map(str, update_chunk_count)),
+            f"time.update.{staging_table.name}": round(t1 - t0, 3),
+        }
+        logger.info("Processed records to be updated", extra=log_extra)
 
         return total_update_count
 
@@ -209,7 +209,7 @@ class LoadOracleDataTask(src.task.task.Task):
         self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table
     ) -> int:
         """Find deleted rows, set is_deleted=TRUE, and reset transformed_at to NULL."""
-        log_extra = {"table": foreign_table.name}
+        log_extra: dict = {"table": foreign_table.name}
 
         logger.info("Fetching records to be deleted", extra=log_extra)
         update_sql = sql.build_mark_deleted_sql(foreign_table, staging_table).values(
@@ -225,9 +225,13 @@ class LoadOracleDataTask(src.task.task.Task):
         delete_count = result.rowcount
 
         self.increment("count.delete.total", delete_count)
-        self.set_metrics({f"count.delete.{staging_table.name}": delete_count})
-        self.set_metrics({f"time.delete.{staging_table.name}": round(t1 - t0, 3)})
-        logger.info("Delete done", extra=log_extra | {"count": delete_count})
+
+        log_extra |= {
+            f"count.delete.{staging_table.name}": delete_count,
+            f"time.delete.{staging_table.name}": round(t1 - t0, 3),
+        }
+
+        logger.info("Processed records to be deleted", extra=log_extra)
 
         return delete_count
 
@@ -239,7 +243,6 @@ class LoadOracleDataTask(src.task.task.Task):
                 count = self.db_session.query(table).count()
                 extra["table"] = table.name
                 extra[f"count.{table.schema}.{table.name}"] = count
-                self.set_metrics({f"count.{message}.{table.schema}.{table.name}": count})
         logger.info(f"row count {message}", extra=extra, stacklevel=2)
 
 


### PR DESCRIPTION
## Summary
Fixes #4355

### Time to review: __5 mins__

## Changes proposed
Updated logging in LoadOracleDataTask to not put it all in metrics / log everything at once

## Context for reviewers
New Relic has a limit of ~255 key/value pairs in a log statement. Right now we're putting about 200+ values into the metric object just for this one task - which is causing it to break when combined with the ~50 or so we always add. To work around this, instead of adding all these values as we go, just log a bunch of them as we go. Only keep metrics for the overall counts, and just log insert/update/delete metrics when we calculate them. Still have all the same info, just spread out a bit.


