### PR TITLE
[Unticketed] Temporary modification to let user force 5xx for Newrelic testing

### DIFF
--- a/api/src/api/agencies_v1/agency_schema.py
+++ b/api/src/api/agencies_v1/agency_schema.py
@@ -96,7 +96,7 @@ class AgencyV1Schema(Schema):
     )
 
     has_active_opportunity = fields.Boolean(
-        default=False,
+        dump_default=False,
         metadata={
             "description": "Indicates if the agency is linked to an opportunity that is currently active.",
             "example": "False",


### PR DESCRIPTION
## Summary

### Time to review: __1 mins__

## Changes proposed
Make it so passing in a specific header causes a 5xx

## Context for reviewers
We make sure to initialize this after logging before_request stuff is done so the route metadata is still attached.

## Additional information
Tested locally with the healthcheck endpoint:
```sh
curl -X 'GET' \
  'http://localhost:8080/health' \
  -H 'accept: application/json' -H 'newrelic-failure-header: FAIL'
```

Produced a few logs, most notably the end request log has a 500:
```
grants-api  | 16:59:57.977  src.logging.flask_logger             _log_end_request             INFO     end request                                        response.status_code=500 response.content_length=158 response.content_type=application/json response.mimetype=application/json response.time_ms=6.371625000610948 app.name=src.app app_name=api run_mode=service environment=local deploy_whoami=local-developer request.id= request.method=GET request.path=/health request.url_rule=/health request.internal_id=e87733cd-3ed5-4441-b000-ac2fe1b09f0e
```
