### PR TITLE
NOFOs vuln scans

### DIFF
--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -36,6 +36,7 @@ jobs:
 
   vulnerability-scans:
     name: Vulnerability Scans
+    needs: [checks]
     uses: ./.github/workflows/vulnerability-scans-nofos.yml
 
   deploy:

--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -5,10 +5,9 @@ on:
   push:
     branches:
       - "main"
+      - "kai/nofos-vulns"
     paths:
-      - ".github/workflows/cd-nofos.yml"
-      - ".github/workflows/ci-nofos.yml"
-      - ".github/workflows/deploy-nofos.yml"
+      - ".github/workflows/*-nofos.yml"
       - "infra/nofos/**"
       - "infra/modules/**"
   workflow_dispatch:
@@ -35,9 +34,14 @@ jobs:
     with:
       version: ${{ inputs.version || 'main' }}
 
+  vulnerability-scans:
+    name: Vulnerability Scans
+    uses: ./.github/workflows/vulnerability-scans-nofos.yml
+
   deploy:
     name: Deploy
     needs: [checks]
+    # needs: [checks, vulnerability-scans] <= enable when vulnerability scans have started passing
     uses: ./.github/workflows/deploy-nofos.yml
     with:
       environment: ${{ inputs.environment || 'dev' }}

--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - "main"
-      - "kai/nofos-vulns"
     paths:
       - ".github/workflows/*-nofos.yml"
       - "infra/nofos/**"
@@ -50,6 +49,6 @@ jobs:
 
   send-slack-notification:
     if: failure()
-    needs: [checks, deploy]
+    needs: [checks, deploy, vulnerability-scans]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/ci-nofos.yml
+++ b/.github/workflows/ci-nofos.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Save built image to file
         run: docker save nofos:"$(git rev-parse HEAD)" > /tmp/docker-image.tar
 
+      - name: Save built image to file
+        run: docker save nofos:latest > /tmp/docker-image-latest.tar
+
       - name: Cache commit hash
         uses: actions/cache/save@v4
         with:
@@ -50,3 +53,9 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Cache Docker image With Latest Tag
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/docker-image-latest.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest

--- a/.github/workflows/ci-nofos.yml
+++ b/.github/workflows/ci-nofos.yml
@@ -37,10 +37,7 @@ jobs:
         run: git rev-parse HEAD > /tmp/commit-hash.txt
 
       - name: Save built image to file
-        run: docker save nofos:"$(git rev-parse HEAD)" > /tmp/docker-image.tar
-
-      - name: Save built image to file
-        run: docker save nofos:latest > /tmp/docker-image-latest.tar
+        run: docker save nofos:latest > /tmp/docker-image.tar
 
       - name: Cache commit hash
         uses: actions/cache/save@v4
@@ -53,9 +50,3 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           key: nofos-image-${{ github.sha }}-${{ github.run_id }}
-
-      - name: Cache Docker image With Latest Tag
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/docker-image-latest.tar
-          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest

--- a/.github/workflows/deploy-nofos.yml
+++ b/.github/workflows/deploy-nofos.yml
@@ -40,7 +40,7 @@ jobs:
         run: docker load < /tmp/docker-image.tar
 
       - name: Expand docker image tag
-        run: docker image tag nofos:"$(cat /tmp/commit-hash.txt)" simpler-grants-gov-nofos:"$(cat /tmp/commit-hash.txt)"
+        run: docker image tag nofos:latest simpler-grants-gov-nofos:"$(cat /tmp/commit-hash.txt)"
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -78,6 +78,8 @@ jobs:
         run: |
           docker load < /tmp/docker-image.tar
 
+      - run: docker images
+
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Run Anchore vulnerability scan (json)
         if: always() # Runs even if there is a failure
-        uses: anchore/scan-action@v4
+        uses: anchore/scan-action@v6
         id: anchore-scan-json
         with:
           image: nofos:latest
@@ -135,7 +135,7 @@ jobs:
 
       - name: Run Anchore vulnerability scan (table)
         if: always() # Runs even if there is a failure
-        uses: anchore/scan-action@v4
+        uses: anchore/scan-action@v6
         with:
           image: nofos:latest
           output-format: table

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -71,12 +71,12 @@ jobs:
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/docker-image.tar
-          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/docker-image-latest.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest
 
       - name: Load cached Docker image
         run: |
-          docker load < /tmp/docker-image.tar
+          docker load < /tmp/docker-image-latest.tar
 
       - run: docker images
 
@@ -120,12 +120,12 @@ jobs:
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/docker-image.tar
-          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/docker-image-latest.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest
 
       - name: Load cached Docker image
         run: |
-          docker load < /tmp/docker-image.tar
+          docker load < /tmp/docker-image-latest.tar
 
       - name: Run Anchore vulnerability scan (json)
         if: always() # Runs even if there is a failure
@@ -161,12 +161,12 @@ jobs:
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/docker-image.tar
-          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/docker-image-latest.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest
 
       - name: Load cached Docker image
         run: |
