### PR TITLE
[Issue #5059] redirect users on protected routes using x-redirectOnLogout header

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -115,6 +115,10 @@ const headers = [
         key: "Cache-Control",
         value: "no-store, must-revalidate",
       },
+      {
+        key: "x-redirectOnLogout",
+        value: "1",
+      },
     ],
   },
   // don't cache if users has a session cookie

--- a/frontend/src/components/user/UserControl.tsx
+++ b/frontend/src/components/user/UserControl.tsx
@@ -4,7 +4,7 @@ import { useUser } from "src/services/auth/useUser";
 import { UserProfile } from "src/types/authTypes";
 
 import { useTranslations } from "next-intl";
-import { useRouter } from "next/navigation";
+import { redirect, usePathname, useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import {
   IconListContent,
@@ -124,6 +124,7 @@ export const UserControl = () => {
 
   const { user, logoutLocalUser } = useUser();
   const router = useRouter();
+  const pathname = usePathname();
 
   const logout = useCallback(async (): Promise<void> => {
     // this isn't using the clientFetch hook because we don't really need all that added functionality here
@@ -131,9 +132,18 @@ export const UserControl = () => {
       method: "POST",
     });
 
+    const res = await fetch(pathname, {
+      method: "GET",
+    });
+
     logoutLocalUser();
-    router.refresh();
-  }, [logoutLocalUser, router]);
+
+    if (res.headers.has("x-redirectOnLogout")) {
+      redirect("/");
+    } else {
+      router.refresh(); // call router.refresh() before so we can grab the header in AuthenticationGate as 1 and redirect while also logging out
+    }
+  }, [logoutLocalUser, router, pathname]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

Fixes #5059 

## Changes proposed

This PR adds a `x-redirectOnLogout` header to `next.config.js` to routes which content are protected.

## Context for reviewers

The precedent to this pull request is #5074 which used url search parameters as an alternative to being able to log out users gracefully back to the homepage when authenticated. 

However, #5074 incurs the issue of being hacky as if `useSearchParams()` is called, a `<Suspense />` boundary **must** be placed around it ([https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout)) which for handling authentication hinders the UX with a temporary loading page on logouts [feedback](https://github.com/HHS/simpler-grants-gov/pull/5074#discussion_r2116064542).

As a solution to determining whether or not a route (or a series of routes that fall under a path name) are authenticated routes that desire the behavior of logging out back to the homepage, the `x-redirectOnLogout` header is used. By using the header instead of a search param or modified anonymous session token this prevents any unwanted mutation of the current user session or window location [feedback](https://github.com/HHS/simpler-grants-gov/pull/5074#discussion_r2116058548).

If any route wants the desired behavior of being able to log back out to the homepage the only change they must add to their route is adding the `x-redirectOnLogout` header in `next.config.js`. This allows for future authenticated pages to opt-out of the `redirectOnLogout` behavior if it is not necessary but still preserves the default behavior of refreshing the page and displaying the Need to Sign In Call To Action (CTA) if the headers is not applied.

## Validation steps
![headers-auth-control](https://github.com/user-attachments/assets/b3a1c673-ffce-46b9-8684-15770d3e3b2b)


