### PR TITLE
[Issue #4701] Add validation rules for opening_date, grace_period, closing_date

### DIFF
--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -29,28 +29,14 @@ def create_application(db_session: db.Session, competition_id: UUID) -> Applicat
 
     current_date = get_now_us_eastern_date()
 
-    # Validate opening_date
-    if competition.opening_date is None:
-        raise_flask_error(
-            422,
-            "Cannot start application - competition is not open for applications",
-            validation_issues=[
-                ValidationErrorDetail(
-                    type=ValidationErrorType.INVALID,
-                    message="Competition is not open for applications",
-                    field="opening_date",
-                )
-            ],
-        )
-
     # Check if current date is before opening date
-    if current_date < competition.opening_date:
+    if competition.opening_date is not None and current_date < competition.opening_date:
         raise_flask_error(
             422,
             "Cannot start application - competition is not yet open for applications",
             validation_issues=[
                 ValidationErrorDetail(
-                    type=ValidationErrorType.INVALID,
+                    type=ValidationErrorType.COMPETITION_NOT_YET_OPEN,
                     message="Competition is not yet open for applications",
                     field="opening_date",
                 )
@@ -67,13 +53,13 @@ def create_application(db_session: db.Session, competition_id: UUID) -> Applicat
                 days=competition.grace_period
             )
 
-        if current_date > actual_closing_date:
+        if current_date >= actual_closing_date:
             raise_flask_error(
                 422,
                 "Cannot start application - competition is already closed for applications",
                 validation_issues=[
                     ValidationErrorDetail(
-                        type=ValidationErrorType.INVALID,
+                        type=ValidationErrorType.COMPETITION_ALREADY_CLOSED,
                         message="Competition is already closed for applications",
                         field="closing_date",
                     )

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -1,12 +1,16 @@
 import logging
 import uuid
+from datetime import timedelta
 from uuid import UUID
 
 from sqlalchemy import select
 
 import src.adapters.db as db
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.competition_models import Application, Competition
+from src.util.datetime_util import get_now_us_eastern_date
+from src.validation.validation_constants import ValidationErrorType
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +26,59 @@ def create_application(db_session: db.Session, competition_id: UUID) -> Applicat
 
     if not competition:
         raise_flask_error(404, f"Competition with ID {competition_id} not found")
+
+    current_date = get_now_us_eastern_date()
+
+    # Validate opening_date
+    if competition.opening_date is None:
+        raise_flask_error(
+            422,
+            "Cannot start application - competition is not open for applications",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.INVALID,
+                    message="Competition is not open for applications",
+                    field="opening_date",
+                )
+            ],
+        )
+
+    # Check if current date is before opening date
+    if current_date < competition.opening_date:
+        raise_flask_error(
+            422,
+            "Cannot start application - competition is not yet open for applications",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.INVALID,
+                    message="Competition is not yet open for applications",
+                    field="opening_date",
+                )
+            ],
+        )
+
+    # If closing_date is not null, check if current date is after closing date
+    if competition.closing_date is not None:
+        actual_closing_date = competition.closing_date
+
+        # If grace_period is not null, add that many days to the closing date
+        if competition.grace_period is not None and competition.grace_period > 0:
+            actual_closing_date = competition.closing_date + timedelta(
+                days=competition.grace_period
+            )
+
+        if current_date > actual_closing_date:
+            raise_flask_error(
+                422,
+                "Cannot start application - competition is already closed for applications",
+                validation_issues=[
+                    ValidationErrorDetail(
+                        type=ValidationErrorType.INVALID,
+                        message="Competition is already closed for applications",
+                        field="closing_date",
+                    )
+                ],
+            )
 
     # Create a new application
     application = Application(application_id=uuid.uuid4(), competition_id=competition_id)

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -25,7 +25,7 @@ def create_application(db_session: db.Session, competition_id: UUID) -> Applicat
     ).scalar_one_or_none()
 
     if not competition:
-        raise_flask_error(404, f"Competition with ID {competition_id} not found")
+        raise_flask_error(404, "Competition not found")
 
     current_date = get_now_us_eastern_date()
 

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -32,3 +32,7 @@ class ValidationErrorType(StrEnum):
     MIN_OR_MAX_VALUE = "min_or_max_value"
 
     NOT_IN_PROGRESS = "not_in_progress"
