### PR TITLE
[Issue #1532] track search item click position

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "lint": "next lint",
     "lint-fix": "npm run lint -- --fix",
     "postinstall": "node ./scripts/postinstall.js",
-    "start:nr": "NEW_RELIC_ENABLED=true NODE_OPTIONS='-r @newrelic/next' next start -p ${PORT:-3000}",
+    "start:nr": "NEW_RELIC_ENABLED=true NODE_OPTIONS='-r newrelic' next start -p ${PORT:-3000}",
     "start": "next start -p ${PORT:-3000}",
     "storybook": "storybook dev -p 6006",
     "storybook-build": "storybook build",

--- a/frontend/src/app/[locale]/saved-grants/page.tsx
+++ b/frontend/src/app/[locale]/saved-grants/page.tsx
@@ -19,18 +19,20 @@ const SavedOpportunitiesList = ({
 }: {
   opportunities: SearchResponseData;
 }) => {
+  const savedGrantsListItems = opportunities.map(
+    (opportunity, index) =>
+      opportunity && (
+        <li key={opportunity.opportunity_id}>
+          <SearchResultsListItem
+            opportunity={opportunity}
+            saved={true}
+            index={index}
+          />
+        </li>
+      ),
+  );
   return (
-    <ul className="usa-prose usa-list--unstyled">
-      {opportunities.map((opportunity) => (
-        <>
-          {opportunity && (
-            <li key={opportunity.opportunity_id}>
-              <SearchResultsListItem opportunity={opportunity} saved={true} />
-            </li>
-          )}
-        </>
-      ))}
-    </ul>
+    <ul className="usa-prose usa-list--unstyled">{savedGrantsListItems}</ul>
   );
 };
 

--- a/frontend/src/components/search/SearchResults.tsx
+++ b/frontend/src/components/search/SearchResults.tsx
@@ -91,7 +91,7 @@ const ResolvedSearchResults = async ({
             totalResults={totalResults}
           />
         </div>
-        <SearchResultsList searchResults={searchResults} />
+        <SearchResultsList searchResults={searchResults} page={page} />
         <SearchPagination
           totalPages={totalPages}
           page={page}

--- a/frontend/src/components/search/SearchResultsList.tsx
+++ b/frontend/src/components/search/SearchResultsList.tsx
@@ -10,10 +10,12 @@ import ServerErrorAlert from "src/components/ServerErrorAlert";
 
 interface ServerPageProps {
   searchResults: SearchAPIResponse;
+  page: number;
 }
 
 export default async function SearchResultsList({
   searchResults,
+  page,
 }: ServerPageProps) {
   const t = await getTranslations("Search");
 
@@ -41,11 +43,13 @@ export default async function SearchResultsList({
 
   return (
     <ul className="usa-list--unstyled">
-      {searchResults.data.map((opportunity) => (
+      {searchResults.data.map((opportunity, index) => (
         <li key={opportunity?.opportunity_id}>
           <SearchResultsListItem
             opportunity={opportunity}
             saved={savedOpportunityIds.includes(opportunity?.opportunity_id)}
+            index={index}
+            page={page}
           />
         </li>
       ))}

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -13,6 +13,8 @@ import SearchResultListItemStatus from "./SearchResultListItemStatus";
 interface SearchResultsListItemProps {
   opportunity: BaseOpportunity;
   saved?: boolean;
+  index: number;
+  page?: number;
 }
 
 const metadataBorderClasses = `
@@ -37,6 +39,8 @@ const resultBorderClasses = `
 export default function SearchResultsListItem({
   opportunity,
   saved = false,
+  index,
+  page = 1,
 }: SearchResultsListItemProps) {
   const t = useTranslations("Search");
 
@@ -50,6 +54,7 @@ export default function SearchResultsListItem({
                 <Link
                   href={`/opportunity/${opportunity?.opportunity_id}`}
                   className="usa-link usa-link"
+                  id={`search-result-link-${page}-${index + 1}`}
                 >
                   {opportunity?.opportunity_title}
                 </Link>

--- a/frontend/tests/components/search/SearchResultsList.test.tsx
+++ b/frontend/tests/components/search/SearchResultsList.test.tsx
@@ -69,6 +69,7 @@ const makeOpportunity = (overrides = {}) => ({
 describe("SearchResultsList", () => {
   it("should not have accessibility violations", async () => {
     const component = await SearchResultsList({
+      page: 1,
       searchResults: makeSearchResults({}),
     });
     const { container } = render(component);
@@ -77,6 +78,7 @@ describe("SearchResultsList", () => {
   });
   it("renders an error if search results have no data", async () => {
     const component = await SearchResultsList({
+      page: 1,
       searchResults: makeSearchResults({ status_code: 404 }),
     });
     render(component);
@@ -84,6 +86,7 @@ describe("SearchResultsList", () => {
   });
   it('renders a "not found" page if no records are passed in', async () => {
     const component = await SearchResultsList({
+      page: 1,
       searchResults: makeSearchResults({}),
     });
     render(component);
@@ -93,6 +96,7 @@ describe("SearchResultsList", () => {
   });
   it("renders an list item for each search result", async () => {
     const component = await SearchResultsList({
+      page: 1,
       searchResults: makeSearchResults({
         data: [makeOpportunity({}), makeOpportunity({ opportunity_id: 2 })],
       }),
@@ -106,6 +110,7 @@ describe("SearchResultsList", () => {
       token: "fakeToken",
     }));
     const component = await SearchResultsList({
+      page: 1,
       searchResults: makeSearchResults({
         data: [
           makeOpportunity({ opportunity_id: 1 }),

--- a/frontend/tests/components/search/SearchResultsListItem.test.tsx
+++ b/frontend/tests/components/search/SearchResultsListItem.test.tsx
@@ -9,14 +9,14 @@ import SearchResultsListItem from "src/components/search/SearchResultsListItem";
 describe("SearchResultsListItem", () => {
   it("should not have basic accessibility issues", async () => {
     const { container } = render(
-      <SearchResultsListItem opportunity={mockOpportunity} />,
+      <SearchResultsListItem index={1} opportunity={mockOpportunity} />,
     );
     const results = await waitFor(() => axe(container));
     expect(results).toHaveNoViolations();
   });
 
   it("renders opportunity title and number", () => {
-    render(<SearchResultsListItem opportunity={mockOpportunity} />);
+    render(<SearchResultsListItem index={1} opportunity={mockOpportunity} />);
     expect(screen.getByText("Test Opportunity")).toBeInTheDocument();
     expect(screen.getByText("OPP-12345")).toBeInTheDocument();
   });
@@ -31,7 +31,9 @@ describe("SearchResultsListItem", () => {
         },
       };
 
-      render(<SearchResultsListItem opportunity={opportunityWithDate} />);
+      render(
+        <SearchResultsListItem index={1} opportunity={opportunityWithDate} />,
+      );
       expect(screen.getByText(ui_date)).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
Fixes #1532

### Time to review: __10 mins__

## Changes proposed
Adds an id containing the index and page number of each search result to each search result item link that will allow new relic to track clicks.

## Context for reviewers
### Test steps

1. start a local server on this branch with `npm run build -- --no-lint && NEW_RELIC_APP_NAME="frontend-dev" NEW_RELIC_LICENSE_KEY="<dev new relic license key from 1pass>" npm run start:nr`
2. visit http://localhost:3000/search
3. click a few search results
4. navigate to a different page of results
5. click a few search results
6. go to the new relic query builder from https://one.newrelic.com/
7. enter the following query 
```
FROM UserAction
SELECT targetId WHERE action = 'click'
WHERE appName IN ('frontend-dev')
SINCE 10 minutes AGO
```
8. _VERIFY_: you see targetIds coming up that match the page and index of the search results you just clicked

## Additional information
<img width="810" alt="Screenshot 2025-04-17 at 12 05 58 PM" src="https://github.com/user-attachments/assets/f66c3b6c-9d60-4d15-bfb4-486671c5c14a" />


