### PR TITLE
[Issue #4722] add and / or (query operator) search option to frontend

### DIFF
--- a/frontend/src/components/search/AndOrPanel.tsx
+++ b/frontend/src/components/search/AndOrPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 
-import { useCallback } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { andOrOptions } from "./SearchFilterAccordion/SearchFilterOptions";
 import { SearchFilterRadio } from "./SearchFilterRadio";
@@ -14,31 +14,52 @@ export function AndOrPanel({
   hasSearchTerm: boolean;
   andOrParam: Set<string>;
 }) {
-  const { setStaticQueryParam, setQueryParam } = useSearchParamUpdater();
+  const {
+    // setStaticQueryParam,
+    setQueryParam,
+    setQueuedQueryParam,
+    // localParams,
+  } = useSearchParamUpdater();
+
+  const [localAndOrParam, setLocalAndOrParam] = useState<string | null>(
+    andOrParam.has("or") ? "or" : "and",
+  );
+
+  // const andOrParam = localParams.get("andOr");
 
   const toggleAndOrSelection = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       if (hasSearchTerm) {
+        setLocalAndOrParam(event.target.value);
         return setQueryParam("andOr", event.target.value);
       }
-      setStaticQueryParam("andOr", event.target.value);
+      const localParams = setQueuedQueryParam("andOr", event.target.value);
+      setLocalAndOrParam(localParams?.get("andOr"));
+      // setStaticQueryParam("andOr", event.target.value);
+      // return setQueryParam("andOr", event.target.value);
     },
     [hasSearchTerm],
   );
 
+  const checkedOptionValue = useMemo(() => {
+    if (!localAndOrParam || localAndOrParam === "and") {
+      return "and";
+    }
+    return "or";
+  }, [localAndOrParam]);
+
+  console.log("$$$ memo", checkedOptionValue);
   return andOrOptions.map((option) => {
+    console.log("$$$", option.value, localAndOrParam);
     return (
       <SearchFilterRadio
+        key={option.value}
         id={option.id}
         name={option.value}
         label={option.label}
         onChange={toggleAndOrSelection}
         value={option.value}
-        checked={
-          option.value === "and"
-            ? !andOrParam.size || andOrParam.has(option.value)
-            : andOrParam.has(option.value)
-        }
+        checked={option.value === checkedOptionValue}
       />
     );
   });

--- a/frontend/src/components/search/AndOrPanel.tsx
+++ b/frontend/src/components/search/AndOrPanel.tsx
@@ -1,55 +1,30 @@
 "use client";
 
-import { update } from "lodash";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { QueryContext } from "src/services/search/QueryProvider";
 
-import { useCallback, useContext, useMemo, useState } from "react";
+import { useCallback, useContext } from "react";
 
 import { andOrOptions } from "./SearchFilterAccordion/SearchFilterOptions";
 import { SearchFilterRadio } from "./SearchFilterRadio";
 
-export function AndOrPanel({
-  hasSearchTerm,
-  andOrParam,
-}: {
-  hasSearchTerm: boolean;
-  andOrParam: Set<string>;
-}) {
-  const {
-    // setStaticQueryParam,
-    setQueryParam,
-    // setQueuedQueryParam,
-    // // localParams,
-  } = useSearchParamUpdater();
+export function AndOrPanel({ hasSearchTerm }: { hasSearchTerm: boolean }) {
+  const { setQueryParam } = useSearchParamUpdater();
 
   const { localAndOrParam, updateLocalAndOrParam } = useContext(QueryContext);
 
-  // const [localAndOrParam, setLocalAndOrParam] = useState<string | null>(
-  //   andOrParam.has("or") ? "or" : "and",
-  // );
-
-  // const andOrParam = localParams.get("andOr");
-
   const toggleAndOrSelection = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
+      // when a search term is present, we're good with re-running the search with the new and/or
       if (hasSearchTerm) {
         updateLocalAndOrParam(event.target.value);
         return setQueryParam("andOr", event.target.value);
       }
-      // const localParams = setQueuedQueryParam("andOr", event.target.value);
+      // if a search term isn't present, queue up the and/or value to be applied when we run the next search
       updateLocalAndOrParam(event.target.value);
-      // setStaticQueryParam("andOr", event.target.value); // does not trigger any re-renders, so url updates but useSearchParams doesn't pick up the change
     },
     [hasSearchTerm],
   );
