### PR TITLE
[unticketed] fix issue with opportunity page content display toggle e2e tests

### DIFF
--- a/frontend/src/components/opportunity/OpportunityDescription.tsx
+++ b/frontend/src/components/opportunity/OpportunityDescription.tsx
@@ -88,42 +88,41 @@ const OpportunityDescription = ({
   );
 
   return (
-    <>
-      <div className="usa-prose margin-top-3">
-        <div className="display-block tablet:display-flex usa-prose flex-align-end">
-          <h2 className="flex-1">{t("title")}</h2>
-          <OpportunityDownload attachments={attachments} />
-        </div>
-        <SummaryDescriptionDisplay
-          summaryDescription={summary.summary_description || ""}
-        />
-        <h2>{t("eligibility")}</h2>
-        <h3>{t("eligible_applicants")}</h3>
-        <OpportunityEligibility
-          applicantTypes={summary.applicant_types || []}
-        />
-        <h3>{t("additional_info")}</h3>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(additionalInformationOnEligibility),
-          }}
-        />
-        <h2>{t("contact_info")}</h2>
-        <h3>{t("contact_description")}</h3>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: DOMPurify.sanitize(
-              summary?.agency_contact_description || "--",
-            ),
-          }}
-        />
-        <h4>{t("email")}</h4>
-        {summary?.agency_email_address_description && (
-          <p>{summary.agency_email_address_description}</p>
-        )}
-        <p>{agencyEmailLink}</p>
+    <div
+      className="usa-prose margin-top-3"
+      data-testid="opportunity-description"
+    >
+      <div className="display-block tablet:display-flex usa-prose flex-align-end">
+        <h2 className="flex-1">{t("title")}</h2>
+        <OpportunityDownload attachments={attachments} />
       </div>
-    </>
+      <SummaryDescriptionDisplay
+        summaryDescription={summary.summary_description || ""}
+      />
+      <h2>{t("eligibility")}</h2>
+      <h3>{t("eligible_applicants")}</h3>
+      <OpportunityEligibility applicantTypes={summary.applicant_types || []} />
+      <h3>{t("additional_info")}</h3>
+      <div
+        dangerouslySetInnerHTML={{
+          __html: DOMPurify.sanitize(additionalInformationOnEligibility),
+        }}
+      />
+      <h2>{t("contact_info")}</h2>
+      <h3>{t("contact_description")}</h3>
+      <div
+        dangerouslySetInnerHTML={{
+          __html: DOMPurify.sanitize(
+            summary?.agency_contact_description || "--",
+          ),
+        }}
+      />
+      <h4>{t("email")}</h4>
+      {summary?.agency_email_address_description && (
+        <p>{summary.agency_email_address_description}</p>
+      )}
+      <p>{agencyEmailLink}</p>
+    </div>
   );
 };
 

--- a/frontend/src/components/opportunity/OpportunityStatusWidget.tsx
+++ b/frontend/src/components/opportunity/OpportunityStatusWidget.tsx
@@ -114,7 +114,7 @@ const OpportunityStatusWidget = ({ opportunityData }: Props) => {
   };
 
   return (
-    <div className={"usa-prose"}>
+    <div className="usa-prose" data-testid="opportunity-status-widget">
       {statusTagFormatter(
         opportunityStatus,
         opportunityCloseDate,

--- a/frontend/tests/e2e/opportunity.spec.ts
+++ b/frontend/tests/e2e/opportunity.spec.ts
@@ -19,46 +19,88 @@ test("has page attributes", async ({ page }) => {
   await expect(page.getByText("Application process")).toBeVisible();
 });
 
-test("can expand and collapse summary", async ({ page }) => {
-  await expect(page.getByText("Show full summary")).toBeVisible();
-  await expect(page.getByText("Hide full description")).not.toBeVisible();
+// a bit tough to target the content display toggles on the page, since they have the same text and there's
+// nothing really special about the markup surrounding them
+test("can expand and collapse opportunity description", async ({ page }) => {
+  const descriptionExpander = page.locator(
+    "div[data-testid='opportunity-description'] div[data-testid='content-display-toggle']",
+  );
+
+  await expect(
+    descriptionExpander.getByText("Show full description"),
+  ).toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Hide full description"),
+  ).not.toBeVisible();
   const divCountBeforeExpanding = await page.locator("div:visible").count();
 
-  await page.getByRole("button", { name: /^Show full summary$/ }).click();
+  await descriptionExpander
+    .getByRole("button", { name: /^Show full description$/ })
+    .click();
 
   // validate that summary has been expanded
-  await expect(page.getByText("Show full summary")).not.toBeVisible();
-  await expect(page.getByText("Hide full description")).toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Show full description"),
+  ).not.toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Hide full description"),
+  ).toBeVisible();
   const divCountAfterExpanding = await page.locator("div:visible").count();
   expect(divCountBeforeExpanding).toBeLessThan(divCountAfterExpanding);
 
-  await page.getByRole("button", { name: /^Hide full description$/ }).click();
+  await descriptionExpander
+    .getByRole("button", { name: /^Hide full description$/ })
+    .click();
 
   // validate that summary has been collapsed
-  await expect(page.getByText("Show full summary")).toBeVisible();
-  await expect(page.getByText("Hide full description")).not.toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Show full description"),
+  ).toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Hide full description"),
+  ).not.toBeVisible();
   const divCountAfterCollapsing = await page.locator("div:visible").count();
   expect(divCountAfterExpanding).toBeGreaterThan(divCountAfterCollapsing);
 });
 
