### PR TITLE
[Issue #5123] Update start application auth handling

### DIFF
--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -39,40 +39,64 @@ export const LoginModal = ({
       titleText={titleText}
       className="text-wrap"
     >
-      <>
-        <p>{helpText}</p>
-        <p className="font-sans-2xs margin-y-4">{descriptionText}</p>
-        <ModalFooter>
-          <ButtonGroup>
-            <a
-              href={LOGIN_URL}
-              key="login-link"
-              className="usa-button"
-              onClick={() => {
-                const startURL = `${location.pathname}${location.search}`;
-                if (startURL !== "") {
-                  SessionStorage.setItem("login-redirect", startURL);
-                }
-              }}
-            >
-              {buttonText}
-              <USWDSIcon
-                className="usa-icon margin-right-05 margin-left-neg-05"
-                name="launch"
-                key="login-gov-link-icon"
-              />
-            </a>
-            <ModalToggleButton
-              modalRef={modalRef}
-              closer
-              unstyled
-              className="padding-105 text-center"
-            >
-              {closeText}
-            </ModalToggleButton>
-          </ButtonGroup>
-        </ModalFooter>
-      </>
+      <LoginModalBody
+        buttonText={buttonText}
+        closeText={closeText}
+        descriptionText={descriptionText}
+        helpText={helpText}
+        modalRef={modalRef}
+      />
     </SimplerModal>
+  );
+};
+
+export const LoginModalBody = ({
+  buttonText,
+  closeText,
+  descriptionText,
+  helpText,
+  modalRef,
+}: {
+  buttonText: string;
+  closeText: string;
+  descriptionText: string;
+  helpText: string;
+  modalRef: RefObject<ModalRef | null>;
+}) => {
+  return (
+    <>
+      <p>{helpText}</p>
+      <p className="font-sans-2xs margin-y-4">{descriptionText}</p>
+      <ModalFooter>
+        <ButtonGroup>
+          <a
+            href={LOGIN_URL}
+            key="login-link"
+            className="usa-button"
+            onClick={() => {
+              const startURL = `${location.pathname}${location.search}`;
+              if (startURL !== "") {
+                SessionStorage.setItem("login-redirect", startURL);
+              }
+            }}
+          >
+            {buttonText}
+            <USWDSIcon
+              className="usa-icon margin-right-05 margin-left-neg-05"
+              name="launch"
+              key="login-gov-link-icon"
+            />
+          </a>
+          <ModalToggleButton
+            modalRef={modalRef}
+            closer
+            unstyled
+            className="padding-105 text-center"
+          >
+            {closeText}
+          </ModalToggleButton>
+        </ButtonGroup>
+      </ModalFooter>
+    </>
   );
 };

--- a/frontend/src/components/user/OpportunityCompetitionStart.tsx
+++ b/frontend/src/components/user/OpportunityCompetitionStart.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useFeatureFlags } from "src/hooks/useFeatureFlags";
-import { useUser } from "src/services/auth/useUser";
 import { Competition } from "src/types/competitionsResponseTypes";
 
 import StartApplicationModal from "src/components/workspace/StartApplicationModal";
