### PR TITLE
[no ticket] Fix application networking

### DIFF
--- a/infra/modules/service/networking.tf
+++ b/infra/modules/service/networking.tf
@@ -69,4 +69,20 @@ resource "aws_security_group" "app" {
     # just ignore it
     ignore_changes = [description]
   }
+
+  ingress {
+    description     = "Allow HTTP traffic to application container port"
+    protocol        = "tcp"
+    from_port       = var.container_port
+    to_port         = var.container_port
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    description = "Allow all outgoing traffic from application"
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }


### PR DESCRIPTION
## Context

This is related to the NOFOs stuff, but is inside of the service module so it would in theory impact every service. In practice, every service already has the permission, and the NOFOs service got stood up without it. That happened because the permission was removed here:

https://github.com/HHS/simpler-grants-gov/commit/9f0858dc064ea6dbb5ada70795f9528d971a61a3#diff-a1feeeb6afc18f0e1a2598ea4702b9d1d4810a565e24e3e696681dad91d8fab5

The ??? part is how this didn't manage to cause a problem when I was testing that PR. Because it should have broken networking for the API container, which was my test case. But it didn't! No idea why. But I don't need to unpack that, the important part is that I'm fixing it now.