### PR TITLE
[no ticket] Fix permanent CDN diffs

### DIFF
--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -3,7 +3,7 @@ locals {
   # We do not currently do this, though.
   default_origin_id        = "default"
   ssl_protocols            = ["TLSv1.2"]
-  minimum_protocol_version = "TLSv1.2_2021"
+  minimum_protocol_version = "TLSv1"
   enable_cdn               = var.enable_alb_cdn || var.enable_s3_cdn
 
   # The domain name of the CDN, ie. URL people use in order to access the CDN.
@@ -40,10 +40,8 @@ resource "aws_cloudfront_cache_policy" "default" {
   name = var.service_name
 
   # Default to caching for 1 hour.
-  # The default TTL can be overriden by the `Cache-Control max-age` or `Expires` headers
-  # There's also a `max_ttl` option, which can be used to override the above headers.
-  min_ttl     = 0
-  default_ttl = 3600
+  # There's also a `max_ttl` option.
+  min_ttl = 3600
 
   parameters_in_cache_key_and_forwarded_to_origin {
     cookies_config {
@@ -135,7 +133,6 @@ resource "aws_cloudfront_distribution" "cdn" {
     acm_certificate_arn            = var.certificate_arn == null ? null : var.certificate_arn
     cloudfront_default_certificate = var.certificate_arn == null ? true : false
     minimum_protocol_version       = local.minimum_protocol_version
-    ssl_support_method             = "sni-only"
   }
 
   depends_on = [

--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -40,7 +40,6 @@ resource "aws_cloudfront_cache_policy" "default" {
   name = var.service_name
 
   # Default to caching for 1 hour.
-  # There's also a `max_ttl` option.
   min_ttl = 3600
 
   parameters_in_cache_key_and_forwarded_to_origin {
@@ -115,12 +114,6 @@ resource "aws_cloudfront_distribution" "cdn" {
     cache_policy_id        = aws_cloudfront_cache_policy.default[0].id
     compress               = true
     viewer_protocol_policy = var.certificate_arn == null ? "allow-all" : "redirect-to-https"
-
-    # Default to caching for 1 hour.
-    # The default TTL can be overriden by the `Cache-Control max-age` or `Expires` headers
-    # There's also a `max_ttl` option, which can be used to override the above headers.
-    min_ttl     = 0
-    default_ttl = 3600
   }
 
   restrictions {


### PR DESCRIPTION
## Current Behavior

The `aws_cloudfront_distribution` resource has a terraform diff on it every single time we deploy. It's confusing and wastes time. Also it's unclear if the changes are even applying... since we try to apply them on every single deploy.

## Desired Behavior

There's only a terraform diff on the resource when you actually change it!!!

## Changes

I change every attribute that had a permanent diff to the value of the attribute that terraform keeps changing it to. So that there's no more diff when you deploy the CDN resource back to back. I'm slightly worried that these changes make it so that caching is disabled by default, but we should be setting cache headers on all our objects, to ensure that the CDN is actually being utilized.

## Testing

These routes are still accessible:

- https://d20lnyycqwjw31.cloudfront.net/
- https://d3e8vod9uic4zv.cloudfront.net/bg.svg