### PR TITLE
[no ticket] Remove evidently vpc endpoints

### DIFF
--- a/infra/modules/network/vpc_endpoints.tf
+++ b/infra/modules/network/vpc_endpoints.tf
@@ -13,9 +13,6 @@ locals {
     # AWS service endpoint(s) reccommended by AWS for all VPCs
     ["ec2"],
 
-    # Feature flags with AWS Evidently
-    ["evidently", "evidently-dataplane"],
-
     # AWS services used by the database's role manager
     var.has_database ? ["ssm", "kms", "secretsmanager"] : [],
 


### PR DESCRIPTION
## Context

I was looking for things that cost too much money, and we don't use evidently at all. In fact, its deprecated.