### PR TITLE
[Issue #4712]  Clean up saved search page part 1

### DIFF
--- a/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
+++ b/frontend/src/components/workspace/DeleteSavedSearchModal.tsx
@@ -114,7 +114,7 @@ export function DeleteSavedSearchModal({
         className="padding-1 hover:bg-base-lightest"
         unstyled
       >
-        <USWDSIcon name="edit" key="delete-saved-search" />
+        <USWDSIcon name="delete" key="delete-saved-search" />
         {deleteText}
       </ModalToggleButton>
       <Modal

--- a/frontend/src/components/workspace/SavedSearchesList.tsx
+++ b/frontend/src/components/workspace/SavedSearchesList.tsx
@@ -36,11 +36,14 @@ export const SavedSearchesList = ({
                 <h2 className="margin-y-105 line-height-sans-2">
                   <Link
                     href={`/search${queryParamsToQueryString(savedSearch.searchParams)}savedSearch=${savedSearch.id}`}
-                    className="margin-right-05"
+                    className="margin-right-05 font-sans-lg"
                   >
+                    <USWDSIcon
+                      name="search"
+                      className="usa-icon--size-3 text-middle text-primary-dark margin-right-1"
+                    />
                     {savedSearch.name}
                   </Link>
-                  <USWDSIcon name="search" />
                 </h2>
               </div>
               <div className="grid-col margin-top-2 text-right">


### PR DESCRIPTION
## Summary

Fixes #4712 

## Changes proposed

saved queries page magnifying glass - match green color from designs, and move to left of link
use trash can icon for delete button
Fixed font size on Saved Search Link
[figma](https://www.figma.com/design/FGxWtAgToKhehLJCiuy1zL/Simpler.Grants.gov-Project?node-id=3436-37989&t=V65waFSHhQcKWpeu-4) 
## Context for reviewers

I also went ahead and fixed the font size on the saved search link to match the font-lg setting in Figma so that we wouldn't need to readjust the icon again once the font was correct. 

## Validation steps

![Screenshot 2025-05-27 at 1 09 50 PM](https://github.com/user-attachments/assets/c3613995-e408-4015-925d-c139e2984225)
![Screenshot 2025-05-27 at 1 09 33 PM](https://github.com/user-attachments/assets/bf98cf2c-0061-454b-9cd5-2df068e586d6)

