### PR TITLE
[Issue #4924] Adjust API queries for opps and users to select less

### DIFF
--- a/api/src/adapters/db/clients/postgres_client.py
+++ b/api/src/adapters/db/clients/postgres_client.py
@@ -48,7 +48,6 @@ class PostgresDBClient(DBClient):
             pool=conn_pool,
             hide_parameters=db_config.hide_sql_parameter_logs,
             execution_options={"schema_translate_map": db_config.get_schema_translate_map()},
-            echo=True,
             # TODO: Don't think we need this as we aren't using JSON columns, but keeping for reference
             # json_serializer=lambda o: json.dumps(o, default=pydantic.json.pydantic_encoder),
         )

--- a/api/src/adapters/db/clients/postgres_client.py
+++ b/api/src/adapters/db/clients/postgres_client.py
@@ -48,6 +48,7 @@ class PostgresDBClient(DBClient):
             pool=conn_pool,
             hide_parameters=db_config.hide_sql_parameter_logs,
             execution_options={"schema_translate_map": db_config.get_schema_translate_map()},
+            echo=True,
             # TODO: Don't think we need this as we aren't using JSON columns, but keeping for reference
             # json_serializer=lambda o: json.dumps(o, default=pydantic.json.pydantic_encoder),
         )

--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -153,7 +153,7 @@ def parse_jwt_for_user(
     token_session: UserTokenSession | None = db_session.execute(
         select(UserTokenSession)
         .where(UserTokenSession.token_id == sub_id)
-        .options(selectinload("*"))
+        .options(selectinload(UserTokenSession.user))
     ).scalar()
 
     # We check both the token expires_at timestamp as well as an

--- a/api/src/services/users/login_gov_callback_handler.py
+++ b/api/src/services/users/login_gov_callback_handler.py
@@ -141,7 +141,7 @@ def _process_token(db_session: db.Session, token: str, nonce: str) -> LoginGovCa
         # We only support login.gov right now, so this does nothing, but let's
         # be explicit just in case.
         .where(LinkExternalUser.external_user_type == ExternalUserType.LOGIN_GOV)
-        .options(selectinload("*"))
+        .options(selectinload(LinkExternalUser.user))
     ).scalar()
 
     is_user_new = external_user is None


### PR DESCRIPTION
## Summary

Fixes #4924

## Changes proposed
Adjust queries in the GET /opportunity endpoint and user auth logic to not automatically load as many relationships

## Context for reviewers
https://docs.sqlalchemy.org/en/20/orm/queryguide/relationships.html

SQLAlchemy relationships allow you to configure how they load. By default, all relationships are lazy loaded which means that if you do `opportunity.current_opportunity_summary` it will emit a select statement to the DB to fetch the current opportunity summary record unless it already has fetched it. There are several loading strategies that you can set (see the above link), but besides lazy loading, `selectinload` tends to work the best. It works by emitting several select statements alongside your primary select statement all in one query to improve performance.

When we do a `selectinload("*")` it says to load all relationships recursively. This is fine-ish, but the opportunity table especially is connected to everything. This means that before this change, the GET /opportunity endpoint actually runs roughly this set of queries (not even the full set because I didn't have any user records setup):

<details>
<summary>Click me to see the full query</summary>
<br>

```sql
SELECT * FROM api.opportunity 
WHERE api.opportunity.opportunity_id = %(opportunity_id_1)s::BIGINT AND api.opportunity.is_draft IS false

SELECT * FROM api.user_saved_opportunity 
WHERE api.user_saved_opportunity.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity AS opportunity_1 JOIN api.agency ON opportunity_1.agency_code = api.agency.agency_code 
WHERE opportunity_1.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.competition 
WHERE api.competition.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_version 
WHERE api.opportunity_version.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_attachment 
WHERE api.opportunity_attachment.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_assistance_listing 
WHERE api.opportunity_assistance_listing.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_change_audit 
WHERE api.opportunity_change_audit.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.current_opportunity_summary 
WHERE api.current_opportunity_summary.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_summary 
WHERE api.opportunity_summary.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.user_opportunity_notification_log 
WHERE api.user_opportunity_notification_log.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_summary 
WHERE api.opportunity_summary.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.current_opportunity_summary 
WHERE api.current_opportunity_summary.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_funding_instrument 
WHERE api.link_opportunity_summary_funding_instrument.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_funding_category 
WHERE api.link_opportunity_summary_funding_category.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_applicant_type 
WHERE api.link_opportunity_summary_applicant_type.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_funding_instrument 
WHERE api.link_opportunity_summary_funding_instrument.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_funding_category 
WHERE api.link_opportunity_summary_funding_category.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_applicant_type 
WHERE api.link_opportunity_summary_applicant_type.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT) 
```
</details>

If you notice, this contains tables like the saved opportunities table which we don't return in the API endpoint itself. As more folks saved opportunities, this means we're fetching more and more.

The change made here changes several relationships back to `lazyload` (which is the default - so effectively removes it from the "*" list). This changes the queries to roughly:

<details>
<summary>See after query</summary>
<br>

```sql
SELECT * FROM api.opportunity 
WHERE api.opportunity.opportunity_id = %(opportunity_id_1)s::BIGINT AND api.opportunity.is_draft IS false

SELECT * FROM api.opportunity AS opportunity_1 JOIN api.agency ON opportunity_1.agency_code = api.agency.agency_code 
WHERE opportunity_1.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_attachment 
WHERE api.opportunity_attachment.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_assistance_listing 
WHERE api.opportunity_assistance_listing.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.current_opportunity_summary 
WHERE api.current_opportunity_summary.opportunity_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.opportunity_summary 
WHERE api.opportunity_summary.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_funding_instrument 
WHERE api.link_opportunity_summary_funding_instrument.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_funding_category 
WHERE api.link_opportunity_summary_funding_category.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)

SELECT * FROM api.link_opportunity_summary_applicant_type 
WHERE api.link_opportunity_summary_applicant_type.opportunity_summary_id IN (%(primary_keys_1)s::BIGINT)
```
</details>

Additionally, I updated two auth related queries to not use `*` and instead specify what we want to fetch. This is for a similar reason, but the fix is simpler. Both fetch a row connected to a user, and want the user, but having `*` meant that user which has saved opportunities then fetched all opportunities, and saved searches, and more. That's way, way too much. The bit of logic for each of them just needs the `user` connection.

## Validation steps
If you ever want to see the SQLAlchemy queries emitted, you can turn `echo=True` on when we call `sqlalchemy.create_engine` in the postgres_client.py file. Warning, the info it emits is way, way more than shown above, I trimmed these massively for readability.
