### PR TITLE
[Issue #4723] update opportunity terminology

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -160,7 +160,10 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
             <OpportunityStatusWidget opportunityData={opportunityData} />
             <OpportunityCTA id={opportunityData.opportunity_id} />
             <OpportunityAwardInfo opportunityData={opportunityData} />
-            <OpportunityHistory summary={opportunityData.summary} />
+            <OpportunityHistory
+              summary={opportunityData.summary}
+              status={opportunityData.opportunity_status}
+            />
           </div>
         </div>
       </ContentLayout>

--- a/frontend/src/components/application/OpportunityCard.tsx
+++ b/frontend/src/components/application/OpportunityCard.tsx
@@ -90,6 +90,7 @@ const OpportunityOverview = ({ opportunity }: OpportunityOverviewProps) => {
     opportunity_title,
     opportunity_number,
     summary,
+    opportunity_status,
   } = opportunity;
 
   return (
@@ -103,7 +104,11 @@ const OpportunityOverview = ({ opportunity }: OpportunityOverviewProps) => {
           />
           <OpportunityItem opKey={t("number")} opValue={opportunity_number} />
           <OpportunityItem
-            opKey={t("posted")}
+            opKey={
+              opportunity_status === "forecasted"
+                ? t("forecastDate")
+                : t("posted")
+            }
             opValue={displayDate(summary.post_date)}
           />
           <OpportunityItem

--- a/frontend/src/components/opportunity/OpportunityHistory.tsx
+++ b/frontend/src/components/opportunity/OpportunityHistory.tsx
@@ -1,11 +1,10 @@
-import { Summary } from "src/types/opportunity/opportunityResponseTypes";
+import {
+  OpportunityStatus,
+  Summary,
+} from "src/types/opportunity/opportunityResponseTypes";
 import { formatDate } from "src/utils/dateUtil";
 
 import { useTranslations } from "next-intl";
-
-type Props = {
-  summary: Summary;
-};
 
 const formatHistoryDate = (date: string | null) => {
   return date === null ? "--" : formatDate(date);
@@ -29,7 +28,13 @@ export const OpportunityHistoryItem = ({
   );
 };
 
-const OpportunityHistory = ({ summary }: Props) => {
+const OpportunityHistory = ({
+  summary,
+  status,
+}: {
+  summary: Summary;
+  status: OpportunityStatus;
+}) => {
   const t = useTranslations("OpportunityListing.history");
 
   return (
@@ -42,7 +47,9 @@ const OpportunityHistory = ({ summary }: Props) => {
         }
       />
       <OpportunityHistoryItem
-        title={t("postedDate")}
+        title={
+          status === "forecasted" ? t("forecastPostedDate") : t("postedDate")
+        }
         content={formatHistoryDate(summary.post_date)}
       />
       <OpportunityHistoryItem

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterOptions.ts
@@ -17,8 +17,8 @@ export const statusOptions: FilterOption[] = [
     value: "forecasted",
   },
   {
-    id: "status-posted",
-    label: "Posted",
+    id: "status-open",
+    label: "Open",
     value: "posted",
   },
   {

--- a/frontend/src/components/search/SearchResultsListItem.tsx
+++ b/frontend/src/components/search/SearchResultsListItem.tsx
@@ -73,7 +73,11 @@ export default function SearchResultsListItem({
               <span
                 className={`${metadataBorderClasses} tablet:order-0 order-2`}
               >
-                <strong>{t("resultsListItem.summary.posted")}</strong>
+                <strong>
+                  {opportunity.opportunity_status === "forecasted"
+                    ? t("resultsListItem.summary.forecasted")
+                    : t("resultsListItem.summary.posted")}
+                </strong>
                 {opportunity?.summary?.post_date
                   ? formatDate(opportunity?.summary?.post_date)
                   : "--"}

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -172,6 +172,7 @@ export const messages = {
     history: {
       history: "History",
       postedDate: "Posted date",
+      forecastPostedDate: "Forecast posted date",
       closingDate: "Original closing date for applications",
       archiveDate: "Archive date",
       forecastedAwardDate: "Estimated Award Date",
@@ -207,7 +208,7 @@ export const messages = {
       opportunity: "Opportunity",
       name: "Name",
       number: "Number",
-      posted: "Posted",
+      posted: "Posted date",
       agency: "Agency",
       assistanceListings: "Assistance listings",
       costSharingOrMatchingRequirement: "Cost Sharing or matching requirement",
@@ -509,7 +510,8 @@ export const messages = {
         forecasted: "Forecasted",
       },
       summary: {
-        posted: "Posted: ",
+        forecasted: "Forecast posted date: ",
+        posted: "Posted date: ",
         agency: "Agency: ",
       },
       opportunityNumber: "Opportunity Number: ",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -209,6 +209,7 @@ export const messages = {
       name: "Name",
       number: "Number",
       posted: "Posted date",
+      forecastDate: "Forecast posted date",
       agency: "Agency",
       assistanceListings: "Assistance listings",
       costSharingOrMatchingRequirement: "Cost Sharing or matching requirement",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -159,8 +159,8 @@ export const messages = {
       no: "No",
       programFunding: "Program Funding",
       expectedAwards: "Expected awards",
-      awardCeiling: "Award Ceiling",
-      awardFloor: "Award Floor",
+      awardCeiling: "Award Maximum",
+      awardFloor: "Award Minimum",
       opportunityNumber: "Funding opportunity number",
       costSharing: "Cost sharing or matching requirement",
       fundingInstrument: "Funding instrument type",
@@ -469,7 +469,7 @@ export const messages = {
       options: {
         status: {
           forecasted: "Forecasted",
-          posted: "Posted",
+          posted: "Open",
           closed: "Closed",
           archived: "Archived",
         },
@@ -513,8 +513,8 @@ export const messages = {
         agency: "Agency: ",
       },
       opportunityNumber: "Opportunity Number: ",
-      awardCeiling: "Award Ceiling: ",
-      floor: "Floor: ",
+      awardCeiling: "Award Maximum: ",
+      floor: "Minimum: ",
     },
     sortBy: {
       options: {

--- a/frontend/src/types/opportunity/opportunityResponseTypes.ts
+++ b/frontend/src/types/opportunity/opportunityResponseTypes.ts
@@ -90,4 +90,5 @@ export type OpportunityOverview = Pick<
   | "agency_code"
   | "opportunity_assistance_listings"
   | "summary"
+  | "opportunity_status"
 >;

--- a/frontend/tests/components/opportunity/OpportunityHistory.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityHistory.test.tsx
@@ -25,7 +25,7 @@ const mockSummary = {
 
 describe("OpportunityHistory", () => {
   it("renders history section with dates formatted correctly", () => {
-    render(<OpportunityHistory summary={mockSummary} />);
+    render(<OpportunityHistory status="posted" summary={mockSummary} />);
 
     expect(screen.getByText("history")).toBeInTheDocument();
 
@@ -40,7 +40,7 @@ describe("OpportunityHistory", () => {
   });
 
   it("calls formatDate for date fields", () => {
-    render(<OpportunityHistory summary={mockSummary} />);
+    render(<OpportunityHistory status="posted" summary={mockSummary} />);
 
     // Check that formatDate is called with the right dates
     expect(formatDate).toHaveBeenCalledWith("2024-01-15");
@@ -50,6 +50,7 @@ describe("OpportunityHistory", () => {
   it("displays correct defaults when null values are present", () => {
     render(
       <OpportunityHistory
+        status="posted"
         summary={
           {
             post_date: null,

--- a/frontend/tests/e2e/search/search-navigate.spec.ts
+++ b/frontend/tests/e2e/search/search-navigate.spec.ts
@@ -21,5 +21,5 @@ test("should navigate from index to search page", async ({
 
   // Verify that the 'forecasted' and 'posted' are checked
   await expectCheckboxIDIsChecked(page, "#status-forecasted");
-  await expectCheckboxIDIsChecked(page, "#status-posted");
+  await expectCheckboxIDIsChecked(page, "#status-open");
 });

--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -204,7 +204,7 @@ test.describe("Search page tests", () => {
     // check all 4 boxes
     const statusCheckboxes = {
       "status-forecasted": "forecasted",
-      "status-posted": "posted",
+      "status-open": "posted",
       "status-closed": "closed",
       "status-archived": "archived",
     };


### PR DESCRIPTION
## Summary

Fixes #4723

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
User facing terminology updates in various opportunity related locations

* "award ceiling" -> "award maximum"
* "award floor" -> "award minimum"
* for opportunity status values: "posted" -> "open"
* for expressing the value of an opportunity's "post_date": 
  * if the opportunity is in a "forecasted" status: "forecast posted date"
  * otherwise: "posted date"
 
## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search
3. _VERIFY_: status filter option displays "Open"
4. _VERIFY_: search results for "posted" opportunities display "Posted date"
5. _VERIFY_: search results for "forecasted" opportunities display "Forecast posted date"
6. _VERIFY_: search results display "Award maximum" and "minimum"
7. open both a forecasted and posted opportunity detail
3. _VERIFY_: history section for "posted" opportunity displays "Posted date"
3. _VERIFY_: history section for "forecasted" opportunity displays "Forecast posted date"
4. _VERIFY_: award section displays "Award maximum" and "Award minimum"
5. visit http://localhost:3000/opportunity/112?_ff=applyFormPrototypeOff:false
6. create a new application
4. _VERIFY_: summary displays "Posted date"
5. update the `opportunity_status_id` of opportunity 112 in the `current_opportunity_summary` table in your local DB to `1`
6. refresh the page
4. _VERIFY_: summary displays "Forecast posted date"

### Screenshots
<img width="1208" alt="Screenshot 2025-06-11 at 5 23 27 PM" src="https://github.com/user-attachments/assets/ba1d5087-8543-41af-bef0-989cc7b99946" />
<img width="1210" alt="Screenshot 2025-06-12 at 9 01 58 AM" src="https://github.com/user-attachments/assets/dcc4c53d-5882-4fa5-a11c-b5a674392aea" />
<img width="1174" alt="Screenshot 2025-06-12 at 9 02 09 AM" src="https://github.com/user-attachments/assets/e848b72a-4dc3-4012-9f01-68e884329d7e" />
<img width="1197" alt="Screenshot 2025-06-12 at 9 08 58 AM" src="https://github.com/user-attachments/assets/017c155f-7209-439b-a1b5-84f94da6184f" />
<img width="1240" alt="Screenshot 2025-06-12 at 9 20 45 AM" src="https://github.com/user-attachments/assets/94152d90-027f-4236-8994-5f4523db349d" />
<img width="1222" alt="Screenshot 2025-06-12 at 9 47 17 AM" src="https://github.com/user-attachments/assets/8e02c315-b817-4426-8ba8-52ebaa80cb82" />


