### PR TITLE
[Unticketed] Fix agency transform to not break for is_deleted rows

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_agency.py
+++ b/api/src/data_migration/transformation/subtask/transform_agency.py
@@ -413,6 +413,14 @@ def get_agency_updates(tgroup_agency: TgroupAgency) -> AgencyUpdates:
 
         tgroup_field_name = tgroup.get_field_name()
 
+        if tgroup_field_name in NOT_MAPPED_FIELDS:
+            logger.info(
+                "Skipping processing of field %s for %s",
+                tgroup_field_name,
+                tgroup_agency.agency_code,
+            )
+            continue
+
         # TODO - how we want to actually handle deleted rows likely needs more investigation
         #        and discussion - do we assume that if certain fields are deleted that the
         #        entire agency should be deleted? Can they even be deleted once an opportunity refers to them?
@@ -440,14 +448,6 @@ def get_agency_updates(tgroup_agency: TgroupAgency) -> AgencyUpdates:
         elif tgroup_field_name in AGENCY_CONTACT_INFO_FIELD_MAP:
             field_name = AGENCY_CONTACT_INFO_FIELD_MAP[tgroup_field_name]
             updates.agency_contact_info_updates[field_name] = value
-
-        elif tgroup_field_name in NOT_MAPPED_FIELDS:
-            logger.info(
-                "Skipping processing of field %s for %s",
-                tgroup_field_name,
-                tgroup_agency.agency_code,
-            )
-            continue
 
         else:
             raise ValueError("Unknown tgroups agency field %s" % tgroup_field_name)

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
@@ -117,7 +117,8 @@ class TestTransformAgency(BaseTransformTestClass):
         update_agency2 = setup_agency(
             "UPDATE-AGENCY-2",
             create_existing=True,
-            deleted_fields={"AgencyContactEMail2", "ldapGp", "description"},
+            deleted_fields={"AgencyContactEMail2", "ldapGp", "description", "SAMValidation"},
+            source_values={"SAMValidation": "1"},
         )
         update_agency3 = setup_agency(
             "UPDATE-AGENCY-3",


### PR DESCRIPTION
## Summary

### Time to review: __3 mins__

## Changes proposed
Modify the transform agency job to not error when trying to transform a row that is deleted that we also don't want to process

## Context for reviewers
Before this change, the job would fail to update/insert an agency if there was a row marked as `is_deleted=True` that also was one that we didn't even care to map. This fixes that by doing the mapping check first before any other processing, not at the end.


