### PR TITLE
[Issue #5355] top level agency search frontend implementation

### DIFF
--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -43,8 +43,15 @@ function Search({ searchParams, params }: SearchPageProps) {
 
   const convertedSearchParams =
     convertSearchParamsToProperTypes(resolvedSearchParams);
-  const { agency, category, eligibility, fundingInstrument, query, status } =
-    convertedSearchParams;
+  const {
+    agency,
+    category,
+    eligibility,
+    fundingInstrument,
+    query,
+    status,
+    topLevelAgency,
+  } = convertedSearchParams;
 
   if (!("page" in resolvedSearchParams)) {
     resolvedSearchParams.page = "1";
@@ -78,6 +85,7 @@ function Search({ searchParams, params }: SearchPageProps) {
                   category={category}
                   fundingInstrument={fundingInstrument}
                   agency={agency}
+                  topLevelAgency={topLevelAgency}
                   searchResultsPromise={searchResultsPromise}
                 />
               </ContentDisplayToggle>

--- a/frontend/src/components/search/Filters/AgencyFilterBody.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterBody.tsx
@@ -4,6 +4,7 @@ import {
   FilterOption,
   FilterOptionWithChildren,
 } from "src/types/search/searchFilterTypes";
+import { ValidSearchQueryParamData } from "src/types/search/searchQueryTypes";
 import {
   getAgencyParent,
   getSiblingOptionValues,
@@ -54,12 +55,12 @@ export function AgencyFilterBody({
     const siblingOptions = getSiblingOptionValues(value, filterOptions);
     // remove top level agency
     topLevelQuery.delete(getAgencyParent(value));
-    const paramsToUpdate = [
-      ["agency", Array.from(newParamValue).concat(siblingOptions).join(",")],
-      ["topLevelAgency", Array.from(topLevelQuery).join(",")],
-    ];
+    const paramsToUpdate = {
+      agency: Array.from(newParamValue).concat(siblingOptions).join(","),
+      topLevelAgency: Array.from(topLevelQuery).join(","),
+    } as ValidSearchQueryParamData;
     if (queryTerm) {
-      paramsToUpdate.push(["query", queryTerm]);
+      paramsToUpdate.query = queryTerm;
     }
     return setQueryParams(paramsToUpdate);
   };
@@ -77,7 +78,8 @@ export function AgencyFilterBody({
             <AnyOptionCheckbox
               title={title.toLowerCase()}
               checked={isNoneSelected}
-              queryParamKey={"agency"}
+              queryParamKey="agency"
+              topLevelQueryParamKey="topLevelAgency"
             />
           </li>
         )}
@@ -96,8 +98,8 @@ export function AgencyFilterBody({
                 }
                 query={query}
                 topLevelQuery={topLevelQuery}
-                topLevelQueryParamKey={"topLevelAgency"}
-                queryParamKey={"agency"}
+                topLevelQueryParamKey="topLevelAgency"
+                queryParamKey="agency"
                 updateCheckedOption={toggleOptionChecked}
                 accordionTitle={title}
                 facetCounts={facetCounts}

--- a/frontend/src/components/search/Filters/AgencyFilterBody.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterBody.tsx
@@ -1,0 +1,112 @@
+import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
+import { QueryContext } from "src/services/search/QueryProvider";
+import {
+  FilterOption,
+  FilterOptionWithChildren,
+} from "src/types/search/searchFilterTypes";
+
+import { useContext, useMemo } from "react";
+
+import { AnyOptionCheckbox } from "src/components/search/SearchFilterAccordion/AnyOptionCheckbox";
+import { SearchFilterAccordionProps } from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
+import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
+import SearchFilterSection from "src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection";
+
+interface AgencyFilterBodyProps extends SearchFilterAccordionProps {
+  referenceOptions?: FilterOption[];
+  topLevelQuery?: Set<string>;
+  topLevelQueryParamKey?: string;
+  isParentSelected?: (value: string) => boolean;
+}
+
+// can rename to NestedCheckboxFilterBody if we can generalize a bit more
+export function AgencyFilterBody({
+  includeAnyOption,
+  title,
+  queryParamKey,
+  defaultEmptySelection,
+  filterOptions,
+  query,
+  facetCounts,
+  referenceOptions,
+  topLevelQuery,
+  topLevelQueryParamKey,
+  isParentSelected = () => false,
+}: AgencyFilterBodyProps) {
+  const { queryTerm } = useContext(QueryContext);
+  const { updateQueryParams, setQueryParams } = useSearchParamUpdater();
+
+  const toggleOptionChecked = (value: string, isChecked: boolean) => {
+    const newParamValue = new Set(query);
+    isChecked ? newParamValue.add(value) : newParamValue.delete(value);
+    // handle status filter custom behavior to set param when all options are unselected
+    const updatedParamValue =
+      !newParamValue.size && defaultEmptySelection?.size
+        ? defaultEmptySelection
+        : newParamValue;
+    // if removing a value, and topLevelValue is present, remove them both
+    if (!isChecked && topLevelQuery && isParentSelected(value)) {
+      topLevelQuery.delete(value.split("-")[0]);
+      const paramsToUpdate = [
+        [queryParamKey, Array.from(updatedParamValue).join(",")],
+        [topLevelQueryParamKey, Array.from(topLevelQuery).join(",")],
+      ];
+      if (queryTerm) {
+        paramsToUpdate.push(["query", queryTerm]);
+      }
+      return setQueryParams(paramsToUpdate);
+    }
+    updateQueryParams(updatedParamValue, queryParamKey, queryTerm);
+  };
+
+  const isNoneSelected = useMemo(() => query.size === 0, [query]);
+
+  return (
+    <div data-testid={`${title}-filter`}>
+      <ul className="usa-list usa-list--unstyled">
+        {includeAnyOption && (
+          <li>
+            <AnyOptionCheckbox
+              title={title.toLowerCase()}
+              checked={isNoneSelected}
+              queryParamKey={queryParamKey}
+              defaultEmptySelection={defaultEmptySelection}
+            />
+          </li>
+        )}
+        {filterOptions.map((option) => (
+          <li key={option.id}>
+            {/* If we have children, show a "section", otherwise show just a checkbox */}
+            {option.children ? (
+              // SearchFilterSection will map over all children of this option
+              <SearchFilterSection
+                option={option as FilterOptionWithChildren}
+                referenceOption={
+                  referenceOptions &&
+                  (referenceOptions.find(
+                    (referenceOption) => referenceOption.id === option.id,
+                  ) as FilterOptionWithChildren)
+                }
+                query={query}
+                topLevelQuery={topLevelQuery}
+                topLevelQueryParamKey={topLevelQueryParamKey}
+                updateCheckedOption={toggleOptionChecked}
+                accordionTitle={title}
+                facetCounts={facetCounts}
+                isParentSelected={isParentSelected}
+              />
+            ) : (
+              <SearchFilterCheckbox
+                option={option}
+                query={query}
+                updateCheckedOption={toggleOptionChecked}
+                accordionTitle={title}
+                facetCounts={facetCounts}
+              />
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/search/Filters/AgencyFilterBody.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterBody.tsx
@@ -74,7 +74,7 @@ export function AgencyFilterBody({
     <div data-testid={`${title}-filter`}>
       <ul className="usa-list usa-list--unstyled">
         {includeAnyOption && (
-          <li>
+          <li className="margin-y-2">
             <AnyOptionCheckbox
               title={title.toLowerCase()}
               checked={isNoneSelected}

--- a/frontend/src/components/search/Filters/AgencyFilterBody.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterBody.tsx
@@ -64,7 +64,10 @@ export function AgencyFilterBody({
     return setQueryParams(paramsToUpdate);
   };
 
-  const isNoneSelected = useMemo(() => query.size === 0, [query]);
+  const isNoneSelected = useMemo(
+    () => !query.size && !topLevelQuery?.size,
+    [query, topLevelQuery],
+  );
 
   return (
     <div data-testid={`${title}-filter`}>

--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -3,6 +3,7 @@
 import { debounce } from "lodash";
 import { agencySearch } from "src/services/fetch/fetchers/clientAgenciesFetcher";
 import { FilterOption } from "src/types/search/searchFilterTypes";
+import { getAgencyParent } from "src/utils/search/searchUtils";
 
 import { useCallback, useState } from "react";
 import { TextInput } from "@trussworks/react-uswds";
@@ -49,7 +50,7 @@ export function AgencyFilterContent({
 
   const isParentAgencySelected = useCallback(
     (subAgencyCode: string): boolean => {
-      return topLevelQuery?.has(subAgencyCode.split("-")[0]);
+      return topLevelQuery?.has(getAgencyParent(subAgencyCode));
     },
     [topLevelQuery],
   );
@@ -75,15 +76,14 @@ export function AgencyFilterContent({
       ) : (
         <AgencyFilterBody
           query={query}
-          queryParamKey={"agency"}
           title={title}
           includeAnyOption={!searchTerm}
           filterOptions={agencySearchResults || allAgencies}
           facetCounts={facetCounts}
           referenceOptions={allAgencies}
           topLevelQuery={topLevelQuery}
-          topLevelQueryParamKey="topLevelAgency"
           isParentSelected={isParentAgencySelected}
+          queryParamKey={"agency"}
         />
       )}
     </>

--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -74,7 +74,7 @@ export function AgencyFilterContent({
           facetCounts={facetCounts}
           referenceOptions={allAgencies}
           topLevelQuery={topLevelQuery}
-          queryParamKey={"agency"}
+          queryParamKey={"agency"} // this is unused, but here to satisfy prop types
         />
       )}
     </>

--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -3,9 +3,8 @@
 import { debounce } from "lodash";
 import { agencySearch } from "src/services/fetch/fetchers/clientAgenciesFetcher";
 import { FilterOption } from "src/types/search/searchFilterTypes";
-import { getAgencyParent } from "src/utils/search/searchUtils";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { TextInput } from "@trussworks/react-uswds";
 
 import { USWDSIcon } from "src/components/USWDSIcon";
@@ -48,13 +47,6 @@ export function AgencyFilterContent({
     { leading: false, trailing: true },
   );
 
-  const isParentAgencySelected = useCallback(
-    (subAgencyCode: string): boolean => {
-      return topLevelQuery?.has(getAgencyParent(subAgencyCode));
-    },
-    [topLevelQuery],
-  );
-
   return (
     <>
       <div className="position-relative">
@@ -82,7 +74,6 @@ export function AgencyFilterContent({
           facetCounts={facetCounts}
           referenceOptions={allAgencies}
           topLevelQuery={topLevelQuery}
-          isParentSelected={isParentAgencySelected}
           queryParamKey={"agency"}
         />
       )}

--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -4,11 +4,11 @@ import { debounce } from "lodash";
 import { agencySearch } from "src/services/fetch/fetchers/clientAgenciesFetcher";
 import { FilterOption } from "src/types/search/searchFilterTypes";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { TextInput } from "@trussworks/react-uswds";
 
-import { CheckboxFilterBody } from "src/components/search/Filters/CheckboxFilter";
 import { USWDSIcon } from "src/components/USWDSIcon";
+import { AgencyFilterBody } from "./AgencyFilterBody";
 import { FilterSearchNoResults } from "./FilterSearchNoResults";
 
 export function AgencyFilterContent({
@@ -16,11 +16,13 @@ export function AgencyFilterContent({
   title,
   allAgencies,
   facetCounts,
+  topLevelQuery,
 }: {
   query: Set<string>;
   title: string;
   allAgencies: FilterOption[];
   facetCounts: { [key: string]: number };
+  topLevelQuery: Set<string>;
 }) {
   const [agencySearchResults, setAgencySearchResults] =
     useState<FilterOption[]>();
@@ -45,6 +47,13 @@ export function AgencyFilterContent({
     { leading: false, trailing: true },
   );
 
+  const isParentAgencySelected = useCallback(
+    (subAgencyCode: string): boolean => {
+      return topLevelQuery?.has(subAgencyCode.split("-")[0]);
+    },
+    [topLevelQuery],
+  );
+
   return (
     <>
       <div className="position-relative">
@@ -64,7 +73,7 @@ export function AgencyFilterContent({
       {agencySearchResults && !agencySearchResults.length ? (
         <FilterSearchNoResults />
       ) : (
-        <CheckboxFilterBody
+        <AgencyFilterBody
           query={query}
           queryParamKey={"agency"}
           title={title}
@@ -72,6 +81,9 @@ export function AgencyFilterContent({
           filterOptions={agencySearchResults || allAgencies}
           facetCounts={facetCounts}
           referenceOptions={allAgencies}
+          topLevelQuery={topLevelQuery}
+          topLevelQueryParamKey="topLevelAgency"
+          isParentSelected={isParentAgencySelected}
         />
       )}
     </>

--- a/frontend/src/components/search/Filters/CheckboxFilter.tsx
+++ b/frontend/src/components/search/Filters/CheckboxFilter.tsx
@@ -2,24 +2,16 @@
 
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { QueryContext } from "src/services/search/QueryProvider";
-import {
-  FilterOption,
-  FilterOptionWithChildren,
-} from "src/types/search/searchFilterTypes";
 
 import { useContext, useMemo } from "react";
 
 import { AnyOptionCheckbox } from "src/components/search/SearchFilterAccordion/AnyOptionCheckbox";
 import {
   BasicSearchFilterAccordion,
+  SearchFilterAccordionProps,
   SearchFilterProps,
 } from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
 import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
-import SearchFilterSection from "src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection";
-
-interface CheckboxFilterBodyProps extends SearchFilterProps {
-  referenceOptions?: FilterOption[];
-}
 
 export function CheckboxFilterBody({
   includeAnyOption,
@@ -29,8 +21,7 @@ export function CheckboxFilterBody({
   filterOptions,
   query,
   facetCounts,
-  referenceOptions,
-}: CheckboxFilterBodyProps) {
+}: SearchFilterAccordionProps) {
   const { queryTerm } = useContext(QueryContext);
   const { updateQueryParams } = useSearchParamUpdater();
 
@@ -62,31 +53,13 @@ export function CheckboxFilterBody({
         )}
         {filterOptions.map((option) => (
           <li key={option.id}>
-            {/* If we have children, show a "section", otherwise show just a checkbox */}
-            {option.children ? (
-              // SearchFilterSection will map over all children of this option
-              <SearchFilterSection
-                option={option as FilterOptionWithChildren}
-                referenceOption={
-                  referenceOptions &&
-                  (referenceOptions.find(
-                    (referenceOption) => referenceOption.id === option.id,
-                  ) as FilterOptionWithChildren)
-                }
-                query={query}
-                updateCheckedOption={toggleOptionChecked}
-                accordionTitle={title}
-                facetCounts={facetCounts}
-              />
-            ) : (
-              <SearchFilterCheckbox
-                option={option}
-                query={query}
-                updateCheckedOption={toggleOptionChecked}
-                accordionTitle={title}
-                facetCounts={facetCounts}
-              />
-            )}
+            <SearchFilterCheckbox
+              option={option}
+              query={query}
+              updateCheckedOption={toggleOptionChecked}
+              accordionTitle={title}
+              facetCounts={facetCounts}
+            />
           </li>
         ))}
       </ul>

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -19,7 +19,7 @@ import { Accordion } from "@trussworks/react-uswds";
 
 import { CheckboxFilter } from "./Filters/CheckboxFilter";
 import { RadioButtonFilter } from "./Filters/RadioButtonFilter";
-import { AgencyFilter } from "./SearchFilterAccordion/AgencyFilterAccordion";
+import { AgencyFilterAccordion } from "./SearchFilterAccordion/AgencyFilterAccordion";
 import SearchSortBy from "./SearchSortBy";
 
 export async function SearchDrawerFilters({
@@ -40,6 +40,7 @@ export async function SearchDrawerFilters({
     costSharing,
     sortby,
     query,
+    topLevelAgency,
   } = searchParams;
 
   const agenciesPromise = Promise.all([
@@ -103,7 +104,12 @@ export async function SearchDrawerFilters({
           />
         }
       >
-        <AgencyFilter query={agency} agencyOptionsPromise={agenciesPromise} />
+        <AgencyFilterAccordion
+          query={agency}
+          agencyOptionsPromise={agenciesPromise}
+          topLevelQuery={topLevelAgency}
+          className="width-100 padding-right-5"
+        />
       </Suspense>
       <CheckboxFilter
         filterOptions={categoryOptions}

--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -4,15 +4,18 @@ import { SearchAPIResponse } from "src/types/search/searchRequestTypes";
 import { useTranslations } from "next-intl";
 
 import { AgencyFilterContent } from "src/components/search/Filters/AgencyFilterContent";
-import { CheckboxFilter } from "src/components/search/Filters/CheckboxFilter";
 import { BasicSearchFilterAccordion } from "src/components/search/SearchFilterAccordion/SearchFilterAccordion";
 
 export async function AgencyFilterAccordion({
   query,
   agencyOptionsPromise,
+  topLevelQuery,
+  className,
 }: {
   query: Set<string>;
   agencyOptionsPromise: Promise<[FilterOption[], SearchAPIResponse]>;
+  topLevelQuery: Set<string>;
+  className?: string;
 }) {
   const t = useTranslations("Search");
 
@@ -31,6 +34,7 @@ export async function AgencyFilterAccordion({
       query={query}
       queryParamKey={"agency"}
       title={t("accordion.titles.agency")}
+      className={className}
       contentClassName="maxh-mobile-lg overflow-auto position-relative"
     >
       <AgencyFilterContent
@@ -38,38 +42,8 @@ export async function AgencyFilterAccordion({
         title={t("accordion.titles.agency")}
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        topLevelQuery={topLevelQuery}
       />
     </BasicSearchFilterAccordion>
-  );
-}
-
-export async function AgencyFilter({
-  query,
-  agencyOptionsPromise,
-}: {
-  query: Set<string>;
-  agencyOptionsPromise: Promise<[FilterOption[], SearchAPIResponse]>;
-}) {
-  const t = useTranslations("Search");
-
-  let agencies: FilterOption[] = [];
-  let facetCounts: { [key: string]: number } = {};
-  try {
-    let searchResults: SearchAPIResponse;
-    [agencies, searchResults] = await agencyOptionsPromise;
-    facetCounts = searchResults.facet_counts.agency;
-  } catch (e) {
-    // Come back to this to show the user an error
-    console.error("Unable to fetch agencies for filter list", e);
-  }
-  return (
-    <CheckboxFilter
-      filterOptions={agencies}
-      query={query}
-      queryParamKey={"agency"}
-      title={t("accordion.titles.agency")}
-      facetCounts={facetCounts}
-      contentClassName="maxh-mobile-lg overflow-auto position-relative"
-    />
   );
 }

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -117,12 +117,18 @@ export const AllOptionCheckbox = ({
     if (!topLevelQueryParamKey || !topLevelQueryValue) {
       return;
     }
+    topLevelQuery?.delete(topLevelQueryValue);
     const newChildValue = difference(
       currentSelectionValues,
       childOptionValues,
     ).join(",");
     setQueryParams([
-      [topLevelQueryParamKey, ""],
+      [
+        topLevelQueryParamKey,
+        topLevelQuery && topLevelQuery.size
+          ? Array.from(topLevelQuery?.values()).join(",")
+          : "",
+      ],
       [queryParamKey, newChildValue],
     ]);
   };

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -22,11 +22,17 @@ export const AllOptionCheckbox = ({
   currentSelections,
   childOptions,
   queryParamKey,
+  topLevelQueryParamKey,
+  topLevelQuery,
+  topLevelQueryValue,
 }: {
   title: string;
   currentSelections: Set<string>;
   childOptions: FilterOption[];
   queryParamKey: string;
+  topLevelQueryParamKey?: string;
+  topLevelQuery?: Set<string>;
+  topLevelQueryValue?: string;
 }) => {
   const currentSelectionValues = useMemo(
     () => Array.from(currentSelections.values()),
@@ -37,8 +43,13 @@ export const AllOptionCheckbox = ({
     [childOptions],
   );
 
+  const topLevelSelected = useMemo(() => {
+    return topLevelQuery && topLevelQuery.has(topLevelQueryValue);
+  }, [topLevelQuery, topLevelQueryValue]);
+
   const [checked, setChecked] = useState<boolean>(
-    isSubset<string>(childOptionValues, currentSelectionValues),
+    topLevelSelected ||
+      isSubset<string>(childOptionValues, currentSelectionValues),
   );
   const { setQueryParam } = useSearchParamUpdater();
   const id = `${title.replace(/\s/, "-").toLowerCase()}-all`;
@@ -68,12 +79,31 @@ export const AllOptionCheckbox = ({
     setQueryParam(queryParamKey, newSelectedOptions.join(","));
   };
 
+  const checkTopLevel = () => {
+    if (!topLevelQueryParamKey || !topLevelQueryValue) {
+      return;
+    }
+    setQueryParam(topLevelQueryParamKey, topLevelQueryValue);
+  };
+  const uncheckTopLevel = () => {
+    if (!topLevelQueryParamKey || !topLevelQueryValue) {
+      return;
+    }
+    setQueryParam(topLevelQueryParamKey, "");
+  };
+
+  const handleCheckChange = () => (checked ? uncheckOptions() : checkOptions());
+  const handleTopLevelCheckChange = () =>
+    checked ? uncheckTopLevel() : checkTopLevel();
+
   return (
     <Checkbox
       id={id}
       name={id}
       label={label}
-      onChange={checked ? uncheckOptions : checkOptions}
+      onChange={
+        topLevelQueryParamKey ? handleTopLevelCheckChange : handleCheckChange
+      }
       disabled={false}
       checked={checked}
       value={"all"}

--- a/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AllOptionCheckbox.tsx
@@ -107,10 +107,10 @@ export const AllOptionCheckbox = ({
       currentSelectionValues,
       childOptionValues,
     ).join(",");
-    setQueryParams([
-      [topLevelQueryParamKey, newValueTopLevelValue],
-      [queryParamKey, newChildValue],
-    ]);
+    setQueryParams({
+      [topLevelQueryParamKey]: newValueTopLevelValue,
+      [queryParamKey]: newChildValue,
+    });
   };
 
   const uncheckTopLevel = () => {
@@ -122,15 +122,13 @@ export const AllOptionCheckbox = ({
       currentSelectionValues,
       childOptionValues,
     ).join(",");
-    setQueryParams([
-      [
-        topLevelQueryParamKey,
+    setQueryParams({
+      [topLevelQueryParamKey]:
         topLevelQuery && topLevelQuery.size
           ? Array.from(topLevelQuery?.values()).join(",")
           : "",
-      ],
-      [queryParamKey, newChildValue],
-    ]);
+      [queryParamKey]: newChildValue,
+    });
   };
 
   // allows for implementing this via a top level query param, or by updating child values directly via child inputs

--- a/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AnyOptionCheckbox.tsx
@@ -29,13 +29,15 @@ export const AnyOptionCheckbox = ({
   checked,
   defaultEmptySelection,
   queryParamKey,
+  topLevelQueryParamKey,
 }: {
   title: string;
   checked: boolean;
   defaultEmptySelection?: Set<string>;
   queryParamKey: string;
+  topLevelQueryParamKey?: string;
 }) => {
-  const { setQueryParam } = useSearchParamUpdater();
+  const { setQueryParam, setQueryParams } = useSearchParamUpdater();
   const id = `${title.replace(/\s/, "-").toLowerCase()}-any`;
   const t = useTranslations("Search.accordion");
   const label = `${t("any")} ${title}`;
@@ -44,6 +46,13 @@ export const AnyOptionCheckbox = ({
     const clearedSelections = defaultEmptySelection?.size
       ? Array.from(defaultEmptySelection).join(",")
       : "";
+    if (topLevelQueryParamKey) {
+      setQueryParams({
+        [queryParamKey]: clearedSelections,
+        [topLevelQueryParamKey]: "",
+      });
+      return;
+    }
     setQueryParam(queryParamKey, clearedSelections);
   };
 

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -125,6 +125,7 @@ const AccordionContent = ({
                 updateCheckedOption={toggleOptionChecked}
                 accordionTitle={title}
                 facetCounts={facetCounts}
+                queryParamKey={queryParamKey}
               />
             ) : (
               <SearchFilterCheckbox

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterCheckbox.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterCheckbox.tsx
@@ -11,6 +11,7 @@ interface SearchFilterCheckboxProps {
   accordionTitle: string;
   query: Set<string>;
   facetCounts?: { [key: string]: number };
+  parentSelected?: boolean;
 }
 
 const SearchFilterCheckbox = ({
@@ -19,6 +20,7 @@ const SearchFilterCheckbox = ({
   accordionTitle,
   query,
   facetCounts,
+  parentSelected,
 }: SearchFilterCheckboxProps) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const checked = event.target.checked;
@@ -34,7 +36,7 @@ const SearchFilterCheckbox = ({
       label={<FilterOptionLabel option={option} facetCounts={facetCounts} />}
       name={getNameAttribute()} // value passed to server action  {name: "{option.label}", value: "on" } (if no value provided)
       onChange={handleChange}
-      checked={query.has(option.value)}
+      checked={query.has(option.value) || parentSelected}
       value={option.value}
     />
   );

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { noop } from "lodash";
 import { FilterOptionWithChildren } from "src/types/search/searchFilterTypes";
 
 import { AllOptionCheckbox } from "src/components/search/SearchFilterAccordion/AllOptionCheckbox";
@@ -12,6 +13,9 @@ interface SearchFilterSectionProps {
   query: Set<string>;
   facetCounts?: { [key: string]: number };
   referenceOption?: FilterOptionWithChildren;
+  topLevelQuery?: Set<string>;
+  topLevelQueryParamKey?: string;
+  isParentSelected?: (value: string) => boolean;
 }
 
 const SearchFilterSection = ({
@@ -21,6 +25,9 @@ const SearchFilterSection = ({
   query,
   facetCounts,
   referenceOption,
+  topLevelQuery,
+  topLevelQueryParamKey,
+  isParentSelected = () => false,
 }: SearchFilterSectionProps) => {
   return (
     <>
@@ -28,11 +35,14 @@ const SearchFilterSection = ({
       <div className="padding-y-1">
         <AllOptionCheckbox
           title={option.label}
-          queryParamKey="agency"
+          queryParamKey="topLevelAgency"
           childOptions={
             referenceOption ? referenceOption.children : option.children
           }
           currentSelections={query}
+          topLevelQueryParamKey={topLevelQueryParamKey}
+          topLevelQuery={topLevelQuery}
+          topLevelQueryValue={option.value}
         />
         <ul className="usa-list usa-list--unstyled margin-left-4">
           {option.children?.map((child) => (
@@ -43,6 +53,7 @@ const SearchFilterSection = ({
                 updateCheckedOption={updateCheckedOption}
                 accordionTitle={accordionTitle}
                 facetCounts={facetCounts}
+                parentSelected={isParentSelected(option.value)}
               />
             </li>
           ))}

--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { noop } from "lodash";
 import { FilterOptionWithChildren } from "src/types/search/searchFilterTypes";
+import { ValidSearchQueryParam } from "src/types/search/searchQueryTypes";
 
 import { AllOptionCheckbox } from "src/components/search/SearchFilterAccordion/AllOptionCheckbox";
 import SearchFilterCheckbox from "src/components/search/SearchFilterAccordion/SearchFilterCheckbox";
@@ -16,6 +16,7 @@ interface SearchFilterSectionProps {
   topLevelQuery?: Set<string>;
   topLevelQueryParamKey?: string;
   isParentSelected?: (value: string) => boolean;
+  queryParamKey: ValidSearchQueryParam;
 }
 
 const SearchFilterSection = ({
@@ -27,6 +28,7 @@ const SearchFilterSection = ({
   referenceOption,
   topLevelQuery,
   topLevelQueryParamKey,
+  queryParamKey,
   isParentSelected = () => false,
 }: SearchFilterSectionProps) => {
   return (
@@ -35,7 +37,7 @@ const SearchFilterSection = ({
       <div className="padding-y-1">
         <AllOptionCheckbox
           title={option.label}
-          queryParamKey="topLevelAgency"
+          queryParamKey={queryParamKey}
           childOptions={
             referenceOption ? referenceOption.children : option.children
           }

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -21,6 +21,7 @@ export default async function SearchFilters({
   agency,
   category,
   opportunityStatus,
+  topLevelAgency,
   searchResultsPromise,
 }: {
   fundingInstrument: Set<string>;
@@ -28,6 +29,7 @@ export default async function SearchFilters({
   agency: Set<string>;
   category: Set<string>;
   opportunityStatus: Set<string>;
+  topLevelAgency: Set<string>;
   searchResultsPromise: Promise<SearchAPIResponse>;
 }) {
   const t = useTranslations("Search");
@@ -84,6 +86,7 @@ export default async function SearchFilters({
         <AgencyFilterAccordion
           query={agency}
           agencyOptionsPromise={agenciesPromise}
+          topLevelQuery={topLevelAgency}
         />
       </Suspense>
       <SearchFilterAccordion

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -47,7 +47,7 @@ export function SearchVersionTwo({
       <QueryProvider>
         <div className="grid-container">
           <div className="desktop:display-flex desktop:margin-bottom-2">
-            <div className="flex-6">
+            <div className="flex-6 flex-align-self-end">
               <SearchBar
                 tableView={true}
                 queryTermFromParent={convertedSearchParams.query}

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -193,6 +193,9 @@ function convertSearchInputSetsToArrays(
     costSharing: searchInputs.costSharing
       ? Array.from(searchInputs.costSharing)
       : [],
+    topLevelAgency: searchInputs.topLevelAgency
+      ? Array.from(searchInputs.topLevelAgency)
+      : [],
     query: searchInputs.query,
     sortby: searchInputs.sortby,
     page: searchInputs.page,

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -61,7 +61,6 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 
-  // accepts an array of tuples of type [key, value]
   const setQueryParams = (
     updates: ValidSearchQueryParamData,
     scroll = false,

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -62,13 +62,14 @@ export function useSearchParamUpdater() {
   };
 
   // accepts an array of tuples of type [key, value]
-  const setQueryParams = (updates: string[][], scroll = false) => {
-    updates.forEach((update) => {
-      if (!update[0]) {
-        return;
-      }
-      params.set(update[0], update[1]);
+  const setQueryParams = (
+    updates: ValidSearchQueryParamData,
+    scroll = false,
+  ) => {
+    Object.entries(updates).forEach(([queryParamKey, queryParamValue]) => {
+      params.set(queryParamKey, queryParamValue);
     });
+
     router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -61,6 +61,17 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 
+  // accepts an array of tuples of type [key, value]
+  const setQueryParams = (updates: string[][], scroll = false) => {
+    updates.forEach((update) => {
+      if (!update[0]) {
+        return;
+      }
+      params.set(update[0], update[1]);
+    });
+    router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
+  };
+
   const removeQueryParam = (paramKey: string, scroll = false) => {
     params.delete(paramKey);
     router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
@@ -81,5 +92,6 @@ export function useSearchParamUpdater() {
     removeQueryParam,
     setQueryParam,
     clearQueryParams,
+    setQueryParams,
   };
 }

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -688,6 +688,7 @@ export const messages = {
       sortby: "Sort by",
       closeDate: "Close date",
       costSharing: "Cost sharing",
+      topLevelAgency: "Top level agency",
     },
     editModal: {
       loading: "Updating",

--- a/frontend/src/services/fetch/fetchers/savedSearchFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/savedSearchFetcher.ts
@@ -67,7 +67,6 @@ export const fetchSavedSearches = async (): Promise<SavedSearchRecord[]> => {
   if (!session || !session.token) {
     return [];
   }
-  console.log("!!!", session.token);
   const ssgToken = {
     "X-SGG-Token": session.token,
   };

--- a/frontend/src/services/fetch/fetchers/savedSearchFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/savedSearchFetcher.ts
@@ -67,6 +67,7 @@ export const fetchSavedSearches = async (): Promise<SavedSearchRecord[]> => {
   if (!session || !session.token) {
     return [];
   }
+  console.log("!!!", session.token);
   const ssgToken = {
     "X-SGG-Token": session.token,
   };

--- a/frontend/src/types/search/searchFilterTypes.ts
+++ b/frontend/src/types/search/searchFilterTypes.ts
@@ -16,6 +16,7 @@ export const searchFilterNames = [
   "category",
   "closeDate",
   "costSharing",
+  "topLevelAgency",
 ] as const;
 
 export type FrontendFilterNames = (typeof searchFilterNames)[number];

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -10,6 +10,7 @@ export interface FilterQueryParamData {
   category: Set<string>;
   closeDate: Set<string>;
   costSharing: Set<string>;
+  topLevelAgency: Set<string>;
 }
 
 // this is used for UI display so order matters

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -47,6 +47,7 @@ export type SearchRequestBody = {
   query?: string;
   format?: string;
   query_operator?: QueryOperator;
+  top_level_agency?: string;
 };
 
 export enum SearchFetcherActionType {

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -17,6 +17,7 @@ export interface SearchFilterRequestBody {
   funding_category?: OneOfFilter;
   close_date?: RelativeDateRangeFilter;
   is_cost_sharing?: BooleanFilter;
+  top_level_agency?: OneOfFilter;
 }
 
 export type QueryOperator = "AND" | "OR";
@@ -47,7 +48,6 @@ export type SearchRequestBody = {
   query?: string;
   format?: string;
   query_operator?: QueryOperator;
-  top_level_agency?: string;
 };
 
 export enum SearchFetcherActionType {

--- a/frontend/src/utils/search/searchFormatUtils.ts
+++ b/frontend/src/utils/search/searchFormatUtils.ts
@@ -63,6 +63,11 @@ const filterConfigurations = [
     backendName: "is_cost_sharing",
     dataType: "boolean",
   },
+  {
+    frontendName: "topLevelAgency",
+    backendName: "top_level_agency",
+    dataType: "oneOf",
+  },
 ] as const;
 
 const toOneOfFilter = (data: Set<string>): OneOfFilter => {
@@ -116,7 +121,7 @@ const backendFilterToQueryParamValue = (
 
 // transforms raw query param data into structured search object format that the API needs
 export const formatSearchRequestBody = (searchInputs: QueryParamData) => {
-  const { query, andOr, topLevelAgency } = searchInputs;
+  const { query, andOr } = searchInputs;
 
   const filters = buildFilters(searchInputs);
   const pagination = buildPagination(searchInputs);
@@ -133,11 +138,6 @@ export const formatSearchRequestBody = (searchInputs: QueryParamData) => {
   }
   if (andOr) {
     requestBody.query_operator = andOr;
-  }
-  if (topLevelAgency && topLevelAgency.size) {
-    requestBody.top_level_agency = Array.from(topLevelAgency.values()).join(
-      ",",
-    );
   }
   return requestBody;
 };

--- a/frontend/src/utils/search/searchFormatUtils.ts
+++ b/frontend/src/utils/search/searchFormatUtils.ts
@@ -116,7 +116,7 @@ const backendFilterToQueryParamValue = (
 
 // transforms raw query param data into structured search object format that the API needs
 export const formatSearchRequestBody = (searchInputs: QueryParamData) => {
-  const { query, andOr } = searchInputs;
+  const { query, andOr, topLevelAgency } = searchInputs;
 
   const filters = buildFilters(searchInputs);
   const pagination = buildPagination(searchInputs);
@@ -133,6 +133,11 @@ export const formatSearchRequestBody = (searchInputs: QueryParamData) => {
   }
   if (andOr) {
     requestBody.query_operator = andOr;
+  }
+  if (topLevelAgency && topLevelAgency.size) {
+    requestBody.top_level_agency = Array.from(topLevelAgency.values()).join(
+      ",",
+    );
   }
   return requestBody;
 };

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -70,6 +70,7 @@ export function convertSearchParamsToProperTypes(
     closeDate: paramToDateRange(params.closeDate),
     costSharing: paramToSet(params.costSharing),
     andOr: (params.andOr as QueryOperator) || "",
+    topLevelAgency: paramToSet(params.topLevelAgency),
     sortby: (params.sortby as SortOptions) || null, // Convert empty string to null if needed
 
     // Ensure page is at least 1 or default to 1 if undefined

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -188,3 +188,23 @@ export const agenciesToFilterOptions = (
     return acc;
   }, [] as FilterOption[]);
 };
+
+export const getAgencyParent = (agencyCode: string) => agencyCode.split("-")[0];
+
+// for now this assumes that child values will be prefixed with the parent's code (as is true for agencies)
+// a more robust but slower implementation with full traversal can be done later if need be
+export const getSiblingOptionValues = (
+  value: string,
+  options: FilterOption[],
+): string[] => {
+  const parentCode = getAgencyParent(value);
+  const parent = options.find((option) => option.value === parentCode);
+  return parent?.children
+    ? parent.children.reduce((acc, child) => {
+        if (child.value !== value) {
+          acc.push(child.value);
+        }
+        return acc;
+      }, [] as string[])
+    : [];
+};

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -155,6 +155,64 @@ export const initialFilterOptions: FilterOption[] = [
     value: "other",
   },
 ];
+export const filterOptionsWithChildren = [
+  {
+    id: "AGNC",
+    label: "Top Level Agency",
+    value: "AGNC",
+    children: [
+      {
+        id: "AGNC-KID",
+        label: "Kid",
+        value: "AGNC-KID",
+      },
+      {
+        id: "AGNC-CHILD",
+        label: "Child",
+        value: "AGNC-CHILD",
+      },
+    ],
+  },
+  {
+    id: "DOC-NIST",
+    label: "National Institute of Standards and Technology",
+    value: "DOC-NIST",
+    children: [
+      {
+        id: "HI",
+        label: "Hello",
+        value: "HI",
+      },
+      {
+        id: "There",
+        label: "Again",
+        value: "There",
+      },
+    ],
+  },
+  {
+    id: "MOCK-NIST",
+    label: "Mational Institute",
+    value: "MOCK-NIST",
+  },
+  {
+    id: "MOCK-TRASH",
+    label: "Mational TRASH",
+    value: "MOCK-TRASH",
+    children: [
+      {
+        id: "TRASH",
+        label: "More TRASH",
+        value: "TRASH",
+      },
+    ],
+  },
+  {
+    id: "FAKE",
+    label: "Completely fake",
+    value: "FAKE",
+  },
+];
 
 export const fakeAttachments = [
   {

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -37,6 +37,7 @@ export const searchFetcherParams: QueryParamData = {
   eligibility: new Set(),
   closeDate: new Set(),
   costSharing: new Set(),
+  topLevelAgency: new Set(),
   query: "research",
   sortby: "opportunityNumberAsc",
   actionType: "fun" as SearchFetcherActionType,

--- a/frontend/tests/api/search/export/route.test.ts
+++ b/frontend/tests/api/search/export/route.test.ts
@@ -22,6 +22,7 @@ const fakeConvertedParams = {
   fundingInstrument: new Set(),
   closeDate: new Set(),
   costSharing: new Set(),
+  topLevelAgency: new Set(),
   andOr: "",
   page: 1,
   query: "",

--- a/frontend/tests/components/search/Filters/AgencyFilterBody.test.tsx
+++ b/frontend/tests/components/search/Filters/AgencyFilterBody.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  filterOptionsWithChildren,
+  initialFilterOptions,
+} from "src/utils/testing/fixtures";
+import { useTranslationsMock } from "src/utils/testing/intlMocks";
+
+import { AgencyFilterBody } from "src/components/search/Filters/AgencyFilterBody";
+
+const fakeFacetCounts = {
+  grant: 1,
+  other: 1,
+  procurement_contract: 1,
+  cooperative_agreement: 1,
+};
+
+const mockUpdateQueryParams = jest.fn();
+const mockSetQueryParams = jest.fn();
+
+const title = "Test Accordion";
+const queryParamKey = "fundingInstrument";
+
+jest.mock("src/hooks/useSearchParamUpdater", () => ({
+  useSearchParamUpdater: () => ({
+    updateQueryParams: mockUpdateQueryParams,
+    setQueryParams: mockSetQueryParams,
+  }),
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => useTranslationsMock(),
+}));
+
+jest.mock("react", () => ({
+  ...jest.requireActual<typeof import("react")>("react"),
+  useContext: () => ({
+    queryTerm: "query term",
+  }),
+}));
+
+describe("AgencyFilterBody", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("adds an any option checkbox when specified", () => {
+    render(
+      <AgencyFilterBody
+        includeAnyOption={true}
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
+    const anyCheckbox = screen.getByRole("checkbox", {
+      name: "any test accordion",
+    });
+    expect(anyCheckbox).toBeInTheDocument();
+  });
+  it("displays filter section children when present", () => {
+    render(
+      <AgencyFilterBody
+        includeAnyOption={true}
+        filterOptions={filterOptionsWithChildren}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={{}}
+      />,
+    );
+    const childCheckbox = screen.getByRole("checkbox", {
+      name: "Hello [0]",
+    });
+    expect(childCheckbox).toBeInTheDocument();
+  });
+  it("correctly toggles a checkbox (simple)", async () => {
+    render(
+      <AgencyFilterBody
+        includeAnyOption={true}
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
+    const otherCheckbox = screen.getByRole("checkbox", {
+      name: "Other [1]",
+    });
+    expect(otherCheckbox).toBeInTheDocument();
+
+    await userEvent.click(otherCheckbox);
+
+    expect(mockUpdateQueryParams).toHaveBeenCalledWith(
+      new Set(["other"]),
+      "agency",
+      "query term",
+    );
+  });
+  it("correctly toggles a checkbox (unchecking with parent selected)", async () => {
+    render(
+      <AgencyFilterBody
+        includeAnyOption={true}
+        filterOptions={filterOptionsWithChildren}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={fakeFacetCounts}
+        topLevelQuery={new Set(["AGNC"])}
+      />,
+    );
+    const previouslyCheckedChildCheckbox = screen.getByRole("checkbox", {
+      name: "Kid [0]",
+    });
+    expect(previouslyCheckedChildCheckbox).toBeInTheDocument();
+    expect(previouslyCheckedChildCheckbox).toBeChecked();
+
+    await userEvent.click(previouslyCheckedChildCheckbox);
+
+    expect(mockUpdateQueryParams).not.toHaveBeenCalled();
+
+    expect(mockSetQueryParams).toHaveBeenCalledWith([
+      ["agency", "AGNC-CHILD"],
+      ["topLevelAgency", ""],
+      ["query", "query term"],
+    ]);
+  });
+});

--- a/frontend/tests/components/search/Filters/AgencyFilterBody.test.tsx
+++ b/frontend/tests/components/search/Filters/AgencyFilterBody.test.tsx
@@ -121,10 +121,10 @@ describe("AgencyFilterBody", () => {
 
     expect(mockUpdateQueryParams).not.toHaveBeenCalled();
 
-    expect(mockSetQueryParams).toHaveBeenCalledWith([
-      ["agency", "AGNC-CHILD"],
-      ["topLevelAgency", ""],
-      ["query", "query term"],
-    ]);
+    expect(mockSetQueryParams).toHaveBeenCalledWith({
+      agency: "AGNC-CHILD",
+      topLevelAgency: "",
+      query: "query term",
+    });
   });
 });

--- a/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
+++ b/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
@@ -47,6 +47,7 @@ describe("AgencyFilterContent", () => {
   it("should not have accessibility violations", async () => {
     const { container } = render(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -60,6 +61,7 @@ describe("AgencyFilterContent", () => {
   it("renders the TextInput and CheckboxFilterBody with all agencies by default", () => {
     render(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -74,6 +76,7 @@ describe("AgencyFilterContent", () => {
   it("calls agencySearch when user types in the TextInput", async () => {
     render(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -91,6 +94,7 @@ describe("AgencyFilterContent", () => {
   it("shows search results returned by agencySearch", async () => {
     const { rerender } = render(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -102,6 +106,7 @@ describe("AgencyFilterContent", () => {
 
     rerender(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -121,6 +126,7 @@ describe("AgencyFilterContent", () => {
     mockAgencySearch.mockResolvedValue([]);
     render(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -138,6 +144,7 @@ describe("AgencyFilterContent", () => {
   it("restores all agencies when input is cleared", async () => {
     render(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -165,6 +172,7 @@ describe("AgencyFilterContent", () => {
     mockAgencySearch.mockRejectedValue(new Error("Network error"));
     const { rerender } = render(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}
@@ -176,6 +184,7 @@ describe("AgencyFilterContent", () => {
 
     rerender(
       <AgencyFilterContent
+        topLevelQuery={new Set()}
         query={query}
         title="Agencies"
         allAgencies={allAgencies}

--- a/frontend/tests/components/search/SearchFilterAccordion/AgencyFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AgencyFilterAccordion.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import { fakeSearchAPIResponse } from "src/utils/testing/fixtures";
+import {
+  fakeSearchAPIResponse,
+  filterOptionsWithChildren,
+} from "src/utils/testing/fixtures";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import { ReadonlyURLSearchParams } from "next/navigation";
@@ -23,53 +26,12 @@ jest.mock("react", () => ({
   Suspense: ({ fallback }: { fallback: React.Component }) => fallback,
 }));
 
-const fakeOptions = [
-  {
-    id: "DOC-NIST",
-    label: "National Institute of Standards and Technology",
-    value: "DOC-NIST",
-    children: [
-      {
-        id: "HI",
-        label: "Hello",
-        value: "HI",
-      },
-      {
-        id: "There",
-        label: "Again",
-        value: "There",
-      },
-    ],
-  },
-  {
-    id: "MOCK-NIST",
-    label: "Mational Institute",
-    value: "MOCK-NIST",
-  },
-  {
-    id: "MOCK-TRASH",
-    label: "Mational TRASH",
-    value: "MOCK-TRASH",
-    children: [
-      {
-        id: "TRASH",
-        label: "More TRASH",
-        value: "TRASH",
-      },
-    ],
-  },
-  {
-    id: "FAKE",
-    label: "Completely fake",
-    value: "FAKE",
-  },
-];
-
 describe("AgencyFilterAccordion", () => {
   it("is accessible", async () => {
     const component = await AgencyFilterAccordion({
+      topLevelQuery: new Set(),
       agencyOptionsPromise: Promise.resolve([
-        fakeOptions,
+        filterOptionsWithChildren,
         fakeSearchAPIResponse,
       ]),
       query: new Set(),
@@ -82,8 +44,9 @@ describe("AgencyFilterAccordion", () => {
   // just want to confirm it renders
   it("renders async component (asserting on mock suspended state)", async () => {
     const component = await AgencyFilterAccordion({
+      topLevelQuery: new Set(),
       agencyOptionsPromise: Promise.resolve([
-        fakeOptions,
+        filterOptionsWithChildren,
         fakeSearchAPIResponse,
       ]),
       query: new Set(),

--- a/frontend/tests/components/search/SearchFilterAccordion/AllOptionCheckbox.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AllOptionCheckbox.test.tsx
@@ -1,11 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { initialFilterOptions } from "src/utils/testing/fixtures";
+import {
+  filterOptionsWithChildren,
+  initialFilterOptions,
+} from "src/utils/testing/fixtures";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import { AllOptionCheckbox } from "src/components/search/SearchFilterAccordion/AllOptionCheckbox";
 
 const mockSetQueryParam = jest.fn();
+const mockSetQueryParams = jest.fn();
 
 const optionValues = initialFilterOptions.map((option) => option.value);
 
@@ -16,6 +20,7 @@ jest.mock("next-intl", () => ({
 jest.mock("src/hooks/useSearchParamUpdater", () => ({
   useSearchParamUpdater: () => ({
     setQueryParam: mockSetQueryParam,
+    setQueryParams: mockSetQueryParams,
   }),
 }));
 
@@ -29,7 +34,7 @@ describe("AllOptionCheckbox", () => {
         title={"Fun checkbox"}
         currentSelections={new Set()}
         childOptions={[]}
-        queryParamKey={"whatever"}
+        queryParamKey={"agency"}
       />,
     );
     const checkboxByName = screen.getByRole("checkbox", {
@@ -37,73 +42,166 @@ describe("AllOptionCheckbox", () => {
     });
     expect(checkboxByName).toBeInTheDocument();
   });
-  it("calls setQueryParam as expected when checking", async () => {
-    render(
-      <AllOptionCheckbox
-        title={"Fun checkbox"}
-        currentSelections={new Set(["hi"])}
-        childOptions={initialFilterOptions}
-        queryParamKey={"whatever"}
-      />,
-    );
-    const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).not.toBeChecked();
+  describe("non-top-level scenarios", () => {
+    it("calls setQueryParam as expected when checking", async () => {
+      render(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(["hi"])}
+          childOptions={initialFilterOptions}
+          queryParamKey={"agency"}
+        />,
+      );
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).not.toBeChecked();
 
-    await userEvent.click(checkbox);
+      await userEvent.click(checkbox);
 
-    expect(mockSetQueryParam).toHaveBeenCalledWith(
-      "whatever",
-      optionValues.concat("hi").join(","),
-    );
+      expect(mockSetQueryParam).toHaveBeenCalledWith(
+        "agency",
+        optionValues.concat("hi").join(","),
+      );
+    });
+    it("calls setQueryParam as expected when un-checking", async () => {
+      render(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(optionValues.concat(["hi"]))}
+          childOptions={initialFilterOptions}
+          queryParamKey={"agency"}
+        />,
+      );
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).toBeChecked();
+
+      await userEvent.click(checkbox);
+
+      expect(mockSetQueryParam).toHaveBeenCalledWith("agency", "hi");
+    });
+    it("checks and unchecks the box as expected when outside selections change", () => {
+      const { rerender } = render(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(optionValues)}
+          childOptions={initialFilterOptions}
+          queryParamKey={"agency"}
+        />,
+      );
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).toBeChecked();
+
+      rerender(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(optionValues.slice(0, 1))}
+          childOptions={initialFilterOptions}
+          queryParamKey={"agency"}
+        />,
+      );
+
+      expect(checkbox).not.toBeChecked();
+
+      rerender(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(optionValues)}
+          childOptions={initialFilterOptions}
+          queryParamKey={"agency"}
+        />,
+      );
+
+      expect(checkbox).toBeChecked();
+    });
   });
-  it("calls setQueryParam as expected when un-checking", async () => {
-    render(
-      <AllOptionCheckbox
-        title={"Fun checkbox"}
-        currentSelections={new Set(optionValues.concat(["hi"]))}
-        childOptions={initialFilterOptions}
-        queryParamKey={"whatever"}
-      />,
-    );
-    const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toBeChecked();
+  describe("top-level scenarios", () => {
+    it("checks box if top level params indicate", () => {
+      render(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set([""])}
+          childOptions={initialFilterOptions}
+          queryParamKey="agency"
+          topLevelQuery={new Set(["something"])}
+          topLevelQueryParamKey="topLevelAgency"
+          topLevelQueryValue="something"
+        />,
+      );
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).toBeChecked();
+    });
+    it("checks the box if top level becomes selected", () => {
+      const { rerender } = render(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set([""])}
+          childOptions={initialFilterOptions}
+          queryParamKey="agency"
+          topLevelQuery={new Set([])}
+          topLevelQueryParamKey="topLevelAgency"
+          topLevelQueryValue="something"
+        />,
+      );
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).not.toBeChecked();
 
-    await userEvent.click(checkbox);
+      rerender(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(optionValues)}
+          childOptions={initialFilterOptions}
+          queryParamKey="agency"
+          topLevelQuery={new Set(["something"])}
+          topLevelQueryParamKey="topLevelAgency"
+          topLevelQueryValue="something"
+        />,
+      );
+      expect(checkbox).toBeChecked();
+    });
+    it("responds correctly to check", async () => {
+      // eslint-disable-next-line
+      const children = filterOptionsWithChildren[0]?.children || [];
+      render(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(["hello", "AGNC-KID"])}
+          childOptions={children}
+          queryParamKey="agency"
+          topLevelQuery={new Set(["anything"])}
+          topLevelQueryParamKey="topLevelAgency"
+          topLevelQueryValue="something"
+        />,
+      );
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).not.toBeChecked();
 
-    expect(mockSetQueryParam).toHaveBeenCalledWith("whatever", "hi");
-  });
-  it("checks and unchecks the box as expected when outside selections change", () => {
-    const { rerender } = render(
-      <AllOptionCheckbox
-        title={"Fun checkbox"}
-        currentSelections={new Set(optionValues)}
-        childOptions={initialFilterOptions}
-        queryParamKey={"whatever"}
-      />,
-    );
-    const checkbox = screen.getByRole("checkbox");
-    expect(checkbox).toBeChecked();
+      await userEvent.click(checkbox);
+      expect(mockSetQueryParams).toHaveBeenCalledWith([
+        ["topLevelAgency", "anything,something"],
+        ["agency", "hello"],
+      ]);
+    });
+    it("responds correctly to un-check", async () => {
+      // eslint-disable-next-line
+      const children = filterOptionsWithChildren[0]?.children || [];
+      render(
+        <AllOptionCheckbox
+          title={"Fun checkbox"}
+          currentSelections={new Set(["hello", "AGNC-KID"])}
+          childOptions={children}
+          queryParamKey="agency"
+          topLevelQuery={new Set(["anything", "AGNC"])}
+          topLevelQueryParamKey="topLevelAgency"
+          topLevelQueryValue="AGNC"
+        />,
+      );
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).toBeChecked();
 
-    rerender(
-      <AllOptionCheckbox
-        title={"Fun checkbox"}
-        currentSelections={new Set(optionValues.slice(0, 1))}
-        childOptions={initialFilterOptions}
-        queryParamKey={"whatever"}
-      />,
-    );
-
-    expect(checkbox).not.toBeChecked();
-
-    rerender(
-      <AllOptionCheckbox
-        title={"Fun checkbox"}
-        currentSelections={new Set(optionValues)}
-        childOptions={initialFilterOptions}
-        queryParamKey={"whatever"}
-      />,
-    );
-
-    expect(checkbox).toBeChecked();
+      await userEvent.click(checkbox);
+      expect(mockSetQueryParams).toHaveBeenCalledWith([
+        ["topLevelAgency", "anything"],
+        ["agency", "hello"],
+      ]);
+    });
   });
 });

--- a/frontend/tests/components/search/SearchFilterAccordion/AllOptionCheckbox.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/AllOptionCheckbox.test.tsx
@@ -175,10 +175,10 @@ describe("AllOptionCheckbox", () => {
       expect(checkbox).not.toBeChecked();
 
       await userEvent.click(checkbox);
-      expect(mockSetQueryParams).toHaveBeenCalledWith([
-        ["topLevelAgency", "anything,something"],
-        ["agency", "hello"],
-      ]);
+      expect(mockSetQueryParams).toHaveBeenCalledWith({
+        topLevelAgency: "anything,something",
+        agency: "hello",
+      });
     });
     it("responds correctly to un-check", async () => {
       // eslint-disable-next-line
@@ -198,10 +198,10 @@ describe("AllOptionCheckbox", () => {
       expect(checkbox).toBeChecked();
 
       await userEvent.click(checkbox);
-      expect(mockSetQueryParams).toHaveBeenCalledWith([
-        ["topLevelAgency", "anything"],
-        ["agency", "hello"],
-      ]);
+      expect(mockSetQueryParams).toHaveBeenCalledWith({
+        topLevelAgency: "anything",
+        agency: "hello",
+      });
     });
   });
 });

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterSection/SearchFilterSection.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom";
 
 import { axe } from "jest-axe";
+import { ValidSearchQueryParam } from "src/types/search/searchQueryTypes";
 import { render, screen } from "tests/react-utils";
 
 import React from "react";
@@ -20,6 +21,7 @@ jest.mock(
 const mockSetQueryParam = jest.fn();
 
 const defaultProps = {
+  queryParamKey: "agency" as ValidSearchQueryParam,
   option: {
     id: "1",
     label: "Option 1",
@@ -120,6 +122,9 @@ describe("SearchFilterSection", () => {
         },
       ],
       currentSelections: new Set(""),
+      topLevelQuery: undefined,
+      topLevelQueryParamKey: undefined,
+      topLevelQueryValue: "some value",
     });
   });
 });

--- a/frontend/tests/components/search/SearchFilters.test.tsx
+++ b/frontend/tests/components/search/SearchFilters.test.tsx
@@ -90,6 +90,7 @@ describe("SearchFilters", () => {
       agency: new Set(),
       category: new Set(),
       opportunityStatus: new Set(),
+      topLevelAgency: new Set(),
       searchResultsPromise: Promise.resolve(fakeSearchAPIResponse),
     });
     render(component);

--- a/frontend/tests/components/search/SearchResults.test.tsx
+++ b/frontend/tests/components/search/SearchResults.test.tsx
@@ -65,6 +65,7 @@ describe("SearchResults", () => {
           eligibility: new Set(),
           closeDate: new Set(),
           costSharing: new Set(),
+          topLevelAgency: new Set(),
         }}
         loadingMessage={""}
         searchResultsPromise={Promise.resolve(fakeSearchAPIResponse)}

--- a/frontend/tests/components/workspace/SavedSearchesList.test.tsx
+++ b/frontend/tests/components/workspace/SavedSearchesList.test.tsx
@@ -55,6 +55,7 @@ const fakeParamDisplayMapping = {
   sortby: "sortby",
   closeDate: "closeDate",
   costSharing: "costSharing",
+  topLevelAgency: "topLevelAgency",
 };
 
 describe("SavedSearchesList", () => {

--- a/frontend/tests/errors.test.ts
+++ b/frontend/tests/errors.test.ts
@@ -11,6 +11,7 @@ describe("BadRequestError (as an example of other error types)", () => {
     category: new Set(["science"]),
     closeDate: new Set(["500"]),
     costSharing: new Set(["true"]),
+    topLevelAgency: new Set(["CDC"]),
     query: "space exploration",
     sortby: "relevancy",
     page: 1,

--- a/frontend/tests/hooks/useSearchParamUpdater.test.ts
+++ b/frontend/tests/hooks/useSearchParamUpdater.test.ts
@@ -1,19 +1,16 @@
-/* eslint-disable jest/no-commented-out-tests */
 import { renderHook, waitFor } from "@testing-library/react";
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 
 let mockSearchParams = new URLSearchParams();
-const routerPush = jest.fn(() => Promise.resolve(true));
-const mockQueryParamsToQueryString = jest.fn((..._args) => "?hi=there");
+const mockPush = jest.fn();
+const mockQueryParamsToQueryString = jest.fn();
 
 jest.mock("next/navigation", () => ({
-  usePathname: jest.fn(() => "/test") as jest.Mock<string>,
+  usePathname: () => "/test",
   useRouter: () => ({
-    push: routerPush,
+    push: mockPush,
   }),
-  useSearchParams: jest.fn(
-    () => mockSearchParams,
-  ) as jest.Mock<URLSearchParams>,
+  useSearchParams: () => mockSearchParams,
 }));
 
 jest.mock("src/utils/generalUtils", () => ({
@@ -21,18 +18,25 @@ jest.mock("src/utils/generalUtils", () => ({
     mockQueryParamsToQueryString(...args) as unknown,
 }));
 
-// this is dumb - the original function only works in jest node envs
-// and there is a reference to `document` somewhere in the import tree here so
-// switching over doesn't work - reimplemented without `size` reference,
-// since that's the only part that's broken in JSdom
+// tldr; this is here to work around with some testing environment issues, rather
+// than anything specfically related to this test.
+// long version; the original function only works in jest node envs
+// and there is a reference to `document` somewhere in the import tree
+// so using the node env doesn't work either. Reimplemented without reference to
+// `params.size` since that seems to be what JSDom doesn't like
 jest.mock("src/utils/search/searchUtils", () => ({
   paramsToFormattedQuery: (params: URLSearchParams) =>
     `?${decodeURIComponent(params.toString())}`,
 }));
 
 describe("useSearchParamUpdater", () => {
-  afterEach(() => {
+  beforeEach(() => {
     mockSearchParams = new URLSearchParams();
+    mockPush.mockResolvedValue(true);
+    mockQueryParamsToQueryString.mockReturnValue("?hi=there");
+  });
+  afterEach(() => {
+    jest.resetAllMocks();
   });
   describe("updateQueryParams", () => {
     it("updates a singular param and pushes new path", async () => {
@@ -41,7 +45,7 @@ describe("useSearchParamUpdater", () => {
       result.current.updateQueryParams("", "query", "testQuery");
 
       await waitFor(() => {
-        expect(routerPush).toHaveBeenCalledWith("/test?query=testQuery", {
+        expect(mockPush).toHaveBeenCalledWith("/test?query=testQuery", {
           scroll: false,
         });
       });
@@ -54,7 +58,7 @@ describe("useSearchParamUpdater", () => {
       result.current.updateQueryParams(statuses, "status", "test", true);
 
       await waitFor(() => {
-        expect(routerPush).toHaveBeenCalledWith(
+        expect(mockPush).toHaveBeenCalledWith(
           "/test?status=forecasted,posted&query=test",
           { scroll: true },
         );
@@ -68,7 +72,7 @@ describe("useSearchParamUpdater", () => {
       result.current.updateQueryParams(statuses, "status", "test");
 
       await waitFor(() => {
-        expect(routerPush).toHaveBeenCalledWith("/test?query=test", {
+        expect(mockPush).toHaveBeenCalledWith("/test?query=test", {
           scroll: false,
         });
       });
@@ -88,7 +92,7 @@ describe("useSearchParamUpdater", () => {
       expect(mockQueryParamsToQueryString).toHaveBeenCalledWith(
         fakeQueryParams,
       );
-      expect(routerPush).toHaveBeenCalledWith("/test?hi=there");
+      expect(mockPush).toHaveBeenCalledWith("/test?hi=there");
     });
   });
   describe("removeQueryParam", () => {
@@ -96,24 +100,48 @@ describe("useSearchParamUpdater", () => {
       mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
       const { result } = renderHook(() => useSearchParamUpdater());
       result.current.removeQueryParam("removeMe");
-      expect(routerPush).toHaveBeenCalledWith("/test?keepMe=cool", {
+      expect(mockPush).toHaveBeenCalledWith("/test?keepMe=cool", {
         scroll: false,
       });
     });
   });
-});
-
-describe("clearQueryParams", () => {
-  it("clears all query params if no argument is passed", () => {
-    mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
-    const { result } = renderHook(() => useSearchParamUpdater());
-    result.current.clearQueryParams();
-    expect(routerPush).toHaveBeenCalledWith("/test?");
+  describe("clearQueryParams", () => {
+    it("clears all query params if no argument is passed", () => {
+      mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
+      const { result } = renderHook(() => useSearchParamUpdater());
+      result.current.clearQueryParams();
+      expect(mockPush).toHaveBeenCalledWith("/test?");
+    });
+    it("clears selected query params based on passed argument", () => {
+      mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
+      const { result } = renderHook(() => useSearchParamUpdater());
+      result.current.clearQueryParams(["removeMe"]);
+      expect(mockPush).toHaveBeenCalledWith("/test?keepMe=cool");
+    });
   });
-  it("clears selected query params based on passed argument", () => {
-    mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
-    const { result } = renderHook(() => useSearchParamUpdater());
-    result.current.clearQueryParams(["removeMe"]);
-    expect(routerPush).toHaveBeenCalledWith("/test?keepMe=cool");
+  describe("setQueryParam", () => {
+    it("sets a query param", () => {
+      mockSearchParams = new URLSearchParams("keepMe=cool&removeMe=uncool");
+      const { result } = renderHook(() => useSearchParamUpdater());
+      result.current.setQueryParam("keepMe", "updated");
+      expect(mockPush).toHaveBeenCalledWith(
+        "/test?keepMe=updated&removeMe=uncool",
+        { scroll: false },
+      );
+    });
+  });
+  describe("setQueryParams", () => {
+    it("sets multiple query params", () => {
+      mockSearchParams = new URLSearchParams("query=cool&agency=uncool");
+      const { result } = renderHook(() => useSearchParamUpdater());
+      result.current.setQueryParams({
+        query: "updated",
+        agency: "alsoUpdated",
+      });
+      expect(mockPush).toHaveBeenCalledWith(
+        "/test?query=updated&agency=alsoUpdated",
+        { scroll: false },
+      );
+    });
   });
 });

--- a/frontend/tests/utils/search/searchUtils.test.ts
+++ b/frontend/tests/utils/search/searchUtils.test.ts
@@ -10,6 +10,8 @@ import {
   areSetsEqual,
   convertSearchParamsToProperTypes,
   getAgencyDisplayName,
+  getAgencyParent,
+  getSiblingOptionValues,
   paramsToFormattedQuery,
   paramToDateRange,
   sortFilterOptions,
@@ -17,6 +19,7 @@ import {
 import {
   fakeAgencyResponseData,
   fakeSearchParamDict,
+  initialFilterOptions,
 } from "src/utils/testing/fixtures";
 
 describe("sortFilterOptions", () => {
@@ -396,10 +399,57 @@ describe("convertSearchParamsToProperTypes", () => {
       category: new Set([fakeSearchParamDict.category]),
       closeDate: new Set(["7"]),
       costSharing: new Set(),
+      topLevelAgency: new Set(),
       andOr: fakeSearchParamDict.andOr,
       sortby: fakeSearchParamDict.sortby,
       page: 1,
       actionType: SearchFetcherActionType.InitialLoad,
     });
+  });
+});
+
+describe("getAgencyParent", () => {
+  it("returns the pre dash part of the agency code", () => {
+    expect(getAgencyParent("PREFIX-SUFFIX")).toEqual("PREFIX");
+  });
+  it("does not break if there is no dash", () => {
+    expect(getAgencyParent("WHATEVER")).toEqual("WHATEVER");
+  });
+  it("works with multiple dashes", () => {
+    expect(getAgencyParent("HI-THERE-HOW-ARE-YOU")).toEqual("HI");
+  });
+});
+
+describe("getSiblingOptionValues", () => {
+  it("returns an empty array if parent is not found or has no children", () => {
+    expect(getSiblingOptionValues("no-children", [])).toEqual([]);
+    expect(getSiblingOptionValues("no-children", initialFilterOptions)).toEqual(
+      [],
+    );
+    expect(
+      getSiblingOptionValues("no-children", [
+        { value: "no", id: "no", label: "no" },
+      ]),
+    ).toEqual([]);
+  });
+  it("returns all siblings but not the target node", () => {
+    expect(
+      getSiblingOptionValues("parent-target", [
+        {
+          value: "parent",
+          id: "parent",
+          label: "parent",
+          children: [
+            { value: "parent-target", id: "target", label: "target" },
+            { value: "parent-sibling", id: "sibling", label: "sibling" },
+            {
+              value: "parent-another-sibling",
+              id: "another-sibling",
+              label: "another-sibling",
+            },
+          ],
+        },
+      ]),
+    ).toEqual(["parent-sibling", "parent-another-sibling"]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #5355

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Allows for the frontend to search explicitly by top level agency.

* fixes alignment of filter drawer button when logged in
* refactors agency filter components to establish the agency filter as a "unicorn" implementation and separate its specific needs from those of the other more straightforward filters as much as possible
* updates the AllOption and AnyOption check boxes to support the new top level query functionality
* updates the SearchFilterCheckbox to correctly reflect state where a parent top level option has been selected
* adds related helper functions

## Context for reviewers

This change is being made for two main reasons:

* to future proof saved searches against changes to a top level agency's sub agencies. If a user wants to save a search for a top level agency, they should receive, at any time, the search results related to the current sub agencies of that top level, not the frozen in time list of sub agencies from when the search was initially saved
* To allow for filter pills (see https://github.com/HHS/simpler-grants-gov/issues/4718) to list only top level agencies when a top level agency is selected, rather than overwhelming the UI with the full list of selected sub agencies

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search
3. open the agency filter and select an "all <top level agency>" check box
4. _VERIFY_: "Any" checkbox is unchecked, all child boxes are checked, agency code for top level agency is added as "topLevelAgency" query param value, agency query param is not present, search results update as expected
5. uncheck a checked child agency box
6. _VERIFY_: top level box is unchecked, all other child boxes remain checked, topLevelAgency query param is empty, agency query param is populated with list of remaining child agencies, search results update as expected
7. check two top level agency boxes
8. _VERIFY_: all expected children are selected, topLevelAgency query param contains comma separated values for each selected top level agency, search results update as expected
9. select a child agency with an unselected parent
10. select the parent
11. _VERIFY_: the agency query param for the previously selected child agency is removed while the top level agency param is added

BONUS: repeat from step 2 with the searchDrawerOn feature flag enabled using the agency filter from the drawer