-
-  const checkedOptionValue = useMemo(() => {
-    if (!localAndOrParam || localAndOrParam === "and") {
-      return "and";
-    }
-    return "or";
-  }, [localAndOrParam]);
 
   return andOrOptions.map((option) => {
     return (
@@ -60,23 +35,12 @@ export function AndOrPanel({
         label={option.label}
         onChange={toggleAndOrSelection}
         value={option.value}
-        checked={option.value === checkedOptionValue}
+        checked={
+          !localAndOrParam
+            ? option.value === "AND"
+            : localAndOrParam === option.value
+        }
       />
     );
   });
-
-  // return (
-  //   <div>
-  //     <SearchFilterRadio
-  //       id="andOr-"
-  //       name={`Any ${title}`}
-  //       label={`Any ${title.toLowerCase()}`}
-  //       onChange={toggleAndOrSelection}
-  //       value={undefined}
-  //       facetCount={undefined}
-  //       checked={isNoneSelected}
-  //     />
-  //     <SearchFilterRadio />
-  //   </div>
-  // );
 }

--- a/frontend/src/components/search/AndOrPanel.tsx
+++ b/frontend/src/components/search/AndOrPanel.tsx
@@ -1,3 +1,60 @@
-export function AndOrPanel({ hasSearchTerm }: { hasSearchTerm: boolean }) {
-  return <div></div>;
+"use client";
+
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+
+import { useCallback } from "react";
+
+import { andOrOptions } from "./SearchFilterAccordion/SearchFilterOptions";
+import { SearchFilterRadio } from "./SearchFilterRadio";
+
+export function AndOrPanel({
+  hasSearchTerm,
+  andOrParam,
+}: {
+  hasSearchTerm: boolean;
+  andOrParam: Set<string>;
+}) {
+  const { setStaticQueryParam, setQueryParam } = useSearchParamUpdater();
+
+  const toggleAndOrSelection = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (hasSearchTerm) {
+        return setQueryParam("andOr", event.target.value);
+      }
+      setStaticQueryParam("andOr", event.target.value);
+    },
+    [hasSearchTerm],
+  );
+
+  return andOrOptions.map((option) => {
+    return (
+      <SearchFilterRadio
+        id={option.id}
+        name={option.value}
+        label={option.label}
+        onChange={toggleAndOrSelection}
+        value={option.value}
+        checked={
+          option.value === "and"
+            ? !andOrParam.size || andOrParam.has(option.value)
+            : andOrParam.has(option.value)
+        }
+      />
+    );
+  });
+
+  // return (
+  //   <div>
+  //     <SearchFilterRadio
+  //       id="andOr-"
+  //       name={`Any ${title}`}
+  //       label={`Any ${title.toLowerCase()}`}
+  //       onChange={toggleAndOrSelection}
+  //       value={undefined}
+  //       facetCount={undefined}
+  //       checked={isNoneSelected}
+  //     />
+  //     <SearchFilterRadio />
+  //   </div>
+  // );
 }

--- a/frontend/src/components/search/AndOrPanel.tsx
+++ b/frontend/src/components/search/AndOrPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { update } from "lodash";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { QueryContext } from "src/services/search/QueryProvider";
 
