### PR TITLE
[Issue #4057] Add e2e test for search copy URL functionality

### DIFF
--- a/frontend/tests/e2e/search/search-copy-url.spec.ts
+++ b/frontend/tests/e2e/search/search-copy-url.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+import { fillSearchInputAndSubmit } from "./searchSpecUtil";
+
+test("should copy search query URL to clipboard", async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto("/search");
+  
+  const searchTerm = "education grants";
+  await fillSearchInputAndSubmit(searchTerm, page);
+  await page.click("button:has-text('Search')");
+  await page.waitForSelector(".search-results, .result-item", { timeout: 5000 });
+  
+  // Try multiple selectors for the copy button
+  const copySelectors = [
+    "a:has-text('Copy this search query')",
+  ]
+  
+  // Increase timeout for clipboard operations
+  await page.waitForTimeout(300);
+  const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
+  const encodedTerm = encodeURIComponent(searchTerm).replace(/%20/g, "+");
+  expect(clipboardContent).toContain(`/search?keywords=${encodedTerm}`);
+});


### PR DESCRIPTION
## Summary
Fixes #4057

### Time to review: 20mins

## Changes proposed
Create a code file under research folder that contains code to help with e2e testing `URL copy functionality `
## Context for reviewers
Following **`PR is ready for review,`** since e2e testing is partially completed (playwright), had some error API realated.

## Additional information

![image](https://github.com/user-attachments/assets/1610a314-a8ec-49ee-9734-1f17a4eabff4)