### PR TITLE
[Issue #4454] auto close nav sub menus

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import clsx from "clsx";
+import { noop } from "lodash";
 import GrantsLogo from "public/img/grants-logo.svg";
 import { useFeatureFlags } from "src/hooks/useFeatureFlags";
 import { useSnackbar } from "src/hooks/useSnackbar";
@@ -177,18 +178,22 @@ const NavLinks = ({
               label={link.text}
               menuId={link.text}
               isOpen={secondaryNavOpen}
-              onToggle={() => {
+              onClick={(e) => {
                 if (!secondaryNavOpen) {
                   setSecondaryNavOpen(true);
-                  document.addEventListener(
-                    "click",
-                    () => {
-                      setSecondaryNavOpen(false);
-                    },
-                    { once: true },
+                  e.stopPropagation();
+                  requestAnimationFrame(() =>
+                    document.addEventListener(
+                      "click",
+                      () => {
+                        setSecondaryNavOpen(false);
+                      },
+                      { once: true },
+                    ),
                   );
                 }
               }}
+              onToggle={noop}
               className={clsx({
                 "usa-current": currentNavItemIndex === index,
                 "simpler-subnav-open": secondaryNavOpen,

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -152,39 +152,6 @@ const NavLinks = ({
     }
   }, [mobileExpanded, onToggleMobileNav]);
 
-  // const closeSecondaryNav = useCallback(() => {
-  //   console.log("!!! calling");
-  //   if (secondaryNavOpen) {
-  //     console.log("!!! closing");
-  //     setSecondaryNavOpen(false);
-  //   }
-  // }, [secondaryNavOpen]);
-
-  // useEffect(() => {
-  //   document.addEventListener("click", closeSecondaryNav);
-  // }, [closeSecondaryNav]);
-
-  // useEffect(() => {
-  //   if (secondaryNavOpen) {
-  //     console.log("!!! adding");
-  //     document.addEventListener("click", () => {
-  //       console.log("!!! calling");
-  //       setSecondaryNavOpen(false);
-  //     });
-  //   } else {
-  //     console.log("!!! removing");
-
-  //     document.removeEventListener("click", () => {
-  //       console.log("!!! calling");
-  //       setSecondaryNavOpen(false);
-  //     });
-  //   }
-  //   return document.removeEventListener("click", () => {
-  //     console.log("!!! calling");
-  //     setSecondaryNavOpen(false);
-  //   });
-  // }, [secondaryNavOpen, setSecondaryNavOpen]);
-
   const navItems = useMemo(() => {
     return navLinkList.map((link: PrimaryLink, index: number) => {
       if (!link.text) {
@@ -211,25 +178,15 @@ const NavLinks = ({
               menuId={link.text}
               isOpen={secondaryNavOpen}
               onToggle={() => {
-                /*
-                  I cannot figure this out why is it so hard
-                  I add the thing and it keeps running on the click that should be removing it
-                  even if I manage to turn this into a click handler and prevent default on it
-                */
-                if (secondaryNavOpen) {
-                  console.log("!!! removing");
-                  document.removeEventListener("click", () => {
-                    console.log("!!! calling");
-                    setSecondaryNavOpen(false);
-                  });
-                }
-                setSecondaryNavOpen(!secondaryNavOpen);
                 if (!secondaryNavOpen) {
-                  console.log("!!! adding");
-                  document.addEventListener("click", () => {
-                    console.log("!!! calling");
-                    setSecondaryNavOpen(false);
-                  });
+                  setSecondaryNavOpen(true);
+                  document.addEventListener(
+                    "click",
+                    () => {
+                      setSecondaryNavOpen(false);
+                    },
+                    { once: true },
+                  );
                 }
               }}
               className={clsx({
@@ -267,7 +224,6 @@ const NavLinks = ({
     closeMobileNav,
   ]);
 
-  console.log("$$$ render", secondaryNavOpen);
   return (
     <PrimaryNav
       items={navItems}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -152,6 +152,39 @@ const NavLinks = ({
     }
   }, [mobileExpanded, onToggleMobileNav]);
 
+  // const closeSecondaryNav = useCallback(() => {
+  //   console.log("!!! calling");
+  //   if (secondaryNavOpen) {
+  //     console.log("!!! closing");
+  //     setSecondaryNavOpen(false);
+  //   }
+  // }, [secondaryNavOpen]);
+
+  // useEffect(() => {
+  //   document.addEventListener("click", closeSecondaryNav);
+  // }, [closeSecondaryNav]);
+
+  // useEffect(() => {
+  //   if (secondaryNavOpen) {
+  //     console.log("!!! adding");
+  //     document.addEventListener("click", () => {
+  //       console.log("!!! calling");
+  //       setSecondaryNavOpen(false);
+  //     });
+  //   } else {
+  //     console.log("!!! removing");
+
+  //     document.removeEventListener("click", () => {
+  //       console.log("!!! calling");
+  //       setSecondaryNavOpen(false);
+  //     });
+  //   }
+  //   return document.removeEventListener("click", () => {
+  //     console.log("!!! calling");
+  //     setSecondaryNavOpen(false);
+  //   });
+  // }, [secondaryNavOpen, setSecondaryNavOpen]);
+
   const navItems = useMemo(() => {
     return navLinkList.map((link: PrimaryLink, index: number) => {
       if (!link.text) {
@@ -177,7 +210,28 @@ const NavLinks = ({
               label={link.text}
               menuId={link.text}
               isOpen={secondaryNavOpen}
-              onToggle={() => setSecondaryNavOpen(!secondaryNavOpen)}
+              onToggle={() => {
+                /*
+                  I cannot figure this out why is it so hard
+                  I add the thing and it keeps running on the click that should be removing it
+                  even if I manage to turn this into a click handler and prevent default on it
+                */
+                if (secondaryNavOpen) {
+                  console.log("!!! removing");
+                  document.removeEventListener("click", () => {
+                    console.log("!!! calling");
+                    setSecondaryNavOpen(false);
+                  });
+                }
+                setSecondaryNavOpen(!secondaryNavOpen);
+                if (!secondaryNavOpen) {
+                  console.log("!!! adding");
+                  document.addEventListener("click", () => {
+                    console.log("!!! calling");
+                    setSecondaryNavOpen(false);
+                  });
+                }
+              }}
               className={clsx({
                 "usa-current": currentNavItemIndex === index,
                 "simpler-subnav-open": secondaryNavOpen,
@@ -205,8 +259,15 @@ const NavLinks = ({
         />
       );
     });
-  }, [navLinkList, currentNavItemIndex, secondaryNavOpen, closeMobileNav]);
+  }, [
+    navLinkList,
+    currentNavItemIndex,
+    secondaryNavOpen,
+    setSecondaryNavOpen,
+    closeMobileNav,
+  ]);
 
+  console.log("$$$ render", secondaryNavOpen);
   return (
     <PrimaryNav
       items={navItems}

--- a/frontend/src/components/user/UserControl.tsx
+++ b/frontend/src/components/user/UserControl.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { noop } from "lodash";
 import { useUser } from "src/services/auth/useUser";
 import { UserProfile } from "src/types/authTypes";
 
@@ -85,18 +86,22 @@ const UserDropdown = ({
         // @ts-ignore: Type 'Element' is not assignable to type 'string'
         label={<UserEmailItem isSubnav={false} email={user.email} />}
         isOpen={userProfileMenuOpen}
-        onToggle={() => {
+        onClick={(e) => {
           if (!userProfileMenuOpen) {
             setUserProfileMenuOpen(true);
-            document.addEventListener(
-              "click",
-              () => {
-                setUserProfileMenuOpen(false);
-              },
-              { once: true },
+            e.stopPropagation();
+            requestAnimationFrame(() =>
+              document.addEventListener(
+                "click",
+                () => {
+                  setUserProfileMenuOpen(false);
+                },
+                { once: true },
+              ),
             );
           }
         }}
+        onToggle={noop}
         isCurrent={false}
         menuId="user-control"
       />

--- a/frontend/src/components/user/UserControl.tsx
+++ b/frontend/src/components/user/UserControl.tsx
@@ -85,7 +85,18 @@ const UserDropdown = ({
         // @ts-ignore: Type 'Element' is not assignable to type 'string'
         label={<UserEmailItem isSubnav={false} email={user.email} />}
         isOpen={userProfileMenuOpen}
-        onToggle={() => setUserProfileMenuOpen(!userProfileMenuOpen)}
+        onToggle={() => {
+          if (!userProfileMenuOpen) {
+            setUserProfileMenuOpen(true);
+            document.addEventListener(
+              "click",
+              () => {
+                setUserProfileMenuOpen(false);
+              },
+              { once: true },
+            );
+          }
+        }}
         isCurrent={false}
         menuId="user-control"
       />


### PR DESCRIPTION
## Summary
Fixes #4454

### Time to review: __10 mins__

## Changes proposed
The workspace and user dropdowns in the nav are currently not closing unless you specifically click on them to close them. With this change they will close on any click after they are opened.

## Context for reviewers
### Test steps

1. start a server on this branch with `npm run dev`
2. visit http://localhost:3000?_ff=authOn:true;savedSearchesOn:true
3. log in
4. click the workspace nav
5. click anywhere (you should probably test clicking a bunch of different places)
6. _VERIFY_: subnav closes
7. repeat 4 - 6 for the user dropdown nav

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

