### PR TITLE
NOFOs: Build a "prod" image after tests pass

### DIFF
--- a/.github/workflows/ci-nofos.yml
+++ b/.github/workflows/ci-nofos.yml
@@ -27,7 +27,7 @@ jobs:
           repository: HHS/simpler-grants-pdf-builder
           ref: ${{ inputs.version || 'main' }}
 
-      - name: Build docker image
+      - name: Build Docker container DEV
         run: make build
 
       - name: Run tests
@@ -36,7 +36,10 @@ jobs:
       - name: Save commit hash to file
         run: git rev-parse HEAD > /tmp/commit-hash.txt
 
-      - name: Save built image to file
+      - name: Build Docker container PROD
+        run: make build IS_PROD_ARG=1
+
+      - name: Save prod container image to file
         run: docker save nofos:latest > /tmp/docker-image.tar
 
       - name: Cache commit hash
@@ -45,7 +48,7 @@ jobs:
           path: /tmp/commit-hash.txt
           key: nofos-commit-${{ github.sha }}-${{ github.run_id }}
 
-      - name: Cache Docker image
+      - name: Cache Docker image PROD
         uses: actions/cache/save@v4
         with:
           path: /tmp/docker-image.tar


### PR DESCRIPTION


## Summary

The NOFO app container we use to run tests is not the one we should deploy.

We have an [`IS_PROD`](https://github.com/HHS/simpler-grants-pdf-builder/blob/main/Dockerfile#L6) variable that sets up our prod configuration, but if we turn it on from the get go, some of our tests fail.

## Changes proposed

Previously, we would do this:

- Build container
- Run tests
- Cache image
- Another workflow deploys cached image

Now, we do this:

- Build container
- Run tests
- Build PROD container
- Cache prod image
- Another workflow deploys cached image

## Validation steps

It works!

https://github.com/HHS/simpler-grants-gov/actions/runs/15619933756