### PR TITLE
[Issue #3915] add "any" filter option

### DIFF
--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -30,6 +30,7 @@ export async function AgencyFilterAccordion({
       query={query}
       queryParamKey={"agency"}
       title={t("accordion.titles.agency")}
+      includeAnyOption={false}
       // agency filters will not show facet counts
     />
   );

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -1,3 +1,5 @@
+import { noop } from "lodash";
+
 import { useTranslations } from "next-intl";
 import { Checkbox } from "@trussworks/react-uswds";
 
@@ -5,12 +7,10 @@ export const AnyOptionCheckbox = ({
   onAnySelection,
   title,
   checked,
-  clickable,
 }: {
   onAnySelection: () => void;
   title: string;
   checked: boolean;
-  clickable: boolean;
 }) => {
   const id = `${title}-any`;
   const t = useTranslations("Search.accordion");
@@ -20,7 +20,7 @@ export const AnyOptionCheckbox = ({
       id={id}
       name={id}
       label={label}
-      onChange={clickable ? onAnySelection : () => {}}
+      onChange={checked ? noop : onAnySelection}
       disabled={false}
       checked={checked}
       value={"any"}

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -1,0 +1,29 @@
+import { useTranslations } from "next-intl";
+import { Checkbox } from "@trussworks/react-uswds";
+
+export const AnyOptionCheckbox = ({
+  onAnySelection,
+  title,
+  checked,
+  clickable,
+}: {
+  onAnySelection: () => void;
+  title: string;
+  checked: boolean;
+  clickable: boolean;
+}) => {
+  const id = `${title}-any`;
+  const t = useTranslations("Search.accordion");
+  const label = t("any");
+  return (
+    <Checkbox
+      id={id}
+      name={id}
+      label={label}
+      onChange={clickable ? onAnySelection : () => {}}
+      disabled={false}
+      checked={checked}
+      value={"any"}
+    />
+  );
+};

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -14,7 +14,7 @@ export const AnyOptionCheckbox = ({
 }) => {
   const id = `${title}-any`;
   const t = useTranslations("Search.accordion");
-  const label = t("any");
+  const label = `${t("any")} ${title.toLowerCase()}`;
   return (
     <Checkbox
       id={id}

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -1,26 +1,42 @@
 import { noop } from "lodash";
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 
 import { useTranslations } from "next-intl";
 import { Checkbox } from "@trussworks/react-uswds";
 
 export const AnyOptionCheckbox = ({
-  onAnySelection,
   title,
   checked,
+  defaultEmptySelection,
+  queryParamKey,
 }: {
-  onAnySelection: () => void;
   title: string;
   checked: boolean;
+  defaultEmptySelection?: Set<string>;
+  queryParamKey: string;
 }) => {
+  const { setQueryParam } = useSearchParamUpdater();
   const id = `${title}-any`;
   const t = useTranslations("Search.accordion");
   const label = `${t("any")} ${title.toLowerCase()}`;
+
+  /*
+    When checked: remove param for the filter from the query, which will unselect all checkboxes
+    When unchecked: this will not happen on any box click. any box will become unchecked whenever another option is checked
+  */
+  const clearAllOptions = () => {
+    const clearedSelections = defaultEmptySelection?.size
+      ? Array.from(defaultEmptySelection).join(",")
+      : "";
+    setQueryParam(queryParamKey, clearedSelections);
+  };
+
   return (
     <Checkbox
       id={id}
       name={id}
       label={label}
-      onChange={checked ? noop : onAnySelection}
+      onChange={checked ? noop : clearAllOptions}
       disabled={false}
       checked={checked}
       value={"any"}

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -16,7 +16,7 @@ export const AnyOptionCheckbox = ({
   queryParamKey: string;
 }) => {
   const { setQueryParam } = useSearchParamUpdater();
-  const id = `${title}-any`;
+  const id = `${title.replace(/\s/, "-").toLowerCase()}-any`;
   const t = useTranslations("Search.accordion");
   const label = `${t("any")} ${title.toLowerCase()}`;
 

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -6,12 +6,13 @@ import { QueryContext } from "src/services/search/QueryProvider";
 import { ValidSearchQueryParam } from "src/types/search/searchResponseTypes";
 import { areSetsEqual } from "src/utils/search/searchUtils";
 
-import { useContext } from "react";
+import { useCallback, useContext, useMemo } from "react";
 import { Accordion } from "@trussworks/react-uswds";
 
 import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
 import SearchFilterSection from "src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection";
 import SearchFilterToggleAll from "src/components/search/SearchFilterAccordion/SearchFilterToggleAll";
+import { AnyOptionCheckbox } from "./AnyOptionCheckbox";
 
 export interface AccordionItemProps {
   title: React.ReactNode | string;
@@ -37,6 +38,7 @@ export interface SearchFilterAccordionProps {
   filterOptions: FilterOption[];
   facetCounts?: { [key: string]: number };
   defaultEmptySelection?: Set<string>;
+  includeAnyOption?: boolean;
 }
 
 export interface FilterOptionWithChildren {
@@ -73,9 +75,17 @@ const AccordionContent = ({
   query,
   facetCounts,
   defaultEmptySelection,
+  includeAnyOption = true,
 }: SearchFilterAccordionProps) => {
   const { queryTerm } = useContext(QueryContext);
   const { updateQueryParams, searchParams } = useSearchParamUpdater();
+  const onAnySelection = useCallback(() => {}, []);
+  const anyChecked = useMemo(() => {
+    return false;
+  }, [includeAnyOption]);
+  const anyClickable = useMemo(() => {
+    return false;
+  }, [includeAnyOption]);
 
   // TODO: implement this within the components where it's used to make it more testable
   const toggleOptionChecked = (value: string, isChecked: boolean) => {
@@ -132,6 +142,14 @@ const AccordionContent = ({
       />
 
       <ul className="usa-list usa-list--unstyled">
+        {includeAnyOption && (
+          <AnyOptionCheckbox
+            onAnySelection={onAnySelection}
+            title={title}
+            checked={anyChecked}
+            clickable={anyClickable}
+          />
+        )}
         {filterOptions.map((option) => (
           <li key={option.id}>
             {/* If we have children, show a "section" dropdown, otherwise show just a checkbox */}
@@ -171,6 +189,7 @@ export function SearchFilterAccordion({
   query,
   facetCounts,
   defaultEmptySelection,
+  includeAnyOption = true,
 }: SearchFilterAccordionProps) {
   const accordionOptions: AccordionItemProps[] = [
     {
@@ -183,6 +202,7 @@ export function SearchFilterAccordion({
           query={query}
           facetCounts={facetCounts}
           defaultEmptySelection={defaultEmptySelection}
+          includeAnyOption={includeAnyOption}
         />
       ),
       expanded: !!query.size,

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -6,7 +6,7 @@ import { QueryContext } from "src/services/search/QueryProvider";
 import { ValidSearchQueryParam } from "src/types/search/searchResponseTypes";
 import { areSetsEqual } from "src/utils/search/searchUtils";
 
-import { useCallback, useContext, useMemo } from "react";
+import { useContext, useMemo } from "react";
 import { Accordion } from "@trussworks/react-uswds";
 
 import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
@@ -111,36 +111,25 @@ const AccordionContent = ({
 
   // need to add any existing relevant search params to the passed in set
   // TODO: split this into two functions and implement within the components where they're used to make it more testable
-  const toggleSelectAll = useCallback(
-    (all: boolean, newSelections?: Set<string>): void => {
-      if (all && newSelections) {
-        // get existing current selected options for this accordion from url
-        const currentSelections = new Set(
-          searchParams.get(camelCase(title))?.split(","),
-        );
-        // add existing to newly selected section
-        const sectionPlusCurrent = new Set([
-          ...currentSelections,
-          ...newSelections,
-        ]);
-        updateQueryParams(sectionPlusCurrent, queryParamKey, queryTerm);
-      } else {
-        const clearedSelections = newSelections?.size
-          ? newSelections
-          : new Set<string>();
-        updateQueryParams(clearedSelections, queryParamKey, queryTerm);
-      }
-    },
-    [queryParamKey, queryTerm, searchParams, title, updateQueryParams],
-  );
-
-  /*
-    When checked: remove param for the filter from the query, which will unselect all checkboxes
-    When unchecked: this will not happen on any box click. any box will become unchecked whenever another option is checked
-  */
-  const onAnySelection = useCallback(() => {
-    toggleSelectAll(false, defaultEmptySelection);
-  }, [toggleSelectAll, defaultEmptySelection]);
+  const toggleSelectAll = (all: boolean, newSelections?: Set<string>): void => {
+    if (all && newSelections) {
+      // get existing current selected options for this accordion from url
+      const currentSelections = new Set(
+        searchParams.get(camelCase(title))?.split(","),
+      );
+      // add existing to newly selected section
+      const sectionPlusCurrent = new Set([
+        ...currentSelections,
+        ...newSelections,
+      ]);
+      updateQueryParams(sectionPlusCurrent, queryParamKey, queryTerm);
+    } else {
+      const clearedSelections = newSelections?.size
+        ? newSelections
+        : new Set<string>();
+      updateQueryParams(clearedSelections, queryParamKey, queryTerm);
+    }
+  };
 
   return (
     <>
@@ -154,9 +143,10 @@ const AccordionContent = ({
       <ul className="usa-list usa-list--unstyled">
         {includeAnyOption && (
           <AnyOptionCheckbox
-            onAnySelection={onAnySelection}
             title={title}
             checked={isNoneSelected}
+            queryParamKey={queryParamKey}
+            defaultEmptySelection={defaultEmptySelection}
           />
         )}
         {filterOptions.map((option) => (

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -78,16 +78,12 @@ const AccordionContent = ({
   includeAnyOption = true,
 }: SearchFilterAccordionProps) => {
   const { queryTerm } = useContext(QueryContext);
-  const { updateQueryParams, searchParams, removeQueryParam } =
-    useSearchParamUpdater();
-
-  /*
-    When checked: remove param for the filter from the query, which will unselect all checkboxes
-    When unchecked: this will not happen on any box click. any box will become unchecked whenever another option is checked
-  */
-  const onAnySelection = useCallback(() => {
-    removeQueryParam(queryParamKey);
-  }, [removeQueryParam, queryParamKey]);
+  const {
+    updateQueryParams,
+    searchParams,
+    removeQueryParam,
+    replaceQueryParams,
+  } = useSearchParamUpdater();
 
   // TODO: implement this within the components where it's used to make it more testable
   const toggleOptionChecked = (value: string, isChecked: boolean) => {
@@ -120,25 +116,36 @@ const AccordionContent = ({
 
   // need to add any existing relevant search params to the passed in set
   // TODO: split this into two functions and implement within the components where they're used to make it more testable
-  const toggleSelectAll = (all: boolean, newSelections?: Set<string>): void => {
-    if (all && newSelections) {
-      // get existing current selected options for this accordion from url
-      const currentSelections = new Set(
-        searchParams.get(camelCase(title))?.split(","),
-      );
-      // add existing to newly selected section
-      const sectionPlusCurrent = new Set([
-        ...currentSelections,
-        ...newSelections,
-      ]);
-      updateQueryParams(sectionPlusCurrent, queryParamKey, queryTerm);
-    } else {
-      const clearedSelections = newSelections?.size
-        ? newSelections
-        : new Set<string>();
-      updateQueryParams(clearedSelections, queryParamKey, queryTerm);
-    }
-  };
+  const toggleSelectAll = useCallback(
+    (all: boolean, newSelections?: Set<string>): void => {
+      if (all && newSelections) {
+        // get existing current selected options for this accordion from url
+        const currentSelections = new Set(
+          searchParams.get(camelCase(title))?.split(","),
+        );
+        // add existing to newly selected section
+        const sectionPlusCurrent = new Set([
+          ...currentSelections,
+          ...newSelections,
+        ]);
+        updateQueryParams(sectionPlusCurrent, queryParamKey, queryTerm);
+      } else {
+        const clearedSelections = newSelections?.size
+          ? newSelections
+          : new Set<string>();
+        updateQueryParams(clearedSelections, queryParamKey, queryTerm);
+      }
+    },
+    [queryParamKey, queryTerm, searchParams, title, updateQueryParams],
+  );
+
+  /*
+    When checked: remove param for the filter from the query, which will unselect all checkboxes
+    When unchecked: this will not happen on any box click. any box will become unchecked whenever another option is checked
+  */
+  const onAnySelection = useCallback(() => {
+    toggleSelectAll(false, defaultEmptySelection);
+  }, [toggleSelectAll, defaultEmptySelection]);
 
   return (
     <>

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -78,12 +78,7 @@ const AccordionContent = ({
   includeAnyOption = true,
 }: SearchFilterAccordionProps) => {
   const { queryTerm } = useContext(QueryContext);
-  const {
-    updateQueryParams,
-    searchParams,
-    removeQueryParam,
-    replaceQueryParams,
-  } = useSearchParamUpdater();
+  const { updateQueryParams, searchParams } = useSearchParamUpdater();
 
   // TODO: implement this within the components where it's used to make it more testable
   const toggleOptionChecked = (value: string, isChecked: boolean) => {

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -142,12 +142,14 @@ const AccordionContent = ({
 
       <ul className="usa-list usa-list--unstyled">
         {includeAnyOption && (
-          <AnyOptionCheckbox
-            title={title}
-            checked={isNoneSelected}
-            queryParamKey={queryParamKey}
-            defaultEmptySelection={defaultEmptySelection}
-          />
+          <li>
+            <AnyOptionCheckbox
+              title={title}
+              checked={isNoneSelected}
+              queryParamKey={queryParamKey}
+              defaultEmptySelection={defaultEmptySelection}
+            />
+          </li>
         )}
         {filterOptions.map((option) => (
           <li key={option.id}>

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -58,6 +58,11 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${queryParamsToQueryString(params)}`);
   };
 
+  const setQueryParam = (key: string, value: string, scroll = false) => {
+    params.set(key, value);
+    router.push(`${pathname}?${params.toString()}`, { scroll });
+  };
+
   const removeQueryParam = (paramKey: string, scroll = false) => {
     params.delete(paramKey);
     router.push(`${pathname}?${params.toString()}`, { scroll });
@@ -68,6 +73,7 @@ export function useSearchParamUpdater() {
     updateQueryParams,
     replaceQueryParams,
     removeQueryParam,
+    setQueryParam,
   };
 }
 

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -58,9 +58,9 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${queryParamsToQueryString(params)}`);
   };
 
-  const removeQueryParam = (paramKey: string) => {
+  const removeQueryParam = (paramKey: string, scroll = false) => {
     params.delete(paramKey);
-    router.push(`${pathname}?${params.toString()}`);
+    router.push(`${pathname}?${params.toString()}`, { scroll });
   };
 
   return {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -543,6 +543,7 @@ export const messages = {
       "Search for and discover relevant opportunities using our improved search.",
     description: "Try out our experimental search page.",
     accordion: {
+      any: "Any",
       titles: {
         funding: "Funding instrument",
         eligibility: "Eligibility",

--- a/frontend/tests/components/search/SearchFilterAccordion/AnyOptionCheckbox.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AnyOptionCheckbox.test.tsx
@@ -1,0 +1,90 @@
+import "@testing-library/jest-dom";
+
+import { waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { render, screen } from "tests/react-utils";
+
+import React from "react";
+
+import { AnyOptionCheckbox } from "src/components/search/SearchFilterAccordion/AnyOptionCheckbox";
+
+const mockSetQueryParam = jest.fn();
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    setQueryParam: mockSetQueryParam,
+  }),
+}));
+
+describe("AnyOptionCheckbox", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("should not have basic accessibility issues", async () => {
+    const { container } = render(
+      <AnyOptionCheckbox title={"any"} checked={false} queryParamKey={"any"} />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("calls the appropriate handlers when the checkbox is checked", async () => {
+    render(
+      <AnyOptionCheckbox title={"any"} checked={false} queryParamKey={"any"} />,
+    );
+
+    // Simulate user clicking the checkbox
+    const checkbox = await screen.findByRole("checkbox");
+    userEvent.click(checkbox);
+
+    // Wait for the updateCheckedOption function to be called with the checkbox being checked
+    await waitFor(() => {
+      expect(mockSetQueryParam).toHaveBeenCalledWith("any", "");
+    });
+  });
+
+  it("calls the appropriate handlers when the checkbox is checked (default value edition)", async () => {
+    render(
+      <AnyOptionCheckbox
+        title={"any"}
+        checked={false}
+        queryParamKey={"any"}
+        defaultEmptySelection={new Set(["default"])}
+      />,
+    );
+
+    // Simulate user clicking the checkbox
+    const checkbox = await screen.findByRole("checkbox");
+    userEvent.click(checkbox);
+
+    // Wait for the updateCheckedOption function to be called with the checkbox being checked
+    await waitFor(() => {
+      expect(mockSetQueryParam).toHaveBeenCalledWith("any", "default");
+    });
+  });
+
+  it("does nothing when clicked if the checkbox is already checked", async () => {
+    render(
+      <AnyOptionCheckbox title={"any"} checked={true} queryParamKey={"any"} />,
+    );
+
+    // Simulate user clicking the checkbox
+    const checkbox = await screen.findByRole("checkbox");
+    userEvent.click(checkbox);
+
+    expect(mockSetQueryParam).toHaveBeenCalledTimes(0);
+  });
+
+  it("displays the correct label", () => {
+    render(
+      <AnyOptionCheckbox
+        title={"For the title"}
+        checked={false}
+        queryParamKey={"any"}
+      />,
+    );
+    const label = screen.getByText("Any for the title");
+    expect(label).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/search/SearchFilterAccordion/AnyOptionCheckbox.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AnyOptionCheckbox.test.tsx
@@ -36,7 +36,7 @@ describe("AnyOptionCheckbox", () => {
 
     // Simulate user clicking the checkbox
     const checkbox = await screen.findByRole("checkbox");
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     // Wait for the updateCheckedOption function to be called with the checkbox being checked
     await waitFor(() => {
@@ -56,7 +56,7 @@ describe("AnyOptionCheckbox", () => {
 
     // Simulate user clicking the checkbox
     const checkbox = await screen.findByRole("checkbox");
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     // Wait for the updateCheckedOption function to be called with the checkbox being checked
     await waitFor(() => {
@@ -71,7 +71,7 @@ describe("AnyOptionCheckbox", () => {
 
     // Simulate user clicking the checkbox
     const checkbox = await screen.findByRole("checkbox");
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     expect(mockSetQueryParam).toHaveBeenCalledTimes(0);
   });

--- a/frontend/tests/e2e/search/searchSpecUtil.ts
+++ b/frontend/tests/e2e/search/searchSpecUtil.ts
@@ -177,15 +177,27 @@ export async function toggleMobileSearchFilters(page: Page) {
   );
   await toggleButton.click();
 }
+
+export const getCountOfTopLevelFilterOptions = async (
+  page: Page,
+  filterType: string,
+): Promise<number> => {
+  const filterOptions = await page
+    .locator(`#opportunity-filter-${filterType} > ul > li > div > input`)
+    .all();
+
+  const ids = await Promise.all(
+    filterOptions.map((option) => option.getAttribute("id")),
+  );
+  return ids.filter((id) => !id?.match(/any$/)).length;
+};
+
 // returns the number of options available to be selected
 export const selectAllTopLevelFilterOptions = async (
   page: Page,
   filterType: string,
-): Promise<number> => {
+): Promise<undefined> => {
   // gather number of (top level) filter options for filter type
-  const numberOfFilterOptions = await page
-    .locator(`#opportunity-filter-${filterType} > ul > li > div > input`)
-    .count();
 
   // click select all for filter type
   const selectAllButton = page
@@ -195,8 +207,6 @@ export const selectAllTopLevelFilterOptions = async (
 
   // validate that url is updated
   await waitForURLContainsQueryParam(page, filterType);
-
-  return numberOfFilterOptions;
 };
 
 export const validateTopLevelAndNestedSelectedFilterCounts = async (

--- a/frontend/tests/hooks/useSearchParamUpdater.test.ts
+++ b/frontend/tests/hooks/useSearchParamUpdater.test.ts
@@ -87,7 +87,9 @@ describe("useSearchParamUpdater", () => {
       mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
       const { result } = renderHook(() => useSearchParamUpdater());
       result.current.removeQueryParam("removeMe");
-      expect(routerPush).toHaveBeenCalledWith("/test?keepMe=cool");
+      expect(routerPush).toHaveBeenCalledWith("/test?keepMe=cool", {
+        scroll: false,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #3915

### Time to review: __20 mins__

## Changes proposed
Adds "any" check boxes to all filter accordions except for agency. This checkbox effectively does the same thing as the "clear all" link, removing any currently selected options for a given filter. The box should be checked automatically if no other options are checked for a given filter, and will be unchecked as soon as any option for the filter is selected.

## Context for reviewers
### Test steps

1. start a server on this branch with `npm run dev`
2. visit http://localhost:3000/search
3. _VERIFY_: "any" checkboxes are available for all filter accordions except agency
4. _VERIFY_: "any" checkboxes are selected by default for all filters except status and agency
5. click an already checked any checkbox
6. _VERIFY_: nothing happens
7. click a non-any filter option in eligibility
8. _VERIFY_: any checkbox is no longer selected, selected option is set in url and search results as expected
9. click the any checkbox for eligibility
10. _VERIFY_: the previously selected eligibility option is unselected
11. click the any checkbox for status
12. _VERIFY_: `status=none` is set in the url and search results are updated as expected

## Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