-          docker load < /tmp/docker-image.tar
+          docker load < /tmp/docker-image-latest.tar
 
       # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
       # variable, this will save the variable in this file to env for Dockle

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -71,14 +71,11 @@ jobs:
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/docker-image-latest.tar
-          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
 
       - name: Load cached Docker image
-        run: |
-          docker load < /tmp/docker-image-latest.tar
-
-      - run: docker images
+        run: docker load < /tmp/docker-image.tar
 
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
@@ -120,12 +117,11 @@ jobs:
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/docker-image-latest.tar
-          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
 
       - name: Load cached Docker image
-        run: |
-          docker load < /tmp/docker-image-latest.tar
+        run: docker load < /tmp/docker-image.tar
 
       - name: Run Anchore vulnerability scan (json)
         if: always() # Runs even if there is a failure
@@ -161,12 +157,11 @@ jobs:
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
-          path: /tmp/docker-image-latest.tar
-          key: nofos-image-${{ github.sha }}-${{ github.run_id }}-latest
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
 
       - name: Load cached Docker image
-        run: |
-          docker load < /tmp/docker-image-latest.tar
+        run: docker load < /tmp/docker-image.tar
 
       # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
       # variable, this will save the variable in this file to env for Dockle

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -68,12 +68,6 @@ jobs:
           path: ${{ github.workspace }}/.cache/trivy
           key: trivy-cache-${{ steps.date.outputs.date }}
 
-      - name: Restore NOFOs commit hash
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/commit-hash.txt
-          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
-
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
@@ -84,11 +78,13 @@ jobs:
         run: |
           docker load < /tmp/docker-image.tar
 
+      - run: docker images
+
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: image
-          image-ref: nofos:"$(cat /tmp/commit-hash.txt)"
+          image-ref: nofos:latest
           format: table
           exit-code: 1
           ignore-unfixed: true
@@ -121,12 +117,6 @@ jobs:
           rm .grype.yml
           mv new.grype.yml .grype.yml
 
-      - name: Restore NOFOs commit hash
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/commit-hash.txt
-          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
-
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
@@ -142,7 +132,7 @@ jobs:
         uses: anchore/scan-action@v4
         id: anchore-scan-json
         with:
-          image: nofos:"$(cat /tmp/commit-hash.txt)"
+          image: nofos:latest
           output-format: json
           fail-build: true
           severity-cutoff: medium
@@ -151,7 +141,7 @@ jobs:
         if: always() # Runs even if there is a failure
         uses: anchore/scan-action@v4
         with:
-          image: nofos:"$(cat /tmp/commit-hash.txt)"
+          image: nofos:latest
           output-format: table
           fail-build: true
           severity-cutoff: medium
@@ -167,12 +157,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Restore NOFOs commit hash
-        uses: actions/cache/restore@v4
-        with:
-          path: /tmp/commit-hash.txt
-          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
 
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
@@ -195,7 +179,7 @@ jobs:
       - name: Run Dockle container linter
         uses: erzz/dockle-action@v1.4.0
         with:
-          image: nofos:"$(cat /tmp/commit-hash.txt)"
+          image: nofos:latest
           exit-code: "1"
           failure-threshold: WARN
           accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -1,0 +1,192 @@
