### PR TITLE
[Issue #4970] Set apply endpoints to only allow the owner of an application to interact

### DIFF
--- a/api/src/api/application_alpha/application_route.py
+++ b/api/src/api/application_alpha/application_route.py
@@ -66,10 +66,14 @@ def application_form_update(
 
     application_response = json_data["application_response"]
 
+    # Get user from token session
+    token_session = api_jwt_auth.get_user_token_session()
+    user = token_session.user
+
     with db_session.begin():
         # Call the service to update the application form
         _, warnings = update_application_form(
-            db_session, application_id, form_id, application_response
+            db_session, application_id, form_id, application_response, user
         )
 
     return response.ApiResponse(
@@ -96,8 +100,14 @@ def application_form_get(
     )
     logger.info("GET /alpha/applications/:application_id/application_form/:app_form_id")
 
+    # Get user from token session
+    token_session = api_jwt_auth.get_user_token_session()
+    user = token_session.user
+
     with db_session.begin():
-        application_form, warnings = get_application_form(db_session, application_id, app_form_id)
+        application_form, warnings = get_application_form(
+            db_session, application_id, app_form_id, user
+        )
 
     return response.ApiResponse(
         message="Success",
@@ -119,8 +129,12 @@ def application_get(
     add_extra_data_to_current_request_logs({"application_id": application_id})
     logger.info("GET /alpha/applications/:application_id")
 
+    # Get user from token session
+    token_session = api_jwt_auth.get_user_token_session()
+    user = token_session.user
+
     with db_session.begin():
-        application = get_application(db_session, application_id)
+        application = get_application(db_session, application_id, user)
 
     # Return the application form data
     return response.ApiResponse(
@@ -139,8 +153,12 @@ def application_submit(db_session: db.Session, application_id: UUID) -> response
     add_extra_data_to_current_request_logs({"application_id": application_id})
     logger.info("POST /alpha/applications/:application_id/submit")
 
+    # Get user from token session
+    token_session = api_jwt_auth.get_user_token_session()
+    user = token_session.user
+
     with db_session.begin():
-        submit_application(db_session, application_id)
+        submit_application(db_session, application_id, user)
 
     # Return success response
     return response.ApiResponse(message="Success")

--- a/api/src/db/models/competition_models.py
+++ b/api/src/db/models/competition_models.py
@@ -157,9 +157,7 @@ class Application(ApiSchemaTable, TimestampMixin):
     )
 
     application_users: Mapped[list["ApplicationUser"]] = relationship(
-        "ApplicationUser",
-        back_populates="application",
-        uselist=True,
+        "ApplicationUser", back_populates="application", uselist=True, cascade="all, delete-orphan"
     )
 
 

--- a/api/src/services/applications/auth_utils.py
+++ b/api/src/services/applications/auth_utils.py
@@ -1,0 +1,37 @@
+import logging
+
+from src.api.response import ValidationErrorDetail
+from src.api.route_utils import raise_flask_error
+from src.db.models.competition_models import Application
+from src.db.models.user_models import User
+
+logger = logging.getLogger(__name__)
+
+
+def check_user_application_access(application: Application, user: User) -> None:
+    """
+    Check if a user has access to an application.
+    """
+    user_has_access = any(
+        app_user.user_id == user.user_id for app_user in application.application_users
+    )
+
+    if not user_has_access:
+        logger.info(
+            "User attempted to access an application they are not associated with",
+            extra={
+                "user_id": user.user_id,
+                "application_id": application.application_id,
+            },
+        )
+        raise_flask_error(
+            403,
+            "Unauthorized",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type="unauthorized_application_access",
+                    message="Unauthorized",
+                    field="application_id",
+                )
+            ],
+        )

--- a/api/src/services/applications/auth_utils.py
+++ b/api/src/services/applications/auth_utils.py
@@ -1,6 +1,5 @@
 import logging
 
-from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.competition_models import Application
 from src.db.models.user_models import User
@@ -24,14 +23,4 @@ def check_user_application_access(application: Application, user: User) -> None:
                 "application_id": application.application_id,
             },
         )
-        raise_flask_error(
-            403,
-            "Unauthorized",
-            validation_issues=[
-                ValidationErrorDetail(
-                    type="unauthorized_application_access",
-                    message="Unauthorized",
-                    field="application_id",
-                )
-            ],
-        )
+        raise_flask_error(403, "Unauthorized")

--- a/api/src/services/applications/get_application.py
+++ b/api/src/services/applications/get_application.py
@@ -6,10 +6,14 @@ from sqlalchemy.orm import selectinload
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
 from src.db.models.competition_models import Application
+from src.db.models.user_models import User
+from src.services.applications.auth_utils import check_user_application_access
 
 
-def get_application(db_session: db.Session, application_id: UUID) -> Application:
-    # Check if application exists
+def get_application(db_session: db.Session, application_id: UUID, user: User) -> Application:
+    """
+    Get an application by ID, checking if the user has access to it.
+    """
     application = db_session.execute(
         select(Application)
         .options(selectinload(Application.application_forms))  # Fetch the application forms
@@ -18,5 +22,8 @@ def get_application(db_session: db.Session, application_id: UUID) -> Application
 
     if not application:
         raise_flask_error(404, f"Application with ID {application_id} not found")
+
+    # Check if the user has access to the application
+    check_user_application_access(application, user)
 
     return application

--- a/api/src/services/applications/get_application_form.py
+++ b/api/src/services/applications/get_application_form.py
@@ -4,20 +4,25 @@ from sqlalchemy import select
 
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
-from src.db.models.competition_models import Application, ApplicationForm
+from src.db.models.competition_models import ApplicationForm
+from src.services.applications.get_application import get_application
+from src.db.models.user_models import User
 from src.form_schema.jsonschema_validator import (
     ValidationErrorDetail,
     validate_json_schema_for_form,
 )
+from src.services.applications.auth_utils import check_user_application_access
 
 
 def get_application_form(
-    db_session: db.Session, application_id: UUID, app_form_id: UUID
+    db_session: db.Session, application_id: UUID, app_form_id: UUID, user: User
 ) -> tuple[ApplicationForm, list[ValidationErrorDetail]]:
-    # Check if application exists
-    application = db_session.execute(
-        select(Application).where(Application.application_id == application_id)
-    ).scalar_one_or_none()
+    """
+    Get an application form by ID, checking if the user has access to it.
+    """
+
+    # Get the application
+    application = get_application(db_session, application_id, user)
 
     if not application:
         raise_flask_error(404, f"Application with ID {application_id} not found")
@@ -32,6 +37,9 @@ def get_application_form(
 
     if not application_form:
         raise_flask_error(404, f"Application form with ID {app_form_id} not found")
+
+    # Check if the user has access to the application
+    check_user_application_access(application, user)
 
     warnings: list[ValidationErrorDetail] = validate_json_schema_for_form(
         application_form.application_response, application_form.form

--- a/api/src/services/applications/get_application_form.py
+++ b/api/src/services/applications/get_application_form.py
@@ -5,13 +5,13 @@ from sqlalchemy import select
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
 from src.db.models.competition_models import ApplicationForm
-from src.services.applications.get_application import get_application
 from src.db.models.user_models import User
 from src.form_schema.jsonschema_validator import (
     ValidationErrorDetail,
     validate_json_schema_for_form,
 )
 from src.services.applications.auth_utils import check_user_application_access
+from src.services.applications.get_application import get_application
 
 
 def get_application_form(
@@ -20,7 +20,6 @@ def get_application_form(
     """
     Get an application form by ID, checking if the user has access to it.
     """
-
     # Get the application
     application = get_application(db_session, application_id, user)
 

--- a/api/src/services/applications/get_application_form.py
+++ b/api/src/services/applications/get_application_form.py
@@ -23,9 +23,6 @@ def get_application_form(
     # Get the application
     application = get_application(db_session, application_id, user)
 
-    if not application:
-        raise_flask_error(404, f"Application with ID {application_id} not found")
-
     # Get the application form
     application_form = db_session.execute(
         select(ApplicationForm).where(

--- a/api/src/services/applications/submit_application.py
+++ b/api/src/services/applications/submit_application.py
@@ -7,6 +7,7 @@ from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.constants.lookup_constants import ApplicationStatus
 from src.db.models.competition_models import Application
+from src.db.models.user_models import User
 from src.services.applications.get_application import get_application
 from src.util.datetime_util import get_now_us_eastern_date
 from src.validation.validation_constants import ValidationErrorType
@@ -76,14 +77,14 @@ def validate_competition_open(application: Application) -> None:
             )
 
 
-def submit_application(db_session: db.Session, application_id: UUID) -> Application:
+def submit_application(db_session: db.Session, application_id: UUID, user: User) -> Application:
     """
     Submit an application for a competition.
     """
 
     logger.info("Processing application submit")
 
-    application = get_application(db_session, application_id)
+    application = get_application(db_session, application_id, user)
 
     # Run validations
     validate_application_in_progress(application)

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -36,3 +36,6 @@ class ValidationErrorType(StrEnum):
     # Competition window validation error types
     COMPETITION_NOT_YET_OPEN = "competition_not_yet_open"
     COMPETITION_ALREADY_CLOSED = "competition_already_closed"
+
+    # Application access validation error type
+    UNAUTHORIZED_APPLICATION_ACCESS = "unauthorized_application_access"

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1503,9 +1503,7 @@ def test_application_submit_success_when_associated(client, enable_factory_creat
 
     # Create an application form with valid data to ensure validation passes
     ApplicationFormFactory.create(
-        application=application, 
-        form=form, 
-        application_response={"name": "Valid Name"}
+        application=application, form=form, application_response={"name": "Valid Name"}
     )
 
     # Create ApplicationUser association

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1220,7 +1220,6 @@ def test_application_get_forbidden_if_not_associated(
 
     assert response.status_code == 403
     assert "Unauthorized" in response.json["message"]
-    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
 
 
 def test_application_form_get_forbidden_if_not_associated(
@@ -1238,7 +1237,6 @@ def test_application_form_get_forbidden_if_not_associated(
 
     assert response.status_code == 403
     assert "Unauthorized" in response.json["message"]
-    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
 
 
 def test_application_form_update_forbidden_if_not_associated(
@@ -1259,7 +1257,6 @@ def test_application_form_update_forbidden_if_not_associated(
 
     assert response.status_code == 403
     assert "Unauthorized" in response.json["message"]
-    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
 
 
 def test_application_submit_forbidden_if_not_associated(
@@ -1275,7 +1272,6 @@ def test_application_submit_forbidden_if_not_associated(
 
     assert response.status_code == 403
     assert "Unauthorized" in response.json["message"]
-    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
 
 
 def test_application_get_success_when_associated(client, enable_factory_create, db_session):

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -5,7 +5,7 @@ import pytest
 from freezegun import freeze_time
 from sqlalchemy import select
 
-from src.auth.api_jwt_auth import create_jwt_for_user
+from src.auth.api_jwt_auth import create_jwt_for_user, parse_jwt_for_user
 from src.db.models.competition_models import Application, ApplicationForm, ApplicationStatus
 from src.db.models.user_models import ApplicationUser
 from src.util.datetime_util import get_now_us_eastern_date
@@ -13,6 +13,7 @@ from src.validation.validation_constants import ValidationErrorType
 from tests.src.db.models.factories import (
     ApplicationFactory,
     ApplicationFormFactory,
+    ApplicationUserFactory,
     CompetitionFactory,
     CompetitionFormFactory,
     FormFactory,
@@ -372,6 +373,12 @@ def test_application_form_update_success_create(
 
     competition_form = CompetitionFormFactory.create(competition=application.competition)
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
+
     application_id = str(application.application_id)
     form_id = str(competition_form.form_id)
     request_data = {"application_response": {"name": "John Doe"}}
@@ -385,8 +392,6 @@ def test_application_form_update_success_create(
     # Assert
     assert response.status_code == 200
     assert response.json["message"] == "Success"
-    assert response.json["data"]["application_id"] == application_id
-    assert "warnings" in response.json
 
     # Verify application form was created in the database
     application_form = db_session.execute(
@@ -419,6 +424,12 @@ def test_application_form_update_success_update(
         form=form,
         application_response={"name": "Original Name"},
     )
+
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
 
     application_id = str(application.application_id)
     form_id = str(existing_form.form_id)
@@ -482,6 +493,12 @@ def test_application_form_update_with_validation_warnings(
         application_response={"name": "Original Name"},
     )
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
+
     request_data = {"application_response": application_response}
 
     response = client.put(
@@ -520,6 +537,12 @@ def test_application_form_update_with_invalid_schema_500(
         form=form,
         application_response={"name": "Original Name"},
     )
+
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
 
     request_data = {"application_response": {"name": "Changed Name"}}
 
@@ -575,6 +598,12 @@ def test_application_form_update_form_not_found(
 
     # Create application
     application = ApplicationFactory.create()
+
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
 
     application_id = str(application.application_id)
     non_existent_form_id = str(uuid.uuid4())
@@ -678,6 +707,12 @@ def test_application_form_update_complex_json(
         form=application_form.form,
     )
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
+
     application_id = str(application.application_id)
     form_id = str(application_form.form_id)
     complex_json = {
@@ -730,6 +765,12 @@ def test_application_form_get_success(client, enable_factory_create, db_session,
         form=application_form.form,
     )
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application_form.application)
+
     response = client.get(
         f"/alpha/applications/{application_form.application_id}/application_form/{application_form.application_form_id}",
         headers={"X-SGG-Token": user_auth_token},
@@ -765,6 +806,12 @@ def test_application_form_get_form_not_found(
 ):
     application = ApplicationFactory.create()
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
+
     non_existent_app_form_id = str(uuid.uuid4())
 
     response = client.get(
@@ -798,6 +845,12 @@ def test_application_form_get_unauthorized(client, enable_factory_create, db_ses
 def test_application_get_success(client, enable_factory_create, db_session, user_auth_token):
     application = ApplicationFactory.create(with_forms=True)
     application_forms = sorted(application.application_forms, key=lambda x: x.application_form_id)
+
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
 
     response = client.get(
         f"/alpha/applications/{application.application_id}",
@@ -897,6 +950,12 @@ def test_application_form_get_with_validation_warnings(
         application_response=application_response,
     )
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
+
     # Make the GET request
     response = client.get(
         f"/alpha/applications/{application.application_id}/application_form/{application_form.application_form_id}",
@@ -936,6 +995,12 @@ def test_application_form_get_with_invalid_schema(
         application_response={"name": "Test Name"},
     )
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
+
     # Make the GET request
     response = client.get(
         f"/alpha/applications/{application.application_id}/application_form/{application_form.application_form_id}",
@@ -960,6 +1025,12 @@ def test_application_submit_success(client, enable_factory_create, db_session, u
     )
     application_id = str(application.application_id)
 
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
+
     response = client.post(
         f"/alpha/applications/{application_id}/submit",
         headers={"X-SGG-Token": user_auth_token},
@@ -969,7 +1040,7 @@ def test_application_submit_success(client, enable_factory_create, db_session, u
     assert response.status_code == 200
     assert response.json["message"] == "Success"
 
-    # Verify application status updated in the database
+    # Verify application status was updated
     db_session.refresh(application)
     assert application.application_status == ApplicationStatus.SUBMITTED
 
@@ -984,6 +1055,12 @@ def test_application_submit_forbidden(
     # Create an application with a status other than IN_PROGRESS
     application = ApplicationFactory.create(application_status=initial_status)
     application_id = str(application.application_id)
+
+    # Get the user from the auth token and associate with application
+    user = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user.user, application=application)
 
     response = client.post(
         f"/alpha/applications/{application_id}/submit",
@@ -1127,3 +1204,193 @@ def test_application_start_with_default_name(client, enable_factory_create, db_s
     assert application is not None
     assert str(application.competition_id) == competition_id
     assert application.application_name == "TEST-OPP-123"
+
+
+def test_application_get_forbidden_if_not_associated(
+    client, enable_factory_create, db_session, user_auth_token
+):
+    """Test application get fails when user is not associated with the application"""
+    # Create a user for the auth token and a separate user for the application
+    application = ApplicationFactory.create()
+
+    response = client.get(
+        f"/alpha/applications/{application.application_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 403
+    assert "Unauthorized" in response.json["message"]
+    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
+
+
+def test_application_form_get_forbidden_if_not_associated(
+    client, enable_factory_create, db_session, user_auth_token
+):
+    """Test application form get fails when user is not associated with the application"""
+    application_form = ApplicationFormFactory.create(
+        application_response={"name": "John Doe"},
+    )
+
+    response = client.get(
+        f"/alpha/applications/{application_form.application_id}/application_form/{application_form.application_form_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 403
+    assert "Unauthorized" in response.json["message"]
+    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
+
+
+def test_application_form_update_forbidden_if_not_associated(
+    client, enable_factory_create, db_session, user_auth_token
+):
+    """Test application form update fails when user is not associated with the application"""
+    application = ApplicationFactory.create()
+    form = FormFactory.create()
+    CompetitionFormFactory.create(competition=application.competition, form=form)
+
+    request_data = {"application_response": {"name": "John Doe"}}
+
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/forms/{form.form_id}",
+        json=request_data,
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 403
+    assert "Unauthorized" in response.json["message"]
+    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
+
+
+def test_application_submit_forbidden_if_not_associated(
+    client, enable_factory_create, db_session, user_auth_token
+):
+    """Test application submit fails when user is not associated with the application"""
+    application = ApplicationFactory.create(application_status=ApplicationStatus.IN_PROGRESS)
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/submit",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 403
+    assert "Unauthorized" in response.json["message"]
+    assert response.json["errors"][0]["type"] == ValidationErrorType.UNAUTHORIZED_APPLICATION_ACCESS
+
+
+def test_application_get_success_when_associated(client, enable_factory_create, db_session):
+    """Test application get succeeds when user is associated with the application"""
+    # Create a user and associate it with an application
+    user = UserFactory.create()
+    user_auth_token, _ = create_jwt_for_user(user, db_session)
+
+    application = ApplicationFactory.create(with_forms=True)
+
+    ApplicationUserFactory.create(application=application, user=user)
+
+    response = client.get(
+        f"/alpha/applications/{application.application_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert response.json["data"]["application_id"] == str(application.application_id)
+
+
+def test_application_form_get_success_when_associated(client, enable_factory_create, db_session):
+    """Test application form get succeeds when user is associated with the application"""
+    # Create a user and associate it with an application
+    user = UserFactory.create()
+    user_auth_token, _ = create_jwt_for_user(user, db_session)
+
+    application_form = ApplicationFormFactory.create(
+        application_response={"name": "John Doe"},
+    )
+
+    ApplicationUserFactory.create(application=application_form.application, user=user)
+
+    response = client.get(
+        f"/alpha/applications/{application_form.application_id}/application_form/{application_form.application_form_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert response.json["data"]["application_form_id"] == str(application_form.application_form_id)
+
+
+def test_application_form_update_success_when_associated(client, enable_factory_create, db_session):
+    """Test application form update succeeds when user is associated with the application"""
+    # Create a user and associate it with an application
+    user = UserFactory.create()
+    user_auth_token, _ = create_jwt_for_user(user, db_session)
+
+    application = ApplicationFactory.create()
+
+    competition_form = CompetitionFormFactory.create(competition=application.competition)
+
+    ApplicationUserFactory.create(application=application, user=user)
+
+    request_data = {"application_response": {"name": "John Doe"}}
+
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/forms/{competition_form.form_id}",
+        json=request_data,
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Verify application form was created
+    application_form = db_session.execute(
+        select(ApplicationForm).where(
+            ApplicationForm.application_id == application.application_id,
+            ApplicationForm.form_id == competition_form.form_id,
+        )
+    ).scalar_one_or_none()
+
+    assert application_form is not None
+    assert application_form.application_response == {"name": "John Doe"}
+
+
+def test_application_submit_success_when_associated(client, enable_factory_create, db_session):
+    """Test application submit succeeds when user is associated with the application"""
+    # Create a user and associate it with an application
+    user = UserFactory.create()
+    user_auth_token, _ = create_jwt_for_user(user, db_session)
+
+    # Create a competition with a future closing date
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+    competition = CompetitionFactory.create(closing_date=future_date)
+
+    # Create an application in the IN_PROGRESS state
+    application = ApplicationFactory.create(
+        application_status=ApplicationStatus.IN_PROGRESS, competition=competition
+    )
+
+    # Create ApplicationUser association
+    ApplicationUserFactory.create(application=application, user=user)
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/submit",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Verify application status was updated
+    db_session.refresh(application)
+    assert application.application_status == ApplicationStatus.SUBMITTED
+
+
+def get_user_from_token(db_session, user_auth_token):
+    """Helper function to get the user from an auth token for testing"""
+    # Parse the JWT and get the user token session
+    user_token_session = parse_jwt_for_user(user_auth_token, db_session)
+
+    # Return the user associated with the token session
+    return user_token_session.user

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -2287,3 +2287,14 @@ class OrganizationFactory(BaseFactory):
     sam_gov_entity_id = factory.LazyAttribute(
         lambda o: o.sam_gov_entity.sam_gov_entity_id if o.sam_gov_entity else None
     )
+
+
+class ApplicationUserFactory(BaseFactory):
+    class Meta:
+        model = user_models.ApplicationUser
+
+    application = factory.SubFactory(ApplicationFactory)
+    application_id = factory.LazyAttribute(lambda o: o.application.application_id)
+
+    user = factory.SubFactory(UserFactory)
+    user_id = factory.LazyAttribute(lambda o: o.user.user_id)

--- a/api/tests/src/services/applications/test_auth_utils.py
+++ b/api/tests/src/services/applications/test_auth_utils.py
@@ -1,0 +1,41 @@
+import pytest
+from apiflask.exceptions import HTTPError
+
+from src.services.applications.auth_utils import check_user_application_access
+from tests.src.db.models.factories import ApplicationFactory, ApplicationUserFactory, UserFactory
+
+
+def test_check_user_application_access_success(enable_factory_create, db_session):
+    """Test that a user with access to an application passes the check."""
+    # Create a user and an application
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+
+    # Associate the user with the application using the factory
+    ApplicationUserFactory.create(user=user, application=application)
+
+    # Call the function - should return None without raising an exception
+    result = check_user_application_access(application, user)
+
+    assert result is None
+
+
+def test_check_user_application_access_unauthorized(enable_factory_create, db_session):
+    """Test that a user without access to an application raises a 403 error."""
+    # Create a user and an application, but don't associate them
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+
+    # Call the function - should raise a 403 HTTPError
+    with pytest.raises(HTTPError) as excinfo:
+        check_user_application_access(application, user)
+
+    # Verify error details
+    assert excinfo.value.status_code == 403
+    assert "Unauthorized" in excinfo.value.message
+
+    # Check that the validation issue is included
+    validation_issues = excinfo.value.extra_data["validation_issues"]
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "unauthorized_application_access"
+    assert validation_issues[0].field == "application_id"

--- a/api/tests/src/services/applications/test_auth_utils.py
+++ b/api/tests/src/services/applications/test_auth_utils.py
@@ -33,9 +33,3 @@ def test_check_user_application_access_unauthorized(enable_factory_create, db_se
     # Verify error details
     assert excinfo.value.status_code == 403
     assert "Unauthorized" in excinfo.value.message
-
-    # Check that the validation issue is included
-    validation_issues = excinfo.value.extra_data["validation_issues"]
-    assert len(validation_issues) == 1
-    assert validation_issues[0].type == "unauthorized_application_access"
-    assert validation_issues[0].field == "application_id"

--- a/api/tests/src/services/applications/test_submit_application.py
+++ b/api/tests/src/services/applications/test_submit_application.py
@@ -174,9 +174,13 @@ def test_submit_application_with_missing_required_form(enable_factory_create, db
     application = ApplicationFactory.create(
         application_status=ApplicationStatus.IN_PROGRESS, competition=competition
     )
+    
+    # Create a user and associate with the application
+    user = UserFactory.create()
+    ApplicationUserFactory.create(user=user, application=application)
 
     with pytest.raises(apiflask.exceptions.HTTPError) as excinfo:
-        submit_application(db_session, application.application_id)
+        submit_application(db_session, application.application_id, user)
 
     assert excinfo.value.status_code == 422
     assert excinfo.value.message == "The application has issues in its form responses."
@@ -200,9 +204,13 @@ def test_submit_application_with_invalid_field(enable_factory_create, db_session
     ApplicationFormFactory.create(
         application=application, form=form, application_response={"name": 5}
     )
+    
+    # Create a user and associate with the application
+    user = UserFactory.create()
+    ApplicationUserFactory.create(user=user, application=application)
 
     with pytest.raises(apiflask.exceptions.HTTPError) as excinfo:
-        submit_application(db_session, application.application_id)
+        submit_application(db_session, application.application_id, user)
 
     assert excinfo.value.status_code == 422
     assert excinfo.value.message == "The application has issues in its form responses."
@@ -212,7 +220,7 @@ def test_submit_application_with_invalid_field(enable_factory_create, db_session
     )
 
 
-def test_submit_application_not_found(db_session):
+def test_submit_application_not_found(db_session, enable_factory_create):
     """Test that submitting a non-existent application."""
     non_existent_id = uuid.uuid4()
     user = UserFactory.create()

--- a/api/tests/src/services/applications/test_submit_application.py
+++ b/api/tests/src/services/applications/test_submit_application.py
@@ -163,6 +163,7 @@ def test_submit_application_success(enable_factory_create, db_session):
     db_session.refresh(application)
     assert application.application_status == ApplicationStatus.SUBMITTED
 
+
 def test_submit_application_with_missing_required_form(enable_factory_create, db_session):
     today = get_now_us_eastern_date()
     competition = CompetitionFactory.create(
@@ -174,7 +175,7 @@ def test_submit_application_with_missing_required_form(enable_factory_create, db
     application = ApplicationFactory.create(
         application_status=ApplicationStatus.IN_PROGRESS, competition=competition
     )
-    
+
     # Create a user and associate with the application
     user = UserFactory.create()
     ApplicationUserFactory.create(user=user, application=application)
@@ -204,7 +205,7 @@ def test_submit_application_with_invalid_field(enable_factory_create, db_session
     ApplicationFormFactory.create(
         application=application, form=form, application_response={"name": 5}
     )
-    
+
     # Create a user and associate with the application
     user = UserFactory.create()
     ApplicationUserFactory.create(user=user, application=application)


### PR DESCRIPTION
## Summary

Fixes #4970 

## Changes proposed

Add `auth_utils` file that checks user authorized access to an application
Add `ApplicationUser` factory
Update existing and add new tests
Adjusted SQLAlchemy relationship cascade rules to prevent primary key errors when associating users with applications

## Context for reviewers

After this is merged, other new tickets (e.g. 4984) may need to be updated to account for these changes.

## Validation steps

See updated and new unit tests