@@ -22,7 +23,7 @@ export function AndOrPanel({
     // // localParams,
   } = useSearchParamUpdater();
 
-  const { localAndOrParam, setLocalAndOrParam } = useContext(QueryContext);
+  const { localAndOrParam, updateLocalAndOrParam } = useContext(QueryContext);
 
   // const [localAndOrParam, setLocalAndOrParam] = useState<string | null>(
   //   andOrParam.has("or") ? "or" : "and",
@@ -33,11 +34,11 @@ export function AndOrPanel({
   const toggleAndOrSelection = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       if (hasSearchTerm) {
-        setLocalAndOrParam(event.target.value);
+        updateLocalAndOrParam(event.target.value);
         return setQueryParam("andOr", event.target.value);
       }
       // const localParams = setQueuedQueryParam("andOr", event.target.value);
-      setLocalAndOrParam(event.target.value);
+      updateLocalAndOrParam(event.target.value);
       // setStaticQueryParam("andOr", event.target.value); // does not trigger any re-renders, so url updates but useSearchParams doesn't pick up the change
     },
     [hasSearchTerm],

--- a/frontend/src/components/search/AndOrPanel.tsx
+++ b/frontend/src/components/search/AndOrPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+import { QueryContext } from "src/services/search/QueryProvider";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 import { andOrOptions } from "./SearchFilterAccordion/SearchFilterOptions";
 import { SearchFilterRadio } from "./SearchFilterRadio";
@@ -17,13 +18,15 @@ export function AndOrPanel({
   const {
     // setStaticQueryParam,
     setQueryParam,
-    setQueuedQueryParam,
-    // localParams,
+    // setQueuedQueryParam,
+    // // localParams,
   } = useSearchParamUpdater();
 
-  const [localAndOrParam, setLocalAndOrParam] = useState<string | null>(
-    andOrParam.has("or") ? "or" : "and",
-  );
+  const { localAndOrParam, setLocalAndOrParam } = useContext(QueryContext);
+
+  // const [localAndOrParam, setLocalAndOrParam] = useState<string | null>(
+  //   andOrParam.has("or") ? "or" : "and",
+  // );
 
   // const andOrParam = localParams.get("andOr");
 
@@ -33,10 +36,9 @@ export function AndOrPanel({
         setLocalAndOrParam(event.target.value);
         return setQueryParam("andOr", event.target.value);
       }
-      const localParams = setQueuedQueryParam("andOr", event.target.value);
-      setLocalAndOrParam(localParams?.get("andOr"));
-      // setStaticQueryParam("andOr", event.target.value);
-      // return setQueryParam("andOr", event.target.value);
+      // const localParams = setQueuedQueryParam("andOr", event.target.value);
+      setLocalAndOrParam(event.target.value);
+      // setStaticQueryParam("andOr", event.target.value); // does not trigger any re-renders, so url updates but useSearchParams doesn't pick up the change
     },
     [hasSearchTerm],
   );
@@ -48,9 +50,7 @@ export function AndOrPanel({
     return "or";
   }, [localAndOrParam]);
 
-  console.log("$$$ memo", checkedOptionValue);
   return andOrOptions.map((option) => {
-    console.log("$$$", option.value, localAndOrParam);
     return (
       <SearchFilterRadio
         key={option.value}

--- a/frontend/src/components/search/AndOrPanel.tsx
+++ b/frontend/src/components/search/AndOrPanel.tsx
@@ -1,0 +1,3 @@
+export function AndOrPanel({ hasSearchTerm }: { hasSearchTerm: boolean }) {
+  return <div></div>;
+}

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+
+import { useMemo } from "react";
+
+import {
+  BasicSearchFilterAccordion,
+  SearchFilterAccordionProps,
+} from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
+import { SearchFilterRadio } from "src/components/search/SearchFilterRadio";
+
+export function RadioButtonFilter({
+  query,
+  queryParamKey,
+  title,
+  wrapForScroll = true,
+  includeAnyOption = true,
+  filterOptions,
+  facetCounts,
+}: SearchFilterAccordionProps) {
+  const { setQueryParam } = useSearchParamUpdater();
+
+  const toggleRadioSelection = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setQueryParam(queryParamKey, event.target.value);
+  };
+
+  const isNoneSelected = useMemo(() => query.size === 0, [query]);
+
+  return (
+    <BasicSearchFilterAccordion
+      query={query}
+      queryParamKey={queryParamKey}
+      title={title}
+      wrapForScroll={wrapForScroll}
+      expanded={!!query.size}
+      className="width-100 padding-right-5"
+    >
+      <div data-testid={`${title}-filter`}>
+        <ul className="usa-list usa-list--unstyled">
+          {includeAnyOption && (
+            <li>
+              <SearchFilterRadio
+                id={`${title}-any-radio`}
+                name={`Any ${title}`}
+                label={`Any ${title.toLowerCase()}`}
+                onChange={toggleRadioSelection}
+                value={undefined}
+                facetCount={undefined}
+                checked={isNoneSelected}
+              />
+            </li>
+          )}
+          {filterOptions.map((option) => (
+            <li key={option.id}>
+              <SearchFilterRadio
+                id={option.id}
+                name={option.label}
+                label={option.label}
+                onChange={toggleRadioSelection}
+                value={option.value}
+                facetCount={facetCounts && (facetCounts?.[option.value] || 0)}
+                checked={query.has(option.value)}
+              />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </BasicSearchFilterAccordion>
+  );
+}

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -33,7 +33,7 @@ export default function SearchBar({
       setValidationError(undefined);
     }
     if (localAndOrParam) {
-      updateQueryParams("andOr", localAndOrParam, queryTerm);
+      updateQueryParams(localAndOrParam, "andOr", queryTerm);
       return;
     }
     updateQueryParams("", "", queryTerm);

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -18,7 +18,8 @@ export default function SearchBar({
   tableView = false,
 }: SearchBarProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const { queryTerm, updateQueryTerm } = useContext(QueryContext);
+  const { queryTerm, updateQueryTerm, localAndOrParam } =
+    useContext(QueryContext);
   const { updateQueryParams, searchParams } = useSearchParamUpdater();
   const t = useTranslations("Search");
   const [validationError, setValidationError] = useState<string>();
@@ -31,7 +32,11 @@ export default function SearchBar({
     if (validationError) {
       setValidationError(undefined);
     }
-    updateQueryParams("", "query", queryTerm);
+    if (localAndOrParam) {
+      updateQueryParams("andOr", localAndOrParam, queryTerm);
+      return;
+    }
+    updateQueryParams("", "", queryTerm);
   };
 
   // if we have "refresh=true" query param, clear the input

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -10,9 +10,11 @@ import { Suspense } from "react";
 import { Accordion } from "@trussworks/react-uswds";
 
 import { CheckboxFilter } from "./Filters/CheckboxFilter";
+import { RadioButtonFilter } from "./Filters/RadioButtonFilter";
 import { AgencyFilter } from "./SearchFilterAccordion/AgencyFilterAccordion";
 import {
   categoryOptions,
+  closeDateOptions,
   eligibilityOptions,
   fundingOptions,
   statusOptions,
@@ -26,8 +28,14 @@ export async function SearchDrawerFilters({
   searchResultsPromise: Promise<SearchAPIResponse>;
 }) {
   const t = useTranslations("Search");
-  const { eligibility, fundingInstrument, category, status, agency } =
-    searchParams;
+  const {
+    eligibility,
+    fundingInstrument,
+    category,
+    status,
+    agency,
+    closeDate,
+  } = searchParams;
 
   const agenciesPromise = Promise.all([
     getAgenciesForFilterOptions(),
@@ -93,6 +101,13 @@ export async function SearchDrawerFilters({
         queryParamKey={"category"}
         title={t("accordion.titles.category")}
         facetCounts={facetCounts?.funding_category || {}}
+      />
+      <RadioButtonFilter
+        filterOptions={closeDateOptions}
+        query={closeDate}
+        queryParamKey={"closeDate"}
+        title={t("accordion.titles.closeDate")}
+        facetCounts={facetCounts?.close_date}
       />
     </>
   );

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
@@ -152,3 +152,26 @@ export const categoryOptions: FilterOption[] = [
   },
   { id: "category-other", label: "Other", value: "other" },
 ];
+
+export const closeDateOptions: FilterOption[] = [
+  {
+    id: "close-date-7",
+    label: "Next 7 days",
+    value: "7",
+  },
+  {
+    id: "close-date-30",
+    label: "Next 30 days",
+    value: "30",
+  },
+  {
+    id: "close-date-90",
+    label: "Next 90 days",
+    value: "90",
+  },
+  {
+    id: "close-date-120",
+    label: "Next 120 days",
+    value: "120",
+  },
+];

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
@@ -175,3 +175,16 @@ export const closeDateOptions: FilterOption[] = [
     value: "120",
   },
 ];
+
+export const andOrOptions = [
+  {
+    id: "andOr-and",
+    label: "Must include all words (|ex. labor AND welfare|)",
+    value: "and",
+  },
+  {
+    id: "andOr-or",
+    label: "May include any words (|ex. labor OR welfare|)",
+    value: "or",
+  },
+];

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
@@ -180,11 +180,11 @@ export const andOrOptions = [
   {
     id: "andOr-and",
     label: "Must include all words (ex. labor AND welfare)",
-    value: "and",
+    value: "AND",
   },
   {
     id: "andOr-or",
     label: "May include any words (ex. labor OR welfare)",
-    value: "or",
+    value: "OR",
   },
 ];

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
@@ -179,12 +179,12 @@ export const closeDateOptions: FilterOption[] = [
 export const andOrOptions = [
   {
     id: "andOr-and",
-    label: "Must include all words (|ex. labor AND welfare|)",
+    label: "Must include all words (ex. labor AND welfare)",
     value: "and",
   },
   {
     id: "andOr-or",
-    label: "May include any words (|ex. labor OR welfare|)",
+    label: "May include any words (ex. labor OR welfare)",
     value: "or",
   },
 ];

--- a/frontend/src/components/search/SearchFilterRadio.tsx
+++ b/frontend/src/components/search/SearchFilterRadio.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React, { ReactNode } from "react";
+import { Radio } from "@trussworks/react-uswds";
+
+interface FilterRadioProps {
+  id: string;
+  name?: string;
+  label: ReactNode;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  checked?: boolean;
+  value?: string;
+  facetCount?: number;
+}
+
+export const SearchFilterRadio = ({
+  id,
+  name,
+  label,
+  onChange,
+  disabled = false,
+  checked = false,
+  value,
+  facetCount,
+}: FilterRadioProps) => (
+  <Radio
+    id={id}
+    name={name || ""}
+    label={
+      <>
+        <span>{label}</span>
+        {Number.isInteger(facetCount) && (
+          <span className="text-base-dark padding-left-05">[{facetCount}]</span>
+        )}
+      </>
+    }
+    onChange={onChange}
+    disabled={disabled}
+    checked={checked}
+    value={value || ""}
+  />
+);

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -13,6 +13,7 @@ import { SaveSearchPanel } from "src/components/search/SaveSearchPanel";
 import SearchAnalytics from "src/components/search/SearchAnalytics";
 import SearchBar from "src/components/search/SearchBar";
 import SearchResults from "src/components/search/SearchResults";
+import { AndOrPanel } from "./AndOrPanel";
 import { SearchDrawerFilters } from "./SearchDrawerFilters";
 import { SearchDrawerHeading } from "./SearchDrawerHeading";
 
@@ -72,6 +73,7 @@ export function SearchVersionTwo({
               </div>
             </div>
           </div>
+          <AndOrPanel hasSearchTerm={!!convertedSearchParams.query} />
           <SearchResults
             searchParams={convertedSearchParams}
             loadingMessage={t("loading")}

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -73,7 +73,10 @@ export function SearchVersionTwo({
               </div>
             </div>
           </div>
-          <AndOrPanel hasSearchTerm={!!convertedSearchParams.query} />
+          <AndOrPanel
+            hasSearchTerm={!!convertedSearchParams.query}
+            andOrParam={convertedSearchParams.andOr}
+          />
           <SearchResults
             searchParams={convertedSearchParams}
             loadingMessage={t("loading")}

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -73,10 +73,7 @@ export function SearchVersionTwo({
               </div>
             </div>
           </div>
-          <AndOrPanel
-            hasSearchTerm={!!convertedSearchParams.query}
-            andOrParam={convertedSearchParams.andOr}
-          />
+          <AndOrPanel hasSearchTerm={!!convertedSearchParams.query} />
           <SearchResults
             searchParams={convertedSearchParams}
             loadingMessage={t("loading")}

--- a/frontend/src/components/workspace/SavedSearchesList.tsx
+++ b/frontend/src/components/workspace/SavedSearchesList.tsx
@@ -76,7 +76,7 @@ export const SavedSearchesList = ({
                   return value ? (
                     <div key={key}>
                       <span className="text-bold">{paramDisplay}: </span>
-                      <span>{value.replaceAll(",", ", ")}</span>
+                      <span>{value.toString().replaceAll(",", ", ")}</span>
                     </div>
                   ) : null;
                 },

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -188,6 +188,7 @@ function convertSearchInputSetsToArrays(
       : [],
     agency: searchInputs.agency ? Array.from(searchInputs.agency) : [],
     category: searchInputs.category ? Array.from(searchInputs.category) : [],
+    closeDate: searchInputs.closeDate ? Array.from(searchInputs.closeDate) : [],
     query: searchInputs.query,
     sortby: searchInputs.sortby,
     page: searchInputs.page,

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -14,7 +14,7 @@ export function useSearchParamUpdater() {
   const params = new URLSearchParams(searchParams);
 
   // note that providing an empty string as `queryParamValue` will remove the param.
-  // also note that "query" is the name of a query param, but it being handled separately
+  // also note that "query" is the name of a query param, but it is being handled separately
   // in this implementation. To set a new keyword query in the url without touching other params,
   // you can use a call such as `updateQueryParams("", "query", queryTerm)`.
   const updateQueryParams = (
@@ -74,15 +74,25 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${paramsToFormattedQuery(params)}`);
   };
 
-  const setStaticQueryParam = (key: string, value: string) => {
+  // const setStaticQueryParam = (key: string, value: string) => {
+  //   params.set(key, value);
+  //   window.history.pushState(
+  //     null,
+  //     "",
+  //     `${pathname}${paramsToFormattedQuery(params)}`,
+  //   );
+  // };
+
+  // updates local query params but does not navigate
+  // queued query param update will be applied during next call to
+  // any other useSearchParamUpdater function
+  // returns the local params state
+  const setQueuedQueryParam = (key: string, value: string) => {
     params.set(key, value);
-    window.history.pushState(
-      null,
-      "",
-      `${pathname}${paramsToFormattedQuery(params)}`,
-    );
+    return params;
   };
 
+  console.log("$$$ local params", params);
   return {
     searchParams,
     updateQueryParams,
@@ -90,6 +100,8 @@ export function useSearchParamUpdater() {
     removeQueryParam,
     setQueryParam,
     clearQueryParams,
-    setStaticQueryParam,
+    // setStaticQueryParam,
+    setQueuedQueryParam,
+    // localParams: params,
   };
 }

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -74,6 +74,15 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${paramsToFormattedQuery(params)}`);
   };
 
+  const setStaticQueryParam = (key: string, value: string) => {
+    params.set(key, value);
+    window.history.pushState(
+      null,
+      "",
+      `${pathname}${paramsToFormattedQuery(params)}`,
+    );
+  };
+
   return {
     searchParams,
     updateQueryParams,
@@ -81,5 +90,6 @@ export function useSearchParamUpdater() {
     removeQueryParam,
     setQueryParam,
     clearQueryParams,
+    setStaticQueryParam,
   };
 }

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -432,6 +432,7 @@ export const messages = {
         agency: "Agency",
         category: "Category",
         status: "Opportunity status",
+        closeDate: "Closing date range",
       },
       options: {
         status: {
@@ -587,6 +588,7 @@ export const messages = {
       query: "Search terms",
       page: "Page",
       sortby: "Sort by",
+      closeDate: "Close date",
     },
     editModal: {
       loading: "Updating",

--- a/frontend/src/services/search/QueryProvider.tsx
+++ b/frontend/src/services/search/QueryProvider.tsx
@@ -24,6 +24,7 @@ export default function QueryProvider({
   const [queryTerm, setQueryTerm] = useState(defaultTerm);
   const [totalPages, setTotalPages] = useState("na");
   const [totalResults, setTotalResults] = useState("");
+  const [localAndOrParam, setLocalAndOrParam] = useState("");
 
   const updateQueryTerm = useCallback((term: string) => {
     setQueryTerm(term);
@@ -37,6 +38,10 @@ export default function QueryProvider({
     setTotalPages(page);
   }, []);
 
+  const updateLocalAndOrParam = useCallback((paramValue: string) => {
+    setLocalAndOrParam(paramValue);
+  }, []);
+
   const contextValue = useMemo(
     () => ({
       queryTerm,
@@ -45,6 +50,8 @@ export default function QueryProvider({
       updateTotalPages,
       totalResults,
       updateTotalResults,
+      updateLocalAndOrParam,
+      localAndOrParam,
     }),
     [
       queryTerm,
@@ -53,6 +60,8 @@ export default function QueryProvider({
       updateTotalPages,
       totalResults,
       updateTotalResults,
+      updateLocalAndOrParam,
+      localAndOrParam,
     ],
   );
 

--- a/frontend/src/services/search/QueryProvider.tsx
+++ b/frontend/src/services/search/QueryProvider.tsx
@@ -10,6 +10,8 @@ interface QueryContextParams {
   updateTotalPages: (page: string) => void;
   totalResults: string;
   updateTotalResults: (total: string) => void;
+  updateLocalAndOrParam: (value: string) => void;
+  localAndOrParam: string;
 }
 
 export const QueryContext = createContext({} as QueryContextParams);

--- a/frontend/src/types/search/searchFilterTypes.ts
+++ b/frontend/src/types/search/searchFilterTypes.ts
@@ -4,6 +4,7 @@ export const backendFilterNames = [
   "applicant_type",
   "agency",
   "funding_category",
+  "close_date",
 ] as const;
 
 export const searchFilterNames = [
@@ -12,6 +13,7 @@ export const searchFilterNames = [
   "eligibility",
   "agency",
   "category",
+  "closeDate",
 ] as const;
 
 export type FrontendFilterNames = (typeof searchFilterNames)[number];

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -8,6 +8,7 @@ export interface FilterQueryParamData {
   eligibility: Set<string>;
   agency: Set<string>;
   category: Set<string>;
+  closeDate: Set<string>;
 }
 
 // this is used for UI display so order matters

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -9,6 +9,7 @@ export interface FilterQueryParamData {
   agency: Set<string>;
   category: Set<string>;
   closeDate: Set<string>;
+  andOr: Set<string>;
 }
 
 // this is used for UI display so order matters

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -9,7 +9,6 @@ export interface FilterQueryParamData {
   agency: Set<string>;
   category: Set<string>;
   closeDate: Set<string>;
-  andOr: Set<string>;
 }
 
 // this is used for UI display so order matters

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -5,12 +5,16 @@ import { BackendFilterNames } from "./searchFilterTypes";
 import { FilterQueryParamData } from "./searchQueryTypes";
 import { SortOptions } from "./searchSortTypes";
 
+export type OneOfFilter = { one_of: string[] };
+export type RelativeDateRangeFilter = { end_date_relative: string };
+
 export interface SearchFilterRequestBody {
-  opportunity_status?: { one_of: string[] };
-  funding_instrument?: { one_of: string[] };
-  applicant_type?: { one_of: string[] };
-  agency?: { one_of: string[] };
-  funding_category?: { one_of: string[] };
+  opportunity_status?: OneOfFilter;
+  funding_instrument?: OneOfFilter;
+  applicant_type?: OneOfFilter;
+  agency?: OneOfFilter;
+  funding_category?: OneOfFilter;
+  close_date?: RelativeDateRangeFilter;
 }
 
 export type PaginationOrderBy =

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -17,6 +17,8 @@ export interface SearchFilterRequestBody {
   close_date?: RelativeDateRangeFilter;
 }
 
+export type QueryOperator = "AND" | "OR";
+
 export type PaginationOrderBy =
   | "relevancy"
   | "opportunity_id"
@@ -42,6 +44,7 @@ export type SearchRequestBody = {
   filters?: SearchFilterRequestBody;
   query?: string;
   format?: string;
+  query_operator?: QueryOperator;
 };
 
 export enum SearchFetcherActionType {
@@ -86,6 +89,7 @@ export interface QueryParamData extends FilterQueryParamData {
   page: number;
   sortby: SortOptions | null;
   query?: string | null;
+  andOr?: QueryOperator;
   actionType?: SearchFetcherActionType;
   fieldChanged?: string;
 }

--- a/frontend/src/utils/search/searchFormatUtils.ts
+++ b/frontend/src/utils/search/searchFormatUtils.ts
@@ -83,7 +83,7 @@ const fromRelativeDateRangeFilter = (data: RelativeDateRangeFilter): string => {
 
 // transforms raw query param data into structured search object format that the API needs
 export const formatSearchRequestBody = (searchInputs: QueryParamData) => {
-  const { query } = searchInputs;
+  const { query, andOr } = searchInputs;
 
   const filters = buildFilters(searchInputs);
   const pagination = buildPagination(searchInputs);
@@ -97,6 +97,9 @@ export const formatSearchRequestBody = (searchInputs: QueryParamData) => {
 
   if (query) {
     requestBody.query = query;
+  }
+  if (andOr) {
+    requestBody.query_operator = andOr;
   }
   return requestBody;
 };

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -66,6 +66,7 @@ export function convertSearchParamsToProperTypes(
     eligibility: paramToSet(params.eligibility),
     agency: paramToSet(params.agency),
     category: paramToSet(params.category),
+    closeDate: paramToDateRange(params.closeDate),
     sortby: (params.sortby as SortOptions) || null, // Convert empty string to null if needed
 
     // Ensure page is at least 1 or default to 1 if undefined
@@ -89,6 +90,20 @@ function paramToSet(param: QuerySetParam, type?: string): Set<string> {
     return new Set(param);
   }
   return new Set(param.split(","));
+}
+
+// for now, assuming that param values represent "number of days from the current day"
+export function paramToDateRange(paramValue?: string): Set<string> {
+  if (!paramValue) {
+    return new Set();
+  }
+  const selectedDates = paramValue.split(",");
+  // for relativeDates
+  if (selectedDates.length === 1) {
+    return new Set([selectedDates[0]]);
+  }
+  // for absolute dates, unused at the moment
+  return new Set([selectedDates[0], selectedDates[1]]);
 }
 
 // Keeps page >= 1.

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -7,6 +7,7 @@ import {
 } from "src/types/search/searchFilterTypes";
 import { QuerySetParam } from "src/types/search/searchQueryTypes";
 import {
+  QueryOperator,
   QueryParamData,
   SearchFetcherActionType,
 } from "src/types/search/searchRequestTypes";
@@ -67,7 +68,7 @@ export function convertSearchParamsToProperTypes(
     agency: paramToSet(params.agency),
     category: paramToSet(params.category),
     closeDate: paramToDateRange(params.closeDate),
-    andOr: paramToSet(params.andOr),
+    andOr: (params.andOr as QueryOperator) || "",
     sortby: (params.sortby as SortOptions) || null, // Convert empty string to null if needed
 
     // Ensure page is at least 1 or default to 1 if undefined

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -67,6 +67,7 @@ export function convertSearchParamsToProperTypes(
     agency: paramToSet(params.agency),
     category: paramToSet(params.category),
     closeDate: paramToDateRange(params.closeDate),
+    andOr: paramToSet(params.andOr),
     sortby: (params.sortby as SortOptions) || null, // Convert empty string to null if needed
 
     // Ensure page is at least 1 or default to 1 if undefined

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -35,6 +35,7 @@ export const searchFetcherParams: QueryParamData = {
   agency: new Set(),
   category: new Set(),
   eligibility: new Set(),
+  closeDate: new Set(),
   query: "research",
   sortby: "opportunityNumberAsc",
   actionType: "fun" as SearchFetcherActionType,
@@ -101,6 +102,9 @@ export const fakeFacetCounts = {
     arbitraryKey: 1,
   },
   funding_category: {
+    arbitraryKey: 1,
+  },
+  close_date: {
     arbitraryKey: 1,
   },
 };

--- a/frontend/tests/api/search/export/route.test.ts
+++ b/frontend/tests/api/search/export/route.test.ts
@@ -20,6 +20,7 @@ const fakeConvertedParams = {
   category: new Set(),
   eligibility: new Set(),
   fundingInstrument: new Set(),
+  closeDate: new Set(),
   page: 1,
   query: "",
   sortby: null,

--- a/frontend/tests/components/search/SearchFilterRadio.test.tsx
+++ b/frontend/tests/components/search/SearchFilterRadio.test.tsx
@@ -1,0 +1,80 @@
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import { render, screen } from "tests/react-utils";
+
+import React from "react";
+
+import { SearchFilterRadio } from "src/components/search/SearchFilterRadio";
+
+const mockOnChange = jest.fn();
+
+describe("SearchFilterRadio", () => {
+  const baseProps = {
+    id: "test-radio",
+    name: "testRadioGroup",
+    label: "Test Radio Option",
+    onChange: mockOnChange,
+    checked: false,
+    value: "testValue",
+    facetCount: 3,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not have basic accessibility issues", async () => {
+    const { container } = render(<SearchFilterRadio {...baseProps} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("renders the radio button with correct label, name, and facet count", () => {
+    render(<SearchFilterRadio {...baseProps} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).toBeInTheDocument();
+    expect(radio).toHaveAttribute("type", "radio");
+    expect(radio).toHaveAttribute("name", baseProps.name);
+  });
+
+  it("calls onChange handler when clicked", async () => {
+    render(<SearchFilterRadio {...baseProps} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    await userEvent.click(radio);
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it("is checked when checked prop is true", () => {
+    render(<SearchFilterRadio {...baseProps} checked={true} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).toBeChecked();
+  });
+
+  it("is not checked when checked prop is false", () => {
+    render(<SearchFilterRadio {...baseProps} checked={false} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).not.toBeChecked();
+  });
+
+  it("renders without facet count if not provided", () => {
+    render(<SearchFilterRadio {...baseProps} facetCount={undefined} />);
+    const radio = screen.getByRole("radio", { name: "Test Radio Option" });
+    expect(radio).toBeInTheDocument();
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    render(<SearchFilterRadio {...baseProps} disabled={true} />);
+    const radio = screen.getByRole("radio", {
+      name: /Test Radio Option \[3\]/,
+    });
+    expect(radio).toBeDisabled();
+  });
+});

--- a/frontend/tests/components/search/SearchResults.test.tsx
+++ b/frontend/tests/components/search/SearchResults.test.tsx
@@ -58,6 +58,7 @@ describe("SearchResults", () => {
           category: new Set(),
           agency: new Set(),
           eligibility: new Set(),
+          closeDate: new Set(),
         }}
         loadingMessage={""}
         searchResultsPromise={Promise.resolve(fakeSearchAPIResponse)}

--- a/frontend/tests/components/workspace/SavedSearchesList.test.tsx
+++ b/frontend/tests/components/workspace/SavedSearchesList.test.tsx
@@ -53,6 +53,7 @@ const fakeParamDisplayMapping = {
   category: "category",
   page: "page",
   sortby: "sortby",
+  closeDate: "closeDate",
 };
 
 describe("SavedSearchesList", () => {

--- a/frontend/tests/errors.test.ts
+++ b/frontend/tests/errors.test.ts
@@ -9,6 +9,7 @@ describe("BadRequestError (as an example of other error types)", () => {
     eligibility: new Set(["public"]),
     agency: new Set(["NASA"]),
     category: new Set(["science"]),
+    closeDate: new Set(["500"]),
     query: "space exploration",
     sortby: "relevancy",
     page: 1,

--- a/frontend/tests/utils/Search/searchFormatUtils.test.ts
+++ b/frontend/tests/utils/Search/searchFormatUtils.test.ts
@@ -86,6 +86,17 @@ describe("buildFilters", () => {
     expect(filters.agency).toEqual(undefined);
     expect(filters.funding_category).toEqual(undefined);
   });
+  it("handles date ranges", () => {
+    const filters = buildFilters({
+      ...searchFetcherParams,
+      ...{
+        closeDate: new Set(["500"]),
+      },
+    });
+    expect(filters.close_date).toEqual({
+      end_date_relative: "500",
+    });
+  });
 });
 
 describe("buildPagination", () => {
@@ -204,6 +215,17 @@ describe("searchToQueryParams", () => {
 
     const emptyQueryParams = searchToQueryParams({} as SavedSearchQuery);
     expect(emptyQueryParams).toEqual({ query: "" });
+  });
+  it("correctly handles date ranges", () => {
+    const queryParams = searchToQueryParams({
+      ...fakeSavedSearch,
+      filters: {
+        ...fakeSavedSearch.filters,
+        close_date: { end_date_relative: "500" },
+      },
+    });
+
+    expect(queryParams.closeDate).toEqual("500");
   });
 });
 

--- a/frontend/tests/utils/search/searchUtils.test.ts
+++ b/frontend/tests/utils/search/searchUtils.test.ts
@@ -9,6 +9,7 @@ import {
   areSetsEqual,
   getAgencyDisplayName,
   paramsToFormattedQuery,
+  paramToDateRange,
   sortFilterOptions,
 } from "src/utils/search/searchUtils";
 import { fakeAgencyResponseData } from "src/utils/testing/fixtures";
@@ -354,5 +355,20 @@ describe("agenciesToFilterOptions", () => {
         value: "FAKEORG",
       },
     ]);
+  });
+});
+
+describe("paramToDateRange", () => {
+  it("returns empty set if no param value", () => {
+    expect(paramToDateRange()).toEqual(new Set());
+  });
+  it("returns first value in set if only one param value", () => {
+    expect(paramToDateRange("hi")).toEqual(new Set(["hi"]));
+  });
+  it("returns set of first two values (comma separated) in param otherwise", () => {
+    expect(paramToDateRange("hi,there")).toEqual(new Set(["hi", "there"]));
+    expect(paramToDateRange("hi,there,again")).toEqual(
+      new Set(["hi", "there"]),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #4722

Review https://github.com/HHS/simpler-grants-gov/pull/5231 first

TODO:

- [ ] tests

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds a toggle to the filter drawer enabled search experience (behind the "searchDrawerOn" feature flag) that will toggle whether terms in a keyword search are treated with boolean AND or OR when performing the search

## Context for reviewers

This includes the changes from https://github.com/HHS/simpler-grants-gov/pull/5231 in order to pull in the radio button based components that are added there


<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
