### PR TITLE
[Unticketed] Change the accept header for calling sam.gov

### DIFF
--- a/api/src/adapters/sam_gov/client.py
+++ b/api/src/adapters/sam_gov/client.py
@@ -72,7 +72,7 @@ class SamGovClient(BaseSamGovClient):
 
         return {
             "Content-Type": "application/json",
-            "Accept": "application/json",
+            "Accept": "application/zip",
             "x-api-key": self.api_key,
         }
 


### PR DESCRIPTION
## Summary

## Changes proposed
Change the `Accept` header to `application/zip`

## Context for reviewers
Getting this error when trying to call the endpoint right now:
```
["<class 'Exception'>","Error downloading extract: Failed to download extract: 406 Not Acceptable, Details: {'httpStatus': 'NOT_ACCEPTABLE', 'title': 'Invalid Accept Header', 'errorCode': '406', 'detail': 'No acceptable representation'}","<traceback object at 0x7f45ae3e90c0>"]
```

The docs say `The "Accept" parameter must be sent as "application/json" under "Headers".` but every example says to use `application/zip` - so I think that's a mistake.
https://open.gsa.gov/api/sam-entity-extracts-api/

## Validation steps
Can't validate locally due to IP restrictions when calling sam.gov
