### PR TITLE
[Issue #5280] TraceId was at wrong parent in the Pinpoint Request

### DIFF
--- a/api/src/adapters/aws/pinpoint_adapter.py
+++ b/api/src/adapters/aws/pinpoint_adapter.py
@@ -84,8 +84,8 @@ def send_pinpoint_email_raw(
                     }
                 }
             },
+            "TraceId": trace_id,
         },
-        "TraceId": trace_id,
     }
     # If we are running locally (or in unit tests), don't actually query
     # AWS - unlike our other AWS integrations, there is no mocking support yet


### PR DESCRIPTION
## Summary

TraceId goes in the MessageRequest, not the top level of the Pinpoint Request 
