### PR TITLE
Require vulnerability scans to pass before NOFO app deploys

### DIFF
--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -40,8 +40,7 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [checks]
-    # needs: [checks, vulnerability-scans] <= enable when vulnerability scans have started passing
+    needs: [checks, vulnerability-scans]
     uses: ./.github/workflows/deploy-nofos.yml
     with:
       environment: ${{ inputs.environment || 'dev' }}


### PR DESCRIPTION

## Summary

Fixes #4949

Require vulnerability scans to pass before the NOFO Builder app deploys. Before this, it would always deploy as long as the unit tests were passing.


## Context for reviewers

Technically this issue is already closed but this is the final thing we needed to do.