### PR TITLE
[Issue #5109] Adds GH action to rollover open sprint tix

### DIFF
--- a/.github/workflows/lint-sprint-rollover.yml
+++ b/.github/workflows/lint-sprint-rollover.yml
@@ -1,0 +1,25 @@
+name: Lint - Sprint rollover
+
+on:
+  workflow_dispatch: # for manual runs
+  schedule:
+    # Runs "at 09:00 UTC, every week on Wednesday" (see https://crontab.guru)
+    # Sprints are 2 weeks long, but crons don't easily support biweekly schedules
+    # and this GitHub action won't move tickets out of the current sprint
+    - cron: "0 9 * * 3"
+
+jobs:
+  sprint-rollover:
+    name: Roll over open tickets
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: blombard/move-to-next-iteration@master
+        with:
+          owner: HHS
+          number: 13
+          token: ${{ secrets.GH_TOKEN_PROJECT_ACCESS }}
+          iteration-field: Sprint
+          iteration: last
+          new-iteration: current
+          excluded-statuses: "Done"


### PR DESCRIPTION
## Summary

Rolls over open tickets from the previous sprint into the current sprint. It runs on a schedule by default but can be triggered manually. @margaretspring and @chrisw-nava requested this along with other proposed changes to how we use  GitHub in [this document](https://docs.google.com/document/d/1B04xDeg_9PnMu_4COVo7O6bnhnDE_QvD5uCf2rke9Ik/edit?tab=t.0#heading=h.sl8i9r9yex9j).

Fixes #5109 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds `lint-sprint-rollover.yml` which uses the [move-to-next-iteration](https://github.com/marketplace/actions/move-to-next-iteration) GH action.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

- This runs on a schedule or can be triggered manually.
- It only moves tickets from the previous sprint into the current sprint, so tickets left from earlier sprints won't be automatically moved over. This shouldn't be an issue though, once we have this running regularly since all open tickets will be moved over at the start of the next sprint.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Here's a [loom video](https://www.loom.com/share/836a54bc00234a8f80c8ba33139e3534) demonstrating how the GitHub action works on a test repository.

It's unfortunately hard to test in our own repo until we merge it in.
