### PR TITLE
[Issue #5065] Add 2 static env vars to the nofos app

### DIFF
--- a/infra/nofos/app-config/env-config/environment_variables.tf
+++ b/infra/nofos/app-config/env-config/environment_variables.tf
@@ -2,7 +2,10 @@ locals {
   # Map from environment variable name to environment variable value
   # This is a map rather than a list so that variables can be easily
   # overridden per environment using terraform's `merge` function
-  default_extra_environment_variables = {}
+  default_extra_environment_variables = {
+    DEBUG                = "false"
+    DJANGO_ALLOWED_HOSTS = "*"
+  }
 
   # Configuration for secrets
   # List of configurations for defining environment variables that pull from SSM parameter


### PR DESCRIPTION
## Summary

This is part of #5065 

## Changes proposed

Right now, the `ALLOWED_HOSTS` var is causing Django to throw a 500 error.

Until we figure that out, let's add this wildcard.
