### PR TITLE
redirect to homepage on auth page logout

### DIFF
--- a/frontend/src/components/user/UserControl.tsx
+++ b/frontend/src/components/user/UserControl.tsx
@@ -132,7 +132,7 @@ export const UserControl = () => {
     });
 
     logoutLocalUser();
-    router.refresh();
+    router.push("/")
   }, [logoutLocalUser, router]);
 
   return (


### PR DESCRIPTION
## Summary

Fixes #5059 

## Changes proposed

Redirect user to homepage on logout

## Context for reviewers

Removed `router.refresh()` in preference to `router.push("/")` where the user is returned back to the simpler.grants.gov homepage.

> Proposed behavior: If users sign out from an authenticated experience page, they should be redirected to the homepage (simpler.grants.gov), not shown an error message as they do now. No need to show a toast.

Since the below is called when the `logout()` [callback](https://github.com/GlennTatum/simpler-grants-gov/blob/9882251551d21755e14e0b33af618dfa107548d1/frontend/src/components/user/UserControl.tsx#L128) is triggered, the JWT session token is still deleted. The behavior in the session being deleted remains the same between calling `router.refresh()` and `router.push("/")`.
```js
    await fetch("/api/auth/logout", {
      method: "POST",
    });
```

If @doug-s-nava could chime and give feedback in on this change as this partially removes the need of `AuthenticationGate` at routes which use the mechanism for making it protected from unauthenticated users to the system that would be great. 

## Validation steps

A basic user saving a grant and then logging out.

![auth-logout](https://github.com/user-attachments/assets/1e662772-5992-46cb-a568-f68d2be60dcd)