### PR TITLE
[Issue #5260] Add HTTPs for NOFOs Dev

### DIFF
--- a/infra/nofos/app-config/dev.tf
+++ b/infra/nofos/app-config/dev.tf
@@ -5,8 +5,8 @@ module "dev_config" {
   default_region = module.project_config.default_region
   environment    = "dev"
   network_name   = "dev"
-  domain_name    = null
-  enable_https   = false
+  domain_name    = "nofos.dev.simpler.grants.gov"
+  enable_https   = true
 
   instance_desired_instance_count = 1
   instance_scaling_min_capacity   = 1


### PR DESCRIPTION
## Summary

Fixes #5260

## Changes proposed
Add HTTPS to NOFOs Dev using previously uploaded certificate: https://github.com/HHS/simpler-grants-gov/blob/main/OPERATIONS.md#application-certificates-part-2b-upload-multiple-certs 