### PR TITLE
[Unticketed] Fix scenario where user declines to use login.gov

### DIFF
--- a/api/tests/src/task/opportunities/test_store_opportunity_version_task.py
+++ b/api/tests/src/task/opportunities/test_store_opportunity_version_task.py
@@ -1,11 +1,10 @@
-from datetime import datetime
-
 import pytest
 
 from src.constants.lookup_constants import JobStatus
 from src.db.models.opportunity_models import Opportunity, OpportunityVersion
 from src.db.models.task_models import JobLog
 from src.task.opportunities.store_opportunity_version_task import StoreOpportunityVersionTask
+from src.util import datetime_util
 from tests.conftest import BaseTestClass
 from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.db.models.factories import (
@@ -125,7 +124,7 @@ class TestStoreOpportunityVersionTask(BaseTestClass):
 
         # run with a second update
         oca.opportunity.current_opportunity_summary = None
-        oca.updated_at = datetime.now()
+        oca.updated_at = datetime_util.utcnow()
         db_session.commit()
 
         store_opportunity_version_task.run()


### PR DESCRIPTION
## Summary

### Time to review: __5 mins__

## Changes proposed
Adjusts behavior when a user declines to login to login.gov via our endpoint

## Context for reviewers
When implementing this, I didn't read the detail for `access_denied` very closely and assumed it was "us" being denied access to login.gov entirely. In reality, it's the user saying no. The change here makes it so we raise a 401 instead of a 500 (which both get redirected the same) which effectively just makes us avoid logging an error message / tripping an alert. No meaningful experience change will happen for a user.

