### PR TITLE
[Issue #4546] Modify search logic to avoid querying for more than 10k records

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -1426,7 +1426,7 @@ components:
           type:
           - object
           $ref: '#/components/schemas/HasActiveOpportunityFilterV1'
-    SortOrderAgencyPaginationV11:
+    SortOrderAgencySearchPaginationV1:
       type: object
       properties:
         order_by:
@@ -1445,7 +1445,7 @@ components:
       required:
       - order_by
       - sort_direction
-    AgencyPaginationV11:
+    AgencySearchPaginationV1:
       type: object
       properties:
         sort_order:
@@ -1459,7 +1459,7 @@ components:
           items:
             type:
             - object
-            $ref: '#/components/schemas/SortOrderAgencyPaginationV11'
+            $ref: '#/components/schemas/SortOrderAgencySearchPaginationV1'
         page_size:
           type: integer
           minimum: 1
@@ -1500,7 +1500,7 @@ components:
         pagination:
           type:
           - object
-          $ref: '#/components/schemas/AgencyPaginationV11'
+          $ref: '#/components/schemas/AgencySearchPaginationV1'
       required:
       - pagination
     AgencyV1:
@@ -1675,7 +1675,7 @@ components:
             - archived
             type:
             - string
-    AgencySearchFilterV11:
+    AgencyOppSearchFilterV1:
       type: object
       properties:
         one_of:
@@ -1837,7 +1837,7 @@ components:
         agency:
           type:
           - object
-          $ref: '#/components/schemas/AgencySearchFilterV11'
+          $ref: '#/components/schemas/AgencyOppSearchFilterV1'
         assistance_listing_number:
           type:
           - object

--- a/api/src/api/agencies_v1/agency_schema.py
+++ b/api/src/api/agencies_v1/agency_schema.py
@@ -49,7 +49,7 @@ class AgencySearchRequestSchema(Schema):
     filters = fields.Nested(AgencySearchFilterV1Schema())
     pagination = fields.Nested(
         generate_pagination_schema(
-            "AgencyPaginationV1Schema",
+            "AgencySearchPaginationV1Schema",
             ["agency_code", "agency_name"],
             default_sort_order=[{"order_by": "agency_code", "sort_direction": "ascending"}],
         ),

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -354,7 +354,7 @@ class OpportunitySearchFilterV1Schema(Schema):
         .build()
     )
     agency = fields.Nested(
-        StrSearchSchemaBuilder("AgencySearchFilterV1Schema")
+        StrSearchSchemaBuilder("AgencyOppSearchFilterV1Schema")
         .with_one_of(example="USAID", minimum_length=2)
         .build()
     )

--- a/api/src/pagination/pagination_models.py
+++ b/api/src/pagination/pagination_models.py
@@ -65,10 +65,16 @@ class PaginationInfo:
     def from_search_response(
         cls, pagination_params: PaginationParams, search_response: SearchResponse
     ) -> Self:
+        # OpenSearch cannot return records past 10,000, so even if the count
+        # is greater, reduce it to 10,000 exactly.
         total_records = search_response.total_records
         if total_records > 10000:
             total_records = 10000
 
+        # If the total records was reduced, the page count will get reduced
+        # accordingly. It's fine if the last page partially goes over 10k as
+        # in our request building logic to OpenSearch we will make sure this page
+        # fully fits within the 10k.
         total_pages = int(math.ceil(total_records / pagination_params.page_size))
 
         return cls(

--- a/api/src/pagination/pagination_models.py
+++ b/api/src/pagination/pagination_models.py
@@ -1,9 +1,11 @@
 import dataclasses
+import math
 from enum import StrEnum
 from typing import Self
 
 from pydantic import BaseModel, Field
 
+from src.adapters.search.opensearch_response import SearchResponse
 from src.pagination.paginator import Paginator
 
 
@@ -56,5 +58,26 @@ class PaginationInfo:
             total_pages=paginator.total_pages,
             sort_order=[
                 SortOrder(p.order_by, p.sort_direction) for p in pagination_params.sort_order
+            ],
+        )
+
+    @classmethod
+    def from_search_response(
+        cls, pagination_params: PaginationParams, search_response: SearchResponse
+    ) -> Self:
+        total_records = search_response.total_records
+        if total_records > 10000:
+            total_records = 10000
+
+        total_pages = int(math.ceil(total_records / pagination_params.page_size))
+
+        return cls(
+            page_offset=pagination_params.page_offset,
+            page_size=pagination_params.page_size,
+            total_records=total_records,
+            total_pages=total_pages,
+            sort_order=[
+                SortOrder(order_by=p.order_by, sort_direction=p.sort_direction)
+                for p in pagination_params.sort_order
             ],
         )

--- a/api/src/services/agencies_v1/search_agencies.py
+++ b/api/src/services/agencies_v1/search_agencies.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from typing import Sequence, Tuple
 
 from pydantic import BaseModel, Field
@@ -8,12 +7,7 @@ from src.adapters import search
 from src.adapters.search.opensearch_response import SearchResponse
 from src.api.agencies_v1.agency_schema import AgencyV1Schema
 from src.api.opportunities_v1.opportunity_schemas import SearchQueryOperator
-from src.pagination.pagination_models import (
-    PaginationInfo,
-    PaginationParams,
-    SortDirection,
-    SortOrder,
-)
+from src.pagination.pagination_models import PaginationInfo, PaginationParams, SortDirection
 from src.search.search_config import get_search_config
 from src.search.search_models import BoolSearchFilter
 from src.services.agencies_v1.experimental_constant import DEFAULT
@@ -99,16 +93,7 @@ def search_agencies(
 
     params = AgencySearchParams.model_validate(raw_search_params)
     response = _search_agencies(search_client, params)
-    pagination_info = PaginationInfo(
-        page_offset=params.pagination.page_offset,
-        page_size=params.pagination.page_size,
-        total_records=response.total_records,
-        total_pages=int(math.ceil(response.total_records / params.pagination.page_size)),
-        sort_order=[
-            SortOrder(order_by=p.order_by, sort_direction=p.sort_direction)
-            for p in params.pagination.sort_order
-        ],
-    )
+    pagination_info = PaginationInfo.from_search_response(params.pagination, response)
 
     records = SCHEMA.load(response.records, many=True)
 

--- a/api/src/services/opportunities_v1/search_opportunities.py
+++ b/api/src/services/opportunities_v1/search_opportunities.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from typing import Sequence, Tuple
 
 from pydantic import BaseModel, Field
@@ -7,12 +6,7 @@ from pydantic import BaseModel, Field
 import src.adapters.search as search
 from src.adapters.search.opensearch_response import SearchResponse
 from src.api.opportunities_v1.opportunity_schemas import OpportunityV1Schema, SearchQueryOperator
-from src.pagination.pagination_models import (
-    PaginationInfo,
-    PaginationParams,
-    SortDirection,
-    SortOrder,
-)
+from src.pagination.pagination_models import PaginationInfo, PaginationParams, SortDirection
 from src.search.search_config import get_search_config
 from src.search.search_models import (
     BoolSearchFilter,
@@ -204,16 +198,7 @@ def search_opportunities(
     search_params = SearchOpportunityParams.model_validate(raw_search_params)
     response = _search_opportunities(search_client, search_params)
 
-    pagination_info = PaginationInfo(
-        page_offset=search_params.pagination.page_offset,
-        page_size=search_params.pagination.page_size,
-        total_records=response.total_records,
-        total_pages=int(math.ceil(response.total_records / search_params.pagination.page_size)),
-        sort_order=[
-            SortOrder(order_by=p.order_by, sort_direction=p.sort_direction)
-            for p in search_params.pagination.sort_order
-        ],
-    )
+    pagination_info = PaginationInfo.from_search_response(search_params.pagination, response)
 
     # While the data returned is already JSON/dicts like we want to return
     # APIFlask will try to run whatever we return through the deserializers

--- a/api/tests/src/pagination/test_pagination_models.py
+++ b/api/tests/src/pagination/test_pagination_models.py
@@ -1,0 +1,32 @@
+import pytest
+
+from src.adapters.search.opensearch_response import SearchResponse
+from src.pagination.pagination_models import PaginationInfo, PaginationParams
+
+
+@pytest.mark.parametrize(
+    "total_records, page_size, expected_total_records, expected_total_pages",
+    [
+        # Scenarios under 10k total records
+        (517, 25, 517, 21),
+        (5101, 1, 5101, 5101),
+        (9999, 1000, 9999, 10),
+        # Scenarios over 10k total records
+        (13000, 4000, 10000, 3),
+        (15000, 1000, 10000, 10),
+        (10001, 25, 10000, 400),
+        (10001, 1, 10000, 10000),
+    ],
+)
+def test_from_search_response(
+    total_records, page_size, expected_total_records, expected_total_pages
+):
+    pagination_params = PaginationParams(page_offset=1, page_size=page_size)
+    search_response = SearchResponse(
+        total_records=total_records, records=[], aggregations={}, scroll_id=None
+    )
+
+    info = PaginationInfo.from_search_response(pagination_params, search_response)
+
+    assert info.total_records == expected_total_records
+    assert info.total_pages == expected_total_pages


### PR DESCRIPTION
## Summary
Fixes #4546

### Time to review: __10 mins__

## Changes proposed
Modified the logic around parsing the search response to cap the total results at 10k

Modified the logic around creating a request to the search index to prevent a user from asking for anything past 10k

## Context for reviewers
If you try to query a search index for any record past 10k, it will error.

For example, if we tried to do this following query against the search index, it would error saying you tried to ask for record 10005, which is more than 10k. There is no way around this limit in a way that still supports pagination (there is a scroll API, but you have to iterate one page at a time).

```
GET opportunity-index-alias/_search
{
  "size": 10,
  "from": 9995
}
```

To work around this issue, we changed two things:
1. Even if the search index says it has more than 10k results, cap it to 10k (note our metrics for facet counts are not affected by this and can still be more than 10k). This way any user like our frontend that respects the page counts/total records won't hit any issues.
2. If a user does request a page that would go over 10k results then adjust that page's size so it only goes up to 10k, but not past it (in the above example, we'd change the size to `5` and it would work). If they fully request something past 10k, then we'll do a page size of 0, and start from 10k. This keeps a valid request and means things like facet counts still work.

## Additional information
In addition to the unit tests, I loaded more than 10k records into my local search index and queried it with a bunch of things around 10k and couldn't get any errors to happen.

