### PR TITLE
[Issue #4599] Update ApplyForm.tsx to turn off html validation

### DIFF
--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -57,6 +57,8 @@ const ApplyForm = ({
       <form
         className="usa-form usa-form--large flex-1 margin-top-neg-5"
         action={formAction}
+        // turns off html5 validation so all error displays are consistent
+        noValidate
       >
         <ApplyFormSuccessMessage message={successMessage} />
         <ApplyFormErrorMessage


### PR DESCRIPTION
## Summary
Fixes #4599

### Time to review: __15 mins__

## Changes proposed
Before this commit, the form submission triggered [client-side form validation by the browser](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation) for certain fields, which provides a different UI for some form fields:

<img width="515" alt="Image" src="https://github.com/user-attachments/assets/976cbb53-d542-4777-a471-2fc54e42857a" />


After this change, the form is able to submit and provide the same validation for fields that were picked up by the HTML5 validation:

![image](https://github.com/user-attachments/assets/efd3a9c6-7662-4ffb-a611-dd72203ebfe5)


## Context for reviewers

This will be easier to test after: https://github.com/HHS/simpler-grants-gov/pull/4563 is pulled in as an email field as added to the test form.
