### PR TITLE
[Issue #4555] Add New Relic support to Analytics code

### DIFF
--- a/.dockleconfig
+++ b/.dockleconfig
@@ -3,4 +3,4 @@
 # DOCKLE_ACCEPT_FILES="file1,path/to/file2,file3/path,etc"
 # https://github.com/goodwithtech/dockle#accept-suspicious-environment-variables--files--file-extensions
 # The apiflask/settings file is a stub file that apiflask creates, and has no sensitive data in. We are ignoring it since it is unused
-DOCKLE_ACCEPT_FILES=api/.venv/lib/python3.13/site-packages/newrelic/api/settings.py,api/.venv/lib/python3.13/site-packages/apiflask/settings.py,analytics/.venv/lib/python3.13/site-packages/jedi/settings.py
+DOCKLE_ACCEPT_FILES=api/.venv/lib/python3.13/site-packages/newrelic/api/settings.py,analytics/.venv/lib/python3.13/site-packages/newrelic/api/settings.py,api/.venv/lib/python3.13/site-packages/apiflask/settings.py,analytics/.venv/lib/python3.13/site-packages/jedi/settings.py

--- a/analytics/local.env
+++ b/analytics/local.env
@@ -1,3 +1,5 @@
+ENVIRONMENT=local
+
 ############################
 # DB Environment Variables #
 ############################
@@ -53,6 +55,9 @@ LOG_FORMAT=human-readable
 
 # Change the message length for the human readable formatter
 # LOG_HUMAN_READABLE_FORMATTER__MESSAGE_WIDTH=50
+
+# Make typer print pretty exceptions locally
+ENABLE_PRETTY_EXCEPTIONS=1
 
 ############################
 # S3

--- a/analytics/newrelic.ini
+++ b/analytics/newrelic.ini
@@ -1,0 +1,206 @@
+# ---------------------------------------------------------------------------
+
+#
+# This file configures the New Relic Python Agent.
+#
+# The path to the configuration file should be supplied to the function
+# newrelic.agent.initialize() when the agent is being initialized.
+#
+# The configuration file follows a structure similar to what you would
+# find for Microsoft Windows INI files. For further information on the
+# configuration file format see the Python ConfigParser documentation at:
+#
+#    http://docs.python.org/library/configparser.html
+#
+# For further discussion on the behaviour of the Python agent that can
+# be configured via this configuration file see:
+#
+#    https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/
+#
+
+# ---------------------------------------------------------------------------
+
+# Here are the settings that are common to all environments.
+
+[newrelic]
+
+# You must specify the license key associated with your New
+# Relic account. This key binds the Python Agent's data to your
+# account in the New Relic service. For more information on
+# storing and generating license keys, see
+# https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key
+# license_key = # Supplied through NEW_RELIC_LICENSE_KEY by AWS SSM.
+
+# The application name. Set this to be the name of your
+# application as you would like it to show up in New Relic UI.
+# The UI will then auto-map instances of your application into a
+# entry on your home dashboard page. You can also specify multiple
+# app names to group your aggregated data. For further details,
+# please see:
+# https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/app-naming/use-multiple-names-app/
+# app_name = # Parameterized by environment at the end of this file.
+
+# When "true", the agent collects performance data about your
+# application and reports this data to the New Relic UI at
+# newrelic.com. This global switch is normally overridden for
+# each environment below.
+monitor_mode = false
+
+# Sets the name of a file to log agent messages to. Whatever you
+# set this to, you must ensure that the permissions for the
+# containing directory and the file itself are correct, and
+# that the user that your web application runs as can write out
+# to the file. If not able to out a log file, it is also
+# possible to say "stderr" and output to standard error output.
+# This would normally result in output appearing in your web
+# server log.
+log_file = stderr
+
+# Sets the level of detail of messages sent to the log file, if
+# a log file location has been provided. Possible values, in
+# increasing order of detail, are: "critical", "error", "warning",
+# "info" and "debug". When reporting any agent issues to New
+# Relic technical support, the most useful setting for the
+# support engineers is "debug". However, this can generate a lot
+# of information very quickly, so it is best not to keep the
+# agent at this level for longer than it takes to reproduce the
+# problem you are experiencing.
+log_level = info
+
+# High Security Mode enforces certain security settings, and prevents
+# them from being overridden, so that no sensitive data is sent to New
+# Relic. Enabling High Security Mode means that request parameters are
+# not collected and SQL can not be sent to New Relic in its raw form.
+# To activate High Security Mode, it must be set to 'true' in this
+# local .ini configuration file AND be set to 'true' in the
+# server-side configuration in the New Relic user interface. For
+# details, see
+# https://docs.newrelic.com/docs/subscriptions/high-security
+high_security = false
+
+# The Python Agent will attempt to connect directly to the New
+# Relic service. If there is an intermediate firewall between
+# your host and the New Relic service that requires you to use a
+# HTTP proxy, then you should set both the "proxy_host" and
+# "proxy_port" settings to the required values for the HTTP
+# proxy. The "proxy_user" and "proxy_pass" settings should
+# additionally be set if proxy authentication is implemented by
+# the HTTP proxy. The "proxy_scheme" setting dictates what
+# protocol scheme is used in talking to the HTTP proxy. This
+# would normally always be set as "http" which will result in the
+# agent then using a SSL tunnel through the HTTP proxy for end to
+# end encryption.
+# proxy_scheme = http
+# proxy_host = hostname
+# proxy_port = 8080
+# proxy_user =
+# proxy_pass =
+
+# The transaction tracer captures deep information about slow
+# transactions and sends this to the UI on a periodic basis. The
+# transaction tracer is enabled by default. Set this to "false"
+# to turn it off.
+transaction_tracer.enabled = true
+
+# The error collector captures information about uncaught
+# exceptions or logged exceptions and sends them to UI for
+# viewing. The error collector is enabled by default. Set this
+# to "false" to turn it off. For more details on errors, see
+# https://docs.newrelic.com/docs/apm/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-or-mark-expected/
+error_collector.enabled = true
+
+# To stop specific errors from reporting to the UI, set this to
+# a space separated list of the Python exception type names to
+# ignore. The exception name should be of the form 'module:class'.
+#
+# Explicitly not on the list for now:
+# - pydantic.error_wrappers:ValidationError (These seem like real coding issues)
+#
+# Note that most of these except for UnsupportedMediaTypeProblem are 400 responses.
+#
+error_collector.ignore_classes =
+
+# Expected errors are reported to the UI but will not affect the
+# Apdex or error rate. To mark specific errors as expected, set this
+# to a space separated list of the Python exception type names to
+# expected. The exception name should be of the form 'module:class'.
+error_collector.expected_classes =
+
+# Browser monitoring is the Real User Monitoring feature of the UI.
+# For those Python web frameworks that are supported, this
+# setting enables the auto-insertion of the browser monitoring
+# JavaScript fragments.
+browser_monitoring.auto_instrument = false
+
+# A thread profiling session can be scheduled via the UI when
+# this option is enabled. The thread profiler will periodically
+# capture a snapshot of the call stack for each active thread in
+# the application to construct a statistically representative
+# call tree. For more details on the thread profiler tool, see
+# https://docs.newrelic.com/docs/apm/apm-ui-pages/events/thread-profiler-tool/
+thread_profiler.enabled = true
+
+# Your application deployments can be recorded through the
+# New Relic REST API. To use this feature provide your API key
+# below then use the `newrelic-admin record-deploy` command.
+# api_key =
+
+# Distributed tracing lets you see the path that a request takes
+# through your distributed system. For more information, please
+# consult our distributed tracing planning guide.
+# https://docs.newrelic.com/docs/transition-guide-distributed-tracing
+distributed_tracing.enabled = false
+
+# When storing errors in database, distributed tracing solution captures the database query
+# and sends the full, unscrubbed message to New Relic. This enablement will ensure that
+# no PII data is captured in messages of new relic.
+strip_exception_messages.enabled = true
+
+# We don't enable application logging, but do decorate the logs with New Relic metadata
+# Instead of forwarding the logs using New Relic, we use a fluentbit sidecar to do that.
+application_logging.enabled = false
+application_logging.forwarding.enabled = false
+application_logging.local_decorating.enabled = false
+
+# ---------------------------------------------------------------------------
+
+#
+# The application environments. These are specific settings which
+# override the common environment settings. The settings related to a
+# specific environment will be used when the environment argument to the
+# newrelic.agent.initialize() function has been defined to be either
+# "local", "staging", "dev", "prod"
+#
+
+[newrelic:local]
+# Don't turn on data reporting by default when running the API locally.
+#
+# To enable New Relic locally, set the following variables:
+# - developer mode: false
+# - monitor_mode: true
+# - license_key: retrieved from New Relic here: https://one.newrelic.com/launcher/api-keys-ui.launcher
+#
+# NOTE: DO NOT COMMIT THE LICENSE KEY IN A GIT COMMIT.
+#
+# Less scary note: do not wrap your license key in quotes, it should look like this:
+#   license_key=1234abcd
+#
+app_name = analytics-local
+developer_mode = false
+monitor_mode = false
+license_key=replace_me
+transaction_tracer.enabled = false
+
+[newrelic:staging]
+app_name = analytics-staging
+monitor_mode = true
+
+[newrelic:prod]
+app_name = analytics-prod
+monitor_mode = true
+
+[newrelic:dev]
+app_name = analytics-dev
+monitor_mode = true
+
+# ---------------------------------------------------------------------------

--- a/analytics/poetry.lock
+++ b/analytics/poetry.lock
@@ -2264,6 +2264,48 @@ files = [
 ]
 
 [[package]]
+name = "newrelic"
+version = "10.7.0"
+description = "New Relic Python Agent"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "newrelic-10.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08e959814e0b23a8f96383955cceecb6180dc66f240279c45ee8484058f96eb4"},
+    {file = "newrelic-10.7.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e12b7e88e0d78497b4e3dfca0411a76a548ee15842b9d6ef971035bbdc91693"},
+    {file = "newrelic-10.7.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4125d02c016c3b4a0f88d5ce184d78d4101531d1f76525f7f1ee750e453603f1"},
+    {file = "newrelic-10.7.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:680a75e3dd37e86bf1eef2b77408dd1953c94a7b803b56e6f8c3f42164580e35"},
+    {file = "newrelic-10.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:877b53049be9dfb3ad2845f00c57a3eb1aadeaec700f09a8f6c7fec1f6e71c2b"},
+    {file = "newrelic-10.7.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f02916527900f6d209682d3dd77c964fb38ca7d84c31a293085e4a84fa35957d"},
+    {file = "newrelic-10.7.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:683b5158203e28e46b348f9657054eb25cfb7367e21524a457235d9c5a5cc4ed"},
+    {file = "newrelic-10.7.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dac3003f22e1edd564f7d7556c84f1fb2f61140c46040befa626bdc8f69a4a89"},
+    {file = "newrelic-10.7.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fd86115079045e5a9630168ae1a48fdef7f2782c9268d1f04a7ae7716a6129d"},
+    {file = "newrelic-10.7.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecf6a0b560b10c72fd592c1dcb6ea8812e7876d6e30709b6c5184fdd4e399d62"},
+    {file = "newrelic-10.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:30b1c668beb12b9627bac6b037f9a2e3f374e678a75c57f63566a4a7ea055e9e"},
+    {file = "newrelic-10.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9319828bc2b46b9a25a88a97fab1a9e05a4c9d4bed484206f59e04e2f7cbd1cd"},
+    {file = "newrelic-10.7.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6855485d0de0f02271f67617c7a63b44c44f46e50763f37a016a1a117ae8af56"},
+    {file = "newrelic-10.7.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e78adc209e24cc223ac19104616caa3b8cb789d1ed97d082472d3b7e9d04023d"},
+    {file = "newrelic-10.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc1f090a115688fe7829e7aea1dcf37913a24450813908d9ce6b4eb0831cbbbf"},
+    {file = "newrelic-10.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cf6b8f12abf9c984a4e62b0de66d85e2c5153f367dd6d4149544d931e59bcb8d"},
+    {file = "newrelic-10.7.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64708227cf2d56f96f1d2697b23cc5be4952bbd790f0ba63164bedcdbbb457fc"},
+    {file = "newrelic-10.7.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a03832922d05530088aab9acb84bc7758cc8196305852652abb6face3c346ede"},
+    {file = "newrelic-10.7.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:e97b3239159d9a178c07043e9da56e841de2b56b947070b7038ddcb93f99fba0"},
+    {file = "newrelic-10.7.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:32f089e276f36b73de62c61ba7648d77de70893fe4d9a7c15f95e20f4978f461"},
+    {file = "newrelic-10.7.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83bdce11a0a5929ed5ab5db420f54224662c97fbce4fb6efbe27633ad54d30e2"},
+    {file = "newrelic-10.7.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a6b906d8098cd15639f02152a3c94c879c5a841b177b7ee2e6e13ca3a0f37cf"},
+    {file = "newrelic-10.7.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:96f805812a912a8a4008b6f28e109e0d8943c80dd136980a9d3914be5e75a416"},
+    {file = "newrelic-10.7.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:8d47f6041c3f28844eaa9cdf0905415fe5fc617ee6623c391532830a1205133e"},
+    {file = "newrelic-10.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ad5b78a6997ce237185e3911d9a616de0781f600031d53ecce1edeafcca0c79"},
+    {file = "newrelic-10.7.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:772a3c1b5fae12253629771cf677197be48c481c4c6ee7a6233a469dc7e37057"},
+    {file = "newrelic-10.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:650e1818ee404ace26efb2935e6326dbcbf754fbea496710da3889e224c4bcf1"},
+    {file = "newrelic-10.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:fd2f3d2d290555764b587d35700069581dece2158b73e865f9adc6ccbba4375b"},
+    {file = "newrelic-10.7.0.tar.gz", hash = "sha256:ac9716c115ddcf54b54115391a84ed2c318ae943b4f598b4d0248cd6edb12414"},
+]
+
+[package.extras]
+infinite-tracing = ["grpcio", "protobuf"]
+
+[[package]]
 name = "notebook"
 version = "7.3.2"
 description = "Jupyter Notebook - A web-based notebook environment for interactive computing"
