### PR TITLE
[Issue #4720] closing date filter

### DIFF
--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
-import { QueryContext } from "src/services/search/QueryProvider";
 
-import { useContext, useMemo } from "react";
+import { useMemo } from "react";
 
 import {
   BasicSearchFilterAccordion,
@@ -60,7 +59,8 @@ export function RadioButtonFilter({
                 label={option.label}
                 onChange={toggleRadioSelection}
                 value={option.value}
-                facetCount={facetCounts?.[option.value] || 0}
+                facetCount={facetCounts && (facetCounts?.[option.value] || 0)}
+                checked={query.has(option.value)}
               />
             </li>
           ))}

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -43,7 +43,7 @@ export function RadioButtonFilter({
               <SearchFilterRadio
                 id={`${title}-any-radio`}
                 name={`Any ${title}`}
-                label={`Any ${title}`}
+                label={`Any ${title.toLowerCase()}`}
                 onChange={toggleRadioSelection}
                 value={undefined}
                 facetCount={undefined}

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+import { QueryContext } from "src/services/search/QueryProvider";
+
+import { useContext, useMemo } from "react";
+
+import {
+  BasicSearchFilterAccordion,
+  SearchFilterAccordionProps,
+} from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
+import { SearchFilterRadio } from "src/components/search/SearchFilterRadio";
+
+export function RadioButtonFilter({
+  query,
+  queryParamKey,
+  title,
+  wrapForScroll = true,
+  includeAnyOption = true,
+  filterOptions,
+  facetCounts,
+}: SearchFilterAccordionProps) {
+  const { setQueryParam } = useSearchParamUpdater();
+
+  const toggleRadioSelection = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQueryParam(queryParamKey, event.target.value);
+  };
+
+  const isNoneSelected = useMemo(() => query.size === 0, [query]);
+
+  return (
+    <BasicSearchFilterAccordion
+      query={query}
+      queryParamKey={queryParamKey}
+      title={title}
+      wrapForScroll={wrapForScroll}
+      expanded={!!query.size}
+      className="width-100 padding-right-5"
+    >
+      <div data-testid={`${title}-filter`}>
+        <ul className="usa-list usa-list--unstyled">
+          {includeAnyOption && (
+            <li>
+              <SearchFilterRadio
+                id={`${title}-any-radio`}
+                name={`Any ${title}`}
+                label={`Any ${title}`}
+                onChange={toggleRadioSelection}
+                value={undefined}
+                facetCount={undefined}
+                checked={isNoneSelected}
+              />
+            </li>
+          )}
+          {filterOptions.map((option) => (
+            <li key={option.id}>
+              <SearchFilterRadio
+                id={option.id}
+                name={option.label}
+                label={option.label}
+                onChange={toggleRadioSelection}
+                value={option.value}
+                facetCount={facetCounts?.[option.value] || 0}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </BasicSearchFilterAccordion>
+  );
+}

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -13,6 +13,7 @@ import { CheckboxFilter } from "./Filters/CheckboxFilter";
 import { AgencyFilter } from "./SearchFilterAccordion/AgencyFilterAccordion";
 import {
   categoryOptions,
+  closeDateOptions,
   eligibilityOptions,
   fundingOptions,
   statusOptions,
@@ -26,8 +27,14 @@ export async function SearchDrawerFilters({
   searchResultsPromise: Promise<SearchAPIResponse>;
 }) {
   const t = useTranslations("Search");
-  const { eligibility, fundingInstrument, category, status, agency } =
-    searchParams;
+  const {
+    eligibility,
+    fundingInstrument,
+    category,
+    status,
+    agency,
+    closeDate,
+  } = searchParams;
 
   const agenciesPromise = Promise.all([
     getAgenciesForFilterOptions(),
@@ -93,6 +100,13 @@ export async function SearchDrawerFilters({
         queryParamKey={"category"}
         title={t("accordion.titles.category")}
         facetCounts={facetCounts?.funding_category || {}}
+      />
+      <CheckboxFilter
+        filterOptions={closeDateOptions}
+        query={closeDate}
+        queryParamKey={"closeDate"}
+        title={t("accordion.titles.closeDate")}
+        facetCounts={{}}
       />
     </>
   );

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -107,7 +107,7 @@ export async function SearchDrawerFilters({
         query={closeDate}
         queryParamKey={"closeDate"}
         title={t("accordion.titles.closeDate")}
-        facetCounts={{}}
+        facetCounts={facetCounts?.close_date}
       />
     </>
   );

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -10,6 +10,7 @@ import { Suspense } from "react";
 import { Accordion } from "@trussworks/react-uswds";
 
 import { CheckboxFilter } from "./Filters/CheckboxFilter";
+import { RadioButtonFilter } from "./Filters/RadioButtonFilter";
 import { AgencyFilter } from "./SearchFilterAccordion/AgencyFilterAccordion";
 import {
   categoryOptions,
@@ -101,7 +102,7 @@ export async function SearchDrawerFilters({
         title={t("accordion.titles.category")}
         facetCounts={facetCounts?.funding_category || {}}
       />
-      <CheckboxFilter
+      <RadioButtonFilter
         filterOptions={closeDateOptions}
         query={closeDate}
         queryParamKey={"closeDate"}

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterCheckbox.tsx
@@ -19,7 +19,6 @@ const SearchFilterCheckbox: React.FC<SearchFilterCheckboxProps> = ({
   query,
   facetCounts,
 }) => {
-  console.log("!!!!", query, option);
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked;
     updateCheckedOption(event.target.value, checked);

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterCheckbox.tsx
@@ -19,6 +19,7 @@ const SearchFilterCheckbox: React.FC<SearchFilterCheckboxProps> = ({
   query,
   facetCounts,
 }) => {
+  console.log("!!!!", query, option);
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked;
     updateCheckedOption(event.target.value, checked);

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
@@ -152,3 +152,26 @@ export const categoryOptions: FilterOption[] = [
   },
   { id: "category-other", label: "Other", value: "other" },
 ];
+
+export const closeDateOptions: FilterOption[] = [
+  {
+    id: "close-date-7",
+    label: "Next 7 days",
+    value: "7",
+  },
+  {
+    id: "close-date-30",
+    label: "Next 30 days",
+    value: "30",
+  },
+  {
+    id: "close-date-90",
+    label: "Next 90 days",
+    value: "90",
+  },
+  {
+    id: "close-date-120",
+    label: "Next 120 days",
+    value: "120",
+  },
+];

--- a/frontend/src/components/search/SearchFilterRadio.tsx
+++ b/frontend/src/components/search/SearchFilterRadio.tsx
@@ -19,7 +19,7 @@ export const SearchFilterRadio = ({
   name,
   label,
   onChange,
-  disabled = false, // Default enabled. Pass in a mounted from parent if necessary.
+  disabled = false,
   checked = false,
   value,
   facetCount,

--- a/frontend/src/components/search/SearchFilterRadio.tsx
+++ b/frontend/src/components/search/SearchFilterRadio.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React, { ReactNode } from "react";
+import { Radio } from "@trussworks/react-uswds";
+
+interface FilterRadioProps {
+  id: string;
+  name?: string;
+  label: ReactNode;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  checked?: boolean;
+  value?: string;
+  facetCount?: number;
+}
+
+export const SearchFilterRadio = ({
+  id,
+  name,
+  label,
+  onChange,
+  disabled = false, // Default enabled. Pass in a mounted from parent if necessary.
+  checked = false,
+  value,
+  facetCount,
+}: FilterRadioProps) => (
+  <Radio
+    id={id}
+    name={name || ""}
+    label={
+      <>
+        <span>{label}</span>
+        {facetCount && (
+          <span className="text-base-dark padding-left-05">{facetCount}</span>
+        )}
+      </>
+    }
+    onChange={onChange}
+    disabled={disabled}
+    checked={checked}
+    value={value || ""}
+  />
+);

--- a/frontend/src/components/search/SearchFilterRadio.tsx
+++ b/frontend/src/components/search/SearchFilterRadio.tsx
@@ -30,8 +30,8 @@ export const SearchFilterRadio = ({
     label={
       <>
         <span>{label}</span>
-        {facetCount && (
-          <span className="text-base-dark padding-left-05">{facetCount}</span>
+        {Number.isInteger(facetCount) && (
+          <span className="text-base-dark padding-left-05">[{facetCount}]</span>
         )}
       </>
     }

--- a/frontend/src/components/workspace/SavedSearchesList.tsx
+++ b/frontend/src/components/workspace/SavedSearchesList.tsx
@@ -76,7 +76,7 @@ export const SavedSearchesList = ({
                   return value ? (
                     <div key={key}>
                       <span className="text-bold">{paramDisplay}: </span>
-                      <span>{value.replaceAll(",", ", ")}</span>
+                      <span>{value.toString().replaceAll(",", ", ")}</span>
                     </div>
                   ) : null;
                 },

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -188,6 +188,7 @@ function convertSearchInputSetsToArrays(
       : [],
     agency: searchInputs.agency ? Array.from(searchInputs.agency) : [],
     category: searchInputs.category ? Array.from(searchInputs.category) : [],
+    closeDate: searchInputs.closeDate ? Array.from(searchInputs.closeDate) : [],
     query: searchInputs.query,
     sortby: searchInputs.sortby,
     page: searchInputs.page,

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -432,6 +432,7 @@ export const messages = {
         agency: "Agency",
         category: "Category",
         status: "Opportunity status",
+        closeDate: "Closing Date Range",
       },
       options: {
         status: {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -588,6 +588,7 @@ export const messages = {
       query: "Search terms",
       page: "Page",
       sortby: "Sort by",
+      closeDate: "Close date",
     },
     editModal: {
       loading: "Updating",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -432,7 +432,7 @@ export const messages = {
         agency: "Agency",
         category: "Category",
         status: "Opportunity status",
-        closeDate: "Closing Date Range",
+        closeDate: "Closing date range",
       },
       options: {
         status: {

--- a/frontend/src/types/search/searchFilterTypes.ts
+++ b/frontend/src/types/search/searchFilterTypes.ts
@@ -4,6 +4,7 @@ export const backendFilterNames = [
   "applicant_type",
   "agency",
   "funding_category",
+  "close_date",
 ] as const;
 
 export const searchFilterNames = [
@@ -12,6 +13,7 @@ export const searchFilterNames = [
   "eligibility",
   "agency",
   "category",
+  "closeDate",
 ] as const;
 
 export type FrontendFilterNames = (typeof searchFilterNames)[number];

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -8,6 +8,7 @@ export interface FilterQueryParamData {
   eligibility: Set<string>;
   agency: Set<string>;
   category: Set<string>;
+  closeDate: Set<string>;
 }
 
 // this is used for UI display so order matters

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -8,6 +8,7 @@ export interface FilterQueryParamData {
   eligibility: Set<string>;
   agency: Set<string>;
   category: Set<string>;
+  // closeDate: string[]; // order matters here, so using an array instead of set
   closeDate: Set<string>;
 }
 

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -8,7 +8,6 @@ export interface FilterQueryParamData {
   eligibility: Set<string>;
   agency: Set<string>;
   category: Set<string>;
-  // closeDate: string[]; // order matters here, so using an array instead of set
   closeDate: Set<string>;
 }
 

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -5,12 +5,16 @@ import { BackendFilterNames } from "./searchFilterTypes";
 import { FilterQueryParamData } from "./searchQueryTypes";
 import { SortOptions } from "./searchSortTypes";
 
+export type OneOfFilter = { one_of: string[] };
+export type DateRangeFilter = { start_date: string; end_date: string };
+
 export interface SearchFilterRequestBody {
-  opportunity_status?: { one_of: string[] };
-  funding_instrument?: { one_of: string[] };
-  applicant_type?: { one_of: string[] };
-  agency?: { one_of: string[] };
-  funding_category?: { one_of: string[] };
+  opportunity_status?: OneOfFilter;
+  funding_instrument?: OneOfFilter;
+  applicant_type?: OneOfFilter;
+  agency?: OneOfFilter;
+  funding_category?: OneOfFilter;
+  close_date?: DateRangeFilter;
 }
 
 export type PaginationOrderBy =

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -6,7 +6,7 @@ import { FilterQueryParamData } from "./searchQueryTypes";
 import { SortOptions } from "./searchSortTypes";
 
 export type OneOfFilter = { one_of: string[] };
-export type DateRangeFilter = { start_date: string; end_date: string };
+export type RelativeDateRangeFilter = { end_date_relative: string };
 
 export interface SearchFilterRequestBody {
   opportunity_status?: OneOfFilter;
@@ -14,7 +14,7 @@ export interface SearchFilterRequestBody {
   applicant_type?: OneOfFilter;
   agency?: OneOfFilter;
   funding_category?: OneOfFilter;
-  close_date?: DateRangeFilter;
+  close_date?: RelativeDateRangeFilter;
 }
 
 export type PaginationOrderBy =

--- a/frontend/src/utils/search/searchFormatUtils.ts
+++ b/frontend/src/utils/search/searchFormatUtils.ts
@@ -64,6 +64,7 @@ const toOneOfFilter = (data: Set<string>): OneOfFilter => {
     one_of: Array.from(data),
   };
 };
+
 const toRelativeDateRangeFilter = (
   data: Set<string>,
 ): RelativeDateRangeFilter => {

--- a/frontend/src/utils/search/searchFormatUtils.ts
+++ b/frontend/src/utils/search/searchFormatUtils.ts
@@ -63,12 +63,12 @@ const filterConfigurations = [
   },
 ] as const;
 
-const toOneOfFilter = (data: Set<string>): OneOfFilter => {
+export const toOneOfFilter = (data: Set<string>): OneOfFilter => {
   return {
     one_of: Array.from(data),
   };
 };
-const toRelativeDateRangeFilter = (
+export const toRelativeDateRangeFilter = (
   data: Set<string>,
 ): RelativeDateRangeFilter => {
   const convertedData = Array.from(data);
@@ -77,10 +77,12 @@ const toRelativeDateRangeFilter = (
   };
 };
 
-const fromOneOfFilter = (data: OneOfFilter): string =>
+export const fromOneOfFilter = (data: OneOfFilter): string =>
   data?.one_of?.length ? data.one_of.join(",") : "";
-// TODO implement this as a RELATIVE date range filter, which will take  build in optional support for ABSOLUTE
-const fromRelativeDateRangeFilter = (data: RelativeDateRangeFilter): string => {
+
+export const fromRelativeDateRangeFilter = (
+  data: RelativeDateRangeFilter,
+): string => {
   return data?.end_date_relative;
 };
 

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -93,7 +93,7 @@ function paramToSet(param: QuerySetParam, type?: string): Set<string> {
 }
 
 // for now, assuming that param values represent "number of days from the current day"
-function paramToDateRange(paramValue?: string): Set<string> {
+export function paramToDateRange(paramValue?: string): Set<string> {
   if (!paramValue) {
     return new Set();
   }

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -66,6 +66,7 @@ export function convertSearchParamsToProperTypes(
     eligibility: paramToSet(params.eligibility),
     agency: paramToSet(params.agency),
     category: paramToSet(params.category),
+    closeDate: paramToDateRange(params.closeDate),
     sortby: (params.sortby as SortOptions) || null, // Convert empty string to null if needed
 
     // Ensure page is at least 1 or default to 1 if undefined
@@ -89,6 +90,19 @@ function paramToSet(param: QuerySetParam, type?: string): Set<string> {
     return new Set(param);
   }
   return new Set(param.split(","));
+}
+
+// for now, assuming that param values represent "number of days from the current day"
+function paramToDateRange(selectedDates: QuerySetParam): Set<string> {
+  if (!selectedDates || !selectedDates.length || selectedDates.length > 2) {
+    return new Set();
+  }
+  // for relativeDates
+  if (selectedDates.length === 1) {
+    return new Set([selectedDates[0]]);
+  }
+  // for absolute dates, unused at the moment
+  return new Set([selectedDates[0], selectedDates[1]]);
 }
 
 // Keeps page >= 1.

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -93,10 +93,11 @@ function paramToSet(param: QuerySetParam, type?: string): Set<string> {
 }
 
 // for now, assuming that param values represent "number of days from the current day"
-function paramToDateRange(selectedDates: QuerySetParam): Set<string> {
-  if (!selectedDates || !selectedDates.length || selectedDates.length > 2) {
+function paramToDateRange(paramValue?: string): Set<string> {
+  if (!paramValue) {
     return new Set();
   }
+  const selectedDates = paramValue.split(",");
   // for relativeDates
   if (selectedDates.length === 1) {
     return new Set([selectedDates[0]]);

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -35,6 +35,7 @@ export const searchFetcherParams: QueryParamData = {
   agency: new Set(),
   category: new Set(),
   eligibility: new Set(),
+  closeDate: new Set(),
   query: "research",
   sortby: "opportunityNumberAsc",
   actionType: "fun" as SearchFetcherActionType,
@@ -101,6 +102,9 @@ export const fakeFacetCounts = {
     arbitraryKey: 1,
   },
   funding_category: {
+    arbitraryKey: 1,
+  },
+  close_date: {
     arbitraryKey: 1,
   },
 };

--- a/frontend/tests/api/search/export/route.test.ts
+++ b/frontend/tests/api/search/export/route.test.ts
@@ -20,6 +20,7 @@ const fakeConvertedParams = {
   category: new Set(),
   eligibility: new Set(),
   fundingInstrument: new Set(),
+  closeDate: new Set(),
   page: 1,
   query: "",
   sortby: null,

--- a/frontend/tests/components/search/SearchFilterRadio.test.tsx
+++ b/frontend/tests/components/search/SearchFilterRadio.test.tsx
@@ -1,0 +1,80 @@
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { render, screen } from "tests/react-utils";
+
+import React from "react";
+
+import { SearchFilterRadio } from "src/components/search/SearchFilterRadio";
+
+const mockOnChange = jest.fn();
+
+describe("SearchFilterRadio", () => {
+  const baseProps = {
+    id: "test-radio",
+    name: "testRadioGroup",
+    label: "Test Radio Option",
+    onChange: mockOnChange,
+    checked: false,
+    value: "testValue",
+    facetCount: 3,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not have basic accessibility issues", async () => {
+    const { container } = render(<SearchFilterRadio {...baseProps} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("renders the radio button with correct label, name, and facet count", () => {
+    render(<SearchFilterRadio {...baseProps} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).toBeInTheDocument();
+    expect(radio).toHaveAttribute("type", "radio");
+    expect(radio).toHaveAttribute("name", baseProps.name);
+  });
+
+  it("calls onChange handler when clicked", async () => {
+    render(<SearchFilterRadio {...baseProps} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    await userEvent.click(radio);
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it("is checked when checked prop is true", () => {
+    render(<SearchFilterRadio {...baseProps} checked={true} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).toBeChecked();
+  });
+
+  it("is not checked when checked prop is false", () => {
+    render(<SearchFilterRadio {...baseProps} checked={false} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).not.toBeChecked();
+  });
+
+  it("renders without facet count if not provided", () => {
+    render(<SearchFilterRadio {...baseProps} facetCount={undefined} />);
+    const radio = screen.getByRole("radio", { name: "Test Radio Option" });
+    expect(radio).toBeInTheDocument();
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    render(<SearchFilterRadio {...baseProps} disabled={true} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).toBeDisabled();
+  });
+});

--- a/frontend/tests/components/search/SearchResults.test.tsx
+++ b/frontend/tests/components/search/SearchResults.test.tsx
@@ -58,6 +58,7 @@ describe("SearchResults", () => {
           category: new Set(),
           agency: new Set(),
           eligibility: new Set(),
+          closeDate: new Set(),
         }}
         loadingMessage={""}
         searchResultsPromise={Promise.resolve(fakeSearchAPIResponse)}

--- a/frontend/tests/components/workspace/SavedSearchesList.test.tsx
+++ b/frontend/tests/components/workspace/SavedSearchesList.test.tsx
@@ -53,6 +53,7 @@ const fakeParamDisplayMapping = {
   category: "category",
   page: "page",
   sortby: "sortby",
+  closeDate: "closeDate",
 };
 
 describe("SavedSearchesList", () => {

--- a/frontend/tests/errors.test.ts
+++ b/frontend/tests/errors.test.ts
@@ -9,6 +9,7 @@ describe("BadRequestError (as an example of other error types)", () => {
     eligibility: new Set(["public"]),
     agency: new Set(["NASA"]),
     category: new Set(["science"]),
+    closeDate: new Set(["500"]),
     query: "space exploration",
     sortby: "relevancy",
     page: 1,

--- a/frontend/tests/utils/Search/searchFormatUtils.test.ts
+++ b/frontend/tests/utils/Search/searchFormatUtils.test.ts
@@ -86,6 +86,17 @@ describe("buildFilters", () => {
     expect(filters.agency).toEqual(undefined);
     expect(filters.funding_category).toEqual(undefined);
   });
+  it("handles date ranges", () => {
+    const filters = buildFilters({
+      ...searchFetcherParams,
+      ...{
+        closeDate: new Set(["500"]),
+      },
+    });
+    expect(filters.close_date).toEqual({
+      end_date_relative: "500",
+    });
+  });
 });
 
 describe("buildPagination", () => {
@@ -204,6 +215,17 @@ describe("searchToQueryParams", () => {
 
     const emptyQueryParams = searchToQueryParams({} as SavedSearchQuery);
     expect(emptyQueryParams).toEqual({ query: "" });
+  });
+  it("correctly handles date ranges", () => {
+    const queryParams = searchToQueryParams({
+      ...fakeSavedSearch,
+      filters: {
+        ...fakeSavedSearch.filters,
+        close_date: { end_date_relative: "500" },
+      },
+    });
+
+    expect(queryParams.closeDate).toEqual("500");
   });
 });
 

--- a/frontend/tests/utils/search/searchUtils.test.ts
+++ b/frontend/tests/utils/search/searchUtils.test.ts
@@ -9,6 +9,7 @@ import {
   areSetsEqual,
   getAgencyDisplayName,
   paramsToFormattedQuery,
+  paramToDateRange,
   sortFilterOptions,
 } from "src/utils/search/searchUtils";
 import { fakeAgencyResponseData } from "src/utils/testing/fixtures";
@@ -354,5 +355,20 @@ describe("agenciesToFilterOptions", () => {
         value: "FAKEORG",
       },
     ]);
+  });
+});
+
+describe("paramToDateRange", () => {
+  it("returns empty set if no param value", () => {
+    expect(paramToDateRange()).toEqual(new Set());
+  });
+  it("returns first value in set if only one param value", () => {
+    expect(paramToDateRange("hi")).toEqual(new Set(["hi"]));
+  });
+  it("returns set of first two values (comma separated) in param otherwise", () => {
+    expect(paramToDateRange("hi,there")).toEqual(new Set(["hi", "there"]));
+    expect(paramToDateRange("hi,there,again")).toEqual(
+      new Set(["hi", "there"]),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4720

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

* adds a filter for opportunity close date to the filter drawer (behind the searchDrawerOn feature flag)
* refactors search filter helper functions to allow support for date range filters
* creates radio button filter components to support the new filter

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Most of the fun here is in the changes to the functionality to:
* build the filters for the search request
* translate the saved search payload into query params
* support radio buttons

The hope is that these functions should now be flexible enough to pretty easily handle other filter types in the future

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search?_ff=searchDrawerOn:true
3. open the filter drawer
4. _VERIFY_: there is a close date filter using radio buttons to filter for opportunties with close dates 7, 30, 90 or 120 days in the future
5. use the close date filter
6. _VERIFY_: search results update as expected
7. save a search that includes a close date filter
8. visit the saved searches page and click on your saved search
9. _VERIFY_: you're correctly delivered back to the search results page with close date filter enabled

### Screenshot

<img width="1261" alt="Screenshot 2025-06-03 at 12 26 03 PM" src="https://github.com/user-attachments/assets/818b95af-c17d-4ebf-a3eb-a870691bd5a3" />

