### PR TITLE
[Issue #4806] Cleanup API logs for consistency

### DIFF
--- a/api/src/api/application_alpha/application_route.py
+++ b/api/src/api/application_alpha/application_route.py
@@ -33,9 +33,9 @@ logger = logging.getLogger(__name__)
 @flask_db.with_db_session()
 def application_start(db_session: db.Session, json_data: dict) -> response.ApiResponse:
     """Create a new application for a competition"""
-    logger.info("POST /alpha/applications/start")
-
     competition_id = json_data["competition_id"]
+    add_extra_data_to_current_request_logs({"competition_id": competition_id})
+    logger.info("POST /alpha/applications/start")
 
     with db_session.begin():
         application = create_application(db_session, competition_id)
@@ -55,9 +55,7 @@ def application_form_update(
     db_session: db.Session, application_id: UUID, form_id: UUID, json_data: dict
 ) -> response.ApiResponse:
     """Update an application form response"""
-    add_extra_data_to_current_request_logs(
-        {"application.application_id": application_id, "form.form_id": form_id}
-    )
+    add_extra_data_to_current_request_logs({"application_id": application_id, "form_id": form_id})
     logger.info("PUT /alpha/applications/:application_id/forms/:form_id")
 
     application_response = json_data["application_response"]
@@ -86,8 +84,8 @@ def application_form_get(
     """Get an application form by ID"""
     add_extra_data_to_current_request_logs(
         {
-            "application.application_id": application_id,
-            "application_form.application_form_id": app_form_id,
+            "application_id": application_id,
+            "application_form_id": app_form_id,
         }
     )
     logger.info("GET /alpha/applications/:application_id/application_form/:app_form_id")
@@ -112,11 +110,7 @@ def application_get(
     application_id: UUID,
 ) -> response.ApiResponse:
     """Get an application by ID"""
-    add_extra_data_to_current_request_logs(
-        {
-            "application.application_id": application_id,
-        }
-    )
+    add_extra_data_to_current_request_logs({"application_id": application_id})
     logger.info("GET /alpha/applications/:application_id")
 
     with db_session.begin():
@@ -136,11 +130,7 @@ def application_get(
 @flask_db.with_db_session()
 def application_submit(db_session: db.Session, application_id: UUID) -> response.ApiResponse:
     """Submit an application"""
-    add_extra_data_to_current_request_logs(
-        {
-            "application_id": application_id,
-        }
-    )
+    add_extra_data_to_current_request_logs({"application_id": application_id})
     logger.info("POST /alpha/applications/:application_id/submit")
 
     with db_session.begin():

--- a/api/src/api/competition_alpha/competition_route.py
+++ b/api/src/api/competition_alpha/competition_route.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @competition_blueprint.auth_required(api_key_auth)
 @flask_db.with_db_session()
 def competition_get(db_session: db.Session, competition_id: uuid.UUID) -> response.ApiResponse:
-    add_extra_data_to_current_request_logs({"competition.competition_id": competition_id})
+    add_extra_data_to_current_request_logs({"competition_id": competition_id})
     logger.info("GET /alpha/competitions/:competition_id")
 
     with db_session.begin():

--- a/api/src/api/form_alpha/form_route.py
+++ b/api/src/api/form_alpha/form_route.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 @form_blueprint.auth_required(api_key_auth)
 @flask_db.with_db_session()
 def form_get(db_session: db.Session, form_id: uuid.UUID) -> response.ApiResponse:
-    add_extra_data_to_current_request_logs({"form.form_id": form_id})
+    add_extra_data_to_current_request_logs({"form_id": form_id})
     logger.info("GET /alpha/forms/:form_id")
 
     with db_session.begin():

--- a/api/src/api/opportunities_v1/opportunity_routes.py
+++ b/api/src/api/opportunities_v1/opportunity_routes.py
@@ -229,7 +229,7 @@ def opportunity_search(
 @opportunity_blueprint.doc(description=SHARED_ALPHA_DESCRIPTION)
 @flask_db.with_db_session()
 def opportunity_get(db_session: db.Session, opportunity_id: int) -> response.ApiResponse:
-    add_extra_data_to_current_request_logs({"opportunity.opportunity_id": opportunity_id})
+    add_extra_data_to_current_request_logs({"opportunity_id": opportunity_id})
     logger.info("GET /v1/opportunities/:opportunity_id")
     with db_session.begin():
         opportunity = get_opportunity(db_session, opportunity_id)

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -195,8 +195,8 @@ def user_save_opportunity(
     logger.info(
         "Saved opportunity for user",
         extra={
-            "user.id": str(user_id),
-            "opportunity.id": json_data["opportunity_id"],
+            "user_id": user_id,
+            "opportunity_id": json_data["opportunity_id"],
         },
     )
 
@@ -277,8 +277,8 @@ def user_save_search(
     logger.info(
         "Saved search for user",
         extra={
-            "user.id": str(user_id),
-            "saved_search.id": str(saved_search.saved_search_id),
+            "user_id": user_id,
+            "saved_search_id": saved_search.saved_search_id,
         },
     )
 
@@ -307,8 +307,8 @@ def user_delete_saved_search(
     logger.info(
         "Deleted saved search",
         extra={
-            "user.id": str(user_id),
-            "saved_search.id": saved_search_id,
+            "user_id": user_id,
+            "saved_search_id": saved_search_id,
         },
     )
 
@@ -363,8 +363,8 @@ def user_update_saved_search(
     logger.info(
         "Updated saved search for user",
         extra={
-            "user.id": str(user_id),
-            "saved_search.id": str(updated_saved_search.saved_search_id),
+            "user_id": user_id,
+            "saved_search_id": updated_saved_search.saved_search_id,
         },
     )
 

--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -197,8 +197,8 @@ def decode_token(db_session: db.Session, token: str) -> UserTokenSession:
 
         add_extra_data_to_current_request_logs(
             {
-                "auth.user_id": str(user_token_session.user_id),
-                "auth.token_id": str(user_token_session.token_id),
+                "auth.user_id": user_token_session.user_id,
+                "auth.token_id": user_token_session.token_id,
             }
         )
         logger.info("JWT Authentication Successful")

--- a/api/src/logging/formatters.py
+++ b/api/src/logging/formatters.py
@@ -82,6 +82,15 @@ class JsonFormatter(logging.Formatter):
         # see https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L690-L720
         super().format(record)
 
+        # New Relic automatically maps log messages of certain names over
+        # the "message" field in their system. This includes mapping "msg"
+        # which is the unformatted version of a log message. This means the
+        # formatted message doesn't make it into New Relic
+        # https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/#json-logs
+        #
+        # To work around this, we copy the message field to a new field name
+        record.formatted_msg = getattr(record, "message", None)
+
         return json.dumps(record.__dict__, separators=(",", ":"), default=json_encoder)
 
 

--- a/api/tests/src/logging/test_formatters.py
+++ b/api/tests/src/logging/test_formatters.py
@@ -47,6 +47,7 @@ def test_json_formatter(capsys: pytest.CaptureFixture):
     expected = {
         "name": "test_json_formatter",
         "message": "hello interpolated_string",
+        "formatted_msg": "hello interpolated_string",
         "msg": "hello %s",
         "levelname": "WARNING",
         "levelno": 30,


### PR DESCRIPTION
## Summary

Fixes #4806

## Changes proposed
Adjust the API logs to have a more consistent naming structure for common fields (ie. prefer `opportunity_id` instead of `opportunity.opportunity.opportunity_id` or `opportunity.id`)

Adjust the JSON logger to output the message field with a different name to work around a New Relic issue with renaming our fields

## Context for reviewers
Main motivator is so we can easily query for something like an opportunity across all of our logs. For example, if we wanted to see everything that interacted with a particular opportunity whether that's in the API, a backend script, or whatever, it's all the same field name now.
