### PR TITLE
[Issue #5280] Add logging of Pinpoint response to aid troubleshooting 

### DIFF
--- a/api/src/adapters/aws/pinpoint_adapter.py
+++ b/api/src/adapters/aws/pinpoint_adapter.py
@@ -107,7 +107,10 @@ def _handle_mock_response(request: dict, to_address: str) -> PinpointResponse:
     response = PinpointResponse(
         Result={
             to_address: PinpointResult(
-                DeliveryStatus="SUCCESSFUL", StatusCode=200, StatusMessage="Ok", MessageId=str(uuid.uuid4())
+                DeliveryStatus="SUCCESSFUL",
+                StatusCode=200,
+                StatusMessage="Ok",
+                MessageId=str(uuid.uuid4()),
             )
         }
     )

--- a/api/src/adapters/aws/pinpoint_adapter.py
+++ b/api/src/adapters/aws/pinpoint_adapter.py
@@ -41,6 +41,7 @@ class PinpointResult(BaseModel):
     delivery_status: str = Field(alias="DeliveryStatus")
     status_code: int = Field(alias="StatusCode")
     status_message: str = Field(alias="StatusMessage")
+    message_id: str = Field(alias="MessageId")
 
 
 class PinpointResponse(BaseModel):
@@ -106,7 +107,7 @@ def _handle_mock_response(request: dict, to_address: str) -> PinpointResponse:
     response = PinpointResponse(
         Result={
             to_address: PinpointResult(
-                DeliveryStatus="SUCCESSFUL", StatusCode=200, StatusMessage=str(uuid.uuid4())
+                DeliveryStatus="SUCCESSFUL", StatusCode=200, StatusMessage="Ok", MessageId=str(uuid.uuid4())
             )
         }
     )

--- a/api/src/task/notifications/base_notification.py
+++ b/api/src/task/notifications/base_notification.py
@@ -65,24 +65,27 @@ class BaseNotificationTask(Task):
                     message=user_notification.content,
                     app_id=self.notification_config.app_id,
                 )
+
+                email_response = response.results.get(user_notification.user_email, None)
+
                 logger.info(
                     "Successfully delivered notification to user",
                     extra={
                         "user_id": user_notification.user_id,
                         "notification_reason": user_notification.notification_reason,
                         "notification_log_id": notification_log.user_notification_log_id,
-                        "pinpoint_delivery_status": response.results[
-                            user_notification.user_email
-                        ].delivery_status,
-                        "pinpoint_message_id": response.results[
-                            user_notification.user_email
-                        ].message_id,
-                        "pinpoint_status_code": response.results[
-                            user_notification.user_email
-                        ].status_code,
-                        "pinpoint_status_message": response.results[
-                            user_notification.user_email
-                        ].status_message,
+                        "pinpoint_delivery_status": (
+                            email_response.delivery_status if email_response else None
+                        ),
+                        "pinpoint_message_id": (
+                            email_response.message_id if email_response else None
+                        ),
+                        "pinpoint_status_code": (
+                            email_response.status_code if email_response else None
+                        ),
+                        "pinpoint_status_message": (
+                            email_response.status_message if email_response else None
+                        ),
                     },
                 )
                 notification_log.notification_sent = True

--- a/api/src/task/notifications/base_notification.py
+++ b/api/src/task/notifications/base_notification.py
@@ -59,7 +59,7 @@ class BaseNotificationTask(Task):
             )
             self.db_session.add(notification_log)
             try:
-                send_pinpoint_email_raw(
+                response = send_pinpoint_email_raw(
                     to_address=user_notification.user_email,
                     subject=user_notification.subject,
                     message=user_notification.content,
@@ -71,6 +71,10 @@ class BaseNotificationTask(Task):
                         "user_id": user_notification.user_id,
                         "notification_reason": user_notification.notification_reason,
                         "notification_log_id": notification_log.user_notification_log_id,
+                        "pinpoint_delivery_status": response.results[user_notification.user_email].delivery_status,
+                        "pinpoint_message_id": response.results[user_notification.user_email].message_id,
+                        "pinpoint_status_code": response.results[user_notification.user_email].status_code,
+                        "pinpoint_status_message": response.results[user_notification.user_email].status_message
                     },
                 )
                 notification_log.notification_sent = True

--- a/api/src/task/notifications/base_notification.py
+++ b/api/src/task/notifications/base_notification.py
@@ -71,10 +71,18 @@ class BaseNotificationTask(Task):
                         "user_id": user_notification.user_id,
                         "notification_reason": user_notification.notification_reason,
                         "notification_log_id": notification_log.user_notification_log_id,
-                        "pinpoint_delivery_status": response.results[user_notification.user_email].delivery_status,
-                        "pinpoint_message_id": response.results[user_notification.user_email].message_id,
-                        "pinpoint_status_code": response.results[user_notification.user_email].status_code,
-                        "pinpoint_status_message": response.results[user_notification.user_email].status_message
+                        "pinpoint_delivery_status": response.results[
+                            user_notification.user_email
+                        ].delivery_status,
+                        "pinpoint_message_id": response.results[
+                            user_notification.user_email
+                        ].message_id,
+                        "pinpoint_status_code": response.results[
+                            user_notification.user_email
+                        ].status_code,
+                        "pinpoint_status_message": response.results[
+                            user_notification.user_email
+                        ].status_message,
                     },
                 )
                 notification_log.notification_sent = True


### PR DESCRIPTION
## Summary

We're getting log messages that we "successfully" sent the message to Pinpoint, but Pinpoint doesn't send any emails. Adding logging of Pinpoint response values to help understand what's happening.

Fixes #5280 

## Changes proposed

Add one additional Pinpoint response field to the model and log all 4 response values to what we include in the success log.