### PR TITLE
[untickited] Enable soap proxy in prod

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -118,6 +118,9 @@ class SimplerApplicantsS2SClient(BaseSOAPClient):
                 data=e.fault.to_xml(),
                 status_code=500,
             )
+        except Exception as e:
+            logger.info(f"simpler_soap_api_err: Unable to generate soap response: {e}")
+            simpler_soap_response = None
 
         return self.proxy_response, simpler_soap_response
 

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -75,7 +75,7 @@ module "prod_config" {
 
     # grants.gov services/applications URI.
     GRANTS_GOV_URI  = "https://ws07.grants.gov:443"
-    ENABLE_SOAP_API = 0
+    ENABLE_SOAP_API = 1
   }
   instance_cpu    = 1024
   instance_memory = 4096


### PR DESCRIPTION
## Summary

Fixes unticketed

## Changes proposed

This pr enables soap requests to be proxied to grants.gov soap api.

## Context for reviewers

This will enable requests to go through the soap proxy router in prod.

Note that only public soap operations will work.

## Validation steps

The following queries production soap api in grants.gov and is already existing functionality but good to double check:

1. Query GetOpportunityList to production locally by sending the following request and ensure a 200 status code with the appropriate data: 
```
curl --location 'http://0.0.0.0:8080/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort' \
--header 'X-GG-S2S-URI: https://ws07.grants.gov' \
--header 'Content-Type: application/xml' \
--data '
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:app="http://apply.grants.gov/services/ApplicantWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0" xmlns:app1="http://apply.grants.gov/system/ApplicantCommonElements-V1.0">
    <soapenv:Header/>
    <soapenv:Body>
        <app:GetOpportunityListRequest>
            <app1:OpportunityFilter>
                <gran:CFDANumber>12.351</gran:CFDANumber> 
            </app1:OpportunityFilter>
        </app:GetOpportunityListRequest>
    </soapenv:Body>
</soapenv:Envelope>'
```

2. Query GetApplicationInfoRequest (requires authentication) to production locally by sending the following request and ensure 500 status code and the following exists in the response message `Unable to retrieve application information: 02`:
```
curl --location 'http://0.0.0.0:8080/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort' \
--header 'X-GG-S2S-URI: https://ws07.grants.gov' \
--header 'Content-Type: application/xml' \
--data '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:app="http://apply.grants.gov/services/ApplicantWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">
   <soapenv:Header/>
   <soapenv:Body>
      <app:GetApplicationInfoRequest>
         <gran:GrantsGovTrackingNumber>123</gran:GrantsGovTrackingNumber>
      </app:GetApplicationInfoRequest>
   </soapenv:Body>
</soapenv:Envelope>'