### PR TITLE
fix whitespace bug by adding max height to filter content

### DIFF
--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -139,10 +139,7 @@ export function SearchFilterAccordion({
     {
       title: <AccordionTitle title={title} totalCheckedCount={query.size} />,
       content: wrapForScroll ? (
-        <div
-          className="maxh-mobile-lg minh-mobile overflow-scroll"
-          data-testid={`${title}-accordion-scroll`}
-        >
+        <div data-testid={`${title}-accordion-scroll`}>
           <AccordionContent
             filterOptions={filterOptions}
             title={title}
@@ -167,6 +164,9 @@ export function SearchFilterAccordion({
       expanded: !!query.size,
       id: `opportunity-filter-${queryParamKey as string}`,
       headingLevel: "h2",
+      className: wrapForScroll
+        ? "maxh-mobile-lg overflow-auto position-relative"
+        : "",
     },
   ];
 

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -138,19 +138,7 @@ export function SearchFilterAccordion({
   const accordionOptions: AccordionItemProps[] = [
     {
       title: <AccordionTitle title={title} totalCheckedCount={query.size} />,
-      content: wrapForScroll ? (
-        <div data-testid={`${title}-accordion-scroll`}>
-          <AccordionContent
-            filterOptions={filterOptions}
-            title={title}
-            queryParamKey={queryParamKey}
-            query={query}
-            facetCounts={facetCounts}
-            defaultEmptySelection={defaultEmptySelection}
-            includeAnyOption={includeAnyOption}
-          />
-        </div>
-      ) : (
+      content: (
         <AccordionContent
           filterOptions={filterOptions}
           title={title}

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
@@ -144,9 +144,11 @@ describe("SearchFilterAccordion", () => {
       />,
     );
 
-    const scrollableContainer = screen.getByTestId(`${title}-accordion-scroll`);
+    const scrollableContainer = screen.getByTestId(
+      `accordionItem_opportunity-filter-${queryParamKey}`,
+    );
 
-    expect(scrollableContainer).toHaveClass("overflow-scroll");
+    expect(scrollableContainer).toHaveClass("overflow-auto");
 
     const initialScrollTop = scrollableContainer.scrollTop;
 

--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -78,7 +78,7 @@ test.describe("Search page tests", () => {
 
     await clickAccordionWithTitle(page, "Agency");
     const firstSubAgency = page
-      .locator("#opportunity-filter-agency > div > ul > li ul input")
+      .locator("#opportunity-filter-agency > ul > li ul input")
       .first();
 
     const agencyId = await firstSubAgency.getAttribute("id");


### PR DESCRIPTION
## Summary

unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes issue with agency filter scroll behavior that added a bunch of empty space to the bottom of the page when the filter was expanded

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on main with `npm run dev`
2. visit http://localhost:3000/search
3. open the agency filter and scroll to the bottom of the page
4. _VERIFY_: you see a lot of unnecessary white space
5. repeat 1 - 3 on this branch
6. _VERIFY_: you do not see a lot of unnecessary white space
