### PR TITLE
[Issue 4394] Update Metabase query backups

### DIFF
--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-issue.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-issue.sql
@@ -1,133 +1,149 @@
-WITH RECURSIVE 
+WITH RECURSIVE
 
-  -- constants 
+  -- 1. Define constant deliverable_ghid
   constants AS (
-    SELECT 
-        'HHS/simpler-grants-gov/issues/XXXX' AS deliverable_ghid
+    SELECT 'HHS/simpler-grants-gov/issues/2357' AS deliverable_ghid
   ),
 
-  -- Get reporting period dynamically
-  reporting_period AS {{#364-default-reporting-period}},
-
-  -- Fetch deliverable title separately
-  deliverable_info AS (
-    SELECT 
-      id AS deliverable_id,
-      title AS deliverable_title
-    FROM 
-      gh_deliverable
-    WHERE 
-      ghid = (SELECT deliverable_ghid FROM constants)
+  -- 2. Get reporting period dynamically
+  reporting_period AS (
+    {{#364-default-reporting-period}}
   ),
 
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
+  -- 3. Resolve the selected deliverable using the constant deliverable_ghid
+  selected_deliverable AS (
+    SELECT id, ghid
+    FROM gh_deliverable
+    WHERE ghid = (SELECT deliverable_ghid FROM constants)
+  ),
+
+  -- 4. Latest epic-to-deliverable mappings only
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (edm.epic_id)
+      edm.epic_id,
       e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE 
-      gh_deliverable.ghid = (SELECT deliverable_ghid FROM constants)
+      edm.deliverable_id,
+      edm.d_effective
+    FROM gh_epic_deliverable_map edm
+    JOIN gh_epic e ON edm.epic_id = e.id
+    ORDER BY edm.epic_id, edm.d_effective DESC
   ),
 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic (existing logic)
+  -- 5. Epics currently mapped to the selected deliverable
+  epics_in_deliverable AS (
+    SELECT
+      lem.epic_id,
+      lem.epic_ghid,
+      lem.deliverable_id
+    FROM latest_epic_mappings lem
+    JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+  ),
+
+  -- 6. Recursively walk the issue tree from epics
+  epic_issue_tree AS (
     SELECT
       e.deliverable_id,
       e.epic_id,
-      e.epic_ghid AS root_epic_ghid,
+      e.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable itself (new logic)
     SELECT
-      d.deliverable_id,
-      NULL AS epic_id,  -- No epic, directly linked to deliverable
-      NULL AS root_epic_ghid,
+      eit.deliverable_id,
+      eit.epic_id,
+      eit.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      deliverable_info d
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = (SELECT deliverable_ghid FROM constants)
-
-    UNION ALL
-
-    -- Recursively find children of all issues, whether they originate from an epic or deliverable
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.root_epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
+    FROM gh_issue i
+    JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
   ),
 
-  -- Calculate issues opened in the given time period 
+  -- 7. Pre-filter issues that are direct children of the deliverable
+  raw_direct_issues AS (
+    SELECT
+      sd.id AS deliverable_id,
+      i.id AS issue_id,
+      i.ghid AS issue_ghid,
+      i.title AS issue_title,
+      i.parent_issue_ghid
+    FROM selected_deliverable sd
+    JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+  ),
+
+  -- 8. Filter out issues that are actually epics mapped elsewhere
+  direct_issues AS (
+    SELECT
+      rdi.deliverable_id,
+      NULL::integer AS epic_id,
+      NULL::text AS epic_ghid,
+      rdi.issue_id,
+      rdi.issue_ghid,
+      rdi.issue_title,
+      rdi.parent_issue_ghid
+    FROM raw_direct_issues rdi
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM latest_epic_mappings lem
+      JOIN gh_epic ep ON lem.epic_id = ep.id
+      WHERE ep.ghid = rdi.issue_ghid
+    )
+  ),
+
+  -- 9. Combine both sources
+  combined_issues AS (
+    SELECT * FROM epic_issue_tree
+    UNION ALL
+    SELECT * FROM direct_issues
+  ),
+
+  -- 10. Calculate issues opened in the given time period
   opened AS (
     SELECT
       h.d_effective AS issue_day,
       COUNT(DISTINCT h.issue_id) AS total_opened
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+    WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
-  
-  -- Calculate issues closed in the given time period 
+
+  -- 11. Calculate issues closed in the given time period
   closed AS (
     SELECT
       h.d_effective AS issue_day,
       COUNT(DISTINCT h.issue_id) AS total_closed
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.is_closed::BOOLEAN = TRUE
+    WHERE h.is_closed::BOOLEAN = TRUE
       AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
-  
-  -- Aggregate issues opened and closed by day 
+
+  -- 12. Aggregate issues opened and closed by day
   totals AS (
     SELECT
-      COALESCE(opened.issue_day, closed.issue_day) AS issue_day,
-      COALESCE(opened.total_opened, 0) AS total_opened,
-      COALESCE(closed.total_closed, 0) AS total_closed,
-      COALESCE(opened.total_opened, 0) - COALESCE(closed.total_closed, 0) AS total_remaining
-    FROM
-      opened
-    FULL OUTER JOIN closed 
-      ON opened.issue_day = closed.issue_day
+      COALESCE(o.issue_day, c.issue_day) AS issue_day,
+      COALESCE(o.total_opened, 0) AS total_opened,
+      COALESCE(c.total_closed, 0) AS total_closed,
+      COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+    FROM opened o
+    FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
   )
 
+-- Final output
 SELECT
-  (SELECT deliverable_title FROM deliverable_info) AS deliverable_title,
-  (SELECT CONCAT('https://github.com/', deliverable_ghid) FROM constants) as deliverable_url,
   issue_day,
   total_opened,
   total_closed,

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/Bespoke-Burndowns/bespoke-burndown-by-points.sql
@@ -1,133 +1,150 @@
-WITH RECURSIVE 
+WITH RECURSIVE
 
-  -- constants 
+  -- 1. Define constant deliverable_ghid
   constants AS (
-    SELECT 
-        'HHS/simpler-grants-gov/issues/XXXX' AS deliverable_ghid
+    SELECT 'HHS/simpler-grants-gov/issues/2357' AS deliverable_ghid
   ),
 
-  -- Get reporting period dynamically
-  reporting_period AS {{#364-default-reporting-period}},
-
-  -- Fetch deliverable title separately
-  deliverable_info AS (
-    SELECT 
-      id AS deliverable_id,
-      title AS deliverable_title
-    FROM 
-      gh_deliverable
-    WHERE 
-      ghid = (SELECT deliverable_ghid FROM constants)
+  -- 2. Get reporting period dynamically
+  reporting_period AS (
+    {{#364-default-reporting-period}}
   ),
 
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
+  -- 3. Resolve the selected deliverable using the constant deliverable_ghid
+  selected_deliverable AS (
+    SELECT id, ghid
+    FROM gh_deliverable
+    WHERE ghid = (SELECT deliverable_ghid FROM constants)
+  ),
+
+  -- 4. Latest epic-to-deliverable mappings only (current mapping)
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (edm.epic_id)
+      edm.epic_id,
       e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE 
-      gh_deliverable.ghid = (SELECT deliverable_ghid FROM constants)
+      edm.deliverable_id,
+      edm.d_effective
+    FROM gh_epic_deliverable_map edm
+    JOIN gh_epic e ON edm.epic_id = e.id
+    ORDER BY edm.epic_id, edm.d_effective DESC
   ),
 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+  -- 5. Epics currently mapped to the selected deliverable
+  epics_in_deliverable AS (
+    SELECT
+      lem.epic_id,
+      lem.epic_ghid,
+      lem.deliverable_id
+    FROM latest_epic_mappings lem
+    JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+  ),
+
+  -- 6. Recursively walk the issue tree from epics
+  epic_issue_tree AS (
     SELECT
       e.deliverable_id,
       e.epic_id,
-      e.epic_ghid AS root_epic_ghid,
-      i.id AS issue_id,
+      e.epic_ghid,
+      i.id   AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable itself
     SELECT
-      d.deliverable_id,
-      NULL AS epic_id,  -- No epic, directly linked to deliverable
-      NULL AS root_epic_ghid,
-      i.id AS issue_id,
+      eit.deliverable_id,
+      eit.epic_id,
+      eit.epic_ghid,
+      i.id   AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      deliverable_info d
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = (SELECT deliverable_ghid FROM constants)
-
-    UNION ALL
-
-    -- Recursively find children of all issues, whether they originate from an epic or deliverable
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.root_epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
+    FROM gh_issue i
+    JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
   ),
 
-  -- Calculate points opened in the given time period 
+  -- 7. Pre-filter issues that are direct children of the deliverable
+  raw_direct_issues AS (
+    SELECT
+      sd.id AS deliverable_id,
+      i.id   AS issue_id,
+      i.ghid AS issue_ghid,
+      i.title AS issue_title,
+      i.parent_issue_ghid
+    FROM selected_deliverable sd
+    JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+  ),
+
+  -- 8. Filter out issues that are actually epics mapped elsewhere
+  direct_issues AS (
+    SELECT
+      rdi.deliverable_id,
+      NULL::integer AS epic_id,
+      NULL::text AS epic_ghid,
+      rdi.issue_id,
+      rdi.issue_ghid,
+      rdi.issue_title,
+      rdi.parent_issue_ghid
+    FROM raw_direct_issues rdi
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM latest_epic_mappings lem
+      JOIN gh_epic ep ON lem.epic_id = ep.id
+      WHERE ep.ghid = rdi.issue_ghid
+    )
+  ),
+
+  -- 9. Combine both sources of issues
+  combined_issues AS (
+    SELECT * FROM epic_issue_tree
+    UNION ALL
+    SELECT * FROM direct_issues
+  ),
+
+  -- 10. Calculate points opened in the given time period
   opened AS (
     SELECT
       h.d_effective AS issue_day,
       SUM(h.points) AS total_opened
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+    WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
-  
-  -- Calculate points closed in the given time period 
+
+  -- 11. Calculate points closed in the given time period
   closed AS (
     SELECT
       h.d_effective AS issue_day,
       SUM(h.points) AS total_closed
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.is_closed::BOOLEAN = TRUE
+    WHERE h.is_closed::BOOLEAN = TRUE
       AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
-  
-  -- Aggregate issues opened and closed by day 
+
+  -- 12. Aggregate points opened and closed by day
   totals AS (
     SELECT
-      COALESCE(opened.issue_day, closed.issue_day) AS issue_day,
-      COALESCE(opened.total_opened, 0) AS total_opened,
-      COALESCE(closed.total_closed, 0) AS total_closed,
-      COALESCE(opened.total_opened, 0) - COALESCE(closed.total_closed, 0) AS total_remaining
-    FROM
-      opened
-    FULL OUTER JOIN closed 
-      ON opened.issue_day = closed.issue_day
+      COALESCE(o.issue_day, c.issue_day) AS issue_day,
+      COALESCE(o.total_opened, 0) AS total_opened,
+      COALESCE(c.total_closed, 0) AS total_closed,
+      COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+    FROM opened o
+    FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
   )
 
 SELECT
-  (SELECT deliverable_title FROM deliverable_info) AS deliverable_title,
-  (SELECT CONCAT('https://github.com/', deliverable_ghid) FROM constants) as deliverable_url,
+  (SELECT deliverable_title FROM (SELECT title AS deliverable_title FROM gh_deliverable WHERE ghid = (SELECT deliverable_ghid FROM constants)) AS t) AS deliverable_title,
+  (SELECT CONCAT('https://github.com/', deliverable_ghid) FROM constants) AS deliverable_url,
   issue_day,
   total_opened,
   total_closed,

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-percent-done-by-issue-count.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-percent-done-by-issue-count.sql
@@ -1,25 +1,38 @@
 WITH RECURSIVE 
 
-  -- Get all deliverables 
-  deliverable_state AS {{#200-all-deliverables-titles-excluding-done}},
-
-  -- Get epics within each deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      deliverable_state.deliverable_id,
-      deliverable_state.title AS deliverable_title,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      deliverable_state
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = deliverable_state.deliverable_id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
+  -- 1. Get all deliverables (titles excluding done)
+  deliverable_state AS (
+    {{#200-all-deliverables-titles-excluding-done}}
   ),
 
-  -- Recursive issue hierarchy, including direct-to-deliverable issues
+  -- 2. Latest epic-to-deliverable mappings only (current mapping)
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (m.epic_id)
+      m.epic_id,
+      e.ghid AS epic_ghid,
+      m.deliverable_id,
+      m.d_effective
+    FROM gh_epic_deliverable_map m
+    JOIN gh_epic e ON m.epic_id = e.id
+    ORDER BY m.epic_id, m.d_effective DESC
+  ),
+
+  -- 3. Epics currently mapped to each deliverable (using latest mapping)
+  epics_in_deliverable AS (
+    SELECT
+      ds.deliverable_id,
+      ds.title AS deliverable_title,
+      lem.epic_id,
+      lem.epic_ghid,
+      e.title AS epic_title
+    FROM deliverable_state ds
+    JOIN latest_epic_mappings lem ON lem.deliverable_id = ds.deliverable_id
+    JOIN gh_epic e ON e.id = lem.epic_id
+  ),
+
+  -- 4. Build the recursive issue hierarchy, including direct-to-deliverable issues
   issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+    -- 4a. Issues that are direct children of an epic
     SELECT
       e.deliverable_id,
       e.deliverable_title,
@@ -29,15 +42,14 @@ WITH RECURSIVE
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,  
-      EXISTS (SELECT 1 FROM gh_deliverable WHERE gh_deliverable.ghid = i.ghid) AS is_deliverable  
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic,  
+      EXISTS (SELECT 1 FROM gh_deliverable WHERE ghid = i.ghid) AS is_deliverable  
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable
+    -- 4b. Issues that are direct children of the deliverable
     SELECT
       ds.deliverable_id,  
       ds.title AS deliverable_title,
@@ -47,15 +59,14 @@ WITH RECURSIVE
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,
-      EXISTS (SELECT 1 FROM gh_deliverable WHERE gh_deliverable.ghid = i.ghid) AS is_deliverable
-    FROM 
-      deliverable_state ds
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = ds.ghid
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic,
+      EXISTS (SELECT 1 FROM gh_deliverable WHERE ghid = i.ghid) AS is_deliverable
+    FROM deliverable_state ds
+    JOIN gh_issue i ON i.parent_issue_ghid = ds.ghid
 
     UNION ALL
     
-    -- Recursively find the children of each issue
+    -- 4c. Recursively find children of each issue
     SELECT
       ih.deliverable_id,
       ih.deliverable_title,
@@ -65,49 +76,41 @@ WITH RECURSIVE
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,
-      EXISTS (SELECT 1 FROM gh_deliverable WHERE gh_deliverable.ghid = i.ghid) AS is_deliverable
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic,
+      EXISTS (SELECT 1 FROM gh_deliverable WHERE ghid = i.ghid) AS is_deliverable
+    FROM gh_issue i
+    JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
   ),
 
-  -- Find the max d_effective per issue
+  -- 5. For each issue, find the latest effective date from gh_issue_history
   latest_issue_date AS (
     SELECT
-      gh_issue_history.issue_id,
-      MAX(gh_issue_history.d_effective) AS max_d_effective
-    FROM 
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    GROUP BY gh_issue_history.issue_id
+      h.issue_id,
+      MAX(h.d_effective) AS max_d_effective
+    FROM gh_issue_history h
+    JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    GROUP BY h.issue_id
   ),
 
-  -- Aggregate issue status for the max d_effective per issue (excluding epics & deliverables)
+  -- 6. Determine each issue’s current closed state (exclude issues that are epics or deliverables)
   issue_state AS (
     SELECT
-      issue_hierarchy.deliverable_id,
-      issue_hierarchy.deliverable_title,
-      gh_issue_history.issue_id,
-      gh_issue_history.d_effective,
-      MAX(CASE WHEN gh_issue_history.is_closed::BOOLEAN = TRUE THEN 1 ELSE 0 END) AS is_closed
-    FROM 
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    INNER JOIN latest_issue_date ON 
-      gh_issue_history.issue_id = latest_issue_date.issue_id
-      AND gh_issue_history.d_effective = latest_issue_date.max_d_effective
-    WHERE 
-      NOT issue_hierarchy.is_epic  -- Ensure we exclude epics
-      AND NOT issue_hierarchy.is_deliverable  -- Ensure we exclude deliverables
-    GROUP BY 
-      issue_hierarchy.deliverable_id,
-      issue_hierarchy.deliverable_title,
-      gh_issue_history.issue_id,
-      gh_issue_history.d_effective
+      ih.deliverable_id,
+      ih.deliverable_title,
+      h.issue_id,
+      h.d_effective,
+      MAX(CASE WHEN h.is_closed::BOOLEAN = TRUE THEN 1 ELSE 0 END) AS is_closed
+    FROM gh_issue_history h
+    JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    JOIN latest_issue_date lid 
+      ON h.issue_id = lid.issue_id
+     AND h.d_effective = lid.max_d_effective
+    WHERE NOT ih.is_epic
+      AND NOT ih.is_deliverable
+    GROUP BY ih.deliverable_id, ih.deliverable_title, h.issue_id, h.d_effective
   ),
 
-  -- Count open and closed issues per deliverable
+  -- 7. Count open and closed issues per deliverable
   subtotals AS (
     SELECT
       deliverable_id,
@@ -115,34 +118,31 @@ WITH RECURSIVE
       SUM(CASE WHEN is_closed = 0 THEN 1 ELSE 0 END) AS issues_open,
       SUM(CASE WHEN is_closed = 1 THEN 1 ELSE 0 END) AS issues_closed,
       COUNT(*) AS total_issues
-    FROM
-      issue_state
+    FROM issue_state
     GROUP BY deliverable_id, deliverable_title
   ),
 
-  -- Calculate percent complete per deliverable
+  -- 8. Calculate percent complete per deliverable
   total AS (
     SELECT
       deliverable_id,
       deliverable_title,
       CASE 
         WHEN SUM(total_issues) = 0 THEN '0%'
-        ELSE CONCAT(CEIL(100 * (SUM(issues_closed) / NULLIF(SUM(total_issues)::DECIMAL, 0))), '%')
+        ELSE CONCAT(CEIL(100 * (SUM(issues_closed)::DECIMAL / NULLIF(SUM(total_issues)::DECIMAL, 0))), '%')
       END AS percent_complete
-    FROM
-      subtotals
+    FROM subtotals
     GROUP BY deliverable_id, deliverable_title
   )
 
 -- Final output: Percent complete for each deliverable
 SELECT
-  subtotals.deliverable_id,
-  subtotals.deliverable_title,
-  subtotals.issues_open,
-  subtotals.issues_closed,
-  subtotals.total_issues,
-  total.percent_complete
-FROM
-  subtotals
-JOIN total ON subtotals.deliverable_id = total.deliverable_id
-ORDER BY subtotals.deliverable_title;
+  s.deliverable_id,
+  s.deliverable_title,
+  s.issues_open,
+  s.issues_closed,
+  s.total_issues,
+  t.percent_complete
+FROM subtotals s
+JOIN total t ON s.deliverable_id = t.deliverable_id
+ORDER BY s.deliverable_title;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-percent-done-by-points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-percent-done-by-points.sql
@@ -1,25 +1,38 @@
-WITH RECURSIVE 
+WITH RECURSIVE
 
-  -- Get all deliverables
-  deliverable_state AS {{#200-all-deliverables-titles-excluding-done}},
-
-  -- Get epics within each deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      deliverable_state.deliverable_id AS deliverable_id,
-      deliverable_state.title AS deliverable_title,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      deliverable_state
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = deliverable_state.deliverable_id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
+  -- 1. Get all deliverables (titles excluding done)
+  deliverable_state AS (
+    {{#200-all-deliverables-titles-excluding-done}}
   ),
 
-  -- Recursive issue hierarchy, including direct-to-deliverable issues
+  -- 2. Latest epic-to-deliverable mappings only (current mapping)
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (m.epic_id)
+      m.epic_id,
+      m.deliverable_id,
+      e.ghid AS epic_ghid,
+      m.d_effective
+    FROM gh_epic_deliverable_map m
+    JOIN gh_epic e ON m.epic_id = e.id
+    ORDER BY m.epic_id, m.d_effective DESC
+  ),
+
+  -- 3. Epics currently mapped to each deliverable (using latest mapping)
+  epics_in_deliverable AS (
+    SELECT
+      ds.deliverable_id,
+      ds.title AS deliverable_title,
+      lem.epic_id,
+      lem.epic_ghid,
+      e.title AS epic_title
+    FROM deliverable_state ds
+    JOIN latest_epic_mappings lem ON lem.deliverable_id = ds.deliverable_id
+    JOIN gh_epic e ON e.id = lem.epic_id
+  ),
+
+  -- 4. Build the recursive issue hierarchy, including issues directly linked to a deliverable
   issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+    -- 4a. Issues that are direct children of an epic
     SELECT
       e.deliverable_id,
       e.deliverable_title,
@@ -29,15 +42,14 @@ WITH RECURSIVE
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,
-      EXISTS (SELECT 1 FROM deliverable_state WHERE deliverable_state.ghid = i.ghid) AS is_deliverable
-    FROM 
-      epics_in_deliverable e
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic,
+      EXISTS (SELECT 1 FROM gh_deliverable WHERE ghid = i.ghid) AS is_deliverable
+    FROM epics_in_deliverable e
     INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable
+    -- 4b. Issues that are direct children of the deliverable
     SELECT
       ds.deliverable_id,
       ds.title AS deliverable_title,
@@ -47,15 +59,14 @@ WITH RECURSIVE
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,
-      EXISTS (SELECT 1 FROM deliverable_state WHERE deliverable_state.ghid = i.ghid) AS is_deliverable
-    FROM 
-      deliverable_state ds
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic,
+      EXISTS (SELECT 1 FROM gh_deliverable WHERE ghid = i.ghid) AS is_deliverable
+    FROM deliverable_state ds
     INNER JOIN gh_issue i ON i.parent_issue_ghid = ds.ghid
 
     UNION ALL
     
-    -- Recursively find the children of each issue
+    -- 4c. Recursively find the children of each issue
     SELECT
       ih.deliverable_id,
       ih.deliverable_title,
@@ -65,54 +76,41 @@ WITH RECURSIVE
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,
-      EXISTS (SELECT 1 FROM deliverable_state WHERE deliverable_state.ghid = i.ghid) AS is_deliverable
-    FROM 
-      gh_issue i
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic,
+      EXISTS (SELECT 1 FROM gh_deliverable WHERE ghid = i.ghid) AS is_deliverable
+    FROM gh_issue i
     INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
   ),
 
-  -- Find the max d_effective per issue
+  -- 5. For each issue, get the maximum d_effective (latest snapshot) from gh_issue_history
   latest_issue_date AS (
     SELECT
-      gh_issue_history.issue_id,
-      MAX(gh_issue_history.d_effective) AS max_d_effective
-    FROM 
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    GROUP BY gh_issue_history.issue_id
+      h.issue_id,
+      MAX(h.d_effective) AS max_d_effective
+    FROM gh_issue_history h
+    JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    GROUP BY h.issue_id
   ),
 
-  -- Aggregate points and determine closure status for the max d_effective per issue
+  -- 6. Aggregate points and determine closed state for each issue based on its latest snapshot
   issue_state AS (
     SELECT
-      issue_hierarchy.deliverable_id,
-      issue_hierarchy.deliverable_title,
-      gh_issue_history.issue_id,
-      gh_issue_history.d_effective,
-      
-      -- Sum points only for the max d_effective of each issue
-      SUM(gh_issue_history.points) AS total_points,
-
-      -- Determine if the issue is closed based on that single day
-      MAX(CASE WHEN gh_issue_history.is_closed::BOOLEAN = TRUE THEN 1 ELSE 0 END) AS is_closed
-    FROM 
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    INNER JOIN latest_issue_date ON 
-      gh_issue_history.issue_id = latest_issue_date.issue_id
-      AND gh_issue_history.d_effective = latest_issue_date.max_d_effective
-    WHERE
-      NOT issue_hierarchy.is_epic  -- Exclude epics
-      AND NOT issue_hierarchy.is_deliverable  -- Exclude deliverables
-    GROUP BY 
-      issue_hierarchy.deliverable_id,
-      issue_hierarchy.deliverable_title,
-      gh_issue_history.issue_id,
-      gh_issue_history.d_effective
+      ih.deliverable_id,
+      ih.deliverable_title,
+      h.issue_id,
+      h.d_effective,
+      SUM(h.points) AS total_points,
+      MAX(CASE WHEN h.is_closed::BOOLEAN = TRUE THEN 1 ELSE 0 END) AS is_closed
+    FROM gh_issue_history h
+    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    INNER JOIN latest_issue_date lid 
+      ON h.issue_id = lid.issue_id AND h.d_effective = lid.max_d_effective
+    WHERE NOT ih.is_epic     -- Exclude issues that are epics
+      AND NOT ih.is_deliverable  -- Exclude issues that are deliverables
+    GROUP BY ih.deliverable_id, ih.deliverable_title, h.issue_id, h.d_effective
   )
 
--- Count open and closed points and calculate percent complete per deliverable
+-- 7. Count open and closed points per deliverable and calculate percent complete
 SELECT
   deliverable_id,
   deliverable_title,
@@ -121,11 +119,10 @@ SELECT
   SUM(total_points) AS total_points,
   CASE
     WHEN SUM(total_points) = 0 THEN '0%'
-    ELSE CONCAT(CEIL(100 * (SUM(CASE WHEN is_closed = 1 THEN total_points ELSE 0 END) 
+    ELSE CONCAT(CEIL(100 * (SUM(CASE WHEN is_closed = 1 THEN total_points ELSE 0 END)::DECIMAL 
                       / NULLIF(SUM(total_points)::DECIMAL, 0))), '%')
   END AS percent_complete,
   COUNT(*) AS total_issues
-FROM
-  issue_state
+FROM issue_state
 GROUP BY deliverable_id, deliverable_title
 ORDER BY deliverable_title;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-percent-pointed.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/all-deliverables-percent-pointed.sql
@@ -1,118 +1,119 @@
 WITH RECURSIVE
 
-  -- Get all deliverables
-  deliverable_state AS {{#200-all-deliverables-titles-excluding-done}},
-
-  -- Get epics within each deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      deliverable_state.deliverable_id,
-      deliverable_state.title AS deliverable_title,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM
-      deliverable_state
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = deliverable_state.deliverable_id
-    INNER JOIN gh_epic e ON m.epic_id = e.id
+  -- 1. Get all deliverables (titles excluding done)
+  deliverable_state AS (
+    {{#200-all-deliverables-titles-excluding-done}}
   ),
 
-  -- Recursive issue hierarchy, including direct-to-deliverable issues
+  -- 2. Latest epic-to-deliverable mappings only (current mapping)
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (m.epic_id)
+      m.epic_id,
+      m.deliverable_id,
+      e.ghid AS epic_ghid,
+      m.d_effective
+    FROM gh_epic_deliverable_map m
+    JOIN gh_epic e ON m.epic_id = e.id
+    ORDER BY m.epic_id, m.d_effective DESC
+  ),
+
+  -- 3. Epics currently mapped to each deliverable (using latest mapping)
+  epics_in_deliverable AS (
+    SELECT
+      ds.deliverable_id,
+      ds.title AS deliverable_title,
+      lem.epic_id,
+      lem.epic_ghid,
+      e.title AS epic_title
+    FROM deliverable_state ds
+    JOIN latest_epic_mappings lem ON lem.deliverable_id = ds.deliverable_id
+    JOIN gh_epic e ON e.id = lem.epic_id
+  ),
+
+  -- 4. Build recursive issue hierarchy, including direct-to-deliverable issues
   issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+    -- 4a. Issues that are direct children of an epic
     SELECT
       e.deliverable_id,
       e.deliverable_title,
       e.epic_id,
       e.epic_ghid AS root_epic_ghid,
-      i.id AS issue_id,
+      i.id   AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      (epic.ghid IS NOT NULL) AS is_epic
-    FROM
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
-    LEFT JOIN gh_epic epic ON epic.ghid = i.ghid
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable itself
+    -- 4b. Issues that are direct children of the deliverable
     SELECT
       ds.deliverable_id,
       ds.title AS deliverable_title,
       NULL AS epic_id,
       NULL AS root_epic_ghid,
-      i.id AS issue_id,
+      i.id   AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      (epic.ghid IS NOT NULL) AS is_epic
-    FROM
-      deliverable_state ds
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = ds.ghid
-    LEFT JOIN gh_epic epic ON epic.ghid = i.ghid  -- Identify epics
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic
+    FROM deliverable_state ds
+    JOIN gh_issue i ON i.parent_issue_ghid = ds.ghid
 
     UNION ALL
 
-    -- Recursively find the children of each issue
+    -- 4c. Recursively find children of each issue
     SELECT
       ih.deliverable_id,
       ih.deliverable_title,
       ih.epic_id,
       ih.root_epic_ghid,
-      i.id AS issue_id,
+      i.id   AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid,
-      (epic.ghid IS NOT NULL) AS is_epic
-    FROM
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
-    LEFT JOIN gh_epic epic ON epic.ghid = i.ghid  -- Identify epics
+      EXISTS (SELECT 1 FROM gh_epic WHERE ghid = i.ghid) AS is_epic
+    FROM gh_issue i
+    JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
   ),
 
-  -- Find the max d_effective per issue
+  -- 5. Find the latest d_effective per issue
   latest_issue_date AS (
     SELECT
-      gh_issue_history.issue_id,
-      MAX(gh_issue_history.d_effective) AS max_d_effective
-    FROM
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    GROUP BY gh_issue_history.issue_id
+      h.issue_id,
+      MAX(h.d_effective) AS max_d_effective
+    FROM gh_issue_history h
+    JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    GROUP BY h.issue_id
   ),
 
-  -- Determine if an issue has points on its most recent history record
+  -- 6. Determine if an issue has points on its most recent history record
   issue_state AS (
     SELECT
-      issue_hierarchy.deliverable_id,
-      issue_hierarchy.deliverable_title,
-      gh_issue_history.issue_id,
-
-      -- Only check points for the most recent effective date
-      CASE
-        WHEN MAX(gh_issue_history.points) > 0 THEN 1
-        ELSE 0
+      ih.deliverable_id,
+      ih.deliverable_title,
+      h.issue_id,
+      CASE 
+        WHEN MAX(h.points) > 0 THEN 1 
+        ELSE 0 
       END AS has_points
-    FROM
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    INNER JOIN latest_issue_date ON
-      gh_issue_history.issue_id = latest_issue_date.issue_id
-      AND gh_issue_history.d_effective = latest_issue_date.max_d_effective
-    WHERE
-      NOT issue_hierarchy.is_epic  -- Use the flag instead of subquery
-    GROUP BY issue_hierarchy.deliverable_id, issue_hierarchy.deliverable_title, gh_issue_history.issue_id
+    FROM gh_issue_history h
+    JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    JOIN latest_issue_date lid 
+      ON h.issue_id = lid.issue_id
+     AND h.d_effective = lid.max_d_effective
+    WHERE NOT ih.is_epic
+    GROUP BY ih.deliverable_id, ih.deliverable_title, h.issue_id
   )
 
--- Calculate percent pointed and percent non-pointed
+-- Calculate percent pointed and percent non-pointed per deliverable
 SELECT
   deliverable_id,
   deliverable_title,
   ROUND(100.0 * COUNT(CASE WHEN has_points = 1 THEN 1 END) / NULLIF(COUNT(*), 0), 1) AS percent_pointed,
   ROUND(100.0 * COUNT(CASE WHEN has_points = 0 THEN 1 END) / NULLIF(COUNT(*), 0), 1) AS percent_non_pointed
-FROM
-  issue_state
+FROM issue_state
 GROUP BY deliverable_id, deliverable_title
 ORDER BY deliverable_title;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burndown-issue-count.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burndown-issue-count.sql
@@ -1,115 +1,143 @@
-WITH RECURSIVE 
+WITH RECURSIVE
 
-  -- Get reporting period dynamically
-  reporting_period AS {{#364-default-reporting-period}},
-
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE 
-      {{deliverable_title}}
+  -- 1. Get reporting period dynamically
+  reporting_period AS (
+    {{#364-default-reporting-period}}
   ),
 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+  -- 2. Resolve the selected deliverable
+  selected_deliverable AS (
+    SELECT id, ghid
+    FROM gh_deliverable
+    WHERE {{deliverable_title}}
+  ),
+
+  -- 3. Latest epic-to-deliverable mappings only
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (edm.epic_id)
+      edm.epic_id,
+      e.ghid AS epic_ghid,
+      edm.deliverable_id,
+      edm.d_effective
+    FROM gh_epic_deliverable_map edm
+    JOIN gh_epic e ON edm.epic_id = e.id
+    ORDER BY edm.epic_id, edm.d_effective DESC
+  ),
+
+  -- 4. Epics currently mapped to the selected deliverable
+  epics_in_deliverable AS (
+    SELECT
+      lem.epic_id,
+      lem.epic_ghid,
+      lem.deliverable_id
+    FROM latest_epic_mappings lem
+    JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+  ),
+
+  -- 5. Recursively walk the issue tree from epics
+  epic_issue_tree AS (
     SELECT
       e.deliverable_id,
       e.epic_id,
-      e.epic_ghid AS root_epic_ghid,
+      e.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable itself
     SELECT
-      gh_deliverable.id AS deliverable_id,
-      NULL AS epic_id,
-      NULL AS root_epic_ghid,
+      eit.deliverable_id,
+      eit.epic_id,
+      eit.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = gh_deliverable.ghid
-    WHERE 
-       {{deliverable_title}}
-
-    UNION ALL
-
-    -- Recursively find children of all issues, whether from an epic or deliverable
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.root_epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
+    FROM gh_issue i
+    JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
   ),
 
-  -- Calculate issues opened in the given time period 
+  -- 6. Pre-filter issues that are direct children of the deliverable
+  raw_direct_issues AS (
+    SELECT
+      sd.id AS deliverable_id,
+      i.id AS issue_id,
+      i.ghid AS issue_ghid,
+      i.title AS issue_title,
+      i.parent_issue_ghid
+    FROM selected_deliverable sd
+    JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+  ),
+
+  -- 7. Filter out issues that are actually epics mapped elsewhere
+  direct_issues AS (
+    SELECT
+      rdi.deliverable_id,
+      NULL::integer AS epic_id,
+      NULL::text AS epic_ghid,
+      rdi.issue_id,
+      rdi.issue_ghid,
+      rdi.issue_title,
+      rdi.parent_issue_ghid
+    FROM raw_direct_issues rdi
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM latest_epic_mappings lem
+      JOIN gh_epic ep ON lem.epic_id = ep.id
+      WHERE ep.ghid = rdi.issue_ghid
+    )
+  ),
+
+  -- 8. Combine both sources
+  combined_issues AS (
+    SELECT * FROM epic_issue_tree
+    UNION ALL
+    SELECT * FROM direct_issues
+  ),
+
+  -- 9. Calculate issues opened in the given time period
   opened AS (
     SELECT
       h.d_effective AS issue_day,
       COUNT(DISTINCT h.issue_id) AS total_opened
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+    WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
-  
-  -- Calculate issues closed in the given time period 
+
+  -- 10. Calculate issues closed in the given time period
   closed AS (
     SELECT
       h.d_effective AS issue_day,
       COUNT(DISTINCT h.issue_id) AS total_closed
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.is_closed::BOOLEAN = TRUE
+    WHERE h.is_closed::BOOLEAN = TRUE
       AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
-  
-  -- Aggregate issues opened and closed by day 
+
+  -- 11. Aggregate issues opened and closed by day
   totals AS (
     SELECT
-      COALESCE(opened.issue_day, closed.issue_day) AS issue_day,
-      COALESCE(opened.total_opened, 0) AS total_opened,
-      COALESCE(closed.total_closed, 0) AS total_closed,
-      COALESCE(opened.total_opened, 0) - COALESCE(closed.total_closed, 0) AS total_remaining
-    FROM
-      opened
-    FULL OUTER JOIN closed 
-      ON opened.issue_day = closed.issue_day
+      COALESCE(o.issue_day, c.issue_day) AS issue_day,
+      COALESCE(o.total_opened, 0) AS total_opened,
+      COALESCE(c.total_closed, 0) AS total_closed,
+      COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+    FROM opened o
+    FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
   )
 
+-- Final output
 SELECT
   issue_day,
   total_opened,

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burndown-points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burndown-points.sql
@@ -1,113 +1,146 @@
 WITH RECURSIVE 
 
-  -- Get reporting period dynamically
+  -- 1. Get reporting period dynamically
   reporting_period AS {{#364-default-reporting-period}},
 
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE 
-      {{deliverable_title}}
+  -- 2. Select the deliverable using the dynamic filter
+  selected_deliverable AS (
+    SELECT id, ghid
+    FROM gh_deliverable
+    WHERE {{deliverable_title}}
   ),
 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+  -- 3. Get the latest epic-to-deliverable mappings (most recent d_effective per epic)
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (edm.epic_id)
+      edm.epic_id,
+      e.ghid AS epic_ghid,
+      edm.deliverable_id,
+      edm.d_effective
+    FROM gh_epic_deliverable_map edm
+    JOIN gh_epic e ON edm.epic_id = e.id
+    ORDER BY edm.epic_id, edm.d_effective DESC
+  ),
+
+  -- 4. Retrieve epics currently mapped to the selected deliverable
+  epics_in_deliverable AS (
+    SELECT
+      lem.epic_id,
+      lem.epic_ghid,
+      lem.deliverable_id
+    FROM latest_epic_mappings lem
+    JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+  ),
+
+  -- 5. Recursively traverse issues starting from epics
+  epic_issue_tree AS (
     SELECT
       e.deliverable_id,
       e.epic_id,
-      e.epic_ghid AS root_epic_ghid,
+      e.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable itself
     SELECT
-      gh_deliverable.id AS deliverable_id,
-      NULL AS epic_id,
-      NULL AS root_epic_ghid,
+      eit.deliverable_id,
+      eit.epic_id,
+      eit.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = gh_deliverable.ghid
-    WHERE 
-      {{deliverable_title}}
-
-    UNION ALL
-    
-    -- Recursively find the children of each issue
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.root_epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
+    FROM gh_issue i
+    JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
   ),
 
-  -- Calculate points opened in the given time period
+  -- 6. Get raw issues that are direct children of the deliverable
+  raw_direct_issues AS (
+    SELECT
+      sd.id AS deliverable_id,
+      i.id AS issue_id,
+      i.ghid AS issue_ghid,
+      i.title AS issue_title,
+      i.parent_issue_ghid
+    FROM selected_deliverable sd
+    JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+  ),
+
+  -- 7. Filter out any direct issues that are actually epics mapped elsewhere
+  direct_issues AS (
+    SELECT
+      rdi.deliverable_id,
+      NULL::integer AS epic_id,
+      NULL::text AS epic_ghid,
+      rdi.issue_id,
+      rdi.issue_ghid,
+      rdi.issue_title,
+      rdi.parent_issue_ghid
+    FROM raw_direct_issues rdi
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM latest_epic_mappings lem
+      JOIN gh_epic ep ON lem.epic_id = ep.id
+      WHERE ep.ghid = rdi.issue_ghid
+    )
+  ),
+
+  -- 8. Combine epic-based issues and direct deliverable issues
+  combined_issues AS (
+    SELECT * FROM epic_issue_tree
+    UNION ALL
+    SELECT * FROM direct_issues
+  ),
+
+  -- 9. Deduplicate history entries: for each issue and day, only include the latest record
+  latest_history AS (
+    SELECT *
+    FROM (
+      SELECT 
+        h.*,
+        ROW_NUMBER() OVER (PARTITION BY h.issue_id, h.d_effective ORDER BY h.t_modified DESC) AS rn
+      FROM gh_issue_history h
+      JOIN combined_issues ci ON h.issue_id = ci.issue_id
+      WHERE h.d_effective BETWEEN (SELECT start_date FROM reporting_period) AND (SELECT end_date FROM reporting_period)
+    ) sub
+    WHERE rn = 1
+  ),
+
+  -- 10. Aggregate total points opened per day
   opened AS (
     SELECT
-      h.d_effective AS issue_day,
-      SUM(h.points) AS total_opened
-    FROM
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
-    CROSS JOIN reporting_period
-    WHERE
-      h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
-    GROUP BY h.d_effective
-    ORDER BY h.d_effective
+      d_effective AS issue_day,
+      SUM(points) AS total_opened
+    FROM latest_history
+    GROUP BY d_effective
+    ORDER BY d_effective
   ),
   
-  -- Calculate points closed in the given time period
+  -- 11. Aggregate total points closed per day
   closed AS (
     SELECT
-      h.d_effective AS issue_day,
-      SUM(h.points) AS total_closed
-    FROM
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
-    CROSS JOIN reporting_period
-    WHERE
-      h.is_closed::BOOLEAN = TRUE
-      AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
-    GROUP BY h.d_effective
-    ORDER BY h.d_effective
+      d_effective AS issue_day,
+      SUM(points) AS total_closed
+    FROM latest_history
+    WHERE is_closed::BOOLEAN = TRUE
+    GROUP BY d_effective
+    ORDER BY d_effective
   ),
   
-  -- Aggregate points opened and closed by day 
+  -- 12. Combine opened and closed totals by day
   totals AS (
     SELECT
-      COALESCE(opened.issue_day, closed.issue_day) AS issue_day,
-      COALESCE(opened.total_opened, 0) AS total_opened,
-      COALESCE(closed.total_closed, 0) AS total_closed,
-      COALESCE(opened.total_opened, 0) - COALESCE(closed.total_closed, 0) AS total_remaining
-    FROM
-      opened
-    FULL OUTER JOIN closed 
-      ON opened.issue_day = closed.issue_day
+      COALESCE(o.issue_day, c.issue_day) AS issue_day,
+      COALESCE(o.total_opened, 0) AS total_opened,
+      COALESCE(c.total_closed, 0) AS total_closed,
+      COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+    FROM opened o
+    FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
     ORDER BY issue_day
   )
   

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burnup-issue-count.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burnup-issue-count.sql
@@ -1,113 +1,140 @@
-WITH RECURSIVE 
+WITH RECURSIVE
 
-  -- Get reporting period dynamically
-  reporting_period AS {{#364-default-reporting-period}},
-  
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE 
-      {{deliverable_title}}
+  -- 1. Get reporting period dynamically
+  reporting_period AS (
+    {{#364-default-reporting-period}}
   ),
 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+  -- 2. Resolve the selected deliverable
+  selected_deliverable AS (
+    SELECT id, ghid
+    FROM gh_deliverable
+    WHERE {{deliverable_title}}
+  ),
+
+  -- 3. Latest epic-to-deliverable mappings only
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (edm.epic_id)
+      edm.epic_id,
+      e.ghid AS epic_ghid,
+      edm.deliverable_id,
+      edm.d_effective
+    FROM gh_epic_deliverable_map edm
+    JOIN gh_epic e ON edm.epic_id = e.id
+    ORDER BY edm.epic_id, edm.d_effective DESC
+  ),
+
+  -- 4. Epics currently mapped to the selected deliverable
+  epics_in_deliverable AS (
+    SELECT
+      lem.epic_id,
+      lem.epic_ghid,
+      lem.deliverable_id
+    FROM latest_epic_mappings lem
+    JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+  ),
+
+  -- 5. Recursively traverse the issue tree starting from epics
+  epic_issue_tree AS (
     SELECT
       e.deliverable_id,
       e.epic_id,
-      e.epic_ghid AS root_epic_ghid,
+      e.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable itself
     SELECT
-      gh_deliverable.id AS deliverable_id,
-      NULL AS epic_id,
-      NULL AS root_epic_ghid,
+      eit.deliverable_id,
+      eit.epic_id,
+      eit.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = gh_deliverable.ghid
-    WHERE 
-      {{deliverable_title}}
-
-    UNION ALL
-    
-    -- Recursively find the children of each issue
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.root_epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
+    FROM gh_issue i
+    JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
   ),
 
-  -- Calculate issues opened in the given time period
+  -- 6. Pre-filter issues that are direct children of the deliverable
+  raw_direct_issues AS (
+    SELECT
+      sd.id AS deliverable_id,
+      i.id AS issue_id,
+      i.ghid AS issue_ghid,
+      i.title AS issue_title,
+      i.parent_issue_ghid
+    FROM selected_deliverable sd
+    JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+  ),
+
+  -- 7. Filter out issues that are actually epics mapped elsewhere
+  direct_issues AS (
+    SELECT
+      rdi.deliverable_id,
+      NULL::integer AS epic_id,
+      NULL::text AS epic_ghid,
+      rdi.issue_id,
+      rdi.issue_ghid,
+      rdi.issue_title,
+      rdi.parent_issue_ghid
+    FROM raw_direct_issues rdi
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM latest_epic_mappings lem
+      JOIN gh_epic ep ON lem.epic_id = ep.id
+      WHERE ep.ghid = rdi.issue_ghid
+    )
+  ),
+
+  -- 8. Combine both epic-based issues and direct deliverable issues
+  combined_issues AS (
+    SELECT * FROM epic_issue_tree
+    UNION ALL
+    SELECT * FROM direct_issues
+  ),
+
+  -- 9. Calculate issues opened in the given time period
   opened AS (
     SELECT
       h.d_effective AS issue_day,
       COUNT(DISTINCT h.issue_id) AS total_opened
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+    WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
 
-  -- Calculate issues closed in the given time period
+  -- 10. Calculate issues closed in the given time period
   closed AS (
     SELECT
       h.d_effective AS issue_day,
       COUNT(DISTINCT h.issue_id) AS total_closed
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.is_closed::BOOLEAN = TRUE
+    WHERE h.is_closed::BOOLEAN = TRUE
       AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
 
-  -- Aggregate issues opened and closed by day
+  -- 11. Aggregate issues opened and closed by day
   totals AS (
     SELECT
-      COALESCE(opened.issue_day, closed.issue_day) AS issue_day,
-      COALESCE(opened.total_opened, 0) AS total_opened,
-      COALESCE(closed.total_closed, 0) AS total_closed,
-      COALESCE(opened.total_opened, 0) - COALESCE(closed.total_closed, 0) AS total_remaining
-    FROM 
-      opened
-    FULL OUTER JOIN closed 
-      ON opened.issue_day = closed.issue_day
+      COALESCE(o.issue_day, c.issue_day) AS issue_day,
+      COALESCE(o.total_opened, 0) AS total_opened,
+      COALESCE(c.total_closed, 0) AS total_closed,
+      COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+    FROM opened o
+    FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
     ORDER BY issue_day
   )
 

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burnup-points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-burnup-points.sql
@@ -1,117 +1,142 @@
 WITH RECURSIVE 
 
-  -- Get reporting period dynamically
-  reporting_period AS {{#364-default-reporting-period}},
-  
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE 
-      {{deliverable_title}}
+  -- 1. Get reporting period dynamically
+  reporting_period AS (
+    {{#364-default-reporting-period}}
   ),
 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
+  -- 2. Resolve the selected deliverable
+  selected_deliverable AS (
+    SELECT id, ghid
+    FROM gh_deliverable
+    WHERE {{deliverable_title}}
+  ),
+
+  -- 3. Latest epic-to-deliverable mappings only
+  latest_epic_mappings AS (
+    SELECT DISTINCT ON (edm.epic_id)
+      edm.epic_id,
+      e.ghid AS epic_ghid,
+      edm.deliverable_id,
+      edm.d_effective
+    FROM gh_epic_deliverable_map edm
+    JOIN gh_epic e ON edm.epic_id = e.id
+    ORDER BY edm.epic_id, edm.d_effective DESC
+  ),
+
+  -- 4. Epics currently mapped to the selected deliverable
+  epics_in_deliverable AS (
+    SELECT
+      lem.epic_id,
+      lem.epic_ghid,
+      lem.deliverable_id
+    FROM latest_epic_mappings lem
+    JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+  ),
+
+  -- 5. Recursively traverse the issue tree from epics
+  epic_issue_tree AS (
     SELECT
       e.deliverable_id,
       e.epic_id,
-      e.epic_ghid AS root_epic_ghid,
+      e.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+    FROM epics_in_deliverable e
+    JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
     UNION ALL
 
-    -- Issues that are direct children of the deliverable itself
     SELECT
-      gh_deliverable.id AS deliverable_id,
-      NULL AS epic_id,
-      NULL AS root_epic_ghid,
+      eit.deliverable_id,
+      eit.epic_id,
+      eit.epic_ghid,
       i.id AS issue_id,
       i.ghid AS issue_ghid,
       i.title AS issue_title,
       i.parent_issue_ghid
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = gh_deliverable.ghid
-    WHERE 
-      {{deliverable_title}}
-
-    UNION ALL
-    
-    -- Recursively find the children of each issue
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.root_epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
+    FROM gh_issue i
+    JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
   ),
 
-  -- Calculate points opened in the given time period
+  -- 6. Pre-filter issues that are direct children of the deliverable
+  raw_direct_issues AS (
+    SELECT
+      sd.id AS deliverable_id,
+      i.id AS issue_id,
+      i.ghid AS issue_ghid,
+      i.title AS issue_title,
+      i.parent_issue_ghid
+    FROM selected_deliverable sd
+    JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+  ),
+
+  -- 7. Filter out issues that are actually epics mapped elsewhere
+  direct_issues AS (
+    SELECT
+      rdi.deliverable_id,
+      NULL::integer AS epic_id,
+      NULL::text AS epic_ghid,
+      rdi.issue_id,
+      rdi.issue_ghid,
+      rdi.issue_title,
+      rdi.parent_issue_ghid
+    FROM raw_direct_issues rdi
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM latest_epic_mappings lem
+      JOIN gh_epic ep ON lem.epic_id = ep.id
+      WHERE ep.ghid = rdi.issue_ghid
+    )
+  ),
+
+  -- 8. Combine epic-based and direct deliverable issues
+  combined_issues AS (
+    SELECT * FROM epic_issue_tree
+    UNION ALL
+    SELECT * FROM direct_issues
+  ),
+
+  -- 9. Calculate points opened in the given time period
   opened AS (
     SELECT
       h.d_effective AS issue_day,
       SUM(h.points) AS total_opened
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+    WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
   
-  -- Calculate points closed in the given time period
+  -- 10. Calculate points closed in the given time period
   closed AS (
     SELECT
       h.d_effective AS issue_day,
       SUM(h.points) AS total_closed
-    FROM 
-      gh_issue_history h
-    INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+    FROM gh_issue_history h
+    JOIN combined_issues ci ON h.issue_id = ci.issue_id
     CROSS JOIN reporting_period
-    WHERE
-      h.is_closed::BOOLEAN = TRUE
+    WHERE h.is_closed::BOOLEAN = TRUE
       AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
     GROUP BY h.d_effective
     ORDER BY h.d_effective
   ),
   
-  -- Aggregate points opened and closed by day 
+  -- 11. Aggregate points opened and closed by day
   totals AS (
     SELECT
-      COALESCE(opened.issue_day, closed.issue_day) AS issue_day,
-      COALESCE(opened.total_opened, 0) AS total_opened,
-      COALESCE(closed.total_closed, 0) AS total_closed,
-      COALESCE(opened.total_opened, 0) - COALESCE(closed.total_closed, 0) AS total_remaining
-    FROM
-      opened
-    FULL OUTER JOIN closed 
-      ON opened.issue_day = closed.issue_day
+      COALESCE(o.issue_day, c.issue_day) AS issue_day,
+      COALESCE(o.total_opened, 0) AS total_opened,
+      COALESCE(c.total_closed, 0) AS total_closed,
+      COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+    FROM opened o
+    FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
     ORDER BY issue_day
   )
-  
-SELECT
-  *
-FROM
-  totals;
+
+SELECT *
+FROM totals;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-issues-done.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-issues-done.sql
@@ -1,161 +1,175 @@
 WITH RECURSIVE 
 
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE
-      {{deliverable_title}}
-  ),
- 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
-    SELECT
-      e.deliverable_id,
-      e.epic_id,
-      e.epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic  -- Identify if this issue is actually an epic
-    FROM
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+-- Step 1: Resolve the selected deliverable
+selected_deliverable AS (
+  SELECT id, ghid
+  FROM gh_deliverable
+  WHERE 
+  {{deliverable_title}}
+),
 
-    UNION ALL
+-- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS (
+  SELECT DISTINCT ON (edm.epic_id)
+    edm.epic_id,
+    e.ghid AS epic_ghid,
+    edm.deliverable_id,
+    edm.d_effective
+  FROM gh_epic_deliverable_map edm
+  JOIN gh_epic e ON edm.epic_id = e.id
+  ORDER BY edm.epic_id, edm.d_effective DESC
+),
 
-    -- Issues that are direct children of the deliverable itself
-    SELECT
-      gh_deliverable.id AS deliverable_id,
-      NULL AS epic_id,
-      NULL AS epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic
-    FROM
-      gh_deliverable
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = gh_deliverable.ghid
-    WHERE
-      {{deliverable_title}}
+-- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS (
+  SELECT
+    lem.epic_id,
+    lem.epic_ghid,
+    lem.deliverable_id
+  FROM latest_epic_mappings lem
+  JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+),
 
-    UNION ALL
-    
-    -- Recursively find the children of each issue
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic
-    FROM
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
-  ),
+-- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS (
+  SELECT
+    e.deliverable_id,
+    e.epic_id,
+    e.epic_ghid,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM epics_in_deliverable e
+  JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
-  -- Assign a numerical priority to statuses based on importance (Lower value = Higher priority)
-  ranked_statuses AS (
-    SELECT 'Icebox' AS status, 1 AS status_priority UNION ALL
-    SELECT 'Backlog', 2 UNION ALL
-    SELECT 'Prioritized', 3 UNION ALL
-    SELECT 'Planning', 4 UNION ALL
-    SELECT 'Todo', 5 UNION ALL
-    SELECT 'Blocked', 6 UNION ALL
-    SELECT 'In Progress', 7 UNION ALL
-    SELECT 'In Review', 8 UNION ALL
-    SELECT 'Done', 9
-  ),
+  UNION ALL
 
-  -- Find the max d_effective per issue
-  latest_history AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      MAX(gh_issue_history.d_effective) AS latest_d_effective
-    FROM gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    GROUP BY gh_issue_history.issue_id
-  ),
+  SELECT
+    eit.deliverable_id,
+    eit.epic_id,
+    eit.epic_ghid,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM gh_issue i
+  JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
+),
 
-  -- Sum points only for the most recent `d_effective`
-  latest_points AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      SUM(gh_issue_history.points) AS total_points
-    FROM gh_issue_history
-    INNER JOIN latest_history 
-      ON gh_issue_history.issue_id = latest_history.issue_id 
-      AND gh_issue_history.d_effective = latest_history.latest_d_effective
-    GROUP BY gh_issue_history.issue_id
-  ),
+-- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS (
+  SELECT
+    sd.id AS deliverable_id,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM selected_deliverable sd
+  JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+),
 
-  -- Determine if an issue is pointed or not (based only on latest history)
-  issue_pointed_state AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      CASE 
-        WHEN SUM(gh_issue_history.points) > 0 THEN '√'  
-        ELSE NULL  
-      END AS pointed
-    FROM gh_issue_history
-    INNER JOIN latest_history 
-      ON gh_issue_history.issue_id = latest_history.issue_id 
-      AND gh_issue_history.d_effective = latest_history.latest_d_effective
-    GROUP BY gh_issue_history.issue_id
-  ),
-
-  -- Determine the highest-priority status per issue (but don't sum all points)
-  ranked_issues AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      issue_hierarchy.issue_ghid,
-      issue_hierarchy.issue_title,
-      gh_issue_history.d_effective,
-      gh_issue_history.status,
-      ranked_statuses.status_priority,
-      issue_hierarchy.is_epic,  -- Preserve epic identification
-      ROW_NUMBER() OVER (
-        PARTITION BY gh_issue_history.issue_id 
-        ORDER BY ranked_statuses.status_priority DESC  
-      ) AS rn
-    FROM 
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    INNER JOIN ranked_statuses ON gh_issue_history.status = ranked_statuses.status  
-    INNER JOIN latest_history 
-      ON gh_issue_history.issue_id = latest_history.issue_id 
-      AND gh_issue_history.d_effective = latest_history.latest_d_effective
+-- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS (
+  SELECT
+    rdi.deliverable_id,
+    NULL::integer AS epic_id,
+    NULL::text AS epic_ghid,
+    rdi.issue_id,
+    rdi.issue_ghid,
+    rdi.issue_title,
+    rdi.parent_issue_ghid
+  FROM raw_direct_issues rdi
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM latest_epic_mappings lem
+    JOIN gh_epic ep ON lem.epic_id = ep.id
+    WHERE ep.ghid = rdi.issue_ghid
   )
+),
 
--- Select only the highest-priority status per issue and apply pointed logic  
+-- Step 7: Combine both sources
+combined_issues AS (
+  SELECT * FROM epic_issue_tree
+  UNION ALL
+  SELECT * FROM direct_issues
+),
+
+-- Step 8: Assign numerical priorities to statuses
+ranked_statuses AS (
+  SELECT 'Icebox' AS status, 1 AS status_priority UNION ALL
+  SELECT 'Backlog', 2 UNION ALL
+  SELECT 'Prioritized', 3 UNION ALL
+  SELECT 'Planning', 4 UNION ALL
+  SELECT 'Todo', 5 UNION ALL
+  SELECT 'Blocked', 6 UNION ALL
+  SELECT 'In Progress', 7 UNION ALL
+  SELECT 'In Review', 8 UNION ALL
+  SELECT 'Done', 9
+),
+
+-- Step 9: Latest state per issue
+latest_history AS (
+  SELECT 
+    h.issue_id,
+    MAX(h.d_effective) AS latest_d_effective
+  FROM gh_issue_history h
+  JOIN combined_issues ci ON h.issue_id = ci.issue_id
+  GROUP BY h.issue_id
+),
+
+-- Step 10: Points from most recent record
+latest_points AS (
+  SELECT 
+    h.issue_id,
+    SUM(h.points) AS total_points
+  FROM gh_issue_history h
+  JOIN latest_history lh ON h.issue_id = lh.issue_id AND h.d_effective = lh.latest_d_effective
+  GROUP BY h.issue_id
+),
+
+-- Step 11: Mark pointed state
+issue_pointed_state AS (
+  SELECT 
+    h.issue_id,
+    CASE WHEN SUM(h.points) > 0 THEN '√' ELSE NULL END AS pointed
+  FROM gh_issue_history h
+  JOIN latest_history lh ON h.issue_id = lh.issue_id AND h.d_effective = lh.latest_d_effective
+  GROUP BY h.issue_id
+),
+
+-- Step 12: Rank current issue status
+ranked_issues AS (
+  SELECT 
+    h.issue_id,
+    ci.issue_ghid,
+    ci.issue_title,
+    h.d_effective,
+    h.status,
+    rs.status_priority,
+    ROW_NUMBER() OVER (
+      PARTITION BY h.issue_id 
+      ORDER BY rs.status_priority DESC
+    ) AS rn
+  FROM gh_issue_history h
+  JOIN latest_history lh ON h.issue_id = lh.issue_id AND h.d_effective = lh.latest_d_effective
+  JOIN combined_issues ci ON h.issue_id = ci.issue_id
+  JOIN ranked_statuses rs ON h.status = rs.status
+)
+
+-- Final output
 SELECT
-  ranked_issues.issue_title,
-  ranked_issues.status,
-  ranked_issues.issue_ghid,
-  CONCAT('http://github.com/', ranked_issues.issue_ghid) AS issue_url,
-  issue_pointed_state.pointed,  
-  latest_points.total_points AS points,  
-  ranked_issues.d_effective,
-  ranked_issues.issue_id
-FROM
-  ranked_issues
-INNER JOIN issue_pointed_state ON ranked_issues.issue_id = issue_pointed_state.issue_id 
-INNER JOIN latest_points ON ranked_issues.issue_id = latest_points.issue_id  
-WHERE
-  ranked_issues.rn = 1  -- Keeps only the highest-priority status per issue
-  AND ranked_issues.status = 'Done'  -- Include only completed issues
-  AND NOT ranked_issues.is_epic  -- 🚨 EXCLUDE ISSUES THAT ARE ACTUALLY EPICS
-ORDER BY
-  ranked_issues.issue_title;
+  ri.issue_title,
+  ri.status,
+  ri.issue_ghid,
+  CONCAT('http://github.com/', ri.issue_ghid) AS issue_url,
+  ips.pointed,
+  lp.total_points AS points,
+  ri.d_effective,
+  ri.issue_id
+FROM ranked_issues ri
+JOIN issue_pointed_state ips ON ri.issue_id = ips.issue_id
+JOIN latest_points lp ON ri.issue_id = lp.issue_id
+WHERE ri.rn = 1
+  AND ri.status = 'Done'
+ORDER BY ri.issue_title;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-issues-open.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-issues-open.sql
@@ -1,161 +1,175 @@
-WITH RECURSIVE 
+WITH RECURSIVE
 
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE
-      {{deliverable_title}}
-  ),
- 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
-    SELECT
-      e.deliverable_id,
-      e.epic_id,
-      e.epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic  -- Identify if this issue is actually an epic
-    FROM
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+-- Step 1: Resolve the selected deliverable
+selected_deliverable AS (
+  SELECT id, ghid
+  FROM gh_deliverable
+  WHERE 
+  {{deliverable_title}}
+),
 
-    UNION ALL
+-- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS (
+  SELECT DISTINCT ON (edm.epic_id)
+    edm.epic_id,
+    e.ghid AS epic_ghid,
+    edm.deliverable_id,
+    edm.d_effective
+  FROM gh_epic_deliverable_map edm
+  JOIN gh_epic e ON edm.epic_id = e.id
+  ORDER BY edm.epic_id, edm.d_effective DESC
+),
 
-    -- Issues that are direct children of the deliverable itself
-    SELECT
-      gh_deliverable.id AS deliverable_id,
-      NULL AS epic_id,
-      NULL AS epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic
-    FROM
-      gh_deliverable
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = gh_deliverable.ghid
-    WHERE
-      {{deliverable_title}}
+-- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS (
+  SELECT
+    lem.epic_id,
+    lem.epic_ghid,
+    lem.deliverable_id
+  FROM latest_epic_mappings lem
+  JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+),
 
-    UNION ALL
-    
-    -- Recursively find the children of each issue
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic
-    FROM
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
-  ),
+-- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS (
+  SELECT
+    e.deliverable_id,
+    e.epic_id,
+    e.epic_ghid,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM epics_in_deliverable e
+  JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
-  -- Assign a numerical priority to statuses based on importance (Lower value = Higher priority)
-  ranked_statuses AS (
-    SELECT 'Icebox' AS status, 1 AS status_priority UNION ALL
-    SELECT 'Backlog', 2 UNION ALL
-    SELECT 'Prioritized', 3 UNION ALL
-    SELECT 'Planning', 4 UNION ALL
-    SELECT 'Todo', 5 UNION ALL
-    SELECT 'Blocked', 6 UNION ALL
-    SELECT 'In Progress', 7 UNION ALL
-    SELECT 'In Review', 8 UNION ALL
-    SELECT 'Done', 9
-  ),
+  UNION ALL
 
-  -- Find the max d_effective per issue
-  latest_history AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      MAX(gh_issue_history.d_effective) AS latest_d_effective
-    FROM gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    GROUP BY gh_issue_history.issue_id
-  ),
+  SELECT
+    eit.deliverable_id,
+    eit.epic_id,
+    eit.epic_ghid,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM gh_issue i
+  JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
+),
 
-  -- Sum points only for the most recent `d_effective`
-  latest_points AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      SUM(gh_issue_history.points) AS total_points
-    FROM gh_issue_history
-    INNER JOIN latest_history 
-      ON gh_issue_history.issue_id = latest_history.issue_id 
-      AND gh_issue_history.d_effective = latest_history.latest_d_effective
-    GROUP BY gh_issue_history.issue_id
-  ),
+-- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS (
+  SELECT
+    sd.id AS deliverable_id,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM selected_deliverable sd
+  JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+),
 
-  -- Determine if an issue is pointed or not (based only on latest history)
-  issue_pointed_state AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      CASE 
-        WHEN SUM(gh_issue_history.points) > 0 THEN '√'  
-        ELSE NULL  
-      END AS pointed
-    FROM gh_issue_history
-    INNER JOIN latest_history 
-      ON gh_issue_history.issue_id = latest_history.issue_id 
-      AND gh_issue_history.d_effective = latest_history.latest_d_effective
-    GROUP BY gh_issue_history.issue_id
-  ),
-
-  -- Determine the highest-priority status per issue 
-  ranked_issues AS (
-    SELECT 
-      gh_issue_history.issue_id,
-      issue_hierarchy.issue_ghid,
-      issue_hierarchy.issue_title,
-      gh_issue_history.d_effective,
-      gh_issue_history.status,
-      ranked_statuses.status_priority,
-      issue_hierarchy.is_epic,  -- Preserve epic identification
-      ROW_NUMBER() OVER (
-        PARTITION BY gh_issue_history.issue_id 
-        ORDER BY ranked_statuses.status_priority DESC  
-      ) AS rn
-    FROM 
-      gh_issue_history
-    INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-    INNER JOIN ranked_statuses ON gh_issue_history.status = ranked_statuses.status  
-    INNER JOIN latest_history 
-      ON gh_issue_history.issue_id = latest_history.issue_id 
-      AND gh_issue_history.d_effective = latest_history.latest_d_effective
+-- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS (
+  SELECT
+    rdi.deliverable_id,
+    NULL::integer AS epic_id,
+    NULL::text AS epic_ghid,
+    rdi.issue_id,
+    rdi.issue_ghid,
+    rdi.issue_title,
+    rdi.parent_issue_ghid
+  FROM raw_direct_issues rdi
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM latest_epic_mappings lem
+    JOIN gh_epic ep ON lem.epic_id = ep.id
+    WHERE ep.ghid = rdi.issue_ghid
   )
+),
 
--- Select only the highest-priority status per issue and apply pointed logic  
+-- Step 7: Combine both sources
+combined_issues AS (
+  SELECT * FROM epic_issue_tree
+  UNION ALL
+  SELECT * FROM direct_issues
+),
+
+-- Step 8: Assign numerical priorities to statuses
+ranked_statuses AS (
+  SELECT 'Icebox' AS status, 1 AS status_priority UNION ALL
+  SELECT 'Backlog', 2 UNION ALL
+  SELECT 'Prioritized', 3 UNION ALL
+  SELECT 'Planning', 4 UNION ALL
+  SELECT 'Todo', 5 UNION ALL
+  SELECT 'Blocked', 6 UNION ALL
+  SELECT 'In Progress', 7 UNION ALL
+  SELECT 'In Review', 8 UNION ALL
+  SELECT 'Done', 9
+),
+
+-- Step 9: Latest state per issue
+latest_history AS (
+  SELECT 
+    h.issue_id,
+    MAX(h.d_effective) AS latest_d_effective
+  FROM gh_issue_history h
+  JOIN combined_issues ci ON h.issue_id = ci.issue_id
+  GROUP BY h.issue_id
+),
+
+-- Step 10: Points from most recent record
+latest_points AS (
+  SELECT 
+    h.issue_id,
+    SUM(h.points) AS total_points
+  FROM gh_issue_history h
+  JOIN latest_history lh ON h.issue_id = lh.issue_id AND h.d_effective = lh.latest_d_effective
+  GROUP BY h.issue_id
+),
+
+-- Step 11: Mark pointed state
+issue_pointed_state AS (
+  SELECT 
+    h.issue_id,
+    CASE WHEN SUM(h.points) > 0 THEN '√' ELSE NULL END AS pointed
+  FROM gh_issue_history h
+  JOIN latest_history lh ON h.issue_id = lh.issue_id AND h.d_effective = lh.latest_d_effective
+  GROUP BY h.issue_id
+),
+
+-- Step 12: Rank current issue status
+ranked_issues AS (
+  SELECT 
+    h.issue_id,
+    ci.issue_ghid,
+    ci.issue_title,
+    h.d_effective,
+    h.status,
+    rs.status_priority,
+    ROW_NUMBER() OVER (
+      PARTITION BY h.issue_id 
+      ORDER BY rs.status_priority DESC
+    ) AS rn
+  FROM gh_issue_history h
+  JOIN latest_history lh ON h.issue_id = lh.issue_id AND h.d_effective = lh.latest_d_effective
+  JOIN combined_issues ci ON h.issue_id = ci.issue_id
+  JOIN ranked_statuses rs ON h.status = rs.status
+)
+
+-- Final output
 SELECT
-  ranked_issues.issue_title,
-  ranked_issues.status,
-  ranked_issues.issue_ghid,
-  CONCAT('http://github.com/', ranked_issues.issue_ghid) AS issue_url,
-  issue_pointed_state.pointed,  
-  latest_points.total_points AS points,  
-  ranked_issues.d_effective,
-  ranked_issues.issue_id
-FROM
-  ranked_issues
-INNER JOIN issue_pointed_state ON ranked_issues.issue_id = issue_pointed_state.issue_id 
-INNER JOIN latest_points ON ranked_issues.issue_id = latest_points.issue_id  
-WHERE
-  ranked_issues.rn = 1  -- Keeps only the highest-priority status per issue
-  AND ranked_issues.status != 'Done'  -- Exclude completed issues
-  AND NOT ranked_issues.is_epic  
-ORDER BY
-  ranked_issues.issue_title;
+  ri.issue_title,
+  ri.status,
+  ri.issue_ghid,
+  CONCAT('http://github.com/', ri.issue_ghid) AS issue_url,
+  ips.pointed,
+  lp.total_points AS points,
+  ri.d_effective,
+  ri.issue_id
+FROM ranked_issues ri
+JOIN issue_pointed_state ips ON ri.issue_id = ips.issue_id
+JOIN latest_points lp ON ri.issue_id = lp.issue_id
+WHERE ri.rn = 1
+  AND ri.status != 'Done'
+ORDER BY ri.issue_title;

--- a/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-percent-done-by-points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/delivery-metrics/deliverable-percent-done-by-points.sql
@@ -1,113 +1,128 @@
 WITH RECURSIVE 
 
-  -- Get epics within a given deliverable
-  epics_in_deliverable AS (
-    SELECT DISTINCT
-      gh_deliverable.id AS deliverable_id,
-      e.id AS epic_id,
-      e.ghid AS epic_ghid,
-      e.title AS epic_title
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_epic_deliverable_map m ON m.deliverable_id = gh_deliverable.id
-    INNER JOIN gh_epic e ON m.epic_id = e.id 
-    WHERE 
-      {{deliverable_title}}
-  ),
+-- Step 1: Resolve the selected deliverable
+selected_deliverable AS (
+  SELECT id, ghid
+  FROM gh_deliverable
+  WHERE {{deliverable_title}}
+),
 
-  -- Get issues within each epic or directly linked to the deliverable
-  issue_hierarchy AS (
-    -- Issues that are direct children of an epic
-    SELECT
-      e.deliverable_id,
-      e.epic_id,
-      e.epic_ghid AS root_epic_ghid, 
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,  -- Identify epics
-      EXISTS (SELECT 1 FROM gh_deliverable WHERE gh_deliverable.ghid = i.ghid) AS is_deliverable  -- Identify deliverables
-    FROM 
-      epics_in_deliverable e
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+-- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS (
+  SELECT DISTINCT ON (edm.epic_id)
+    edm.epic_id,
+    e.ghid AS epic_ghid,
+    edm.deliverable_id,
+    edm.d_effective
+  FROM gh_epic_deliverable_map edm
+  JOIN gh_epic e ON edm.epic_id = e.id
+  ORDER BY edm.epic_id, edm.d_effective DESC
+),
 
-    UNION ALL
+-- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS (
+  SELECT
+    lem.epic_id,
+    lem.epic_ghid,
+    lem.deliverable_id
+  FROM latest_epic_mappings lem
+  JOIN selected_deliverable sd ON lem.deliverable_id = sd.id
+),
 
-    -- Issues that are direct children of the deliverable itself
-    SELECT
-      gh_deliverable.id AS deliverable_id,
-      NULL AS epic_id,
-      NULL AS root_epic_ghid, 
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,
-      EXISTS (SELECT 1 FROM gh_deliverable WHERE gh_deliverable.ghid = i.ghid) AS is_deliverable
-    FROM 
-      gh_deliverable
-    INNER JOIN gh_issue i ON i.parent_issue_ghid = gh_deliverable.ghid
-    WHERE 
-      {{deliverable_title}}
+-- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS (
+  SELECT
+    e.deliverable_id,
+    e.epic_id,
+    e.epic_ghid,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM epics_in_deliverable e
+  JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
 
-    UNION ALL
-    
-    -- Recursively find the children of each issue
-    SELECT
-      ih.deliverable_id,
-      ih.epic_id,
-      ih.root_epic_ghid,
-      i.id AS issue_id,
-      i.ghid AS issue_ghid,
-      i.title AS issue_title,
-      i.parent_issue_ghid,
-      EXISTS (SELECT 1 FROM gh_epic WHERE gh_epic.ghid = i.ghid) AS is_epic,
-      EXISTS (SELECT 1 FROM gh_deliverable WHERE gh_deliverable.ghid = i.ghid) AS is_deliverable
-    FROM 
-      gh_issue i
-    INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid
-  ),
+  UNION ALL
 
-  -- De-duplicate history records and get most recent state for each issue (excluding epics & deliverables)
-  issue_state AS (
-    SELECT
-      history.d_effective,
-      history.points,
-      history.points_closed,
-      history.points_open
-    FROM (
-      SELECT
-        gh_issue_history.issue_id,
-        gh_issue_history.d_effective,
-        gh_issue_history.points,
-        gh_issue_history.is_closed::BOOLEAN AS is_closed,
-        CASE WHEN gh_issue_history.is_closed::BOOLEAN = TRUE THEN 0 ELSE gh_issue_history.points END AS points_open,
-        CASE WHEN gh_issue_history.is_closed::BOOLEAN = TRUE THEN gh_issue_history.points ELSE 0 END AS points_closed,
-        ROW_NUMBER() OVER (
-          PARTITION BY gh_issue_history.issue_id
-          ORDER BY gh_issue_history.d_effective DESC
-        ) AS ranked_order
-      FROM 
-        gh_issue_history
-      INNER JOIN issue_hierarchy ON gh_issue_history.issue_id = issue_hierarchy.issue_id
-      WHERE 
-        NOT issue_hierarchy.is_epic  -- Exclude epics
-        AND NOT issue_hierarchy.is_deliverable  -- Exclude deliverables
-    ) history
-    WHERE 
-      history.ranked_order = 1
+  SELECT
+    eit.deliverable_id,
+    eit.epic_id,
+    eit.epic_ghid,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM gh_issue i
+  JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid
+),
+
+-- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS (
+  SELECT
+    sd.id AS deliverable_id,
+    i.id AS issue_id,
+    i.ghid AS issue_ghid,
+    i.title AS issue_title,
+    i.parent_issue_ghid
+  FROM selected_deliverable sd
+  JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid
+),
+
+-- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS (
+  SELECT
+    rdi.deliverable_id,
+    NULL::integer AS epic_id,
+    NULL::text AS epic_ghid,
+    rdi.issue_id,
+    rdi.issue_ghid,
+    rdi.issue_title,
+    rdi.parent_issue_ghid
+  FROM raw_direct_issues rdi
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM latest_epic_mappings lem
+    JOIN gh_epic ep ON lem.epic_id = ep.id
+    WHERE ep.ghid = rdi.issue_ghid
   )
-  
--- Count open and closed points and calculate percent complete 
+),
+
+-- Step 7: Combine both sources
+combined_issues AS (
+  SELECT * FROM epic_issue_tree
+  UNION ALL
+  SELECT * FROM direct_issues
+),
+
+-- Step 8: Latest snapshot per issue
+latest_history AS (
+  SELECT 
+    h.issue_id,
+    MAX(h.d_effective) AS latest_d_effective
+  FROM gh_issue_history h
+  JOIN combined_issues ci ON h.issue_id = ci.issue_id
+  GROUP BY h.issue_id
+),
+
+-- Step 9: Pull point data from latest state
+issue_points AS (
+  SELECT
+    h.issue_id,
+    h.points,
+    CASE WHEN h.is_closed = 1 THEN h.points ELSE 0 END AS points_closed,
+    CASE WHEN h.is_closed = 0 THEN h.points ELSE 0 END AS points_open
+  FROM gh_issue_history h
+  JOIN latest_history lh ON h.issue_id = lh.issue_id AND h.d_effective = lh.latest_d_effective
+)
+
+-- Final calculation
 SELECT
   SUM(points_open) AS points_open,
   SUM(points_closed) AS points_closed,
   SUM(points) AS total_points,
   CASE
     WHEN SUM(points) = 0 THEN '0%'
-    ELSE CONCAT(CEIL(100 * (SUM(points_closed) / NULLIF(SUM(points)::DECIMAL, 0))), '%')
+    ELSE CONCAT(CEIL(100 * (SUM(points_closed)::DECIMAL / NULLIF(SUM(points), 0))), '%')
   END AS percent_complete,
   COUNT(*) AS total_issues
-FROM
-  issue_state;
+FROM issue_points;


### PR DESCRIPTION
## Summary
Fixes #{4394}

### Time to review: __5 mins__

## Changes proposed
> What was added, updated, or removed in this PR.

Refactored queries (open issues, burnup, burndown, pct pointed, pct done, etc) to ensure consistent deliverable->epic->issue hierarchy traversal and mapping.

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We do not have automated backups or source control for queries in Metabase. So every time we change a query in Metabase, we have to manually update these backups.

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

