### PR TITLE
[Issue #5067] Proposed changes to local.env for #5067

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -45,12 +45,21 @@ API_AUTH_TOKEN=LOCAL_AUTH_12345678,LOCAL_AUTH_87654321,LOCAL_1234
 
 LOGIN_GOV_CLIENT_ID=local_mock_client_id
 
-LOGIN_GOV_JWK_ENDPOINT=http://host.docker.internal:5001/issuer1/jwks
+LOGIN_GOV_JWK_ENDPOINT=http://mock-oauth2-server:5001/issuer1/jwks
 LOGIN_GOV_AUTH_ENDPOINT=http://localhost:5001/issuer1/authorize
-LOGIN_GOV_TOKEN_ENDPOINT=http://host.docker.internal:5001/issuer1/token
-LOGIN_GOV_ENDPOINT=http://host.docker.internal:5001/issuer1
+LOGIN_GOV_TOKEN_ENDPOINT=http://mock-oauth2-server:5001/issuer1/token
+LOGIN_GOV_ENDPOINT=http://mock-oauth2-server:5001/issuer1
 
+############################
+# OAuth Flow Debug Callback (Default)
+# Remove the comment under the Application Callback to redirect the user to simpler.grants.gov instead
+############################
 LOGIN_FINAL_DESTINATION=http://localhost:8080/v1/users/login/result
+
+############################
+# simpler.grants.gov Application Callback
+############################
+# LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback
 
 FRONTEND_BASE_URL=http://localhost:8080
 
@@ -59,6 +68,15 @@ FRONTEND_BASE_URL=http://localhost:8080
 API_JWT_PRIVATE_KEY=
 API_JWT_PUBLIC_KEY=
 LOGIN_GOV_CLIENT_ASSERTION_PRIVATE_KEY=
+
+############################
+# Feature Flags
+############################
+
+# Enable the simpler.grants.gov (Sign In) Feature
+FEATURE_AUTH_ON=TRUE
+FEATURE_SAVED_OPPORTUNITIES_ON=TRUE
+FEATURE_SAVED_SEARCHES_ON=TRUE
 
 ENABLE_AUTH_ENDPOINT=TRUE
 ENABLE_APPLY_ENDPOINTS=TRUE

--- a/api/local.env
+++ b/api/local.env
@@ -50,15 +50,9 @@ LOGIN_GOV_AUTH_ENDPOINT=http://localhost:5001/issuer1/authorize
 LOGIN_GOV_TOKEN_ENDPOINT=http://mock-oauth2-server:5001/issuer1/token
 LOGIN_GOV_ENDPOINT=http://mock-oauth2-server:5001/issuer1
 
-############################
-# OAuth Flow Debug Callback (Default)
-# Remove the comment under the Application Callback to redirect the user to simpler.grants.gov instead
-############################
+# Set OAuth callback to backend login result
 LOGIN_FINAL_DESTINATION=http://localhost:8080/v1/users/login/result
-
-############################
-# simpler.grants.gov Application Callback
-############################
+# Set OAuth callback to frontend upon login
 # LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback
 
 FRONTEND_BASE_URL=http://localhost:8080
@@ -72,11 +66,6 @@ LOGIN_GOV_CLIENT_ASSERTION_PRIVATE_KEY=
 ############################
 # Feature Flags
 ############################
-
-# Enable the simpler.grants.gov (Sign In) Feature
-FEATURE_AUTH_ON=TRUE
-FEATURE_SAVED_OPPORTUNITIES_ON=TRUE
-FEATURE_SAVED_SEARCHES_ON=TRUE
 
 ENABLE_AUTH_ENDPOINT=TRUE
 ENABLE_APPLY_ENDPOINTS=TRUE


### PR DESCRIPTION
## Summary

Fixes #5067 

## Changes proposed

- Change `host.docker.internal` to `mock-oauth2-server` for DNS name resolution.
- Include the URL for the simpler.grants.gov callback URL in `local.env`
- Add in Feature flags

## Context for reviewers

- Some feature flags may be unnecessary for quick hacking. Maybe some of them such as `FEATURE_AUTH_ON` should be disabled (commented out) by default as it is not commonly needed. 
