### PR TITLE
[Unticketed] Make JSON Schema required checks have right path

### DIFF
--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -413,7 +413,7 @@ def test_application_form_update_success_update(
             {},
             [
                 {
-                    "field": "$",
+                    "field": "$.name",
                     "message": "'name' is a required property",
                     "type": "required",
                     "value": None,
@@ -992,7 +992,7 @@ def test_application_get_success_with_validation_issues(
     ]
     assert form_a_warnings == [
         {
-            "field": "$",
+            "field": "$.name",
             "message": "'name' is a required property",
             "type": "required",
             "value": None,
@@ -1010,7 +1010,7 @@ def test_application_get_success_with_validation_issues(
     ]
     assert form_b_warnings == [
         {
-            "field": "$",
+            "field": "$.name",
             "message": "'name' is a required property",
             "type": "required",
             "value": None,
@@ -1069,7 +1069,7 @@ def test_application_get_unauthorized(client, enable_factory_create, db_session)
             {},
             [
                 {
-                    "field": "$",
+                    "field": "$.name",
                     "message": "'name' is a required property",
                     "type": "required",
                     "value": None,

--- a/api/tests/src/services/applications/test_application_validation.py
+++ b/api/tests/src/services/applications/test_application_validation.py
@@ -256,7 +256,7 @@ def test_validate_forms_invalid_responses(
     assert set(form_a_validation_issues) == {
         ValidationErrorDetail(type="type", message="{} is not of type 'string'", field="$.str_a"),
         ValidationErrorDetail(
-            type="required", message="'int_a' is a required property", field="$.obj_a"
+            type="required", message="'int_a' is a required property", field="$.obj_a.int_a"
         ),
     }
 


### PR DESCRIPTION
## Summary

## Changes proposed
Adjust the JSONSchema library usage to add the field name to the path we produce in our error response

## Context for reviewers
This has been a known gap in the jsonschema library for 10+ years, and unfortunately it seems like we need to work around it by building our own custom validator function (it's just the existing required function with one line added).

## Validation steps
Added some tests, had to fix a few tests that were checking the old path.