### PR TITLE
[Issue #4968] Switch authentication of apply endpoints to support user auth

### DIFF
--- a/api/src/api/application_alpha/application_route.py
+++ b/api/src/api/application_alpha/application_route.py
@@ -14,7 +14,7 @@ from src.api.application_alpha.application_schemas import (
     ApplicationStartResponseSchema,
 )
 from src.api.schemas.response_schema import AbstractResponseSchema
-from src.auth.api_key_auth import api_key_auth
+from src.auth.api_jwt_auth import api_jwt_auth
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 from src.services.applications.create_application import create_application
 from src.services.applications.get_application import get_application
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 @application_blueprint.input(ApplicationStartRequestSchema, location="json")
 @application_blueprint.output(ApplicationStartResponseSchema)
 @application_blueprint.doc(responses=[200, 401, 404])
-@application_blueprint.auth_required(api_key_auth)
+@application_blueprint.auth_required(api_jwt_auth)
 @flask_db.with_db_session()
 def application_start(db_session: db.Session, json_data: dict) -> response.ApiResponse:
     """Create a new application for a competition"""
@@ -49,7 +49,7 @@ def application_start(db_session: db.Session, json_data: dict) -> response.ApiRe
 @application_blueprint.input(ApplicationFormUpdateRequestSchema, location="json")
 @application_blueprint.output(ApplicationFormUpdateResponseSchema)
 @application_blueprint.doc(responses=[200, 401, 404])
-@application_blueprint.auth_required(api_key_auth)
+@application_blueprint.auth_required(api_jwt_auth)
 @flask_db.with_db_session()
 def application_form_update(
     db_session: db.Session, application_id: UUID, form_id: UUID, json_data: dict
@@ -78,7 +78,7 @@ def application_form_update(
 )
 @application_blueprint.output(ApplicationFormGetResponseSchema)
 @application_blueprint.doc(responses=[200, 401, 404])
-@application_blueprint.auth_required(api_key_auth)
+@application_blueprint.auth_required(api_jwt_auth)
 @flask_db.with_db_session()
 def application_form_get(
     db_session: db.Session, application_id: UUID, app_form_id: UUID
@@ -105,7 +105,7 @@ def application_form_get(
 @application_blueprint.get("/applications/<uuid:application_id>")
 @application_blueprint.output(ApplicationGetResponseSchema)
 @application_blueprint.doc(responses=[200, 401, 404])
-@application_blueprint.auth_required(api_key_auth)
+@application_blueprint.auth_required(api_jwt_auth)
 @flask_db.with_db_session()
 def application_get(
     db_session: db.Session,
@@ -132,7 +132,7 @@ def application_get(
 @application_blueprint.post("/applications/<uuid:application_id>/submit")
 @application_blueprint.output(AbstractResponseSchema)
 @application_blueprint.doc(responses=[200, 401, 404])
-@application_blueprint.auth_required(api_key_auth)
+@application_blueprint.auth_required(api_jwt_auth)
 @flask_db.with_db_session()
 def application_submit(db_session: db.Session, application_id: UUID) -> response.ApiResponse:
     """Submit an application"""

--- a/api/src/api/competition_alpha/competition_route.py
+++ b/api/src/api/competition_alpha/competition_route.py
@@ -6,7 +6,7 @@ import src.adapters.db.flask_db as flask_db
 import src.api.competition_alpha.competition_schema as competition_schema
 import src.api.response as response
 from src.api.competition_alpha.competition_blueprint import competition_blueprint
-from src.auth.api_key_auth import api_key_auth
+from src.auth.multi_auth import jwt_or_key_multi_auth
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 from src.services.competition_alpha.get_competition import get_competition
 
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 @competition_blueprint.get("/competitions/<uuid:competition_id>")
 @competition_blueprint.output(competition_schema.CompetitionResponseAlphaSchema())
-@competition_blueprint.auth_required(api_key_auth)
+@competition_blueprint.auth_required(jwt_or_key_multi_auth)
 @flask_db.with_db_session()
 def competition_get(db_session: db.Session, competition_id: uuid.UUID) -> response.ApiResponse:
     add_extra_data_to_current_request_logs({"competition.competition_id": competition_id})

--- a/api/tests/src/api/competition_alpha/test_competition_route_get.py
+++ b/api/tests/src/api/competition_alpha/test_competition_route_get.py
@@ -3,11 +3,26 @@ import uuid
 from tests.src.db.models.factories import CompetitionFactory
 
 
-def test_competition_get_200(client, api_auth_token, enable_factory_create):
+def test_competition_get_200_with_api_key(client, api_auth_token, enable_factory_create):
     competition = CompetitionFactory.create()
 
     resp = client.get(
         f"/alpha/competitions/{competition.competition_id}", headers={"X-Auth": api_auth_token}
+    )
+
+    assert resp.status_code == 200
+    response_competition = resp.get_json()["data"]
+
+    assert response_competition["competition_id"] == str(competition.competition_id)
+    assert response_competition["opportunity_id"] == competition.opportunity_id
+
+
+def test_competition_get_200_with_jwt(client, user_auth_token, enable_factory_create):
+    competition = CompetitionFactory.create()
+
+    resp = client.get(
+        f"/alpha/competitions/{competition.competition_id}",
+        headers={"X-SGG-Token": user_auth_token},
     )
 
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Fixes #4968

## Changes proposed

Update several application endpoints to use `api_jwt_auth` mechanisms
Update competition endpoint ` /competitions/:competionId` to use `jwt_or_key_multi_auth`.
Update tests.

## Context for reviewers

Due to @freeze_time in the first several application test, we have to create a JWT token manually since they are date-reliant (I thought this would work but it doesn't?)

## Validation steps

Run application and competition tests, see new competition test to support multi auth.
