### PR TITLE
[Issue #5436] Adjust Closing Date Email logic and DB logging

### DIFF
--- a/api/src/task/notifications/closing_date_notification.py
+++ b/api/src/task/notifications/closing_date_notification.py
@@ -54,8 +54,8 @@ class ClosingDateNotificationTask(BaseNotificationTask):
             .where(
                 # Check if closing date is within 24 hours of two weeks from now
                 and_(
-                    OpportunitySummary.close_date >= two_weeks_from_now - timedelta(hours=24),
-                    OpportunitySummary.close_date <= two_weeks_from_now + timedelta(hours=24),
+                    OpportunitySummary.close_date <= two_weeks_from_now,
+                    OpportunitySummary.close_date >= datetime_util.utcnow()
                 ),
                 # Ensure we haven't already sent a closing reminder
                 ~exists().where(


### PR DESCRIPTION
## Summary
Adjust the logic and dupe email prevention logic for the closing date email notifications

## Changes proposed

Utilize the Notification Log to allow for notifying on anything with close_date less than 14 days rather than only that specific 14 day window. This way if the job fails or something prevents the notifications from firing today, they'll be sent tomorrow. Checking if they've already been send is made smarter to avoid re-sending the same notification.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

Tests pass, not sure if additional new tests are needed.
