### PR TITLE
Allow nofos tests to be run manually

### DIFF
--- a/.github/workflows/ci-nofos.yml
+++ b/.github/workflows/ci-nofos.yml
@@ -1,7 +1,7 @@
 name: API Checks
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       version:
         description: "Version to run tests against"


### PR DESCRIPTION
I had the wrong `on` key