### PR TITLE
[Issue #4800] fix tooltip styling

### DIFF
--- a/frontend/src/components/InfoTooltip.tsx
+++ b/frontend/src/components/InfoTooltip.tsx
@@ -37,7 +37,9 @@ const InfoTooltip = ({
       asCustom={IconWrapper}
       className={className}
       data-testid="tooltipWrapper"
-    />
+    >
+      <></>
+    </TooltipWrapper>
   );
 };
 

--- a/frontend/src/components/TooltipWrapper.tsx
+++ b/frontend/src/components/TooltipWrapper.tsx
@@ -9,23 +9,14 @@ type TooltipProps = {
   position?: "top" | "bottom" | "left" | "right";
   wrapperclasses?: string;
   className?: string;
-  children?: ReactNode;
+  children: ReactNode;
   asCustom?: ForwardRefExoticComponent<
     Omit<React.HTMLProps<HTMLElement>, "ref"> & React.RefAttributes<HTMLElement>
   >;
 };
 
 export const TooltipWrapper = (props: TooltipProps) => {
-  const { children = <span />, className, ...rest } = props;
-  return (
-    <Tooltip
-      {...rest}
-      aria-label={props.title}
-      wrapperclasses={`usa-tooltip ${className || ""}`}
-    >
-      {children}
-    </Tooltip>
-  );
+  return <Tooltip {...props} aria-label={props.title} />;
 };
 
 export default TooltipWrapper;

--- a/frontend/tests/components/InfoTooltip.test.tsx
+++ b/frontend/tests/components/InfoTooltip.test.tsx
@@ -14,14 +14,6 @@ describe("InfoTooltip", () => {
     expect(screen.getByTestId("triggerElement")).toBeInTheDocument();
   });
 
-  it("applies custom className", () => {
-    const customClass = "custom-class";
-    render(<InfoTooltip text="Test tooltip" className={customClass} />);
-    const tooltipWrapper = screen.getByTestId("tooltipWrapper");
-    expect(tooltipWrapper).toHaveClass("usa-tooltip");
-    expect(tooltipWrapper).toHaveClass(customClass);
-  });
-
   it("shows tooltip on hover", async () => {
     const tooltipText = "Test tooltip";
     render(<InfoTooltip text={tooltipText} />);


### PR DESCRIPTION
## Summary
Fixes #4800

### Time to review: __1 mins__

## Changes proposed
Fixes bug

## Context for reviewers
1. start a local server on this branch
2. visit localhost:3000/search
3. _VERIFY_: tooltip looks normal

## Additional information

<img width="389" alt="Screenshot 2025-04-23 at 12 34 35 PM" src="https://github.com/user-attachments/assets/3874d739-26b9-45e4-b291-29e0e66dd878" />


### VS

<img width="395" alt="Screenshot 2025-04-23 at 12 37 36 PM" src="https://github.com/user-attachments/assets/fe62081f-c3d0-48cd-b660-3f85c4ab2fbd" />

