### PR TITLE
[Issue #5259] Modify the GET /application endpoint to return organization info

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -3156,6 +3156,30 @@ components:
           example: 123e4567-e89b-12d3-a456-426614174000
         email:
           type: string
+    SamGovEntity:
+      type: object
+      properties:
+        uei:
+          type: string
+        legal_business_name:
+          type: string
+        expiration_date:
+          type: string
+          format: date
+    Organization:
+      type: object
+      properties:
+        organization_id:
+          type: string
+          format: uuid
+          example: 123e4567-e89b-12d3-a456-426614174000
+        sam_gov_entity:
+          type:
+          - object
+          - 'null'
+          anyOf:
+          - $ref: '#/components/schemas/SamGovEntity'
+          - type: 'null'
     ApplicationGetResponseData:
       type: object
       properties:
@@ -3183,6 +3207,13 @@ components:
             type:
             - object
             $ref: '#/components/schemas/ApplicationUser'
+        organization:
+          type:
+          - object
+          - 'null'
+          anyOf:
+          - $ref: '#/components/schemas/Organization'
+          - type: 'null'
         form_validation_warnings:
           type: object
           description: Specific form validation issues

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -3158,6 +3158,30 @@ components:
           type: string
         is_application_owner:
           type: boolean
+    SamGovEntity:
+      type: object
+      properties:
+        uei:
+          type: string
+        legal_business_name:
+          type: string
+        expiration_date:
+          type: string
+          format: date
+    Organization:
+      type: object
+      properties:
+        organization_id:
+          type: string
+          format: uuid
+          example: 123e4567-e89b-12d3-a456-426614174000
+        sam_gov_entity:
+          type:
+          - object
+          - 'null'
+          anyOf:
+          - $ref: '#/components/schemas/SamGovEntity'
+          - type: 'null'
     ApplicationGetResponseData:
       type: object
       properties:
@@ -3185,6 +3209,13 @@ components:
             type:
             - object
             $ref: '#/components/schemas/ApplicationUser'
+        organization:
+          type:
+          - object
+          - 'null'
+          anyOf:
+          - $ref: '#/components/schemas/Organization'
+          - type: 'null'
         form_validation_warnings:
           type: object
           description: Specific form validation issues

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -78,6 +78,21 @@ class ApplicationUserSchema(Schema):
     email = fields.String()
 
 
+class SamGovEntitySchema(Schema):
+    """Schema for SAM.gov entity information"""
+
+    uei = fields.String()
+    legal_business_name = fields.String()
+    expiration_date = fields.Date()
+
+
+class OrganizationSchema(Schema):
+    """Schema for organization information"""
+
+    organization_id = fields.UUID()
+    sam_gov_entity = fields.Nested(SamGovEntitySchema(), allow_none=True)
+
+
 class ApplicationGetResponseDataSchema(Schema):
     application_id = fields.UUID()
     competition = fields.Nested(CompetitionAlphaSchema())
@@ -85,6 +100,7 @@ class ApplicationGetResponseDataSchema(Schema):
     application_status = fields.String()
     application_name = fields.String()
     users = fields.List(fields.Nested(ApplicationUserSchema()))
+    organization = fields.Nested(OrganizationSchema(), allow_none=True)
 
     form_validation_warnings = fields.Dict(
         metadata={

--- a/api/src/services/applications/get_application.py
+++ b/api/src/services/applications/get_application.py
@@ -7,6 +7,7 @@ import src.adapters.db as db
 from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.competition_models import Application, Competition
+from src.db.models.entity_models import Organization
 from src.db.models.user_models import ApplicationUser, User
 from src.services.applications.application_validation import get_application_form_errors
 from src.services.applications.auth_utils import check_user_application_access
@@ -20,6 +21,8 @@ def get_application(db_session: db.Session, application_id: UUID, user: User) ->
         select(Application)
         .options(
             selectinload("*"),
+            # Explicitly load organization and its sam_gov_entity
+            selectinload(Application.organization).selectinload(Organization.sam_gov_entity),
             # Explicitly don't load these
             lazyload(Application.competition, Competition.opportunity),
             lazyload(Application.competition, Competition.applications),

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta
+from datetime import date, timedelta
 
 import pytest
 from sqlalchemy import select
@@ -17,6 +17,8 @@ from tests.src.db.models.factories import (
     CompetitionFormFactory,
     FormFactory,
     OpportunityFactory,
+    OrganizationFactory,
+    SamGovEntityFactory,
 )
 
 # Simple JSON schema used for tests below
@@ -1604,3 +1606,111 @@ def test_application_get_includes_application_name_and_users(
     assert len(response.json["data"]["users"]) == 1
     assert response.json["data"]["users"][0]["user_id"] == str(user.user_id)
     assert response.json["data"]["users"][0]["email"] == user.email
+
+
+def test_application_get_includes_organization_with_sam_gov_entity(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test that application GET response includes organization with SAM.gov entity data"""
+    # Create a SAM.gov entity with test data
+    sam_gov_entity = SamGovEntityFactory.create(
+        uei="TEST123456789",
+        legal_business_name="Test Organization LLC",
+        expiration_date=date(2025, 12, 31),
+    )
+
+    # Create an organization linked to the SAM.gov entity
+    organization = OrganizationFactory.create(sam_gov_entity=sam_gov_entity)
+
+    # Create an application with the organization
+    application = ApplicationFactory.create(
+        application_status=ApplicationStatus.IN_PROGRESS,
+        application_name="Test Application with Organization",
+        organization=organization,
+    )
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user, application=application)
+
+    response = client.get(
+        f"/alpha/applications/{application.application_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Check that organization is included
+    assert "organization" in response.json["data"]
+    assert response.json["data"]["organization"] is not None
+    assert response.json["data"]["organization"]["organization_id"] == str(
+        organization.organization_id
+    )
+
+    # Check that sam_gov_entity is included with the required fields
+    sam_gov_data = response.json["data"]["organization"]["sam_gov_entity"]
+    assert sam_gov_data is not None
+    assert sam_gov_data["uei"] == "TEST123456789"
+    assert sam_gov_data["legal_business_name"] == "Test Organization LLC"
+    assert sam_gov_data["expiration_date"] == "2025-12-31"
+
+
+def test_application_get_includes_organization_without_sam_gov_entity(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test that application GET response includes organization without SAM.gov entity data"""
+    # Create an organization without a SAM.gov entity
+    organization = OrganizationFactory.create(sam_gov_entity=None)
+
+    # Create an application with the organization
+    application = ApplicationFactory.create(
+        application_status=ApplicationStatus.IN_PROGRESS,
+        application_name="Test Application with Organization",
+        organization=organization,
+    )
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user, application=application)
+
+    response = client.get(
+        f"/alpha/applications/{application.application_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Check that organization is included but sam_gov_entity is null
+    assert "organization" in response.json["data"]
+    assert response.json["data"]["organization"] is not None
+    assert response.json["data"]["organization"]["organization_id"] == str(
+        organization.organization_id
+    )
+    assert response.json["data"]["organization"]["sam_gov_entity"] is None
+
+
+def test_application_get_without_organization(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test that application GET response handles null organization correctly"""
+    # Create an application without an organization
+    application = ApplicationFactory.create(
+        application_status=ApplicationStatus.IN_PROGRESS,
+        application_name="Test Application without Organization",
+        organization=None,
+    )
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user, application=application)
+
+    response = client.get(
+        f"/alpha/applications/{application.application_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Check that organization field is present but null
+    assert "organization" in response.json["data"]
+    assert response.json["data"]["organization"] is None


### PR DESCRIPTION
## Summary

Fixes #5259

## Changes proposed

Add new schemas
Add select for sam gov entity
Add tests

## Context for reviewers

If the application has no organization, the value will be null. This data structure should mean that any org already on the app will just be passed through uneventfully.

## Validation steps

See new unit tests