### PR TITLE
[Issue #5100] status and agency filters in drawer

### DIFF
--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -1,12 +1,16 @@
 import { SEARCH_NO_STATUS_VALUE } from "src/constants/search";
+import { getAgenciesForFilterOptions } from "src/services/fetch/fetchers/agenciesFetcher";
 import {
   QueryParamData,
   SearchAPIResponse,
 } from "src/types/search/searchRequestTypes";
 
 import { useTranslations } from "next-intl";
+import { Suspense } from "react";
+import { Accordion } from "@trussworks/react-uswds";
 
 import { CheckboxFilter } from "./Filters/CheckboxFilter";
+import { AgencyFilter } from "./SearchFilterAccordion/AgencyFilterAccordion";
 import {
   categoryOptions,
   eligibilityOptions,
@@ -22,7 +26,13 @@ export async function SearchDrawerFilters({
   searchResultsPromise: Promise<SearchAPIResponse>;
 }) {
   const t = useTranslations("Search");
-  const { eligibility, fundingInstrument, category, status } = searchParams;
+  const { eligibility, fundingInstrument, category, status, agency } =
+    searchParams;
+
+  const agenciesPromise = Promise.all([
+    getAgenciesForFilterOptions(),
+    searchResultsPromise,
+  ]);
 
   let searchResults;
   try {
@@ -57,6 +67,26 @@ export async function SearchDrawerFilters({
         filterOptions={eligibilityOptions}
         facetCounts={facetCounts?.applicant_type || {}}
       />
+      <Suspense
+        fallback={
+          <Accordion
+            bordered={true}
+            items={[
+              {
+                title: t("accordion.titles.agency"),
+                content: [],
+                expanded: false,
+                id: "opportunity-filter-agency-disabled",
+                headingLevel: "h2",
+              },
+            ]}
+            multiselectable={true}
+            className="margin-top-4"
+          />
+        }
+      >
+        <AgencyFilter query={agency} agencyOptionsPromise={agenciesPromise} />
+      </Suspense>
       <CheckboxFilter
         filterOptions={categoryOptions}
         query={category}

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -1,3 +1,4 @@
+import { SEARCH_NO_STATUS_VALUE } from "src/constants/search";
 import {
   QueryParamData,
   SearchAPIResponse,
@@ -10,6 +11,7 @@ import {
   categoryOptions,
   eligibilityOptions,
   fundingOptions,
+  statusOptions,
 } from "./SearchFilterAccordion/SearchFilterOptions";
 
 export async function SearchDrawerFilters({
@@ -20,7 +22,7 @@ export async function SearchDrawerFilters({
   searchResultsPromise: Promise<SearchAPIResponse>;
 }) {
   const t = useTranslations("Search");
-  const { eligibility, fundingInstrument, category } = searchParams;
+  const { eligibility, fundingInstrument, category, status } = searchParams;
 
   let searchResults;
   try {
@@ -33,6 +35,14 @@ export async function SearchDrawerFilters({
 
   return (
     <>
+      <CheckboxFilter
+        filterOptions={statusOptions}
+        query={status}
+        queryParamKey="status"
+        title={t("accordion.titles.status")}
+        defaultEmptySelection={new Set([SEARCH_NO_STATUS_VALUE])}
+        facetCounts={facetCounts?.opportunity_status || {}}
+      />
       <CheckboxFilter
         filterOptions={fundingOptions}
         query={fundingInstrument}

--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -3,6 +3,7 @@ import { SearchAPIResponse } from "src/types/search/searchRequestTypes";
 
 import { useTranslations } from "next-intl";
 
+import { CheckboxFilter } from "src/components/search/Filters/CheckboxFilter";
 import SearchFilterAccordion from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
 
 export async function AgencyFilterAccordion({
@@ -31,6 +32,36 @@ export async function AgencyFilterAccordion({
       queryParamKey={"agency"}
       title={t("accordion.titles.agency")}
       wrapForScroll={true}
+      facetCounts={facetCounts}
+    />
+  );
+}
+
+export async function AgencyFilter({
+  query,
+  agencyOptionsPromise,
+}: {
+  query: Set<string>;
+  agencyOptionsPromise: Promise<[FilterOption[], SearchAPIResponse]>;
+}) {
+  const t = useTranslations("Search");
+
+  let agencies: FilterOption[] = [];
+  let facetCounts: { [key: string]: number } = {};
+  try {
+    let searchResults: SearchAPIResponse;
+    [agencies, searchResults] = await agencyOptionsPromise;
+    facetCounts = searchResults.facet_counts.agency;
+  } catch (e) {
+    // Come back to this to show the user an error
+    console.error("Unable to fetch agencies for filter list", e);
+  }
+  return (
+    <CheckboxFilter
+      filterOptions={agencies}
+      query={query}
+      queryParamKey={"agency"}
+      title={t("accordion.titles.agency")}
       facetCounts={facetCounts}
     />
   );

--- a/frontend/tests/components/search/SearchDrawerFilters.test.tsx
+++ b/frontend/tests/components/search/SearchDrawerFilters.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import {
   fakeSearchAPIResponse,
   searchFetcherParams,
@@ -8,6 +8,13 @@ import { useTranslationsMock } from "src/utils/testing/intlMocks";
 import { SearchDrawerFilters } from "src/components/search/SearchDrawerFilters";
 
 const mockUpdateQueryParams = jest.fn();
+const mockGetAgenciesForFilterOptions = jest.fn().mockResolvedValue([]);
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    updateQueryParams: mockUpdateQueryParams,
+  }),
+}));
 
 jest.mock("src/hooks/useSearchParamUpdater", () => ({
   useSearchParamUpdater: () => ({
@@ -18,6 +25,16 @@ jest.mock("src/hooks/useSearchParamUpdater", () => ({
 jest.mock("next-intl", () => ({
   useTranslations: () => useTranslationsMock(),
 }));
+
+jest.mock("src/services/fetch/fetchers/agenciesFetcher", () => ({
+  getAgenciesForFilterOptions: () =>
+    mockGetAgenciesForFilterOptions() as unknown,
+}));
+
+// jest.mock("react", () => ({
+//   ...jest.requireActual<typeof import("react")>("react"),
+//   Suspense: ({ fallback }: { fallback: React.Component }) => fallback,
+// }));
 
 describe("SearchDrawerFilters", () => {
   it("renders without errors", async () => {
@@ -35,7 +52,12 @@ describe("SearchDrawerFilters", () => {
       searchParams: searchFetcherParams,
       searchResultsPromise: Promise.resolve(fakeSearchAPIResponse),
     });
-    render(component);
+
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    await act(() => {
+      return render(component);
+    });
+
     expect(
       screen.getByTestId("accordion.titles.funding-filter"),
     ).toBeInTheDocument();
@@ -45,5 +67,9 @@ describe("SearchDrawerFilters", () => {
     expect(
       screen.getByTestId("accordion.titles.category-filter"),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("accordion.titles.status-filter"),
+    ).toBeInTheDocument();
+    await screen.findByTestId("accordion.titles.agency-filter");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #5100

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds status and agency filters to filter drawer

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search?_ff=filterDrawerOn:true
3. open the filter drawer
4. _VERIFY_: status and agency filters are present in the drawer and work just like they would in the sidebar

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
