### PR TITLE
[Issue #5083] Add GET application attachment endpoint

### DIFF
--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -1,6 +1,10 @@
 from src.api.competition_alpha.competition_schema import CompetitionAlphaSchema
 from src.api.schemas.extension import Schema, fields
-from src.api.schemas.response_schema import AbstractResponseSchema, WarningMixinSchema
+from src.api.schemas.response_schema import (
+    AbstractResponseSchema,
+    FileResponseSchema,
+    WarningMixinSchema,
+)
 from src.constants.lookup_constants import ApplicationFormStatus
 
 
@@ -119,3 +123,27 @@ class ApplicationAttachmentCreateRequestSchema(Schema):
         allow_none=False,
         metadata={"description": "The file to attach to an application"},
     )
+
+
+class ApplicationAttachmentGetSchema(FileResponseSchema):
+    application_attachment_id = fields.UUID(
+        metadata={"description": "The ID of the uploaded application attachment"}
+    )
+
+    file_name = fields.String(
+        metadata={
+            "description": "The name of the application attachment file",
+            "example": "my_example.pdf",
+        }
+    )
+
+    mime_type = fields.String(
+        metadata={
+            "description": "The mime type / content type of the file",
+            "example": "application/pdf",
+        }
+    )
+
+
+class ApplicationAttachmentGetResponseSchema(AbstractResponseSchema):
+    data = fields.Nested(ApplicationAttachmentGetSchema())

--- a/api/src/db/models/competition_models.py
+++ b/api/src/db/models/competition_models.py
@@ -17,6 +17,7 @@ from src.db.models.lookup_models import (
 )
 from src.db.models.opportunity_models import Opportunity, OpportunityAssistanceListing
 from src.util.datetime_util import get_now_us_eastern_date
+from src.util.file_util import pre_sign_file_location
 
 # Add conditional import for type checking
 if TYPE_CHECKING:
@@ -290,6 +291,13 @@ class ApplicationAttachment(ApiSchemaTable, TimestampMixin):
     file_name: Mapped[str]
     mime_type: Mapped[str]
     file_size_bytes: Mapped[int] = mapped_column(BigInteger)
+
+    @property
+    def download_path(self) -> str:
+        """Get the presigned s3 url path for downloading the file"""
+        # NOTE: These attachments will only ever be in a non-public
+        # bucket so we only can presign their URL, we can't use the CDN path.
+        return pre_sign_file_location(self.file_location)
 
 
 class LinkCompetitionOpenToApplicant(ApiSchemaTable, TimestampMixin):

--- a/api/src/services/applications/get_application_attachment.py
+++ b/api/src/services/applications/get_application_attachment.py
@@ -1,0 +1,39 @@
+import logging
+import uuid
+
+from sqlalchemy import select
+
+import src.adapters.db as db
+from src.api.route_utils import raise_flask_error
+from src.db.models.competition_models import ApplicationAttachment
+from src.db.models.user_models import User
+from src.services.applications.get_application import get_application
+
+logger = logging.getLogger(__name__)
+
+
+def get_application_attachment(
+    db_session: db.Session,
+    application_id: uuid.UUID,
+    application_attachment_id: uuid.UUID,
+    user: User,
+) -> ApplicationAttachment:
+
+    # Fetch the application which also validates if the user can access it
+    application = get_application(db_session, application_id, user)
+
+    # Fetch the attachment
+    application_attachment = db_session.execute(
+        select(ApplicationAttachment).where(
+            ApplicationAttachment.application_id == application.application_id,
+            ApplicationAttachment.application_attachment_id == application_attachment_id,
+        )
+    ).scalar_one_or_none()
+
+    # 404 if not found
+    if not application_attachment:
+        raise_flask_error(
+            404, f"Application attachment with ID {application_attachment_id} not found"
+        )
+
+    return application_attachment


### PR DESCRIPTION
## Summary

Fixes #5083

## Changes proposed
Adds a new GET /applications/:application_id/attachments/:application_attachment_id endpoint to fetch application attachments.

## Context for reviewers
Endpoint itself is pretty uneventful, using a slightly different approach for presigning the s3 url to instead do it in a property rather than calculate and add it to the DB model. Some other PRs going on right now will look to do that as well as it should make things a bit easier to follow.

## Validation steps
`make db-seed-local` will make a competition with ID `fd7f5921-9585-48a5-ab0f-e726f4d1ef94`

Create a new application. Use the new upload attachment endpoint, and then fetch it.

This'll give a response roughly like:
```
{
  "data": {
    "application_attachment_id": "77de5306-c46e-4f77-b540-ea9480dfc30e",
    "created_at": "2025-06-03T17:58:21.570338+00:00",
    "download_path": "http://localhost:4566/local-mock-draft-bucket/applications/bec4ced3-f958-4d52-8d52-fa537aa51637/attachments/77de5306-c46e-4f77-b540-ea9480dfc30e/competition_metrics.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=NO_CREDS%2F20250603%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20250603T175846Z&X-Amz-Expires=7200&X-Amz-SignedHeaders=host&X-Amz-Signature=abc123",
    "file_name": "competition_metrics.csv",
    "file_size_bytes": 234610,
    "mime_type": "text/csv",
    "updated_at": "2025-06-03T17:58:21.570338+00:00"
  },
  "message": "Success",
  "status_code": 200
}
```
