### PR TITLE
[no ticket] Improves step function consistency

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -43,18 +43,13 @@ locals {
     ],
   }
   scheduled_jobs = {
-    failing-job = { # This is here to help test alerts, remove it when that's not needed.
-      task_command        = ["this-command-will-fail"]
-      schedule_expression = "cron(0 * * * ? *)"
-      state               = "ENABLED"
-    }
     load-transform = {
       task_command = local.load-transform-args[var.environment]
       # Every hour at the top of the hour
       schedule_expression = "cron(0 * * * ? *)"
       state               = "ENABLED"
     }
-    populate-search-index = {
+    load-search-and-opportunity-data = {
       task_command = ["poetry", "run", "flask", "load-search-data", "load-opportunity-data"]
       # Every hour at the half hour
       schedule_expression = "cron(30 * * * ? *)"

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -64,6 +64,7 @@ locals {
     local.base_environment_variables,
     local.db_environment_variables,
     local.cdn_environment_variables,
+    local.scheduled_job_environment_variables,
     [
       for name, value in var.extra_environment_variables :
       { name : name, value : value }

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -64,7 +64,6 @@ locals {
     local.base_environment_variables,
     local.db_environment_variables,
     local.cdn_environment_variables,
-    local.scheduled_job_environment_variables,
     [
       for name, value in var.extra_environment_variables :
       { name : name, value : value }

--- a/infra/modules/service/scheduled_jobs.tf
+++ b/infra/modules/service/scheduled_jobs.tf
@@ -1,13 +1,3 @@
-locals {
-  scheduled_job_environment_variables = [
-    for name, value in var.scheduled_jobs :
-    {
-      name  = "SCHEDULED_JOB_NAME",
-      value = name
-    }
-  ]
-}
-
 resource "aws_scheduler_schedule" "scheduled_jobs" {
   for_each = var.scheduled_jobs
 
@@ -62,6 +52,12 @@ resource "aws_sfn_state_machine" "scheduled_jobs" {
               {
                 "Name" : var.service_name,
                 "Command" : each.value.task_command
+                "Environment" : [
+                  {
+                    "Name" : "SCHEDULED_JOB_NAME",
+                    "Value" : each.key
+                  },
+                ]
               }
             ]
           }

--- a/infra/modules/service/scheduled_jobs.tf
+++ b/infra/modules/service/scheduled_jobs.tf
@@ -1,3 +1,13 @@
+locals {
+  scheduled_job_environment_variables = [
+    for name, value in var.scheduled_jobs :
+    {
+      name  = "SCHEDULED_JOB_NAME",
+      value = name
+    }
+  ]
+}
+
 resource "aws_scheduler_schedule" "scheduled_jobs" {
   for_each = var.scheduled_jobs
 


### PR DESCRIPTION
## Motivation & Context

Infrastructure will always have a set of concerns regarding scheduled jobs that are slightly different than application layer concerns. Specifically, infrastructure will want to know if any of their changes have broken scheduled jobs in the recent past, via a view that displays all the scheduled jobs at once. In this view, all the jobs should have the same name on the application layer as they do on the infrastructure layer. There can be a different key that the application layer uses (`task_name` or whatever else) but the infrastructure layer dashboards are gonna look for this now, eg. `SCHEDULED_JOB_NAME` / `scheduled_job_name`