### PR TITLE
allow tooltips to display properly in legacy filter rail

### DIFF
--- a/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/SearchFilterAccordion.tsx
@@ -150,9 +150,9 @@ export function SearchFilterAccordion({
   query,
   facetCounts,
   defaultEmptySelection,
+  contentClassName,
   includeAnyOption = true,
-  wrapForScroll = false,
-}: SearchFilterAccordionProps) {
+}: SearchFilterProps) {
   const accordionOptions: AccordionItemProps[] = [
     {
       title: <AccordionTitle title={title} totalCheckedCount={query.size} />,
@@ -170,9 +170,10 @@ export function SearchFilterAccordion({
       expanded: !!query.size,
       id: `opportunity-filter-${queryParamKey as string}`,
       headingLevel: "h2",
-      className: wrapForScroll
-        ? "maxh-mobile-lg overflow-auto position-relative"
-        : "",
+      className: clsx(
+        "maxh-mobile-lg overflow-auto position-relative",
+        contentClassName,
+      ),
     },
   ];
 

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -61,6 +61,7 @@ export default async function SearchFilters({
         queryParamKey="fundingInstrument"
         title={t("accordion.titles.funding")}
         facetCounts={facetCounts?.funding_instrument || {}}
+        contentClassName="overflow-visible"
       />
       <SearchFilterAccordion
         filterOptions={eligibilityOptions}

--- a/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
+++ b/frontend/tests/components/search/SearchFilterAccordion/SearchFilterAccordion.test.tsx
@@ -132,7 +132,7 @@ describe("SearchFilterAccordion", () => {
     });
     expect(anyCheckbox).toBeInTheDocument();
   });
-  it("ensures only the component contents scroll when wrapForScroll is true", () => {
+  it("ensures the component contents scroll", () => {
     render(
       <SearchFilterAccordion
         filterOptions={initialFilterOptions}
@@ -140,7 +140,6 @@ describe("SearchFilterAccordion", () => {
         queryParamKey={queryParamKey}
         query={new Set("")}
         facetCounts={fakeFacetCounts}
-        wrapForScroll={true}
       />,
     );
 


### PR DESCRIPTION
## Summary

unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

fixes bug introduced in https://github.com/HHS/simpler-grants-gov/pull/5311 where funding instrument tooltips did not properly overflow their container in legacy filter implementation

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on main with `npm run dev`
2. visit http://localhost:3000/search
3. open the funding instrument filter and hover over tooltips
4. _VERIFY_: content is cut off
5. restart server on this branch
6. repeat 2 and 3
7. _VERIFY_: tooltips are fully visible

### Screenshots

#### Before
<img width="965" alt="Screenshot 2025-06-24 at 4 49 40 PM" src="https://github.com/user-attachments/assets/ad107dd0-2db1-4e67-8d42-23c975b1fe58" />
<img width="980" alt="Screenshot 2025-06-24 at 4 49 36 PM" src="https://github.com/user-attachments/assets/40d668c6-8f52-476d-a990-64cb3f3c6ae2" />



#### After

<img width="922" alt="Screenshot 2025-06-24 at 4 48 38 PM" src="https://github.com/user-attachments/assets/eab2f3f1-6ca3-4f85-a5ce-f6c0ddc6604d" />
<img width="868" alt="Screenshot 2025-06-24 at 4 48 33 PM" src="https://github.com/user-attachments/assets/7467afe4-6f21-49af-b3e2-77e9b244abd6" />

