### PR TITLE
[Issue #5286] Enable mTLS on a SOAP Proxy/Router specific ALB

### DIFF
--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -158,6 +158,8 @@ module "service" {
   s3_cdn_certificate_arn = local.service_config.s3_cdn_domain_name != null ? data.aws_acm_certificate.s3_cdn_cert[0].arn : null
   hosted_zone_id         = null
 
+  enable_mtls_load_balancer = true
+
   cpu                      = local.service_config.cpu
   memory                   = local.service_config.memory
   desired_instance_count   = local.service_config.desired_instance_count

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -6,8 +6,8 @@
 resource "aws_lb" "alb" {
   # we need an identical alb, with mtls enabled
   # so we piggy back off existing and just spin up two when the api sets this true
-  count = var.enable_load_balancer ? var.enable_mtls_load_balancer ? 2 : 1 : 0
-  depends_on      = [aws_s3_bucket_policy.access_logs]
+  count      = var.enable_load_balancer ? var.enable_mtls_load_balancer ? 2 : 1 : 0
+  depends_on = [aws_s3_bucket_policy.access_logs]
   # adjust name for the mtls alb that's in slot 1
   name            = count.index == 0 ? var.service_name : format("%s-mtls", var.service_name)
   idle_timeout    = "120"

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -4,9 +4,12 @@
 
 # ALB for an app running in ECS
 resource "aws_lb" "alb" {
-  count           = var.enable_load_balancer ? 1 : 0
+  # we need an identical alb, with mtls enabled
+  # so we piggy back off existing and just spin up two when the api sets this true
+  count = var.enable_load_balancer ? var.enable_mtls_load_balancer ? 2 : 1 : 0
   depends_on      = [aws_s3_bucket_policy.access_logs]
-  name            = var.service_name
+  # adjust name for the mtls alb that's in slot 1
+  name            = count.index == 0 ? var.service_name : format("%s-mtls", var.service_name)
   idle_timeout    = "120"
   internal        = false
   security_groups = [aws_security_group.alb.id]
@@ -41,6 +44,8 @@ resource "aws_lb_listener" "alb_listener_http" {
   # TODO(https://github.com/navapbc/template-infra/issues/163) Use HTTPS protocol
   # checkov:skip=CKV_AWS_2:Implement HTTPS in issue #163
   # checkov:skip=CKV_AWS_103:Require TLS 1.2 as part of implementing HTTPS support
+
+  # there is no mtls for http so we don't need to do the same dance here
   count = var.enable_load_balancer ? 1 : 0
 
   load_balancer_arn = aws_lb.alb[0].arn
@@ -59,6 +64,7 @@ resource "aws_lb_listener" "alb_listener_http" {
 }
 
 resource "aws_lb_listener_rule" "app_http_forward" {
+  # there is no mtls for http so we don't need to do the same dance here
   count = var.enable_load_balancer ? 1 : 0
 
   listener_arn = aws_lb_listener.alb_listener_http[0].arn
@@ -76,14 +82,15 @@ resource "aws_lb_listener_rule" "app_http_forward" {
 }
 
 resource "aws_lb_listener" "alb_listener_https" {
-  count = var.certificate_arn != null ? 1 : 0
+  count = var.enable_load_balancer ? var.enable_mtls_load_balancer ? 2 : 1 : 0
 
-  load_balancer_arn = aws_lb.alb[0].arn
+  load_balancer_arn = aws_lb.alb[count.index].arn
   port              = 443
   protocol          = "HTTPS"
-  certificate_arn   = var.certificate_arn
+  #TODO: figure out how we get soap. certificate here for false option
+  certificate_arn = count.index == 0 ? var.certificate_arn : var.certificate_arn
   mutual_authentication {
-    mode = "off"
+    mode = count.index == 1 ? "passthrough" : "off"
   }
 
   # Use security policy that supports TLS 1.3 but requires at least TLS 1.2
@@ -101,14 +108,16 @@ resource "aws_lb_listener" "alb_listener_https" {
 }
 
 resource "aws_lb_listener_rule" "app_https_forward" {
-  count = var.certificate_arn != null ? 1 : 0
+  # we need an identical https forward, with mtls enabled
+  # so we piggy back off existing and just spin up two when the api sets this true
+  count = var.enable_load_balancer ? var.enable_mtls_load_balancer ? 2 : 1 : 0
 
-  listener_arn = aws_lb_listener.alb_listener_https[0].arn
+  listener_arn = aws_lb_listener.alb_listener_https[count.index].arn
   priority     = 91
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.app_tg[0].arn
+    target_group_arn = count.index == 0 ? aws_lb_target_group.app_tg[0].arn : aws_lb_target_group.mtls_tg[0].arn
   }
   condition {
     path_pattern {
@@ -117,11 +126,40 @@ resource "aws_lb_listener_rule" "app_https_forward" {
   }
 }
 
+# these get referenced from the service/main file so we want two distinct onces for easier referencing by app_tg vs mtls_tg names
 resource "aws_lb_target_group" "app_tg" {
   # you must use a prefix, to facilitate successful tg changes
   # checkov:skip=CKV_AWS_378:We are using HTTPS, just not here specifically.
   count                = var.enable_load_balancer ? 1 : 0
   name_prefix          = "app-"
+  port                 = var.container_port
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  target_type          = "ip"
+  deregistration_delay = "30"
+
+  health_check {
+    path                = var.healthcheck_path
+    port                = var.container_port
+    healthy_threshold   = 2
+    unhealthy_threshold = 10
+    interval            = 30
+    timeout             = 29
+    matcher             = "200-299"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_lb_target_group" "mtls_tg" {
+  # you must use a prefix, to facilitate successful tg changes
+  # checkov:skip=CKV_AWS_378:We are using HTTPS, just not here specifically.
+
+  # done a slightly different way from elsewhere in the file to account for naming these from another file being easier this way
+  count                = var.enable_mtls_load_balancer ? 1 : 0
+  name_prefix          = "mtls-"
   port                 = var.container_port
   protocol             = "HTTP"
   vpc_id               = var.vpc_id

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -126,7 +126,7 @@ resource "aws_lb_listener_rule" "app_https_forward" {
   }
 }
 
-# these get referenced from the service/main file so we want two distinct onces for easier referencing by app_tg vs mtls_tg names
+# these get referenced from the service/main file so we want two distinct ones for easier referencing by app_tg vs mtls_tg names
 resource "aws_lb_target_group" "app_tg" {
   # you must use a prefix, to facilitate successful tg changes
   # checkov:skip=CKV_AWS_378:We are using HTTPS, just not here specifically.

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -123,6 +123,16 @@ resource "aws_ecs_service" "app" {
       container_port   = var.container_port
     }
   }
+
+  # add a connection to the mtls target group since these same containers power both
+  dynamic "load_balancer" {
+    for_each = var.enable_mtls_load_balancer ? [1] : []
+    content {
+      target_group_arn = aws_lb_target_group.mtls_tg[0].arn
+      container_name   = var.service_name
+      container_port   = var.container_port
+    }
+  }
 }
 
 resource "aws_ecs_task_definition" "app" {

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -306,3 +306,15 @@ variable "ses_configuration_set" {
   description = "The configuration set (dashed-domain-name) where SES is set up for emails"
   default     = null
 }
+
+variable "enable_mtls_load_balancer" {
+  type        = bool
+  description = "Stand up a second twin LB that will support mTLS client certificate auth passthrough"
+  default     = false
+}
+
+variable "mtls_domain_name" {
+  type        = string
+  description = "The fully qualified domain name for the mTLS-enabled load balancer"
+  default     = null
+}


### PR DESCRIPTION
Fixes #5286

## Summary
We need an ALB that has mutual TLS Client Certificate Passthrough on for the SOAP Proxy/Router but that prompts browsers to ask for a client certificate.

## Changes proposed

Move the SOAP Proxy/Router off to it's own ALB that is configured almost identically, but supports mTLS passthrough. This also gives us the flexibility to use a unique DNS name for this and split it's traffic load off to other containers in the future if needed.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

Ran the terraform apply locally to validate everything was working and happy both in API (which should get an mTLS ALB and frontend which should be totally unaffected by this change).
