### PR TITLE
[Unticketed] Don't keep the raw base64 value in search index

### DIFF
--- a/api/src/search/backend/load_opportunities_to_index.py
+++ b/api/src/search/backend/load_opportunities_to_index.py
@@ -115,7 +115,18 @@ class LoadOpportunitiesToIndex(Task):
                         },
                         "ignore_missing": True,
                     }
-                }
+                },
+                {
+                    "foreach": {
+                        "field": "attachments",
+                        "processor": {
+                            "remove": {
+                                "field": "_ingest._value.data",
+                            }
+                        },
+                        "ignore_missing": True,
+                    }
+                },
             ],
         }
 

--- a/api/src/search/backend/load_opportunities_to_index.py
+++ b/api/src/search/backend/load_opportunities_to_index.py
@@ -116,6 +116,10 @@ class LoadOpportunitiesToIndex(Task):
                         "ignore_missing": True,
                     }
                 },
+                # After we've done the above processing to send the base64
+                # encoded file to OpenSearch, remove the raw base64 "data"
+                # field from what we actually index as it's not useful
+                # and will bloat the size of our index.
                 {
                     "foreach": {
                         "field": "attachments",


### PR DESCRIPTION
## Summary

### Time to review: __2 mins__

## Changes proposed
Adjust the processor that handles file attachments in OpenSearch to also delete the raw file contents

## Context for reviewers
Trying out different performance ideas, at the very least this'll save us a lot of space on the index, even if it doesn't help with the performance.

## Additional information
Before this change, the attachments section of the search data looks like:
```json
"attachments": [
            {
              "filename": "idea.pdf",
              "data": "UHJvcGVydHkgaXQgbGl0dGxlIGFub3RoZXIgbXVzdCBEZW1vY3JhdCBiZWF0LiBGaWd1cmUgcmVtYWluIGJpbGxpb24gc2l0ZSBtZWV0aW5nIHNtaWxlIGNhcGl0YWwuIElkZW50aWZ5IHRodXMgaW4uIEZlYXIgc2l0dWF0aW9uIHN0YXIgaW5jcmVhc2Ugc3RhdGUuIExvdyBkaW5uZXIgc3RhdGlvbiBzZW5pb3IgcmVzcG9uZCB5YXJkIHZhbHVlLiBDYWxsIGZlYXIgdHVybiBpbnZlc3RtZW50LiBUYXggb3VyIHNraW4gYXJ0aWNsZSBSZXB1YmxpY2FuIHByb2R1Y3QgaWRlbnRpZnkuIFNvIGFydGljbGUgcmVwcmVzZW50Lg==",
              "attachment": {
                "content_type": "text/plain; charset=ISO-8859-1",
                "language": "en",
                "content": "Property it little another must Democrat beat. Figure remain billion site meeting smile capital. Identify thus in. Fear situation star increase state. Low dinner station senior respond yard value. Call fear turn investment. Tax our skin article Republican product identify. So article represent.",
                "content_length": 296
              }
            }
          ]
```



After this change, the `data` field is not saved to the index, but the rest still appears:
```json
"attachments": [
            {
              "filename": "idea.pdf",
              "attachment": {
                "content_type": "text/plain; charset=ISO-8859-1",
                "language": "en",
                "content": "Property it little another must Democrat beat. Figure remain billion site meeting smile capital. Identify thus in. Fear situation star increase state. Low dinner station senior respond yard value. Call fear turn investment. Tax our skin article Republican product identify. So article represent.",
                "content_length": 296
              }
            }
          ]
```

