### PR TITLE
[Issue #5144] Propagate milestones to sub issues

### DIFF
--- a/.github/linters/README.md
+++ b/.github/linters/README.md
@@ -21,10 +21,12 @@ root
 
 ### Review automated linters
 
-| Workflow name                                         | Description                                                            | Trigger                        |
-| ----------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------ |
-| [Lint - Set points and sprint][set-points-and-sprint] | Sets default points and sprint value (if unset) when issues are closed | On issue close                 |
-| [Lint - Check wiki links][check-wiki-links]      | Checks that all wiki markdown files are linked in the SUMMARY.md       | Each PR that modifies the wiki |
+| Workflow name                                                                 | Description                                                                 | Trigger                        |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------ |
+| [Lint - Set points and sprint][set-points-and-sprint]                         | Sets default points and sprint value (if unset) when issues are closed       | On issue close                 |
+| [Lint - Check wiki links][check-wiki-links]                                   | Checks that all wiki markdown files are linked in the SUMMARY.md             | Each PR that modifies the wiki |
+| [Lint - Inherit parent milestone][inherit-parent-milestone]                   | Inherits the milestone from the parent issue to the issue and its sub-issues | On issue open                  |
+| [Lint - Propagate milestone to sub-issues][propagate-milestone-to-sub-issues] | Propagates the milestone from the parent issue to its sub-issues             | On issue milestone change       |
 
 ### Manually run the linters
 
@@ -59,3 +61,5 @@ root
 [set-points-and-sprint-script]: ./scripts/set-points-and-sprint.sh
 [get-project-items-query]: ./queries/getItemMetadata.graphql
 [check-wiki-links]: ../workflows/ci-wiki-links.yml
+[inherit-parent-milestone]: ../workflows/lint-inherit-parent-milestone.yml
+[propagate-milestone-to-sub-issues]: ../workflows/lint-propagate-milestone-to-sub-issues.yml

--- a/.github/linters/scripts/inherit-parent-milestone.sh
+++ b/.github/linters/scripts/inherit-parent-milestone.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+##
+# This script inherits the milestone from the parent issue to the child issue.
+# It uses the GitHub CLI to fetch the issue and parent milestone details,
+# and then updates the issue milestone to match the parent's milestone.
+#
+# Usage: ./inherit_parent_milestone.sh [--dry-run] <issue-url>
+
+set -euo pipefail
+
+log() { echo "[info] $1"; }
+err() { echo "[error] $1" >&2; exit 1; }
+
+# #######################################################
+# Parse command line arguments
+# #######################################################
+
+dry_run=false
+issue_url=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -d|--dry-run)
+      dry_run=true
+      shift
+      ;;
+    *)
+      issue_url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$issue_url" ]]; then
+  echo "Usage: $0 [--dry-run] <issue-url>"
+  exit 1
+fi
+
+log "Issue URL: $issue_url"
+if [[ "$dry_run" == "true" ]]; then
+  log "Dry run mode enabled - no changes will be made"
+fi
+
+# #######################################################
+# Pluck a field from a JSON object
+# #######################################################
+
+pluck_field() {
+  local json_data="$1"
+  local field_path="$2"
+  local default_value="${3:-}"
+  jq -r "$field_path" <<< "$json_data"
+}
+
+# #######################################################
+# Define the GraphQL query
+# #######################################################
+
+graphql_query='
+query($url: URI!) {
+  resource(url: $url) {
+    ... on Issue {
+      number
+      repository { nameWithOwner }
+      milestone { number title }
+      parent: parent {
+        ... on Issue {
+          number
+          repository { nameWithOwner }
+          milestone { number title }
+        }
+      }
+    }
+  }
+}
+'
+
+# #######################################################
+# Fetch the issue and parent milestone details
+# #######################################################
+
+log "Fetching issue and parent milestone details using gh CLI..."
+data=$(
+  gh api graphql \
+    -F url="$issue_url" \
+    -f query="$graphql_query" \
+    --jq '.data.resource'
+)
+
+if [[ -z "$data" || "$data" == "null" ]]; then
+  err "Could not retrieve issue data. Check the URL and your authentication."
+fi
+
+# #######################################################
+# Parse issue and parent metadata
+# #######################################################
+
+# issue metadata
+issue_number=$(pluck_field "$data" '.number')
+issue_repo=$(pluck_field "$data" '.repository.nameWithOwner')
+issue_milestone_title=$(pluck_field "$data" '.milestone.title // empty')
+
+# parent issue metadata
+parent_issue=$(pluck_field "$data" '.parent')
+parent_repo=$(pluck_field "$parent_issue" '.repository.nameWithOwner')
+parent_number=$(pluck_field "$parent_issue" '.number')
+parent_milestone_title=$(pluck_field "$parent_issue" '.milestone.title // empty')
+
+# #######################################################
+# Check if the parent issue is in the same repo
+# #######################################################
+
+if [[ "$parent_repo" != "$issue_repo" ]]; then
+  log "Parent issue is not in the same repo ($issue_repo). Exiting."
+  exit 0
+fi
+
+if [[ "$parent_milestone_title" == "" ]]; then
+  log "Parent issue (#$parent_number) has no milestone. Exiting."
+  exit 0
+fi
+
+log "Parent issue: #$parent_number in $parent_repo, milestone: $parent_milestone_title"
+
+if [[ "$issue_milestone_title" == "$parent_milestone_title" ]]; then
+  log "Issue already has the same milestone as its parent. No action needed."
+  exit 0
+fi
+
+# #######################################################
+# Update the issue milestone
+# #######################################################
+
+log "Updating issue milestone to match parent..."
+
+if [[ "$dry_run" == "true" ]]; then
+  log "[DRY RUN] Would update issue #$issue_number milestone to \"$parent_milestone_title\""
+else
+  # Use gh CLI to set milestone by title
+  gh issue edit \
+    --repo "$issue_repo" \
+    --milestone "$parent_milestone_title" \
+    "$issue_number"
+
+  log "Issue milestone updated successfully to \"$parent_milestone_title\"."
+fi

