### PR TITLE
[Issue #4452] Further attempts to prevent saved items caching 

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -76,6 +76,27 @@ const nextConfig = {
           },
         ],
       },
+      // don't cache user specific pages: saved-grants, saved-search-queries
+      {
+        source: "/saved:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, must-revalidate",
+          },
+        ],
+      },
+      // don't cache if users has a session cookie
+      {
+        source: "/:path*",
+        has: [{ type: "cookie", key: "session" }],
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store, must-revalidate",
+          },
+        ],
+      },
     ];
   },
   basePath,


### PR DESCRIPTION
## Summary
Fixes #4452

### Time to review: __5 mins__

## Changes proposed
Use NextJS config to prevent pages we want to always re-render from caching. You don't see the effect of this in npm run dev have to build & start.

Context for reviewers
This is really tough to test, but the Cache-Control headers are better behaved under build & start following this change so 🤞🏻
