### PR TITLE
fix e2e test for test grants link

### DIFF
--- a/frontend/tests/e2e/opportunity.spec.ts
+++ b/frontend/tests/e2e/opportunity.spec.ts
@@ -111,5 +111,7 @@ test("can navigate to grants.gov", async ({ page, context }) => {
 
   const newPage = await newTabPromise;
   // await waitForURLChange(page, (url) => !!url.match(/grants\.gov/));
-  await expect(newPage).toHaveTitle("Search Results Detail | Grants.gov");
+  await expect(newPage).toHaveURL(
+    "https://test.grants.gov/search-results-detail/32",
+  );
 });


### PR DESCRIPTION
## Summary

unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

test.grants.gov began returning 500s at some point recently - this change makes the test more resilient in case something weird is happening on the grants.gov side that we can't control

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

1. _VERIFY_: ci passes
