### PR TITLE
[Issue #4892] Client cert passthrough

### DIFF
--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -83,7 +83,7 @@ resource "aws_lb_listener" "alb_listener_https" {
   protocol          = "HTTPS"
   certificate_arn   = var.certificate_arn
   mutual_authentication {
-    mode = startswith(var.service_name, "api-") ? "passthrough" : "off"
+    mode = "off"
   }
 
   # Use security policy that supports TLS 1.3 but requires at least TLS 1.2


### PR DESCRIPTION
## Summary
Doesn't really fix anything, just a temporary hold while we sort more things out for #4892 

## Changes proposed

Roll back our client auth for now since we don't want to be prompting browser users about sending a client certificate when it's really just a thing for SOAP Proxy clients.