### PR TITLE
Make sure we `terraform-init` inside of `run-command` 

### DIFF
--- a/bin/run-command
+++ b/bin/run-command
@@ -47,6 +47,8 @@ app_name="$1"
 environment="$2"
 command="$3"
 
+./bin/terraform-init "infra/${app_name}/service" "${environment}"
+
 echo "==============="
 echo "Running command"
 echo "==============="

--- a/infra/nofos/service/.terraform.lock.hcl
+++ b/infra/nofos/service/.terraform.lock.hcl
@@ -43,25 +43,6 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/local" {
-  version = "2.5.3"
-  hashes = [
-    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
-    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
-    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
-    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
-    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
-    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
-    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
-    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
-    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
-    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
-    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.7.2"
   hashes = [


### PR DESCRIPTION
## Summary

When we ran ECS tasks from the command line by calling `./bin/run-command ...`, it wasn't actually setting the environment correctly. In fact, it wasn't using the environment variable for anything.

This PR makes sure we call `terraform init` before we do the run command, so that it executes in the right environment.

It also updates the lockfile under nofos/service.

## Context for reviewers

@coilysiren and I discussed this yesterday.

## Validation steps

For me, I ran this against both nofo environments to test this:

- `./bin/run-command nofos dev '["ls"]'`
- `./bin/run-command nofos prod '["ls"]'`

Before this change, it would only ever run tasks in `nofos-dev`.
