### PR TITLE
[Issue #5183] Better error logging when we have trouble talking to Sendy

### DIFF
--- a/frontend/src/app/[locale]/subscribe/actions.tsx
+++ b/frontend/src/app/[locale]/subscribe/actions.tsx
@@ -113,6 +113,7 @@ export async function subscribeEmailAction(
 
     // If the response is not ok or the response data is not what we expect, return an error message
     if (!sendyResponse.ok || !["1", "true"].includes(responseData)) {
+      console.error(JSON.stringify({ sendyResponse }));
       return {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         errorMessage,
@@ -122,7 +123,12 @@ export async function subscribeEmailAction(
   } catch (e) {
     // General try failure catch error
     const error = e as Error;
-    console.error("Error subscribing user:", error.message);
+    console.error(
+      "Error subscribing user:",
+      error.message,
+      " ",
+      error.cause?.toString(),
+    );
     return {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
       errorMessage,

--- a/frontend/src/app/[locale]/subscribe/actions.tsx
+++ b/frontend/src/app/[locale]/subscribe/actions.tsx
@@ -126,10 +126,7 @@ export async function subscribeEmailAction(
     // General try failure catch error
     const error = e as Error;
     console.error(
-      "Error subscribing user: Exception:",
-      error.message,
-      " ",
-      error.cause?.toString(),
+        `Error subscribing user: Exception: ${error.message} ${error.cause?.toString()}`
     );
     return {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call

--- a/frontend/src/app/[locale]/subscribe/actions.tsx
+++ b/frontend/src/app/[locale]/subscribe/actions.tsx
@@ -113,7 +113,9 @@ export async function subscribeEmailAction(
 
     // If the response is not ok or the response data is not what we expect, return an error message
     if (!sendyResponse.ok || !["1", "true"].includes(responseData)) {
-      console.error(JSON.stringify({ sendyResponse }));
+      console.error(
+        `Error subscribing user: Sendy returned an error response: ${responseData}, Status: ${sendyResponse.status}`,
+      );
       return {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         errorMessage,
@@ -124,7 +126,7 @@ export async function subscribeEmailAction(
     // General try failure catch error
     const error = e as Error;
     console.error(
-      "Error subscribing user:",
+      "Error subscribing user: Exception:",
       error.message,
       " ",
       error.cause?.toString(),

--- a/frontend/src/app/[locale]/subscribe/actions.tsx
+++ b/frontend/src/app/[locale]/subscribe/actions.tsx
@@ -126,7 +126,7 @@ export async function subscribeEmailAction(
     // General try failure catch error
     const error = e as Error;
     console.error(
-        `Error subscribing user: Exception: ${error.message} ${error.cause?.toString()}`
+      `Error subscribing user: Exception: ${error.message} ${error.cause?.toString() || ""}`,
     );
     return {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call

--- a/frontend/tests/pages/subscribe/SubscriptionForm.test.tsx
+++ b/frontend/tests/pages/subscribe/SubscriptionForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { mockMessages, useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import SubscriptionForm from "src/components/subscribe/SubscriptionForm";
@@ -28,7 +28,9 @@ describe("SubscriptionForm", () => {
     render(<SubscriptionForm />);
 
     const button = screen.getByRole("button", { name: "form.button" });
-    button.click();
+    act(() => {
+      button.click();
+    });
 
     expect(mockSubscribeEmail).toHaveBeenCalledWith(
       { errorMessage: "", validationErrors: {} },
@@ -54,7 +56,9 @@ describe("SubscriptionForm", () => {
     const { rerender } = render(<SubscriptionForm />);
 
     const button = screen.getByRole("button", { name: "form.button" });
-    button.click();
+    act(() => {
+      button.click();
+    });
 
     rerender(<SubscriptionForm />);
 

--- a/frontend/tests/pages/subscribe/subscribeEmailAction.test.tsx
+++ b/frontend/tests/pages/subscribe/subscribeEmailAction.test.tsx
@@ -77,7 +77,7 @@ describe("subscribeEmailAction", () => {
     try {
       await subscribeEmailAction(t, testFormData);
     } finally {
-      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledTimes(2);
     }
 
     // Test valid response


### PR DESCRIPTION
## Summary

Fixes #5183

## Changes proposed

Log more information in the NextJS server side logs (which will flow to NewRelic) when we have an error communicating with Sendy

## Context for reviewers

Sendy had been timing out but nothing in the logs made that easy to discover

## Validation steps
Examples of the 2 new errors that will log when we fail to reach Sendy or the Sendy call returns an error message:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/c6e82499-3086-4740-91f0-aa707c8de79c" />
