### PR TITLE
[#5090] Add database migrations step to Nofos deploy workflow

### DIFF
--- a/.github/workflows/deploy-nofos.yml
+++ b/.github/workflows/deploy-nofos.yml
@@ -54,5 +54,9 @@ jobs:
       - name: Publish release
         run: make release-publish APP_NAME=nofos IMAGE_TAG="$(cat /tmp/commit-hash.txt)"
 
+      - name: Run migrations
+        run: |
+          make release-run-database-migrations APP_NAME=nofos ENVIRONMENT=${{ inputs.environment || 'dev'  }} IMAGE_TAG="$(cat /tmp/commit-hash.txt)"
+
       - name: Deploy release
         run: make release-deploy APP_NAME=nofos ENVIRONMENT=${{ inputs.environment || 'dev' }} IMAGE_TAG="$(cat /tmp/commit-hash.txt)"


### PR DESCRIPTION
⚠️  [PR 338](https://github.com/HHS/simpler-grants-pdf-builder/pull/338) in simpler-nofos needs to go in first, otherwise this workflow will fail ⚠️ 

## Summary

Fixes #5090 

Adds a database migration step as part of booting up the container. 
If we don't run this initially, the app doesn't even boot. 
If we don't run it continuously, our data model will corrode.

## Context for reviewers

Note that this PR depends on [PR 338 in simpler-grants-pdf-builder](https://github.com/HHS/simpler-grants-pdf-builder/pull/338) to go in first, which adds the `db-migrate` command to the Dockerfile.

Once that one is merged, I'm confident this one will work because [I've run them both using their respective branches already](https://github.com/HHS/simpler-grants-gov/actions/runs/15121098983). 