### PR TITLE
[Issue #4862] Add a button that resets the feature flags cookie

### DIFF
--- a/frontend/src/app/[locale]/dev/feature-flags/page.tsx
+++ b/frontend/src/app/[locale]/dev/feature-flags/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 
 import Head from "next/head";
 import React from "react";
+import { Button } from "@trussworks/react-uswds";
 
 import FeatureFlagsTable from "src/components/dev/FeatureFlagsTable";
 
@@ -22,9 +23,16 @@ export default function FeatureFlags() {
       <Head>
         <title>Manage Feature Flags</title>
       </Head>
-      <div>
+      <div className="grid-container">
         <h1>Manage Feature Flags</h1>
+
         <FeatureFlagsTable />
+
+        <a href="?_ff=reset">
+          <Button type="button" data-testid="reset-defaults">
+            Reset all flags to defaults
+          </Button>
+        </a>
       </div>
     </>
   );

--- a/frontend/tests/pages/dev/feature-flags/page.test.tsx
+++ b/frontend/tests/pages/dev/feature-flags/page.test.tsx
@@ -71,4 +71,32 @@ describe("Feature flags page", () => {
       expect(statusElement).toHaveTextContent("Enabled");
     });
   });
+
+  it("should set feature flags to their default state when clicking reset to default button", () => {
+    const { rerender } = render(<FeatureFlags />);
+    Object.keys(MOCK_DEFAULT_FEATURE_FLAGS).forEach((name) => {
+      const enableButton = screen.getByTestId(`enable-${name}`);
+      const disableButton = screen.getByTestId(`disable-${name}`);
+
+      if (!MOCK_DEFAULT_FEATURE_FLAGS[name as MockFeatureFlagKeys]) {
+        fireEvent.click(enableButton);
+      } else {
+        fireEvent.click(disableButton);
+      }
+      rerender(<FeatureFlags />);
+    });
+
+    const defaultButton = screen.getByTestId(`reset-defaults`);
+    fireEvent.click(defaultButton);
+
+    rerender(<FeatureFlags />);
+    for (const [name, defaultValue] of Object.entries(
+      MOCK_DEFAULT_FEATURE_FLAGS,
+    ) as [MockFeatureFlagKeys, boolean][]) {
+      const statusEl = screen.getByTestId(`${name}-status`);
+
+      const expectedText = defaultValue ? "Enabled" : "Disabled";
+      expect(statusEl).toHaveTextContent(expectedText);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #4862 

Builds on prior work by Austin

## Changes proposed

Adds a button on the Feature Flag page that uses an a tag link to fully refresh the app while reseting the Feature Flags back to defaults.

## Context for reviewers

Do a vanilla a tag so that we get the full app reload after reseting the feature flags cookie, since the flags can adjust nav, etc.

## Validation steps

1. Checkout the branch
2. Run using `npm run dev`
3. Go to http://localhost:3000/dev/feature-flags
4. Try enabling and disabling things to get out of sync with the current default settings
5. Use the Reset button to verify they go back to defaults.
