### PR TITLE
[#5141] Ignore PyJWT METADATA file in nofos container trivy vuln scan

### DIFF
--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -92,7 +92,7 @@ jobs:
           TRIVY_SKIP_JAVA_DB_UPDATE: true
           # PyJWT has an example with a fake JWT that Trivy flags.
           # see: https://github.com/aquasecurity/trivy/discussions/5772
-          TRIVY_SKIP_FILES: "/api/.venv/lib/python*/site-packages/PyJWT-*.dist-info/METADATA"
+          TRIVY_SKIP_FILES: "/app/.venv/lib/python*/site-packages/PyJWT-*.dist-info/METADATA"
 
       - name: Save output to workflow summary
         if: always() # Runs even if there is a failure


### PR DESCRIPTION

## Summary

Addresses #5141, but doesn't solve it.

This PR updates our Trivy configuration in the workflow to ignore a METADATA file in PyJWT. 

This file only contains documentation but Trivy is incorrectly flagging it as code.

## Context for reviewers

The error message we are seeing is:

```
/app/.venv/lib/python3.13/site-packages/PyJWT-2.10.1.dist-info/METADATA (secrets)
=================================================================================
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

MEDIUM: JWT (jwt-token)
════════════════════════════════════════
JWT token
────────────────────────────────────────
 /app/.venv/lib/python3.13/site-packages/PyJWT-2.10.1.dist-info/METADATA:89 (added by 'RUN |2 IS_PROD_ARG=0 GITHUB_SHA_ARG= /bi')
────────────────────────────────────────
  87       >>> encoded = jwt.encode({"some": "payload"}, "secret", algorithm="HS256")
  88       >>> print(encoded)
  89 [     *********************************************************************************************************
  90       >>> jwt.decode(encoded, "secret", algorithms=["HS256"])
────────────────────────────────────────

```

This is telling us that we are printing secrets in one of our python files.

However, this is actaully flagging documentation that is attached to a dependency that comes in as part of the Python container.

When you go into the container and `cat` this file, you see this:

```

Usage
-----

.. code-block:: pycon

    >>> import jwt
    >>> encoded = jwt.encode({"some": "payload"}, "secret", algorithm="HS256")
    >>> print(encoded)
    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg
    >>> jwt.decode(encoded, "secret", algorithms=["HS256"])
    {'some': 'payload'}
```

Which is actually documentation you can read here:

https://github.com/jpadilla/pyjwt/blob/51894c5d187192753bd4221afd55bdf14bf813ea/README.rst#usage

There is also an issue about this in the pyjwt repo confirming this is a false positive:

- https://github.com/jpadilla/pyjwt/issues/933

When I went into the workflow to investigate, I found this file is already being ignored for the /api/, so I just needed to change the file path.

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

It is passing now: https://github.com/HHS/simpler-grants-gov/actions/runs/15194732232/job/42736021645
