### PR TITLE
[Issue #5087] Update GET application form to return attachment info

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -3212,6 +3212,34 @@ components:
           type: integer
           description: The HTTP status code
           example: 200
+    ApplicationAttachmentNoLink:
+      type: object
+      properties:
+        application_attachment_id:
+          type: string
+          format: uuid
+          description: The ID of the application attachment
+          example: 123e4567-e89b-12d3-a456-426614174000
+        file_name:
+          type: string
+          description: The name of the application attachment file
+          example: my_example.pdf
+        mime_type:
+          type: string
+          description: The MIME type / content-type of the file
+          example: application/pdf
+        file_size_bytes:
+          type: integer
+          description: The size of the attachment in bytes
+          example: 12340
+        created_at:
+          type: string
+          format: date-time
+          description: When the application attachment was created
+        updated_at:
+          type: string
+          format: date-time
+          description: When the application attachment was last updated
     ApplicationFormGetResponseData:
       type: object
       properties:
@@ -3249,6 +3277,12 @@ components:
         is_required:
           type: boolean
           description: Whether this form is required for the application
+        application_attachments:
+          type: array
+          items:
+            type:
+            - object
+            $ref: '#/components/schemas/ApplicationAttachmentNoLink'
     ApplicationUser:
       type: object
       properties:
@@ -3274,34 +3308,6 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SamGovEntity'
           - type: 'null'
-    ApplicationAttachmentNoLink:
-      type: object
-      properties:
-        application_attachment_id:
-          type: string
-          format: uuid
-          description: The ID of the application attachment
-          example: 123e4567-e89b-12d3-a456-426614174000
-        file_name:
-          type: string
-          description: The name of the application attachment file
-          example: my_example.pdf
-        mime_type:
-          type: string
-          description: The MIME type / content-type of the file
-          example: application/pdf
-        file_size_bytes:
-          type: integer
-          description: The size of the attachment in bytes
-          example: 12340
-        created_at:
-          type: string
-          format: date-time
-          description: When the application attachment was created
-        updated_at:
-          type: string
-          format: date-time
-          description: When the application attachment was last updated
     ApplicationGetResponseData:
       type: object
       properties:

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -56,31 +56,6 @@ class ApplicationFormUpdateResponseSchema(AbstractResponseSchema, WarningMixinSc
     data = fields.Nested(ApplicationFormUpdateResponseDataSchema())
 
 
-class ApplicationFormGetResponseDataSchema(Schema):
-    application_form_id = fields.UUID()
-    application_id = fields.UUID()
-    form_id = fields.UUID()
-    application_response = fields.Dict()
-
-    application_form_status = fields.Enum(
-        ApplicationFormStatus,
-        metadata={"description": "Status indicating how much of a form has been filled out"},
-    )
-
-    created_at = fields.DateTime(metadata={"description": "When the application form was created"})
-    updated_at = fields.DateTime(
-        metadata={"description": "When the application form was last updated"}
-    )
-
-    is_required = fields.Boolean(
-        metadata={"description": "Whether this form is required for the application"}
-    )
-
-
-class ApplicationFormGetResponseSchema(AbstractResponseSchema, WarningMixinSchema):
-    data = fields.Nested(ApplicationFormGetResponseDataSchema())
-
-
 class ApplicationUserSchema(Schema):
     """Schema for users associated with an application"""
 
@@ -132,6 +107,33 @@ class ApplicationAttachmentNoLinkSchema(Schema):
     updated_at = fields.DateTime(
         metadata={"description": "When the application attachment was last updated"}
     )
+
+
+class ApplicationFormGetResponseDataSchema(Schema):
+    application_form_id = fields.UUID()
+    application_id = fields.UUID()
+    form_id = fields.UUID()
+    application_response = fields.Dict()
+
+    application_form_status = fields.Enum(
+        ApplicationFormStatus,
+        metadata={"description": "Status indicating how much of a form has been filled out"},
+    )
+
+    created_at = fields.DateTime(metadata={"description": "When the application form was created"})
+    updated_at = fields.DateTime(
+        metadata={"description": "When the application form was last updated"}
+    )
+
+    is_required = fields.Boolean(
+        metadata={"description": "Whether this form is required for the application"}
+    )
+
+    application_attachments = fields.List(fields.Nested(ApplicationAttachmentNoLinkSchema()))
+
+
+class ApplicationFormGetResponseSchema(AbstractResponseSchema, WarningMixinSchema):
+    data = fields.Nested(ApplicationFormGetResponseDataSchema())
 
 
 class ApplicationGetResponseDataSchema(Schema):

--- a/api/src/db/models/competition_models.py
+++ b/api/src/db/models/competition_models.py
@@ -292,6 +292,11 @@ class ApplicationForm(ApiSchemaTable, TimestampMixin):
         """Property function for slightly easier access to the form ID"""
         return self.competition_form.form_id
 
+    @property
+    def application_attachments(self) -> list["ApplicationAttachment"]:
+        """Property function to access application attachments"""
+        return self.application.application_attachments
+
 
 class ApplicationAttachment(ApiSchemaTable, TimestampMixin):
     __tablename__ = "application_attachment"

--- a/api/src/services/applications/get_application.py
+++ b/api/src/services/applications/get_application.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import lazyload, selectinload
 import src.adapters.db as db
 from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
-from src.db.models.competition_models import Application, Competition
+from src.db.models.competition_models import Application, ApplicationForm, Competition
 from src.db.models.entity_models import Organization
 from src.db.models.user_models import ApplicationUser, User
 from src.services.applications.application_validation import (
@@ -26,6 +26,8 @@ def get_application(db_session: db.Session, application_id: UUID, user: User) ->
             selectinload("*"),
             # Explicitly load organization and its sam_gov_entity
             selectinload(Application.organization).selectinload(Organization.sam_gov_entity),
+            # Explicitly load application relationships for application forms to prevent DetachedInstanceError
+            selectinload(Application.application_forms).selectinload(ApplicationForm.application),
             # Explicitly don't load these
             lazyload(Application.competition, Competition.opportunity),
             lazyload(Application.competition, Competition.applications),

--- a/api/src/services/applications/get_application_form.py
+++ b/api/src/services/applications/get_application_form.py
@@ -1,10 +1,11 @@
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
-from src.db.models.competition_models import ApplicationForm
+from src.db.models.competition_models import Application, ApplicationForm
 from src.db.models.user_models import User
 from src.form_schema.jsonschema_validator import ValidationErrorDetail
 from src.services.applications.application_validation import (
@@ -24,9 +25,15 @@ def get_application_form(
     # Get the application
     application = get_application(db_session, application_id, user)
 
-    # Get the application form
+    # Get the application form with eagerly loaded application and its attachments
     application_form = db_session.execute(
-        select(ApplicationForm).where(
+        select(ApplicationForm)
+        .options(
+            selectinload(ApplicationForm.application).selectinload(
+                Application.application_attachments
+            )
+        )
+        .where(
             ApplicationForm.application_id == application_id,
             ApplicationForm.application_form_id == app_form_id,
         )

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -738,6 +738,8 @@ def test_application_form_get_success(
     assert response.json["data"]["application_id"] == str(application_form.application_id)
     assert response.json["data"]["form_id"] == str(application_form.form_id)
     assert response.json["data"]["application_response"] == {"name": "John Doe"}
+    # Verify application_attachments field exists (empty list in this case)
+    assert response.json["data"]["application_attachments"] == []
 
 
 def test_application_form_get_application_not_found(
@@ -793,6 +795,70 @@ def test_application_form_get_unauthorized(client, enable_factory_create, db_ses
     )
 
     assert response.status_code == 401
+
+
+def test_application_form_get_with_attachments(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    # Create an application form
+    application_form = ApplicationFormFactory.create(
+        application_response={"name": "John Doe"},
+    )
+
+    # Create attachments for the application
+    attachment1 = ApplicationAttachmentFactory.create(
+        application=application_form.application, file_name="my_file_a.txt"
+    )
+    attachment2 = ApplicationAttachmentFactory.create(
+        application=application_form.application, file_name="my_file_b.pdf"
+    )
+
+    CompetitionFormFactory.create(
+        competition=application_form.application.competition,
+        form=application_form.form,
+    )
+
+    # Associate user with application
+    ApplicationUserFactory.create(user=user, application=application_form.application)
+
+    response = client.get(
+        f"/alpha/applications/{application_form.application_id}/application_form/{application_form.application_form_id}",
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Verify basic application form data
+    assert response.json["data"]["application_form_id"] == str(application_form.application_form_id)
+    assert response.json["data"]["application_id"] == str(application_form.application_id)
+    assert response.json["data"]["form_id"] == str(application_form.form_id)
+    assert response.json["data"]["application_response"] == {"name": "John Doe"}
+
+    # Verify application attachments are included
+    resp_application_attachments = response.json["data"]["application_attachments"]
+    assert len(resp_application_attachments) == 2
+
+    # Sort by file name which we set above so attachment1 is always first
+    resp_application_attachments.sort(key=lambda a: a["file_name"])
+
+    assert resp_application_attachments[0]["application_attachment_id"] == str(
+        attachment1.application_attachment_id
+    )
+    assert resp_application_attachments[0]["file_name"] == attachment1.file_name
+    assert resp_application_attachments[0]["mime_type"] == attachment1.mime_type
+    assert resp_application_attachments[0]["file_size_bytes"] == attachment1.file_size_bytes
+    assert resp_application_attachments[0]["created_at"] == attachment1.created_at.isoformat()
+    assert resp_application_attachments[0]["updated_at"] == attachment1.updated_at.isoformat()
+
+    assert resp_application_attachments[1]["application_attachment_id"] == str(
+        attachment2.application_attachment_id
+    )
+    assert resp_application_attachments[1]["file_name"] == attachment2.file_name
+    assert resp_application_attachments[1]["mime_type"] == attachment2.mime_type
+    assert resp_application_attachments[1]["file_size_bytes"] == attachment2.file_size_bytes
+    assert resp_application_attachments[1]["created_at"] == attachment2.created_at.isoformat()
+    assert resp_application_attachments[1]["updated_at"] == attachment2.updated_at.isoformat()
 
 
 def test_application_get_success(client, enable_factory_create, db_session, user, user_auth_token):

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -893,6 +893,7 @@ def test_application_get_success(client, enable_factory_create, db_session, user
             "created_at": application_form.created_at.isoformat(),
             "updated_at": application_form.updated_at.isoformat(),
             "is_required": True,
+            "application_attachments": [],
         }
 
 


### PR DESCRIPTION
## Summary

Fixes #5087

## Changes proposed

Add `application_attachments` property to `ApplicationForm`
Add `application_attachments ` to `ApplicationFormGetResponseDataSchema` 

Update / add tests

## Context for reviewers

Update the GET /application/../application_form endpoint to return application attachments.

## Validation steps

See unit tests