### PR TITLE
[Issue #5080] Add more fields to the competition response schema

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -2988,6 +2988,41 @@ components:
             type:
             - object
             $ref: '#/components/schemas/CompetitionFormAlpha'
+        competition_title:
+          type: string
+          description: The title of the competition
+          example: Proposal for Advanced Research
+        opening_date:
+          type: string
+          format: date
+          description: The opening date of the competition, the first day applications
+            are accepted
+        closing_date:
+          type: string
+          format: date
+          description: The closing date of the competition, the last day applications
+            are accepted
+        contact_info:
+          type: string
+          description: Contact info getting assistance with the competition
+          example: 'Bob Smith
+
+            FakeMail@fake.com'
+        opportunity_assistance_listing:
+          type:
+          - object
+          $ref: '#/components/schemas/OpportunityAssistanceListingV1'
+        open_to_applicants:
+          type: array
+          items:
+            enum:
+            - individual
+            - organization
+            type:
+            - string
+        is_open:
+          type: boolean
+          description: Whether the competition is open and accepting applications
     CompetitionResponseAlpha:
       type: object
       properties:

--- a/api/src/api/competition_alpha/competition_schema.py
+++ b/api/src/api/competition_alpha/competition_schema.py
@@ -1,6 +1,8 @@
 from src.api.form_alpha.form_schema import FormAlphaSchema
 from src.api.schemas.extension import Schema, fields
 from src.api.schemas.response_schema import AbstractResponseSchema
+from src.api.schemas.shared_schema import OpportunityAssistanceListingV1Schema
+from src.constants.lookup_constants import CompetitionOpenToApplicant
 
 
 class CompetitionFormAlphaSchema(Schema):
@@ -20,6 +22,37 @@ class CompetitionAlphaSchema(Schema):
     )
 
     competition_forms = fields.List(fields.Nested(CompetitionFormAlphaSchema()))
+
+    competition_title = fields.String(
+        metadata={
+            "description": "The title of the competition",
+            "example": "Proposal for Advanced Research",
+        }
+    )
+    opening_date = fields.Date(
+        metadata={
+            "description": "The opening date of the competition, the first day applications are accepted"
+        }
+    )
+    closing_date = fields.Date(
+        metadata={
+            "description": "The closing date of the competition, the last day applications are accepted"
+        }
+    )
+    contact_info = fields.String(
+        metadata={
+            "description": "Contact info getting assistance with the competition",
+            "example": "Bob Smith\nFakeMail@fake.com",
+        }
+    )
+
+    opportunity_assistance_listing = fields.Nested(OpportunityAssistanceListingV1Schema())
+
+    open_to_applicants = fields.List(fields.Enum(CompetitionOpenToApplicant))
+
+    is_open = fields.Boolean(
+        metadata={"description": "Whether the competition is open and accepting applications"}
+    )
 
 
 class CompetitionResponseAlphaSchema(AbstractResponseSchema):

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -12,6 +12,7 @@ from src.api.schemas.search_schema import (
     IntegerSearchSchemaBuilder,
     StrSearchSchemaBuilder,
 )
+from src.api.schemas.shared_schema import OpportunityAssistanceListingV1Schema
 from src.constants.lookup_constants import (
     ApplicantType,
     FundingCategory,
@@ -213,23 +214,6 @@ class OpportunitySummaryV1Schema(Schema):
     )
     updated_at = fields.DateTime(
         metadata={"description": "When the opportunity summary was last updated"}
-    )
-
-
-class OpportunityAssistanceListingV1Schema(Schema):
-    program_title = fields.String(
-        allow_none=True,
-        metadata={
-            "description": "The name of the program, see https://sam.gov/content/assistance-listings for more detail",
-            "example": "Space Technology",
-        },
-    )
-    assistance_listing_number = fields.String(
-        allow_none=True,
-        metadata={
-            "description": "The assistance listing number, see https://sam.gov/content/assistance-listings for more detail",
-            "example": "43.012",
-        },
     )
 
 

