### PR TITLE
[Issue #3920] Email notification content for new matches to a saved search content

### DIFF
--- a/api/tests/src/task/notifications/test_search_notification.py
+++ b/api/tests/src/task/notifications/test_search_notification.py
@@ -322,6 +322,13 @@ def test_search_notification_email_format_single_opportunity(
     mock_responses = _get_mock_responses()
     assert len(mock_responses) == 1
 
+    assert (
+        mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
+            "SimpleEmail"
+        ]["Subject"]["Data"]
+        == f"New Grant Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
+    )
+
     email_content = mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
         "SimpleEmail"
     ]["TextPart"]["Data"]
@@ -410,6 +417,13 @@ def test_search_notification_email_format_multiple_opportunities(
     # Get the email content from mock responses
     mock_responses = _get_mock_responses()
     assert len(mock_responses) == 1
+
+    assert (
+        mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
+            "SimpleEmail"
+        ]["Subject"]["Data"]
+        == f"2 New Grants Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
+    )
 
     email_content = mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
         "SimpleEmail"


### PR DESCRIPTION
## Summary

Fixes #4059

## Changes proposed

Content on the Email for saved search notifications was improved.
Added tests to show the email output.

## Context for reviewers

These are example emails generated from inspecting the tests.

### Singular

**Subject**
```
New Grant Published on 5/15/2025
```

**Body**
```
A funding opportunity matching your saved search query was recently published.

2025 Port Infrastructure Development Program

Status: Posted
Submission period: 1/31/2025–4/30/2025
Award range: $1,000,000-$112,500,000
Expected awards: 40
Cost sharing: Yes

To unsubscribe from email notifications for this query, delete it from your saved search queries.
```

### Multiple
**Subject**
```
2 New Grants Published on 5/15/2025
```

**Body**
```
The following funding opportunities matching your saved search queries were recently published.

2025 Port Infrastructure Development Program

Status: Posted
Submission period: 1/31/2025–4/30/2025
Award range: $1,000,000-$112,500,000
Expected awards: 40
Cost sharing: Yes

Cooperative Agreement for affiliated Partner with Rocky Mountains Cooperative Ecosystem Studies Unit (CESU)

Status: Forecasted
Submission period: To be announced.
Award range: $1-$30,000
Expected awards: --
Cost sharing: No

To unsubscribe from email notifications for a query, delete it from your saved search queries.
```


## Validation steps

To run relevant tests:
```bash
make test args="-vv tests/src/task/notifications/test_search_notification.py
```