### PR TITLE
[Issue #5280] Clean up Pinpoint permissions and logging

### DIFF
--- a/api/src/adapters/aws/pinpoint_adapter.py
+++ b/api/src/adapters/aws/pinpoint_adapter.py
@@ -41,7 +41,8 @@ class PinpointResult(BaseModel):
     delivery_status: str = Field(alias="DeliveryStatus")
     status_code: int = Field(alias="StatusCode")
     status_message: str = Field(alias="StatusMessage")
-    message_id: str = Field(alias="MessageId", default="not-sent")
+    message_id: str = Field(alias="MessageId", default="message-not-sent")
+    trace_id: str | None = Field(alias="TraceId", default=None)
 
 
 class PinpointResponse(BaseModel):

--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -114,24 +114,18 @@ data "aws_iam_policy_document" "runtime_logs" {
 }
 
 data "aws_iam_policy_document" "email_access" {
-  dynamic "statement" {
-    for_each = length(var.pinpoint_app_id) > 0 ? [1] : []
-    content {
+    statement {
       sid       = "SendViaPinpoint"
       actions   = ["mobiletargeting:SendMessages"]
       resources = ["arn:aws:mobiletargeting:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:apps/${var.pinpoint_app_id}/messages"]
     }
-  }
-
-  dynamic "statement" {
-    for_each = length(var.pinpoint_app_id) > 0 ? [1] : []
-    content {
+    statement {
       sid       = "SendSESEmail"
       actions   = ["ses:SendEmail"]
       resources = ["arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:identity/${var.domain_name}"]
     }
   }
-}
+
 
 resource "aws_iam_role_policy" "task_executor" {
   name   = "${var.service_name}-task-executor-role-policy"
@@ -162,6 +156,8 @@ resource "aws_iam_role_policy_attachment" "runtime_logs" {
 }
 
 resource "aws_iam_role_policy_attachment" "email_access" {
+  count      = length(var.pinpoint_app_id) > 0 ? 1 : 0
+
   role       = aws_iam_role.app_service.name
   policy_arn = aws_iam_policy.email_access.arn
 }


### PR DESCRIPTION
## Summary

Permissions apply was breaking in services that don't have email enabled like FE. 
Need to handle TraceIds in Pinpoint Responses because if we send them in, AWS mirrors them back (without documenting that)