+
+    # Competition window validation error types
+    COMPETITION_NOT_YET_OPEN = "competition_not_yet_open"
+    COMPETITION_ALREADY_CLOSED = "competition_already_closed"

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date, timedelta
+from datetime import timedelta
 
 import pytest
 from freezegun import freeze_time

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -137,7 +137,7 @@ def test_application_start_after_closing_date(
     past_closing_date = today - timedelta(days=5)
 
     competition = CompetitionFactory.create(
-        opening_date=past_opening_date, closing_date=past_closing_date
+        opening_date=past_opening_date, closing_date=past_closing_date, grace_period=0
     )
 
     competition_id = str(competition.competition_id)
@@ -280,9 +280,7 @@ def test_application_start_competition_not_found(
     )
 
     assert response.status_code == 404
-    assert (
-        f"Competition with ID {non_existent_competition_id} not found" in response.json["message"]
-    )
+    assert "Competition not found" in response.json["message"]
 
     # Verify no application was created
     applications_count = (

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import date, timedelta
 
 import pytest
+from freezegun import freeze_time
 from sqlalchemy import select
 
 from src.db.models.competition_models import Application, ApplicationForm, ApplicationStatus
@@ -25,10 +26,12 @@ SIMPLE_JSON_SCHEMA = {
     "required": ["name"],
 }
 
+TEST_DATE = "2023-06-15 12:00:00"  # June 15, 2023 at noon UTC
 
+
+@freeze_time(TEST_DATE)
 def test_application_start_success(client, api_auth_token, enable_factory_create, db_session):
     """Test successful creation of an application"""
-    # Use today's date for competition opening_date to ensure it's open
     today = get_now_us_eastern_date()
     future_date = today + timedelta(days=10)
 
@@ -55,13 +58,15 @@ def test_application_start_success(client, api_auth_token, enable_factory_create
     assert str(application.competition_id) == competition_id
 
 
+@freeze_time(TEST_DATE)
 def test_application_start_null_opening_date(
     client, api_auth_token, enable_factory_create, db_session
 ):
     """Test application creation fails when opening_date is null"""
-    competition = CompetitionFactory.create(
-        opening_date=None, closing_date=date.today() + timedelta(days=10)
-    )
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    competition = CompetitionFactory.create(opening_date=None, closing_date=future_date)
 
     competition_id = str(competition.competition_id)
     request_data = {"competition_id": competition_id}
@@ -87,6 +92,7 @@ def test_application_start_null_opening_date(
     assert len(applications_count) == 0
 
 
+@freeze_time(TEST_DATE)
 def test_application_start_before_opening_date(
     client, api_auth_token, enable_factory_create, db_session
 ):
@@ -123,6 +129,7 @@ def test_application_start_before_opening_date(
     assert len(applications_count) == 0
 
 
+@freeze_time(TEST_DATE)
 def test_application_start_after_closing_date(
     client, api_auth_token, enable_factory_create, db_session
 ):
@@ -159,6 +166,7 @@ def test_application_start_after_closing_date(
     assert len(applications_count) == 0
 
 
+@freeze_time(TEST_DATE)
 def test_application_start_with_grace_period(
     client, api_auth_token, enable_factory_create, db_session
 ):
@@ -193,6 +201,7 @@ def test_application_start_with_grace_period(
     assert str(application.competition_id) == competition_id
 
 
+@freeze_time(TEST_DATE)
 def test_application_start_after_grace_period(
     client, api_auth_token, enable_factory_create, db_session
 ):
@@ -230,6 +239,7 @@ def test_application_start_after_grace_period(
     assert len(applications_count) == 0
 
 
+@freeze_time(TEST_DATE)
 def test_application_start_null_closing_date(
     client, api_auth_token, enable_factory_create, db_session
 ):


### PR DESCRIPTION
## Summary

Fixes #4701

## Changes proposed
Implements validation logic to prevent users from starting applications outside a competition's open/close window.
Add tests to cover multiple scenarios

## Context for reviewers

The competition table has an opening+closing date. We shouldn't let a user start an application if it is outside these dates.
The scenarios covered include ifthe opening_date is null - reject anyone. If the closing_date is null, allow it as long as it is on/after the opening date.

## Validation steps

Run new unit tests.
