### PR TITLE
[Isssue #4342] Add save to form prototype

### DIFF
--- a/frontend/src/app/[locale]/formPrototype/[applicationId]/[formId]/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/[applicationId]/[formId]/page.tsx
@@ -84,8 +84,9 @@ async function FormPage({ params }: formPageProps) {
 
   const emptyApplicationForm = {
     application_response: {},
-    application_form_id: "",
   };
+  // TODO: this currently calls all forms for an application since we don't
+  // have the app_form_id in the path.
   const applicationForm =
     applicationData.application_forms.length > 0
       ? (applicationData.application_forms.find(

--- a/frontend/src/app/[locale]/formPrototype/[applicationId]/[formId]/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/[applicationId]/[formId]/page.tsx
@@ -3,7 +3,12 @@ import TopLevelError from "src/app/[locale]/error/page";
 import NotFound from "src/app/[locale]/not-found";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
+import { getApplicationDetails } from "src/services/fetch/fetchers/applicationFetcher";
 import { getFormDetails } from "src/services/fetch/fetchers/formsFetcher";
+import {
+  ApplicationDetail,
+  ApplicationFormDetail,
+} from "src/types/applicationResponseTypes";
 import { FormDetail } from "src/types/formResponseTypes";
 
 import { redirect } from "next/navigation";
@@ -31,31 +36,71 @@ interface formPageProps {
 }
 
 async function FormPage({ params }: formPageProps) {
-  const { formId } = await params;
+  const { applicationId, formId } = await params;
   let formData = {} as FormDetail;
+  let applicationData = {} as ApplicationDetail;
 
   try {
     const response = await getFormDetails(formId);
     if (response.status_code !== 200) {
-      throw new Error(
-        `Error retrieving competition details: ${JSON.stringify(response.errors)}`,
+      console.error(
+        `Error retrieving form details for formID (${formId})`,
+        response,
       );
+      return <TopLevelError />;
     }
     formData = response.data;
-  } catch (error) {
-    if (parseErrorStatus(error as ApiRequestError) === 404) {
+  } catch (e) {
+    console.error(
+      `Error retrieving application details for formId ${formId}:`,
+      e,
+    );
+    if (parseErrorStatus(e as ApiRequestError) === 404) {
       return <NotFound />;
     }
-    throw error;
+    return <TopLevelError />;
   }
 
+  try {
+    const response = await getApplicationDetails(applicationId);
+    if (response.status_code !== 200) {
+      console.error(
+        `Error retrieving form details for applicationID (${applicationId}), formID (${formId})`,
+        response,
+      );
+      return <TopLevelError />;
+    }
+    applicationData = response.data;
+  } catch (e) {
+    if (parseErrorStatus(e as ApiRequestError) === 404) {
+      console.error(
+        `Error retrieving application details for applicationID (${applicationId}), formId ${formId}:`,
+        e,
+      );
+      return <NotFound />;
+    }
+    return <TopLevelError />;
+  }
+
+  const emptyApplicationForm = {
+    application_response: {},
+    application_form_id: "",
+  };
+  const applicationForm =
+    applicationData.application_forms.length > 0
+      ? (applicationData.application_forms.find(
+          (form) => form.form_id === formId,
+        ) as ApplicationFormDetail)
+      : emptyApplicationForm;
+
+  const { application_response } = applicationForm;
   const { form_id, form_name, form_json_schema, form_ui_schema } = formData;
 
   try {
     validateUiSchema(form_ui_schema);
     validateFormSchema(form_json_schema);
-  } catch (error) {
-    console.error("Error validating", error);
+  } catch (e) {
+    console.error("Error validating form", e);
     return <TopLevelError />;
   }
 
@@ -77,9 +122,11 @@ async function FormPage({ params }: formPageProps) {
         ).
       </p>
       <ApplyForm
+        rawFormData={application_response}
         formSchema={form_json_schema}
         uiSchema={form_ui_schema}
         formId={form_id}
+        applicationId={applicationId}
       />
     </GridContainer>
   );

--- a/frontend/src/app/[locale]/formPrototype/[applicationId]/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/[applicationId]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import TopLevelError from "src/app/[locale]/error/page";
 import NotFound from "src/app/[locale]/not-found";
 import { COMPETITION_ID } from "src/constants/competitions";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
@@ -58,16 +59,22 @@ async function ApplicationLandingPage({ params }: ApplicationLandingPageProps) {
   try {
     const response = await getCompetitionDetails(COMPETITION_ID);
     if (response.status_code !== 200) {
-      throw new Error(
-        `Error retrieving competition details: ${JSON.stringify(response.errors)}`,
+      console.error(
+        `Error retrieving competition details for competitionId (${COMPETITION_ID})`,
+        response,
       );
+      return <TopLevelError />;
     }
     forms = response.data.competition_forms;
-  } catch (error) {
-    if (parseErrorStatus(error as ApiRequestError) === 404) {
+  } catch (e) {
+    if (parseErrorStatus(e as ApiRequestError) === 404) {
+      console.error(
+        `Error retrieving competition details for competitionId (${COMPETITION_ID})`,
+        e,
+      );
       return <NotFound />;
     }
-    throw error;
+    return <TopLevelError />;
   }
 
   return (

--- a/frontend/src/app/[locale]/formPrototype/success/page.tsx
+++ b/frontend/src/app/[locale]/formPrototype/success/page.tsx
@@ -3,7 +3,7 @@ import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import { WithFeatureFlagProps } from "src/types/uiTypes";
 
 import { redirect } from "next/navigation";
-import { GridContainer } from "@trussworks/react-uswds";
+import { Alert, GridContainer } from "@trussworks/react-uswds";
 
 import BetaAlert from "src/components/BetaAlert";
 
@@ -20,7 +20,13 @@ function FormSuccess() {
     <GridContainer>
       <BetaAlert />
       <h1>Form Demo Success</h1>
-      You successfully submitted the form.
+      <Alert
+        heading="Successful form submission"
+        headingLevel="h3"
+        type="success"
+      >
+        You successfully submitted the form.
+      </Alert>
     </GridContainer>
   );
 }

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -4,51 +4,71 @@ import { RJSFSchema } from "@rjsf/utils";
 import { useFormStatus } from "react-dom";
 
 import { useActionState } from "react";
-import { Button, FormGroup } from "@trussworks/react-uswds";
+import { Button, Fieldset, FormGroup } from "@trussworks/react-uswds";
 
 import { submitApplyForm } from "./actions";
 import { ApplyFormErrorMessage } from "./ApplyFormErrorMessage";
 import ApplyFormNav from "./ApplyFormNav";
+import { ApplyFormSuccessMessage } from "./ApplyFormSuccessMessage";
 import { UiSchema } from "./types";
 import { buildForTreeRecursive, getWrappersForNav } from "./utils";
 
 const ApplyForm = ({
-  formSchema,
-  uiSchema,
+  applicationId,
   formId,
+  formSchema,
+  rawFormData,
+  uiSchema,
 }: {
-  formSchema: RJSFSchema;
-  uiSchema: UiSchema;
+  applicationId: string;
   formId: string;
+  formSchema: RJSFSchema;
+  rawFormData?: object;
+  uiSchema: UiSchema;
 }) => {
   const { pending } = useFormStatus();
 
   const [formState, formAction] = useActionState(submitApplyForm, {
+    applicationId,
     errorMessage: "",
-    validationErrors: [],
-    formData: new FormData(),
     formId,
+    formData: new FormData(),
+    successMessage: "",
+    validationErrors: [],
   });
 
-  const { errorMessage, validationErrors, formData } = formState;
-  const formObject = Object.fromEntries(formData.entries());
-  const fields = buildForTreeRecursive(
-    formSchema,
+  const { formData, errorMessage, successMessage, validationErrors } =
+    formState;
+  const formObject = rawFormData || Object.fromEntries(formData.entries());
+  const fields = buildForTreeRecursive({
+    errors: validationErrors,
+    formData: formObject,
+    schema: formSchema,
     uiSchema,
-    validationErrors,
-    formObject,
-  );
+  });
   const navFields = getWrappersForNav(uiSchema);
   return (
     <div className="usa-in-page-nav-container flex-justify">
-      {navFields.length > 0 && <ApplyFormNav fields={navFields} />}
-      <form action={formAction}>
+      <ApplyFormNav fields={navFields} />
+      <form className="usa-form usa-form-large flex-1" action={formAction}>
+        <ApplyFormSuccessMessage message={successMessage} />
         <ApplyFormErrorMessage
-          heading={errorMessage}
+          message={errorMessage}
           errors={validationErrors}
         />
-        <FormGroup>{fields}</FormGroup>
+        <FormGroup>
+          <Fieldset legendStyle="large">{fields}</Fieldset>
+        </FormGroup>
         <p>
+          <Button
+            data-testid="apply-form-save"
+            type="submit"
+            secondary
+            name="apply-form-button"
+            value="save"
+          >
+            {pending ? "Saving..." : "Save"}
+          </Button>
           <Button
             data-testid="apply-form-submit"
             onClick={() =>
@@ -56,6 +76,8 @@ const ApplyForm = ({
                 ? window.scrollTo({ top: 0, behavior: "smooth" })
                 : undefined
             }
+            name="apply-form-button"
+            value="submit"
             type="submit"
           >
             {pending ? "Submitting..." : "Submit"}

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -6,7 +6,7 @@ import { useFormStatus } from "react-dom";
 import { useActionState } from "react";
 import { Button, Fieldset, FormGroup } from "@trussworks/react-uswds";
 
-import { submitApplyForm } from "./actions";
+import { handleFormAction } from "./actions";
 import { ApplyFormErrorMessage } from "./ApplyFormErrorMessage";
 import ApplyFormNav from "./ApplyFormNav";
 import { ApplyFormSuccessMessage } from "./ApplyFormSuccessMessage";
@@ -28,7 +28,7 @@ const ApplyForm = ({
 }) => {
   const { pending } = useFormStatus();
 
-  const [formState, formAction] = useActionState(submitApplyForm, {
+  const [formState, formAction] = useActionState(handleFormAction, {
     applicationId,
     errorMessage: "",
     formId,

--- a/frontend/src/components/applyForm/ApplyFormErrorMessage.tsx
+++ b/frontend/src/components/applyForm/ApplyFormErrorMessage.tsx
@@ -3,15 +3,15 @@ import { ErrorObject } from "ajv";
 import { Alert } from "@trussworks/react-uswds";
 
 export const ApplyFormErrorMessage = ({
-  heading,
+  message,
   errors,
 }: {
-  heading: string;
+  message: string;
   errors: ErrorObject<string, Record<string, unknown>, unknown>[];
 }) => {
   return (
     errors.length > 0 && (
-      <Alert heading={heading} headingLevel="h3" type="error">
+      <Alert heading={message} headingLevel="h3" type="error">
         This form has {errors.length} errors.
       </Alert>
     )

--- a/frontend/src/components/applyForm/ApplyFormNav.tsx
+++ b/frontend/src/components/applyForm/ApplyFormNav.tsx
@@ -13,18 +13,20 @@ const ApplyFormNav = ({
     </li>
   ));
   return (
-    <aside
-      className="usa-in-page-nav top-3"
-      aria-label="On this form"
-      data-testid="InPageNavigation"
-    >
-      <nav className="usa-in-page-nav__nav">
-        <h4 className="usa-in-page-nav__heading" tabIndex={0}>
-          On this form
-        </h4>
-        <ul className="usa-in-page-nav__list">{Links}</ul>
-      </nav>
-    </aside>
+    fields.length > 0 && (
+      <aside
+        className="usa-in-page-nav top-3"
+        aria-label="On this form"
+        data-testid="InPageNavigation"
+      >
+        <nav className="usa-in-page-nav__nav">
+          <h4 className="usa-in-page-nav__heading" tabIndex={0}>
+            On this form
+          </h4>
+          <ul className="usa-in-page-nav__list">{Links}</ul>
+        </nav>
+      </aside>
+    )
   );
 };
 

--- a/frontend/src/components/applyForm/ApplyFormSuccessMessage.tsx
+++ b/frontend/src/components/applyForm/ApplyFormSuccessMessage.tsx
@@ -1,0 +1,11 @@
+import { Alert } from "@trussworks/react-uswds";
+
+export const ApplyFormSuccessMessage = ({ message }: { message: string }) => {
+  return (
+    message && (
+      <Alert heading={message} headingLevel="h3" type="success">
+        Form succesfully saved.
+      </Alert>
+    )
+  );
+};

--- a/frontend/src/components/applyForm/actions.ts
+++ b/frontend/src/components/applyForm/actions.ts
@@ -22,7 +22,7 @@ type applyFormResponse = {
   successMessage: string;
 };
 
-export async function submitApplyForm(
+export async function handleFormAction(
   _prevState: applyFormResponse & applyFormErrors,
   formData: FormData,
 ) {

--- a/frontend/src/components/applyForm/actions.ts
+++ b/frontend/src/components/applyForm/actions.ts
@@ -1,71 +1,145 @@
 "use server";
 
 import { ErrorObject } from "ajv";
-import { ApiRequestError, parseErrorStatus } from "src/errors";
+import { handleUpdateApplicationForm } from "src/services/fetch/fetchers/applicationFetcher";
 import { getFormDetails } from "src/services/fetch/fetchers/formsFetcher";
+import { ApplicationResponseDetail } from "src/types/applicationResponseTypes";
 import { FormDetail } from "src/types/formResponseTypes";
 
 import { redirect } from "next/navigation";
 
+import { filterFormData } from "./utils";
 import { validateFormData } from "./validate";
 
-type applyFormResponse = {
+type applyFormErrors = {
   errorMessage: string;
   validationErrors: ErrorObject<string, Record<string, unknown>, unknown>[];
+}
+type applyFormResponse = {
+  applicationId: string;
   formData: object;
   formId: string;
+  successMessage: string;
 };
 
 export async function submitApplyForm(
-  _prevState: applyFormResponse,
+  _prevState: applyFormResponse & applyFormErrors,
   formData: FormData,
 ) {
-  const { formId } = _prevState;
-  const { validationErrors, errorMessage } = await applyFormAction(
+  const { formId, applicationId, successMessage } = _prevState;
+  const { validationErrors, errorMessage } = await formValidate({
     formData,
     formId,
-  );
+  });
   if (validationErrors.length) {
     return {
+      applicationId,
       errorMessage,
-      validationErrors,
       formData,
       formId,
+      successMessage,
+      validationErrors,
     };
   } else {
-    redirect(`/formPrototype/success`);
+    const applicationFormData =
+    filterFormData<ApplicationResponseDetail>(formData);
+
+    const saveSuccess = await handleSave(
+      applicationFormData,
+      applicationId,
+      formId,
+    );
+    if (saveSuccess) {
+      if (formData.get("apply-form-button") === "submit") {
+        redirect(`/formPrototype/success`);
+      } else {
+        return {
+          applicationId,
+          errorMessage,
+          formData,
+          formId,
+          successMessage: "Form saved",
+          validationErrors,
+        };
+      }
+    }
+    return {
+      applicationId,
+      errorMessage: "Error saving the form",
+      formData,
+      formId,
+      successMessage,
+      validationErrors,
+    };
   }
 }
 
-export async function applyFormAction(
-  formData: FormData,
+const handleSave = async (
+  applicationFormData: ApplicationResponseDetail,
+  applicationId: string,
   formId: string,
-): Promise<applyFormResponse> {
+) => {
+  try {
+    const resp = await handleUpdateApplicationForm(
+      applicationFormData,
+      applicationId,
+      formId,
+    );
+    if (resp.status_code === 200) {
+      return true;
+    }
+    return false;
+  } catch (e) {
+    console.error(
+      `Error saving the form (${formId}) for application (${applicationId}):`,
+      e,
+    );
+    return false;
+  }
+};
+
+async function formValidate({
+  formData,
+  formId,
+}: {
+  formData: FormData;
+  formId: string;
+}): Promise<applyFormErrors> {
   let formSchema = <FormDetail>{};
   try {
     const response = await getFormDetails(formId);
-    formSchema = response.data;
-  } catch (error) {
-    if (parseErrorStatus(error as ApiRequestError) === 404) {
-      throw new Error();
+    if (response.status_code!==200) {
+      console.error(
+        `Error retrieving form details for formID (${formId})`,
+        response,
+      );
+      return {
+        errorMessage: "Error submitting form",
+        validationErrors: [],
+      };
     }
-    throw error;
+    formSchema = response.data;
+  } catch (e) {
+    console.error(
+      `Error retrieving form details for formID (${formId})`,
+      e,
+    );
+    return {
+      errorMessage: "Error submitting form",
+      validationErrors: [],
+    };
   }
 
   const errors = validateFormData(formData, formSchema.form_json_schema);
   if (errors) {
     return {
-      validationErrors: errors,
       errorMessage: "Error submitting form",
-      formData,
-      formId,
+      validationErrors: errors,
     };
   } else {
     return {
-      validationErrors: [],
       errorMessage: "",
-      formData,
-      formId,
+      validationErrors: [],
     };
   }
 }

--- a/frontend/src/components/applyForm/actions.ts
+++ b/frontend/src/components/applyForm/actions.ts
@@ -14,7 +14,7 @@ import { validateFormData } from "./validate";
 type applyFormErrors = {
   errorMessage: string;
   validationErrors: ErrorObject<string, Record<string, unknown>, unknown>[];
-}
+};
 type applyFormResponse = {
   applicationId: string;
   formData: object;
@@ -42,7 +42,7 @@ export async function submitApplyForm(
     };
   } else {
     const applicationFormData =
-    filterFormData<ApplicationResponseDetail>(formData);
+      filterFormData<ApplicationResponseDetail>(formData);
 
     const saveSuccess = await handleSave(
       applicationFormData,
@@ -108,7 +108,7 @@ async function formValidate({
   let formSchema = <FormDetail>{};
   try {
     const response = await getFormDetails(formId);
-    if (response.status_code!==200) {
+    if (response.status_code !== 200) {
       console.error(
         `Error retrieving form details for formID (${formId})`,
         response,
@@ -120,10 +120,7 @@ async function formValidate({
     }
     formSchema = response.data;
   } catch (e) {
-    console.error(
-      `Error retrieving form details for formID (${formId})`,
-      e,
-    );
+    console.error(`Error retrieving form details for formID (${formId})`, e);
     return {
       errorMessage: "Error submitting form",
       validationErrors: [],

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -208,7 +208,7 @@ const wrapSection = (
     </FieldsetWidget>
   );
 };
-
+// filter and retrieve data from the FormData object
 export const filterFormData = <T extends object>(formData: FormData): T => {
   return Object.fromEntries(
     Array.from(formData.keys())

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -11,12 +11,17 @@ import SelectWidget from "./widgets/SelectWidget";
 import TextareaWidget from "./widgets/TextAreaWidget";
 import TextWidget from "./widgets/TextWidget";
 
-export function buildForTreeRecursive(
-  schema: RJSFSchema,
-  uiSchema: UiSchema,
-  errors: ErrorObject<string, Record<string, unknown>, unknown>[],
-  formData: object,
-) {
+export function buildForTreeRecursive({
+  errors,
+  formData,
+  schema,
+  uiSchema,
+}: {
+  errors: ErrorObject<string, Record<string, unknown>, unknown>[];
+  formData: object;
+  schema: RJSFSchema;
+  uiSchema: UiSchema;
+}) {
   let acc: JSX.Element[] = [];
 
   const buildFormTree = (
@@ -202,4 +207,17 @@ const wrapSection = (
       {tree}
     </FieldsetWidget>
   );
+};
+
+export const filterFormData = <T extends object>(formData: FormData): T => {
+  return Object.fromEntries(
+    Array.from(formData.keys())
+      .filter((key) => !key.startsWith("$ACTION_"))
+      .map((key) => [
+        key,
+        formData.getAll(key).length > 1
+          ? formData.getAll(key)
+          : formData.get(key),
+      ]),
+  ) as T;
 };

--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -68,10 +68,3 @@ export const fetchAgenciesEndpoint = {
   namespace: "agencies",
   method: "POST" as ApiMethod,
 };
-
-export const fetchApplicationsEndpoint = {
-  basePath: environment.API_URL,
-  version: "alpha",
-  namespace: "applications",
-  method: "POST" as ApiMethod,
-};

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -1,21 +1,53 @@
-import { APIResponse } from "src/types/apiResponseTypes";
+import {
+  ApplicationDetailApiResponse,
+  ApplicationFormDetailApiResponse,
+  ApplicationResponseDetail,
+  ApplicationStartApiResponse,
+} from "src/types/applicationResponseTypes";
 
 import { fetchApplicationWithMethod } from "./fetchers";
 
-interface ApplicationStartResponse extends APIResponse {
-  data: {
-    application_id: string;
-  };
-}
-
-// make call from server to API to start an application
 export const handleStartApplication = async (
   competitionID: string,
-): Promise<ApplicationStartResponse> => {
+): Promise<ApplicationStartApiResponse> => {
   const response = await fetchApplicationWithMethod("POST")({
     subPath: `start`,
     body: { competition_id: competitionID },
   });
 
-  return (await response.json()) as ApplicationStartResponse;
+  return (await response.json()) as ApplicationStartApiResponse;
+};
+
+export const getApplicationDetails = async (
+  applicationId: string,
+): Promise<ApplicationDetailApiResponse> => {
+  const response = await fetchApplicationWithMethod("GET")({
+    subPath: applicationId,
+  });
+
+  return (await response.json()) as ApplicationDetailApiResponse;
+};
+
+export const getApplicationFormDetails = async (
+  applicationId: string,
+  applicationFormId: string,
+): Promise<ApplicationFormDetailApiResponse> => {
+  const response = await fetchApplicationWithMethod("GET")({
+    subPath: `${applicationId}/application_form/${applicationFormId}`,
+  });
+
+  return (await response.json()) as ApplicationFormDetailApiResponse;
+};
+
+export const handleUpdateApplicationForm = async (
+  values: ApplicationResponseDetail,
+  applicationId: string,
+  applicationFormId: string,
+): Promise<ApplicationStartApiResponse> => {
+  const response = await fetchApplicationWithMethod("PUT")({
+    subPath: `${applicationId}/forms/${applicationFormId}`,
+    body: { application_response: values },
+  });
+
+  return (await response.json()) as ApplicationStartApiResponse;
 };

--- a/frontend/src/services/fetch/fetchers/formsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/formsFetcher.ts
@@ -1,11 +1,11 @@
-import { formDetailApiResponse } from "src/types/formResponseTypes";
+import { FormDetailApiResponse } from "src/types/formResponseTypes";
 
 import { fetchForm } from "./fetchers";
 
 export const getFormDetails = async (
   id: string,
-): Promise<formDetailApiResponse> => {
+): Promise<FormDetailApiResponse> => {
   const response = await fetchForm({ subPath: id });
-  const responseBody = (await response.json()) as formDetailApiResponse;
+  const responseBody = (await response.json()) as FormDetailApiResponse;
   return responseBody;
 };

--- a/frontend/src/types/applicationResponseTypes.ts
+++ b/frontend/src/types/applicationResponseTypes.ts
@@ -1,0 +1,32 @@
+import { APIResponse } from "src/types/apiResponseTypes";
+
+export interface ApplicationResponseDetail {
+  [key: string]: string;
+}
+
+export interface ApplicationFormDetail {
+  application_form_id: string;
+  application_id: string;
+  application_response: ApplicationResponseDetail;
+  form_id: string;
+}
+
+export interface ApplicationDetail {
+  application_forms: Array<ApplicationFormDetail>;
+  application_id: string;
+  competition_id: string;
+}
+
+export interface ApplicationStartApiResponse extends APIResponse {
+  data: {
+    application_id: string;
+  };
+}
+
+export interface ApplicationFormDetailApiResponse extends APIResponse {
+  data: ApplicationFormDetail;
+}
+
+export interface ApplicationDetailApiResponse extends APIResponse {
+  data: ApplicationDetail;
+}

--- a/frontend/src/types/formResponseTypes.ts
+++ b/frontend/src/types/formResponseTypes.ts
@@ -10,6 +10,6 @@ export interface FormDetail {
   form_ui_schema: UiSchema;
 }
 
-export interface formDetailApiResponse extends APIResponse {
+export interface FormDetailApiResponse extends APIResponse {
   data: FormDetail;
 }

--- a/frontend/tests/components/applyForm/ApplyForm.test.tsx
+++ b/frontend/tests/components/applyForm/ApplyForm.test.tsx
@@ -4,11 +4,11 @@ import { render, screen } from "@testing-library/react";
 import ApplyForm from "src/components/applyForm/ApplyForm";
 import { UiSchema } from "src/components/applyForm/types";
 
-const mockSubmitApplyForm = jest.fn();
+const mockHandleFormAction = jest.fn();
 
 jest.mock("src/components/applyForm/actions", () => ({
-  submitApplyForm: (...args: unknown[]): unknown =>
-    mockSubmitApplyForm(...args),
+  handleFormAction: (...args: unknown[]): unknown =>
+    mockHandleFormAction(...args),
 }));
 
 const formSchema: RJSFSchema = {
@@ -96,7 +96,7 @@ describe("ApplyForm", () => {
   });
 
   it("calls submitApplyForm action on submit", () => {
-    mockSubmitApplyForm.mockImplementation(() => Promise.resolve());
+    mockHandleFormAction.mockImplementation(() => Promise.resolve());
 
     render(
       <ApplyForm
@@ -111,7 +111,7 @@ describe("ApplyForm", () => {
     const button = screen.getByTestId("apply-form-submit");
     button.click();
 
-    expect(mockSubmitApplyForm).toHaveBeenCalledWith(
+    expect(mockHandleFormAction).toHaveBeenCalledWith(
       {
         applicationId: "test",
         errorMessage: "",

--- a/frontend/tests/components/applyForm/ApplyForm.test.tsx
+++ b/frontend/tests/components/applyForm/ApplyForm.test.tsx
@@ -58,7 +58,13 @@ const uiSchema: UiSchema = [
 describe("ApplyForm", () => {
   it("renders form correctly", () => {
     render(
-      <ApplyForm applicationId="" rawFormData={{name: "myself"}} formSchema={formSchema} uiSchema={uiSchema} formId="test" />,
+      <ApplyForm
+        applicationId=""
+        rawFormData={{ name: "myself" }}
+        formSchema={formSchema}
+        uiSchema={uiSchema}
+        formId="test"
+      />,
     );
 
     const nameLabel = screen.getByText("test name");
@@ -72,7 +78,6 @@ describe("ApplyForm", () => {
     expect(nameField).toHaveAttribute("maxLength", "60");
     expect(nameField).toHaveAttribute("name", "name");
     expect(nameField).toHaveValue("myself");
-
 
     const dobLabel = screen.getByText("Date of birth");
     expect(dobLabel).toBeInTheDocument();
@@ -94,7 +99,13 @@ describe("ApplyForm", () => {
     mockSubmitApplyForm.mockImplementation(() => Promise.resolve());
 
     render(
-      <ApplyForm applicationId="test" rawFormData={{}} formSchema={formSchema} uiSchema={uiSchema} formId="test" />,
+      <ApplyForm
+        applicationId="test"
+        rawFormData={{}}
+        formSchema={formSchema}
+        uiSchema={uiSchema}
+        formId="test"
+      />,
     );
 
     const button = screen.getByTestId("apply-form-submit");

--- a/frontend/tests/components/applyForm/ApplyForm.test.tsx
+++ b/frontend/tests/components/applyForm/ApplyForm.test.tsx
@@ -58,7 +58,7 @@ const uiSchema: UiSchema = [
 describe("ApplyForm", () => {
   it("renders form correctly", () => {
     render(
-      <ApplyForm formSchema={formSchema} uiSchema={uiSchema} formId="test" />,
+      <ApplyForm applicationId="" rawFormData={{name: "myself"}} formSchema={formSchema} uiSchema={uiSchema} formId="test" />,
     );
 
     const nameLabel = screen.getByText("test name");
@@ -71,6 +71,8 @@ describe("ApplyForm", () => {
     expect(nameField).toHaveAttribute("type", "text");
     expect(nameField).toHaveAttribute("maxLength", "60");
     expect(nameField).toHaveAttribute("name", "name");
+    expect(nameField).toHaveValue("myself");
+
 
     const dobLabel = screen.getByText("Date of birth");
     expect(dobLabel).toBeInTheDocument();
@@ -92,7 +94,7 @@ describe("ApplyForm", () => {
     mockSubmitApplyForm.mockImplementation(() => Promise.resolve());
 
     render(
-      <ApplyForm formSchema={formSchema} uiSchema={uiSchema} formId="test" />,
+      <ApplyForm applicationId="test" rawFormData={{}} formSchema={formSchema} uiSchema={uiSchema} formId="test" />,
     );
 
     const button = screen.getByTestId("apply-form-submit");
@@ -100,9 +102,11 @@ describe("ApplyForm", () => {
 
     expect(mockSubmitApplyForm).toHaveBeenCalledWith(
       {
+        applicationId: "test",
         errorMessage: "",
         formData: new FormData(),
         formId: "test",
+        successMessage: "",
         validationErrors: [],
       },
 

--- a/frontend/tests/components/applyForm/widgets/TextWidget.test.tsx
+++ b/frontend/tests/components/applyForm/widgets/TextWidget.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import TextWidget from "src/components/applyForm/widgets/TextWidget";
 
@@ -16,6 +16,8 @@ const WidgetProps = {
   required: undefined,
   options: {},
 };
+
+const mockOnChange = jest.fn();
 
 describe("TextWidget", () => {
   it("renders the value content and title", () => {
@@ -49,6 +51,36 @@ describe("TextWidget", () => {
     expect(input).toHaveAttribute("type", "email");
   });
 
+  it("renders number input type", async () => {
+    const props = {
+      ...WidgetProps,
+      schema: { ...WidgetProps.schema, type: "number" as const},
+    };
+    render(<TextWidget {...props} />);
+    const input = await screen.findByTestId("test");
+    expect(input).toHaveAttribute("type", "number");
+  });
+
+  it("renders password input type", async () => {
+    const props = {
+      ...WidgetProps,
+      schema: { ...WidgetProps.schema, format: "password"},
+    };
+    render(<TextWidget {...props} />);
+    const input = await screen.findByTestId("test");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("renders date input type", async () => {
+    const props = {
+      ...WidgetProps,
+      schema: { ...WidgetProps.schema, format: "date"},
+    };
+    render(<TextWidget {...props} />);
+    const input = await screen.findByTestId("test");
+    expect(input).toHaveAttribute("type", "date");
+  });
+
   it("renders datalist when examples are provided", () => {
     const props = {
       ...WidgetProps,
@@ -61,17 +93,6 @@ describe("TextWidget", () => {
   });
 
   it("ignores onChange event", () => {
-    const mockOnChange = jest.fn();
-    const props = { ...WidgetProps, onChange: mockOnChange };
-    render(<TextWidget {...props} />);
-    const input = screen.getByRole("textbox");
-    input.focus();
-    input.blur();
-    expect(mockOnChange).not.toHaveBeenCalled();
-  });
-
-  it("handles onChange event", () => {
-    const mockOnChange = jest.fn();
     const props = {
       ...WidgetProps,
       onChange: mockOnChange,
@@ -82,5 +103,36 @@ describe("TextWidget", () => {
     input.focus();
     input.blur();
     expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it("handles onBlur, onFocus events", () => {
+    const mockOnBlur = jest.fn();
+    const mockOnFocus = jest.fn();
+    const props = {
+      ...WidgetProps,
+      onBlur: mockOnBlur,
+      onFocus: mockOnFocus,
+      updateOnInput: true,
+    };
+    render(<TextWidget {...props} />);
+    const input = screen.getByRole("textbox");
+    input.focus();
+    input.blur();
+    expect(mockOnBlur).toHaveBeenCalled();
+    expect(mockOnFocus).toHaveBeenCalled();
+
+  });
+
+  it("handles onChange event", () => {
+    const props = {
+      ...WidgetProps,
+      onChange: mockOnChange,
+      updateOnInput: true,
+    };
+    render(<TextWidget {...props} />);
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: '123' } });
+    expect(mockOnChange).toHaveBeenCalled();
   });
 });

--- a/frontend/tests/components/applyForm/widgets/TextWidget.test.tsx
+++ b/frontend/tests/components/applyForm/widgets/TextWidget.test.tsx
@@ -54,7 +54,7 @@ describe("TextWidget", () => {
   it("renders number input type", async () => {
     const props = {
       ...WidgetProps,
-      schema: { ...WidgetProps.schema, type: "number" as const},
+      schema: { ...WidgetProps.schema, type: "number" as const },
     };
     render(<TextWidget {...props} />);
     const input = await screen.findByTestId("test");
@@ -64,7 +64,7 @@ describe("TextWidget", () => {
   it("renders password input type", async () => {
     const props = {
       ...WidgetProps,
-      schema: { ...WidgetProps.schema, format: "password"},
+      schema: { ...WidgetProps.schema, format: "password" },
     };
     render(<TextWidget {...props} />);
     const input = await screen.findByTestId("test");
@@ -74,7 +74,7 @@ describe("TextWidget", () => {
   it("renders date input type", async () => {
     const props = {
       ...WidgetProps,
-      schema: { ...WidgetProps.schema, format: "date"},
+      schema: { ...WidgetProps.schema, format: "date" },
     };
     render(<TextWidget {...props} />);
     const input = await screen.findByTestId("test");
@@ -120,7 +120,6 @@ describe("TextWidget", () => {
     input.blur();
     expect(mockOnBlur).toHaveBeenCalled();
     expect(mockOnFocus).toHaveBeenCalled();
-
   });
 
   it("handles onChange event", () => {
@@ -132,7 +131,7 @@ describe("TextWidget", () => {
     render(<TextWidget {...props} />);
     const input = screen.getByRole("textbox");
 
-    fireEvent.change(input, { target: { value: '123' } });
+    fireEvent.change(input, { target: { value: "123" } });
     expect(mockOnChange).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Fixes #4342

### Time to review: __20 mins__

## Changes proposed

### Form flow
This change adds the save ability to the apply form.

The desired flow is that a user:

1. Starts at /formProtype
2. Clicks "Create new application"
3. Is directed to the "Application" page that has a list of forms (currently one)
4. *Change in this PR*

There is now a "save" button. A user can enter form info and save their place by clicking "Save":

![image](https://github.com/user-attachments/assets/a11f1879-a5be-48e4-b1c3-0f9fe37e55f1)

Clicking "Submit" sends the user to the temporary success page. If you go back after clicking submit you should see values last entered.


## Context for reviewers
Remember this is a demo with no designs.

