### PR TITLE
[Unticketed] Update column order for `user_account_mapper` in legacy schema

### DIFF
--- a/api/src/db/models/legacy_mixin/user_mixin.py
+++ b/api/src/db/models/legacy_mixin/user_mixin.py
@@ -8,8 +8,8 @@ class TuserAccountMapperMixin:
     user_account_id: Mapped[int] = mapped_column(primary_key=True)
     ext_user_id: Mapped[str]
     ext_issuer: Mapped[str]
-    last_auth_date: Mapped[datetime]
     ext_subject: Mapped[str | None]
+    last_auth_date: Mapped[datetime]
     created_date: Mapped[datetime | None]
     creator_id: Mapped[str | None]
     last_upd_date: Mapped[datetime | None]


### PR DESCRIPTION
## Summary
Fixes an issue discovered while setting up foreign tables in dev schema. `last_auth_date` was in an incorrect order.

### Time to review: 2 mins

## Changes proposed
Reorder column to match Oracle schema.