-test("can expand and collapse description", async ({ page }) => {
-  await expect(page.getByText("Show full description")).toBeVisible();
-  await expect(page.getByText("Hide full description")).not.toBeVisible();
+test("can expand and collapse close date description", async ({ page }) => {
+  const descriptionExpander = page.locator(
+    "div[data-testid='opportunity-status-widget'] div[data-testid='content-display-toggle']",
+  );
+
+  await expect(
+    descriptionExpander.getByText("Show full description"),
+  ).toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Hide full description"),
+  ).not.toBeVisible();
   const divCountBeforeExpanding = await page.locator("div:visible").count();
 
-  await page.getByRole("button", { name: /^Show full description$/ }).click();
+  await descriptionExpander
+    .getByRole("button", { name: /^Show full description$/ })
+    .click();
 
-  // validate that description has been expanded
-  await expect(page.getByText("Show full description")).not.toBeVisible();
-  await expect(page.getByText("Hide full description")).toBeVisible();
+  // validate that summary has been expanded
+  await expect(
+    descriptionExpander.getByText("Show full description"),
+  ).not.toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Hide full description"),
+  ).toBeVisible();
   const divCountAfterExpanding = await page.locator("div:visible").count();
   expect(divCountBeforeExpanding).toBeLessThan(divCountAfterExpanding);
 
-  await page.getByRole("button", { name: /^Hide full description$/ }).click();
+  await descriptionExpander
+    .getByRole("button", { name: /^Hide full description$/ })
+    .click();
 
-  // validate that description has been collapsed
-  await expect(page.getByText("Show full description")).toBeVisible();
-  await expect(page.getByText("Hide full description")).not.toBeVisible();
+  // validate that summary has been collapsed
+  await expect(
+    descriptionExpander.getByText("Show full description"),
+  ).toBeVisible();
+  await expect(
+    descriptionExpander.getByText("Hide full description"),
+  ).not.toBeVisible();
   const divCountAfterCollapsing = await page.locator("div:visible").count();
   expect(divCountAfterExpanding).toBeGreaterThan(divCountAfterCollapsing);
 });

--- a/frontend/tests/e2e/search/search-copy-url.spec.ts
+++ b/frontend/tests/e2e/search/search-copy-url.spec.ts
@@ -1,16 +1,18 @@
 import { expect, test } from "@playwright/test";
 
+import { fillSearchInputAndSubmit } from "./searchSpecUtil";
+
 test("should copy search query URL to clipboard", async ({ page }) => {
   await page.goto("/search");
 
-  const searchInput = page.getByLabel("Search terms Enter keywords,");
-  await searchInput.fill("education grants");
-  await searchInput.press("Enter");
-
-  await page.waitForURL(/.*search.*query=education\+grants.*/, {
-    timeout: 10000,
-  });
-
+  // this is dumb but webkit has an issue with trying to fill in the input too quickly
+  // if the expect in here fails, we give it another shot after 5 seconds
+  // this way we avoid an arbitrary timeout, and do not slow down the other tests
+  try {
+    await fillSearchInputAndSubmit("education grants", page);
+  } catch (e) {
+    await fillSearchInputAndSubmit("education grants", page);
+  }
   // Check if we need to show filters
   const showFiltersButton = page.getByRole("button", { name: "Show Filters" });
   if (await showFiltersButton.isVisible()) {


### PR DESCRIPTION
## Summary

unticketed

## Changes proposed

due to some changes in the wording on the opportunity page that were not taken into account with tests introduced in https://github.com/HHS/simpler-grants-gov/pull/4837 there are some failing tests. This fixes the tests

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

1. _VERIFY_: all opportunity page e2e tests pass locally and in CI
