### PR TITLE
[Issue #4994] Allow feature flags to know defaults and user values independently

### DIFF
--- a/frontend/src/app/[locale]/dev/feature-flags/page.tsx
+++ b/frontend/src/app/[locale]/dev/feature-flags/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 
 import Head from "next/head";
 import React from "react";
+import { Button } from "@trussworks/react-uswds";
 
 import FeatureFlagsTable from "src/components/dev/FeatureFlagsTable";
 
@@ -22,9 +23,16 @@ export default function FeatureFlags() {
       <Head>
         <title>Manage Feature Flags</title>
       </Head>
-      <div>
+      <div className="grid-container">
         <h1>Manage Feature Flags</h1>
+
         <FeatureFlagsTable />
+
+        <a href="?_ff=reset">
+          <Button type="button" data-testid="reset-defaults">
+            Reset all flags to defaults
+          </Button>
+        </a>
       </div>
     </>
   );

--- a/frontend/src/components/dev/FeatureFlagsTable.tsx
+++ b/frontend/src/components/dev/FeatureFlagsTable.tsx
@@ -9,14 +9,14 @@ import { Button, Table } from "@trussworks/react-uswds";
  * View for managing feature flags
  */
 export default function FeatureFlagsTable() {
-  const { setFeatureFlag, featureFlags } = useFeatureFlags();
-
+  const { setFeatureFlag, featureFlags, defaultFlags } = useFeatureFlags();
   return (
     <>
       <Table>
         <thead>
           <tr>
-            <th scope="col">Status</th>
+            <th scope="col">Current </th>
+            <th scope="col">Default</th>
             <th scope="col">Feature Flag</th>
             <th scope="col">Actions</th>
           </tr>
@@ -29,6 +29,14 @@ export default function FeatureFlagsTable() {
                 style={{ background: enabled ? "#81cc81" : "#fc6a6a" }}
               >
                 {enabled ? "Enabled" : "Disabled"}
+              </td>
+              <td
+                data-testid={`${featureName}-default`}
+                style={{
+                  background: defaultFlags[featureName] ? "#81cc81" : "#fc6a6a",
+                }}
+              >
+                {defaultFlags[featureName] ? "Enable" : "Disable"}
               </td>
               <th scope="row">{featureName}</th>
               <td>

--- a/frontend/src/services/featureFlags/FeatureFlagManager.ts
+++ b/frontend/src/services/featureFlags/FeatureFlagManager.ts
@@ -6,10 +6,13 @@ import {
   defaultFeatureFlags,
   FeatureFlags,
 } from "src/constants/defaultFeatureFlags";
-import { environment, featureFlags } from "src/constants/environments";
+import { featureFlags } from "src/constants/environments";
 import {
   assignBaseFlags,
+  deleteCookie,
+  FEATURE_FLAGS_DEFAULTS_KEY,
   FEATURE_FLAGS_KEY,
+  getDefaultFlagsFromCookie,
   getFeatureFlagsFromCookie,
   isValidFeatureFlag,
   parseFeatureFlagsFromString,
@@ -93,6 +96,7 @@ export class FeatureFlagsManager {
 
     // Start with the default feature flag setting
     const currentFeatureFlags = {
+      ...getDefaultFlagsFromCookie(cookies),
       ...this.featureFlags,
       ...getFeatureFlagsFromCookie(cookies),
     };
@@ -125,26 +129,32 @@ export class FeatureFlagsManager {
   middleware(request: NextRequest, response: NextResponse): NextResponse {
     const paramValue = request.nextUrl.searchParams.get(FEATURE_FLAGS_KEY);
 
-    const featureFlagsFromQuery =
-      paramValue === "reset"
-        ? this.featureFlags
-        : parseFeatureFlagsFromString(paramValue);
+    // this needs to set early, before the return if we're resetting
+    setCookie(
+      JSON.stringify(this.featureFlags),
+      response.cookies,
+      FEATURE_FLAGS_DEFAULTS_KEY,
+    );
+
+    if (paramValue === "reset") {
+      deleteCookie(response.cookies);
+      return response;
+    }
+
+    const featureFlagsFromQuery = parseFeatureFlagsFromString(paramValue);
 
     // previously there was logic here to return early if there were no feature flags active
     // beyond default values. Unfortunately, this breaks the implementation of the feature
-    // flag admin view, which depends on reading all flags from cookies, so the logic has beeen removed
+    // flag admin view, which depends on reading all flags from cookies, so the logic has been removed
 
-    const featureFlags =
-      environment.ENVIRONMENT === "prod"
-        ? { ...this.featureFlags }
-        : {
-            ...this.featureFlags,
-            ...getFeatureFlagsFromCookie(request.cookies),
-            ...featureFlagsFromQuery,
-          };
+    const featureFlags = {
+      ...getFeatureFlagsFromCookie(request.cookies),
+      ...featureFlagsFromQuery,
+    };
 
-    setCookie(JSON.stringify(featureFlags), response.cookies);
-
+    if (Object.keys(featureFlags).length > 0) {
+      setCookie(JSON.stringify(featureFlags), response.cookies);
+    }
     return response;
   }
 }

--- a/frontend/tests/pages/dev/feature-flags/page.test.tsx
+++ b/frontend/tests/pages/dev/feature-flags/page.test.tsx
@@ -71,4 +71,32 @@ describe("Feature flags page", () => {
       expect(statusElement).toHaveTextContent("Enabled");
     });
   });
+
+  it("should set feature flags to their default state when clicking reset to default button", () => {
+    const { rerender } = render(<FeatureFlags />);
+    Object.keys(MOCK_DEFAULT_FEATURE_FLAGS).forEach((name) => {
+      const enableButton = screen.getByTestId(`enable-${name}`);
+      const disableButton = screen.getByTestId(`disable-${name}`);
+
+      if (!MOCK_DEFAULT_FEATURE_FLAGS[name as MockFeatureFlagKeys]) {
+        fireEvent.click(enableButton);
+      } else {
+        fireEvent.click(disableButton);
+      }
+      rerender(<FeatureFlags />);
+    });
+
+    const defaultButton = screen.getByTestId(`reset-defaults`);
+    fireEvent.click(defaultButton);
+
+    rerender(<FeatureFlags />);
+    for (const [name, defaultValue] of Object.entries(
+      MOCK_DEFAULT_FEATURE_FLAGS,
+    ) as [MockFeatureFlagKeys, boolean][]) {
+      const statusEl = screen.getByTestId(`${name}-status`);
+
+      const expectedText = defaultValue ? "Enabled" : "Disabled";
+      expect(statusEl).toHaveTextContent(expectedText);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #4994

## Changes proposed
We need to store user set feature flags separately from system/default values. This is important so that user's cookies don't lock out new features from when the default was set to off.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
