### PR TITLE
disable reading client side feature flag cookie in prod

### DIFF
--- a/frontend/src/services/featureFlags/FeatureFlagManager.ts
+++ b/frontend/src/services/featureFlags/FeatureFlagManager.ts
@@ -6,7 +6,7 @@ import {
   defaultFeatureFlags,
   FeatureFlags,
 } from "src/constants/defaultFeatureFlags";
-import { featureFlags } from "src/constants/environments";
+import { environment, featureFlags } from "src/constants/environments";
 import {
   FEATURE_FLAGS_KEY,
   getFeatureFlagsFromCookie,
@@ -133,11 +133,14 @@ export class FeatureFlagsManager {
     // beyond default values. Unfortunately, this breaks the implementation of the feature
     // flag admin view, which depends on reading all flags from cookies, so the logic has beeen removed
 
-    const featureFlags = {
-      ...this.featureFlags,
-      ...getFeatureFlagsFromCookie(request.cookies),
-      ...featureFlagsFromQuery,
-    };
+    const featureFlags =
+      environment.ENVIRONMENT === "prod"
+        ? { ...this.featureFlags }
+        : {
+            ...this.featureFlags,
+            ...getFeatureFlagsFromCookie(request.cookies),
+            ...featureFlagsFromQuery,
+          };
 
     setCookie(JSON.stringify(featureFlags), response.cookies);
 

--- a/frontend/tests/services/featureFlags/FeatureFlagManager.test.ts
+++ b/frontend/tests/services/featureFlags/FeatureFlagManager.test.ts
@@ -22,6 +22,9 @@ jest.mock("src/constants/environments", () => ({
     fakeTwo: false,
     nonBool: "sure",
   },
+  environment: {
+    ENVIRONMENT: "not prod",
+  },
 }));
 
 jest.mock("src/services/featureFlags/featureFlagHelpers", () => ({


### PR DESCRIPTION
## Summary
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Temporary change to disable non-environment variable feature flag values in prod

## Context for reviewers

Users that had used the site without any feature flags prior to turning on the auth flag in prod reported not being able to see the sign in button.

This is because the client side cookie is a high priority determinator of the feature flag values. The cookie overrides env var based values, has a 3 month expiration, and cannot easily be removed with a hard refresh. This change will allow prod users to fall back to the intended default feature flags to fix this issue temporarily while we work on a longer term fix for the problem.

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. rebase this branch against dschrashun/4903-feature-flags-default
2. start a local server on this branch
3. visit http://localhost:3000
4. _VERIFY_: you see the login button
5. update your "ff" cookie in dev tools to something like `%7B%22searchOff%22%3Afalse%2C%22opportunityOff%22%3Afalse%2C%22authOn%22%3Afalse%2C%22savedOpportunitiesOn%22%3Afalse%2C%22savedSearchesOn%22%3Afalse%2C%22applyFormPrototypeOff%22%3Afalse%7D`
6. refresh
7. _VERIFY_: you still see the login button
