### PR TITLE
[Issue #4933] add search keyword exclusion hint label

### DIFF
--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -1,16 +1,49 @@
 "use client";
 
 import clsx from "clsx";
+import { useFeatureFlags } from "src/hooks/useFeatureFlags";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { QueryContext } from "src/services/search/QueryProvider";
 
 import { useTranslations } from "next-intl";
 import { useContext, useEffect, useRef, useState } from "react";
-import { ErrorMessage, Icon } from "@trussworks/react-uswds";
+import { ErrorMessage, Icon, Label } from "@trussworks/react-uswds";
+
+import { USWDSIcon } from "src/components/USWDSIcon";
 
 interface SearchBarProps {
   queryTermFromParent: string | null | undefined;
   tableView?: boolean;
+}
+
+function LegacySearchLabel() {
+  const t = useTranslations("Search.bar");
+  return (
+    <label
+      htmlFor="query"
+      className="font-sans-lg display-block margin-bottom-2"
+    >
+      {t.rich("label", {
+        strong: (chunks) => <span className="text-bold">{chunks}</span>,
+        small: (chunks) => (
+          <small className="font-sans-sm display-inline-block">{chunks}</small>
+        ),
+      })}
+    </label>
+  );
+}
+
+function SearchLabel() {
+  const t = useTranslations("Search.bar");
+  return (
+    <Label htmlFor="query" className="maxw-full margin-bottom-2">
+      <USWDSIcon
+        name="lightbulb_outline"
+        className="usa-icon--size-3 text-middle margin-right-05"
+      />
+      <span className="text-middle">{t("exclusionTip")}</span>
+    </Label>
+  );
 }
 
 export default function SearchBar({
@@ -22,6 +55,7 @@ export default function SearchBar({
   const { updateQueryParams, searchParams } = useSearchParamUpdater();
   const t = useTranslations("Search");
   const [validationError, setValidationError] = useState<string>();
+  const { checkFeatureFlag } = useFeatureFlags();
 
   const handleSubmit = () => {
     if (queryTerm && queryTerm.length > 99) {
@@ -61,19 +95,11 @@ export default function SearchBar({
         "usa-form-group--error": !!validationError,
       })}
     >
-      <label
-        htmlFor="query"
-        className="font-sans-lg display-block margin-bottom-2"
-      >
-        {t.rich("bar.label", {
-          strong: (chunks) => <span className="text-bold">{chunks}</span>,
-          small: (chunks) => (
-            <small className="font-sans-sm display-inline-block">
-              {chunks}
-            </small>
-          ),
-        })}
-      </label>
+      {checkFeatureFlag("searchDrawerOn") ? (
+        <SearchLabel />
+      ) : (
+        <LegacySearchLabel />
+      )}
       {validationError && <ErrorMessage>{validationError}</ErrorMessage>}
       <div className="usa-search usa-search--big" role="search">
         <input

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -466,6 +466,7 @@ export const messages = {
       label:
         "<strong>Search terms </strong><small>Enter keywords, opportunity numbers, or assistance listing numbers</small>",
       button: "Search",
+      exclusionTip: `Tip: Use a minus sign to exclude words or phrases, like "-research"`,
     },
     drawer: {
       title: "Filters",


### PR DESCRIPTION

## Summary

Fixes #4933

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

update search input label for drawer experience with keyword exclusion hint

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This change is only visible with the `searchDrawerOn` filter flag active

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search?_ff=searchDrawerOn:true
3. _VERIFY_: label above search input shows keyword exclusion hint text

### Screenshot

<img width="1270" alt="Screenshot 2025-06-10 at 1 46 21 PM" src="https://github.com/user-attachments/assets/3609d683-e780-4d17-85e6-3ce2bdf35a9a" />

