### PR TITLE
[Issue #4564] Modify process that turns .DAT files into JsonSchema to populate the title from the Field Label

### DIFF
--- a/api/src/form_schema/csv_to_jsonschema.py
+++ b/api/src/form_schema/csv_to_jsonschema.py
@@ -135,7 +135,7 @@ def add_field_to_builder(builder: JsonSchemaBuilder, field_info: FieldInfo) -> N
     # Add appropriate property based on type
     if field_type == "Radio Group" or data_type == "LIST" or list_of_values:
         builder.add_string_property(
-            field_id,
+            title,
             is_nullable=is_nullable,
             is_required=required,
             title=title,
@@ -147,7 +147,7 @@ def add_field_to_builder(builder: JsonSchemaBuilder, field_info: FieldInfo) -> N
         )
     elif data_type == "DATE":
         builder.add_string_property(
-            field_id,
+            title,
             is_nullable=is_nullable,
             is_required=required,
             title=title,
@@ -156,7 +156,7 @@ def add_field_to_builder(builder: JsonSchemaBuilder, field_info: FieldInfo) -> N
         )
     elif data_type == "AN":  # Alphanumeric
         builder.add_string_property(
-            field_id,
+            title,
             is_nullable=is_nullable,
             is_required=required,
             title=title,
@@ -168,7 +168,7 @@ def add_field_to_builder(builder: JsonSchemaBuilder, field_info: FieldInfo) -> N
     else:
         # Default to string
         builder.add_string_property(
-            field_id,
+            title,
             is_nullable=is_nullable,
             is_required=required,
             title=title,

--- a/api/tests/src/form_schema/test_csv_to_jsonschema.py
+++ b/api/tests/src/form_schema/test_csv_to_jsonschema.py
@@ -84,7 +84,6 @@ def test_required_fields_are_marked_correctly(csv_file_content):
     """Test that required fields are properly marked in the schema."""
     schema, _ = csv_to_jsonschema(csv_file_content)
 
-    print(schema)
     # Known required fields from CSV
     known_required_fields = ["First Name:", "Last Name:", "Email:"]
 

--- a/api/tests/src/form_schema/test_csv_to_jsonschema.py
+++ b/api/tests/src/form_schema/test_csv_to_jsonschema.py
@@ -34,11 +34,11 @@ def expected_schema_keys():
 def expected_fields():
     # A sample of fields we expect to find in the schema
     return [
-        "FirstName",
-        "LastName",
-        "City",
+        "First Name:",
+        "Last Name:",
+        "City:",
         "Country",
-        "citizenship",
+        "U.S. Citizenship",
     ]
 
 
@@ -61,7 +61,6 @@ def test_csv_to_jsonschema_contains_expected_fields(csv_file_content, expected_f
     """Test that the generated schema contains expected fields."""
     schema, _ = csv_to_jsonschema(csv_file_content)
 
-    print(schema)
     # Look for each field in the schema properties
     for field in expected_fields:
         # Fields might be in the main schema or in a section
@@ -85,8 +84,9 @@ def test_required_fields_are_marked_correctly(csv_file_content):
     """Test that required fields are properly marked in the schema."""
     schema, _ = csv_to_jsonschema(csv_file_content)
 
+    print(schema)
     # Known required fields from CSV
-    known_required_fields = ["FirstName", "LastName", "AuthorizedRepresentativeEmail"]
+    known_required_fields = ["First Name:", "Last Name:", "Email:"]
 
     # Check if these fields are marked as required
     for field in known_required_fields:
@@ -138,7 +138,7 @@ def test_date_fields_have_correct_format(csv_file_content):
     schema, _ = csv_to_jsonschema(csv_file_content)
 
     # Find fields that should be dates
-    date_field_names = ["FundingPeriodStartDate", "FundingPeriodEndDate"]
+    date_field_names = ["Start Date:", "End Date:"]
 
     for field_name in date_field_names:
         field = schema["properties"][field_name]
@@ -167,7 +167,7 @@ def test_ui_schema_has_correct_structure(csv_file_content):
             "/properties/"
         ), "Definition should start with '/properties/'"
 
-    assert ui_schema[0]["definition"] == "/properties/FederalAgency"
+    assert ui_schema[0]["definition"] == "/properties/1. NAME OF FEDERAL AGENCY:"
 
 
 def test_state_and_country_fields_auto_detection():
@@ -317,11 +317,11 @@ def test_add_field_to_builder_state_country_references():
     assert "birthCountry" not in schema["required"]  # Shouldn't be required
 
     # Verify regular field is NOT added as a reference
-    assert "fullName" in schema["properties"]
-    assert "$ref" not in schema["properties"]["fullName"]
-    assert schema["properties"]["fullName"]["type"] == "string"
-    assert schema["properties"]["fullName"]["title"] == "Full Name"
-    assert "fullName" in schema["required"]
+    assert "Full Name" in schema["properties"]
+    assert "$ref" not in schema["properties"]["Full Name"]
+    assert schema["properties"]["Full Name"]["type"] == "string"
+    assert schema["properties"]["Full Name"]["title"] == "Full Name"
+    assert "Full Name" in schema["required"]
 
 
 def test_add_field_to_builder_genc_country_detection():
@@ -376,7 +376,7 @@ def test_add_field_to_builder_genc_country_detection():
     assert schema["properties"]["nationalOrigin"]["$ref"] == "#/$defs/CountryCode"
 
     # Verify the regular dropdown is NOT treated as a reference
-    assert "favoriteColor" in schema["properties"]
-    assert "$ref" not in schema["properties"]["favoriteColor"]
-    assert "enum" in schema["properties"]["favoriteColor"]
-    assert schema["properties"]["favoriteColor"]["enum"] == ["Red", "Green", "Blue"]
+    assert "Favorite Color" in schema["properties"]
+    assert "$ref" not in schema["properties"]["Favorite Color"]
+    assert "enum" in schema["properties"]["Favorite Color"]
+    assert schema["properties"]["Favorite Color"]["enum"] == ["Red", "Green", "Blue"]


### PR DESCRIPTION
## Summary
Fixes #4564

### Time to review: 10 mins

## Changes proposed
Use field label instead of field ID in generating our schema files. 
Update tests

## Context for reviewers
The `title` field in the schema is duplicative. Should this be changed / removed? Or stay as is?

## Additional information
Modified unit tests to pass given the new schema fields.
