### PR TITLE
[#5065] Add load balancer name to task definition (if load balancer exists)

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -52,6 +52,11 @@ locals {
     { name : "DEPLOY_WHOAMI", value : data.external.whoami.result.value },
     { name : "IMAGE_TAG", value : var.image_tag },
   ], local.hostname)
+
+  alb_environment_variables = var.enable_load_balancer ? [
+    { name : "LOAD_BALANCER_DNS_NAME", value : aws_lb.alb[0].dns_name },
+  ] : []
+
   db_environment_variables = var.db_vars == null ? [] : [
     { name : "DB_HOST", value : var.db_vars.connection_info.host },
     { name : "DB_PORT", value : var.db_vars.connection_info.port },
@@ -64,6 +69,7 @@ locals {
   ] : []
   environment_variables = concat(
     local.base_environment_variables,
+    local.alb_environment_variables,
     local.db_environment_variables,
     local.cdn_environment_variables,
     [


### PR DESCRIPTION
## Summary

Makes progress on #5065 

If there is a load balancer resource, add its `dns_name` as an env var under: `LOAD_BALANCER_DNS_NAME`

## Context for reviewers

The reason we are doing this is that some (Django) apps require [a list of domains to be whitelisted as "allowed hosts"](https://docs.djangoproject.com/en/5.2/ref/settings/#allowed-hosts), otherwise the app will refuse to run in production.

So, adding this to the environment will allow us to add the load balancer DNS name to our ALLOWED_HOSTS so that the app will boot up and not throw a 500 error.
