### PR TITLE
[#5065] Add missing environment variables to the NOFO Builder

### DIFF
--- a/infra/nofos/app-config/env-config/environment_variables.tf
+++ b/infra/nofos/app-config/env-config/environment_variables.tf
@@ -3,14 +3,28 @@ locals {
   # This is a map rather than a list so that variables can be easily
   # overridden per environment using terraform's `merge` function
   default_extra_environment_variables = {
-    DEBUG                = "false"
-    DJANGO_ALLOWED_HOSTS = "*"
+    DEBUG = "false"
   }
 
   secrets = {
+    API_TOKEN = {
+      manage_method     = "manual"
+      secret_store_name = "/nofos/${var.environment}/api-token"
+    }
+
+    DJANGO_ALLOWED_HOSTS = {
+      manage_method     = "manual"
+      secret_store_name = "/nofos/${var.environment}/django-allowed-hosts"
+    }
+
     DOCRAPTOR_API_KEY = {
       manage_method     = "manual"
       secret_store_name = "/nofos/${var.environment}/docraptor-api-key"
+    }
+
+    SECRET_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/nofos/${var.environment}/secret-key"
     }
   }
 }


### PR DESCRIPTION
## Summary

Makes progress on #5065 

This is a small PR that adds some of our missing env vars to the NOFO builder, in `nofos-dev` and `nofos-prod`.

## Changes proposed

Adds several missing environment variables. [Env vars used by the NOFO Builder are documented in the README](https://github.com/HHS/simpler-grants-pdf-builder?tab=readme-ov-file#environment-variables).

I am creating corresponding variables for them in AWS.

## Context for reviewers

This follows the same pattern as this previous PR to add an env var: https://github.com/HHS/simpler-grants-gov/pull/5098/files
