### PR TITLE
[Unticketed] Add sam.gov env vars

### DIFF
--- a/api/src/task/sam_extracts/fetch_sam_extracts.py
+++ b/api/src/task/sam_extracts/fetch_sam_extracts.py
@@ -25,7 +25,6 @@ from src.util import datetime_util
 logger = logging.getLogger(__name__)
 
 
-
 @task_blueprint.cli.command("fetch-sam-extracts", help="Fetch SAM.gov daily and monthly extracts")
 @ecs_background_task("fetch-sam-extracts")
 @flask_db.with_db_session()

--- a/api/src/task/sam_extracts/fetch_sam_extracts.py
+++ b/api/src/task/sam_extracts/fetch_sam_extracts.py
@@ -6,7 +6,6 @@ from datetime import date, timedelta
 from enum import StrEnum
 
 from botocore.client import BaseClient
-from pydantic import Field
 from sqlalchemy import select
 
 import src.adapters.db as db
@@ -22,15 +21,9 @@ from src.task.ecs_background_task import ecs_background_task
 from src.task.task import Task
 from src.task.task_blueprint import task_blueprint
 from src.util import datetime_util
-from src.util.env_config import PydanticBaseEnvConfig
 
 logger = logging.getLogger(__name__)
 
-
-class SamExtractsConfig(PydanticBaseEnvConfig):
-    """Configuration for SAM extracts fetching task"""
-
-    sam_gov_api_url: str = Field(alias="SAM_GOV_BASE_URL", default="https://api.sam.gov")
 
 
 @task_blueprint.cli.command("fetch-sam-extracts", help="Fetch SAM.gov daily and monthly extracts")
@@ -61,7 +54,6 @@ class SamExtractsTask(Task):
         s3_client: BaseClient | None = None,
     ) -> None:
         super().__init__(db_session)
-        self.config = SamExtractsConfig()
         self.s3_config = S3Config()
         self.sam_gov_client = sam_gov_client
         self.s3_client = s3_client or get_s3_client()

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -29,6 +29,9 @@ locals {
     # grants.gov services/applications URI.
     GRANTS_GOV_URI  = "https://trainingws.grants.gov:443"
     ENABLE_SOAP_API = 0
+
+    # Sam.gov
+    SAM_GOV_BASE_URL = "https://api-alpha.sam.gov"
   }
 
   # Configuration for secrets
@@ -79,6 +82,11 @@ locals {
     DOMAIN_VERIFICATION_CONTENT = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/domain-verification-content"
+    }
+
+    SAM_GOV_API_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/sam-gov-api-key"
     }
   }
 }

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -76,6 +76,9 @@ module "prod_config" {
     # grants.gov services/applications URI.
     GRANTS_GOV_URI  = "https://ws07.grants.gov:443"
     ENABLE_SOAP_API = 1
+
+    # Sam.gov
+    SAM_GOV_BASE_URL = "https://api.sam.gov"
   }
   instance_cpu    = 1024
   instance_memory = 4096


### PR DESCRIPTION
## Summary

## Changes proposed
Adds sam.gov env vars to terraform

## Context for reviewers
We just got access to sam.gov - want to test it / see what failures we'll encounter before we test it more thoroughly. Need to have the key passed in via a secret + set the right URL.

I have set the secret in parameter store based on the value from 1password - for prod I just set a TODO value for when we get that key.

