### PR TITLE
Enable https in prod and add domain name

### DIFF
--- a/infra/nofos/app-config/prod.tf
+++ b/infra/nofos/app-config/prod.tf
@@ -5,8 +5,8 @@ module "prod_config" {
   default_region = module.project_config.default_region
   environment    = "prod"
   network_name   = "prod"
-  domain_name    = null
-  enable_https   = false
+  domain_name    = "nofos.simpler.grants.gov"
+  enable_https   = true
 
   instance_desired_instance_count = 1
   instance_scaling_min_capacity   = 1


### PR DESCRIPTION
Domain is: nofos.simpler.grants.gov

## Summary

Adds a domain and turns on https for nofos prod.

Related PR for nofos-dev: https://github.com/HHS/simpler-grants-gov/pull/5261