--- a/api/src/api/schemas/shared_schema.py
+++ b/api/src/api/schemas/shared_schema.py
@@ -1,0 +1,18 @@
+from src.api.schemas.extension import Schema, fields
+
+
+class OpportunityAssistanceListingV1Schema(Schema):
+    program_title = fields.String(
+        allow_none=True,
+        metadata={
+            "description": "The name of the program, see https://sam.gov/content/assistance-listings for more detail",
+            "example": "Space Technology",
+        },
+    )
+    assistance_listing_number = fields.String(
+        allow_none=True,
+        metadata={
+            "description": "The assistance listing number, see https://sam.gov/content/assistance-listings for more detail",
+            "example": "43.012",
+        },
+    )

--- a/api/src/services/applications/submit_application.py
+++ b/api/src/services/applications/submit_application.py
@@ -1,63 +1,19 @@
 import logging
-from datetime import timedelta
 from uuid import UUID
 
 import src.adapters.db as db
-from src.api.response import ValidationErrorDetail
-from src.api.route_utils import raise_flask_error
 from src.constants.lookup_constants import ApplicationStatus
 from src.db.models.competition_models import Application
 from src.db.models.user_models import User
 from src.services.applications.application_validation import (
     ApplicationAction,
     validate_application_in_progress,
+    validate_competition_open,
     validate_forms,
 )
 from src.services.applications.get_application import get_application
-from src.util.datetime_util import get_now_us_eastern_date
-from src.validation.validation_constants import ValidationErrorType
 
 logger = logging.getLogger(__name__)
-
-
-def validate_competition_open(application: Application) -> None:
-    """
-    Validate that the competition is still open for submissions.
-    Takes into account the competition closing date and grace period.
-    """
-    competition = application.competition
-    current_date = get_now_us_eastern_date()
-
-    if competition.closing_date is not None:
-        actual_closing_date = competition.closing_date
-
-        # If grace_period is not null, add that many days to the closing date
-        if competition.grace_period is not None and competition.grace_period > 0:
-            actual_closing_date = competition.closing_date + timedelta(
-                days=competition.grace_period
-            )
-
-        if current_date > actual_closing_date:
-            message = "Cannot submit application - competition is closed"
-            logger.info(
-                message,
-                extra={
-                    "application_id": application.application_id,
-                    "closing_date": competition.closing_date,
-                    "grace_period": competition.grace_period,
-                },
-            )
-            raise_flask_error(
-                422,
-                message,
-                validation_issues=[
-                    ValidationErrorDetail(
-                        type=ValidationErrorType.COMPETITION_ALREADY_CLOSED,
-                        message="Competition is closed for submissions",
-                        field="closing_date",
-                    )
-                ],
-            )
 
 
 def submit_application(db_session: db.Session, application_id: UUID, user: User) -> Application:
@@ -71,7 +27,7 @@ def submit_application(db_session: db.Session, application_id: UUID, user: User)
 
     # Run validations
     validate_application_in_progress(application, ApplicationAction.SUBMIT)
-    validate_competition_open(application)
+    validate_competition_open(application.competition, ApplicationAction.SUBMIT)
     validate_forms(application)
 
     # Update application status

--- a/api/src/services/competition_alpha/get_competition.py
+++ b/api/src/services/competition_alpha/get_competition.py
@@ -11,11 +11,19 @@ from src.db.models.competition_models import Competition, CompetitionForm
 def get_competition(db_session: db.Session, competition_id: uuid.UUID) -> Competition:
 
     competition: Competition | None = db_session.execute(
-        select(Competition).where(Competition.competition_id == competition_id)
+        select(Competition)
+        .where(Competition.competition_id == competition_id)
         # Fetch the competition forms + actual form objects in the query
         # We don't do "*" here as this endpoint doesn't need to fetch things
         # like the opportunity or applications
-        .options(selectinload(Competition.competition_forms).selectinload(CompetitionForm.form))
+        .options(
+            selectinload(Competition.competition_forms).selectinload(CompetitionForm.form),
+            # Grab the assistance listing object
+            selectinload(Competition.opportunity_assistance_listing),
+            # Grab who can apply to the application
+            selectinload(Competition.link_competition_open_to_applicant),
+        )
+        .options()
     ).scalar_one_or_none()
 
     if competition is None:

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -34,8 +34,7 @@ class ValidationErrorType(StrEnum):
     NOT_IN_PROGRESS = "not_in_progress"
 
     # Competition window validation error types
