### PR TITLE
[Issue #4994] Better handling of Feature Flag Defaults

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "ajv-formats": "^3.0.1",
         "axios": "^1.8.2",
         "clsx": "^2.1.1",
+        "cookies-next": "^6.0.0",
         "dayjs": "^1.11.13",
         "focus-trap-react": "^10.2.3",
         "isomorphic-dompurify": "^2.15.0",
@@ -8945,6 +8946,28 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cookies-next": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-6.0.0.tgz",
+      "integrity": "sha512-Xq87TPIe7faqluf7gr3mobzO2JRe65oX+pnv4nrnDE/ak49Ic6QhNZSLCk+E5xOKtpVm1EoEazu0iBNyr5TXTA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1"
+      },
+      "peerDependencies": {
+        "next": ">=15.0.0",
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.40.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "ajv-formats": "^3.0.1",
     "axios": "^1.8.2",
     "clsx": "^2.1.1",
+    "cookies-next": "^6.0.0",
     "dayjs": "^1.11.13",
     "focus-trap-react": "^10.2.3",
     "isomorphic-dompurify": "^2.15.0",

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,3 @@
-import { CookiesNextProvider } from "cookies-next";
 import { defaultFeatureFlags } from "src/constants/defaultFeatureFlags";
 import UserProvider from "src/services/auth/UserProvider";
 
@@ -20,20 +19,18 @@ export default function Layout({ children, locale }: Props) {
   const t = useTranslations();
 
   return (
-    <CookiesNextProvider pollingOptions={{ enabled: true, intervalMs: 1000 }}>
-      <UserProvider featureFlagDefaults={defaultFeatureFlags}>
-        <div className="display-flex flex-column minh-viewport">
-          <a className="usa-skipnav" href="#main-content">
-            {t("Layout.skipToMain")}
-          </a>
-          <Header locale={locale} />
-          <main id="main-content" className="border-top-0">
-            {children}
-          </main>
-          <Footer />
-          <GrantsIdentifier />
-        </div>
-      </UserProvider>
-    </CookiesNextProvider>
+    <UserProvider featureFlagDefaults={defaultFeatureFlags}>
+      <div className="display-flex flex-column minh-viewport">
+        <a className="usa-skipnav" href="#main-content">
+          {t("Layout.skipToMain")}
+        </a>
+        <Header locale={locale} />
+        <main id="main-content" className="border-top-0">
+          {children}
+        </main>
+        <Footer />
+        <GrantsIdentifier />
+      </div>
+    </UserProvider>
   );
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,3 +1,5 @@
+import { CookiesNextProvider } from "cookies-next";
+import { defaultFeatureFlags } from "src/constants/defaultFeatureFlags";
 import UserProvider from "src/services/auth/UserProvider";
 
 import { useTranslations } from "next-intl";
@@ -18,18 +20,20 @@ export default function Layout({ children, locale }: Props) {
   const t = useTranslations();
 
   return (
-    <UserProvider>
-      <div className="display-flex flex-column minh-viewport">
-        <a className="usa-skipnav" href="#main-content">
-          {t("Layout.skipToMain")}
-        </a>
-        <Header locale={locale} />
-        <main id="main-content" className="border-top-0">
-          {children}
-        </main>
-        <Footer />
-        <GrantsIdentifier />
-      </div>
-    </UserProvider>
+    <CookiesNextProvider pollingOptions={{ enabled: true, intervalMs: 1000 }}>
+      <UserProvider featureFlagDefaults={defaultFeatureFlags}>
+        <div className="display-flex flex-column minh-viewport">
+          <a className="usa-skipnav" href="#main-content">
+            {t("Layout.skipToMain")}
+          </a>
+          <Header locale={locale} />
+          <main id="main-content" className="border-top-0">
+            {children}
+          </main>
+          <Footer />
+          <GrantsIdentifier />
+        </div>
+      </UserProvider>
+    </CookiesNextProvider>
   );
 }

--- a/frontend/src/components/dev/FeatureFlagsTable.tsx
+++ b/frontend/src/components/dev/FeatureFlagsTable.tsx
@@ -1,22 +1,38 @@
 "use client";
 
+import { defaultFeatureFlags } from "src/constants/defaultFeatureFlags";
 import { useFeatureFlags } from "src/hooks/useFeatureFlags";
 
-import React from "react";
+import React, { useState } from "react";
 import { Button, Table } from "@trussworks/react-uswds";
+
+import BetaAlert from "src/components/BetaAlert";
 
 /**
  * View for managing feature flags
  */
 export default function FeatureFlagsTable() {
   const { setFeatureFlag, featureFlags } = useFeatureFlags();
+  const [pendingChanges, setPendingChanges] = useState(false);
+
+  const handleFeatureChange = (flagName: string, value: boolean) => {
+    setPendingChanges(true);
+    setFeatureFlag(flagName, value);
+  };
 
   return (
     <>
+      {pendingChanges && (
+        <BetaAlert
+          heading="Refresh your page"
+          alertMessage="Hard refresh your page when done changing Flags for the changes to fully apply."
+        />
+      )}
       <Table>
         <thead>
           <tr>
-            <th scope="col">Status</th>
+            <th scope="col">Default</th>
+            <th scope="col">Current</th>
             <th scope="col">Feature Flag</th>
             <th scope="col">Actions</th>
           </tr>
@@ -24,6 +40,16 @@ export default function FeatureFlagsTable() {
         <tbody>
           {Object.entries(featureFlags).map(([featureName, enabled]) => (
             <tr key={featureName}>
+              <td
+                data-testid={`${featureName}-default`}
+                style={{
+                  background: defaultFeatureFlags?.[featureName]
+                    ? "#81cc81"
+                    : "#fc6a6a",
+                }}
+              >
+                {defaultFeatureFlags?.[featureName] ? "Enable" : "Disable"}
+              </td>
               <td
                 data-testid={`${featureName}-status`}
                 style={{ background: enabled ? "#81cc81" : "#fc6a6a" }}
@@ -35,7 +61,7 @@ export default function FeatureFlagsTable() {
                 <Button
                   data-testid={`enable-${featureName}`}
                   disabled={!!enabled}
-                  onClick={() => setFeatureFlag(featureName, true)}
+                  onClick={() => handleFeatureChange(featureName, true)}
                   type="button"
                 >
                   Enable
@@ -43,7 +69,7 @@ export default function FeatureFlagsTable() {
                 <Button
                   data-testid={`disable-${featureName}`}
                   disabled={!enabled}
-                  onClick={() => setFeatureFlag(featureName, false)}
+                  onClick={() => handleFeatureChange(featureName, false)}
                   type="button"
                 >
                   Disable

--- a/frontend/src/services/auth/UserProvider.tsx
+++ b/frontend/src/services/auth/UserProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // note that importing these individually allows us to mock them, otherwise mocks don't work :shrug:
-import { useReactiveGetCookie } from "cookies-next";
+import { useGetCookie } from "cookies-next";
 import noop from "lodash/noop";
 import { FeatureFlags } from "src/constants/defaultFeatureFlags";
 import { UserContext } from "src/services/auth/useUser";
@@ -19,7 +19,7 @@ export default function UserProvider({
   featureFlagDefaults: FeatureFlags;
   children: React.ReactNode;
 }) {
-  const getCookie = useReactiveGetCookie();
+  const getCookie = useGetCookie();
   const cookie = decodeURIComponent(getCookie(FEATURE_FLAGS_KEY) || "{}");
   const [localUser, setLocalUser] = useState<UserProfile>();
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/frontend/src/services/auth/UserProvider.tsx
+++ b/frontend/src/services/auth/UserProvider.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 // note that importing these individually allows us to mock them, otherwise mocks don't work :shrug:
+import { useReactiveGetCookie } from "cookies-next";
 import noop from "lodash/noop";
+import { FeatureFlags } from "src/constants/defaultFeatureFlags";
 import { UserContext } from "src/services/auth/useUser";
+import { FEATURE_FLAGS_KEY } from "src/services/featureFlags/featureFlagHelpers";
 import { debouncedUserFetcher } from "src/services/fetch/fetchers/clientUserFetcher";
 import { UserProfile, UserSession } from "src/types/authTypes";
 import { isExpired, isExpiring } from "src/utils/dateUtil";
@@ -10,14 +13,33 @@ import { isExpired, isExpiring } from "src/utils/dateUtil";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 export default function UserProvider({
+  featureFlagDefaults,
   children,
 }: {
+  featureFlagDefaults: FeatureFlags;
   children: React.ReactNode;
 }) {
+  const getCookie = useReactiveGetCookie();
+  const cookie = decodeURIComponent(getCookie(FEATURE_FLAGS_KEY) || "{}");
   const [localUser, setLocalUser] = useState<UserProfile>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [userFetchError, setUserFetchError] = useState<Error | undefined>();
   const [hasBeenLoggedOut, setHasBeenLoggedOut] = useState<boolean>(false);
+  const [defaultFeatureFlags] = useState<FeatureFlags>(featureFlagDefaults);
+  const [userFeatureFlags, setUserFeatureFlags] = useState<FeatureFlags>({});
+
+  // a workaround, as setting this in default state value results in hydration error
+  useEffect(() => {
+    const flagsFromCookie = JSON.parse(cookie) as FeatureFlags;
+    setUserFeatureFlags(flagsFromCookie);
+  }, [cookie]);
+
+  const featureFlags = useMemo(() => {
+    return {
+      ...defaultFeatureFlags,
+      ...userFeatureFlags,
+    };
+  }, [defaultFeatureFlags, userFeatureFlags]);
 
   const getUserSession = useCallback(async (): Promise<void> => {
     setHasBeenLoggedOut(false);
@@ -88,6 +110,9 @@ export default function UserProvider({
       refreshIfExpired,
       refreshIfExpiring,
       resetHasBeenLoggedOut,
+      featureFlags,
+      userFeatureFlags,
+      defaultFeatureFlags,
     }),
     [
       localUser,
@@ -99,6 +124,9 @@ export default function UserProvider({
       refreshIfExpired,
       refreshIfExpiring,
       resetHasBeenLoggedOut,
+      featureFlags,
+      userFeatureFlags,
+      defaultFeatureFlags,
     ],
   );
 

--- a/frontend/src/services/featureFlags/featureFlagHelpers.ts
+++ b/frontend/src/services/featureFlags/featureFlagHelpers.ts
@@ -10,9 +10,9 @@ import { NextRequest, NextResponse } from "next/server";
 
 export const FEATURE_FLAGS_KEY = "_ff";
 
-// 3 months
+// 7 days
 export const getCookieExpiration = () =>
-  new Date(Date.now() + 1000 * 60 * 60 * 24 * 90);
+  new Date(Date.now() + 1000 * 60 * 60 * 24 * 7);
 
 /**
  * Check whether it is a valid feature flag.
@@ -71,6 +71,13 @@ export function setCookie(value: string, cookies: NextResponse["cookies"]) {
     value,
     expires,
   });
+}
+
+/**
+ * Delete a cookie using the NextResponse['cookies'] interface
+ */
+export function deleteCookie(cookies: NextResponse["cookies"]) {
+  cookies?.delete({ name: FEATURE_FLAGS_KEY });
 }
 
 /**

--- a/frontend/src/types/authTypes.ts
+++ b/frontend/src/types/authTypes.ts
@@ -1,4 +1,5 @@
 import { JWTPayload } from "jose";
+import { FeatureFlags } from "src/constants/defaultFeatureFlags";
 
 /**
  * Configure the UserProvider component.
@@ -70,4 +71,7 @@ export type UserProviderState = {
   resetHasBeenLoggedOut: () => void;
   refreshIfExpired: () => Promise<boolean | undefined>;
   refreshIfExpiring: () => Promise<boolean | undefined>;
+  featureFlags: FeatureFlags;
+  userFeatureFlags: FeatureFlags;
+  defaultFeatureFlags: FeatureFlags;
 };


### PR DESCRIPTION
## Summary

Fixes #4994

## Changes proposed

1. We need to separate out the FF defaults from the values the user has changed themselves so when we update the defaults we don't have old values stuck in folks' cookies. 
2. As part of that work we're standardizing on only using the middleware to set the FF cookie values, and it will check to make sure the value being "set" isn't the current default (it will just remove that flag instead).
3. Instead of trying to have the FF page "react" to a user's changes immediately we pop a message warning them they'll need to refresh the page to apply the FF changes. 
   - This is because while we could make this features buttons and content react to the FF changes, the rest of the site (including the Nav) won't reflect those changes reliably until the page is refreshed.

## Context for reviewers
This is not an end-user facing page so we leaned into simplicity not perfect UX or seamless rendering.

## Validation steps
1. Check out the branch
2. Visit http://localhost:3000/dev/feature-flags
3. Validate that now there are two columns for each feature, noting the default and the current setting. This allows for easy scanning for differences when trying to test features.
4. Click to enable/disable a feature flag.
    - This should pop up the warning message that you need to refresh the page to fully apply the flags you're changing

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/f6dd6930-a627-427b-ac26-cadc30d87d5a" />
