### PR TITLE
[Issue #4174] Update GET /applications/:applicationId/application_form/:appFormId to include JsonSchema validations

### DIFF
--- a/api/src/api/application_alpha/application_route.py
+++ b/api/src/api/application_alpha/application_route.py
@@ -14,6 +14,7 @@ from src.api.application_alpha.application_schemas import (
     ApplicationStartResponseSchema,
 )
 from src.auth.api_key_auth import api_key_auth
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 from src.services.applications.create_application import create_application
 from src.services.applications.get_application import get_application
@@ -90,13 +91,33 @@ def application_form_get(
     )
     logger.info("GET /alpha/applications/:application_id/application_form/:app_form_id")
 
+    validation_warnings = []
+
     with db_session.begin():
         application_form = get_application_form(db_session, application_id, app_form_id)
 
-    # Return the application form data
+        # Validate the form data against the JSON schema
+        if application_form and hasattr(application_form, "form") and application_form.form:
+            try:
+                # Run validation on the application response
+                if application_form.application_response is not None:
+                    validation_warnings = validate_json_schema_for_form(
+                        application_form.application_response, application_form.form
+                    )
+            except Exception as e:
+                # Log the exception but continue
+                logger.exception(
+                    "Error validating application form data against schema",
+                    extra={
+                        "application_form_id": app_form_id,
+                        "application_id": application_id,
+                    },
+                )
+
     return response.ApiResponse(
         message="Success",
         data=application_form,
+        warnings=validation_warnings,
     )
 
 

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -602,3 +602,104 @@ def test_application_get_unauthorized(client, enable_factory_create, db_session)
     )
 
     assert response.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "application_response,expected_warnings",
+    [
+        # Valid data - no warnings
+        ({"name": "John Doe", "age": 30}, []),
+        # Missing required field
+        ({}, [{"field": "$", "message": "'name' is a required property", "type": "required"}]),
+        # Validation on age field
+        (
+            {"name": "bob", "age": 500},
+            [
+                {
+                    "field": "$.age",
+                    "message": "500 is greater than the maximum of 200",
+                    "type": "maximum",
+                }
+            ],
+        ),
+    ],
+)
+def test_application_form_get_with_validation_warnings(
+    client,
+    enable_factory_create,
+    db_session,
+    api_auth_token,
+    application_response,
+    expected_warnings,
+):
+    """Test that GET application form endpoint includes schema validation warnings"""
+    # Create a form with our test schema
+    form = FormFactory.create(form_json_schema=SIMPLE_JSON_SCHEMA)
+
+    # Create application with the form
+    application = ApplicationFactory.create()
+
+    CompetitionFormFactory.create(
+        competition=application.competition,
+        form=form,
+    )
+
+    # Create application form with the test response data
+    application_form = ApplicationFormFactory.create(
+        application=application,
+        form=form,
+        application_response=application_response,
+    )
+
+    # Make the GET request
+    response = client.get(
+        f"/alpha/applications/{application.application_id}/application_form/{application_form.application_form_id}",
+        headers={"X-Auth": api_auth_token},
+    )
+
+    # Verify response
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert response.json["data"]["application_form_id"] == str(application_form.application_form_id)
+    assert response.json["data"]["application_response"] == application_response
+    assert response.json["warnings"] == expected_warnings
+
+
+def test_application_form_get_with_invalid_schema(
+    client,
+    enable_factory_create,
+    db_session,
+    api_auth_token,
+):
+    """Test behavior when form has an invalid JSON schema"""
+    # Create a form with intentionally invalid schema
+    form = FormFactory.create(form_json_schema={"properties": ["bad"]})
+
+    # Create application with the form
+    application = ApplicationFactory.create()
+
+    CompetitionFormFactory.create(
+        competition=application.competition,
+        form=form,
+    )
+
+    # Create application form with some data
+    application_form = ApplicationFormFactory.create(
+        application=application,
+        form=form,
+        application_response={"name": "Test Name"},
+    )
+
+    # Make the GET request
+    response = client.get(
+        f"/alpha/applications/{application.application_id}/application_form/{application_form.application_form_id}",
+        headers={"X-Auth": api_auth_token},
+    )
+
+    # Should return the data but with empty warnings (handled exception)
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert response.json["data"]["application_form_id"] == str(application_form.application_form_id)
+    assert (
+        response.json["warnings"] == []
+    )  # No warnings since validation was skipped due to invalid schema


### PR DESCRIPTION
## Summary
Fixes #4174 

### Time to review: 10 mins

## Changes proposed
- Run `validate_json_schema_for_form` inside `application_form_get`
- Add tests

## Context for reviewers
Form data is now validated against its schema and any validation issues are returned as warnings in the response. The implementation includes proper error handling for invalid schemas and comprehensive test coverage for various validation scenarios.

## Additional information
Is exception handing in the route correct?
