### PR TITLE
[Unticketed] Adjust OpenSearch docker config to be version 2 specfically

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - default
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:latest
+    image: opensearchproject/opensearch-dashboards:2
     container_name: opensearch-dashboards
     ports:
       - 5601:5601 # Map host port 5601 to container port 5601

--- a/api/opensearch/Dockerfile
+++ b/api/opensearch/Dockerfile
@@ -1,9 +1,8 @@
 # Dockerfile for building opensearch image with Ingest-attachment plugin
 
 # Use OpenSearch base image
-FROM opensearchproject/opensearch:latest
+FROM opensearchproject/opensearch:2
 
 # Install the Ingest Attachment plugin
 # This image is only used for local development
 RUN /usr/share/opensearch/bin/opensearch-plugin install --batch ingest-attachment
-


### PR DESCRIPTION
## Summary

## Changes proposed

Instead of `latest` set OpenSearch version to 2

## Context for reviewers

OpenSearch v3 came out recently: https://opensearch.org/blog/unveiling-opensearch-3-0/

However, the opensearch dashboard (the UI we can access locally) is still only on v2, so they're not compatible (gives an error if you try to access it).

We're not running v3 yet in AWS either, so let's keep everything on a known working version