@@ -13,15 +12,10 @@ export const OpportunityCompetitionStart = ({
   competitions: [Competition];
   opportunityTitle: string;
 }) => {
-  const { user } = useUser();
   const { checkFeatureFlag } = useFeatureFlags();
   const openCompetitions = selectOpenCompetitions({ competitions });
 
-  if (
-    !openCompetitions.length ||
-    !user?.token ||
-    checkFeatureFlag("applyFormPrototypeOff")
-  ) {
+  if (!openCompetitions.length || checkFeatureFlag("applyFormPrototypeOff")) {
     return <></>;
   } else {
     return (

--- a/frontend/src/components/workspace/CompetitionStartFormIndividiual.tsx
+++ b/frontend/src/components/workspace/CompetitionStartFormIndividiual.tsx
@@ -68,6 +68,7 @@ const CompetitionStartFormIndividiual = ({
             onClick={onSubmit}
             type="button"
             data-testid="competition-start-individual-save"
+            disabled={!!loading}
           >
             {loading
               ? "loading..."

--- a/frontend/src/components/workspace/CompetitionStartFormIndividiual.tsx
+++ b/frontend/src/components/workspace/CompetitionStartFormIndividiual.tsx
@@ -41,7 +41,7 @@ const CompetitionStartFormIndividiual = ({
           {opportunityTitle}
         </p>
         <p className="font-sans-3xs">
-          {t("startAppplicationModal.requiredText")}
+          {t("startApplicationModal.requiredText")}
         </p>
         <Label
           id={`label-for-name`}
@@ -49,9 +49,9 @@ const CompetitionStartFormIndividiual = ({
           htmlFor="application-name"
           className="font-sans-2xs"
         >
-          {t("startAppplicationModal.name")}
+          {t("startApplicationModal.name")}
           <span>
-            <br /> {t("startAppplicationModal.description")}
+            <br /> {t("startApplicationModal.description")}
           </span>
         </Label>
         {validationError && <ErrorMessage>{validationError}</ErrorMessage>}
@@ -70,9 +70,7 @@ const CompetitionStartFormIndividiual = ({
             data-testid="competition-start-individual-save"
             disabled={!!loading}
           >
-            {loading
-              ? "loading..."
-              : t("startAppplicationModal.saveButtonText")}
+            {loading ? "loading..." : t("startApplicationModal.saveButtonText")}
           </Button>
           <ModalToggleButton
             modalRef={modalRef}
@@ -81,7 +79,7 @@ const CompetitionStartFormIndividiual = ({
             className="padding-105 text-center"
             onClick={onClose}
           >
-            {t("startAppplicationModal.cancelButtonText")}
+            {t("startApplicationModal.cancelButtonText")}
           </ModalToggleButton>
         </ModalFooter>
       </FormGroup>

--- a/frontend/src/components/workspace/StartApplicationModal.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useRef, useState } from "react";
 import { ModalRef, ModalToggleButton } from "@trussworks/react-uswds";
 
+import { LoginModalBody } from "src/components/LoginModal";
 import { SimplerModal } from "src/components/SimplerModal";
 import { USWDSIcon } from "src/components/USWDSIcon";
 import CompetitionStartFormIndividiual from "src/components/workspace/CompetitionStartFormIndividiual";
@@ -25,15 +26,19 @@ const StartApplicationModal = ({
   const { user } = useUser();
   const router = useRouter();
   const t = useTranslations("OpportunityListing");
+  const headerTranslation = useTranslations("HeaderLoginModal");
   const modalId = "start-application";
   const [validationError, setValidationError] = useState<string>();
   const [savedSearchName, setSavedSearchName] = useState<string>();
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState<boolean>();
+  const token = user && user.token ? user.token : null;
 
   const handleSubmit = useCallback(() => {
-    if (!user?.token) return;
-
+    if (!token) {
+      setValidationError(t("startAppplicationModal.loggedOut"));
+      return;
+    }
     if (validationError) {
       setValidationError(undefined);
     }
@@ -42,7 +47,7 @@ const StartApplicationModal = ({
       return;
     }
     setLoading(true);
-    startApplication(competitionId, savedSearchName, user.token)
+    startApplication(competitionId, savedSearchName, token)
       .then((data) => {
         const { applicationId } = data;
         router.push(`/workspace/applications/application/${applicationId}`);
@@ -54,7 +59,7 @@ const StartApplicationModal = ({
       .finally(() => {
         setLoading(false);
       });
-  }, [competitionId, router, savedSearchName, t, user, validationError]);
+  }, [competitionId, router, savedSearchName, t, token, validationError]);
 
   const onClose = useCallback(() => {
     setError("");
@@ -82,22 +87,36 @@ const StartApplicationModal = ({
         modalRef={modalRef}
         className="text-wrap"
         modalId={modalId}
-        titleText={t("startAppplicationModal.title")}
+        titleText={
+          token
+            ? t("startAppplicationModal.title")
+            : t("startAppplicationModal.login")
+        }
         onKeyDown={(e) => {
           if (e.key === "Enter") handleSubmit();
         }}
         onClose={onClose}
       >
-        <CompetitionStartFormIndividiual
-          opportunityTitle={opportunityTitle}
-          loading={loading}
-          error={error}
-          onClose={onClose}
-          onSubmit={handleSubmit}
-          onChange={onChange}
-          modalRef={modalRef}
-          validationError={validationError}
-        />
+        {token ? (
+          <CompetitionStartFormIndividiual
+            opportunityTitle={opportunityTitle}
+            loading={loading}
+            error={error}
+            onClose={onClose}
+            onSubmit={handleSubmit}
+            onChange={onChange}
+            modalRef={modalRef}
+            validationError={validationError}
+          />
+        ) : (
+          <LoginModalBody
+            helpText={headerTranslation("help")}
+            buttonText={headerTranslation("button")}
+            closeText={headerTranslation("close")}
+            descriptionText={headerTranslation("description")}
+            modalRef={modalRef}
+          />
+        )}
       </SimplerModal>
     </div>
   );

--- a/frontend/src/components/workspace/StartApplicationModal.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal.tsx
@@ -32,7 +32,7 @@ const StartApplicationModal = ({
   const [savedSearchName, setSavedSearchName] = useState<string>();
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState<boolean>();
-  const token = user && user.token ? user.token : null;
+  const token = user?.token || null;
 
   const handleSubmit = useCallback(() => {
     if (!token) {
@@ -42,7 +42,7 @@ const StartApplicationModal = ({
       setValidationError(undefined);
     }
     if (!savedSearchName) {
-      setValidationError(t("startAppplicationModal.validationError"));
+      setValidationError(t("startApplicationModal.validationError"));
       return;
     }
     setLoading(true);
@@ -54,9 +54,9 @@ const StartApplicationModal = ({
       .catch((error) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (error.cause === "401") {
-          setError(t("startAppplicationModal.loggedOut"));
+          setError(t("startApplicationModal.loggedOut"));
         } else {
-          setError(t("startAppplicationModal.error"));
+          setError(t("startApplicationModal.error"));
         }
         console.error(error);
       });
@@ -90,8 +90,8 @@ const StartApplicationModal = ({
         modalId={modalId}
         titleText={
           token
-            ? t("startAppplicationModal.title")
-            : t("startAppplicationModal.login")
+            ? t("startApplicationModal.title")
+            : t("startApplicationModal.login")
         }
         onKeyDown={(e) => {
           if (e.key === "Enter") handleSubmit();

--- a/frontend/src/components/workspace/StartApplicationModal.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal.tsx
@@ -36,7 +36,6 @@ const StartApplicationModal = ({
 
   const handleSubmit = useCallback(() => {
     if (!token) {
-      setValidationError(t("startAppplicationModal.loggedOut"));
       return;
     }
     if (validationError) {
@@ -53,11 +52,13 @@ const StartApplicationModal = ({
         router.push(`/workspace/applications/application/${applicationId}`);
       })
       .catch((error) => {
-        setError(t("startAppplicationModal.error"));
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (error.cause === "401") {
+          setError(t("startAppplicationModal.loggedOut"));
+        } else {
+          setError(t("startAppplicationModal.error"));
+        }
         console.error(error);
-      })
-      .finally(() => {
-        setLoading(false);
       });
   }, [competitionId, router, savedSearchName, t, token, validationError]);
 

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -119,6 +119,9 @@ export const messages = {
       description:
         "Create a unique and descriptive application filing name so it is easy for you and the granting agency to track.",
       error: "Error starting the application. Please try again.",
+      login: "Login to start the application",
+      loggedOut:
+        "You must be logged in to proceed. Please login and start your application again.",
       name: "Name of this application",
       requiredText: "All fields are required.",
       saveButtonText: "Save",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -114,12 +114,12 @@ export const messages = {
       title: "Sign in to save this opportunity",
     },
     startApplicationButtonText: "Start new application",
-    startAppplicationModal: {
+    startApplicationModal: {
       cancelButtonText: "Cancel",
       description:
         "Create a unique and descriptive application filing name so it is easy for you and the granting agency to track.",
       error: "Error starting the application. Please try again.",
-      login: "Login to start the application",
+      login: "Sign in to work on the application",
       loggedOut:
         "You must be logged in to proceed. Please login and start your application again.",
       name: "Name of this application",

--- a/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientApplicationFetcher.ts
@@ -23,6 +23,8 @@ export const startApplication = async (
   if (res.ok && res.status === 200) {
     return (await res.json()) as ClientApplicationStartResponse;
   } else {
-    throw new Error(`Error starting application: ${res.status}`);
+    throw new Error(`Error sssssss application: ${res.status}`, {
+      cause: `${res.status}`,
+    });
   }
 };

--- a/frontend/tests/components/workspace/StartApplicationModal.test.tsx
+++ b/frontend/tests/components/workspace/StartApplicationModal.test.tsx
@@ -115,7 +115,7 @@ describe("StartApplicationModal", () => {
     );
 
     const closeButton = await screen.findByText(
-      "startAppplicationModal.cancelButtonText",
+      "startApplicationModal.cancelButtonText",
     );
     act(() => closeButton.click());
 
@@ -161,7 +161,7 @@ describe("StartApplicationModal", () => {
     );
 
     const validationError = await screen.findByText(
-      "startAppplicationModal.validationError",
+      "startApplicationModal.validationError",
     );
 
     expect(validationError).toBeInTheDocument();
@@ -201,7 +201,46 @@ describe("StartApplicationModal", () => {
       />,
     );
 
-    const error = await screen.findByText("startAppplicationModal.error");
+    const error = await screen.findByText("startApplicationModal.error");
+
+    expect(error).toBeInTheDocument();
+  });
+  it("displays an login error if API 401", async () => {
+    fetchMock.mockRejectedValue(new Error("401 error", { cause: "401" }));
+    const { rerender } = render(
+      <StartApplicationModal
+        competitionId="1"
+        opportunityTitle="blessed opportunity"
+      />,
+    );
+
+    const toggle = await screen.findByTestId(
+      "open-start-application-modal-button",
+    );
+    act(() => toggle.click());
+
+    rerender(
+      <StartApplicationModal
+        competitionId="1"
+        opportunityTitle="blessed opportunity"
+      />,
+    );
+
+    const saveButton = await screen.findByTestId(
+      "competition-start-individual-save",
+    );
+    const input = await screen.findByTestId("textInput");
+    fireEvent.change(input, { target: { value: "new application" } });
+    act(() => saveButton.click());
+
+    rerender(
+      <StartApplicationModal
+        competitionId="1"
+        opportunityTitle="blessed opportunity"
+      />,
+    );
+
+    const error = await screen.findByText("startApplicationModal.loggedOut");
 
     expect(error).toBeInTheDocument();
   });
@@ -255,7 +294,7 @@ describe("StartApplicationModal", () => {
     );
 
     expect(screen.queryAllByTestId("modalWindow")[0]).toHaveTextContent(
-      "startAppplicationModal.login",
+      "startApplicationModal.login",
     );
   });
 });

--- a/frontend/tests/components/workspace/StartApplicationModal.test.tsx
+++ b/frontend/tests/components/workspace/StartApplicationModal.test.tsx
@@ -245,4 +245,17 @@ describe("StartApplicationModal", () => {
       );
     });
   });
+  it("displays login message if user not logged in", () => {
+    mockUseUser.mockImplementation(() => ({}) as { user: { token: string } });
+    render(
+      <StartApplicationModal
+        competitionId="1"
+        opportunityTitle="blessed opportunity"
+      />,
+    );
+
+    expect(screen.queryAllByTestId("modalWindow")[0]).toHaveTextContent(
+      "startAppplicationModal.login",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #5123

## Changes proposed

1. Start app button is now visible for anon users and directs user to login if they aren't already logged in: ![image](https://github.com/user-attachments/assets/03f56cb1-a628-49be-85cb-558dbbc41401)
2. Provides a specific error for "unauthorized" for if the user times out while submitting the app:
![image](https://github.com/user-attachments/assets/a5001f16-de62-4382-bf51-e97dfc6b5538)

Keeps the same error if there is another error with the API:

![image](https://github.com/user-attachments/assets/6a4f7b9e-2f2c-4133-98bc-d27f806963f0)

## Context for reviewers

It would be ideal perhaps to provide more than an error state, but that would blow up the scope of the ticket.

## Validation steps

1. start dev server and api server locally
2. go to an opportunity with a competition (112 or 114). You can check the `opportunity_id` in the competition table in the database to be sure
3. click "Start new application" when not logged in. You should be directed to login
4. login and find you are rerouted back to the opp page
5. click "Start new application" and confirm the form still works
6. go back to opp and click button again. log out in another tab before submitting. submit the modal form and see that it directs you to login.


