### PR TITLE
[Issue #4983] Take in an optional application name to start application endpoint

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -2482,7 +2482,9 @@ components:
           format: uuid
           example: 123e4567-e89b-12d3-a456-426614174000
         application_name:
-          type: string
+          type:
+          - string
+          - 'null'
       required:
       - competition_id
     ApplicationStartResponseData:

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -2481,6 +2481,8 @@ components:
           type: string
           format: uuid
           example: 123e4567-e89b-12d3-a456-426614174000
+        application_name:
+          type: string
       required:
       - competition_id
     ApplicationStartResponseData:

--- a/api/src/api/application_alpha/application_route.py
+++ b/api/src/api/application_alpha/application_route.py
@@ -34,6 +34,8 @@ logger = logging.getLogger(__name__)
 def application_start(db_session: db.Session, json_data: dict) -> response.ApiResponse:
     """Create a new application for a competition"""
     competition_id = json_data["competition_id"]
+    # application_name is optional, so we use get to avoid a KeyError
+    application_name = json_data.get("application_name", None)
     add_extra_data_to_current_request_logs({"competition_id": competition_id})
     logger.info("POST /alpha/applications/start")
 
@@ -42,7 +44,7 @@ def application_start(db_session: db.Session, json_data: dict) -> response.ApiRe
     user = token_session.user
 
     with db_session.begin():
-        application = create_application(db_session, competition_id, user)
+        application = create_application(db_session, competition_id, user, application_name)
 
     return response.ApiResponse(
         message="Success", data={"application_id": application.application_id}

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -4,7 +4,7 @@ from src.api.schemas.response_schema import AbstractResponseSchema, WarningMixin
 
 class ApplicationStartRequestSchema(Schema):
     competition_id = fields.UUID(required=True)
-    application_name = fields.String(required=False)
+    application_name = fields.String(required=False, allow_none=True)
 
 
 class ApplicationStartResponseDataSchema(Schema):

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -4,6 +4,7 @@ from src.api.schemas.response_schema import AbstractResponseSchema, WarningMixin
 
 class ApplicationStartRequestSchema(Schema):
     competition_id = fields.UUID(required=True)
+    application_name = fields.String(required=False)
 
 
 class ApplicationStartResponseDataSchema(Schema):

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -16,7 +16,9 @@ from src.validation.validation_constants import ValidationErrorType
 logger = logging.getLogger(__name__)
 
 
-def create_application(db_session: db.Session, competition_id: UUID, user: User) -> Application:
+def create_application(
+    db_session: db.Session, competition_id: UUID, user: User, application_name: str | None = None
+) -> Application:
     """
     Create a new application for a competition.
     """
@@ -67,8 +69,20 @@ def create_application(db_session: db.Session, competition_id: UUID, user: User)
                 ],
             )
 
+    # Get default application name if not provided
+    if (
+        application_name is None
+        and competition.opportunity
+        and competition.opportunity.opportunity_number
+    ):
+        application_name = competition.opportunity.opportunity_number
+
     # Create a new application
-    application = Application(application_id=uuid.uuid4(), competition_id=competition_id)
+    application = Application(
+        application_id=uuid.uuid4(),
+        competition_id=competition_id,
+        application_name=application_name,
+    )
     db_session.add(application)
 
     application_user = ApplicationUser(application=application, user=user)

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -70,13 +70,8 @@ def create_application(
             )
 
     # Get default application name if not provided
-    if (
-        application_name is None
-        and competition.opportunity
-        and competition.opportunity.opportunity_number
-    ):
+    if application_name is None:
         application_name = competition.opportunity.opportunity_number
-
     # Create a new application
     application = Application(
         application_id=uuid.uuid4(),


### PR DESCRIPTION
## Summary

Fixes #4983

## Changes proposed

Add optional application name to start application endpoint. Updated API schema, added validation, and included tests for both custom name and default name scenarios.

## Context for reviewers

This change allows users to specify a custom name when creating applications, with the opportunity number used as the default when no name is provided. 

## Validation steps

See modified existing and new unit tests.