### PR TITLE
Make the nofos github workflow cache id more specific

### DIFF
--- a/.github/workflows/ci-nofos.yml
+++ b/.github/workflows/ci-nofos.yml
@@ -43,10 +43,10 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: /tmp/commit-hash.txt
-          key: nofos-commit-${{ github.sha }}
+          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
 
       - name: Cache Docker image
         uses: actions/cache/save@v4
         with:
           path: /tmp/docker-image.tar
-          key: nofos-image-${{ github.sha }}
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}

--- a/.github/workflows/deploy-nofos.yml
+++ b/.github/workflows/deploy-nofos.yml
@@ -28,13 +28,13 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /tmp/commit-hash.txt
-          key: nofos-commit-${{ github.sha }}
+          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
 
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
           path: /tmp/docker-image.tar
-          key: nofos-image-${{ github.sha }}
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
 
       - name: Load cached Docker image
         run: docker load < /tmp/docker-image.tar


### PR DESCRIPTION

## Summary

We are seeing the same container deployed on new runs and we think that the cache name is not unique enough.

