### PR TITLE
[Unticketed] Allow blank issues to be created

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
## Summary

### Time to review: __1 mins__

## Changes proposed
Allow (at least temporarily) the ability to create blank issues and not use one of our templates.

## Context for reviewers
I've been dealing with some sort of bug in GitHub that refuses to allow me to create an issue with an issue type. I have an open bug report with GitHub to try and figure out the problem, but this unblocks my ability to create tickets. We can revert this later if we don't want to keep this.