@@ -4225,4 +4267,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13"
-content-hash = "01e20bb10394c52eb07ef75fbbb1557a9ac67a9808eb8501e0c9aa859ed91060"
+content-hash = "297b6fec7b000939877e800743af9e8070537ce940853524c86537e582249a02"

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -5,6 +5,7 @@ name = "simpler-grants-gov-analytics"
 packages = [{ include = "analytics", from = "src" }]
 readme = "README.md"
 version = "0.1.0"
+include = ["newrelic.ini"]
 
 [tool.poetry.scripts]
 analytics = "analytics.cli:app"
@@ -28,6 +29,7 @@ boto3 = "^1.35.56"
 boto3-stubs = "^1.35.56"
 psycopg = "^3.2.3"
 smart-open = "^7.0.5"
+newrelic = "10.7.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"
@@ -50,7 +52,7 @@ python_version = "3.12"
 
 [[tool.mypy.overrides]]
 ignore_missing_imports = true
-module = ["plotly.*", "dynaconf.*"]
+module = ["plotly.*", "dynaconf.*", "newrelic.*"]
 
 [tool.pylint."MESSAGE CONTROL"]
 disable = [

--- a/analytics/src/analytics/logs/app_logger.py
+++ b/analytics/src/analytics/logs/app_logger.py
@@ -17,6 +17,8 @@ Usage:
 import logging
 import os
 
+import newrelic.api.time_trace
+
 EXTRA_LOG_DATA_ATTR = "extra_log_data"
 
 _GLOBAL_LOG_CONTEXT: dict = {}
@@ -43,6 +45,7 @@ def init_app(app_logger: logging.Logger) -> None:
     # See https://docs.python.org/3/library/logging.html#logging.Logger.propagate
     for handler in app_logger.handlers:
         handler.addFilter(_add_global_context_info_to_log_record)
+        handler.addFilter(_add_new_relic_context_to_log_record)
 
     # Add some metadata to all log messages globally
     add_extra_data_to_global_logs({"environment": os.environ.get("ENVIRONMENT")})
@@ -61,5 +64,28 @@ def add_extra_data_to_global_logs(
 def _add_global_context_info_to_log_record(record: logging.LogRecord) -> bool:
     global _GLOBAL_LOG_CONTEXT  # noqa: PLW0602
     record.__dict__ |= _GLOBAL_LOG_CONTEXT
+
+    return True
+
+
+def _add_new_relic_context_to_log_record(record: logging.LogRecord) -> bool:
+    """Add New Relic tracing info to our log record."""
+    # This is not the recommended way of implementing this, but the alternatives
+    # either change the structure of our logging to not be JSON, or would
+    # entirely replace the formatter we have for outputting logs.
+    #
+    # The NewRelicContextFormatter calls this function internally when it
+    # creates the output object.
+    #
+    # This sets the following fields:
+    # entity.type
+    # entity.name
+    # entity.guid
+    # hostname
+    # span.id
+    # trace.id
+    newrelic_metadata = newrelic.api.time_trace.get_linking_metadata()
+
+    record.__dict__ |= newrelic_metadata
 
     return True

--- a/analytics/src/analytics/logs/config.py
+++ b/analytics/src/analytics/logs/config.py
@@ -149,7 +149,7 @@ def log_program_info(program_name: str) -> None:
             # throw an unused “type: ignore” comment error. Casting to Any instead ensures this
             # passes regardless of where mypy is being run
             "cpu_usable": (
-                len(cast(Any, os).sched_getaffinity(0))
+                len(cast(Any, os).sched_getaffinity(0))  # pylint: disable=E1101
                 if "sched_getaffinity" in dir(os)
                 else "unknown"
             ),

--- a/analytics/src/analytics/newrelic/__init__.py
+++ b/analytics/src/analytics/newrelic/__init__.py
@@ -1,0 +1,30 @@
+"""Entrypoint for initializing NewRelic."""
+
+import logging
+import os
+from pathlib import Path
+
+import newrelic.agent
+
+logger = logging.getLogger(__name__)
+
+__is_initialized: bool = False
+
+
+def init_newrelic() -> None:
+    """Initialize New Relic agent."""
+    # The unit tests can call this function multiple
+    # times which New Relic doesn't like, so only
+    # initialize it once.
+    global __is_initialized  # noqa: PLW0603, pylint: disable=global-statement
+    if not __is_initialized:
+        _init_newrelic()
+        __is_initialized = True
+
+
+def _init_newrelic() -> None:
+    logger.info("Initializing New Relic")
+    newrelic.agent.initialize(
+        config_file=Path(Path(__file__).parent) / "../../.." / "newrelic.ini",
+        environment=os.environ.get("ENVIRONMENT", "local"),
+    )

--- a/infra/analytics/app-config/env-config/environment_variables.tf
+++ b/infra/analytics/app-config/env-config/environment_variables.tf
@@ -73,5 +73,10 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/${var.app_name}/${var.environment}/metabase-db-pass"
     }
+
+    NEW_RELIC_LICENSE_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/${var.app_name}/${var.environment}/new-relic-license-key"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #4555

### Time to review: __15 mins__

## Changes proposed
Add NewRelic setup to Analytics code including:
* ini file
* Initializing New Relic at startup with that ini file
* Marking the tasks with the Background task designation
* Adding New Relic metadata to all log messages

Non-locally disable the pretty-print error messages

Make all tasks also be wrapped by ecs_background_task

## Context for reviewers
A lot of this is copied from the API code, just without some of the API-specific things configured (ie. we don't need certain New Relic features if it's not an API serving requests).

Perhaps the most important thing here is the `@ecs_background_task` added to each of the tasks, this accomplishes a few things:
* When a process errors, it makes it so it will **ALWAYS** emit at least one error level log. (It adds a try-except around the entire function and logs + rethrows the error). This means we can easily find logs in New Relic
* Configures the logging to work with New Relic a bit better by marking it as a background task
* Adds some general info to all logs like ECS info, timing metrics, and more.

`pretty_exceptions_enable` is a feature of Typer that prints a convenient error message for you and dumps the local variables, but that gets a bit broken in New Relic + could log secret values, so is disabled by default (locally it's re-enabled).

