### PR TITLE
[Unticketed] Fix error when a non-string is passed for an enum

### DIFF
--- a/api/src/api/schemas/extension/schema_fields.py
+++ b/api/src/api/schemas/extension/schema_fields.py
@@ -252,6 +252,11 @@ class Enum(MixinField):
     ) -> typing.Any:
         val = self.field._deserialize(value, attr, data, **kwargs)
 
+        # If the value isn't a string, we know
+        # it can't be a StrEnum
+        if not isinstance(val, str):
+            raise self.make_error("unknown", choices=self.choices_text)
+
         enum_type = self.enum_mapping.get(val)
         if not enum_type:
             raise self.make_error("unknown", choices=self.choices_text)

--- a/api/tests/src/schemas/extension/test_schema_fields.py
+++ b/api/tests/src/schemas/extension/test_schema_fields.py
@@ -42,6 +42,11 @@ def test_enum_field():
     ):
         both_ab_field._deserialize("not_a_value", None, None)
 
+    with pytest.raises(
+        ValidationError, match="Must be one of: value1, value2, value3, value4, value5, value6."
+    ):
+        both_ab_field._deserialize({}, None, None)
+
 
 @pytest.mark.parametrize(
     "payload,expected_errors",

--- a/api/tests/src/schemas/schema_validation_utils.py
+++ b/api/tests/src/schemas/schema_validation_utils.py
@@ -179,6 +179,7 @@ class FieldTestSchema(Schema):
 
     field_enum = fields.Enum(EnumA)
     field_enum_invalid_choice = fields.Enum(EnumA)
+    field_enum_invalid_type = fields.Enum(EnumA)
     field_enum_required = fields.Enum(EnumB, required=True)
 
 
@@ -285,6 +286,7 @@ def get_invalid_field_test_schema_req():
         # field_raw_required not present
         "field_enum": 12345,
         "field_enum_invalid_choice": "notvalid",
+        "field_enum_invalid_type": {},
     }
 
 
@@ -333,5 +335,6 @@ def get_expected_validation_errors():
         "field_raw_required": [MISSING_DATA],
         "field_enum": [get_enum_error_msg(EnumA)],
         "field_enum_invalid_choice": [get_enum_error_msg(EnumA)],
+        "field_enum_invalid_type": [get_enum_error_msg(EnumA)],
         "field_enum_required": [MISSING_DATA],
     }


### PR DESCRIPTION
## Summary

## Changes proposed

Fixes an issue where if a non-string is passed in a request body for something that is a str enum, it would cause a 500 error when failing to hash the value

## Context for reviewers
We have a custom handler for str enums in our Marshmallow schema definitions. Internally we setup a dict that is a mapping of strings to enum values. If the value a user passes in is not hashable (like `{}`), it would break and return a 500 error. This fix adds a guardrail to shortcut the check to not break when a non-string is passed in.

## Validation steps
Calling the opportunity search endpoint, a request like:
```json
{
  "format": {},
  "pagination": {
    "page_offset": 1,
    "page_size": 25,
    "sort_order": [
      {
        "order_by": "opportunity_id",
        "sort_direction": "ascending"
      }
    ]
  }
}
```
Would cause the error before because the format value which is a str enum would hit the above issue. Now it just says it's an invalid value and returns a 422 instead.