### PR TITLE
[Unticketed] Need same hash on build as we use on Release

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -83,4 +83,4 @@ jobs:
 
       - name: Publish release
         if: steps.check-image-published.outputs.is_image_published == 'false'
-        run: make APP_NAME=${{ inputs.app_name }} release-publish
+        run: make APP_NAME=${{ inputs.app_name }} IMAGE_TAG=${{needs.get-commit-hash.outputs.commit_hash }} release-publish

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build release
         if: steps.check-image-published.outputs.is_image_published == 'false'
-        run: make APP_NAME=${{ inputs.app_name }} release-build
+        run: make APP_NAME=${{ inputs.app_name }} IMAGE_TAG=${{needs.get-commit-hash.outputs.commit_hash }} release-build
 
       - name: Publish release
         if: steps.check-image-published.outputs.is_image_published == 'false'

--- a/Makefile
+++ b/Makefile
@@ -256,11 +256,16 @@ GIT_REPO_AVAILABLE := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
 
 # Generate a unique tag based solely on the git hash.
 # This will be the identifier used for deployment via terraform.
-ifdef GIT_REPO_AVAILABLE
-IMAGE_TAG := $(shell git rev-parse HEAD)
+
+ifdef IMAGE_TAG
 else
-IMAGE_TAG := "unknown-dev.$(DATE)"
+	ifdef GIT_REPO_AVAILABLE
+	IMAGE_TAG := $(shell git rev-parse HEAD)
+	else
+	IMAGE_TAG := "unknown-dev.$(DATE)"
+	endif
 endif
+
 
 # Generate an informational tag so we can see where every image comes from.
 DATE := $(shell date -u '+%Y%m%d.%H%M%S')


### PR DESCRIPTION
## Summary
Fix follow up build problem 

## Changes proposed

I thought publish applied the tags, but publish pushes the existing tags, so caller of build needs to pass in the correct tags too