### PR TITLE
[Issue #4380] auth token refresh on request

### DIFF
--- a/frontend/src/app/api/auth/callback/route.ts
+++ b/frontend/src/app/api/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { createSession } from "src/services/auth/session";
+import { newExpirationDate } from "src/services/auth/sessionUtils";
 
 import { redirect } from "next/navigation";
 import { NextRequest } from "next/server";
@@ -9,7 +10,7 @@ export async function GET(request: NextRequest) {
     return redirect("/unauthenticated");
   }
   try {
-    await createSession(token);
+    await createSession(token, newExpirationDate());
   } catch (_e) {
     console.error("Error creating session for token", { token });
     console.error(_e);

--- a/frontend/src/app/api/auth/session/route.ts
+++ b/frontend/src/app/api/auth/session/route.ts
@@ -1,4 +1,5 @@
-import { getSession } from "src/services/auth/session";
+import { getSession, refreshSession } from "src/services/auth/session";
+import { isExpiring } from "src/utils/dateUtil";
 
 import { NextResponse } from "next/server";
 
@@ -7,6 +8,10 @@ export const revalidate = 0;
 export async function GET() {
   const currentSession = await getSession();
   if (currentSession) {
+    if (isExpiring(currentSession.expiresAt)) {
+      const refreshedSession = await refreshSession(currentSession.token);
+      return NextResponse.json(refreshedSession);
+    }
     return NextResponse.json(currentSession);
   } else {
     return NextResponse.json({ token: "" });

--- a/frontend/src/constants/auth.ts
+++ b/frontend/src/constants/auth.ts
@@ -1,0 +1,5 @@
+// 10 minutes
+export const clientTokenRefreshInterval = 10 * 60 * 1000;
+
+// 15 minutes
+export const clientTokenExpirationInterval = 15 * 60 * 1000;

--- a/frontend/src/hooks/useClientFetch.ts
+++ b/frontend/src/hooks/useClientFetch.ts
@@ -15,7 +15,7 @@ export const useClientFetch = <T>(
   errorMessage: string,
   { jsonResponse = true, authGatedRequest = false } = {},
 ) => {
-  const { refreshIfExpired, refreshUser } = useUser();
+  const { refreshIfExpired, refreshUser, refreshIfExpiring } = useUser();
   const router = useRouter();
 
   const fetchWithAuthCheck = async (
@@ -27,6 +27,7 @@ export const useClientFetch = <T>(
       router.refresh();
       throw new Error("local token expired, logging out");
     }
+    await refreshIfExpiring();
     const response = await fetch(url, options);
     if (response.status === 401) {
       await refreshUser();

--- a/frontend/src/services/auth/session.ts
+++ b/frontend/src/services/auth/session.ts
@@ -55,25 +55,39 @@ const decryptLoginGovToken = async (
   return (payload as UserSession) ?? null;
 };
 
-// sets client token on cookie
-export const createSession = async (token: string) => {
+// ecrypts the api token into client token, then sets client token on cookie
+export const createSession = async (token: string, expiration: Date) => {
   if (!clientJwtKey) {
     initializeSessionSecrets();
   }
-  const expiresAt = newExpirationDate();
-  const session = await encrypt(token, expiresAt, clientJwtKey);
+  const session = await encrypt(token, expiration, clientJwtKey);
   const cookie = await cookies();
   cookie.set("session", session, {
     httpOnly: true,
     secure: environment.ENVIRONMENT === "prod",
-    expires: expiresAt,
+    expires: expiration,
     sameSite: "lax",
     path: "/",
   });
 };
 
+// sets a client token based on an API token and expiration, then
+// returns the user info as in getSession.
+// Similar to running createSession & getSession, but skips unnecessarily decrypting the client token after encrypting
+const createAndReturnSession = async (token: string, expiration: Date) => {
+  await createSession(token, expiration);
+  const apiSession = await decryptLoginGovToken(token);
+  return apiSession
+    ? {
+        ...apiSession,
+        token,
+        expiresAt: expiration ? expiration.getTime() : undefined,
+      }
+    : null;
+};
+
 // returns the necessary user info from decrypted login gov token
-// plus api token and expiration
+// plus the encrypted api token and expiration decrypted from the client token
 export const getSession = async (): Promise<UserSession | null> => {
   if (!clientJwtKey || !loginGovJwtKey) {
     initializeSessionSecrets();
@@ -91,22 +105,23 @@ export const getSession = async (): Promise<UserSession | null> => {
     ? {
         ...session,
         token,
-        // expiration timestamp in the token is in seconds, in order to compare using
+        // expiration timestamp in the login.gov token is in seconds, in order to compare using
         // JS date functions it should be in ms
         expiresAt: exp ? exp * 1000 : undefined,
       }
     : null;
 };
 
-// for use when we want to refresh a user's token expiration
+// for use whenever we want to refresh a user's token expiration
+// note that the API token itself is not updated other than bumping the expiration
 export const refreshSession = async (
   apiSessionToken: string,
 ): Promise<UserSession | null> => {
-  // update expiration on the API
-  await postTokenRefresh();
-  // re-encrypt the existing API token with a new expiration date
-  // or do we want to use a new token that comes down from the postTokenRefresh call?
-  await createSession(apiSessionToken);
-  // return the new decrypted session
-  return getSession();
+  // update expiration on the API side
+  await postTokenRefresh({
+    additionalHeaders: { "X-SGG-Token": apiSessionToken },
+  });
+  // re-encrypt the existing API token with a refreshed expiration date
+  // and return decrypted user info
+  return createAndReturnSession(apiSessionToken, newExpirationDate());
 };

--- a/frontend/src/services/auth/session.ts
+++ b/frontend/src/services/auth/session.ts
@@ -71,21 +71,6 @@ export const createSession = async (token: string, expiration: Date) => {
   });
 };
 
-// sets a client token based on an API token and expiration, then
-// returns the user info as in getSession.
-// Similar to running createSession & getSession, but skips unnecessarily decrypting the client token after encrypting
-const createAndReturnSession = async (token: string, expiration: Date) => {
-  await createSession(token, expiration);
-  const apiSession = await decryptLoginGovToken(token);
-  return apiSession
-    ? {
-        ...apiSession,
-        token,
-        expiresAt: expiration ? expiration.getTime() : undefined,
-      }
-    : null;
-};
-
 // returns the necessary user info from decrypted login gov token
 // plus the encrypted api token and expiration decrypted from the client token
 export const getSession = async (): Promise<UserSession | null> => {
@@ -108,6 +93,24 @@ export const getSession = async (): Promise<UserSession | null> => {
         // expiration timestamp in the login.gov token is in seconds, in order to compare using
         // JS date functions it should be in ms
         expiresAt: exp ? exp * 1000 : undefined,
+      }
+    : null;
+};
+
+// sets a client token based on an API token and expiration, then
+// returns the user info as in getSession.
+// Similar to running createSession & getSession, but skips unnecessarily decrypting the client token after encrypting
+export const createAndReturnSession = async (
+  token: string,
+  expiration: Date,
+) => {
+  await createSession(token, expiration);
+  const apiSession = await decryptLoginGovToken(token);
+  return apiSession
+    ? {
+        ...apiSession,
+        token,
+        expiresAt: expiration ? expiration.getTime() : undefined,
       }
     : null;
 };

--- a/frontend/src/services/auth/sessionUtils.ts
+++ b/frontend/src/services/auth/sessionUtils.ts
@@ -8,11 +8,8 @@ import { cookies } from "next/headers";
 export const CLIENT_JWT_ENCRYPTION_ALGORITHM = "HS256";
 export const API_JWT_ENCRYPTION_ALGORITHM = "RS256";
 
-// // returns a new date 15 minutes from time of function call
-// export const newExpirationDate = () => new Date(Date.now() + 15 * 60 * 1000);
-
-// returns a new date 10 minutes from time of function call
-export const newExpirationDate = () => new Date(Date.now() + 10 * 60 * 1000);
+// returns a new date 15 minutes from time of function call
+export const newExpirationDate = () => new Date(Date.now() + 15 * 60 * 1000);
 
 // extracts payload object from jwt string using passed encrytion key and algo
 export const decrypt = async (

--- a/frontend/src/services/auth/sessionUtils.ts
+++ b/frontend/src/services/auth/sessionUtils.ts
@@ -8,8 +8,11 @@ import { cookies } from "next/headers";
 export const CLIENT_JWT_ENCRYPTION_ALGORITHM = "HS256";
 export const API_JWT_ENCRYPTION_ALGORITHM = "RS256";
 
-// returns a new date 15 minutes from time of function call
-export const newExpirationDate = () => new Date(Date.now() + 15 * 60 * 1000);
+// // returns a new date 15 minutes from time of function call
+// export const newExpirationDate = () => new Date(Date.now() + 15 * 60 * 1000);
+
+// returns a new date 10 minutes from time of function call
+export const newExpirationDate = () => new Date(Date.now() + 10 * 60 * 1000);
 
 // extracts payload object from jwt string using passed encrytion key and algo
 export const decrypt = async (

--- a/frontend/src/services/auth/sessionUtils.ts
+++ b/frontend/src/services/auth/sessionUtils.ts
@@ -2,6 +2,7 @@
 
 import { KeyObject } from "crypto";
 import { JWTPayload, jwtVerify, SignJWT } from "jose";
+import { clientTokenExpirationInterval } from "src/constants/auth";
 
 import { cookies } from "next/headers";
 
@@ -9,7 +10,8 @@ export const CLIENT_JWT_ENCRYPTION_ALGORITHM = "HS256";
 export const API_JWT_ENCRYPTION_ALGORITHM = "RS256";
 
 // returns a new date 15 minutes from time of function call
-export const newExpirationDate = () => new Date(Date.now() + 15 * 60 * 1000);
+export const newExpirationDate = () =>
+  new Date(Date.now() + clientTokenExpirationInterval);
 
 // extracts payload object from jwt string using passed encrytion key and algo
 export const decrypt = async (

--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -68,3 +68,10 @@ export const fetchAgenciesEndpoint = {
   namespace: "agencies",
   method: "POST" as ApiMethod,
 };
+
+export const userRefreshEndpoint = {
+  basePath: environment.API_URL,
+  version: "v1",
+  namespace: "users/token/refresh",
+  method: "POST" as ApiMethod,
+};

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -11,6 +11,7 @@ import {
   toDynamicApplicationsEndpoint,
   toDynamicUsersEndpoint,
   userLogoutEndpoint,
+  userRefreshEndpoint,
 } from "src/services/fetch/endpointConfigs";
 import {
   createRequestBody,
@@ -119,3 +120,5 @@ export const fetchUserWithMethod = (type: "POST" | "DELETE" | "PUT") =>
   requesterForEndpoint(toDynamicUsersEndpoint(type));
 
 export const fetchAgencies = requesterForEndpoint(fetchAgenciesEndpoint);
+
+export const postTokenRefresh = requesterForEndpoint(userRefreshEndpoint);

--- a/frontend/src/types/authTypes.ts
+++ b/frontend/src/types/authTypes.ts
@@ -69,4 +69,5 @@ export type UserProviderState = {
   logoutLocalUser: () => void;
   resetHasBeenLoggedOut: () => void;
   refreshIfExpired: () => Promise<boolean | undefined>;
+  refreshIfExpiring: () => Promise<boolean | undefined>;
 };

--- a/frontend/src/utils/dateUtil.ts
+++ b/frontend/src/utils/dateUtil.ts
@@ -22,10 +22,10 @@ export function formatDate(dateStr: string | null): string {
 export const getConfiguredDayJs = () => dayjs;
 
 export const isExpired = (expiration?: number) =>
-  expiration && new Date(expiration) < new Date();
+  !!expiration && expiration < Date.now();
 
 // is a token less than 10 minutes from expiring?
 export const isExpiring = (expiration?: number) =>
   !isExpired(expiration) &&
-  expiration &&
-  new Date(expiration) < new Date(Date.now() + 10 * 60 * 1000);
+  !!expiration &&
+  expiration < Date.now() + 10 * 60 * 1000;

--- a/frontend/src/utils/dateUtil.ts
+++ b/frontend/src/utils/dateUtil.ts
@@ -20,3 +20,12 @@ export function formatDate(dateStr: string | null): string {
 }
 
 export const getConfiguredDayJs = () => dayjs;
+
+export const isExpired = (expiration?: number) =>
+  expiration && new Date(expiration) < new Date();
+
+// is a token less than 10 minutes from expiring?
+export const isExpiring = (expiration?: number) =>
+  !isExpired(expiration) &&
+  expiration &&
+  new Date(expiration) < new Date(Date.now() + 10 * 60 * 1000);

--- a/frontend/src/utils/dateUtil.ts
+++ b/frontend/src/utils/dateUtil.ts
@@ -3,6 +3,7 @@ import advancedFormat from "dayjs/plugin/advancedFormat";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 import timezone from "dayjs/plugin/timezone";
+import { clientTokenRefreshInterval } from "src/constants/auth";
 
 dayjs.extend(advancedFormat);
 dayjs.extend(customParseFormat);
@@ -28,4 +29,4 @@ export const isExpired = (expiration?: number) =>
 export const isExpiring = (expiration?: number) =>
   !isExpired(expiration) &&
   !!expiration &&
-  expiration < Date.now() + 10 * 60 * 1000;
+  expiration < Date.now() + clientTokenRefreshInterval;

--- a/frontend/tests/hooks/useClientFetch.test.ts
+++ b/frontend/tests/hooks/useClientFetch.test.ts
@@ -4,6 +4,7 @@ import { wrapForExpectedError } from "src/utils/testing/commonTestUtils";
 
 const refreshMock = jest.fn();
 const refreshIfExpiredMock = jest.fn();
+const refreshIfExpiringMock = jest.fn();
 const refreshUserMock = jest.fn();
 const jsonMock = jest.fn();
 
@@ -25,6 +26,7 @@ jest.mock("src/services/auth/useUser", () => ({
   useUser: () => ({
     refreshIfExpired: () => refreshIfExpiredMock() as unknown,
     refreshUser: () => refreshUserMock() as unknown,
+    refreshIfExpiring: () => refreshIfExpiringMock() as unknown,
   }),
 }));
 
@@ -43,6 +45,7 @@ describe("useClientFetch", () => {
     const { result } = renderHook(() => useClientFetch("an error!"));
     await result.current.clientFetch("http://wherever");
     expect(refreshIfExpiredMock).toHaveBeenCalledTimes(1);
+    expect(refreshIfExpiringMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(refreshMock).toHaveBeenCalledTimes(0);
     expect(refreshUserMock).toHaveBeenCalledTimes(0);

--- a/frontend/tests/services/auth/session.test.ts
+++ b/frontend/tests/services/auth/session.test.ts
@@ -1,4 +1,10 @@
-import { createSession, getSession } from "src/services/auth/session";
+import {
+  createAndReturnSession,
+  createSession,
+  getSession,
+  refreshSession,
+} from "src/services/auth/session";
+import { postTokenRefresh } from "src/services/fetch/fetchers/fetchers";
 
 const getCookiesMock = jest.fn(() => ({
   value: "some cookie value",
@@ -11,6 +17,8 @@ const createPublicKeyMock = jest.fn((arg: string): string => arg);
 
 const decryptMock = jest.fn();
 const encryptMock = jest.fn();
+
+const mockPostTokenRefresh = jest.fn();
 
 const cookiesMock = () => {
   return {
@@ -45,6 +53,10 @@ jest.mock("src/utils/generalUtils", () => ({
 
 jest.mock("crypto", () => ({
   createPublicKey: (arg: string): string => createPublicKeyMock(arg),
+}));
+
+jest.mock("src/services/fetch/fetchers/fetchers", () => ({
+  postTokenRefresh: (arg: unknown): unknown => mockPostTokenRefresh(arg),
 }));
 
 describe("getSession", () => {
@@ -102,16 +114,16 @@ describe("createSession", () => {
   // to get this to work we'd need to manage resetting all modules before the test, which is a bit of a pain
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("initializes session secrets if necessary", async () => {
-    await createSession("nothingSpecial");
+    await createSession("nothingSpecial", new Date(1));
     expect(encodeTextMock).toHaveBeenCalledWith("session secret");
     expect(createPublicKeyMock).toHaveBeenCalledWith("api secret");
   });
   it("calls cookie.set with expected values", async () => {
     encryptMock.mockReturnValue("encrypted session");
-    await createSession("nothingSpecial");
+    await createSession("nothingSpecial", new Date(1));
     expect(encryptMock).toHaveBeenCalledWith([
       "nothingSpecial",
-      new Date(0),
+      new Date(1),
       "session secret",
     ]);
     expect(setCookiesMock).toHaveBeenCalledTimes(1);
@@ -121,10 +133,106 @@ describe("createSession", () => {
       {
         httpOnly: true,
         secure: false, // true only in prod for now
-        expires: new Date(0),
+        expires: new Date(1),
         sameSite: "lax",
         path: "/",
       },
     );
+  });
+});
+
+describe("createAndReturnSession", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("calls cookie.set with expected values", async () => {
+    encryptMock.mockReturnValue("encrypted session");
+    await createAndReturnSession("nothingSpecial", new Date(1));
+    expect(encryptMock).toHaveBeenCalledWith([
+      "nothingSpecial",
+      new Date(1),
+      "session secret",
+    ]);
+    expect(setCookiesMock).toHaveBeenCalledTimes(1);
+    expect(setCookiesMock).toHaveBeenCalledWith(
+      "session",
+      "encrypted session",
+      {
+        httpOnly: true,
+        secure: false, // true only in prod for now
+        expires: new Date(1),
+        sameSite: "lax",
+        path: "/",
+      },
+    );
+  });
+
+  it("calls decrypt with the correct arguments and returns successfully", async () => {
+    decryptMock.mockReturnValueOnce({
+      arbitrary: "stuff",
+    });
+    const session = await createAndReturnSession("nothingSpecial", new Date(1));
+    expect(decryptMock).toHaveBeenCalledTimes(1);
+    expect(decryptMock).toHaveBeenCalledWith([
+      "nothingSpecial",
+      "api secret",
+      "algo two",
+    ]);
+    expect(session).toEqual({
+      token: "nothingSpecial",
+      arbitrary: "stuff",
+      expiresAt: new Date(1).getTime(),
+    });
+  });
+});
+
+describe("refreshSession", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("calls refresh fetch function correctly", async () => {
+    await refreshSession("a token");
+    expect(mockPostTokenRefresh).toHaveBeenCalledWith({
+      additionalHeaders: { "X-SGG-Token": "a token" },
+    });
+  });
+  it("calls cookie.set with expected values", async () => {
+    encryptMock.mockReturnValue("encrypted session");
+    await createAndReturnSession("nothingSpecial", new Date(1));
+    expect(encryptMock).toHaveBeenCalledWith([
+      "nothingSpecial",
+      new Date(1),
+      "session secret",
+    ]);
+    expect(setCookiesMock).toHaveBeenCalledTimes(1);
+    expect(setCookiesMock).toHaveBeenCalledWith(
+      "session",
+      "encrypted session",
+      {
+        httpOnly: true,
+        secure: false, // true only in prod for now
+        expires: new Date(1),
+        sameSite: "lax",
+        path: "/",
+      },
+    );
+  });
+
+  it("calls decrypt with the correct arguments and returns successfully", async () => {
+    decryptMock.mockReturnValueOnce({
+      arbitrary: "stuff",
+    });
+    const session = await createAndReturnSession("nothingSpecial", new Date(1));
+    expect(decryptMock).toHaveBeenCalledTimes(1);
+    expect(decryptMock).toHaveBeenCalledWith([
+      "nothingSpecial",
+      "api secret",
+      "algo two",
+    ]);
+    expect(session).toEqual({
+      token: "nothingSpecial",
+      arbitrary: "stuff",
+      expiresAt: new Date(1).getTime(),
+    });
   });
 });

--- a/frontend/tests/services/auth/session.test.ts
+++ b/frontend/tests/services/auth/session.test.ts
@@ -4,7 +4,6 @@ import {
   getSession,
   refreshSession,
 } from "src/services/auth/session";
-import { postTokenRefresh } from "src/services/fetch/fetchers/fetchers";
 
 const getCookiesMock = jest.fn(() => ({
   value: "some cookie value",

--- a/frontend/tests/services/auth/useUser.test.tsx
+++ b/frontend/tests/services/auth/useUser.test.tsx
@@ -5,7 +5,6 @@ import { useUser } from "src/services/auth/useUser";
 import { PropsWithChildren } from "react";
 
 const debouncedUserFetcherMock = jest.fn();
-const mockPostTokenRefresh = jest.fn();
 
 jest.mock("src/services/fetch/fetchers/clientUserFetcher", () => ({
   debouncedUserFetcher: () => debouncedUserFetcherMock() as unknown,

--- a/frontend/tests/utils/dateUtil.test.ts
+++ b/frontend/tests/utils/dateUtil.test.ts
@@ -1,5 +1,5 @@
 import { identity } from "lodash";
-import { formatDate } from "src/utils/dateUtil";
+import { formatDate, isExpired, isExpiring } from "src/utils/dateUtil";
 
 describe("formatDate", () => {
   beforeEach(() => {
@@ -24,5 +24,32 @@ describe("formatDate", () => {
     expect(logSpy).toHaveBeenCalledWith(
       "invalid date string provided for parse",
     );
+  });
+});
+
+describe("isExpiring", () => {
+  it("returns false if no expiration", () => {
+    expect(isExpiring()).toEqual(false);
+  });
+  it("returns false if expiration is more than 10 minutes in the future", () => {
+    expect(isExpiring(Date.now() + 11 * 60 * 1000)).toEqual(false);
+  });
+  it("returns false if expiration is in the past", () => {
+    expect(isExpiring(Date.now() - 11 * 60 * 1000)).toEqual(false);
+  });
+  it("returns true if expiration is in the next 10 minutes", () => {
+    expect(isExpiring(Date.now() + 9 * 60 * 1000)).toEqual(true);
+  });
+});
+
+describe("isExpired", () => {
+  it("returns false if no expiration", () => {
+    expect(isExpired()).toEqual(false);
+  });
+  it("returns true if expiration is in the past", () => {
+    expect(isExpired(Date.now() - 1)).toEqual(true);
+  });
+  it("returns false if expiration is in the future", () => {
+    expect(isExpired(Date.now() + 1)).toEqual(false);
   });
 });

--- a/frontend/tests/utils/dateUtil.test.ts
+++ b/frontend/tests/utils/dateUtil.test.ts
@@ -1,6 +1,10 @@
 import { identity } from "lodash";
 import { formatDate, isExpired, isExpiring } from "src/utils/dateUtil";
 
+jest.mock("src/constants/auth", () => ({
+  clientTokenRefreshInterval: 1000,
+}));
+
 describe("formatDate", () => {
   beforeEach(() => {
     jest.spyOn(console, "warn").mockImplementation(identity);
@@ -31,14 +35,14 @@ describe("isExpiring", () => {
   it("returns false if no expiration", () => {
     expect(isExpiring()).toEqual(false);
   });
-  it("returns false if expiration is more than 10 minutes in the future", () => {
-    expect(isExpiring(Date.now() + 11 * 60 * 1000)).toEqual(false);
+  it("returns false if expiration is more than the refresh interval in the future", () => {
+    expect(isExpiring(Date.now() + 1001)).toEqual(false);
   });
   it("returns false if expiration is in the past", () => {
-    expect(isExpiring(Date.now() - 11 * 60 * 1000)).toEqual(false);
+    expect(isExpiring(Date.now() - 1)).toEqual(false);
   });
-  it("returns true if expiration is in the next 10 minutes", () => {
-    expect(isExpiring(Date.now() + 9 * 60 * 1000)).toEqual(true);
+  it("returns true if expiration falls within the refresh interval", () => {
+    expect(isExpiring(Date.now() + 500)).toEqual(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #4380

## Changes proposed

Adds call to refresh auth token if necessary on each client side request to the Next API.

If a user is logged in and has a token expiring within 10 minutes, on an API request, a call will be made to the python API to refresh the token on that side, and then re-encrypt the login.gov token with a new expiration.

## Context for reviewers

* Refactors `createSession` to take in the expiration date for the session in order to make the function more reusable.
* Adds constants to track timing on expiration and refresh intervals

## Validation steps

1. to make testing this easier, set the client token refresh interval to the same value as the token expiration interval. This way the app will always try to refresh your token on API requests once you're logged in. Change line 2 of src/constants/auth.ts to
```
export const clientTokenRefreshInterval = 15 * 60 * 1000;
```
1. start a server on this branch with `npm run dev`
3. visit http://localhost:3000/search?_ff=authOn:true
4. log in
5. open dev tools and find the expiration date for your session cookie
6. _VERIFY_: it's roughly 15 minutes in the future
7. download a search result csv
8. check the session cookie
9. _VERIFY_: new token value, and expiration has been bumped forward a bit


### Bonus

1. repeat steps 7-9 for other actions that trigger API calls (save search or opportunity, etc.)

### Bonus part 2

1. undo change from first step one and repeat test steps
2. _VERIFY_: token and expiration on cookie do not update when you download the csv

### What this looks like in the dev tools


https://github.com/user-attachments/assets/d4317833-1fe2-4536-9888-ba5657b28e54


