### PR TITLE
[Unticketed] Fix run_mode in logs to find gunicorn

### DIFF
--- a/api/src/logging/flask_logger.py
+++ b/api/src/logging/flask_logger.py
@@ -221,15 +221,15 @@ def get_run_mode() -> str:
     # We want to indicate whether the app was run as an API service
     # or as a CLI - use the argv of the command we ran it with
     # to determine that.
-    # CLI commands are always of the form "/path/to/flask <blueprint name> <task name> <commands>
+    # CLI commands are always of the form "/path/to/flask <blueprint name> <task name> <commands>"
     #
     # The API service can be started either as
-    #  "/path/to/flask --app src.app run ..." --> When run locally
-    #  "poetry run gunicorn src.app:create_app()"
+    #  "/path/to/flask --app src.app run ..."         --> When run locally
+    #  "/api/.venv/bin/gunicorn src.app:create_app()" --> When run non-locally
     #
     # So we check for pieces that only appear in the API commands
 
-    _original_argv = tuple(sys.argv)
+    _original_argv = " ".join(sys.argv)
     run_mode = "cli"
     if "gunicorn" in _original_argv or "--app" in _original_argv:
         run_mode = "service"


### PR DESCRIPTION
## Summary

### Time to review: __1 mins__

## Changes proposed
Make run_mode calculation based on the raw query rather than individual parts

## Context for reviewers
The argv non-locally is actually `"/api/.venv/bin/gunicorn src.app:create_app()"` so need to find gunicorn slightly differently.

## Additional information
Verified running in gunicorn mode:
![Screenshot 2025-04-02 at 1 07 15 PM](https://github.com/user-attachments/assets/85b41a25-e4d0-4b8c-850e-705b2ba8bdf4)


