### PR TITLE
[Unticketed] Add step function name and short error logs

### DIFF
--- a/analytics/src/analytics/logs/app_logger.py
+++ b/analytics/src/analytics/logs/app_logger.py
@@ -46,6 +46,7 @@ def init_app(app_logger: logging.Logger) -> None:
     for handler in app_logger.handlers:
         handler.addFilter(_add_global_context_info_to_log_record)
         handler.addFilter(_add_new_relic_context_to_log_record)
+        handler.addFilter(_add_error_info_to_log_record)
 
     # Add some metadata to all log messages globally
     add_extra_data_to_global_logs(
@@ -66,6 +67,18 @@ def add_extra_data_to_global_logs(
 def _add_global_context_info_to_log_record(record: logging.LogRecord) -> bool:
     global _GLOBAL_LOG_CONTEXT  # noqa: PLW0602
     record.__dict__ |= _GLOBAL_LOG_CONTEXT
+
+    return True
+
+
+def _add_error_info_to_log_record(record: logging.LogRecord) -> bool:
+    """Add a shorter form of the error message to our log record."""
+    exc_info = getattr(record, "exc_info", None)
+    # exc_info is a 3-part tuple with the class, error obj, and traceback
+    if exc_info and len(exc_info) == 3:  # noqa:PLR2004
+        # If the error were `raise ValueError("example")`, the
+        # value of this would be "ValueError('example')"
+        record.__dict__["exc_info_short"] = repr(exc_info[1])
 
     return True
 

--- a/analytics/src/analytics/logs/ecs_background_task.py
+++ b/analytics/src/analytics/logs/ecs_background_task.py
@@ -134,12 +134,11 @@ def _get_ecs_metadata() -> dict:
     )
 
     # Step function only
-    sfn_execution_id = os.environ.get("SFN_EXECUTION_ID")
-    sfn_id = sfn_execution_id.split(":")[-2] if sfn_execution_id is not None else None
+    step_function_name = os.environ.get("SCHEDULED_JOB_NAME", None)
 
     return {
         "aws.ecs.task_name": ecs_task_name,
         "aws.ecs.task_id": ecs_task_id,
         "aws.ecs.task_definition": ecs_taskdef,
-        "aws.step_function.id": sfn_id,
+        "scheduled_job_name": step_function_name,
     }

--- a/analytics/tests/logs/test_ecs_background_task.py
+++ b/analytics/tests/logs/test_ecs_background_task.py
@@ -69,3 +69,4 @@ def test_ecs_background_task_when_erroring(caplog: pytest.LogCaptureFixture):
     assert last_record["another_param"] == "hello"
     assert last_record["levelname"] == "ERROR"
     assert last_record["message"] == "ECS task failed"
+    assert last_record["exc_info_short"] == "ValueError('I am an error')"

--- a/api/src/task/ecs_background_task.py
+++ b/api/src/task/ecs_background_task.py
@@ -127,12 +127,11 @@ def _get_ecs_metadata() -> dict:
     # cloudwatch_log_stream = metadata_json["LogOptions"]["awslogs-stream"]
 
     # Step function only
-    sfn_execution_id = os.environ.get("SFN_EXECUTION_ID")
-    sfn_id = sfn_execution_id.split(":")[-2] if sfn_execution_id is not None else None
+    step_function_name = os.environ.get("SCHEDULED_JOB_NAME", None)
 
     return {
         "aws.ecs.task_name": ecs_task_name,
         "aws.ecs.task_id": ecs_task_id,
         "aws.ecs.task_definition": ecs_taskdef,
-        "aws.step_function.id": sfn_id,
+        "scheduled_job_name": step_function_name,
     }

--- a/api/tests/src/task/test_ecs_background_task.py
+++ b/api/tests/src/task/test_ecs_background_task.py
@@ -75,3 +75,4 @@ def test_ecs_background_task_when_erroring(app, caplog, monkeypatch_session):
     assert last_record["another_param"] == "hello"
     assert last_record["levelname"] == "ERROR"
     assert last_record["message"] == "ECS task failed"
+    assert last_record["exc_info_short"] == "ValueError('I am an error')"


### PR DESCRIPTION
## Summary

### Time to review: __5 mins__

## Changes proposed
If a log message has `exc_info` put a short form of it in the logs as well for slightly nicer error log messages in New Relic

If running via a step function, add the name of it to the logs (recently piped through in terraform)

## Context for reviewers
By default, the `exc_info` looks like `(<class 'ValueError'>, ValueError('hello'), <traceback object at 0x1160d4640>)` and the traceback is generally really long. This is useful for debugging, and we'll keep that, but it's usually like 30 lines long and doesn't fit neatly into a dashboard. So I added `exc_info_short` that is the middle of those without the traceback.

## Additional information
![Screenshot 2025-04-15 at 2 47 25 PM](https://github.com/user-attachments/assets/9ae63c12-2ad3-4897-bed0-271242c97574)


