### PR TITLE
[Issue #5265] Create application sets is_application_owner on ApplicationUser

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -3156,6 +3156,8 @@ components:
           example: 123e4567-e89b-12d3-a456-426614174000
         email:
           type: string
+        is_application_owner:
+          type: boolean
     ApplicationGetResponseData:
       type: object
       properties:

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -76,6 +76,7 @@ class ApplicationUserSchema(Schema):
 
     user_id = fields.UUID()
     email = fields.String()
+    is_application_owner = fields.Boolean()
 
 
 class ApplicationGetResponseDataSchema(Schema):

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -49,7 +49,9 @@ def create_application(
     )
     db_session.add(application)
 
-    application_user = ApplicationUser(application=application, user=user)
+    application_user = ApplicationUser(
+        application=application, user=user, is_application_owner=True
+    )
     db_session.add(application_user)
 
     # Initialize the competition forms for the application

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1280,7 +1280,7 @@ def test_application_submit_forbidden_not_in_progress(
 def test_application_start_associates_user(
     client, enable_factory_create, db_session, user, user_auth_token
 ):
-    """Test that application creation associates the user from the token session with the application"""
+    """Test that application creation associates the user from the token session with the application and marks them as owner"""
     today = get_now_us_eastern_date()
     future_date = today + timedelta(days=10)
 
@@ -1306,7 +1306,7 @@ def test_application_start_associates_user(
     assert application is not None
     assert str(application.competition_id) == competition_id
 
-    # Verify user is associated with the application
+    # Verify user is associated with the application and marked as owner
     application_user = db_session.execute(
         select(ApplicationUser).where(
             ApplicationUser.application_id == application_id,
@@ -1317,6 +1317,7 @@ def test_application_start_associates_user(
     assert application_user is not None
     assert application_user.user_id == user.user_id
     assert application_user.application_id == application.application_id
+    assert application_user.is_application_owner is True
 
 
 def test_application_start_with_custom_name(


### PR DESCRIPTION
## Summary

Fixes #5265

## Changes proposed

When creating an application, create the `ApplicationUser` with is_application_owner set to `True`, include in schema.

## Context for reviewers

This is a precursor to eventual work for roles.

## Validation steps

See modified unit tests.