### PR TITLE
[Issue #5352] Follow up for per App image hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,13 +254,16 @@ IMAGE_NAME := $(PROJECT_ROOT)-$(APP_NAME)
 
 GIT_REPO_AVAILABLE := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
 
+
+ROOT_REV := $(shell git rev-parse HEAD)
+
 # Generate a unique tag based solely on the git hash.
 # This will be the identifier used for deployment via terraform.
 
 ifdef IMAGE_TAG
 else
 	ifdef GIT_REPO_AVAILABLE
-	IMAGE_TAG := $(shell git rev-parse HEAD)
+	IMAGE_TAG := $(shell git log --pretty=format:'%H' -n 1 "${ROOT_REV}" -- "${APP_NAME}")
 	else
 	IMAGE_TAG := "unknown-dev.$(DATE)"
 	endif


### PR DESCRIPTION
## Summary

Fixes #5352

## Changes proposed

Update the way the Makefile grabs "current git hash" so it's per App aware. 

## Context for reviewers

This failed in the cron run vulnerability scans because unlike calls from push or release GitHub events, the cron job doesn't have the context of the current git hash it's running under so it was falling back to the old style of picking a hash. We had tried to avoid changing this, to preserve any backward compatibility and minimize delta from the template but this is a necessary code path we need to support.