### PR TITLE
[Issue #4340]  Application and form page

### DIFF
--- a/frontend/src/app/[locale]/formPrototype/CreateApplication.tsx
+++ b/frontend/src/app/[locale]/formPrototype/CreateApplication.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useUser } from "src/services/auth/useUser";
+import { startApplication } from "src/services/fetch/fetchers/clientApplicationFetcher";
+
+import { useCallback, useState } from "react";
+import { Button } from "@trussworks/react-uswds";
+
+const CreateApplicatinButton = () => {
+  const { user } = useUser();
+
+  const [loading, setLoading] = useState<boolean>();
+
+  const handleSubmit = useCallback(() => {
+    setLoading(true);
+    console.log("wtf");
+    startApplication("test")
+      .then((data) => {
+        console.log(data);
+      })
+      .catch((error) => {
+        console.error(error);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [user]);
+  return (
+    <Button onClick={handleSubmit} type="submit">
+      {loading ? "loading..." : "Create new application"}
+    </Button>
+  );
+};
+
+export default CreateApplicatinButton;

--- a/frontend/src/app/[locale]/formPrototype/[applicationId]/[formId]/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/[applicationId]/[formId]/page.tsx
@@ -3,7 +3,7 @@ import TopLevelError from "src/app/[locale]/error/page";
 import NotFound from "src/app/[locale]/not-found";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
 import withFeatureFlag from "src/hoc/withFeatureFlag";
-import { getCompetitionDetails } from "src/services/fetch/fetchers/competitionsFetcher";
+import { getFormDetails } from "src/services/fetch/fetchers/formsFetcher";
 import { FormDetail } from "src/types/formResponseTypes";
 
 import { redirect } from "next/navigation";
@@ -27,22 +27,21 @@ export function generateMetadata() {
 }
 
 interface formPageProps {
-  params: Promise<{ id: string; locale: string }>;
+  params: Promise<{ formId: string; applicationId: string; locale: string }>;
 }
 
 async function FormPage({ params }: formPageProps) {
-  const { id } = await params;
+  const { formId } = await params;
   let formData = {} as FormDetail;
 
   try {
-    const response = await getCompetitionDetails(id);
+    const response = await getFormDetails(formId);
     if (response.status_code !== 200) {
       throw new Error(
         `Error retrieving competition details: ${JSON.stringify(response.errors)}`,
       );
     }
-    // TODO: this update so this is a list of forms on a competition endpoint
-    formData = response.data.competition_forms[0].form;
+    formData = response.data;
   } catch (error) {
     if (parseErrorStatus(error as ApiRequestError) === 404) {
       return <NotFound />;
@@ -50,7 +49,7 @@ async function FormPage({ params }: formPageProps) {
     throw error;
   }
 
-  const { form_id, form_json_schema, form_ui_schema } = formData;
+  const { form_id, form_name, form_json_schema, form_ui_schema } = formData;
 
   try {
     validateUiSchema(form_ui_schema);
@@ -63,11 +62,9 @@ async function FormPage({ params }: formPageProps) {
   return (
     <GridContainer>
       <BetaAlert />
-      <h1>
-        Form Demo: Applicaction for Federal Assistance SF 424 - Individual
-      </h1>
+      <h1>Form demo for &quot;{form_name}&quot; form</h1>
       <legend className="usa-legend">
-        The following is a demo of the SF 424 Individual form.
+        The following is a demo of the apply forms.
       </legend>
       <p>
         Required fields are marked with an asterisk (

--- a/frontend/src/app/[locale]/formPrototype/[applicationId]/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/[applicationId]/page.tsx
@@ -1,0 +1,93 @@
+import { Metadata } from "next";
+import NotFound from "src/app/[locale]/not-found";
+import { ApiRequestError, parseErrorStatus } from "src/errors";
+import withFeatureFlag from "src/hoc/withFeatureFlag";
+import { getCompetitionDetails } from "src/services/fetch/fetchers/competitionsFetcher";
+import { COMPETITION_ID } from "src/types/competitions";
+import { FormDetail } from "src/types/formResponseTypes";
+
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { GridContainer } from "@trussworks/react-uswds";
+
+import BetaAlert from "src/components/BetaAlert";
+
+export const dynamic = "force-dynamic";
+
+export function generateMetadata() {
+  const meta: Metadata = {
+    title: `Form demo application landing page`,
+  };
+  return meta;
+}
+
+interface ApplicactionLandingPageProps {
+  params: Promise<{ applicationId: string; locale: string }>;
+}
+
+const FormLinks = ({
+  forms,
+  applicationId,
+}: {
+  forms: [{ form: FormDetail }];
+  applicationId: string;
+}) => {
+  if (forms.length > 0) {
+    return (
+      <ul>
+        {forms.map((form) => {
+          return (
+            <li key={form.form.form_name}>
+              <Link
+                href={`/formPrototype/${applicationId}/${form.form.form_id}`}
+              >
+                {form.form.form_name}
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  } else {
+    return <></>;
+  }
+};
+
+async function ApplicactionLandingPage({
+  params,
+}: ApplicactionLandingPageProps) {
+  const { applicationId } = await params;
+  let forms = [] as unknown as [{ form: FormDetail }];
+
+  try {
+    const response = await getCompetitionDetails(COMPETITION_ID);
+    if (response.status_code !== 200) {
+      throw new Error(
+        `Error retrieving competition details: ${JSON.stringify(response.errors)}`,
+      );
+    }
+    forms = response.data.competition_forms;
+  } catch (error) {
+    if (parseErrorStatus(error as ApiRequestError) === 404) {
+      return <NotFound />;
+    }
+    throw error;
+  }
+
+  return (
+    <GridContainer>
+      <BetaAlert />
+      <h1>Form demo application page</h1>
+      <legend className="usa-legend">
+        The following is a list of available forms.
+      </legend>
+      <FormLinks forms={forms} applicationId={applicationId} />
+    </GridContainer>
+  );
+}
+
+export default withFeatureFlag<ApplicactionLandingPageProps, never>(
+  ApplicactionLandingPage,
+  "applyFormPrototypeOff",
+  () => redirect("/maintenance"),
+);

--- a/frontend/src/app/[locale]/formPrototype/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 import { GridContainer } from "@trussworks/react-uswds";
 
 import BetaAlert from "src/components/BetaAlert";
-import CreateApplicatinButton from "./CreateApplication";
+import CreateApplicatinButton from "src/components/workspace/CreateApplicationButton";
 
 export function generateMetadata() {
   const meta: Metadata = {

--- a/frontend/src/app/[locale]/formPrototype/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from "next";
 import { GridContainer } from "@trussworks/react-uswds";
 
 import BetaAlert from "src/components/BetaAlert";
-import CreateApplicatinButton from "src/components/workspace/CreateApplicationButton";
+import CreateApplicationButton from "src/components/workspace/CreateApplicationButton";
 
 export function generateMetadata() {
   const meta: Metadata = {
@@ -21,7 +21,7 @@ export default function FormPrototypePage() {
         The following is a demo of the apply process.
       </legend>
       <p>
-        <CreateApplicatinButton />
+        <CreateApplicationButton />
       </p>
     </GridContainer>
   );

--- a/frontend/src/app/[locale]/formPrototype/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/page.tsx
@@ -1,0 +1,28 @@
+import { Metadata } from "next";
+
+import { GridContainer } from "@trussworks/react-uswds";
+
+import BetaAlert from "src/components/BetaAlert";
+import CreateApplicatinButton from "./CreateApplication";
+
+export function generateMetadata() {
+  const meta: Metadata = {
+    title: `Simpler apply form prototype`,
+  };
+  return meta;
+}
+
+export default function FormPrototypePage() {
+  return (
+    <GridContainer>
+      <BetaAlert />
+      <h1>Apply form prototype</h1>
+      <legend className="usa-legend">
+        The following is a demo of the apply process.
+      </legend>
+      <p>
+        <CreateApplicatinButton />
+      </p>
+    </GridContainer>
+  );
+}

--- a/frontend/src/app/api/applications/start/route.ts
+++ b/frontend/src/app/api/applications/start/route.ts
@@ -1,7 +1,6 @@
 import { ApiRequestError, readError, UnauthorizedError } from "src/errors";
 import { handleStartApplication } from "src/services/fetch/fetchers/applicationFetcher";
-
-const COMPETITION_ID = "fd7f5921-9585-48a5-ab0f-e726f4d1ef94";
+import { COMPETITION_ID } from "src/types/competitions";
 
 export const POST = async () => {
   try {

--- a/frontend/src/app/api/applications/start/route.ts
+++ b/frontend/src/app/api/applications/start/route.ts
@@ -10,10 +10,9 @@ export const POST = async () => {
     if (!session || !session.token) {
       throw new UnauthorizedError("No active session start application");
     }
-    console.log("heeey");
 
     const response = await handleStartApplication(COMPETITION_ID);
-    console.log(response);
+
     if (!response || response.status_code !== 200) {
       throw new ApiRequestError(
         `Error starting application: ${response.message}`,
@@ -23,10 +22,9 @@ export const POST = async () => {
     }
     return Response.json({
       message: "Application start success",
-      id: response?.competition_id,
+      applicationId: response?.data?.application_id,
     });
   } catch (e) {
-    console.log("heee", e);
     const { status, message } = readError(e as Error, 500);
     return Response.json(
       {

--- a/frontend/src/app/api/applications/start/route.ts
+++ b/frontend/src/app/api/applications/start/route.ts
@@ -1,0 +1,38 @@
+import { ApiRequestError, readError, UnauthorizedError } from "src/errors";
+import { handleStartApplication } from "src/services/fetch/fetchers/applicationFetcher";
+
+const COMPETITION_ID = "fd7f5921-9585-48a5-ab0f-e726f4d1ef94";
+
+export const POST = async () => {
+  try {
+    // TODO: add session support;
+    const session = { token: true };
+    if (!session || !session.token) {
+      throw new UnauthorizedError("No active session start application");
+    }
+    console.log("heeey");
+
+    const response = await handleStartApplication(COMPETITION_ID);
+    console.log(response);
+    if (!response || response.status_code !== 200) {
+      throw new ApiRequestError(
+        `Error starting application: ${response.message}`,
+        "APIRequestError",
+        response.status_code,
+      );
+    }
+    return Response.json({
+      message: "Application start success",
+      id: response?.competition_id,
+    });
+  } catch (e) {
+    console.log("heee", e);
+    const { status, message } = readError(e as Error, 500);
+    return Response.json(
+      {
+        message: `Error attempting to start application: ${message}`,
+      },
+      { status },
+    );
+  }
+};

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -23,8 +23,6 @@ const ApplyForm = ({
 }) => {
   const { pending } = useFormStatus();
 
-  //   submitApplyForm.bind("", formId)
-
   const [formState, formAction] = useActionState(submitApplyForm, {
     errorMessage: "",
     validationErrors: [],
@@ -39,26 +37,27 @@ const ApplyForm = ({
     formObject,
   );
   const navFields = getWrappersForNav(uiSchema);
-
   return (
     <div className="usa-in-page-nav-container flex-justify">
-      <ApplyFormNav fields={navFields} />
+      {navFields.length > 0 && <ApplyFormNav fields={navFields} />}
       <form action={formAction}>
         <ApplyFormErrorMessage
           heading={formState.errorMessage}
           errors={formState.validationErrors}
         />
         <FormGroup>{fields}</FormGroup>
-        <Button
-          onClick={() =>
-            formState.validationErrors.length > 0
-              ? window.scrollTo({ top: 0, behavior: "smooth" })
-              : undefined
-          }
-          type="submit"
-        >
-          {pending ? "Submitting..." : "Submit"}
-        </Button>
+        <p>
+          <Button
+            onClick={() =>
+              formState.validationErrors.length > 0
+                ? window.scrollTo({ top: 0, behavior: "smooth" })
+                : undefined
+            }
+            type="submit"
+          >
+            {pending ? "Submitting..." : "Submit"}
+          </Button>
+        </p>
       </form>
     </div>
   );

--- a/frontend/src/components/workspace/CreateApplicationButton.tsx
+++ b/frontend/src/components/workspace/CreateApplicationButton.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { Button } from "@trussworks/react-uswds";
 
-const CreateApplicatinButton = () => {
+const CreateApplicationButton = () => {
   const router = useRouter();
   const [loading, setLoading] = useState<boolean>();
 
@@ -31,4 +31,4 @@ const CreateApplicatinButton = () => {
   );
 };
 
-export default CreateApplicatinButton;
+export default CreateApplicationButton;

--- a/frontend/src/components/workspace/CreateApplicationButton.tsx
+++ b/frontend/src/components/workspace/CreateApplicationButton.tsx
@@ -1,22 +1,21 @@
 "use client";
 
-import { useUser } from "src/services/auth/useUser";
 import { startApplication } from "src/services/fetch/fetchers/clientApplicationFetcher";
 
+import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { Button } from "@trussworks/react-uswds";
 
 const CreateApplicatinButton = () => {
-  const { user } = useUser();
-
+  const router = useRouter();
   const [loading, setLoading] = useState<boolean>();
 
   const handleSubmit = useCallback(() => {
     setLoading(true);
-    console.log("wtf");
-    startApplication("test")
+    startApplication("insecuretoken")
       .then((data) => {
-        console.log(data);
+        const { applicationId } = data;
+        router.push(`/formPrototype/${applicationId}`);
       })
       .catch((error) => {
         console.error(error);
@@ -24,7 +23,7 @@ const CreateApplicatinButton = () => {
       .finally(() => {
         setLoading(false);
       });
-  }, [user]);
+  }, [router]);
   return (
     <Button onClick={handleSubmit} type="submit">
       {loading ? "loading..." : "Create new application"}

--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -22,11 +22,13 @@ export const fetchCompetitionEndpoint = {
   method: "GET" as ApiMethod,
 };
 
-export const fetchApplicationEndpoint = {
-  basePath: environment.API_URL,
-  version: "alpha",
-  namespace: "application",
-  method: "GET" as ApiMethod,
+export const toDynamicApplicationsEndpoint = (type: "POST" | "GET" | "PUT") => {
+  return {
+    basePath: environment.API_URL,
+    version: "alpha",
+    namespace: "applications",
+    method: type as ApiMethod,
+  };
 };
 
 export const fetchFormEndpoint = {

--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -66,3 +66,10 @@ export const fetchAgenciesEndpoint = {
   namespace: "agencies",
   method: "POST" as ApiMethod,
 };
+
+export const fetchApplicationsEndpoint = {
+  basePath: environment.API_URL,
+  version: "alpha",
+  namespace: "applications",
+  method: "POST" as ApiMethod,
+};

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -2,7 +2,7 @@ import { APIResponse } from "src/types/apiResponseTypes";
 
 import { fetchApplication } from "./fetchers";
 
-interface applicationStartResponse extends APIResponse {
+interface ApplicationStartResponse extends APIResponse {
   data: {
     application_id: string;
   };

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -1,0 +1,19 @@
+import { APIResponse } from "src/types/apiResponseTypes";
+
+import { fetchApplications } from "./fetchers";
+
+interface applicationStartResponse extends APIResponse {
+  competition_id: string;
+}
+
+// make call from server to API to start an application
+export const handleStartApplication = async (
+  competitionID: string,
+): Promise<applicationStartResponse> => {
+  const response = await fetchApplications({
+    subPath: `start`,
+    body: { competition_id: competitionID },
+  });
+
+  return (await response.json()) as applicationStartResponse;
+};

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -3,7 +3,9 @@ import { APIResponse } from "src/types/apiResponseTypes";
 import { fetchApplications } from "./fetchers";
 
 interface applicationStartResponse extends APIResponse {
-  competition_id: string;
+  data: {
+    application_id: string;
+  };
 }
 
 // make call from server to API to start an application

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -1,6 +1,6 @@
 import { APIResponse } from "src/types/apiResponseTypes";
 
-import { fetchApplications } from "./fetchers";
+import { fetchApplication } from "./fetchers";
 
 interface applicationStartResponse extends APIResponse {
   data: {
@@ -12,7 +12,7 @@ interface applicationStartResponse extends APIResponse {
 export const handleStartApplication = async (
   competitionID: string,
 ): Promise<applicationStartResponse> => {
-  const response = await fetchApplications({
+  const response = await fetchApplication({
     subPath: `start`,
     body: { competition_id: competitionID },
   });

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -11,11 +11,11 @@ interface ApplicationStartResponse extends APIResponse {
 // make call from server to API to start an application
 export const handleStartApplication = async (
   competitionID: string,
-): Promise<applicationStartResponse> => {
+): Promise<ApplicationStartResponse> => {
   const response = await fetchApplication({
     subPath: `start`,
     body: { competition_id: competitionID },
   });
 
-  return (await response.json()) as applicationStartResponse;
+  return (await response.json()) as ApplicationStartResponse;
 };

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -1,6 +1,6 @@
 import { APIResponse } from "src/types/apiResponseTypes";
 
-import { fetchApplication } from "./fetchers";
+import { fetchApplicationWithMethod } from "./fetchers";
 
 interface ApplicationStartResponse extends APIResponse {
   data: {
@@ -12,7 +12,7 @@ interface ApplicationStartResponse extends APIResponse {
 export const handleStartApplication = async (
   competitionID: string,
 ): Promise<ApplicationStartResponse> => {
-  const response = await fetchApplication({
+  const response = await fetchApplicationWithMethod("POST")({
     subPath: `start`,
     body: { competition_id: competitionID },
   });

--- a/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
@@ -1,13 +1,13 @@
 "use client";
 
-interface applicationStartResponse {
+interface ClientApplicationStartResponse {
   message: string;
   applicationId: string;
 }
 
 export const startApplication = async (
   token?: string,
-): Promise<applicationStartResponse> => {
+): Promise<ClientApplicationStartResponse> => {
   if (!token) {
     throw new Error(`Error starting application`);
   }
@@ -15,7 +15,7 @@ export const startApplication = async (
     method: "POST",
   });
   if (res.ok && res.status === 200) {
-    return (await res.json()) as applicationStartResponse;
+    return (await res.json()) as ClientApplicationStartResponse;
   } else {
     throw new Error(`Error starting application: ${res.status}`);
   }

--- a/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
@@ -1,16 +1,22 @@
 "use client";
-export const startApplication = async (token?: string) => {
-  if (!token) return;
 
+interface applicationStartResponse {
+  message: string;
+  applicationId: string;
+}
+
+export const startApplication = async (
+  token?: string,
+): Promise<applicationStartResponse> => {
+  if (!token) {
+    throw new Error(`Error starting application`);
+  }
   const res = await fetch("/api/applications/start", {
     method: "POST",
   });
-  console.log(res);
   if (res.ok && res.status === 200) {
-    const data = (await res.json()) as { id: string };
-    return data;
+    return (await res.json()) as applicationStartResponse;
   } else {
-    console.log(res);
-    throw new Error(`Error posting saved search: ${res.status}`);
+    throw new Error(`Error starting application: ${res.status}`);
   }
 };

--- a/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
@@ -1,0 +1,16 @@
+"use client";
+export const startApplication = async (token?: string) => {
+  if (!token) return;
+
+  const res = await fetch("/api/applications/start", {
+    method: "POST",
+  });
+  console.log(res);
+  if (res.ok && res.status === 200) {
+    const data = (await res.json()) as { id: string };
+    return data;
+  } else {
+    console.log(res);
+    throw new Error(`Error posting saved search: ${res.status}`);
+  }
+};

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -120,7 +120,3 @@ export const fetchUserWithMethod = (type: "POST" | "DELETE" | "PUT") =>
   requesterForEndpoint(toDynamicUsersEndpoint(type));
 
 export const fetchAgencies = requesterForEndpoint(fetchAgenciesEndpoint);
-
-export const fetchApplications = requesterForEndpoint(
-  fetchApplicationsEndpoint,
-);

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -120,3 +120,7 @@ export const fetchUserWithMethod = (type: "POST" | "DELETE" | "PUT") =>
   requesterForEndpoint(toDynamicUsersEndpoint(type));
 
 export const fetchAgencies = requesterForEndpoint(fetchAgenciesEndpoint);
+
+export const fetchApplications = requesterForEndpoint(
+  fetchApplicationsEndpoint,
+);

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -4,11 +4,11 @@ import { ApiRequestError } from "src/errors";
 import {
   EndpointConfig,
   fetchAgenciesEndpoint,
-  fetchApplicationEndpoint,
   fetchCompetitionEndpoint,
   fetchFormEndpoint,
   fetchOpportunityEndpoint,
   opportunitySearchEndpoint,
+  toDynamicApplicationsEndpoint,
   toDynamicUsersEndpoint,
   userLogoutEndpoint,
 } from "src/services/fetch/endpointConfigs";
@@ -106,9 +106,8 @@ export const fetchCompetition = cache(
   requesterForEndpoint(fetchCompetitionEndpoint),
 );
 
-export const fetchApplication = cache(
-  requesterForEndpoint(fetchApplicationEndpoint),
-);
+export const fetchApplicationWithMethod = (type: "POST" | "GET" | "PUT") =>
+  requesterForEndpoint(toDynamicApplicationsEndpoint(type));
 
 export const fetchOpportunitySearch = requesterForEndpoint(
   opportunitySearchEndpoint,

--- a/frontend/src/types/competitions.ts
+++ b/frontend/src/types/competitions.ts
@@ -1,0 +1,2 @@
+// TODO: remove after demo
+export const COMPETITION_ID = "fd7f5921-9585-48a5-ab0f-e726f4d1ef94";

--- a/frontend/tests/api/applications/start/route.test.ts
+++ b/frontend/tests/api/applications/start/route.test.ts
@@ -18,7 +18,7 @@ jest.mock("src/services/fetch/fetchers/applicationFetcher", () => ({
   handleStartApplication: () => mockPostStartApp(),
 }));
 
-describe("POST and DELETE request", () => {
+describe("POST request", () => {
   afterEach(() => jest.clearAllMocks());
   it("saves saved opportunity", async () => {
     getSessionMock.mockImplementation(() => ({

--- a/frontend/tests/api/applications/start/route.test.ts
+++ b/frontend/tests/api/applications/start/route.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST } from "src/app/api/applications/start/route";
+
+const getSessionMock = jest.fn();
+
+jest.mock("src/services/auth/session", () => ({
+  getSession: (): unknown => getSessionMock(),
+}));
+
+const mockPostStartApp = jest.fn((): unknown =>
+  Promise.resolve({ status_code: 200, data: { application_id: 5 } }),
+);
+
+jest.mock("src/services/fetch/fetchers/applicationFetcher", () => ({
+  handleStartApplication: () => mockPostStartApp(),
+}));
+
+describe("POST and DELETE request", () => {
+  afterEach(() => jest.clearAllMocks());
+  it("saves saved opportunity", async () => {
+    getSessionMock.mockImplementation(() => ({
+      token: "fakeToken",
+    }));
+    const response = await POST();
+    const json = (await response.json()) as {
+      message: string;
+      applicationId: string;
+    };
+    expect(response.status).toBe(200);
+    expect(json.applicationId).toBe(5);
+
+    expect(mockPostStartApp).toHaveBeenCalledTimes(1);
+    expect(json.message).toBe("Application start success");
+  });
+});

--- a/frontend/tests/components/workspace/CreateApplicationButton.test.tsx
+++ b/frontend/tests/components/workspace/CreateApplicationButton.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import CreateApplicatinButton from "src/components/workspace/CreateApplicationButton";
+
+const routerPush = jest.fn(() => Promise.resolve(true));
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(() => "/test") as jest.Mock<string>,
+  useRouter: () => ({
+    push: routerPush,
+  }),
+}));
+
+const mockStartApplication = jest.fn((_token) => Promise.resolve(true));
+
+jest.mock("src/services/fetch/fetchers/clientApplicationFetcher", () => ({
+  startApplication: (token: string) => mockStartApplication(token),
+}));
+
+describe("CreateApplicatinButton", () => {
+  afterEach(() => {
+    mockStartApplication.mockReset();
+  });
+
+  it("button click fires startApplication", async () => {
+    const user = userEvent.setup();
+    render(<CreateApplicatinButton />);
+
+    const appButton = await screen.findByText("Create new application");
+    await user.click(appButton);
+    expect(mockStartApplication).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/utils/getRoutes.test.ts
+++ b/frontend/tests/utils/getRoutes.test.ts
@@ -29,6 +29,7 @@ describe("getNextRoutes", () => {
       "/dev/feature-flags",
       "/error",
       "/formPrototype/1",
+      "/formPrototype",
       "/formPrototype/success",
       "/health",
       "/login",


### PR DESCRIPTION
## Summary
Fixes #4340

### Time to review: __25 mins__

## Changes proposed

This wires us the application and form pages.


### NOTES

* Competition ID is hardcoded throughout this prototype.
* the form submit is not wired up yet, that is handled in #4342 

### To QA

1. visit http://localhost:3000/formPrototype 
  * click "Create new application"
2. user should be directed to http://localhost:3001/formPrototype/2451c15c-3cbc-4c5a-83cd-f0e5e69f292c
  * this is the list of forms for a competition, which is hardcoded
  * this in the "application" page, the application ID is necessary
  *  click "[redefine out-of-the-box schemas](http://localhost:3001/formPrototype/2451c15c-3cbc-4c5a-83cd-f0e5e69f292c/17aba328-ed2b-4644-9322-d348ad0b1b3e)"
  * "redefine out-of-the-box schemas" is the name of the test form
3. user should be directed to the test form
  * form has no required fields, so no there is no meaningful validation
  * click submit and be directed to the form success page 