### PR TITLE
[Issue #4226] save search modal cleanup

### DIFF
--- a/frontend/src/components/LoadingButton.tsx
+++ b/frontend/src/components/LoadingButton.tsx
@@ -1,0 +1,18 @@
+import { Button } from "@trussworks/react-uswds";
+
+import Spinner from "src/components/Spinner";
+
+export function LoadingButton({
+  message,
+  id,
+}: {
+  message: string;
+  id?: string;
+}) {
+  return (
+    <Button type="button" disabled data-testid={id}>
+      <Spinner />
+      {message}
+    </Button>
+  );
+}

--- a/frontend/src/components/search/SaveSearchModal.tsx
+++ b/frontend/src/components/search/SaveSearchModal.tsx
@@ -18,10 +18,9 @@ import {
   TextInput,
 } from "@trussworks/react-uswds";
 
-import Loading from "src/components/Loading";
+import { LoadingButton } from "src/components/LoadingButton";
 import SimplerAlert from "src/components/SimplerAlert";
 import { USWDSIcon } from "src/components/USWDSIcon";
-import { LoadingButton } from "../LoadingButton";
 
 function SaveSearchInput({
   validationError,

--- a/frontend/src/components/search/SaveSearchModal.tsx
+++ b/frontend/src/components/search/SaveSearchModal.tsx
@@ -35,7 +35,13 @@ function SaveSearchInput({
 
   return (
     <FormGroup error={!!validationError}>
-      <label htmlFor="saved-search-input">{t("inputLabel")}</label>
+      <label htmlFor="saved-search-input">
+        {t.rich("inputLabel", {
+          required: (chunks) => (
+            <span className="usa-hint usa-hint--required">{chunks}</span>
+          ),
+        })}
+      </label>
       {validationError && <ErrorMessage>{validationError}</ErrorMessage>}
       <div className="usa-search usa-search--big" role="search">
         <TextInput
@@ -48,6 +54,8 @@ function SaveSearchInput({
           defaultValue={""}
           onChange={(e) => updateSavedSearchName(e.target?.value)}
           type="text"
+          required
+          aria-required
         />
       </div>
     </FormGroup>
@@ -68,7 +76,13 @@ function SuccessContent({
     <>
       <ModalHeading id={`${modalId}-heading`}>{t("successTitle")}</ModalHeading>
       <div className="usa-prose">
-        <p className="font-sans-2xs margin-y-4">{t("successDescription")}</p>
+        <p className="font-sans-2xs margin-y-4">
+          {t.rich("successDescription", {
+            workspaceLink: (chunks) => (
+              <a href="/saved-search-queries">{chunks}</a>
+            ),
+          })}
+        </p>
       </div>
       <ModalFooter>
         <ModalToggleButton

--- a/frontend/src/components/search/SaveSearchModal.tsx
+++ b/frontend/src/components/search/SaveSearchModal.tsx
@@ -21,6 +21,7 @@ import {
 import Loading from "src/components/Loading";
 import SimplerAlert from "src/components/SimplerAlert";
 import { USWDSIcon } from "src/components/USWDSIcon";
+import { LoadingButton } from "../LoadingButton";
 
 function SaveSearchInput({
   validationError,
@@ -199,25 +200,25 @@ export function SaveSearchModal({ onSave }: { onSave: (id: string) => void }) {
             <div className="usa-prose">
               <p className="font-sans-2xs margin-y-4">{t("description")}</p>
             </div>
-            {loading ? (
-              <Loading />
-            ) : (
-              <>
-                {apiError && (
-                  <SimplerAlert
-                    alertClick={() => setApiError(false)}
-                    buttonId="saveSearchApiError"
-                    messageText={t("apiError")}
-                    type="error"
-                  />
-                )}
-                <SaveSearchInput
-                  validationError={validationError}
-                  updateSavedSearchName={setSavedSearchName}
-                />
-                <ModalFooter>
+            {apiError && (
+              <SimplerAlert
+                alertClick={() => setApiError(false)}
+                buttonId="saveSearchApiError"
+                messageText={t("apiError")}
+                type="error"
+              />
+            )}
+            <SaveSearchInput
+              validationError={validationError}
+              updateSavedSearchName={setSavedSearchName}
+            />
+            <ModalFooter>
+              {loading ? (
+                <LoadingButton id="save-search-button" message={t("loading")} />
+              ) : (
+                <>
                   <Button
-                    type={"button"}
+                    type="button"
                     onClick={handleSubmit}
                     data-testid="save-search-button"
                   >
@@ -232,9 +233,9 @@ export function SaveSearchModal({ onSave }: { onSave: (id: string) => void }) {
                   >
                     {t("cancelText")}
                   </ModalToggleButton>
-                </ModalFooter>
-              </>
-            )}
+                </>
+              )}
+            </ModalFooter>
           </>
         )}
       </Modal>

--- a/frontend/src/components/subscribe/SubscriptionForm.tsx
+++ b/frontend/src/components/subscribe/SubscriptionForm.tsx
@@ -39,7 +39,7 @@ export default function SubscriptionForm() {
       <FormGroup error={showError("name")}>
         <Label htmlFor="name">
           {t("form.name") + " "}
-          <span title="required" className="usa-hint usa-hint--required ">
+          <span title="required" className="usa-hint usa-hint--required">
             ({t("form.req")})
           </span>
         </Label>

--- a/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
+++ b/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
@@ -140,7 +140,7 @@ export function DeleteSavedSearchModal({
             <ModalHeading id={`${modalId}-heading`}>{t("title")}</ModalHeading>
             <div className="usa-prose">
               <p className="font-sans-2xs margin-y-4">
-                {t("description")} "{queryName}"?
+                {t("description")} &quot;{queryName}&quot;?
               </p>
             </div>
             <>

--- a/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
+++ b/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
@@ -16,7 +16,7 @@ import {
   ModalToggleButton,
 } from "@trussworks/react-uswds";
 
-import Loading from "src/components/Loading";
+import { LoadingButton } from "src/components/LoadingButton";
 import SimplerAlert from "src/components/SimplerAlert";
 import { USWDSIcon } from "src/components/USWDSIcon";
 
@@ -136,39 +136,44 @@ export function DeleteSavedSearchModal({
         ) : (
           <>
             <ModalHeading id={`${modalId}-heading`}>{t("title")}</ModalHeading>
-            {loading ? (
-              <Loading />
-            ) : (
-              <>
-                {apiError && (
-                  <SimplerAlert
-                    alertClick={() => setApiError(false)}
-                    buttonId={`deleteSavedSearchApiError-${savedSearchId}`}
-                    messageText={t("apiError")}
-                    type="error"
-                  />
-                )}
+            <>
+              {apiError && (
+                <SimplerAlert
+                  alertClick={() => setApiError(false)}
+                  buttonId={`deleteSavedSearchApiError-${savedSearchId}`}
+                  messageText={t("apiError")}
+                  type="error"
+                />
+              )}
 
-                <ModalFooter>
-                  <Button
-                    type={"button"}
-                    onClick={handleSubmit}
-                    data-testid={`delete-saved-search-button-${savedSearchId}`}
-                  >
-                    {t("deleteText")}
-                  </Button>
-                  <ModalToggleButton
-                    modalRef={modalRef}
-                    closer
-                    unstyled
-                    className="padding-105 text-center"
-                    onClick={onClose}
-                  >
-                    {t("cancelText")}
-                  </ModalToggleButton>
-                </ModalFooter>
-              </>
-            )}
+              <ModalFooter>
+                {loading ? (
+                  <LoadingButton
+                    id={`delete-saved-search-button-${savedSearchId}`}
+                    message={t("loading")}
+                  />
+                ) : (
+                  <>
+                    <Button
+                      type={"button"}
+                      onClick={handleSubmit}
+                      data-testid={`delete-saved-search-button-${savedSearchId}`}
+                    >
+                      {t("deleteText")}
+                    </Button>
+                    <ModalToggleButton
+                      modalRef={modalRef}
+                      closer
+                      unstyled
+                      className="padding-105 text-center"
+                      onClick={onClose}
+                    >
+                      {t("cancelText")}
+                    </ModalToggleButton>
+                  </>
+                )}
+              </ModalFooter>
+            </>
           </>
         )}
       </Modal>

--- a/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
+++ b/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
@@ -51,9 +51,11 @@ function SuccessContent({
 export function DeleteSavedSearchModal({
   savedSearchId,
   deleteText,
+  queryName,
 }: {
   savedSearchId: string;
   deleteText: string;
+  queryName: string;
 }) {
   const modalId = useMemo(
     () => `delete-save-search-${savedSearchId}`,
@@ -136,6 +138,11 @@ export function DeleteSavedSearchModal({
         ) : (
           <>
             <ModalHeading id={`${modalId}-heading`}>{t("title")}</ModalHeading>
+            <div className="usa-prose">
+              <p className="font-sans-2xs margin-y-4">
+                {t("description")} "{queryName}"?
+              </p>
+            </div>
             <>
               {apiError && (
                 <SimplerAlert

--- a/frontend/src/components/workspace/EditSavedSearchModal.tsx
+++ b/frontend/src/components/workspace/EditSavedSearchModal.tsx
@@ -20,7 +20,7 @@ import {
   TextInput,
 } from "@trussworks/react-uswds";
 
-import Loading from "src/components/Loading";
+import { LoadingButton } from "src/components/LoadingButton";
 import SimplerAlert from "src/components/SimplerAlert";
 import { USWDSIcon } from "src/components/USWDSIcon";
 
@@ -199,43 +199,48 @@ export function EditSavedSearchModal({
                 })}
               </p>
             </div>
-            {loading ? (
-              <Loading />
-            ) : (
-              <>
-                {apiError && (
-                  <SimplerAlert
-                    alertClick={() => setApiError(false)}
-                    buttonId={`editSavedSearchApiError-${savedSearchId}`}
-                    messageText={t("apiError")}
-                    type="error"
-                  />
-                )}
-                <SaveSearchInput
-                  validationError={validationError}
-                  updateSavedSearchName={setSavedSearchName}
-                  id={savedSearchId}
+            <>
+              {apiError && (
+                <SimplerAlert
+                  alertClick={() => setApiError(false)}
+                  buttonId={`editSavedSearchApiError-${savedSearchId}`}
+                  messageText={t("apiError")}
+                  type="error"
                 />
-                <ModalFooter>
-                  <Button
-                    type={"button"}
-                    onClick={handleSubmit}
-                    data-testid={`edit-saved-search-button-${savedSearchId}`}
-                  >
-                    {t("saveText")}
-                  </Button>
-                  <ModalToggleButton
-                    modalRef={modalRef}
-                    closer
-                    unstyled
-                    className="padding-105 text-center"
-                    onClick={onClose}
-                  >
-                    {t("cancelText")}
-                  </ModalToggleButton>
-                </ModalFooter>
-              </>
-            )}
+              )}
+              <SaveSearchInput
+                validationError={validationError}
+                updateSavedSearchName={setSavedSearchName}
+                id={savedSearchId}
+              />
+              <ModalFooter>
+                {loading ? (
+                  <LoadingButton
+                    id={`edit-saved-search-button-${savedSearchId}`}
+                    message={t("loading")}
+                  />
+                ) : (
+                  <>
+                    <Button
+                      type={"button"}
+                      onClick={handleSubmit}
+                      data-testid={`edit-saved-search-button-${savedSearchId}`}
+                    >
+                      {t("saveText")}
+                    </Button>
+                    <ModalToggleButton
+                      modalRef={modalRef}
+                      closer
+                      unstyled
+                      className="padding-105 text-center"
+                      onClick={onClose}
+                    >
+                      {t("cancelText")}
+                    </ModalToggleButton>
+                  </>
+                )}
+              </ModalFooter>
+            </>
           </>
         )}
       </Modal>

--- a/frontend/src/components/workspace/EditSavedSearchModal.tsx
+++ b/frontend/src/components/workspace/EditSavedSearchModal.tsx
@@ -38,7 +38,13 @@ function SaveSearchInput({
 
   return (
     <FormGroup error={!!validationError}>
-      <label htmlFor="saved-search-input">{t("inputLabel")}</label>
+      <label htmlFor="saved-search-input">
+        {t.rich("inputLabel", {
+          required: (chunks) => (
+            <span className="usa-hint usa-hint--required">{chunks}</span>
+          ),
+        })}
+      </label>
       {validationError && <ErrorMessage>{validationError}</ErrorMessage>}
       <div className="usa-search usa-search--big" role="search">
         <TextInput
@@ -51,6 +57,8 @@ function SaveSearchInput({
           defaultValue={""}
           onChange={(e) => updateSavedSearchName(e.target?.value)}
           type="text"
+          required
+          aria-required
         />
       </div>
     </FormGroup>

--- a/frontend/src/components/workspace/EditSavedSearchModal.tsx
+++ b/frontend/src/components/workspace/EditSavedSearchModal.tsx
@@ -28,10 +28,12 @@ function SaveSearchInput({
   validationError,
   updateSavedSearchName,
   id,
+  defaultValue = "",
 }: {
   validationError?: string;
   updateSavedSearchName: (name: string) => void;
   id: string;
+  defaultValue?: string;
 }) {
   const t = useTranslations("Search.saveSearch.modal");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -54,7 +56,7 @@ function SaveSearchInput({
           })}
           id={`edit-saved-search-input-${id}`}
           name={`edit-saved-search-${id}`}
-          defaultValue={""}
+          defaultValue={defaultValue}
           onChange={(e) => updateSavedSearchName(e.target?.value)}
           type="text"
           required
@@ -96,9 +98,11 @@ function SuccessContent({
 export function EditSavedSearchModal({
   savedSearchId,
   editText,
+  queryName,
 }: {
   savedSearchId: string;
   editText: string;
+  queryName: string;
 }) {
   const modalId = useMemo(
     () => `edit-save-search-${savedSearchId}`,
@@ -220,6 +224,7 @@ export function EditSavedSearchModal({
                 validationError={validationError}
                 updateSavedSearchName={setSavedSearchName}
                 id={savedSearchId}
+                defaultValue={queryName}
               />
               <ModalFooter>
                 {loading ? (

--- a/frontend/src/components/workspace/SavedSearchesList.tsx
+++ b/frontend/src/components/workspace/SavedSearchesList.tsx
@@ -53,6 +53,7 @@ export const SavedSearchesList = ({
                     <DeleteSavedSearchModal
                       savedSearchId={savedSearch.id}
                       deleteText={deleteText}
+                      queryName={savedSearch.name}
                     />
                   </div>
                 </div>

--- a/frontend/src/components/workspace/SavedSearchesList.tsx
+++ b/frontend/src/components/workspace/SavedSearchesList.tsx
@@ -47,6 +47,7 @@ export const SavedSearchesList = ({
                     <EditSavedSearchModal
                       savedSearchId={savedSearch.id}
                       editText={editText}
+                      queryName={savedSearch.name}
                     />
                   </div>
                   <div className="grid-col">

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -518,6 +518,7 @@ export const messages = {
       },
       modal: {
         title: "Name this search query",
+        loading: "Saving",
         description:
           "Save these search terms and filters with a name for easy access later.",
         inputLabel: "Name (Required)",
@@ -570,6 +571,7 @@ export const messages = {
       sortby: "Sort by",
     },
     editModal: {
+      loading: "Updating",
       title: "Edit name of search query",
       description:
         "<strong>Tip:</strong> You can’t edit a saved query’s search terms or filters. However, you can apply the query to a new search, make changes, and save it as a new query",
@@ -582,6 +584,7 @@ export const messages = {
       apiError: "Error updating saved query. Try again later.",
     },
     deleteModal: {
+      loading: "Deleting",
       title: "Delete saved query?",
       deleteText: "Yes, delete",
       cancelText: "Cancel",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -521,14 +521,14 @@ export const messages = {
         loading: "Saving",
         description:
           "Save these search terms and filters with a name for easy access later.",
-        inputLabel: "Name (Required)",
+        inputLabel: "Name <required>(required)</required>",
         saveText: "Save",
         cancelText: "Cancel",
         closeText: "Close",
         emptyNameError: "Please name this query.",
-        successTitle: "Success!",
+        successTitle: "Query successfully saved",
         successDescription:
-          "Your search has been saved. To view search results for this search at any time, select the search from the drop down on the search page.",
+          "Manage your quries in your <workspaceLink>Workspace</workspaceLink>.",
         apiError: "Error loading saved query. Try again later.",
       },
       copySearch: {
@@ -575,7 +575,7 @@ export const messages = {
       title: "Edit name of search query",
       description:
         "<strong>Tip:</strong> You can’t edit a saved query’s search terms or filters. However, you can apply the query to a new search, make changes, and save it as a new query",
-      inputLabel: "Query name (required)",
+      inputLabel: "Query name <required>(required)</required>",
       saveText: "Save",
       cancelText: "Cancel",
       closeText: "Close",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -589,6 +589,7 @@ export const messages = {
       deleteText: "Yes, delete",
       cancelText: "Cancel",
       apiError: "Error deleting saved query. Try again later.",
+      description: "Delete ",
     },
   },
   SavedGrants: {

--- a/frontend/tests/components/LoadingButton.test.tsx
+++ b/frontend/tests/components/LoadingButton.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+
+import { LoadingButton } from "src/components/LoadingButton";
+
+describe("LoadingButton", () => {
+  it("is disabled", () => {
+    render(<LoadingButton message="loading" />);
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+  it("displays passed message", () => {
+    render(<LoadingButton message="loading" />);
+    expect(screen.getByRole("button")).toHaveTextContent("loading");
+  });
+  it("displays spinner", () => {
+    render(<LoadingButton message="loading" />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/workspace/DeleteSavedSearchModal.test.tsx
+++ b/frontend/tests/components/workspace/DeleteSavedSearchModal.test.tsx
@@ -42,7 +42,11 @@ describe("DeleteSavedSearchModal", () => {
   });
   it("displays a working modal toggle button", async () => {
     const { rerender } = render(
-      <DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />,
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
     );
 
     expect(screen.queryByRole("dialog")).toHaveClass("is-hidden");
@@ -52,13 +56,23 @@ describe("DeleteSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />);
+    rerender(
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
+    );
 
     expect(screen.getByRole("dialog")).not.toHaveClass("is-hidden");
   });
   it("modal can be closed as expected", async () => {
     const { rerender } = render(
-      <DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />,
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
     );
 
     const toggle = await screen.findByTestId(
@@ -66,12 +80,24 @@ describe("DeleteSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />);
+    rerender(
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
+    );
 
     const closeButton = await screen.findByText("cancelText");
     act(() => closeButton.click());
 
-    rerender(<DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />);
+    rerender(
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
+    );
 
     expect(screen.queryByRole("dialog")).toHaveClass("is-hidden");
   });
@@ -79,7 +105,11 @@ describe("DeleteSavedSearchModal", () => {
   it("displays an API error if API returns an error", async () => {
     clientFetchMock.mockRejectedValue(new Error());
     const { rerender } = render(
-      <DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />,
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
     );
 
     const toggle = await screen.findByTestId(
@@ -87,14 +117,26 @@ describe("DeleteSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />);
+    rerender(
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
+    );
 
     const saveButton = await screen.findByTestId(
       "delete-saved-search-button-1",
     );
     act(() => saveButton.click());
 
-    rerender(<DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />);
+    rerender(
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
+    );
 
     const error = await screen.findByText("apiError");
 
@@ -104,7 +146,11 @@ describe("DeleteSavedSearchModal", () => {
   it("displays a success message on successful save", async () => {
     clientFetchMock.mockResolvedValue({ id: "123" });
     const { rerender } = render(
-      <DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />,
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
     );
 
     const toggle = await screen.findByTestId(
@@ -112,14 +158,26 @@ describe("DeleteSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />);
+    rerender(
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
+    );
 
     const saveButton = await screen.findByTestId(
       "delete-saved-search-button-1",
     );
     act(() => saveButton.click());
 
-    rerender(<DeleteSavedSearchModal savedSearchId="1" deleteText="delete" />);
+    rerender(
+      <DeleteSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        deleteText="delete"
+      />,
+    );
 
     const success = await screen.findByText("successTitle");
 

--- a/frontend/tests/components/workspace/EditSavedSearchModal.test.tsx
+++ b/frontend/tests/components/workspace/EditSavedSearchModal.test.tsx
@@ -55,7 +55,11 @@ describe("EditSavedSearchModal", () => {
   });
   it("displays a working modal toggle button", async () => {
     const { rerender } = render(
-      <EditSavedSearchModal savedSearchId="1" editText="edit" />,
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
     );
 
     expect(screen.queryByRole("dialog")).toHaveClass("is-hidden");
@@ -65,13 +69,23 @@ describe("EditSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     expect(screen.getByRole("dialog")).not.toHaveClass("is-hidden");
   });
   it("modal can be closed as expected", async () => {
     const { rerender } = render(
-      <EditSavedSearchModal savedSearchId="1" editText="edit" />,
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
     );
 
     const toggle = await screen.findByTestId(
@@ -79,18 +93,34 @@ describe("EditSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     const closeButton = await screen.findByText("cancelText");
     act(() => closeButton.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     expect(screen.queryByRole("dialog")).toHaveClass("is-hidden");
   });
   it("displays validation error if submitted without a name", async () => {
     const { rerender } = render(
-      <EditSavedSearchModal savedSearchId="1" editText="edit" />,
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
     );
 
     const toggle = await screen.findByTestId(
@@ -98,12 +128,24 @@ describe("EditSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     const saveButton = await screen.findByTestId("edit-saved-search-button-1");
     act(() => saveButton.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     const validationError = await screen.findByText("emptyNameError");
 
@@ -112,7 +154,11 @@ describe("EditSavedSearchModal", () => {
   it("displays an API error if API returns an error", async () => {
     clientFetchMock.mockRejectedValue(new Error());
     const { rerender } = render(
-      <EditSavedSearchModal savedSearchId="1" editText="edit" />,
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
     );
 
     const toggle = await screen.findByTestId(
@@ -120,14 +166,26 @@ describe("EditSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     const saveButton = await screen.findByTestId("edit-saved-search-button-1");
     const input = await screen.findByTestId("textInput");
     fireEvent.change(input, { target: { value: "save search name" } });
     act(() => saveButton.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     const error = await screen.findByText("apiError");
 
@@ -137,7 +195,11 @@ describe("EditSavedSearchModal", () => {
   it("displays a success message on successful save", async () => {
     clientFetchMock.mockResolvedValue({ id: "123" });
     const { rerender } = render(
-      <EditSavedSearchModal savedSearchId="1" editText="edit" />,
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
     );
 
     const toggle = await screen.findByTestId(
@@ -145,17 +207,39 @@ describe("EditSavedSearchModal", () => {
     );
     act(() => toggle.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     const saveButton = await screen.findByTestId("edit-saved-search-button-1");
     const input = await screen.findByTestId("textInput");
     fireEvent.change(input, { target: { value: "save search name" } });
     act(() => saveButton.click());
 
-    rerender(<EditSavedSearchModal savedSearchId="1" editText="edit" />);
+    rerender(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
 
     const success = await screen.findByText("successTitle");
 
     expect(success).toBeInTheDocument();
+  });
+  it("defaults input to current name of query", () => {
+    render(
+      <EditSavedSearchModal
+        queryName="excellent query"
+        savedSearchId="1"
+        editText="edit"
+      />,
+    );
+    expect(screen.getByRole("textbox")).toHaveValue("excellent query");
   });
 });

--- a/frontend/tests/components/workspace/EditSavedSearchModal.test.tsx
+++ b/frontend/tests/components/workspace/EditSavedSearchModal.test.tsx
@@ -43,7 +43,11 @@ describe("EditSavedSearchModal", () => {
 
   it("matches snapshot", async () => {
     const { container } = render(
-      <EditSavedSearchModal savedSearchId="1" editText="edit" />,
+      <EditSavedSearchModal
+        savedSearchId="1"
+        editText="edit"
+        queryName="excellent query"
+      />,
     );
 
     const toggle = await screen.findByTestId(


### PR DESCRIPTION
## Summary

Fixes #4226

## Changes proposed

Makes a number of updates to saved search related modals for post launch fixes. See the ticket for the full list

## Context for reviewers


Figma! https://www.figma.com/design/FGxWtAgToKhehLJCiuy1zL/Simpler.Grants.gov-Project?node-id=1809-14763&p=f&t=IkaY3oNbF6gkpCqT-0

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. to test loading state, slow down queries by adding this at line 59 of fetchers.ts - `await new Promise((resolve) => setTimeout(resolve, 3000));`
2. start a local server on this branch with `npm run dev`
3. visit http://localhost:3000/search?_ff=authOn:true;savedSearchesOn:true
4. log in
5. click "save" to save a search
6. _VERIFY_: "required" text appears as in the designs
7. enter a name and click save
8. _VERIFY_: loading state matches designs (spinner within the button)
9. _VERIFY_: success message matches designs
10. go to http://localhost:3000/saved-search-queries
11. click edit
12. _VERIFY_: the name of your query is prepopulated in the input
6. _VERIFY_: "required" text appears as in the designs
7. enter a new name and click save
8. _VERIFY_: loading state matches designs (spinner within the button)
9. _VERIFY_: success message matches designs
10. close out of modal and click delete
12. _VERIFY_: the name of your query appears in modal text
13. click delete
8. _VERIFY_: loading state matches designs (spinner within the button)
9. _VERIFY_: success message matches designs
