### PR TITLE
[Issue #5280] Pinpoint permissions and logging fixes

### DIFF
--- a/api/src/adapters/aws/pinpoint_adapter.py
+++ b/api/src/adapters/aws/pinpoint_adapter.py
@@ -41,7 +41,7 @@ class PinpointResult(BaseModel):
     delivery_status: str = Field(alias="DeliveryStatus")
     status_code: int = Field(alias="StatusCode")
     status_message: str = Field(alias="StatusMessage")
-    message_id: str = Field(alias="MessageId")
+    message_id: str = Field(alias="MessageId", default="not-sent")
 
 
 class PinpointResponse(BaseModel):

--- a/api/src/task/notifications/base_notification.py
+++ b/api/src/task/notifications/base_notification.py
@@ -45,11 +45,10 @@ class BaseNotificationTask(Task):
         """Send collected notifications to users"""
 
         for user_notification in notifications:
+            trace_id = str(uuid.uuid4())
             logger.info(
                 "Sending notification to user",
-                extra={
-                    "user_id": user_notification.user_id,
-                },
+                extra={"user_id": user_notification.user_id, "trace_id": trace_id},
             )
             notification_log = UserNotificationLog(
                 user_notification_log_id=uuid.uuid4(),
@@ -86,6 +85,7 @@ class BaseNotificationTask(Task):
                         "pinpoint_status_message": (
                             email_response.status_message if email_response else None
                         ),
+                        "trace_id": trace_id,
                     },
                 )
                 notification_log.notification_sent = True
@@ -100,6 +100,7 @@ class BaseNotificationTask(Task):
                     extra={
                         "user_id": user_notification.user_id,
                         "notification_reason": user_notification.notification_reason,
+                        "trace_id": trace_id,
                     },
                 )
                 self.increment(Metrics.FAILED_TO_SEND)

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -184,6 +184,4 @@ module "service" {
   )
 
   is_temporary = local.is_temporary
-
-  pinpoint_app_id = module.notifications[0].app_id
 }

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -184,4 +184,6 @@ module "service" {
   )
 
   is_temporary = local.is_temporary
+
+  pinpoint_app_id = module.notifications[0].app_id
 }

--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -122,6 +122,15 @@ data "aws_iam_policy_document" "email_access" {
       resources = ["arn:aws:mobiletargeting:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:apps/${var.pinpoint_app_id}/messages"]
     }
   }
+
+  dynamic "statement" {
+    for_each = length(var.pinpoint_app_id) > 0 ? [1] : []
+    content {
+      sid       = "SendSESEmail"
+      actions   = ["ses:SendEmail"]
+      resources = ["arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/${var.domain_name}"]
+    }
+  }
 }
 
 resource "aws_iam_role_policy" "task_executor" {

--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -97,15 +97,6 @@ data "aws_iam_policy_document" "task_executor" {
       resources = [for secret in var.secrets : secret.valueFrom]
     }
   }
-
-  dynamic "statement" {
-    for_each = length(var.pinpoint_app_id) > 0 ? [1] : []
-    content {
-      sid       = "SendViaPinpoint"
-      actions   = ["mobiletargeting:SendMessages"]
-      resources = ["arn:aws:mobiletargeting:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:apps/${var.pinpoint_app_id}/messages"]
-    }
-  }
 }
 
 data "aws_iam_policy_document" "runtime_logs" {
@@ -122,6 +113,17 @@ data "aws_iam_policy_document" "runtime_logs" {
   }
 }
 
+data "aws_iam_policy_document" "email_access" {
+  dynamic "statement" {
+    for_each = length(var.pinpoint_app_id) > 0 ? [1] : []
+    content {
+      sid       = "SendViaPinpoint"
+      actions   = ["mobiletargeting:SendMessages"]
+      resources = ["arn:aws:mobiletargeting:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:apps/${var.pinpoint_app_id}/messages"]
+    }
+  }
+}
+
 resource "aws_iam_role_policy" "task_executor" {
   name   = "${var.service_name}-task-executor-role-policy"
   role   = aws_iam_role.task_executor.id
@@ -131,6 +133,11 @@ resource "aws_iam_role_policy" "task_executor" {
 resource "aws_iam_policy" "runtime_logs" {
   name   = "${var.service_name}-task-executor-role-policy"
   policy = data.aws_iam_policy_document.runtime_logs.json
+}
+
+resource "aws_iam_policy" "email_access" {
+  name   = "${var.service_name}-email-access-role-policy"
+  policy = data.aws_iam_policy_document.email_access.json
 }
 
 resource "aws_iam_role_policy_attachment" "extra_policies" {
@@ -143,4 +150,9 @@ resource "aws_iam_role_policy_attachment" "extra_policies" {
 resource "aws_iam_role_policy_attachment" "runtime_logs" {
   role       = aws_iam_role.app_service.name
   policy_arn = aws_iam_policy.runtime_logs.arn
+}
+
+resource "aws_iam_role_policy_attachment" "email_access" {
+  role       = aws_iam_role.app_service.name
+  policy_arn = aws_iam_policy.email_access.arn
 }


### PR DESCRIPTION
## Summary

Get corrected permissions committed. Add more logging for troubleshooting why emails still aren't getting out even once permissions are manually applied to Dev.

## Changes proposed

- Fix the role we're applying the permissions to so that they apply when the Task runs, not when it gets kicked off.
- MessageId is not set on the Responses we're getting back 
- Adding TraceId to try to track these failing requests since they don't get MessageIds


## Context for reviewers

We had the permissions on the wrong role. Fixing that and when manually applied now we get additional failures because the way our messages are failing to send seems to mean they don't have MessageIds. 

```
"[\"<class 'pydantic_core._pydantic_core.ValidationError'>\",\"1 validation error for PinpointResponse\\nResult.`<emailAddress>`.MessageId\\n  Field required [type=missing, input_value={'DeliveryStatus': 'PERMA...15bce1d2; Proxy: null)\\\"}, input_type=dict]\\n    For further information visit https://errors.pydantic.dev/2.11/v/missing\",\"<traceback object at 0x7faca35b71c0>\"]"

"Traceback (most recent call last):\n  File \"/api/src/task/notifications/base_notification.py\", line 62, in send_notifications\n    response = send_pinpoint_email_raw(\n        to_address=user_notification.user_email,\n    ...<2 lines>...\n        app_id=self.notification_config.app_id,\n    )\n  File \"/api/src/adapters/aws/pinpoint_adapter.py\", line 99, in send_pinpoint_email_raw\n    return PinpointResponse.model_validate(raw_response[\"MessageResponse\"])\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/api/.venv/lib/python3.13/site-packages/pydantic/main.py\", line 703, in model_validate\n    return cls.__pydantic_validator__.validate_python(\n           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        obj, strict=strict, from_attributes=from_attributes, context=context, by_alias=by_alias, by_name=by_name\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\npydantic_core._pydantic_core.ValidationError: 1 validation error for PinpointResponse\nResult.`<emailAddress>`.MessageId\n  Field required [type=missing, input_value={'DeliveryStatus': 'PERMA...15bce1d2; Proxy: null)\"}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.11/v/missing"
```
