### PR TITLE
[Issue #4529] Enable opportunity versioning[2/2]

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -17,6 +17,7 @@ locals {
       "--load",
       "--transform",
       "--set-current",
+      "--store-version"
     ],
     staging = [
       "poetry",
@@ -27,6 +28,7 @@ locals {
       "--load",
       "--transform",
       "--set-current",
+      "--store-version"
     ],
     prod = [
       "poetry",
@@ -37,6 +39,7 @@ locals {
       "--load",
       "--transform",
       "--set-current",
+      "--store-version"
     ],
   }
   scheduled_jobs = {


### PR DESCRIPTION
## Summary
Fixes #{[4529](https://github.com/HHS/simpler-grants-gov/issues/4529)}

### Time to review: __5 mins__

## Changes proposed
Enable opportunity versioning task in all env

Tested in dev, staging and prod. All non-draft opportunities have version records in opportunity_version table
