### PR TITLE
[#5065] Add our first secret env var for the Nofos app: DOCRAPTOR_API_KEY

### DIFF
--- a/infra/nofos/app-config/env-config/environment_variables.tf
+++ b/infra/nofos/app-config/env-config/environment_variables.tf
@@ -7,14 +7,10 @@ locals {
     DJANGO_ALLOWED_HOSTS = "*"
   }
 
-  # Configuration for secrets
-  # List of configurations for defining environment variables that pull from SSM parameter
-  # store. Configurations are of the format
-  # {
-  #   ENV_VAR_NAME = {
-  #     manage_method     = "generated" # or "manual" for a secret that was created and stored in SSM manually
-  #     secret_store_name = "/ssm/param/name"
-  #   }
-  # }
-  secrets = {}
+  secrets = {
+    DOCRAPTOR_API_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/nofos/${var.environment}/docraptor-api-key"
+    }
+  }
 }


### PR DESCRIPTION

## Summary

Makes progress on #5065 

Adds the `DOCRAPTOR_API_KEY` variable. 

This key is needed in order for us to print off un-watermarked PDF NOFO documents.
