### PR TITLE
[Issue #4919] Add shared modules terraform to changes that will deploy services

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "analytics/**"
       - "infra/analytics/**"
+      - "infra/modules/**"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "api/**"
       - "infra/api/**"
+      - "infra/modules/**"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "frontend/**"
       - "infra/frontend/**"
+      - "infra/modules/**"
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Fixes #4919

## Changes proposed

We have shared module code in terraform that may/can affect any of our services. But we don't redeploy those services automatically when changes are made there. This rectifies that and will trigger deploys to all Platform services when a change is made to any of the shared modules.