### PR TITLE
fix: fixes tables that blow out when columns are very wide

### DIFF
--- a/frontend/src/components/opportunity/OpportunityDocuments.tsx
+++ b/frontend/src/components/opportunity/OpportunityDocuments.tsx
@@ -72,7 +72,7 @@ const OpportunityDocuments = ({
               opportunityId={opportunityId}
             ></ZipDownloadButton>
           </Grid>
-          <Table className="width-full">
+          <Table className="width-full overflow-wrap">
             <DocumentTable
               documents={documents}
               opportunityId={opportunityId}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -487,8 +487,9 @@ button.usa-pagination__button.usa-button {
 }
 
 // Tables
-.usa-table--borderless td,
-.usa-table--borderless th {
-  max-width: 0; // magic to prevent tables that are nested inside of a flex element from blowing out
-  word-wrap: break-word;
+.usa-table {
+  &.overflow-wrap {
+    max-width: 0; // magic to prevent tables that are nested inside of a flex element from blowing out
+    overflow-wrap: break-word;
+  }
 }

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -485,3 +485,10 @@ button.usa-pagination__button.usa-button {
   align-items: baseline;
   gap: 5px;
 }
+
+// Tables
+.usa-table--borderless td,
+.usa-table--borderless th {
+  max-width: 0; // magic to prevent tables that are nested inside of a flex element from blowing out
+  word-wrap: break-word;
+}


### PR DESCRIPTION
## Summary

Fixes #4413

## Changes proposed

`
.usa-table {
  &.overflow-wrap {
    max-width: 0;
    word-wrap: break-word;
  }
}
`

I've added some styles to the  newly added `.overflow-wrap` class to allow for word breakage on overflow.

`max-width: 0;`

is a fix for tables inside of flex

## Context for reviewers
<img width="749" alt="Screenshot 2025-05-08 at 8 13 47 AM" src="https://github.com/user-attachments/assets/06b21b48-84bd-42a4-897d-608dc129e7b9" />

checked in firefox, chrome and safari