### PR TITLE
[Issue #5216] Update systemd for vuln failure

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     libgnutls30 \
     liblzma5 \
     xz-utils \
+    systemd \
   # Reduce the image size by clear apt cached lists
   # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
   && rm -fr /var/lib/apt/lists/* \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
         wget \
         libtasn1-6 \
         libgnutls30 \
+        systemd \
     # Reduce the image size by clear apt cached lists
     # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
     && rm -fr /var/lib/apt/lists/* \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -61,7 +61,7 @@ WORKDIR /frontend
 RUN apt-get update \
   && apt-get upgrade -y --no-install-recommends \
   && apt-get install -y --only-upgrade libc-bin libc6 \
-  && apt-get install --no-install-recommends --yes libtasn1-6 libgnutls30 liblzma5 \
+  && apt-get install --no-install-recommends --yes libtasn1-6 libgnutls30 liblzma5 systemd \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Fixes #5216

## Changes proposed

Force upgrade for systemd to get the fixed version

## Context for reviewers

Failed the daily vulnerability scan, so trying to pick up the fixed version that's not being picked up automatically yet.
https://github.com/HHS/simpler-grants-gov/actions/runs/15374800798/job/43258335513 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