-    COMPETITION_NOT_YET_OPEN = "competition_not_yet_open"
-    COMPETITION_ALREADY_CLOSED = "competition_already_closed"
+    COMPETITION_NOT_OPEN = "competition_not_open"
 
     # Application access validation error type
     UNAUTHORIZED_APPLICATION_ACCESS = "unauthorized_application_access"

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -111,12 +111,8 @@ def test_application_start_before_opening_date(
     )
 
     assert response.status_code == 422
-    assert (
-        "Cannot start application - competition is not yet open for applications"
-        in response.json["message"]
-    )
-    assert response.json["errors"][0]["type"] == ValidationErrorType.COMPETITION_NOT_YET_OPEN
-    assert response.json["errors"][0]["field"] == "opening_date"
+    assert "Cannot start application - competition is not open" in response.json["message"]
+    assert response.json["errors"][0]["type"] == ValidationErrorType.COMPETITION_NOT_OPEN
 
     # Verify no application was created
     applications_count = (
@@ -147,12 +143,8 @@ def test_application_start_after_closing_date(
     )
 
     assert response.status_code == 422
-    assert (
-        "Cannot start application - competition is already closed for applications"
-        in response.json["message"]
-    )
-    assert response.json["errors"][0]["type"] == ValidationErrorType.COMPETITION_ALREADY_CLOSED
-    assert response.json["errors"][0]["field"] == "closing_date"
+    assert "Cannot start application - competition is not open" in response.json["message"]
+    assert response.json["errors"][0]["type"] == ValidationErrorType.COMPETITION_NOT_OPEN
 
     # Verify no application was created
     applications_count = (
@@ -218,12 +210,8 @@ def test_application_start_after_grace_period(
     )
 
     assert response.status_code == 422
-    assert (
-        "Cannot start application - competition is already closed for applications"
-        in response.json["message"]
-    )
-    assert response.json["errors"][0]["type"] == ValidationErrorType.COMPETITION_ALREADY_CLOSED
-    assert response.json["errors"][0]["field"] == "closing_date"
+    assert "Cannot start application - competition is not open" in response.json["message"]
+    assert response.json["errors"][0]["type"] == ValidationErrorType.COMPETITION_NOT_OPEN
 
     # Verify no application was created
     applications_count = (

--- a/api/tests/src/api/competition_alpha/test_competition_route_get.py
+++ b/api/tests/src/api/competition_alpha/test_competition_route_get.py
@@ -1,4 +1,8 @@
 import uuid
+from datetime import date
+
+import pytest
+from freezegun import freeze_time
 
 from tests.src.db.models.factories import CompetitionFactory
 
@@ -15,6 +19,19 @@ def test_competition_get_200_with_api_key(client, api_auth_token, enable_factory
 
     assert response_competition["competition_id"] == str(competition.competition_id)
     assert response_competition["opportunity_id"] == competition.opportunity_id
+    assert response_competition["competition_title"] == competition.competition_title
+    assert response_competition["opening_date"] == competition.opening_date.isoformat()
+    assert response_competition["closing_date"] == competition.closing_date.isoformat()
+    assert response_competition["contact_info"] == competition.contact_info
+    assert (
+        response_competition["opportunity_assistance_listing"]["program_title"]
+        == competition.opportunity_assistance_listing.program_title
+    )
+    assert (
+        response_competition["opportunity_assistance_listing"]["assistance_listing_number"]
+        == competition.opportunity_assistance_listing.assistance_listing_number
+    )
+    assert response_competition["open_to_applicants"] == competition.open_to_applicants
 
 
 def test_competition_get_200_with_jwt(client, user_auth_token, enable_factory_create):
@@ -30,6 +47,63 @@ def test_competition_get_200_with_jwt(client, user_auth_token, enable_factory_cr
 
     assert response_competition["competition_id"] == str(competition.competition_id)
     assert response_competition["opportunity_id"] == competition.opportunity_id
+    assert response_competition["competition_title"] == competition.competition_title
+    assert response_competition["opening_date"] == competition.opening_date.isoformat()
+    assert response_competition["closing_date"] == competition.closing_date.isoformat()
+    assert response_competition["contact_info"] == competition.contact_info
+    assert (
+        response_competition["opportunity_assistance_listing"]["program_title"]
+        == competition.opportunity_assistance_listing.program_title
+    )
+    assert (
+        response_competition["opportunity_assistance_listing"]["assistance_listing_number"]
+        == competition.opportunity_assistance_listing.assistance_listing_number
+    )
+    assert response_competition["open_to_applicants"] == competition.open_to_applicants
+
+
+@pytest.mark.parametrize(
+    "opening_date,closing_date,grace_period, expected_is_open",
+    [
+        # None opening/close date means it's always open
+        (None, None, None, True),
+        (date(2025, 1, 1), date(2025, 12, 31), 10, True),
+        # On closing date is fine
+        (date(2025, 1, 1), date(2025, 1, 15), 0, True),
+        # On closing date with help of grace period
+        (date(2025, 1, 1), date(2025, 1, 1), 14, True),
+        # On opening date
+        (date(2025, 1, 15), date(2025, 1, 31), 0, True),
+        # Day before opening date
+        (date(2025, 1, 16), date(2025, 1, 31), 0, False),
+        # Day after closing date
+        (date(2025, 1, 1), date(2025, 1, 14), 0, False),
+        # Day after closing date + grace period
+        (date(2025, 1, 1), date(2025, 1, 10), 4, False),
+    ],
+)
+@freeze_time("2025-01-15 12:00:00", tz_offset=0)
+def test_competition_get_200_is_open(
+    client,
+    api_auth_token,
+    enable_factory_create,
+    opening_date,
+    closing_date,
+    grace_period,
+    expected_is_open,
+):
+    competition = CompetitionFactory.create(
+        opening_date=opening_date, closing_date=closing_date, grace_period=grace_period
+    )
+
+    resp = client.get(
+        f"/alpha/competitions/{competition.competition_id}", headers={"X-Auth": api_auth_token}
+    )
+
+    assert resp.status_code == 200
+    response_competition = resp.get_json()["data"]
+
+    assert response_competition["is_open"] == expected_is_open
 
 
 def test_competition_get_404_not_found(client, api_auth_token):

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -962,6 +962,8 @@ class CompetitionFactory(BaseFactory):
         lambda o: fake.date_time_between(start_date=o.created_at, end_date="-1y")
     )
 
+    opportunity_assistance_listing = factory.SubFactory(OpportunityAssistanceListingFactory)
+
     competition_forms = factory.RelatedFactoryList(
         "tests.src.db.models.factories.CompetitionFormFactory",
         factory_related_name="competition",


### PR DESCRIPTION
## Summary

Fixes #5080 and #5131

## Changes proposed

Adds additional fields to the competition response schema, most notably an `is_open` flag

Refactor some validation logic around how we determine if a competition is open to be more centralized on the DB model itself

## Context for reviewers

Most of the fields come straight from the competition and are uneventful. The `is_open` flag is a calculated field that checks the competition open + close dates (and optionally grace period) to see if a competition is open. We already had implemented validations to check this field to block users from starting/submitting an application, but now the field is calculated in one central location that those validations now check instead. This required slightly rewording the error message, but its behavior is the same.

## Validation steps
Running `make db-seed-local` will create a competition with a static ID of `fd7f5921-9585-48a5-ab0f-e726f4d1ef94` that you can query.

The GET /competition endpoint returns something like:
```json
{
  "data": {
    "closing_date": "2025-06-07",
    "competition_forms": [...], // trimmed for length
    "competition_id": "fd7f5921-9585-48a5-ab0f-e726f4d1ef94",
    "competition_title": "Charge admit hard.",
    "contact_info": null,
    "is_open": true,
    "open_to_applicants": [
      "organization",
      "individual"
    ],
    "opening_date": "2025-05-08",
    "opportunity_assistance_listing": {
      "assistance_listing_number": "14.337",
      "program_title": "Leonard, Lowe and Vang"
    },
    "opportunity_id": 112
  },
  "message": "Success",
  "status_code": 200
}
```
