### PR TITLE
[Issue #5139] Add whether a form is required to the application form response model

### DIFF
--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -66,6 +66,10 @@ class ApplicationFormGetResponseDataSchema(Schema):
         metadata={"description": "Status indicating how much of a form has been filled out"},
     )
 
+    is_required = fields.Boolean(
+        metadata={"description": "Whether this form is required for the application"}
+    )
+
 
 class ApplicationFormGetResponseSchema(AbstractResponseSchema, WarningMixinSchema):
     data = fields.Nested(ApplicationFormGetResponseDataSchema())

--- a/api/src/services/applications/get_application.py
+++ b/api/src/services/applications/get_application.py
@@ -9,7 +9,10 @@ from src.api.route_utils import raise_flask_error
 from src.db.models.competition_models import Application, Competition
 from src.db.models.entity_models import Organization
 from src.db.models.user_models import ApplicationUser, User
-from src.services.applications.application_validation import get_application_form_errors
+from src.services.applications.application_validation import (
+    get_application_form_errors,
+    is_form_required,
+)
 from src.services.applications.auth_utils import check_user_application_access
 
 
@@ -59,5 +62,9 @@ def get_application_with_warnings(
     # Attach the form warning map to the application so it appears
     # in the response object
     application.form_validation_warnings = form_warning_map  # type: ignore[attr-defined]
+
+    # Set the is_required field on all application forms
+    for application_form in application.application_forms:
+        application_form.is_required = is_form_required(application_form)  # type: ignore[attr-defined]
 
     return application, form_warnings

--- a/api/src/services/applications/get_application_form.py
+++ b/api/src/services/applications/get_application_form.py
@@ -7,7 +7,10 @@ from src.api.route_utils import raise_flask_error
 from src.db.models.competition_models import ApplicationForm
 from src.db.models.user_models import User
 from src.form_schema.jsonschema_validator import ValidationErrorDetail
-from src.services.applications.application_validation import validate_application_form
+from src.services.applications.application_validation import (
+    is_form_required,
+    validate_application_form,
+)
 from src.services.applications.auth_utils import check_user_application_access
 from src.services.applications.get_application import get_application
 
@@ -37,5 +40,8 @@ def get_application_form(
 
     # Get a list of validation warnings (also sets form status)
     warnings: list[ValidationErrorDetail] = validate_application_form(application_form)
+
+    # Set the is_required field on the application form object
+    application_form.is_required = is_form_required(application_form)  # type: ignore[attr-defined]
 
     return application_form, warnings

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -820,6 +820,7 @@ def test_application_get_success(client, enable_factory_create, db_session, user
             "form_id": str(application_form.form_id),
             "application_response": application_form.application_response,
             "application_form_status": ApplicationFormStatus.IN_PROGRESS,
+            "is_required": True,
         }
 
 


### PR DESCRIPTION
## Summary

Fixes #5139

## Changes proposed

Add `is_required` to `ApplicationFormGetResponseDataSchema`
Update tests
Set the value based on utility function

## Context for reviewers

Ticket specified to create a new function, but we are reusing `is_form_required` which was added a week ago. We could create a new function, but this one looked correct at first glance.

## Validation steps

See updated unit test.