### PR TITLE
[Issue #4976] Changes to support deploying NOFOs database

### DIFF
--- a/infra/nofos/app-config/env-config/database.tf
+++ b/infra/nofos/app-config/env-config/database.tf
@@ -10,6 +10,7 @@ locals {
     min_capacity                = var.database_min_capacity
     app_access_policy_name      = "${var.app_name}-${var.environment}-app-access"
     migrator_access_policy_name = "${var.app_name}-${var.environment}-migrator-access"
+    enable_http_endpoint        = true
 
     # Enable extensions that require the rds_superuser role to be created here
     # See docs/infra/set-up-database.md for more information

--- a/infra/nofos/database/.terraform.lock.hcl
+++ b/infra/nofos/database/.terraform.lock.hcl
@@ -1,25 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.6.0"
-  hashes = [
-    "h1:upAbF0KeKLAs3UImwwp5veC7jRcLnpKWVjkbd4ziWhM=",
-    "zh:29273484f7423b7c5b3f5df34ccfc53e52bb5e3d7f46a81b65908e7a8fd69072",
-    "zh:3cba58ec3aea5f301caf2acc31e184c55d994cc648126cac39c63ae509a14179",
-    "zh:55170cd17dbfdea842852c6ae2416d057fec631ba49f3bb6466a7268cd39130e",
-    "zh:7197db402ba35631930c3a4814520f0ebe980ae3acb7f8b5a6f70ec90dc4a388",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8bf7fe0915d7fb152a3a6b9162614d2ec82749a06dba13fab3f98d33c020ec4f",
-    "zh:8ce811844fd53adb0dabc9a541f8cb43aacfa7d8e39324e4bd3592b3428f5bfb",
-    "zh:bca795bca815b8ac90e3054c0a9ab1ccfb16eedbb3418f8ad473fc5ad6bf0ef7",
-    "zh:d9355a18df5a36cf19580748b23249de2eb445c231c36a353709f8f40a6c8432",
-    "zh:dc32cc32cfd8abf8752d34f2a783de0d3f7200c573b885ecb64ece5acea173b4",
-    "zh:ef498e20391bf7a280d0fd6fd6675621c85fbe4e92f0f517ae4394747db89bde",
-    "zh:f2bc5226c765b0c8055a7b6207d0fe1eb9484e3ec8880649d158827ac6ed3b22",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.68.0"
   constraints = "~> 5.68.0"


### PR DESCRIPTION
## Context

This one line change (and the lockfile, I guess) were required to deploy the nofos database. The nofos dev / staging / prod databases have now been deployed.

This is half of #4976