### PR TITLE
Double the RAM of nofo app containers to 4096 MB

### DIFF
--- a/infra/nofos/app-config/env-config/variables.tf
+++ b/infra/nofos/app-config/env-config/variables.tf
@@ -98,7 +98,7 @@ variable "instance_cpu" {
 variable "instance_memory" {
   description = "Memory in MiB for the ECS container instances"
   type        = number
-  default     = 2048
+  default     = 4096
 }
 
 variable "instance_desired_instance_count" {


### PR DESCRIPTION
## Summary

This is to help us migrate our data to the NOFOs environments. Once the data is migrated, we can bring this back down to 2048 where it was originally.