### PR TITLE
[no ticket] Adds back API analytics env vars

### DIFF
--- a/infra/analytics/service/main.tf
+++ b/infra/analytics/service/main.tf
@@ -179,7 +179,8 @@ module "service" {
     },
     # local.identity_provider_environment_variables,
     local.notifications_environment_variables,
-    local.service_config.extra_environment_variables
+    local.service_config.extra_environment_variables,
+    local.api_analytics_bucket_environment_variables
   )
 
   secrets = concat(


### PR DESCRIPTION
## Context

I accidentally removed these env vars from the container while working on other things