### PR TITLE
[Issue #5085] Create PUT `/applications/:application_id/attachments/:attachment_id` endpoint

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -1234,6 +1234,53 @@ paths:
       summary: Fetch an application attachment
       security:
       - ApiJwtAuth: []
+    put:
+      parameters:
+      - in: path
+        name: application_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: application_attachment_id
+        schema:
+          type: string
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApplicationAttachmentUpdateResponse'
+          description: Successful response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Validation error
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Authentication error
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+      tags:
+      - Application Alpha
+      summary: Update an attachment on an application
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ApplicationAttachmentUpdateRequest'
+      security:
+      - ApiJwtAuth: []
     delete:
       parameters:
       - in: path
@@ -3772,6 +3819,30 @@ components:
           type:
           - object
           $ref: '#/components/schemas/ApplicationAttachmentGet'
+        status_code:
+          type: integer
+          description: The HTTP status code
+          example: 200
+    ApplicationAttachmentUpdateRequest:
+      type: object
+      properties:
+        file_attachment:
+          description: The file to attach to an application
+          type: string
+          format: binary
+      required:
+      - file_attachment
+    ApplicationAttachmentUpdateResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message to return
+          example: Success
+        data:
+          type:
+          - object
+          $ref: '#/components/schemas/ApplicationAttachmentCreate'
         status_code:
           type: integer
           description: The HTTP status code

--- a/api/src/api/application_alpha/application_route.py
+++ b/api/src/api/application_alpha/application_route.py
@@ -10,6 +10,8 @@ from src.api.application_alpha.application_schemas import (
     ApplicationAttachmentCreateResponseSchema,
     ApplicationAttachmentDeleteResponseSchema,
     ApplicationAttachmentGetResponseSchema,
+    ApplicationAttachmentUpdateRequestSchema,
+    ApplicationAttachmentUpdateResponseSchema,
     ApplicationFormGetResponseSchema,
     ApplicationFormUpdateRequestSchema,
     ApplicationFormUpdateResponseSchema,
@@ -30,6 +32,7 @@ from src.services.applications.get_application_attachment import get_application
 from src.services.applications.get_application_form import get_application_form
 from src.services.applications.submit_application import submit_application
 from src.services.applications.update_application import update_application
+from src.services.applications.update_application_attachment import update_application_attachment
 from src.services.applications.update_application_form import update_application_form
 
 logger = logging.getLogger(__name__)
@@ -254,6 +257,38 @@ def application_attachment_get(
     with db_session.begin():
         application_attachment = get_application_attachment(
             db_session, application_id, application_attachment_id, user
+        )
+
+    return response.ApiResponse(message="Success", data=application_attachment)
+
+
+@application_blueprint.put(
+    "/applications/<uuid:application_id>/attachments/<uuid:application_attachment_id>"
+)
+@application_blueprint.input(ApplicationAttachmentUpdateRequestSchema(), location="form_and_files")
+@application_blueprint.output(ApplicationAttachmentUpdateResponseSchema())
+@application_blueprint.doc(responses=[200, 401, 404, 422])
+@application_blueprint.auth_required(api_jwt_auth)
+@flask_db.with_db_session()
+def application_attachment_update(
+    db_session: db.Session,
+    application_id: UUID,
+    application_attachment_id: UUID,
+    form_and_files_data: dict,
+) -> response.ApiResponse:
+    """Update an attachment on an application"""
+    add_extra_data_to_current_request_logs(
+        {"application_id": application_id, "application_attachment_id": application_attachment_id}
+    )
+    logger.info("PUT /alpha/applications/:application_id/attachments/:application_attachment_id")
+
+    # Get user from token session
+    token_session = api_jwt_auth.get_user_token_session()
+    user = token_session.user
+
+    with db_session.begin():
+        application_attachment = update_application_attachment(
+            db_session, application_id, application_attachment_id, user, form_and_files_data
         )
 
     return response.ApiResponse(message="Success", data=application_attachment)

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -210,3 +210,15 @@ class ApplicationAttachmentGetResponseSchema(AbstractResponseSchema):
 
 class ApplicationAttachmentDeleteResponseSchema(AbstractResponseSchema):
     data = fields.MixinField(metadata={"example": None})
+
+
+class ApplicationAttachmentUpdateRequestSchema(Schema):
+    file_attachment = fields.File(
+        required=True,
+        allow_none=False,
+        metadata={"description": "The file to attach to an application"},
+    )
+
+
+class ApplicationAttachmentUpdateResponseSchema(AbstractResponseSchema):
+    data = fields.Nested(ApplicationAttachmentCreateSchema())

--- a/api/src/services/applications/create_application_attachment.py
+++ b/api/src/services/applications/create_application_attachment.py
@@ -88,9 +88,7 @@ def upsert_application_attachment(
     application_attachment.file_size_bytes = file_size_bytes
     application_attachment.user = user
 
-    # Only add to session if it's a new attachment (checking if it already exists in the session)
-    if application_attachment not in db_session:
-        db_session.add(application_attachment)
+    db_session.add(application_attachment)
 
     logger.info(
         "Created/updated application attachment",

--- a/api/src/services/applications/create_application_attachment.py
+++ b/api/src/services/applications/create_application_attachment.py
@@ -7,7 +7,7 @@ from werkzeug.datastructures import FileStorage
 import src.adapters.db as db
 import src.util.file_util as file_util
 from src.adapters.aws import S3Config
-from src.db.models.competition_models import ApplicationAttachment
+from src.db.models.competition_models import Application, ApplicationAttachment
 from src.db.models.user_models import User
 from src.services.applications.get_application import get_application
 
@@ -20,6 +20,25 @@ def create_application_attachment(
     # Fetch the application - handles checking if application exists & user can access
     application = get_application(db_session, application_id, user)
 
+    return upsert_application_attachment(
+        db_session=db_session,
+        application_id=application_id,
+        user=user,
+        form_and_files_data=form_and_files_data,
+        application=application,
+        application_attachment=None,
+    )
+
+
+def upsert_application_attachment(
+    db_session: db.Session,
+    application_id: uuid.UUID,
+    user: User,
+    form_and_files_data: dict,
+    application: Application,
+    application_attachment: ApplicationAttachment | None = None,
+) -> ApplicationAttachment:
+    """Create or update an application attachment."""
     # This uses a werkzeug FileStorage object for managing the file operations
     # Mimetype is set if the user specifies it when uploading the file which
     # if it's done via a standard HTML file box would include it.
@@ -27,7 +46,15 @@ def create_application_attachment(
 
     # secure_filename makes the file safe in path operations and removes non-ascii characters
     secure_file_name = file_util.get_secure_file_name(file_attachment.filename)
-    application_attachment_id = uuid.uuid4()
+
+    # For new attachments, generate a new ID. For updates, use the existing ID.
+    if application_attachment is None:
+        application_attachment_id = uuid.uuid4()
+        application_attachment = ApplicationAttachment(
+            application_attachment_id=application_attachment_id
+        )
+    else:
+        application_attachment_id = application_attachment.application_attachment_id
 
     # Build the s3 path
     s3_file_location = build_s3_application_attachment_path(
@@ -51,22 +78,22 @@ def create_application_attachment(
     # If we don't do this, we see `Can't attach instance of 'User' to session` errors.
     user = db_session.merge(user)
 
-    # Create the application attachment
-    application_attachment = ApplicationAttachment(
-        application_attachment_id=application_attachment_id,
-        application=application,
-        file_location=s3_file_location,
-        # In the file_name column we store the users actual file name unmodified
-        # so when we display it on the UI it matches whatever they uploaded.
-        file_name=file_util.get_file_name(file_attachment.filename),
-        mime_type=file_attachment.mimetype,
-        file_size_bytes=file_size_bytes,
-        user=user,
-    )
-    db_session.add(application_attachment)
+    # Set or update the application attachment properties
+    application_attachment.application = application
+    application_attachment.file_location = s3_file_location
+    # In the file_name column we store the users actual file name unmodified
+    # so when we display it on the UI it matches whatever they uploaded.
+    application_attachment.file_name = file_util.get_file_name(file_attachment.filename)
+    application_attachment.mime_type = file_attachment.mimetype
+    application_attachment.file_size_bytes = file_size_bytes
+    application_attachment.user = user
+
+    # Only add to session if it's a new attachment (checking if it already exists in the session)
+    if application_attachment not in db_session:
+        db_session.add(application_attachment)
 
     logger.info(
-        "Created application attachment",
+        "Created/updated application attachment",
         extra={"application_attachment_id": application_attachment_id},
     )
     return application_attachment

--- a/api/src/services/applications/update_application_attachment.py
+++ b/api/src/services/applications/update_application_attachment.py
@@ -1,0 +1,85 @@
+import logging
+import uuid
+from typing import cast
+
+from werkzeug.datastructures import FileStorage
+
+import src.adapters.db as db
+import src.util.file_util as file_util
+from src.db.models.competition_models import ApplicationAttachment
+from src.db.models.user_models import User
+from src.services.applications.create_application_attachment import (
+    build_s3_application_attachment_path,
+)
+from src.services.applications.get_application_attachment import get_application_attachment
+
+logger = logging.getLogger(__name__)
+
+
+def update_application_attachment(
+    db_session: db.Session,
+    application_id: uuid.UUID,
+    application_attachment_id: uuid.UUID,
+    user: User,
+    form_and_files_data: dict,
+) -> ApplicationAttachment:
+    # Fetch the application attachment, handles verifying
+    # it exists, and that the user has access attachment.
+    application_attachment = get_application_attachment(
+        db_session, application_id, application_attachment_id, user
+    )
+
+    # This uses a werkzeug FileStorage object for managing the file operations
+    # Mimetype is set if the user specifies it when uploading the file which
+    # if it's done via a standard HTML file box would include it.
+    file_attachment: FileStorage = cast(FileStorage, form_and_files_data.get("file_attachment"))
+
+    # secure_filename makes the file safe in path operations and removes non-ascii characters
+    secure_file_name = file_util.get_secure_file_name(file_attachment.filename)
+
+    # Build the new s3 path
+    new_s3_file_location = build_s3_application_attachment_path(
+        secure_file_name, application_id, application_attachment_id
+    )
+
+    # Store the old file location before updating
+    old_s3_file_location = application_attachment.file_location
+
+    # Upload the file to s3
+    logger.info(
+        "Uploading application attachment to s3",
+        extra={"application_attachment_id": application_attachment_id},
+    )
+    with file_util.open_stream(
+        new_s3_file_location, mode="wb", content_type=file_attachment.mimetype
+    ) as writefile:
+        file_attachment.save(writefile)
+
+    # The content length is not set in most cases on the FileStorage object (needs to be done explicitly by user)
+    # so instead get the content-length from the file on s3 after we upload it.
+    file_size_bytes = file_util.get_file_length_bytes(new_s3_file_location)
+
+    # Update the application attachment record
+    application_attachment.file_location = new_s3_file_location
+    # In the file_name column we store the users actual file name unmodified
+    # so when we display it on the UI it matches whatever they uploaded.
+    application_attachment.file_name = file_util.get_file_name(file_attachment.filename)
+    application_attachment.mime_type = file_attachment.mimetype
+    application_attachment.file_size_bytes = file_size_bytes
+
+    # IF the filepath on s3 is different than before, delete the old file from s3
+    if old_s3_file_location != new_s3_file_location:
+        logger.info(
+            "Deleting old application attachment from s3",
+            extra={
+                "application_attachment_id": application_attachment_id,
+                "old_file_location": old_s3_file_location,
+            },
+        )
+        file_util.delete_file(old_s3_file_location)
+
+    logger.info(
+        "Updated application attachment",
+        extra={"application_attachment_id": application_attachment_id},
+    )
+    return application_attachment

--- a/api/src/services/applications/update_application_attachment.py
+++ b/api/src/services/applications/update_application_attachment.py
@@ -1,16 +1,11 @@
 import logging
 import uuid
-from typing import cast
-
-from werkzeug.datastructures import FileStorage
 
 import src.adapters.db as db
 import src.util.file_util as file_util
 from src.db.models.competition_models import ApplicationAttachment
 from src.db.models.user_models import User
-from src.services.applications.create_application_attachment import (
-    build_s3_application_attachment_path,
-)
+from src.services.applications.create_application_attachment import upsert_application_attachment
 from src.services.applications.get_application_attachment import get_application_attachment
 
 logger = logging.getLogger(__name__)
@@ -29,46 +24,21 @@ def update_application_attachment(
         db_session, application_id, application_attachment_id, user
     )
 
-    # This uses a werkzeug FileStorage object for managing the file operations
-    # Mimetype is set if the user specifies it when uploading the file which
-    # if it's done via a standard HTML file box would include it.
-    file_attachment: FileStorage = cast(FileStorage, form_and_files_data.get("file_attachment"))
-
-    # secure_filename makes the file safe in path operations and removes non-ascii characters
-    secure_file_name = file_util.get_secure_file_name(file_attachment.filename)
-
-    # Build the new s3 path
-    new_s3_file_location = build_s3_application_attachment_path(
-        secure_file_name, application_id, application_attachment_id
-    )
-
     # Store the old file location before updating
     old_s3_file_location = application_attachment.file_location
 
-    # Upload the file to s3
-    logger.info(
-        "Uploading application attachment to s3",
-        extra={"application_attachment_id": application_attachment_id},
+    # Use the upsert function to update the attachment
+    updated_application_attachment = upsert_application_attachment(
+        db_session=db_session,
+        application_id=application_id,
+        user=user,
+        form_and_files_data=form_and_files_data,
+        application=application_attachment.application,
+        application_attachment=application_attachment,
     )
-    with file_util.open_stream(
-        new_s3_file_location, mode="wb", content_type=file_attachment.mimetype
-    ) as writefile:
-        file_attachment.save(writefile)
 
-    # The content length is not set in most cases on the FileStorage object (needs to be done explicitly by user)
-    # so instead get the content-length from the file on s3 after we upload it.
-    file_size_bytes = file_util.get_file_length_bytes(new_s3_file_location)
-
-    # Update the application attachment record
-    application_attachment.file_location = new_s3_file_location
-    # In the file_name column we store the users actual file name unmodified
-    # so when we display it on the UI it matches whatever they uploaded.
-    application_attachment.file_name = file_util.get_file_name(file_attachment.filename)
-    application_attachment.mime_type = file_attachment.mimetype
-    application_attachment.file_size_bytes = file_size_bytes
-
-    # IF the filepath on s3 is different than before, delete the old file from s3
-    if old_s3_file_location != new_s3_file_location:
+    # If the filepath on s3 is different than before, delete the old file from s3
+    if old_s3_file_location != updated_application_attachment.file_location:
         logger.info(
             "Deleting old application attachment from s3",
             extra={
@@ -82,4 +52,4 @@ def update_application_attachment(
         "Updated application attachment",
         extra={"application_attachment_id": application_attachment_id},
     )
-    return application_attachment
+    return updated_application_attachment

--- a/api/tests/src/api/applications/test_application_attachment_routes.py
+++ b/api/tests/src/api/applications/test_application_attachment_routes.py
@@ -240,6 +240,232 @@ def test_application_attachment_get_403_not_the_owner(
 
 
 ##########################################
+# Update application attachment tests
+##########################################
+
+
+@pytest.mark.parametrize(
+    "file_name,expected_mimetype",
+    [
+        ("pdf_file.pdf", "application/pdf"),
+        ("text_file.txt", "text/plain"),
+        ("spaces in file name.txt", "text/plain"),
+    ],
+)
+def test_application_attachment_update_200(
+    db_session,
+    enable_factory_create,
+    client,
+    user,
+    user_auth_token,
+    s3_config,
+    file_name,
+    expected_mimetype,
+):
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(application=application, user=user)
+
+    # Create an existing attachment first
+    existing_attachment = ApplicationAttachmentFactory.create(
+        application=application, file_name="old_file.txt"
+    )
+
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/attachments/{existing_attachment.application_attachment_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        data={"file_attachment": (attachment_dir / file_name).open("rb")},
+    )
+
+    assert response.status_code == 200
+
+    application_attachment_id = response.json["data"]["application_attachment_id"]
+    assert application_attachment_id == str(existing_attachment.application_attachment_id)
+
+    # Refresh the attachment from the database
+    db_session.refresh(existing_attachment)
+
+    assert existing_attachment.file_name == file_name
+    assert existing_attachment.mime_type == expected_mimetype
+    assert existing_attachment.file_size_bytes > 0
+    assert file_util.file_exists(existing_attachment.file_location) is True
+
+
+def test_application_attachment_update_404_application_not_found(
+    db_session, enable_factory_create, client, user, user_auth_token
+):
+    application_id = uuid.uuid4()
+    application_attachment_id = uuid.uuid4()
+
+    response = client.put(
+        f"/alpha/applications/{application_id}/attachments/{application_attachment_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        data={"file_attachment": (attachment_dir / "text_file.txt").open("rb")},
+    )
+
+    assert response.status_code == 404
+    assert response.json["message"] == f"Application with ID {application_id} not found"
+
+
+def test_application_attachment_update_404_attachment_not_found(
+    db_session, enable_factory_create, client, user, user_auth_token
+):
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(application=application, user=user)
+    attachment_id = uuid.uuid4()
+
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/attachments/{attachment_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        data={"file_attachment": (attachment_dir / "text_file.txt").open("rb")},
+    )
+
+    assert response.status_code == 404
+    assert response.json["message"] == f"Application attachment with ID {attachment_id} not found"
+
+
+def test_application_attachment_update_422_not_a_file(
+    db_session, enable_factory_create, client, user, user_auth_token
+):
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(application=application, user=user)
+    existing_attachment = ApplicationAttachmentFactory.create(application=application)
+
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/attachments/{existing_attachment.application_attachment_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        data={"file_attachment": "not-a-file"},
+    )
+
+    assert response.status_code == 422
+    assert response.json["message"] == "Validation error"
+    assert response.json["errors"] == [
+        {
+            "field": "file_attachment",
+            "message": "Not a valid file.",
+            "type": "invalid",
+            "value": None,
+        }
+    ]
+
+
+def test_application_attachment_update_401_invalid_token(
+    db_session, enable_factory_create, client, user, user_auth_token
+):
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(application=application, user=user)
+    existing_attachment = ApplicationAttachmentFactory.create(application=application)
+
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/attachments/{existing_attachment.application_attachment_id}",
+        headers={"X-SGG-Token": "not-a-token"},
+        data={"file_attachment": (attachment_dir / "text_file.txt").open("rb")},
+    )
+
+    assert response.status_code == 401
+    assert response.json["message"] == "Unable to process token"
+
+
+def test_application_attachment_update_403_not_the_owner(
+    db_session, enable_factory_create, client, user, user_auth_token
+):
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(application=application)  # There is an owner, it's someone else
+    existing_attachment = ApplicationAttachmentFactory.create(application=application)
+
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/attachments/{existing_attachment.application_attachment_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        data={"file_attachment": (attachment_dir / "text_file.txt").open("rb")},
+    )
+
+    assert response.status_code == 403
+    assert response.json["message"] == "Unauthorized"
+
+
+def test_application_attachment_update_deletes_old_file_different_name(
+    db_session,
+    enable_factory_create,
+    client,
+    user,
+    user_auth_token,
+    s3_config,
+):
+    """Test that updating an attachment with different filename deletes the old file"""
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(application=application, user=user)
+
+    # Create attachment with initial file
+    existing_attachment = ApplicationAttachmentFactory.create(
+        application=application, file_name="old_file.txt", file_contents="old file contents"
+    )
+    old_file_location = existing_attachment.file_location
+
+    # Verify old file exists
+    assert file_util.file_exists(old_file_location) is True
+
+    # Update with new file
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/attachments/{existing_attachment.application_attachment_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        data={"file_attachment": (attachment_dir / "pdf_file.pdf").open("rb")},
+    )
+
+    assert response.status_code == 200
+
+    # Refresh the attachment from the database
+    db_session.refresh(existing_attachment)
+
+    # Verify new file exists
+    assert file_util.file_exists(existing_attachment.file_location) is True
+    assert existing_attachment.file_name == "pdf_file.pdf"
+
+    # Verify old file was deleted (since filename changed, path would be different)
+    # Only check if the paths are actually different
+    if old_file_location != existing_attachment.file_location:
+        assert file_util.file_exists(old_file_location) is False
+
+
+def test_application_attachment_update_same_filename_overwrites(
+    db_session,
+    enable_factory_create,
+    client,
+    user,
+    user_auth_token,
+    s3_config,
+):
+    """Test that updating an attachment with same filename updates the attachment"""
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(application=application, user=user)
+
+    # Create attachment with initial file
+    existing_attachment = ApplicationAttachmentFactory.create(
+        application=application, file_name="text_file.txt", file_contents="old content"
+    )
+    old_file_location = existing_attachment.file_location
+
+    # Update with new file with same name
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/attachments/{existing_attachment.application_attachment_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        data={"file_attachment": (attachment_dir / "text_file.txt").open("rb")},
+    )
+
+    assert response.status_code == 200
+
+    # Refresh the attachment from the database
+    db_session.refresh(existing_attachment)
+
+    # Verify file still exists and was updated
+    assert file_util.file_exists(existing_attachment.file_location) is True
+    assert existing_attachment.file_name == "text_file.txt"
+
+    # The old file should be deleted since the path changed
+    # (factory creates in public bucket, update service uses draft bucket)
+    if old_file_location != existing_attachment.file_location:
+        assert file_util.file_exists(old_file_location) is False
+
+
+##########################################
 # Delete application attachment tests
 ##########################################
 

--- a/api/tests/src/services/applications/test_update_application_attachment.py
+++ b/api/tests/src/services/applications/test_update_application_attachment.py
@@ -1,0 +1,179 @@
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import apiflask.exceptions
+import pytest
+from werkzeug.datastructures import FileStorage
+
+import src.util.file_util as file_util
+from src.services.applications.update_application_attachment import update_application_attachment
+from tests.src.db.models.factories import (
+    ApplicationAttachmentFactory,
+    ApplicationFactory,
+    ApplicationUserFactory,
+    UserFactory,
+)
+
+attachment_dir = Path(__file__).parent.parent.parent / "api" / "applications" / "attachments"
+
+
+def test_update_application_attachment_success(enable_factory_create, db_session, s3_config):
+    """Test successful update of an application attachment."""
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(user=user, application=application)
+
+    # Create existing attachment
+    existing_attachment = ApplicationAttachmentFactory.create(
+        application=application, file_name="old_file.txt"
+    )
+
+    # Mock file for updating
+    mock_file = MagicMock(spec=FileStorage)
+    mock_file.filename = "new_file.pdf"
+    mock_file.mimetype = "application/pdf"
+    mock_file.save = MagicMock()
+
+    form_and_files_data = {"file_attachment": mock_file}
+
+    with db_session.begin():
+        updated_attachment = update_application_attachment(
+            db_session,
+            application.application_id,
+            existing_attachment.application_attachment_id,
+            user,
+            form_and_files_data,
+        )
+
+    # Verify the attachment was updated
+    assert (
+        updated_attachment.application_attachment_id
+        == existing_attachment.application_attachment_id
+    )
+    assert updated_attachment.file_name == "new_file.pdf"
+    assert updated_attachment.mime_type == "application/pdf"
+
+
+def test_update_application_attachment_not_found(enable_factory_create, db_session):
+    """Test update fails with non-existent attachment."""
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(user=user, application=application)
+
+    non_existent_attachment_id = uuid.uuid4()
+
+    mock_file = MagicMock(spec=FileStorage)
+    mock_file.filename = "test.pdf"
+    mock_file.mimetype = "application/pdf"
+    form_and_files_data = {"file_attachment": mock_file}
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as excinfo:
+        update_application_attachment(
+            db_session,
+            application.application_id,
+            non_existent_attachment_id,
+            user,
+            form_and_files_data,
+        )
+
+    assert excinfo.value.status_code == 404
+    assert (
+        f"Application attachment with ID {non_existent_attachment_id} not found"
+        in excinfo.value.message
+    )
+
+
+def test_update_application_attachment_application_not_found(enable_factory_create, db_session):
+    """Test update fails when application doesn't exist."""
+    user = UserFactory.create()
+    non_existent_application_id = uuid.uuid4()
+    attachment_id = uuid.uuid4()
+
+    mock_file = MagicMock(spec=FileStorage)
+    mock_file.filename = "test.pdf"
+    mock_file.mimetype = "application/pdf"
+    form_and_files_data = {"file_attachment": mock_file}
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as excinfo:
+        update_application_attachment(
+            db_session,
+            non_existent_application_id,
+            attachment_id,
+            user,
+            form_and_files_data,
+        )
+
+    assert excinfo.value.status_code == 404
+    assert f"Application with ID {non_existent_application_id} not found" in excinfo.value.message
+
+
+def test_update_application_attachment_unauthorized(enable_factory_create, db_session):
+    """Test update fails when user is not associated with the application."""
+    user = UserFactory.create()
+    other_user = UserFactory.create()
+    application = ApplicationFactory.create()
+
+    # Associate other_user (not user) with the application
+    ApplicationUserFactory.create(user=other_user, application=application)
+
+    existing_attachment = ApplicationAttachmentFactory.create(application=application)
+
+    mock_file = MagicMock(spec=FileStorage)
+    mock_file.filename = "test.pdf"
+    mock_file.mimetype = "application/pdf"
+    form_and_files_data = {"file_attachment": mock_file}
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as excinfo:
+        update_application_attachment(
+            db_session,
+            application.application_id,
+            existing_attachment.application_attachment_id,
+            user,
+            form_and_files_data,
+        )
+
+    assert excinfo.value.status_code == 403
+    assert "Unauthorized" in excinfo.value.message
+
+
+def test_update_application_attachment_with_real_file(enable_factory_create, db_session, s3_config):
+    """Test update with a real file to verify file operations."""
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+    ApplicationUserFactory.create(user=user, application=application)
+
+    # Create existing attachment with actual file
+    existing_attachment = ApplicationAttachmentFactory.create(
+        application=application, file_name="old_file.txt", file_contents="old content"
+    )
+    old_file_location = existing_attachment.file_location
+
+    # Verify old file exists
+    assert file_util.file_exists(old_file_location) is True
+
+    # Create FileStorage object to simulate proper form upload
+    test_file_path = attachment_dir / "pdf_file.pdf"
+    with test_file_path.open("rb") as file_handle:
+        file_storage = FileStorage(
+            stream=file_handle, filename="pdf_file.pdf", content_type="application/pdf"
+        )
+        form_and_files_data = {"file_attachment": file_storage}
+
+        with db_session.begin():
+            updated_attachment = update_application_attachment(
+                db_session,
+                application.application_id,
+                existing_attachment.application_attachment_id,
+                user,
+                form_and_files_data,
+            )
+
+    # Verify the attachment was updated
+    assert updated_attachment.file_name == "pdf_file.pdf"
+    assert updated_attachment.mime_type == "application/pdf"
+    assert file_util.file_exists(updated_attachment.file_location) is True
+
+    # If the file path changed, old file should be deleted
+    if old_file_location != updated_attachment.file_location:
+        assert file_util.file_exists(old_file_location) is False


### PR DESCRIPTION
## Summary

Fixes #5085

## Changes proposed

Add route and associated service.
Add `ApplicationAttachmentUpdateRequestSchema` and `ApplicationAttachmentUpdateResponseSchema` to handle request/response.
Add tests covering multiple scenarios.

## Context for reviewers

Much of this has been reused from other existing routes / services.

Route updates an attachment. It should effectively be the same as the other one, but will handle "updating" the file for the given attachment ID. Deletes old attachment path if new path is provided. Uses secure_filename to regenerate a file name, if needed.

## Validation steps

See added unit tests.