### PR TITLE
[no ticket] enable readonly root filesystem for analytics

### DIFF
--- a/infra/analytics/service/main.tf
+++ b/infra/analytics/service/main.tf
@@ -166,7 +166,7 @@ module "service" {
   } : null
 
   enable_load_balancer     = false
-  readonly_root_filesystem = false
+  readonly_root_filesystem = true
 
   extra_environment_variables = merge(
     {


### PR DESCRIPTION
## Contex

1. Having a writeable root filesystem is a security concern

2. As of https://github.com/HHS/simpler-grants-gov/pull/3799 we don't need one anymore