### PR TITLE
[Issue #4490] Address anchore flagged libs

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update \
     wget \
     libtasn1-6 \
     libgnutls30 \
+    liblzma5 \
+    xz-utils \
   # Reduce the image size by clear apt cached lists
   # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
   && rm -fr /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary
Fixes #4490

### Time to review: __2 mins__

## Changes proposed
Force install the two failing packages which should get latest patches that update command doesn't get (because they're super new and not vetted yet?)

