### PR TITLE
[Issue #4892] Passthrough Client Certificates at the LB 

### DIFF
--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -83,7 +83,7 @@ resource "aws_lb_listener" "alb_listener_https" {
   protocol          = "HTTPS"
   certificate_arn   = var.certificate_arn
   mutual_authentication {
-    mode = "passthrough"
+    mode = module.app_config.app_name == "api" ? "passthrough" : "off"
   }
 
   # Use security policy that supports TLS 1.3 but requires at least TLS 1.2

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -83,7 +83,7 @@ resource "aws_lb_listener" "alb_listener_https" {
   protocol          = "HTTPS"
   certificate_arn   = var.certificate_arn
   mutual_authentication {
-    mode = module.app_config.app_name == "api" ? "passthrough" : "off"
+    mode = startswith(var.service_name, "api-") ? "passthrough" : "off"
   }
 
   # Use security policy that supports TLS 1.3 but requires at least TLS 1.2

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -82,6 +82,9 @@ resource "aws_lb_listener" "alb_listener_https" {
   port              = 443
   protocol          = "HTTPS"
   certificate_arn   = var.certificate_arn
+  mutual_authentication {
+    mode = "passthrough"
+  }
 
   # Use security policy that supports TLS 1.3 but requires at least TLS 1.2
   ssl_policy = "ELBSecurityPolicy-TLS13-1-2-2021-06"


### PR DESCRIPTION
## Summary

Fixes #4892

## Changes proposed
Make it so the API LBs will passthrough the client certificate that was given to them (which will be present if it's a SOAP Proxy request)

## Context for reviewers
Untested, would see how it worked when applied to Dev.