### PR TITLE
[Unticketed] Disable developer mode for New Relic

### DIFF
--- a/api/newrelic.ini
+++ b/api/newrelic.ini
@@ -253,7 +253,7 @@ application_logging.local_decorating.enabled = false
 #   license_key=1234abcd
 #
 app_name = api-local
-developer_mode = true
+developer_mode = false
 monitor_mode = false
 license_key=replace_me
 transaction_tracer.enabled = false


### PR DESCRIPTION
## Summary

### Time to review: __1 mins__

## Changes proposed
Disable developer mode so New Relic stops trying to trace in tests which has a small chance to cause tests to fail due to our test setup

