### PR TITLE
[#5141] Ignore warning about ":latest" tags in NOFO docker images

### DIFF
--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -171,6 +171,9 @@ jobs:
             grep -s '^DOCKLE_ACCEPT_FILES=' .dockleconfig >> "$GITHUB_ENV"
           fi
 
+      - name: Create temporary .dockleignore
+        run: echo "DKL-DI-0006" > .dockleignore
+
       - name: Run Dockle container linter
         uses: erzz/dockle-action@v1.4.0
         with:


### PR DESCRIPTION
## Summary

Fixes #5141 

This is the last issue raised by the vuln scanners, but for this one we do want to keep the `:latest` tag.

Also, this is a `warning` level message, not a `FATAL` message.

## Changes proposed

Create a temporary .dockleignore file so that we can pass in this one rule.

## Context for reviewers

The `:latest` tag is part of our CI/CD workflow, so removing it would not be good for us.