+# GitHub Actions CI workflow that runs vulnerability scans on the application's Docker image
+# to ensure images built are secure before they are deployed.
+
+name: Vulnerability Scans
+
+on:
+  workflow_call:
+    inputs:
+      bypass_ignore:
+        description: "controls if we want to not honor the scan ignore files during this run"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  trivy-scan:
+    name: Trivy Scan
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clear ignore files
+        # If there's an exact match in cache, skip build entirely
+        if: inputs.bypass_ignore == true
+        run: |
+          rm .trivyignore
+
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached trivy vulnerability and Java DBs
+        id: trivy-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: trivy-cache-${{ steps.date.outputs.date }}
+
+      # Download and extract the vulnerability DB and Java DB
+      # This is based on the instructions here:
+      # https://github.com/aquasecurity/trivy-action/?tab=readme-ov-file#updating-caches-in-the-default-branch
+
+      - name: Setup oras
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        uses: oras-project/setup-oras@v1
+
+      - name: Download and extract the vulnerability DB
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.cache/trivy/db"
+          oras pull ghcr.io/aquasecurity/trivy-db:2
+          tar -xzf db.tar.gz -C "$GITHUB_WORKSPACE/.cache/trivy/db"
+          rm db.tar.gz
+
+      - name: Download and extract the Java DB
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.cache/trivy/java-db"
+          oras pull ghcr.io/aquasecurity/trivy-java-db:1
+          tar -xzf javadb.tar.gz -C "$GITHUB_WORKSPACE/.cache/trivy/java-db"
+          rm javadb.tar.gz
+
+      - name: Cache DBs
+        if: steps.trivy-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/.cache/trivy
+          key: trivy-cache-${{ steps.date.outputs.date }}
+
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Load cached Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: image
+          image-ref: nofos:latest
+          format: table
+          exit-code: 1
+          ignore-unfixed: true
+          vuln-type: os
+          scanners: vuln,secret
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
+          # PyJWT has an example with a fake JWT that Trivy flags.
+          # see: https://github.com/aquasecurity/trivy/discussions/5772
+          TRIVY_SKIP_FILES: "/api/.venv/lib/python*/site-packages/PyJWT-*.dist-info/METADATA"
+
+      - name: Save output to workflow summary
+        if: always() # Runs even if there is a failure
+        run: |
+          echo "View results in GitHub Action logs" >> "$GITHUB_STEP_SUMMARY"
+
+  anchore-scan:
+    name: Anchore Scan
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Clear ignore files
+        # If there's an exact match in cache, skip build entirely
+        if: inputs.bypass_ignore == true
+        run: |
+          grep -v "\- vulnerability:" .grype.yml > new.grype.yml
+          rm .grype.yml
+          mv new.grype.yml .grype.yml
+
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Load cached Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+
+      - name: Run Anchore vulnerability scan (json)
+        if: always() # Runs even if there is a failure
+        uses: anchore/scan-action@v4
+        id: anchore-scan-json
+        with:
+          image: nofos:latest
+          output-format: json
+          fail-build: true
+          severity-cutoff: medium
+
+      - name: Run Anchore vulnerability scan (table)
+        if: always() # Runs even if there is a failure
+        uses: anchore/scan-action@v4
+        with:
+          image: nofos:latest
+          output-format: table
+          fail-build: true
+          severity-cutoff: medium
+
+      - name: Print output to workflow summary
+        if: always() # Runs even if there is a failure
+        run: |
+          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-json.outputs.json }}
+
+  dockle-scan:
+    name: Dockle Scan
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore cached Docker image
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: nofos-image-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Load cached Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+
+      # Dockle doesn't allow you to have an ignore file for the DOCKLE_ACCEPT_FILES
+      # variable, this will save the variable in this file to env for Dockle
+      - name: Set any acceptable Dockle files
+        run: |
+          if grep -q "^DOCKLE_ACCEPT_FILES=.*" .dockleconfig; then
+            grep -s '^DOCKLE_ACCEPT_FILES=' .dockleconfig >> "$GITHUB_ENV"
+          fi
+
+      - name: Run Dockle container linter
+        uses: erzz/dockle-action@v1.4.0
+        with:
+          image: nofos:latest
+          exit-code: "1"
+          failure-threshold: WARN
+          accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}
+
+      - name: Save output to workflow summary
+        if: failure() # Only runs if there is a failure
+        run: |
+          {
+            echo '```json'
+            cat dockle-report.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -68,6 +68,12 @@ jobs:
           path: ${{ github.workspace }}/.cache/trivy
           key: trivy-cache-${{ steps.date.outputs.date }}
 
+      - name: Restore NOFOs commit hash
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/commit-hash.txt
+          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
+
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
@@ -78,13 +84,11 @@ jobs:
         run: |
           docker load < /tmp/docker-image.tar
 
-      - run: docker images
-
       - name: Run Trivy vulnerability scan
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: image
-          image-ref: nofos:latest
+          image-ref: nofos:"$(cat /tmp/commit-hash.txt)"
           format: table
           exit-code: 1
           ignore-unfixed: true
@@ -117,6 +121,12 @@ jobs:
           rm .grype.yml
           mv new.grype.yml .grype.yml
 
+      - name: Restore NOFOs commit hash
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/commit-hash.txt
+          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
+
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
         with:
@@ -132,7 +142,7 @@ jobs:
         uses: anchore/scan-action@v4
         id: anchore-scan-json
         with:
-          image: nofos:latest
+          image: nofos:"$(cat /tmp/commit-hash.txt)"
           output-format: json
           fail-build: true
           severity-cutoff: medium
@@ -141,7 +151,7 @@ jobs:
         if: always() # Runs even if there is a failure
         uses: anchore/scan-action@v4
         with:
-          image: nofos:latest
+          image: nofos:"$(cat /tmp/commit-hash.txt)"
           output-format: table
           fail-build: true
           severity-cutoff: medium
@@ -157,6 +167,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Restore NOFOs commit hash
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/commit-hash.txt
+          key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
 
       - name: Restore cached Docker image
         uses: actions/cache/restore@v4
@@ -179,7 +195,7 @@ jobs:
       - name: Run Dockle container linter
         uses: erzz/dockle-action@v1.4.0
         with:
-          image: nofos:latest
+          image: nofos:"$(cat /tmp/commit-hash.txt)"
           exit-code: "1"
           failure-threshold: WARN
           accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}


### PR DESCRIPTION
## Changes proposed

Adds a vulnerability scan workflow to the NOFOs deployment process. Currently it's optional.

## Context for reviewers

We have an obligation to vuln scan the apps that run within our infrastructure. 

## Validation steps

CI outputs:

https://github.com/HHS/simpler-grants-gov/actions/runs/15147743231/job/42587548429?pr=5113

https://github.com/HHS/simpler-grants-gov/actions/runs/15147743231/job/42587548461?pr=5113

https://github.com/HHS/simpler-grants-gov/actions/runs/15147743231/job/42587548416?pr=5113

The scans are working, but all 3 are failing