### PR TITLE
[Issue #4889] add facet counts to agency filter

### DIFF
--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -1,4 +1,5 @@
 import { FilterOption } from "src/types/search/searchFilterTypes";
+import { SearchAPIResponse } from "src/types/search/searchRequestTypes";
 
 import { useTranslations } from "next-intl";
 
@@ -12,17 +13,19 @@ export async function AgencyFilterAccordion({
   agencyOptionsPromise,
 }: {
   query: Set<string>;
-  agencyOptionsPromise: Promise<FilterOption[]>;
+  agencyOptionsPromise: Promise<[FilterOption[], SearchAPIResponse]>;
 }) {
   const t = useTranslations("Search");
 
-  let agencies: FilterOption[];
+  let agencies: FilterOption[] = [];
+  let facetCounts: { [key: string]: number } = {};
   try {
-    agencies = await agencyOptionsPromise;
+    let searchResults: SearchAPIResponse;
+    [agencies, searchResults] = await agencyOptionsPromise;
+    facetCounts = searchResults.facet_counts.agency;
   } catch (e) {
     // Come back to this to show the user an error
     console.error("Unable to fetch agencies for filter list", e);
-    agencies = [];
   }
   return (
     <SearchFilterAccordion
@@ -31,6 +34,7 @@ export async function AgencyFilterAccordion({
       queryParamKey={"agency"}
       title={t("accordion.titles.agency")}
       wrapForScroll={true}
+      facetCounts={facetCounts}
       // agency filters will not show facet counts
     />
   );

--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -5,9 +5,6 @@ import { useTranslations } from "next-intl";
 
 import SearchFilterAccordion from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
 
-// functionality differs depending on whether `agencyOptions` or `agencyOptionsPromise` is passed
-// with prefetched options we have a synchronous render
-// with a Promise we have an async render with Suspense
 export async function AgencyFilterAccordion({
   query,
   agencyOptionsPromise,
@@ -35,7 +32,6 @@ export async function AgencyFilterAccordion({
       title={t("accordion.titles.agency")}
       wrapForScroll={true}
       facetCounts={facetCounts}
-      // agency filters will not show facet counts
     />
   );
 }

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -38,7 +38,10 @@ export default async function SearchFilters({
   searchResultsPromise: Promise<SearchAPIResponse>;
 }) {
   const t = useTranslations("Search");
-  const agenciesPromise = getAgenciesForFilterOptions();
+  const agenciesPromise = Promise.all([
+    getAgenciesForFilterOptions(),
+    searchResultsPromise,
+  ]);
 
   let searchResults;
   try {

--- a/frontend/tests/components/search/SearchFilterAccordion/AgencyFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AgencyFilterAccordion.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { fakeSearchAPIResponse } from "src/utils/testing/fixtures";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import { ReadonlyURLSearchParams } from "next/navigation";
@@ -67,7 +68,10 @@ const fakeOptions = [
 describe("AgencyFilterAccordion", () => {
   it("is accessible", async () => {
     const component = await AgencyFilterAccordion({
-      agencyOptionsPromise: Promise.resolve(fakeOptions),
+      agencyOptionsPromise: Promise.resolve([
+        fakeOptions,
+        fakeSearchAPIResponse,
+      ]),
       query: new Set(),
     });
     const { container } = render(component);
@@ -78,7 +82,10 @@ describe("AgencyFilterAccordion", () => {
   // just want to confirm it renders
   it("renders async component (asserting on mock suspended state)", async () => {
     const component = await AgencyFilterAccordion({
-      agencyOptionsPromise: Promise.resolve(fakeOptions),
+      agencyOptionsPromise: Promise.resolve([
+        fakeOptions,
+        fakeSearchAPIResponse,
+      ]),
       query: new Set(),
     });
     render(component);


### PR DESCRIPTION
## Summary

Fixes part of #4889 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Depends on https://github.com/HHS/simpler-grants-gov/pull/4980

Adds facet counts to agency filter options

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

* refactors the agency accordion to depend on calls to fetch both search results and agency options list

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search
3. _VERIFY_: agency filter options have proper facet counts
4. select some agency filter options
3. _VERIFY_: agency filter options have proper facet counts

### Screenshot

<img width="1252" alt="Screenshot 2025-05-12 at 3 00 26 PM" src="https://github.com/user-attachments/assets/8c24fe3e-c3a9-4f50-b818-34f882ae69ab" />
