### PR TITLE
[Issue #4889] agency filter refactor

### DIFF
--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -30,6 +30,7 @@ export async function AgencyFilterAccordion({
       query={query}
       queryParamKey={"agency"}
       title={t("accordion.titles.agency")}
+      wrapForScroll={true}
       // agency filters will not show facet counts
     />
   );

--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -30,7 +30,6 @@ export async function AgencyFilterAccordion({
       query={query}
       queryParamKey={"agency"}
       title={t("accordion.titles.agency")}
-      includeAnyOption={false}
       // agency filters will not show facet counts
     />
   );

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -11,9 +11,9 @@ import { Checkbox } from "@trussworks/react-uswds";
 
   AllOptionCheckbox
 
-  * Selecting AnyOptionCheckbox selects all child options
-  * Deselecting AnyOptionCheckbox deselects all child options
-  * Does not respond to child option selections
+  * Selecting AllOptionCheckbox selects all child options
+  * Deselecting AllOptionCheckbox deselects all child options
+  * Will become deselected if any child options are deselected
 
 */
 

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -1,0 +1,74 @@
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+import { FilterOption } from "src/types/search/searchResponseTypes";
+
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+import { Checkbox } from "@trussworks/react-uswds";
+
+/*
+
+  AllOptionCheckbox
+
+  * Selecting AnyOptionCheckbox selects all child options
+  * Deselecting AnyOptionCheckbox deselects all child options
+  * Does not respond to child option selections
+
+*/
+
+export const AllOptionCheckbox = ({
+  title,
+  currentSelections,
+  childOptions,
+  queryParamKey,
+}: {
+  title: string;
+  currentSelections: Set<string>;
+  childOptions: FilterOption[];
+  queryParamKey: string;
+}) => {
+  const [checked, setChecked] = useState<boolean>();
+  const { setQueryParam } = useSearchParamUpdater();
+  const id = `${title.replace(/\s/, "-").toLowerCase()}-any`;
+  const t = useTranslations("Search.accordion");
+  const label = `${t("all")} ${title}`;
+
+  const currentSelectionValues = useMemo(
+    () => Array.from(currentSelections.values()),
+    [currentSelections],
+  );
+  const childOptionValues = useMemo(
+    () => childOptions.map(({ value }) => value),
+    [childOptions],
+  );
+
+  const uncheckOptions = () => {
+    setChecked(false);
+    if (!currentSelections) {
+      return;
+    }
+    const newSelectedOptions = currentSelectionValues.filter(
+      (currentSelection) => {
+        return !childOptionValues.includes(currentSelection);
+      },
+    );
+    setQueryParam(queryParamKey, newSelectedOptions.join(","));
+  };
+
+  const checkOptions = () => {
+    setChecked(true);
+    const newSelectedOptions = childOptionValues.concat(currentSelectionValues);
+    setQueryParam(queryParamKey, newSelectedOptions.join(","));
+  };
+
+  return (
+    <Checkbox
+      id={id}
+      name={id}
+      label={label}
+      onChange={checked ? uncheckOptions : checkOptions}
+      disabled={false}
+      checked={checked}
+      value={"all"}
+    />
+  );
+};

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -1,8 +1,10 @@
+import { isEqual, uniq } from "lodash";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { FilterOption } from "src/types/search/searchResponseTypes";
+import { isSubset } from "src/utils/generalUtils";
 
 import { useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Checkbox } from "@trussworks/react-uswds";
 
 /*
@@ -26,12 +28,6 @@ export const AllOptionCheckbox = ({
   childOptions: FilterOption[];
   queryParamKey: string;
 }) => {
-  const [checked, setChecked] = useState<boolean>();
-  const { setQueryParam } = useSearchParamUpdater();
-  const id = `${title.replace(/\s/, "-").toLowerCase()}-any`;
-  const t = useTranslations("Search.accordion");
-  const label = `${t("all")} ${title}`;
-
   const currentSelectionValues = useMemo(
     () => Array.from(currentSelections.values()),
     [currentSelections],
@@ -41,8 +37,19 @@ export const AllOptionCheckbox = ({
     [childOptions],
   );
 
+  const [checked, setChecked] = useState<boolean>(
+    isSubset<string>(childOptionValues, currentSelectionValues),
+  );
+  const { setQueryParam } = useSearchParamUpdater();
+  const id = `${title.replace(/\s/, "-").toLowerCase()}-any`;
+  const t = useTranslations("Search.accordion");
+  const label = `${t("all")} ${title}`;
+
+  useEffect(() => {
+    setChecked(isSubset<string>(childOptionValues, currentSelectionValues));
+  }, [childOptionValues, currentSelectionValues]);
+
   const uncheckOptions = () => {
-    setChecked(false);
     if (!currentSelections) {
       return;
     }
@@ -55,8 +62,9 @@ export const AllOptionCheckbox = ({
   };
 
   const checkOptions = () => {
-    setChecked(true);
-    const newSelectedOptions = childOptionValues.concat(currentSelectionValues);
+    const newSelectedOptions = uniq(
+      childOptionValues.concat(currentSelectionValues),
+    );
     setQueryParam(queryParamKey, newSelectedOptions.join(","));
   };
 

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -41,7 +41,7 @@ export const AllOptionCheckbox = ({
     isSubset<string>(childOptionValues, currentSelectionValues),
   );
   const { setQueryParam } = useSearchParamUpdater();
-  const id = `${title.replace(/\s/, "-").toLowerCase()}-any`;
+  const id = `${title.replace(/\s/, "-").toLowerCase()}-all`;
   const t = useTranslations("Search.accordion");
   const label = `${t("all")} ${title}`;
 

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -1,4 +1,4 @@
-import { isEqual, uniq } from "lodash";
+import { uniq } from "lodash";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { FilterOption } from "src/types/search/searchResponseTypes";
 import { isSubset } from "src/utils/generalUtils";

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -4,6 +4,26 @@ import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { useTranslations } from "next-intl";
 import { Checkbox } from "@trussworks/react-uswds";
 
+/*
+
+    AnyOptionCheckbox
+
+    A checkbox that can be used to control the automatic unsetting of all checkboxes within a group
+
+    When the AnyOptionCheckbox is checked:
+    * all other checkboxes in the group are unchecked
+    * the AnyOptionCheckbox cannot be unchecked by clicking on it
+    * the AnyOptionCheckbox will be unchecked whenever another box in the group is checked
+
+    When the AnyOptionCheckbox is unchecked:
+    * at least one other checkbox in the group must be checked
+    * checking the AnyOptionCheckbox will uncheck any currently checked boxes in the group
+      * which will clear or reset the query param controlled by the group
+
+    The optional defaultEmptySelection param can be used to reset the query param to a specific value on
+    selection of the AnyOptionCheckbox, rather than clearing it
+
+  */
 export const AnyOptionCheckbox = ({
   title,
   checked,
@@ -20,10 +40,6 @@ export const AnyOptionCheckbox = ({
   const t = useTranslations("Search.accordion");
   const label = `${t("any")} ${title}`;
 
-  /*
-    When checked: remove param for the filter from the query, which will unselect all checkboxes
-    When unchecked: this will not happen on any box click. any box will become unchecked whenever another option is checked
-  */
   const clearAllOptions = () => {
     const clearedSelections = defaultEmptySelection?.size
       ? Array.from(defaultEmptySelection).join(",")

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -18,7 +18,7 @@ export const AnyOptionCheckbox = ({
   const { setQueryParam } = useSearchParamUpdater();
   const id = `${title.replace(/\s/, "-").toLowerCase()}-any`;
   const t = useTranslations("Search.accordion");
-  const label = `${t("any")} ${title.toLowerCase()}`;
+  const label = `${t("any")} ${title}`;
 
   /*
     When checked: remove param for the filter from the query, which will unselect all checkboxes

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -27,7 +27,7 @@ export interface AccordionItemProps {
   className?: string;
 }
 
-export interface SearchFilterAccordionProps {
+export interface SearchAccordionContentProps {
   query: Set<string>;
   queryParamKey: ValidSearchQueryParam; // Ex - In query params, search?{key}=first,second,third
   title: string; // Title in header of accordion
@@ -35,6 +35,10 @@ export interface SearchFilterAccordionProps {
   facetCounts?: { [key: string]: number };
   defaultEmptySelection?: Set<string>;
   includeAnyOption?: boolean;
+}
+
+export interface SearchFilterAccordionProps
+  extends SearchAccordionContentProps {
   wrapForScroll?: boolean;
 }
 
@@ -65,7 +69,7 @@ const AccordionContent = ({
   facetCounts,
   defaultEmptySelection,
   includeAnyOption = true,
-}: SearchFilterAccordionProps) => {
+}: SearchAccordionContentProps) => {
   const { queryTerm } = useContext(QueryContext);
   const { updateQueryParams, searchParams } = useSearchParamUpdater();
 
@@ -181,7 +185,10 @@ export function SearchFilterAccordion({
     {
       title: <AccordionTitle title={title} totalCheckedCount={query.size} />,
       content: wrapForScroll ? (
-        <div>
+        <div
+          className="maxh-mobile-lg minh-mobile overflow-scroll"
+          data-testid={`${title}-accordion-scroll`}
+        >
           <AccordionContent
             filterOptions={filterOptions}
             title={title}

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -132,7 +132,7 @@ const AccordionContent = ({
         {includeAnyOption && (
           <li>
             <AnyOptionCheckbox
-              title={title}
+              title={title.toLowerCase()}
               checked={isNoneSelected}
               queryParamKey={queryParamKey}
               defaultEmptySelection={defaultEmptySelection}

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -35,6 +35,7 @@ export interface SearchFilterAccordionProps {
   facetCounts?: { [key: string]: number };
   defaultEmptySelection?: Set<string>;
   includeAnyOption?: boolean;
+  wrapForScroll?: boolean;
 }
 
 const AccordionTitle = ({
@@ -127,7 +128,6 @@ const AccordionContent = ({
         isAllSelected={areSetsEqual(allOptionValues, query)}
         isNoneSelected={isNoneSelected}
       />
-
       <ul className="usa-list usa-list--unstyled">
         {includeAnyOption && (
           <li>
@@ -175,11 +175,26 @@ export function SearchFilterAccordion({
   facetCounts,
   defaultEmptySelection,
   includeAnyOption = true,
+  wrapForScroll = false,
 }: SearchFilterAccordionProps) {
   const accordionOptions: AccordionItemProps[] = [
     {
       title: <AccordionTitle title={title} totalCheckedCount={query.size} />,
-      content: (
+      content: wrapForScroll ? (
+        <div>
+          (
+          <AccordionContent
+            filterOptions={filterOptions}
+            title={title}
+            queryParamKey={queryParamKey}
+            query={query}
+            facetCounts={facetCounts}
+            defaultEmptySelection={defaultEmptySelection}
+            includeAnyOption={includeAnyOption}
+          />
+          )
+        </div>
+      ) : (
         <AccordionContent
           filterOptions={filterOptions}
           title={title}

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -182,7 +182,6 @@ export function SearchFilterAccordion({
       title: <AccordionTitle title={title} totalCheckedCount={query.size} />,
       content: wrapForScroll ? (
         <div>
-          (
           <AccordionContent
             filterOptions={filterOptions}
             title={title}
@@ -192,7 +191,6 @@ export function SearchFilterAccordion({
             defaultEmptySelection={defaultEmptySelection}
             includeAnyOption={includeAnyOption}
           />
-          )
         </div>
       ) : (
         <AccordionContent

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -141,18 +141,14 @@ const AccordionContent = ({
         )}
         {filterOptions.map((option) => (
           <li key={option.id}>
-            {/* If we have children, show a "section" dropdown, otherwise show just a checkbox */}
+            {/* If we have children, show a "section", otherwise show just a checkbox */}
             {option.children ? (
               // SearchFilterSection will map over all children of this option
               <SearchFilterSection
                 option={option as FilterOptionWithChildren}
-                value={option.value}
                 query={query}
                 updateCheckedOption={toggleOptionChecked}
-                toggleSelectAll={toggleSelectAll}
                 accordionTitle={title}
-                isSectionAllSelected={areSetsEqual}
-                isSectionNoneSelected={() => query.size === 0}
                 facetCounts={facetCounts}
               />
             ) : (

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
@@ -7,9 +7,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
 import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
-import SectionLinkCount from "src/components/search/SearchFilterAccordion/SearchFilterSection/SectionLinkCount";
-import SectionLinkLabel from "src/components/search/SearchFilterAccordion/SearchFilterSection/SectionLinkLabel";
-import SearchFilterToggleAll from "src/components/search/SearchFilterAccordion/SearchFilterToggleAll";
+import { AnyOptionCheckbox } from "../AnyOptionCheckbox";
 
 interface SearchFilterSectionProps {
   option: FilterOptionWithChildren;
@@ -37,26 +35,12 @@ const SearchFilterSection = ({
   value,
   facetCounts,
 }: SearchFilterSectionProps) => {
-  const [childrenVisible, setChildrenVisible] = useState<boolean>(false);
   const searchParams = useSearchParams();
 
-  const sectionQuery = new Set<string>();
-  query.forEach((queryValue) => {
-    // The value is treated as a child for some agencies if has children in the UI and so
-    // is added to the count.
-    if (queryValue.startsWith(`${value}-`) || query.has(value)) {
-      sectionQuery.add(queryValue);
-    }
-  });
   const allSectionOptions = useMemo(
     () => new Set(option.children.map((options) => options.value)),
     [option],
   );
-
-  const sectionCount = sectionQuery.size;
-
-  const getHiddenName = (name: string) =>
-    accordionTitle === "Agency" ? `agency-${name}` : name;
 
   const clearSection = useCallback(() => {
     const currentSelections = new Set(
@@ -68,60 +52,54 @@ const SearchFilterSection = ({
     toggleSelectAll(false, currentSelections);
   }, [toggleSelectAll, accordionTitle, searchParams, allSectionOptions]);
 
+  // const isNoneSelected = useMemo(() => query.size === 0, [query]);
+  // const isNoneSelected = useMemo(() => {
+  //   return (
+  //     query.size === 0 ||
+  //     !option.children.some((childOption) => {
+  //       query.has(childOption.value);
+  //     })
+  //   );
+  // }, [query]);
+
+  const isNoneSelected =
+    query.size === 0 ||
+    !option.children.some((childOption) => {
+      query.has(childOption.value);
+    });
+
+  console.log("!!!", isNoneSelected);
+
+  // console.log(
+  //   "$$$",
+  //   option.children.some((childOption) => {
+  //     console.log("!!!", query, childOption.value);
+  //     query.has(childOption.value);
+  //   }),
+  // );
   return (
     <div>
-      <button
-        className="usa-button usa-button--unstyled width-full border-bottom-2px border-base-lighter"
-        onClick={(event) => {
-          event.preventDefault();
-          setChildrenVisible(!childrenVisible);
-        }}
-      >
-        <span className="grid-row flex-align-center margin-left-neg-1">
-          <SectionLinkLabel childrenVisible={childrenVisible} option={option} />
-          <SectionLinkCount sectionCount={sectionCount} />
-        </span>
-      </button>
-      {childrenVisible ? (
-        <div className="padding-y-1">
-          <SearchFilterToggleAll
-            onSelectAll={() => toggleSelectAll(true, allSectionOptions)}
-            onClearAll={() => clearSection()}
-            isAllSelected={isSectionAllSelected(
-              allSectionOptions,
-              sectionQuery,
-            )}
-            isNoneSelected={isSectionNoneSelected(sectionQuery)}
-          />
-          <ul className="usa-list usa-list--unstyled margin-left-4">
-            {option.children?.map((child) => (
-              <li key={child.id}>
-                <SearchFilterCheckbox
-                  option={child}
-                  query={query}
-                  updateCheckedOption={updateCheckedOption}
-                  accordionTitle={accordionTitle}
-                  facetCounts={facetCounts}
-                />
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : (
-        // Collapsed sections won't send checked values to the server action.
-        // So we need hidden inputs.
-        option.children?.map((child) =>
-          child.isChecked ? (
-            <input
-              key={child.id}
-              type="hidden"
-              //   name={child.value}
-              name={getHiddenName(child.id)}
-              value="on"
-            />
-          ) : null,
-        )
-      )}
+      <div>{option.label}</div>
+      <div className="padding-y-1">
+        <AnyOptionCheckbox
+          title={option.label}
+          queryParamKey="agency"
+          checked={isNoneSelected}
+        />
+        <ul className="usa-list usa-list--unstyled margin-left-4">
+          {option.children?.map((child) => (
+            <li key={child.id}>
+              <SearchFilterCheckbox
+                option={child}
+                query={query}
+                updateCheckedOption={updateCheckedOption}
+                accordionTitle={accordionTitle}
+                facetCounts={facetCounts}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
@@ -31,7 +31,6 @@ const SearchFilterSection = ({
   accordionTitle,
   query,
   isSectionAllSelected,
-  isSectionNoneSelected,
   value,
   facetCounts,
 }: SearchFilterSectionProps) => {
@@ -52,31 +51,15 @@ const SearchFilterSection = ({
     toggleSelectAll(false, currentSelections);
   }, [toggleSelectAll, accordionTitle, searchParams, allSectionOptions]);
 
-  // const isNoneSelected = useMemo(() => query.size === 0, [query]);
-  // const isNoneSelected = useMemo(() => {
-  //   return (
-  //     query.size === 0 ||
-  //     !option.children.some((childOption) => {
-  //       query.has(childOption.value);
-  //     })
-  //   );
-  // }, [query]);
+  const isSectionNoneSelected = useMemo(
+    () =>
+      query.size === 0 ||
+      !option.children.some((childOption) => query.has(childOption.value)),
+    [query, option.children],
+  );
 
-  const isNoneSelected =
-    query.size === 0 ||
-    !option.children.some((childOption) => {
-      query.has(childOption.value);
-    });
+  const selectionsFromOtherSections = useMemo(() => {}, []);
 
-  console.log("!!!", isNoneSelected);
-
-  // console.log(
-  //   "$$$",
-  //   option.children.some((childOption) => {
-  //     console.log("!!!", query, childOption.value);
-  //     query.has(childOption.value);
-  //   }),
-  // );
   return (
     <div>
       <div>{option.label}</div>
@@ -84,7 +67,8 @@ const SearchFilterSection = ({
         <AnyOptionCheckbox
           title={option.label}
           queryParamKey="agency"
-          checked={isNoneSelected}
+          checked={isSectionNoneSelected}
+          defaultEmptySelection={selectionsFromOtherSections}
         />
         <ul className="usa-list usa-list--unstyled margin-left-4">
           {option.children?.map((child) => (

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
@@ -7,6 +7,7 @@ import { useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 
 import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
+import { AllOptionCheckbox } from "../AllOptionCheckbox";
 import { AnyOptionCheckbox } from "../AnyOptionCheckbox";
 
 interface SearchFilterSectionProps {
@@ -41,34 +42,40 @@ const SearchFilterSection = ({
     [option],
   );
 
-  const clearSection = useCallback(() => {
-    const currentSelections = new Set(
-      searchParams.get(camelCase(accordionTitle))?.split(","),
-    );
-    allSectionOptions.forEach((option) => {
-      currentSelections.delete(option);
-    });
-    toggleSelectAll(false, currentSelections);
-  }, [toggleSelectAll, accordionTitle, searchParams, allSectionOptions]);
+  // const clearSection = useCallback(() => {
+  //   const currentSelections = new Set(
+  //     searchParams.get(camelCase(accordionTitle))?.split(","),
+  //   );
+  //   allSectionOptions.forEach((option) => {
+  //     currentSelections.delete(option);
+  //   });
+  //   toggleSelectAll(false, currentSelections);
+  // }, [toggleSelectAll, accordionTitle, searchParams, allSectionOptions]);
 
-  const isSectionNoneSelected = useMemo(
-    () =>
-      query.size === 0 ||
-      !option.children.some((childOption) => query.has(childOption.value)),
-    [query, option.children],
-  );
+  // const isSectionNoneSelected = useMemo(
+  //   () =>
+  //     query.size === 0 ||
+  //     !option.children.some((childOption) => query.has(childOption.value)),
+  //   [query, option.children],
+  // );
 
-  const selectionsFromOtherSections = useMemo(() => {}, []);
+  // const selectionsFromOtherSections = useMemo(() => {}, []);
 
   return (
     <div>
       <div>{option.label}</div>
       <div className="padding-y-1">
-        <AnyOptionCheckbox
+        {/* <AnyOptionCheckbox
           title={option.label}
           queryParamKey="agency"
           checked={isSectionNoneSelected}
           defaultEmptySelection={selectionsFromOtherSections}
+        /> */}
+        <AllOptionCheckbox
+          title={option.label}
+          queryParamKey="agency"
+          childOptions={option.children}
+          currentSelections={query}
         />
         <ul className="usa-list usa-list--unstyled margin-left-4">
           {option.children?.map((child) => (

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
@@ -22,7 +22,7 @@ const SearchFilterSection = ({
 }: SearchFilterSectionProps) => {
   return (
     <div>
-      <div>{option.label}</div>
+      <div className="text-bold margin-top-1">{option.label}</div>
       <div className="padding-y-1">
         <AllOptionCheckbox
           title={option.label}

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
@@ -1,76 +1,29 @@
 "use client";
 
-import { camelCase } from "lodash";
 import { FilterOptionWithChildren } from "src/types/search/searchResponseTypes";
 
-import { useSearchParams } from "next/navigation";
-import { useCallback, useMemo, useState } from "react";
-
+import { AllOptionCheckbox } from "src/components/search/SearchFilterAccordion/AllOptionCheckbox";
 import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
-import { AllOptionCheckbox } from "../AllOptionCheckbox";
-import { AnyOptionCheckbox } from "../AnyOptionCheckbox";
 
 interface SearchFilterSectionProps {
   option: FilterOptionWithChildren;
   updateCheckedOption: (optionId: string, isChecked: boolean) => void;
-  toggleSelectAll: (all: boolean, allSelected?: Set<string>) => void;
   accordionTitle: string;
-  isSectionAllSelected: (
-    allSelected: Set<string>,
-    query: Set<string>,
-  ) => boolean;
-  isSectionNoneSelected: (query: Set<string>) => boolean;
   query: Set<string>;
-  value: string;
   facetCounts?: { [key: string]: number };
 }
 
 const SearchFilterSection = ({
   option,
   updateCheckedOption,
-  toggleSelectAll,
   accordionTitle,
   query,
-  isSectionAllSelected,
-  value,
   facetCounts,
 }: SearchFilterSectionProps) => {
-  const searchParams = useSearchParams();
-
-  const allSectionOptions = useMemo(
-    () => new Set(option.children.map((options) => options.value)),
-    [option],
-  );
-
-  // const clearSection = useCallback(() => {
-  //   const currentSelections = new Set(
-  //     searchParams.get(camelCase(accordionTitle))?.split(","),
-  //   );
-  //   allSectionOptions.forEach((option) => {
-  //     currentSelections.delete(option);
-  //   });
-  //   toggleSelectAll(false, currentSelections);
-  // }, [toggleSelectAll, accordionTitle, searchParams, allSectionOptions]);
-
-  // const isSectionNoneSelected = useMemo(
-  //   () =>
-  //     query.size === 0 ||
-  //     !option.children.some((childOption) => query.has(childOption.value)),
-  //   [query, option.children],
-  // );
-
-  // const selectionsFromOtherSections = useMemo(() => {}, []);
-
   return (
     <div>
       <div>{option.label}</div>
       <div className="padding-y-1">
-        {/* <AnyOptionCheckbox
-          title={option.label}
-          queryParamKey="agency"
-          checked={isSectionNoneSelected}
-          defaultEmptySelection={selectionsFromOtherSections}
-        /> */}
         <AllOptionCheckbox
           title={option.label}
           queryParamKey="agency"

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -1,4 +1,4 @@
-import { stringToBoolean } from "src/utils/generalUtils";
+import { stringToBoolean } from "src/utils/middlewareSafeUtils";
 
 const {
   NEXT_PUBLIC_BASE_PATH,

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -3,6 +3,7 @@
 import { sendGAEvent } from "@next/third-parties/google";
 import { ValidSearchQueryParamData } from "src/types/search/searchRequestTypes";
 import { queryParamsToQueryString } from "src/utils/generalUtils";
+import { paramsToFormattedQuery } from "src/utils/search/searchUtils";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
@@ -48,10 +49,7 @@ export function useSearchParamUpdater() {
     }
 
     sendGAEvent("event", "search_term", { key: finalQueryParamValue });
-    let newPath = `${pathname}?${params.toString()}`;
-    newPath = removeURLEncodedCommas(newPath);
-    newPath = removeQuestionMarkIfNoParams(params, newPath);
-    router.push(newPath, { scroll });
+    router.push(`${pathname}?${paramsToFormattedQuery(params)}`, { scroll });
   };
 
   const replaceQueryParams = (params: ValidSearchQueryParamData) => {
@@ -60,12 +58,12 @@ export function useSearchParamUpdater() {
 
   const setQueryParam = (key: string, value: string, scroll = false) => {
     params.set(key, value);
-    router.push(`${pathname}?${params.toString()}`, { scroll });
+    router.push(`${pathname}?${paramsToFormattedQuery(params)}`, { scroll });
   };
 
   const removeQueryParam = (paramKey: string, scroll = false) => {
     params.delete(paramKey);
-    router.push(`${pathname}?${params.toString()}`, { scroll });
+    router.push(`${pathname}?${paramsToFormattedQuery(params)}`, { scroll });
   };
 
   return {
@@ -75,17 +73,4 @@ export function useSearchParamUpdater() {
     removeQueryParam,
     setQueryParam,
   };
-}
-
-function removeURLEncodedCommas(newPath: string) {
-  return newPath.replaceAll("%2C", ",");
-}
-
-// When we remove all query params we also need to remove
-// the question mark from the URL
-function removeQuestionMarkIfNoParams(
-  params: URLSearchParams,
-  newPath: string,
-) {
-  return params.toString() === "" ? newPath.replaceAll("?", "") : newPath;
 }

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -49,7 +49,7 @@ export function useSearchParamUpdater() {
     }
 
     sendGAEvent("event", "search_term", { key: finalQueryParamValue });
-    router.push(`${pathname}?${paramsToFormattedQuery(params)}`, { scroll });
+    router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 
   const replaceQueryParams = (params: ValidSearchQueryParamData) => {
@@ -58,12 +58,12 @@ export function useSearchParamUpdater() {
 
   const setQueryParam = (key: string, value: string, scroll = false) => {
     params.set(key, value);
-    router.push(`${pathname}?${paramsToFormattedQuery(params)}`, { scroll });
+    router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 
   const removeQueryParam = (paramKey: string, scroll = false) => {
     params.delete(paramKey);
-    router.push(`${pathname}?${paramsToFormattedQuery(params)}`, { scroll });
+    router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 
   return {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -414,6 +414,7 @@ export const messages = {
     description: "Try out our experimental search page.",
     accordion: {
       any: "Any",
+      all: "All",
       titles: {
         funding: "Funding instrument",
         eligibility: "Eligibility",

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -5,6 +5,7 @@
 // * the character count is zero indexed
 // * the split will happen on the first whitespace AFTER the supplied split point
 
+import { difference } from "lodash";
 import { OptionalStringDict } from "src/types/generalTypes";
 
 // Refer to tests to see how this works in practice
@@ -128,3 +129,7 @@ export const isCurrentPath = (href: string, currentPath: string): boolean =>
 export function isExternalLink(href: string): boolean {
   return !!(href && href.includes("http"));
 }
+
+export const isSubset = <T>(subset: T[], superset: T[]) => {
+  return !difference(subset, superset).length;
+};

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -97,10 +97,6 @@ export const findFirstWhitespace = (content: string, startAt: number): number =>
 export const encodeText = (valueToEncode: string) =>
   new TextEncoder().encode(valueToEncode);
 
-export const stringToBoolean = (
-  mightRepresentABoolean: string | undefined,
-): boolean => mightRepresentABoolean === "true";
-
 // a hack to get filenames to work on blob based downloads across all browsers
 // see https://stackoverflow.com/a/48968694
 export const saveBlobToFile = (blob: Blob, filename: string) => {

--- a/frontend/src/utils/middlewareSafeUtils.ts
+++ b/frontend/src/utils/middlewareSafeUtils.ts
@@ -1,0 +1,12 @@
+/*
+
+  Next JS does not allow lodash to be imported into anything in the require tree for middleware functions, due
+  to lodash in some very isolated cases using an eval method. See https://github.com/lodash/lodash/issues/5525
+
+  As a result, we should isolate utility functions used within middleware within this file to avoid build errors
+
+*/
+
+export const stringToBoolean = (
+  mightRepresentABoolean: string | undefined,
+): boolean => mightRepresentABoolean === "true";

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -94,6 +94,11 @@ function getSafePage(page: string | undefined) {
   return Math.max(1, parseInt(page || "1"));
 }
 
+// stringifies query params, unencrypts any encrypted commas, and prepends a ?
 export const paramsToFormattedQuery = (params: URLSearchParams): string => {
-  return params.toString().replaceAll("%2C", ",").replaceAll(/\?$/g, "");
+  if (!params.size) {
+    return "";
+  }
+  // return `?${params.toString().replaceAll("%2C", ",")}`;
+  return `?${decodeURIComponent(params.toString())}`;
 };

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -93,3 +93,7 @@ function paramToSet(param: QuerySetParam, type?: string): Set<string> {
 function getSafePage(page: string | undefined) {
   return Math.max(1, parseInt(page || "1"));
 }
+
+export const paramsToFormattedQuery = (params: URLSearchParams): string => {
+  return params.toString().replaceAll("%2C", ",").replaceAll(/\?$/g, "");
+};

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -7,7 +7,10 @@ import {
   SearchFetcherActionType,
   ValidSearchQueryParamData,
 } from "src/types/search/searchRequestTypes";
-import { SearchAPIResponse } from "src/types/search/searchResponseTypes";
+import {
+  FilterOption,
+  SearchAPIResponse,
+} from "src/types/search/searchResponseTypes";
 
 export const mockOpportunity: BaseOpportunity = {
   opportunity_id: 12345,
@@ -118,3 +121,26 @@ export const fakeOpportunityDocument = {
   updated_at: Date.now().toString(),
   file_description: "a description for your file",
 };
+
+export const initialFilterOptions: FilterOption[] = [
+  {
+    id: "funding-instrument-cooperative_agreement",
+    label: "Cooperative Agreement",
+    value: "cooperative_agreement",
+  },
+  {
+    id: "funding-instrument-grant",
+    label: "Grant",
+    value: "grant",
+  },
+  {
+    id: "funding-instrument-procurement_contract",
+    label: "Procurement Contract ",
+    value: "procurement_contract",
+  },
+  {
+    id: "funding-instrument-other",
+    label: "Other",
+    value: "other",
+  },
+];

--- a/frontend/tests/components/search/SearchFilterAccordion/AllOptionCheckbox.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AllOptionCheckbox.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { initialFilterOptions } from "src/utils/testing/fixtures";
+import { useTranslationsMock } from "src/utils/testing/intlMocks";
+
+import { AllOptionCheckbox } from "src/components/search/SearchFilterAccordion/AllOptionCheckbox";
+
+const mockSetQueryParam = jest.fn();
+
+const optionValues = initialFilterOptions.map((option) => option.value);
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => useTranslationsMock(),
+}));
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    setQueryParam: mockSetQueryParam,
+  }),
+}));
+
+describe("AllOptionCheckbox", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("displays a checkbox with the correct name and label", () => {
+    render(
+      <AllOptionCheckbox
+        title={"Fun checkbox"}
+        currentSelections={new Set()}
+        childOptions={[]}
+        queryParamKey={"whatever"}
+      />,
+    );
+    const checkboxByName = screen.getByRole("checkbox", {
+      name: "all Fun checkbox",
+    });
+    expect(checkboxByName).toBeInTheDocument();
+  });
+  it("calls setQueryParam as expected when checking", async () => {
+    render(
+      <AllOptionCheckbox
+        title={"Fun checkbox"}
+        currentSelections={new Set(["hi"])}
+        childOptions={initialFilterOptions}
+        queryParamKey={"whatever"}
+      />,
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).not.toBeChecked();
+
+    await userEvent.click(checkbox);
+
+    expect(mockSetQueryParam).toHaveBeenCalledWith(
+      "whatever",
+      optionValues.concat("hi").join(","),
+    );
+  });
+  it("calls setQueryParam as expected when un-checking", async () => {
+    render(
+      <AllOptionCheckbox
+        title={"Fun checkbox"}
+        currentSelections={new Set(optionValues.concat(["hi"]))}
+        childOptions={initialFilterOptions}
+        queryParamKey={"whatever"}
+      />,
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+
+    await userEvent.click(checkbox);
+
+    expect(mockSetQueryParam).toHaveBeenCalledWith("whatever", "hi");
+  });
+  it("checks and unchecks the box as expected when outside selections change", () => {
+    const { rerender } = render(
+      <AllOptionCheckbox
+        title={"Fun checkbox"}
+        currentSelections={new Set(optionValues)}
+        childOptions={initialFilterOptions}
+        queryParamKey={"whatever"}
+      />,
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+
+    rerender(
+      <AllOptionCheckbox
+        title={"Fun checkbox"}
+        currentSelections={new Set(optionValues.slice(0, 1))}
+        childOptions={initialFilterOptions}
+        queryParamKey={"whatever"}
+      />,
+    );
+
+    expect(checkbox).not.toBeChecked();
+
+    rerender(
+      <AllOptionCheckbox
+        title={"Fun checkbox"}
+        currentSelections={new Set(optionValues)}
+        childOptions={initialFilterOptions}
+        queryParamKey={"whatever"}
+      />,
+    );
+
+    expect(checkbox).toBeChecked();
+  });
+});

--- a/frontend/tests/components/search/SearchFilterAccordion/AnyOptionCheckbox.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AnyOptionCheckbox.test.tsx
@@ -84,7 +84,7 @@ describe("AnyOptionCheckbox", () => {
         queryParamKey={"any"}
       />,
     );
-    const label = screen.getByText("Any for the title");
+    const label = screen.getByText("Any For the title");
     expect(label).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
@@ -2,35 +2,12 @@ import "@testing-library/jest-dom/extend-expect";
 
 import { fireEvent } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { FilterOption } from "src/types/search/searchResponseTypes";
+import { initialFilterOptions } from "src/utils/testing/fixtures";
 import { render, screen } from "tests/react-utils";
 
 import React from "react";
 
 import SearchFilterAccordion from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
-
-const initialFilterOptions: FilterOption[] = [
-  {
-    id: "funding-instrument-cooperative_agreement",
-    label: "Cooperative Agreement",
-    value: "cooperative_agreement",
-  },
-  {
-    id: "funding-instrument-grant",
-    label: "Grant",
-    value: "grant",
-  },
-  {
-    id: "funding-instrument-procurement_contract",
-    label: "Procurement Contract ",
-    value: "procurement_contract",
-  },
-  {
-    id: "funding-instrument-other",
-    label: "Other",
-    value: "other",
-  },
-];
 
 const fakeFacetCounts = {
   grant: 1,
@@ -190,5 +167,30 @@ describe("SearchFilterAccordion", () => {
       name: "Any test accordion",
     });
     expect(anyCheckbox).toBeInTheDocument();
+  });
+  it("ensures only the component contents scroll when wrapForScroll is true", () => {
+    render(
+      <SearchFilterAccordion
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={fakeFacetCounts}
+        wrapForScroll={true}
+      />,
+    );
+
+    const scrollableContainer = screen.getByTestId(`${title}-accordion-scroll`);
+
+    expect(scrollableContainer).toHaveClass("overflow-scroll");
+
+    const initialScrollTop = scrollableContainer.scrollTop;
+
+    fireEvent.scroll(scrollableContainer, { target: { scrollTop: 100 } });
+
+    expect(scrollableContainer.scrollTop).toBeGreaterThan(initialScrollTop);
+
+    // Assert that the document body has not scrolled
+    expect(window.scrollY).toBe(0);
   });
 });

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
@@ -174,4 +174,21 @@ describe("SearchFilterAccordion", () => {
     });
     expect(countSpan).toBeInTheDocument();
   });
+  it("adds an any option checkbox by default", () => {
+    render(
+      <SearchFilterAccordion
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
+    const accordionToggleButton = screen.getByRole("button");
+    fireEvent.click(accordionToggleButton);
+    const anyCheckbox = screen.getByRole("checkbox", {
+      name: "Any test accordion",
+    });
+    expect(anyCheckbox).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.test.tsx
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom";
 
-import { fireEvent } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { render, screen } from "tests/react-utils";
 
@@ -8,24 +7,9 @@ import React from "react";
 
 import SearchFilterSection from "src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection";
 
-const isSectionAllSelected = (
-  allSelected: Set<string>,
-  query: Set<string>,
-): boolean => {
-  if (allSelected && query) {
-    return false;
-  }
-  return true;
-};
-const isSectionNoneSelected = (query: Set<string>): boolean => {
-  if (query) {
-    return false;
-  }
-  return true;
-};
+const mockSetQueryParam = jest.fn();
+
 const defaultProps = {
-  isSectionAllSelected,
-  isSectionNoneSelected,
   option: {
     id: "1",
     label: "Option 1",
@@ -45,18 +29,20 @@ const defaultProps = {
       },
     ],
   },
-  incrementTotal: jest.fn(),
-  decrementTotal: jest.fn(),
   updateCheckedOption: jest.fn(),
-  toggleSelectAll: jest.fn(),
   accordionTitle: "Default Title",
   query: new Set(""),
-  value: "",
   facetCounts: {
     "1st-child-value": 1,
     "2nd-child-value": 2,
   },
 };
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    setQueryParam: mockSetQueryParam,
+  }),
+}));
 
 describe("SearchFilterSection", () => {
   it("should not have accessibility violations", async () => {
@@ -64,46 +50,9 @@ describe("SearchFilterSection", () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
-
-  it("toggles children visibility on button click", () => {
+  it("displays select all checkbox and checkbox for each child", () => {
     render(<SearchFilterSection {...defaultProps} />);
 
-    // Section is collapsed on not visible
-    expect(screen.queryByText("Select All")).not.toBeInTheDocument();
-    expect(screen.queryByText("Clear All")).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("checkbox", { name: "Child 1" }),
-    ).not.toBeInTheDocument();
-
-    // uncollapse section
-    fireEvent.click(screen.getByRole("button"));
-
-    // Toggle all links and checkbox appear
-    expect(screen.getByText("Select All")).toBeInTheDocument();
-    expect(screen.getByText("Clear All")).toBeInTheDocument();
-    expect(
-      screen.getByRole("checkbox", { name: "Child 1 [1]" }),
-    ).toBeInTheDocument();
-  });
-
-  it("renders hidden inputs for checked children when collapsed", () => {
-    // checkbox "1-2" is checked, but when the section is collapsed we still need to send the value
-    // to the form to submit, so we use a hidden input. It must be present.
-    render(<SearchFilterSection {...defaultProps} />);
-    const hiddenInput = screen.getByDisplayValue("on");
-    expect(hiddenInput).toBeInTheDocument();
-    expect(hiddenInput).toHaveAttribute("name", "1-2");
-  });
-  it("does not render if there are no children with facetCounts > 0", () => {
-    render(
-      <SearchFilterSection
-        {...defaultProps}
-        facetCounts={{
-          "1st-child-value": 0,
-          "2nd-child-value": 0,
-        }}
-      />,
-    );
-    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("checkbox")).toHaveLength(3);
   });
 });

--- a/frontend/tests/e2e/search/search-copy-url.spec.ts
+++ b/frontend/tests/e2e/search/search-copy-url.spec.ts
@@ -28,6 +28,7 @@ test("should copy search query URL to clipboard", async ({ page }) => {
   await copyButton.click();
 
   // Get the current URL to verify it contains the expected query
-  const currentUrl = page.url();
-  expect(currentUrl).toContain("/search?query=education+grants");
+  const clipboardText = await page.evaluate("navigator.clipboard.readText()");
+  // const currentUrl = page.url();
+  expect(clipboardText).toContain("/search?query=education+grants");
 });

--- a/frontend/tests/e2e/search/search-copy-url.spec.ts
+++ b/frontend/tests/e2e/search/search-copy-url.spec.ts
@@ -9,11 +9,11 @@ import {
 test("should copy search query URL to clipboard", async ({ page }, {
   project,
 }) => {
-  // navigator.clipboard only works in secure contexts (https) except, apparently in webkit
-  // for now, we'll only run this test in webkit
-  if (!project.name.match(/[Ww]ebkit/)) {
+  // clipboard testing does not work in webkit
+  if (project.name.match(/[Ww]ebkit/)) {
     return;
   }
+
   await page.goto("/search");
 
   // this is dumb but webkit has an issue with trying to fill in the input too quickly
@@ -35,6 +35,14 @@ test("should copy search query URL to clipboard", async ({ page }, {
 
   await copyButton.click();
 
-  const clipboardText = await page.evaluate("navigator.clipboard.readText()");
-  expect(clipboardText).toContain("/search?query=education+grants");
+  // const clipboardText = await page.evaluate("navigator.clipboard.readText()");
+  // expect(clipboardText).toContain("/search?query=education+grants");
+
+  const searchInput = page.locator("#query");
+  await searchInput.fill("");
+  await searchInput.press("ControlOrMeta+V");
+
+  await expect(searchInput).toHaveValue(
+    "http://127.0.0.1:3000/search?query=education+grants",
+  );
 });

--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -1,10 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { camelCase } from "lodash";
-import {
-  waitForAnyURLChange,
-  waitForUrl,
-  waitForURLContainsQueryParam,
-} from "tests/e2e/playwrightUtils";
+import { waitForAnyURLChange } from "tests/e2e/playwrightUtils";
 import {
   clickAccordionWithTitle,
   clickLastPaginationPage,
@@ -12,20 +7,35 @@ import {
   expectCheckboxIDIsChecked,
   expectSortBy,
   fillSearchInputAndSubmit,
-  getCountOfTopLevelFilterOptions,
   getFirstSearchResultTitle,
   getLastSearchResultTitle,
   getNumberOfOpportunitySearchResults,
   getSearchInput,
   refreshPageWithCurrentURL,
-  selectAllTopLevelFilterOptions,
   selectSortBy,
   toggleCheckboxes,
   toggleMobileSearchFilters,
-  validateTopLevelAndNestedSelectedFilterCounts,
   waitForFilterOptions,
   waitForSearchResultsInitialLoad,
 } from "tests/e2e/search/searchSpecUtil";
+
+const searchTerm = "education";
+const statusCheckboxes = {
+  "status-closed": "closed",
+};
+const fundingInstrumentCheckboxes = {
+  "funding-instrument-cooperative_agreement": "cooperative_agreement",
+  "funding-instrument-grant": "grant",
+};
+
+const eligibilityCheckboxes = {
+  "eligibility-state_governments": "state_governments",
+  "eligibility-county_governments": "county_governments",
+};
+const categoryCheckboxes = {
+  "category-recovery_act": "recovery_act",
+  "category-agriculture": "agriculture",
+};
 
 test.describe("Search page tests", () => {
   // Set all inputs, then refresh the page. Those same inputs should be
@@ -33,24 +43,7 @@ test.describe("Search page tests", () => {
   test("should refresh and retain filters in a new tab", async ({ page }, {
     project,
   }) => {
-    const searchTerm = "education";
-    const statusCheckboxes = {
-      "status-closed": "closed",
-    };
-    const fundingInstrumentCheckboxes = {
-      "funding-instrument-cooperative_agreement": "cooperative_agreement",
-      "funding-instrument-grant": "grant",
-    };
-
-    const eligibilityCheckboxes = {
-      "eligibility-state_governments": "state_governments",
-      "eligibility-county_governments": "county_governments",
-    };
     const agencyCheckboxes: { [key: string]: string } = {};
-    const categoryCheckboxes = {
-      "category-recovery_act": "recovery_act",
-      "category-agriculture": "agriculture",
-    };
     await page.goto("/search");
 
     if (project.name.match(/[Mm]obile/)) {
@@ -84,13 +77,9 @@ test.describe("Search page tests", () => {
     await toggleCheckboxes(page, eligibilityCheckboxes, "eligibility");
 
     await clickAccordionWithTitle(page, "Agency");
-    const subAgencyExpander = page.locator(
-      "#opportunity-filter-agency ul li:first-child",
-    );
-    await subAgencyExpander.click();
-    const firstSubAgency = page.locator(
-      "#opportunity-filter-agency ul ul li:first-child .usa-checkbox:first-child input",
-    );
+    const firstSubAgency = page
+      .locator("#opportunity-filter-agency > div > ul > li ul input")
+      .first();
 
     const agencyId = await firstSubAgency.getAttribute("id");
     expect(agencyId).toBeTruthy();
@@ -129,7 +118,6 @@ test.describe("Search page tests", () => {
     for (const [checkboxID] of Object.entries(eligibilityCheckboxes)) {
       await expectCheckboxIDIsChecked(page, `#${checkboxID}`);
     }
-    await subAgencyExpander.click();
     for (const [checkboxID] of Object.entries(agencyCheckboxes)) {
       await expectCheckboxIDIsChecked(page, `#${checkboxID}`);
     }
@@ -241,407 +229,5 @@ test.describe("Search page tests", () => {
     await waitForAnyURLChange(page, "/search?page=1000000");
 
     expect(page.url()).toMatch(/search\?page=\d{1,3}/);
-  });
-  test.describe("selecting and clearing filters", () => {
-    const filterTypes = [
-      "Funding instrument",
-      "Eligibility",
-      "Category",
-      "Agency",
-    ];
-
-    filterTypes.forEach((filterType) => {
-      test(`correctly clears and selects all for ${filterType} filter`, async ({
-        page,
-      }, { project }) => {
-        const unselectedUrl = "http://127.0.0.1:3000/search";
-
-        const camelCaseFilterType = camelCase(filterType);
-
-        // load search page
-        await page.goto("/search");
-
-        // open accordion for filter type
-        if (project.name.match(/[Mm]obile/)) {
-          await toggleMobileSearchFilters(page);
-        }
-        await Promise.all([
-          waitForSearchResultsInitialLoad(page),
-          waitForFilterOptions(page, camelCaseFilterType),
-        ]);
-
-        const initialSearchResultsCount =
-          await getNumberOfOpportunitySearchResults(page);
-
-        await clickAccordionWithTitle(page, filterType);
-
-        const numberOfFilterOptions = await getCountOfTopLevelFilterOptions(
-          page,
-          camelCaseFilterType,
-        );
-
-        await selectAllTopLevelFilterOptions(page, camelCaseFilterType);
-
-        // validate that new search results are returned
-        let updatedSearchResultsCount =
-          await getNumberOfOpportunitySearchResults(page);
-        expect(initialSearchResultsCount).not.toBe(updatedSearchResultsCount);
-
-        // validate that checkboxes are checked
-        let checkboxes = await page
-          .locator(
-            `#opportunity-filter-${camelCaseFilterType} > ul > li > div > input`,
-          )
-          .all();
-
-        await Promise.all(
-          checkboxes.map((checkbox) => {
-            return checkbox.getAttribute("id").then((id) => {
-              if (!id?.match(/any$/)) {
-                return expect(checkbox).toBeChecked();
-              }
-            });
-          }),
-        );
-
-        // validate that the correct number of filter options is displayed
-        const accordionButton = page.locator(
-          `button[data-testid="accordionButton_opportunity-filter-${camelCaseFilterType}"]`,
-        );
-
-        await expect(accordionButton).toHaveText(
-          `${filterType}${numberOfFilterOptions}`,
-        );
-
-        // click clear all
-        await page
-          .locator(
-            `#opportunity-filter-${camelCaseFilterType} button:has-text("Clear All")`,
-          )
-          .first()
-          .click();
-
-        // validate that url is updated
-        await waitForUrl(page, unselectedUrl);
-
-        // validate that new search results are returned
-        updatedSearchResultsCount =
-          await getNumberOfOpportunitySearchResults(page);
-        expect(initialSearchResultsCount).toBe(updatedSearchResultsCount);
-
-        // validate that checkboxes are not checked
-        checkboxes = await page
-          .locator(
-            `#opportunity-filter-${camelCaseFilterType} > ul > li > div > input`,
-          )
-          .all();
-
-        await Promise.all(
-          checkboxes.map((checkbox) => {
-            return checkbox.getAttribute("id").then((id) => {
-              if (!id?.match(/any$/)) {
-                return expect(checkbox).not.toBeChecked();
-              }
-            });
-          }),
-        );
-
-        // validate that the correct number of filter options is displayed
-        await expect(accordionButton).toHaveText(filterType);
-      });
-    });
-
-    test(`correctly clears and selects all for status filter`, async ({
-      page,
-    }, { project }) => {
-      const unselectedUrl = "http://127.0.0.1:3000/search?status=none";
-
-      const camelCaseFilterType = "status";
-
-      // load search page
-      await page.goto("/search");
-
-      // open accordion for filter type
-      if (project.name.match(/[Mm]obile/)) {
-        await toggleMobileSearchFilters(page);
-      }
-      await Promise.all([
-        waitForSearchResultsInitialLoad(page),
-        waitForFilterOptions(page, camelCaseFilterType),
-      ]);
-
-      const initialSearchResultsCount =
-        await getNumberOfOpportunitySearchResults(page);
-
-      const numberOfFilterOptions = await getCountOfTopLevelFilterOptions(
-        page,
-        camelCaseFilterType,
-      );
-
-      await selectAllTopLevelFilterOptions(page, camelCaseFilterType);
-
-      // validate that new search results are returned
-      const updatedSearchResultsCount =
-        await getNumberOfOpportunitySearchResults(page);
-      expect(initialSearchResultsCount).not.toBe(updatedSearchResultsCount);
-
-      // validate that checkboxes are checked
-      let checkboxes = await page
-        .locator(
-          `#opportunity-filter-${camelCaseFilterType} > ul > li > div > input`,
-        )
-        .all();
-
-      await Promise.all(
-        checkboxes.map((checkbox) => {
-          return checkbox.getAttribute("id").then((id) => {
-            if (!id?.match(/any$/)) {
-              return expect(checkbox).toBeChecked();
-            }
-          });
-        }),
-      );
-
-      // validate that the correct number of filter options is displayed
-      const accordionButton = page.locator(
-        `button[data-testid="accordionButton_opportunity-filter-${camelCaseFilterType}"]`,
-      );
-
-      await expect(accordionButton).toHaveText(
-        `Opportunity status${numberOfFilterOptions}`,
-      );
-
-      // click clear all
-      await page
-        .locator(
-          `#opportunity-filter-${camelCaseFilterType} button:has-text("Clear All")`,
-        )
-        .first()
-        .click();
-
-      // validate that url is updated
-      await waitForUrl(page, unselectedUrl);
-
-      // validate that checkboxes are not checked
-      checkboxes = await page
-        .locator(
-          `#opportunity-filter-${camelCaseFilterType} > ul > li > div > input`,
-        )
-        .all();
-
-      await Promise.all(
-        checkboxes.map((checkbox) => {
-          return checkbox.getAttribute("id").then((id) => {
-            if (!id?.match(/any$/)) {
-              return expect(checkbox).not.toBeChecked();
-            }
-          });
-        }),
-      );
-
-      // validate that the correct number of filter options is displayed
-      await expect(accordionButton).toHaveText("Opportunity status");
-    });
-
-    /*
-      Scenarios
-
-      - click select all agencies -> click select all nested agency
-      - click clear all
-      - click select all nested agency -> click select all agencies
-      - click clear all nested agency
-    */
-    // flaky
-    test("selects and clears nested agency filters", async ({ page }, {
-      project,
-    }) => {
-      const nestedFilterCheckboxesSelector =
-        "#opportunity-filter-agency > ul > li:first-child > div > div input";
-
-      await page.goto("/search");
-
-      // open accordion for filter type
-      if (project.name.match(/[Mm]obile/)) {
-        await toggleMobileSearchFilters(page);
-      }
-      await Promise.all([
-        waitForSearchResultsInitialLoad(page),
-        waitForFilterOptions(page, "agency"),
-      ]);
-
-      const initialSearchResultsCount =
-        await getNumberOfOpportunitySearchResults(page);
-
-      await clickAccordionWithTitle(page, "Agency");
-
-      // gather number of (top level) filter options
-      // and select all top level filter options
-      const numberOfTopLevelFilterOptions =
-        await getCountOfTopLevelFilterOptions(page, "agency");
-
-      await selectAllTopLevelFilterOptions(page, "agency");
-
-      const topLevelSelectedNumberOfSearchResults =
-        await getNumberOfOpportunitySearchResults(page);
-
-      // open first nested agency and get number of nested options
-      const firstExpander = page
-        .locator('#opportunity-filter-agency svg[aria-label="Expand section"]')
-        .first();
-      await firstExpander.click();
-
-      const numberOfNestedFilterOptions = await page
-        .locator(nestedFilterCheckboxesSelector)
-        .count();
-
-      let urlBeforeInteraction = page.url();
-
-      // click nested select all for first nested agency in list
-      const selectAllNestedButton = page
-        .locator('#opportunity-filter-agency button:has-text("Select All")')
-        .nth(1);
-      await selectAllNestedButton.click();
-
-      await waitForAnyURLChange(page, urlBeforeInteraction);
-
-      const topLevelAndNestedSelectedNumberOfSearchResults =
-        await getNumberOfOpportunitySearchResults(page);
-
-      // we've selected more agencies, so there should be more results
-      expect(
-        topLevelAndNestedSelectedNumberOfSearchResults,
-      ).toBeGreaterThanOrEqual(topLevelSelectedNumberOfSearchResults);
-
-      // validate that nested checkboxes are checked
-      let checkboxes = await page.locator(nestedFilterCheckboxesSelector).all();
-
-      await Promise.all(
-        checkboxes.map((checkbox) => expect(checkbox).toBeChecked()),
-      );
-
-      // validate that the correct number of filter options is displayed
-      const accordionButton = page.locator(
-        'button[data-testid="accordionButton_opportunity-filter-agency"]',
-      );
-
-      await expect(accordionButton).toHaveText(
-        `Agency${numberOfTopLevelFilterOptions + numberOfNestedFilterOptions}`,
-      );
-
-      const expanderButton = page.locator(
-        "#opportunity-filter-agency > ul > li:first-child > div > button",
-      );
-
-      await expect(expanderButton).toContainText(
-        `${numberOfNestedFilterOptions}`,
-      );
-
-      await validateTopLevelAndNestedSelectedFilterCounts(
-        page,
-        "Agency",
-        numberOfTopLevelFilterOptions,
-        numberOfNestedFilterOptions,
-      );
-
-      // click top level clear all
-      await page
-        .locator(`#opportunity-filter-agency button:has-text("Clear All")`)
-        .first()
-        .click();
-
-      // validate that url is updated
-      await waitForUrl(page, "http://127.0.0.1:3000/search");
-
-      // validate that new search results are returned with no filters in place (all results)
-      const fullyClearedSearchResultsCount =
-        await getNumberOfOpportunitySearchResults(page);
-      expect(initialSearchResultsCount).toBe(fullyClearedSearchResultsCount);
-
-      // validate that nested checkboxes are not checked
-      checkboxes = await page.locator(nestedFilterCheckboxesSelector).all();
-
-      await Promise.all(
-        checkboxes.map((checkbox) => expect(checkbox).not.toBeChecked()),
-      );
-
-      // validate that the correct number of filter options is displayed
-      await expect(accordionButton).toHaveText("Agency");
-
-      // select all from first nested agency
-      await selectAllNestedButton.click();
-
-      await waitForURLContainsQueryParam(page, "agency");
-
-      // validate that new filtered search results are returned for nested agency, and correct counts displayed
-      // (fewer results than with top level agencies + nested agencies selected)
-      const nestedSelectedNumberOfSearchResults =
-        await getNumberOfOpportunitySearchResults(page);
-
-      expect(nestedSelectedNumberOfSearchResults).toBeLessThanOrEqual(
-        topLevelAndNestedSelectedNumberOfSearchResults,
-      );
-
-      await validateTopLevelAndNestedSelectedFilterCounts(
-        page,
-        "Agency",
-        0,
-        numberOfNestedFilterOptions,
-      );
-
-      // select all top level agencies
-      urlBeforeInteraction = page.url();
-      await selectAllTopLevelFilterOptions(page, "agency");
-
-      await waitForAnyURLChange(page, urlBeforeInteraction);
-
-      const newTopLevelAndNestedSelectedNumberOfSearchResults =
-        await getNumberOfOpportunitySearchResults(page);
-
-      // validate that counts equal previous counts for this state (top level and first nested agency selected)
-      expect(newTopLevelAndNestedSelectedNumberOfSearchResults).toEqual(
-        topLevelAndNestedSelectedNumberOfSearchResults,
-      );
-
-      await validateTopLevelAndNestedSelectedFilterCounts(
-        page,
-        "Agency",
-        numberOfTopLevelFilterOptions,
-        numberOfNestedFilterOptions,
-      );
-
-      urlBeforeInteraction = page.url();
-
-      // clear nested agency selection
-      await page
-        .locator(`#opportunity-filter-agency button:has-text("Clear All")`)
-        .nth(1)
-        .click();
-
-      // validate that url is updated
-      await waitForAnyURLChange(page, urlBeforeInteraction);
-
-      // validate that new unfiltered filtered results are returned with fewer results than with
-      // sub-agencies selected
-      const partiallyClearedSearchResultsCount =
-        await getNumberOfOpportunitySearchResults(page);
-      expect(partiallyClearedSearchResultsCount).toBeLessThanOrEqual(
-        topLevelAndNestedSelectedNumberOfSearchResults,
-      );
-
-      // validate that nested agency checkboxes are not checked
-      checkboxes = await page.locator(nestedFilterCheckboxesSelector).all();
-
-      await Promise.all(
-        checkboxes.map((checkbox) => expect(checkbox).not.toBeChecked()),
-      );
-
-      // validate that the correct number of filter options is displayed
-      await validateTopLevelAndNestedSelectedFilterCounts(
-        page,
-        "Agency",
-        numberOfTopLevelFilterOptions,
-        0,
-      );
-    });
   });
 });

--- a/frontend/tests/hooks/useSearchParamUpdater.test.ts
+++ b/frontend/tests/hooks/useSearchParamUpdater.test.ts
@@ -21,6 +21,15 @@ jest.mock("src/utils/generalUtils", () => ({
     mockQueryParamsToQueryString(...args) as unknown,
 }));
 
+// this is dumb - the original function only works in jest node envs
+// and there is a reference to `document` somewhere in the import tree here so
+// switching over doesn't work - reimplemented without `size` reference,
+// since that's the only part that's broken in JSdom
+jest.mock("src/utils/search/searchUtils", () => ({
+  paramsToFormattedQuery: (params: URLSearchParams) =>
+    `?${decodeURIComponent(params.toString())}`,
+}));
+
 describe("useSearchParamUpdater", () => {
   afterEach(() => {
     mockSearchParams = new URLSearchParams();

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -42,23 +42,23 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: { ...devices["Desktop Chrome"], permissions: ["clipboard-read"] },
     },
 
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
+      use: { ...devices["Desktop Firefox"], permissions: ["clipboard-read"] },
     },
 
     {
       name: "webkit",
-      use: { ...devices["Desktop Safari"] },
+      use: { ...devices["Desktop Safari"], permissions: ["clipboard-read"] },
     },
 
     /* Test against mobile viewports. */
     {
       name: "Mobile Chrome",
-      use: { ...devices["Pixel 7"] },
+      use: { ...devices["Pixel 7"], permissions: ["clipboard-read"] },
     },
   ],
 

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -42,23 +42,34 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"], permissions: ["clipboard-read"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        permissions: ["clipboard-read", "clipboard-write"],
+      },
     },
 
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"], permissions: ["clipboard-read"] },
+      use: {
+        ...devices["Desktop Firefox"], // firefox doesn't support clipboard-write or clipboard-read
+      },
     },
 
     {
       name: "webkit",
-      use: { ...devices["Desktop Safari"], permissions: ["clipboard-read"] },
+      use: {
+        ...devices["Desktop Safari"],
+        permissions: ["clipboard-read"], // webkit doesn't support clipboard-write
+      },
     },
 
     /* Test against mobile viewports. */
     {
       name: "Mobile Chrome",
-      use: { ...devices["Pixel 7"], permissions: ["clipboard-read"] },
+      use: {
+        ...devices["Pixel 7"],
+        permissions: ["clipboard-read", "clipboard-write"],
+      },
     },
   ],
 

--- a/frontend/tests/utils/search/searchUtils.test.ts
+++ b/frontend/tests/utils/search/searchUtils.test.ts
@@ -1,7 +1,12 @@
+/**
+ * @jest-environment node
+ */
+
 import { BaseOpportunity } from "src/types/opportunity/opportunityResponseTypes";
 import {
   areSetsEqual,
   getAgencyDisplayName,
+  paramsToFormattedQuery,
   sortFilterOptions,
 } from "src/utils/search/searchUtils";
 
@@ -188,5 +193,33 @@ describe("areSetsEqual", () => {
     expect(areSetsEqual(new Set(["2", "1"]), new Set(["1", "2"]))).toEqual(
       true,
     );
+  });
+});
+
+describe("paramsToFormattedQuery", () => {
+  it("returns empty string if no params are passed", () => {
+    expect(paramsToFormattedQuery(new URLSearchParams())).toEqual("");
+  });
+  it("stringifies URLSearchParams and prepends a question mark", () => {
+    expect(
+      paramsToFormattedQuery(
+        new URLSearchParams([
+          ["key", "value"],
+          ["big", "small"],
+          ["simpler", "grants"],
+        ]),
+      ),
+    ).toEqual("?key=value&big=small&simpler=grants");
+  });
+  it("unencrypts commas", () => {
+    expect(
+      paramsToFormattedQuery(
+        new URLSearchParams([
+          ["key", "value,anotherValue"],
+          ["big", "small"],
+          ["simpler", "grants"],
+        ]),
+      ),
+    ).toEqual("?key=value,anotherValue&big=small&simpler=grants");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4889

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

The first part of an agency filter refactor as per designs and requirements in the ticket

* removes accordion behavior for top level agencies in the agency filter
* creates "all" button and adds it to each top level agency in filter
* adds "any" option to agency filter
* adds the ability for a filter accordion contents to scroll (and enables this on agency filter)

## Context for reviewers

https://github.com/HHS/simpler-grants-gov/pull/4981 depends on this PR and should be rebased and opened once this is merged.

### Technical changes

* moves some utils around to working around Next JS's middleware / lodash incompatibility)
* refactors path formatting utilities
* pre-emptively removes e2e tests that are not broken and related to the "clear all / select all" behavior that will be deprecated in https://github.com/HHS/simpler-grants-gov/pull/4981 as a follow up ticket (this is to allow this change to go out without having to rewrite tests that will be shortly removed)

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search
3. expand the agency filter accordion
4. _VERIFY_: there is an "any" checkbox that is checked by default
5. click the "any agency" checkbox
6. _VERIFY_: nothing happens
7. _VERIFY_: each top level agency has an "all" checkbox
8. _VERIFY_: not all agencies are immediately shown, but accordion contents will scroll to show all options

--- Note at each of the following steps, verify that url and search results are updated as expected
9. click an "all" checkbox
10. _VERIFY_: all sub agencies for the top level agency are selected
11. click the "all" checkbox again
9. _VERIFY_: all sub agencies for the top level agency are un-selected
10. click the "all" checkbox again
12. click a subagency for the top level agency
13. _VERIFY_: "all" checkbox is unchecked
