### PR TITLE
[Issue #5248] When a user logs in for the first time - check if they are an ebiz POC and create their org

### DIFF
--- a/api/src/services/users/login_gov_callback_handler.py
+++ b/api/src/services/users/login_gov_callback_handler.py
@@ -14,6 +14,7 @@ from src.auth.auth_errors import JwtValidationError
 from src.auth.login_gov_jwt_auth import get_login_gov_client_assertion, validate_token
 from src.constants.lookup_constants import ExternalUserType
 from src.db.models.user_models import LinkExternalUser, LoginGovState, User
+from src.services.users.organization_from_ebiz_poc import handle_ebiz_poc_organization_during_login
 from src.util.string_utils import is_valid_uuid
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,23 @@ def _process_token(db_session: db.Session, token: str, nonce: str) -> LoginGovCa
     # prior to us trying to work with the user further.
     # NOTE: This doesn't commit yet - but effectively moves the cache from memory to the DB transaction
     db_session.flush()
+
+    # Check if the user is an ebiz POC and create/link their organization
+    # Only do this for new users
+    if is_user_new:
+        org_user = handle_ebiz_poc_organization_during_login(db_session, external_user.user)
+
+        if org_user:
+            logger.info(
+                "User linked to organization as organization owner (ebiz POC)",
+                extra={
+                    "user_id": str(external_user.user.user_id),
+                    "organization_id": str(org_user.organization_id),
+                    "is_organization_owner": org_user.is_organization_owner,
+                },
+            )
+            # Flush again to ensure organization data is persisted
+            db_session.flush()
 
     token, user_token_session = create_jwt_for_user(
         external_user.user, db_session, email=external_user.email

--- a/api/src/services/users/login_gov_callback_handler.py
+++ b/api/src/services/users/login_gov_callback_handler.py
@@ -162,19 +162,7 @@ def _process_token(db_session: db.Session, token: str, nonce: str) -> LoginGovCa
     # Check if the user is an ebiz POC and create/link their organization
     # Only do this for new users
     if is_user_new:
-        org_user = handle_ebiz_poc_organization_during_login(db_session, external_user.user)
-
-        if org_user:
-            logger.info(
-                "User linked to organization as organization owner (ebiz POC)",
-                extra={
-                    "user_id": str(external_user.user.user_id),
-                    "organization_id": str(org_user.organization_id),
-                    "is_organization_owner": org_user.is_organization_owner,
-                },
-            )
-            # Flush again to ensure organization data is persisted
-            db_session.flush()
+        handle_ebiz_poc_organization_during_login(db_session, external_user.user)
 
     token, user_token_session = create_jwt_for_user(
         external_user.user, db_session, email=external_user.email

--- a/api/src/services/users/organization_from_ebiz_poc.py
+++ b/api/src/services/users/organization_from_ebiz_poc.py
@@ -1,0 +1,63 @@
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+import src.adapters.db as db
+from src.db.models.entity_models import SamGovEntity
+from src.db.models.user_models import OrganizationUser, User
+from src.util.sam_gov_utils import link_sam_gov_entity_if_not_exists
+
+logger = logging.getLogger(__name__)
+
+
+def find_sam_gov_entity_for_ebiz_poc(
+    db_session: db.Session, user_email: str
+) -> SamGovEntity | None:
+    """
+    Find a SAM.gov entity where the user's email matches the ebiz POC email.
+
+    Returns the first SAM.gov entity found or None if user is not an ebiz POC.
+    """
+    return (
+        db_session.execute(
+            select(SamGovEntity)
+            .where(SamGovEntity.ebiz_poc_email == user_email)
+            .options(selectinload(SamGovEntity.organization))
+        )
+        .scalars()
+        .first()
+    )
+
+
+def handle_ebiz_poc_organization_during_login(
+    db_session: db.Session, user: User
+) -> OrganizationUser | None:
+    """
+    Handle organization creation and linking for new users who are ebiz POCs.
+    """
+    # Check if user has an email
+    if not user.email:
+        return None
+
+    # Check if the user is an ebiz POC for any SAM.gov entity
+    sam_gov_entity = find_sam_gov_entity_for_ebiz_poc(db_session, user.email)
+
+    if sam_gov_entity is None:
+        logger.debug(
+            "User is not an ebiz POC for any SAM.gov entity",
+            extra={"user_id": str(user.user_id), "user_email": user.email},
+        )
+        return None
+
+    # User is an ebiz POC, link them to the organization
+    logger.info(
+        "User is ebiz POC, linking to organization",
+        extra={
+            "user_id": str(user.user_id),
+            "user_email": user.email,
+            "sam_gov_entity_id": str(sam_gov_entity.sam_gov_entity_id),
+        },
+    )
+
+    return link_sam_gov_entity_if_not_exists(db_session, sam_gov_entity, user)

--- a/api/src/services/users/organization_from_ebiz_poc.py
+++ b/api/src/services/users/organization_from_ebiz_poc.py
@@ -11,28 +11,28 @@ from src.util.sam_gov_utils import link_sam_gov_entity_if_not_exists
 logger = logging.getLogger(__name__)
 
 
-def find_sam_gov_entity_for_ebiz_poc(
+def find_sam_gov_entities_for_ebiz_poc(
     db_session: db.Session, user_email: str
-) -> SamGovEntity | None:
+) -> list[SamGovEntity]:
     """
-    Find a SAM.gov entity where the user's email matches the ebiz POC email.
+    Find SAM.gov entities where the user's email matches the ebiz POC email.
 
-    Returns the first SAM.gov entity found or None if user is not an ebiz POC.
+    Returns a list of SAM.gov entities or empty list if user is not an ebiz POC.
     """
-    return (
+    return list(
         db_session.execute(
             select(SamGovEntity)
             .where(SamGovEntity.ebiz_poc_email == user_email)
             .options(selectinload(SamGovEntity.organization))
         )
         .scalars()
-        .first()
+        .all()
     )
 
 
 def handle_ebiz_poc_organization_during_login(
     db_session: db.Session, user: User
-) -> OrganizationUser | None:
+) -> list[OrganizationUser] | None:
     """
     Handle organization creation and linking for new users who are ebiz POCs.
     """
@@ -40,24 +40,24 @@ def handle_ebiz_poc_organization_during_login(
     if not user.email:
         return None
 
-    # Check if the user is an ebiz POC for any SAM.gov entity
-    sam_gov_entity = find_sam_gov_entity_for_ebiz_poc(db_session, user.email)
+    # Check if the user is an ebiz POC for any SAM.gov entities
+    sam_gov_entities = find_sam_gov_entities_for_ebiz_poc(db_session, user.email)
 
-    if sam_gov_entity is None:
-        logger.debug(
-            "User is not an ebiz POC for any SAM.gov entity",
-            extra={"user_id": str(user.user_id), "user_email": user.email},
-        )
+    if not sam_gov_entities:
         return None
 
-    # User is an ebiz POC, link them to the organization
-    logger.info(
-        "User is ebiz POC, linking to organization",
-        extra={
-            "user_id": str(user.user_id),
-            "user_email": user.email,
-            "sam_gov_entity_id": str(sam_gov_entity.sam_gov_entity_id),
-        },
-    )
+    # User is an ebiz POC, link them to all their organizations
+    organization_users = []
+    for sam_gov_entity in sam_gov_entities:
+        org_user = link_sam_gov_entity_if_not_exists(db_session, sam_gov_entity, user)
+        logger.info(
+            "User is ebiz POC, linking to organization",
+            extra={
+                "user_id": str(user.user_id),
+                "sam_gov_entity_id": str(sam_gov_entity.sam_gov_entity_id),
+                "organization_id": str(org_user.organization_id),
+            },
+        )
+        organization_users.append(org_user)
 
-    return link_sam_gov_entity_if_not_exists(db_session, sam_gov_entity, user)
+    return organization_users

--- a/api/src/services/users/organization_from_ebiz_poc.py
+++ b/api/src/services/users/organization_from_ebiz_poc.py
@@ -50,14 +50,6 @@ def handle_ebiz_poc_organization_during_login(
     organization_users = []
     for sam_gov_entity in sam_gov_entities:
         org_user = link_sam_gov_entity_if_not_exists(db_session, sam_gov_entity, user)
-        logger.info(
-            "User is ebiz POC, linking to organization",
-            extra={
-                "user_id": str(user.user_id),
-                "sam_gov_entity_id": str(sam_gov_entity.sam_gov_entity_id),
-                "organization_id": str(org_user.organization_id),
-            },
-        )
         organization_users.append(org_user)
 
     return organization_users

--- a/api/src/util/sam_gov_utils.py
+++ b/api/src/util/sam_gov_utils.py
@@ -1,0 +1,79 @@
+import logging
+import uuid
+from typing import Callable
+
+import src.adapters.db as db
+from src.db.models.entity_models import Organization, SamGovEntity
+from src.db.models.user_models import OrganizationUser, User
+
+logger = logging.getLogger(__name__)
+
+
+def link_sam_gov_entity_if_not_exists(
+    db_session: db.Session,
+    sam_gov_entity: SamGovEntity,
+    user: User,
+    increment_metric: Callable[[str], None] | None = None,
+) -> OrganizationUser:
+    """Link a sam.gov entity record to the EBIZ POC (owner) through an organization record
+
+    This will potentially do the following:
+    * Create the organization if it does not exist
+    * Add the user to the organization if they aren't already
+    * Mark that UserOrganization record as the owner of the organization
+
+    Each of these steps is done independently, which means the following:
+    * If the EBIZ POC email changes on the sam.gov entity record, a new owner will be added
+    * If that owner was already in the org, they just get a new permission
+    * Any existing owner will NOT be removed
+    * If the organization, and owner are already setup, this will do nothing
+
+    Args:
+        db_session: Database session
+        sam_gov_entity: The SAM.gov entity to link
+        user: The user to link as organization owner
+        increment_metric: Optional callback to increment metrics (used by tasks)
+
+    Returns:
+        The OrganizationUser record that was created or updated
+    """
+    log_extra = {"sam_gov_entity_id": sam_gov_entity.sam_gov_entity_id, "user_id": user.user_id}
+    logger.info("Processing sam.gov entity record connection to user", extra=log_extra)
+
+    # If an organization does not already exist for the sam.gov entity
+    # create and associate it
+    organization = sam_gov_entity.organization
+    if organization is None:
+        if increment_metric:
+            increment_metric("new_organization_created_count")
+        organization = Organization(organization_id=uuid.uuid4(), sam_gov_entity=sam_gov_entity)
+        db_session.add(organization)
+
+        log_extra["organization_id"] = organization.organization_id
+        logger.info("Created new organization attached to sam.gov entity", extra=log_extra)
+    else:
+        log_extra["organization_id"] = organization.organization_id
+
+    # If the user is not already a member of the organization, add them
+    organization_user = None
+    for org_user in user.organizations:  # TODO - use filter or something
+        if org_user.organization_id == organization.organization_id:
+            organization_user = org_user
+            break
+
+    if organization_user is None:
+        if increment_metric:
+            increment_metric("new_organization_user_created_count")
+        organization_user = OrganizationUser(organization=organization, user=user)
+        db_session.add(organization_user)
+        logger.info("Added user to organization", extra=log_extra)
+
+    # As we know they're the ebiz POC from the initial query,
+    # make them the owner if they aren't already
+    if organization_user.is_organization_owner is not True:
+        if increment_metric:
+            increment_metric("new_organization_owner_count")
+        organization_user.is_organization_owner = True
+        logger.info("Made user an owner of the organization", extra=log_extra)
+
+    return organization_user

--- a/api/src/util/sam_gov_utils.py
+++ b/api/src/util/sam_gov_utils.py
@@ -64,7 +64,7 @@ def link_sam_gov_entity_if_not_exists(
 
     # If the user is not already a member of the organization, add them
     organization_user = None
-    for org_user in user.organizations:  # TODO - use filter or something
+    for org_user in user.organizations:
         if org_user.organization_id == organization.organization_id:
             organization_user = org_user
             break

--- a/api/tests/src/services/users/test_login_gov_callback_handler_ebiz_poc.py
+++ b/api/tests/src/services/users/test_login_gov_callback_handler_ebiz_poc.py
@@ -19,9 +19,11 @@ def test_ebiz_poc_organization_during_login_creates_organization(enable_factory_
     LinkExternalUserFactory.create(user=user, email="integration_creates@example.com")
 
     # Call the service directly
-    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
 
-    assert org_user is not None
+    assert result is not None
+    assert len(result) == 1
+    org_user = result[0]
     assert org_user.user == user
     assert org_user.organization.sam_gov_entity == sam_gov_entity
     assert org_user.is_organization_owner is True
@@ -51,9 +53,11 @@ def test_ebiz_poc_organization_during_login_existing_organization(
     LinkExternalUserFactory.create(user=user, email="integration_existing@example.com")
 
     # Call the service directly
-    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
 
-    assert org_user is not None
+    assert result is not None
+    assert len(result) == 1
+    org_user = result[0]
     assert org_user.user == user
     assert org_user.organization == organization
     assert org_user.is_organization_owner is True
@@ -75,16 +79,22 @@ def test_ebiz_poc_organization_during_login_multiple_sam_entities(
 ):
     """Test handling of multiple SAM entities with same ebiz POC email"""
     # Create multiple SAM entities with the same ebiz POC email
-    sam_gov_entity1 = SamGovEntityFactory.create(ebiz_poc_email="integration_multi@example.com")
+    SamGovEntityFactory.create(ebiz_poc_email="integration_multi@example.com")
     SamGovEntityFactory.create(ebiz_poc_email="integration_multi@example.com")
 
     user = UserFactory.create()
     LinkExternalUserFactory.create(user=user, email="integration_multi@example.com")
 
     # Call the service directly
-    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
 
-    assert org_user is not None
-    assert org_user.user == user
-    assert org_user.organization.sam_gov_entity == sam_gov_entity1
-    assert org_user.is_organization_owner is True
+    assert result is not None
+    assert len(result) == 2  # Should return both organization users
+
+    # Verify all organization users are for the same user and are owners
+    for org_user in result:
+        assert org_user.user == user
+        assert org_user.is_organization_owner is True
+
+    # Verify user is linked to both organizations
+    assert len(user.organizations) == 2

--- a/api/tests/src/services/users/test_login_gov_callback_handler_ebiz_poc.py
+++ b/api/tests/src/services/users/test_login_gov_callback_handler_ebiz_poc.py
@@ -1,0 +1,90 @@
+from src.services.users.organization_from_ebiz_poc import handle_ebiz_poc_organization_during_login
+from tests.src.db.models.factories import (
+    LinkExternalUserFactory,
+    OrganizationFactory,
+    SamGovEntityFactory,
+    UserFactory,
+)
+
+
+def test_ebiz_poc_organization_during_login_creates_organization(enable_factory_create, db_session):
+    """Test that new users who are ebiz POCs get organization created and linked"""
+    # Create a SAM.gov entity for the user's email
+    sam_gov_entity = SamGovEntityFactory.create(
+        ebiz_poc_email="integration_creates@example.com",
+        legal_business_name="Test Organization",
+        uei="ABC123456789",
+    )
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="integration_creates@example.com")
+
+    # Call the service directly
+    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert org_user is not None
+    assert org_user.user == user
+    assert org_user.organization.sam_gov_entity == sam_gov_entity
+    assert org_user.is_organization_owner is True
+
+
+def test_ebiz_poc_organization_during_login_existing_organization(
+    enable_factory_create, db_session
+):
+    """Test that users get linked to existing organizations when they are ebiz POCs"""
+    # Create organization first
+    organization = OrganizationFactory.create(no_sam_gov_entity=True)
+
+    # Create SAM.gov entity and link it to the organization
+    sam_gov_entity = SamGovEntityFactory.create(
+        ebiz_poc_email="integration_existing@example.com",
+        legal_business_name="Existing Organization",
+        uei="DEF456789012",
+    )
+
+    # Update the organization to reference the SAM.gov entity
+    organization.sam_gov_entity_id = sam_gov_entity.sam_gov_entity_id
+    organization.sam_gov_entity = sam_gov_entity
+    db_session.add(organization)
+    db_session.flush()
+
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="integration_existing@example.com")
+
+    # Call the service directly
+    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert org_user is not None
+    assert org_user.user == user
+    assert org_user.organization == organization
+    assert org_user.is_organization_owner is True
+
+
+def test_ebiz_poc_organization_during_login_not_ebiz_poc(enable_factory_create, db_session):
+    """Test that users who are not ebiz POCs don't get organizations created"""
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="integration_not_ebiz@example.com")
+
+    # Call the service directly
+    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert org_user is None
+
+
+def test_ebiz_poc_organization_during_login_multiple_sam_entities(
+    enable_factory_create, db_session
+):
+    """Test handling of multiple SAM entities with same ebiz POC email"""
+    # Create multiple SAM entities with the same ebiz POC email
+    sam_gov_entity1 = SamGovEntityFactory.create(ebiz_poc_email="integration_multi@example.com")
+    SamGovEntityFactory.create(ebiz_poc_email="integration_multi@example.com")
+
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="integration_multi@example.com")
+
+    # Call the service directly
+    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert org_user is not None
+    assert org_user.user == user
+    assert org_user.organization.sam_gov_entity == sam_gov_entity1
+    assert org_user.is_organization_owner is True

--- a/api/tests/src/services/users/test_organization_from_ebiz_poc.py
+++ b/api/tests/src/services/users/test_organization_from_ebiz_poc.py
@@ -1,0 +1,172 @@
+from src.services.users.organization_from_ebiz_poc import (
+    find_sam_gov_entity_for_ebiz_poc,
+    handle_ebiz_poc_organization_during_login,
+)
+from tests.src.db.models.factories import (
+    LinkExternalUserFactory,
+    OrganizationFactory,
+    OrganizationUserFactory,
+    SamGovEntityFactory,
+    UserFactory,
+)
+
+
+def test_find_sam_gov_entity_for_ebiz_poc_not_found(db_session):
+    """Test that we return None when user is not an ebiz POC"""
+    # Don't create any SAM.gov entities for this test
+    sam_gov_entity = find_sam_gov_entity_for_ebiz_poc(db_session, "nonexistent@example.com")
+
+    assert sam_gov_entity is None
+
+
+def test_find_sam_gov_entity_for_ebiz_poc_found(db_session, enable_factory_create):
+    """Test that we return the SAM.gov entity when user is an ebiz POC"""
+    # Create a SAM.gov entity for the user's email
+    sam_gov_entity = SamGovEntityFactory.create(ebiz_poc_email="found@example.com")
+
+    result = find_sam_gov_entity_for_ebiz_poc(db_session, "found@example.com")
+
+    assert result is not None
+    assert result.ebiz_poc_email == "found@example.com"
+    assert result.sam_gov_entity_id == sam_gov_entity.sam_gov_entity_id
+
+
+def test_find_sam_gov_entity_for_ebiz_poc_multiple_entities(db_session, enable_factory_create):
+    """Test that we return the first SAM.gov entity when multiple exist for same email"""
+    # Create multiple SAM.gov entities with the same ebiz POC email
+    first_entity = SamGovEntityFactory.create(ebiz_poc_email="multiple@example.com")
+    SamGovEntityFactory.create(ebiz_poc_email="multiple@example.com")
+
+    result = find_sam_gov_entity_for_ebiz_poc(db_session, "multiple@example.com")
+
+    assert result is not None
+    assert result.ebiz_poc_email == "multiple@example.com"
+    # Should return the first one found (database order)
+    assert result.sam_gov_entity_id == first_entity.sam_gov_entity_id
+
+
+def test_handle_ebiz_poc_organization_during_login_not_ebiz_poc(db_session, enable_factory_create):
+    """Test that we return None when user is not an ebiz POC"""
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="not_ebiz@example.com")
+
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert result is None
+
+
+def test_handle_ebiz_poc_organization_during_login_creates_organization(
+    db_session, enable_factory_create
+):
+    """Test that we create organization when user is an ebiz POC with no existing organization"""
+    # Create SAM.gov entity without an organization
+    sam_gov_entity = SamGovEntityFactory.create(
+        ebiz_poc_email="creates@example.com",
+        legal_business_name="New Org",
+        uei="ABC123456789",
+    )
+
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="creates@example.com")
+
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert result is not None
+    assert result.user == user
+    assert result.organization.sam_gov_entity == sam_gov_entity
+    assert result.is_organization_owner is True
+
+
+def test_handle_ebiz_poc_organization_during_login_existing_organization(
+    db_session, enable_factory_create
+):
+    """Test that we link user to existing organization when they are an ebiz POC"""
+    # Create organization first
+    organization = OrganizationFactory.create(no_sam_gov_entity=True)
+
+    # Create SAM.gov entity and link it to the organization
+    sam_gov_entity = SamGovEntityFactory.create(
+        ebiz_poc_email="ebiz_existing@example.com",
+        legal_business_name="Existing Org",
+        uei="DEF987654321",
+    )
+
+    # Update the organization to reference the SAM.gov entity
+    organization.sam_gov_entity_id = sam_gov_entity.sam_gov_entity_id
+    organization.sam_gov_entity = sam_gov_entity
+    db_session.add(organization)
+    db_session.flush()
+
+    # Create user with matching email
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="ebiz_existing@example.com")
+
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert result is not None
+    assert result.user == user
+    assert result.organization == organization
+    assert result.is_organization_owner is True
+
+
+def test_handle_ebiz_poc_organization_during_login_existing_organization_user(
+    db_session, enable_factory_create
+):
+    """Test that we update existing organization user to be owner when they are an ebiz POC"""
+    # Create organization first
+    organization = OrganizationFactory.create(no_sam_gov_entity=True)
+
+    # Create SAM.gov entity and link it to the organization
+    sam_gov_entity = SamGovEntityFactory.create(
+        ebiz_poc_email="ebiz_update@example.com",
+        legal_business_name="Update Org",
+        uei="GHI555666777",
+    )
+
+    # Update the organization to reference the SAM.gov entity
+    organization.sam_gov_entity_id = sam_gov_entity.sam_gov_entity_id
+    organization.sam_gov_entity = sam_gov_entity
+    db_session.add(organization)
+
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="ebiz_update@example.com")
+    org_user = OrganizationUserFactory.create(
+        organization=organization, user=user, is_organization_owner=False
+    )
+    db_session.flush()
+
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert result is not None
+    assert result == org_user
+    assert result.is_organization_owner is True
+
+
+def test_handle_ebiz_poc_organization_during_login_multiple_sam_entities(
+    db_session, enable_factory_create
+):
+    """Test that we handle multiple SAM entities for the same email"""
+    # Create multiple SAM entities with the same ebiz POC email
+    sam_gov_entity1 = SamGovEntityFactory.create(ebiz_poc_email="multi@example.com")
+    SamGovEntityFactory.create(ebiz_poc_email="multi@example.com")
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="multi@example.com")
+
+    org_user = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    # Should use the first entity found and create organization for it
+    assert org_user is not None
+    assert org_user.organization.sam_gov_entity == sam_gov_entity1
+
+
+def test_handle_ebiz_poc_organization_during_login_rollback_on_error(
+    db_session, enable_factory_create
+):
+    """Test that if an error occurs, the transaction is properly handled"""
+    user = UserFactory.create()
+    LinkExternalUserFactory.create(user=user, email="rollback@example.com")
+
+    # This should gracefully return None since no SAM.gov entity exists
+    result = handle_ebiz_poc_organization_during_login(db_session, user)
+
+    assert result is None


### PR DESCRIPTION
## Summary

Fixes #5248

## Changes proposed

For new users, link to organization as organization owner if applicable

Refactor `link_sam_gov_entity_if_not_exists` to be reused with optional metrics.
Add tests

## Context for reviewers

Heavily reuses logic in https://github.com/HHS/simpler-grants-gov/issues/5248, as most of the complexity in this task is reusing the `link_sam_gov_entity_if_not_exists` function.
Additional context provided in ticket: https://github.com/HHS/simpler-grants-gov/issues/5250

## Validation steps

See new unit tests.