### PR TITLE
Allow a user to connect an organization to their application in the create application endpoint 

### DIFF
--- a/api/src/api/application_alpha/application_route.py
+++ b/api/src/api/application_alpha/application_route.py
@@ -46,6 +46,8 @@ def application_start(db_session: db.Session, json_data: dict) -> response.ApiRe
     competition_id = json_data["competition_id"]
     # application_name is optional, so we use get to avoid a KeyError
     application_name = json_data.get("application_name", None)
+    # organization_id is optional, so we use get to avoid a KeyError
+    organization_id = json_data.get("organization_id", None)
     add_extra_data_to_current_request_logs({"competition_id": competition_id})
     logger.info("POST /alpha/applications/start")
 
@@ -54,7 +56,9 @@ def application_start(db_session: db.Session, json_data: dict) -> response.ApiRe
     user = token_session.user
 
     with db_session.begin():
-        application = create_application(db_session, competition_id, user, application_name)
+        application = create_application(
+            db_session, competition_id, user, application_name, organization_id
+        )
 
     return response.ApiResponse(
         message="Success", data={"application_id": application.application_id}

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -11,6 +11,7 @@ from src.constants.lookup_constants import ApplicationFormStatus
 class ApplicationStartRequestSchema(Schema):
     competition_id = fields.UUID(required=True)
     application_name = fields.String(required=False, allow_none=True)
+    organization_id = fields.UUID(required=False, allow_none=True)
 
 
 class ApplicationStartResponseDataSchema(Schema):

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -9,7 +9,8 @@ import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
 from src.constants.lookup_constants import ApplicationStatus
 from src.db.models.competition_models import Application, ApplicationForm, Competition
-from src.db.models.user_models import ApplicationUser, User
+from src.db.models.entity_models import Organization
+from src.db.models.user_models import ApplicationUser, OrganizationUser, User
 from src.services.applications.application_validation import (
     ApplicationAction,
     validate_competition_open,
@@ -18,8 +19,36 @@ from src.services.applications.application_validation import (
 logger = logging.getLogger(__name__)
 
 
+def _validate_organization_membership(
+    db_session: db.Session, organization_id: UUID, user: User
+) -> Organization:
+    # Fetch the organization
+    organization = db_session.execute(
+        select(Organization).where(Organization.organization_id == organization_id)
+    ).scalar_one_or_none()
+
+    if not organization:
+        raise_flask_error(404, "Organization not found")
+
+    # Check if the user is a member of the organization
+    is_member = db_session.execute(
+        select(OrganizationUser)
+        .where(OrganizationUser.organization_id == organization_id)
+        .where(OrganizationUser.user_id == user.user_id)
+    ).scalar_one_or_none()
+
+    if not is_member:
+        raise_flask_error(403, "User is not a member of the organization")
+
+    return organization
+
+
 def create_application(
-    db_session: db.Session, competition_id: UUID, user: User, application_name: str | None = None
+    db_session: db.Session,
+    competition_id: UUID,
+    user: User,
+    application_name: str | None = None,
+    organization_id: UUID | None = None,
 ) -> Application:
     """
     Create a new application for a competition.
@@ -37,15 +66,21 @@ def create_application(
     # Verify the competition is open
     validate_competition_open(competition, ApplicationAction.START)
 
+    # Validate organization if provided
+    if organization_id is not None:
+        _validate_organization_membership(db_session, organization_id, user)
+
     # Get default application name if not provided
     if application_name is None:
         application_name = competition.opportunity.opportunity_number
+
     # Create a new application
     application = Application(
         application_id=uuid.uuid4(),
         competition_id=competition_id,
         application_name=application_name,
         application_status=ApplicationStatus.IN_PROGRESS,
+        organization_id=organization_id,  # Set the organization ID if provided
     )
     db_session.add(application)
 
@@ -67,6 +102,7 @@ def create_application(
         extra={
             "application_id": application.application_id,
             "competition_id": competition_id,
+            "organization_id": organization_id,
         },
     )
 

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -4,6 +4,7 @@ from datetime import date, timedelta
 import pytest
 from sqlalchemy import select
 
+from src.auth.api_jwt_auth import create_jwt_for_user
 from src.constants.lookup_constants import ApplicationFormStatus
 from src.db.models.competition_models import Application, ApplicationForm, ApplicationStatus
 from src.db.models.user_models import ApplicationUser
@@ -19,6 +20,7 @@ from tests.src.db.models.factories import (
     FormFactory,
     OpportunityFactory,
     OrganizationFactory,
+    OrganizationUserFactory,
     SamGovEntityFactory,
 )
 
@@ -1762,3 +1764,301 @@ def test_application_get_without_organization(
     # Check that organization field is present but null
     assert "organization" in response.json["data"]
     assert response.json["data"]["organization"] is None
+
+
+def test_application_start_with_organization_success(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test successful creation of an application with an organization"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create organization and associate user with it
+    organization = OrganizationFactory.create()
+    OrganizationUserFactory.create(organization=organization, user=user)
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    organization_id = str(organization.organization_id)
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": organization_id,
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert "application_id" in response.json["data"]
+
+    # Verify application was created with the organization
+    application_id = response.json["data"]["application_id"]
+    application = db_session.execute(
+        select(Application).where(Application.application_id == application_id)
+    ).scalar_one_or_none()
+
+    assert application is not None
+    assert str(application.competition_id) == competition_id
+    assert str(application.organization_id) == organization_id
+    assert application.application_status == ApplicationStatus.IN_PROGRESS
+
+
+def test_application_start_with_organization_and_custom_name(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation with organization and custom name"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create organization and associate user with it
+    organization = OrganizationFactory.create()
+    OrganizationUserFactory.create(organization=organization, user=user)
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    organization_id = str(organization.organization_id)
+    custom_name = "My Custom Application"
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": organization_id,
+        "application_name": custom_name,
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert "application_id" in response.json["data"]
+
+    # Verify application was created with the organization and custom name
+    application_id = response.json["data"]["application_id"]
+    application = db_session.execute(
+        select(Application).where(Application.application_id == application_id)
+    ).scalar_one_or_none()
+
+    assert application is not None
+    assert str(application.competition_id) == competition_id
+    assert str(application.organization_id) == organization_id
+    assert application.application_name == custom_name
+    assert application.application_status == ApplicationStatus.IN_PROGRESS
+
+
+def test_application_start_organization_not_found(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation fails when organization doesn't exist"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    nonexistent_organization_id = str(uuid.uuid4())  # Random UUID that doesn't exist
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": nonexistent_organization_id,
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 404
+    assert "Organization not found" in response.json["message"]
+
+    # Verify no application was created
+    applications_count = (
+        db_session.execute(select(Application).where(Application.competition_id == competition_id))
+        .scalars()
+        .all()
+    )
+    assert len(applications_count) == 0
+
+
+def test_application_start_user_not_organization_member(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation fails when user is not a member of the organization"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create organization but DON'T associate user with it
+    organization = OrganizationFactory.create()
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    organization_id = str(organization.organization_id)
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": organization_id,
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 403
+    assert "User is not a member of the organization" in response.json["message"]
+
+    # Verify no application was created
+    applications_count = (
+        db_session.execute(select(Application).where(Application.competition_id == competition_id))
+        .scalars()
+        .all()
+    )
+    assert len(applications_count) == 0
+
+
+def test_application_start_without_organization_still_works(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test that application creation still works without organization_id (backward compatibility)"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    request_data = {
+        "competition_id": competition_id,
+        # No organization_id provided
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert "application_id" in response.json["data"]
+
+    # Verify application was created without organization
+    application_id = response.json["data"]["application_id"]
+    application = db_session.execute(
+        select(Application).where(Application.application_id == application_id)
+    ).scalar_one_or_none()
+
+    assert application is not None
+    assert str(application.competition_id) == competition_id
+    assert application.organization_id is None
+    assert application.application_status == ApplicationStatus.IN_PROGRESS
+
+
+def test_application_start_with_null_organization_id(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test that application creation works with explicit null organization_id"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": None,  # Explicitly set to null
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert "application_id" in response.json["data"]
+
+    # Verify application was created without organization
+    application_id = response.json["data"]["application_id"]
+    application = db_session.execute(
+        select(Application).where(Application.application_id == application_id)
+    ).scalar_one_or_none()
+
+    assert application is not None
+    assert str(application.competition_id) == competition_id
+    assert application.organization_id is None
+    assert application.application_status == ApplicationStatus.IN_PROGRESS
+
+
+def test_application_start_invalid_organization_id_format(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation fails with invalid organization_id format"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": "invalid-uuid-format",  # Invalid UUID format
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 422
+    assert "validation error" in response.json["message"].lower()
+
+    # Verify no application was created
+    applications_count = (
+        db_session.execute(select(Application).where(Application.competition_id == competition_id))
+        .scalars()
+        .all()
+    )
+    assert len(applications_count) == 0
+
+
+def test_application_start_organization_membership_validation_works_with_multiple_users(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test that organization membership validation works correctly with multiple users"""
+    from tests.src.db.models.factories import UserFactory
+
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create organization
+    organization = OrganizationFactory.create()
+
+    # Create two users - one is member, one is not
+    user_member = user  # This user will be a member
+    user_non_member = UserFactory.create()
+
+    # Associate only the first user with the organization
+    OrganizationUserFactory.create(organization=organization, user=user_member)
+
+    competition = CompetitionFactory.create(opening_date=today, closing_date=future_date)
+
+    competition_id = str(competition.competition_id)
+    organization_id = str(organization.organization_id)
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": organization_id,
+    }
+
+    # Test with member user - should succeed
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Test with non-member user - should fail
+    non_member_token, _ = create_jwt_for_user(user_non_member, db_session)
+    db_session.commit()
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": non_member_token}
+    )
+
+    assert response.status_code == 403
+    assert "User is not a member of the organization" in response.json["message"]


### PR DESCRIPTION
## Summary

Fixes #5251

## Changes proposed

Add a `_validate_organization_membership` to validate org membership
Add new tests to cover scenarios
Return `organization_id` in `ApplicationStartRequestSchema`

## Context for reviewers

The org is optional but is validated and returned if provided.

## Validation steps

See added unit tests.