### PR TITLE
[Issue #5188] Lookup the app folder specific most recent hash (no later than the current ref being deployed)

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -40,9 +40,10 @@ jobs:
       - name: Get commit hash
         id: get-commit-hash
         run: |
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{inputs.ref}} ${{ inputs.app_name}})
           COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
-          echo "Commit hash: $COMMIT_HASH"
-          echo "commit_hash=$COMMIT_HASH" >> "$GITHUB_OUTPUT"
+          echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
+          echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
   build-and-publish:
     name: Build and publish
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          fetch-depth: 100
+          fetch-depth: 1000
       - name: Get commit hash
         id: get-commit-hash
         run: |
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-          fetch-depth: 100
+          fetch-depth: 1000
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 100
       - name: Get commit hash
         id: get-commit-hash
         run: |
@@ -58,6 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 100
 
       - name: Set up Terraform
         uses: ./.github/actions/setup-terraform

--- a/bin/is-image-published
+++ b/bin/is-image-published
@@ -8,7 +8,7 @@ app_name="$1"
 git_ref="$2"
 
 # Get commit hash
-image_tag=$(git log --pretty=format:'%H' -n 1 ${git_ref} ${app_name})
+image_tag=$(git log --pretty=format:'%H' -n 1 "${git_ref}" "${app_name}")
 
 # Need to init module when running in CD since GitHub actions does a fresh checkout of repo
 terraform -chdir="infra/$app_name/app-config" init >/dev/null

--- a/bin/is-image-published
+++ b/bin/is-image-published
@@ -8,7 +8,7 @@ app_name="$1"
 git_ref="$2"
 
 # Get commit hash
-image_tag=$(git rev-parse "${git_ref}")
+image_tag=$(git log --pretty=format:'%H' -n 1 ${git_ref} ${app_name})
 
 # Need to init module when running in CD since GitHub actions does a fresh checkout of repo
 terraform -chdir="infra/$app_name/app-config" init >/dev/null


### PR DESCRIPTION
## Summary

Fixes #5188

## Changes proposed

This change attempts to locate the most recent git commit hash within each app folder (which is not the same as the top level commit for 2 of 3 apps) and use that to check if the container already exists and can just be deployed as already built.

## Context for reviewers

Currently the deploy steps attempt to re-use already built containers (built for the lower environment). But due to it checking by the top level git hash associated with the merge/release, we will only ever find an existing container for the app that had the most recent git commit.

## Validation steps

<img width="1027" alt="image" src="https://github.com/user-attachments/assets/275a9dfa-75c7-4afb-84f5-7fbb7f8321b4" />
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/7fa33252-98aa-48bf-b188-1ea16bece549" />
Previously, the build and deploy steps would have checked if the top level repo HEAD existed as a frontend container. But c60e4a2a0b113fd5d91551b1ae676a7a7930844a was created by my commits working on the deploy scripts, so there wouldn't be a FE container representing that hash. So we would rebuild the FE container even though there was no changes to the FE. Now it will use the hash from the most recent commit to frontend folder specifically, 6f51edeb383bc1b0bc46da1fe2d3087f3e102a97 which is found, and deployed without rebuilding.

This is a bit contrived because I'm force running the FE deploy on a branch with no FE changes. But this mirrors how the Prod release works, where we deploy all 3 services, but usually at most one of those 3 services actually had changes in the most HEAD so we were rebuilding 2 of 3 services for every Prod Release.