### PR TITLE
[Issue #4716] add clear all filters button

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -84,7 +84,7 @@ const Footer = () => {
         <GridContainer>
           <Grid row gap>
             <Grid tablet={{ col: 4 }}>
-              <div className="footer-logo-container position-relative dekstop:height-5">
+              <div className="footer-logo-container position-relative">
                 <Image
                   className="height-auto position-relative"
                   alt={t("logoAlt")}

--- a/frontend/src/components/drawer/Drawer.tsx
+++ b/frontend/src/components/drawer/Drawer.tsx
@@ -18,7 +18,7 @@ export function Drawer({
 }: {
   drawerRef: RefObject<ModalRef | null>;
   drawerId: string;
-  headingText: string;
+  headingText: string | ReactNode;
   closeText: string;
   children: ReactNode;
 }) {
@@ -34,11 +34,11 @@ export function Drawer({
       id={drawerId}
       renderToPortal={!isSSR}
     >
-      <div className="width-full display-flex flex-column maxh-tablet">
+      <div className="width-full display-flex flex-column maxh-tablet height-full">
         <div className="flex-1">
           <ModalHeading id={`${drawerId}-heading`}>{headingText}</ModalHeading>
         </div>
-        <div className="overflow-auto border-top-05 flex-8 border-bottom-05 border-base-lightest padding-bottom-1">
+        <div className="overflow-auto border-top-05 flex-10 border-bottom-05 border-base-lightest padding-bottom-1">
           {children}
         </div>
         <div className="flex-1">

--- a/frontend/src/components/drawer/Drawer.tsx
+++ b/frontend/src/components/drawer/Drawer.tsx
@@ -34,14 +34,14 @@ export function Drawer({
       id={drawerId}
       renderToPortal={!isSSR}
     >
-      <div className="width-full display-flex flex-column maxh-tablet height-full">
-        <div className="flex-1">
+      <div className="width-full display-flex flex-column height-full">
+        <div className="flex-auto">
           <ModalHeading id={`${drawerId}-heading`}>{headingText}</ModalHeading>
         </div>
-        <div className="overflow-auto border-top-05 flex-10 border-bottom-05 border-base-lightest padding-bottom-1">
+        <div className="overflow-auto border-top-05 flex-fill border-bottom-05 border-base-lightest padding-bottom-1">
           {children}
         </div>
-        <div className="flex-1">
+        <div className="flex-auto">
           <ModalFooter>
             <ModalToggleButton
               modalRef={drawerRef}

--- a/frontend/src/components/drawer/DrawerUnit.tsx
+++ b/frontend/src/components/drawer/DrawerUnit.tsx
@@ -21,7 +21,7 @@ export function DrawerUnit({
   children: ReactNode;
   closeText: string;
   openText: string;
-  headingText: string;
+  headingText: string | ReactNode;
   iconName?: UswdsIconNames;
 }) {
   const drawerRef = useRef<ModalRef>(null);

--- a/frontend/src/components/search/ClearSearchButton.tsx
+++ b/frontend/src/components/search/ClearSearchButton.tsx
@@ -10,17 +10,19 @@ export function ClearSearchButton({
   buttonText,
   includeIcon = false,
   className,
+  paramsToClear,
 }: {
   buttonText: string;
   includeIcon?: boolean;
   className?: string;
+  paramsToClear?: string[];
 }) {
   const { clearQueryParams } = useSearchParamUpdater();
   return (
     <Button
       unstyled
       type="button"
-      onClick={() => clearQueryParams()}
+      onClick={() => clearQueryParams(paramsToClear)}
       className={className}
     >
       {includeIcon && (

--- a/frontend/src/components/search/ClearSearchButton.tsx
+++ b/frontend/src/components/search/ClearSearchButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+
+import { Button } from "@trussworks/react-uswds";
+
+import { USWDSIcon } from "src/components/USWDSIcon";
+
+export function ClearSearchButton({
+  buttonText,
+  includeIcon = false,
+  className,
+}: {
+  buttonText: string;
+  includeIcon?: boolean;
+  className?: string;
+}) {
+  const { clearQueryParams } = useSearchParamUpdater();
+  return (
+    <Button
+      unstyled
+      type="button"
+      onClick={() => clearQueryParams()}
+      className={className}
+    >
+      {includeIcon && (
+        <USWDSIcon
+          name="close"
+          className="margin-right-05 margin-left-neg-05"
+        />
+      )}
+      {buttonText}
+    </Button>
+  );
+}

--- a/frontend/src/components/search/SearchDrawerHeading.tsx
+++ b/frontend/src/components/search/SearchDrawerHeading.tsx
@@ -1,20 +1,14 @@
-"use client";
-
-import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
-
 import { useTranslations } from "next-intl";
-import { Button } from "@trussworks/react-uswds";
+
+import { ClearSearchButton } from "./ClearSearchButton";
 
 export function SearchDrawerHeading() {
   const t = useTranslations("Search.drawer");
-  const { clearQueryParams } = useSearchParamUpdater();
   return (
     <div className="display-flex">
       <div className="flex-2">{t("title")}</div>
       <div className="flex-1">
-        <Button unstyled type="button" onClick={() => clearQueryParams()}>
-          {t("clearAll")}
-        </Button>
+        <ClearSearchButton buttonText={t("clearAll")} />
       </div>
     </div>
   );

--- a/frontend/src/components/search/SearchDrawerHeading.tsx
+++ b/frontend/src/components/search/SearchDrawerHeading.tsx
@@ -11,7 +11,7 @@ export function SearchDrawerHeading() {
       <div className="flex-2">{t("title")}</div>
       <div className="flex-1">
         <ClearSearchButton
-          buttonText={t("clearAll")}
+          buttonText={t("clearFilters")}
           paramsToClear={[...searchFilterNames]}
         />
       </div>

--- a/frontend/src/components/search/SearchDrawerHeading.tsx
+++ b/frontend/src/components/search/SearchDrawerHeading.tsx
@@ -1,3 +1,5 @@
+import { searchFilterNames } from "src/types/search/searchFilterTypes";
+
 import { useTranslations } from "next-intl";
 
 import { ClearSearchButton } from "./ClearSearchButton";
@@ -8,7 +10,10 @@ export function SearchDrawerHeading() {
     <div className="display-flex">
       <div className="flex-2">{t("title")}</div>
       <div className="flex-1">
-        <ClearSearchButton buttonText={t("clearAll")} />
+        <ClearSearchButton
+          buttonText={t("clearAll")}
+          paramsToClear={[...searchFilterNames]}
+        />
       </div>
     </div>
   );

--- a/frontend/src/components/search/SearchDrawerHeading.tsx
+++ b/frontend/src/components/search/SearchDrawerHeading.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+
+import { useTranslations } from "next-intl";
+import { Button } from "@trussworks/react-uswds";
+
+export function SearchDrawerHeading() {
+  const t = useTranslations("Search.drawer");
+  const { clearQueryParams } = useSearchParamUpdater();
+  return (
+    <div className="display-flex">
+      <div className="flex-2">{t("title")}</div>
+      <div className="flex-1">
+        <Button unstyled type="button" onClick={() => clearQueryParams()}>
+          {t("clearAll")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -13,7 +13,6 @@ import { SaveSearchPanel } from "src/components/search/SaveSearchPanel";
 import SearchAnalytics from "src/components/search/SearchAnalytics";
 import SearchBar from "src/components/search/SearchBar";
 import SearchResults from "src/components/search/SearchResults";
-import { ClearSearchButton } from "./ClearSearchButton";
 import { SearchDrawerFilters } from "./SearchDrawerFilters";
 import { SearchDrawerHeading } from "./SearchDrawerHeading";
 
@@ -72,17 +71,6 @@ export function SearchVersionTwo({
                 <SaveSearchPanel />
               </div>
             </div>
-          </div>
-          <div className="desktop:display-flex desktop:margin-bottom-2 desktop:margin-top-0 margin-top-2">
-            <div className="flex-6"></div>
-            <div className="flex-3">
-              <ClearSearchButton
-                buttonText={t("drawer.clearAll")}
-                includeIcon={true}
-                className="display-block margin-x-auto"
-              />
-            </div>
-            <div className="flex-3"></div>
           </div>
           <SearchResults
             searchParams={convertedSearchParams}

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -14,6 +14,7 @@ import SearchAnalytics from "src/components/search/SearchAnalytics";
 import SearchBar from "src/components/search/SearchBar";
 import SearchResults from "src/components/search/SearchResults";
 import { SearchDrawerFilters } from "./SearchDrawerFilters";
+import { SearchDrawerHeading } from "./SearchDrawerHeading";
 
 export function SearchVersionTwo({
   searchParams,
@@ -57,7 +58,7 @@ export function SearchVersionTwo({
                   drawerId="search-filter-drawer"
                   closeText={t("drawer.submit")}
                   openText={t("filterDisplayToggle.drawer")}
-                  headingText={t("drawer.title")}
+                  headingText={<SearchDrawerHeading />}
                   iconName="filter_list"
                 >
                   <SearchDrawerFilters

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -13,6 +13,7 @@ import { SaveSearchPanel } from "src/components/search/SaveSearchPanel";
 import SearchAnalytics from "src/components/search/SearchAnalytics";
 import SearchBar from "src/components/search/SearchBar";
 import SearchResults from "src/components/search/SearchResults";
+import { ClearSearchButton } from "./ClearSearchButton";
 import { SearchDrawerFilters } from "./SearchDrawerFilters";
 import { SearchDrawerHeading } from "./SearchDrawerHeading";
 
@@ -52,7 +53,7 @@ export function SearchVersionTwo({
                 queryTermFromParent={convertedSearchParams.query}
               />
             </div>
-            <div className="display-flex desktop:flex-5 dsektop:margin-top-0">
+            <div className="display-flex desktop:flex-5">
               <div className="flex-2 flex-align-self-end">
                 <DrawerUnit
                   drawerId="search-filter-drawer"
@@ -71,6 +72,17 @@ export function SearchVersionTwo({
                 <SaveSearchPanel />
               </div>
             </div>
+          </div>
+          <div className="desktop:display-flex desktop:margin-bottom-2 desktop:margin-top-0 margin-top-2">
+            <div className="flex-6"></div>
+            <div className="flex-3">
+              <ClearSearchButton
+                buttonText={t("drawer.clearAll")}
+                includeIcon={true}
+                className="display-block margin-x-auto"
+              />
+            </div>
+            <div className="flex-3"></div>
           </div>
           <SearchResults
             searchParams={convertedSearchParams}

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -66,11 +66,20 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 
+  const clearQueryParams = (paramsToRemove?: string[]) => {
+    const paramsToClear = paramsToRemove || Array.from(params.keys());
+    paramsToClear.forEach((paramKey) => {
+      params.delete(paramKey);
+    });
+    router.push(`${pathname}${paramsToFormattedQuery(params)}`);
+  };
+
   return {
     searchParams,
     updateQueryParams,
     replaceQueryParams,
     removeQueryParam,
     setQueryParam,
+    clearQueryParams,
   };
 }

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -439,6 +439,7 @@ export const messages = {
     drawer: {
       title: "Filters",
       submit: "View results",
+      clearAll: "Clear all",
     },
     callToAction: {
       title: "Search funding opportunities",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -439,7 +439,7 @@ export const messages = {
     drawer: {
       title: "Filters",
       submit: "View results",
-      clearAll: "Clear all",
+      clearFilters: "Clear filters",
     },
     callToAction: {
       title: "Search funding opportunities",

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -518,5 +518,9 @@ button.usa-pagination__button.usa-button {
   }
   .usa-modal__main {
     width: 100%;
+    height: 100%;
+  }
+  .usa-modal__content {
+    height: 100%;
   }
 }

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -519,6 +519,7 @@ button.usa-pagination__button.usa-button {
   .usa-modal__main {
     width: 100%;
     height: 100%;
+    min-height: 0;
   }
   .usa-modal__content {
     height: 100%;

--- a/frontend/tests/components/search/ClearSearchButton.test.tsx
+++ b/frontend/tests/components/search/ClearSearchButton.test.tsx
@@ -8,7 +8,8 @@ const mockClearQueryParams = jest.fn();
 
 jest.mock("src/hooks/useSearchParamUpdater", () => ({
   useSearchParamUpdater: () => ({
-    clearQueryParams: () => mockClearQueryParams() as unknown,
+    clearQueryParams: (params: unknown) =>
+      mockClearQueryParams(params) as unknown,
   }),
 }));
 
@@ -27,8 +28,18 @@ describe("ClearSearchButton", () => {
     const button = screen.getByRole("button");
     await userEvent.click(button);
 
-    expect(mockClearQueryParams).toHaveBeenCalled();
+    expect(mockClearQueryParams).toHaveBeenCalledWith(undefined);
   });
+  it("calls clearQueryParams with `paramsToClear` if provided", async () => {
+    const paramsToClear = ["a", "bunch", "of", "random", "keys"];
+    render(<ClearSearchButton buttonText="hi" paramsToClear={paramsToClear} />);
+
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+
+    expect(mockClearQueryParams).toHaveBeenCalledWith(paramsToClear);
+  });
+
   it("includes icon where directed", () => {
     render(<ClearSearchButton buttonText="hi" includeIcon={true} />);
 

--- a/frontend/tests/components/search/ClearSearchButton.test.tsx
+++ b/frontend/tests/components/search/ClearSearchButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+
+import { ClearSearchButton } from "src/components/search/ClearSearchButton";
+
+const mockClearQueryParams = jest.fn();
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    clearQueryParams: () => mockClearQueryParams() as unknown,
+  }),
+}));
+
+describe("ClearSearchButton", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("does not have any accessibility violations", async () => {
+    const { container } = render(<ClearSearchButton buttonText="hi" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+  it("calls clearQueryParams on click", async () => {
+    render(<ClearSearchButton buttonText="hi" />);
+
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+
+    expect(mockClearQueryParams).toHaveBeenCalled();
+  });
+  it("includes icon where directed", () => {
+    render(<ClearSearchButton buttonText="hi" includeIcon={true} />);
+
+    // not sure why it's hidden, likely a jest thing
+    const icon = screen.getByRole("img", { hidden: true });
+
+    expect(icon).toBeInTheDocument();
+  });
+  it("displays button text", () => {
+    render(<ClearSearchButton buttonText="hi" includeIcon={true} />);
+
+    const buttonText = screen.getByText("hi");
+
+    expect(buttonText).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/hooks/useSearchParamUpdater.test.ts
+++ b/frontend/tests/hooks/useSearchParamUpdater.test.ts
@@ -102,3 +102,18 @@ describe("useSearchParamUpdater", () => {
     });
   });
 });
+
+describe("clearQueryParams", () => {
+  it("clears all query params if no argument is passed", () => {
+    mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
+    const { result } = renderHook(() => useSearchParamUpdater());
+    result.current.clearQueryParams();
+    expect(routerPush).toHaveBeenCalledWith("/test?");
+  });
+  it("clears selected query params based on passed argument", () => {
+    mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
+    const { result } = renderHook(() => useSearchParamUpdater());
+    result.current.clearQueryParams(["removeMe"]);
+    expect(routerPush).toHaveBeenCalledWith("/test?keepMe=cool");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4716

## Changes proposed

**NOTE** this functionality all lives behind the `filterDrawerOn` feature flag

<!-- What was added, updated, or removed in this PR. -->

* creates button that will clear out query params from URL
* adds this button to the filter drawer
* adjusts some drawer styling to be more in line with designs

This does not add a clear button outside the drawer as requirements on that implementation are still TBD

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->


## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search?_ff=filterDrawerOn:true
3. open filter drawer and apply filters
5. click "view results"
5. _VERIFY_: results have updated to reflect filter selection
6. click "clear filters" button
7. _VERIFY_: status filter returns to default state
8. click "view results"
9.  _VERIFY_: results have updated to reflect filter selection
10. enter a search term and submit
11. open drawer
12. add a filter
13. click "clear filters"
14. _VERIFY_: filter param is removed, search query param remains in place

### Screenshots

<img width="1319" alt="Screenshot 2025-05-29 at 3 40 30 PM" src="https://github.com/user-attachments/assets/ccc49403-14d3-4997-afa5-03c5b9798689" />


