### PR TITLE
[Issue #4519] Update headers for security

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -61,7 +61,7 @@ jobs:
           cat .env.development >> .env.local
           # Use the localhost url for tests
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://localhost:3000|' .env.local
-          IS_CI=true npm run build -- --no-lint
+          npm run build -- --no-lint
 
       - name: Run e2e tests (Shard ${{ matrix.shard }}/${{ matrix.total_shards }})
         env:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -26,8 +26,8 @@ jobs:
 
     strategy:
       matrix:
-        shard: [1, 2, 3]
-        total_shards: [3]
+        shard: [1, 2, 3, 4]
+        total_shards: [4]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -61,7 +61,7 @@ jobs:
           cat .env.development >> .env.local
           # Use the localhost url for tests
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://localhost:3000|' .env.local
-          npm run build -- --no-lint
+          IS_CI=true npm run build -- --no-lint
 
       - name: Run e2e tests (Shard ${{ matrix.shard }}/${{ matrix.total_shards }})
         env:

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,6 +14,22 @@ const nrExternals = require("@newrelic/next/load-externals");
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
 const appSassOptions = sassOptions(basePath);
 
+const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'unsafe-eval' 'unsafe-inline';
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' blob: data:;
+    font-src 'self' https://fonts.gstatic.com;
+    object-src 'none';
+    connect-src 'self' https://bam.nr-data.net https://www.google-analytics.com;
+    base-uri 'self';
+    media-src 'self';
+    style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com/;
+    script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com/ https://fonts.googleapis.com/ https://js-agent.newrelic.com/;
+    form-action 'self';
+    frame-ancestors 'none';
+    upgrade-insecure-requests;
+    `;
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   async headers() {
@@ -28,6 +44,10 @@ const nextConfig = {
           {
             key: "Strict-Transport-Security",
             value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: cspHeader.replace(/\n/g, ""),
           },
         ],
       },

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -19,6 +19,19 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+        ],
+      },
+      {
         // static pages are stored for 6 hours, refreshed in the background for
         // up to 10 minutes, and up to 12 hours if there is an error
         source: "/:path*",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -130,7 +130,7 @@ const headers = [
   },
 ];
 
-const isCi = Boolean(process.env.IS_CI);
+const isCi = Boolean(process.env.CI);
 
 if (!isCi)
   headers.push({

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -49,6 +49,10 @@ const nextConfig = {
             key: "Content-Security-Policy",
             value: cspHeader.replace(/\n/g, ""),
           },
+          {
+            key: "X-Frame-Options",
+            value: "SAMEORIGIN",
+          },
         ],
       },
       {

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 3 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   // Use 'blob' for CI to allow merging of reports. See https://playwright.dev/docs/test-reporters


### PR DESCRIPTION
## Summary

Fixes #4519

## Changes proposed

This adds the following headers to improve security:


* [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options) set to `no-sniff` to to avoid [MIME type sniffing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types#mime_sniffing)
* [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security), aka [HSTS](https://developer.mozilla.org/en-US/docs/Glossary/HSTS), lets browsers know to always use HTTPS for the site instead of trying to make an initial request that is insecure
* [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy) helps stop cross-site scripting by regulating what resources can be domains can be loaded and from which domains. This could be done more securely if we switch to all dynamic content by using [nonces](https://nextjs.org/docs/app/guides/content-security-policy) to ensure assets are actually coming from our servers.
* [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options) doesn't allow other sites to embed our site content in iframes. This is little "un-open webby", and maybe at some point we would want to allow other sites to embed our search or something, but on the other hand this helps ensure that these assets are not embedded in insecure contexts.

## Context for reviewers

This is good security policy, as well as helping to promote best practices as sites like https://dri.es/headers?url=https://simpler.grants.gov and scangov.org are publicly evaluating the site.

## Validation steps

Everything should work locally the same. To QA you could click around and try a couple of user actions. HSTS [doesn't appear to be an issue](https://issues.chromium.org/issues/41251622) with localhost anymore.