--- a/.github/linters/scripts/propagate-milestone-to-sub-issues.sh
+++ b/.github/linters/scripts/propagate-milestone-to-sub-issues.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+##
+# This script inherits the milestone from the parent issue to the child issue.
+# It uses the GitHub CLI to fetch the issue and parent milestone details,
+# and then updates the issue milestone to match the parent's milestone.
+#
+# Usage: ./propagate-milestone-to-sub-issues.sh [--dry-run] <issue-url>
+
+set -euo pipefail
+
+log() { echo "[info] $1"; }
+err() { echo "[error] $1" >&2; exit 1; }
+
+# #######################################################
+# Parse command line arguments
+# #######################################################
+
+dry_run=false
+issue_url=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -d|--dry-run)
+      dry_run=true
+      shift
+      ;;
+    *)
+      issue_url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$issue_url" ]]; then
+  echo "Usage: $0 [--dry-run] <issue-url>"
+  exit 1
+fi
+
+log "Issue URL: $issue_url"
+if [[ "$dry_run" == "true" ]]; then
+  log "Dry run mode enabled - no changes will be made"
+fi
+
+# #######################################################
+# Pluck a field from a JSON object
+# #######################################################
+
+pluck_field() {
+  local json_data="$1"
+  local field_path="$2"
+  local default_value="${3:-}"
+  jq -r "$field_path" <<< "$json_data"
+}
+
+# #######################################################
+# Define the GraphQL query
+# #######################################################
+
+graphql_query='
+query($url: URI!) {
+  resource(url: $url) {
+    ... on Issue {
+      number
+      repository { nameWithOwner }
+      milestone { number title }
+      subIssues: subIssues(first: 100) {
+        nodes {
+          ... on Issue {
+            number
+            repository { nameWithOwner }
+            milestone { number title }
+          }
+        }
+      }
+    }
+  }
+}
+'
+
+# #######################################################
+# Fetch the issue and parent milestone details
+# #######################################################
+
+log "Fetching issue and parent milestone details using gh CLI..."
+data=$(
+  gh api graphql \
+    -F url="$issue_url" \
+    -f query="$graphql_query" \
+    --jq '.data.resource'
+)
+
+if [[ -z "$data" || "$data" == "null" ]]; then
+  err "Could not retrieve issue data. Check the URL and your authentication."
+fi
+
+# #######################################################
+# Parse issue metadata
+# #######################################################
+
+issue_number=$(pluck_field "$data" '.number')
+issue_repo=$(pluck_field "$data" '.repository.nameWithOwner')
+issue_milestone_title=$(pluck_field "$data" '.milestone.title // empty')
+sub_issues=$(pluck_field "$data" '.subIssues.nodes')
+
+# #######################################################
+# Check if the parent issue is in the same repo
+# #######################################################
+
+if [[ "$issue_milestone_title" == "" ]]; then
+  log "Parent issue (#$issue_number) has no milestone. Exiting."
+  exit 0
+fi
+
+log "Parent issue: #$issue_number in $issue_repo, milestone: $issue_milestone_title"
+
+# #######################################################
+# Filter the sub-issues and extract numbers
+# #######################################################
+
+# Filter the sub-issues for issues that:
+# - Are in the same repo
+# - Have a different milestone from the parent issue
+sub_issue_numbers=$(
+  echo "$sub_issues" |\
+  jq -r \
+    --arg repo "$issue_repo" \
+    --arg milestone "$issue_milestone_title" \
+    '.[] | select(
+      .repository.nameWithOwner == $repo
+      and (.milestone.title != $milestone or .milestone == null)
+    ) | .number'
+)
+
+# #######################################################
+# Update the sub-issues milestones
+# #######################################################
+
+# Read the numbers into an array
+issue_numbers=()
+while read -r number; do
+  if [[ -n "$number" ]]; then
+    issue_numbers+=("$number")
+  fi
+done <<< "$sub_issue_numbers"
+
+if [[ ${#issue_numbers[@]} -eq 0 ]]; then
+  log "No sub-issues need milestone updates. Exiting."
+  exit 0
+fi
+
+log "Found ${#issue_numbers[@]} sub-issues that need milestone updates"
+
+# Update each sub-issue's milestone
+for issue_number in "${issue_numbers[@]}"; do
+  log "Updating milestone for issue #$issue_number"
+
+  if [[ "$dry_run" == "true" ]]; then
+    log "[DRY RUN] Would update issue #$issue_number milestone to \"$issue_milestone_title\""
+  else
+    # Use gh CLI to set milestone by title
+    if gh issue edit \
+      --repo "$issue_repo" \
+      --milestone "$issue_milestone_title" \
+      "$issue_number"; then
+      log "Successfully updated milestone for issue #$issue_number to \"$issue_milestone_title\""
+    else
+      err "Failed to update milestone for issue #$issue_number"
+    fi
+  fi
+done
+
+if [[ "$dry_run" == "true" ]]; then
+  log "[DRY RUN] Would have updated milestones for ${#issue_numbers[@]} sub-issues"
+else
+  log "Finished updating milestones for all sub-issues"
+fi

--- a/.github/workflows/ci-project-linters.yml
+++ b/.github/workflows/ci-project-linters.yml
@@ -23,6 +23,10 @@ jobs:
       # Test issue with points and sprint values unset, but no linked PR,
       # to be used with set-points-and-sprint.sh test to demonstrate skipping
       ISSUE_WITHOUT_PR: "https://github.com/HHS/grants-product-and-delivery/issues/261"
+      # Test issue with parent, for inherit-parent-milestone.sh test
+      ISSUE_WITH_PARENT: "https://github.com/HHS/simpler-grants-gov/issues/5144"
+      # Test issue with sub-issues, for propagate-milestone-to-sub-issues.sh test
+      ISSUE_WITH_SUB_ISSUES: "https://github.com/HHS/simpler-grants-gov/issues/5107"
     steps:
       - uses: actions/checkout@v4
 
@@ -44,4 +48,14 @@ jobs:
             --project 17 \
             --sprint-field "Sprint" \
             --points-field "Points" \
+            --dry-run
+
+      - name: Dry run - Inherit parent milestone
+        run: |
+          ./scripts/inherit-parent-milestone.sh "${ISSUE_WITH_PARENT}" \
+            --dry-run
+
+      - name: Dry run - Propagate milestone to sub-issues
+        run: |
+          ./scripts/propagate-milestone-to-sub-issues.sh "${ISSUE_WITH_SUB_ISSUES}" \
             --dry-run

--- a/.github/workflows/lint-inherit-parent-milestone.yml
+++ b/.github/workflows/lint-inherit-parent-milestone.yml
@@ -1,0 +1,25 @@
+name: Lint - Inherit parent milestone
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+defaults:
+  run:
+    working-directory: ./.github/linters # ensures that this job runs from the ./linters sub-directory
+
+jobs:
+  inherit-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run inherit parent milestone script
+        run: |
+          ./scripts/inherit-parent-milestone.sh "${{ github.event.issue.html_url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-propagate-milestone-to-sub-issues.yml
+++ b/.github/workflows/lint-propagate-milestone-to-sub-issues.yml
@@ -28,9 +28,9 @@ jobs:
         id: set-url
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "url=${{ inputs.issue_url }}" >> $GITHUB_OUTPUT
+            echo "url=${{ inputs.issue_url }}" >> "$GITHUB_OUTPUT"
           else
-            echo "url=${{ github.event.issue.html_url }}" >> $GITHUB_OUTPUT
+            echo "url=${{ github.event.issue.html_url }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run propagate milestone to sub-issues script

--- a/.github/workflows/lint-propagate-milestone-to-sub-issues.yml
+++ b/.github/workflows/lint-propagate-milestone-to-sub-issues.yml
@@ -1,0 +1,40 @@
+name: Lint - Propagate milestone to sub-issues
+
+on:
+  issues:
+    types: [milestoned]
+  workflow_dispatch:
+    inputs:
+      issue_url:
+        description: "URL of the issue whose sub-issues should be updated"
+        required: true
+        type: string
+
+permissions:
+  issues: write
+
+defaults:
+  run:
+    working-directory: ./.github/linters # ensures that this job runs from the ./linters sub-directory
+
+jobs:
+  propagate-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set issue URL
+        id: set-url
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "url=${{ inputs.issue_url }}" >> $GITHUB_OUTPUT
+          else
+            echo "url=${{ github.event.issue.html_url }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run propagate milestone to sub-issues script
+        run: |
+          ./scripts/propagate-milestone-to-sub-issues.sh "${{ steps.set-url.outputs.url }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Sets up linters to propagate milestones from parent issues (e.g. Epics) to their sub issues (e.g. tasks) per the request in [this document](https://docs.google.com/document/d/1B04xDeg_9PnMu_4COVo7O6bnhnDE_QvD5uCf2rke9Ik/edit?tab=t.0#heading=h.sl8i9r9yex9j).

Fixes #5144 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

1. Adds script and GH action to inherit the parent issue's milestone when a new sub-issue is created
2. Adds script and GH action to update all sub-issues when a parent issue's milestone is changed
3. Adds these scripts to the README in the `.github/linter/` sub-directory

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

In the future there is a desire to propagate other values (e.g. fields from the product backlog board), but we're starting with milestone because that is the most commonly used and the easiest to implement.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

This was tested in a sandbox repo and here's a [loom](https://www.loom.com/share/8c48f0f332904755bcf830fde202c4ab) demoing the behavior.