### PR TITLE
[Unticketed] Fix HASH passing to Release Publish

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -83,4 +83,4 @@ jobs:
 
       - name: Publish release
         if: steps.check-image-published.outputs.is_image_published == 'false'
-        run: make APP_NAME=${{ inputs.app_name }} release-publish
+        run: make APP_NAME=${{ inputs.app_name }} IMAGE_TAG=${{needs.get-commit-hash.outputs.commit_hash }} release-publish

--- a/Makefile
+++ b/Makefile
@@ -256,11 +256,16 @@ GIT_REPO_AVAILABLE := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
 
 # Generate a unique tag based solely on the git hash.
 # This will be the identifier used for deployment via terraform.
-ifdef GIT_REPO_AVAILABLE
-IMAGE_TAG := $(shell git rev-parse HEAD)
+
+ifdef IMAGE_TAG
 else
-IMAGE_TAG := "unknown-dev.$(DATE)"
+	ifdef GIT_REPO_AVAILABLE
+	IMAGE_TAG := $(shell git rev-parse HEAD)
+	else
+	IMAGE_TAG := "unknown-dev.$(DATE)"
+	endif
 endif
+
 
 # Generate an informational tag so we can see where every image comes from.
 DATE := $(shell date -u '+%Y%m%d.%H%M%S')


### PR DESCRIPTION
## Summary

The Release Publish step tags the Docker image that was built. It was using git rev-parse to figure out the hash to tag with, but the caller already knows a better hash, so utilize that if it's passed in

## Changes proposed

Allow caller to tell us the git hash for tagging purposes, if not supplied calculate it as it was already being figured out.

## Context for reviewers

Causes the image to publish with the wrong tag if the change made that triggered the built happens outside the service folder (such as a change to our shared Terraform).

## Validation steps
Tested locally
When passed in
<img width="968" alt="image" src="https://github.com/user-attachments/assets/a5f3df69-2955-4327-be93-7d42f00da8bd" />
When not passed in
<img width="754" alt="image" src="https://github.com/user-attachments/assets/e446e627-62a1-4001-8eae-cc669d14dfd9" />

