### PR TITLE
[Issue #5388] Add attachment ID support for list fields in validation

### DIFF
--- a/api/src/form_schema/rule_processing/json_rule_util.py
+++ b/api/src/form_schema/rule_processing/json_rule_util.py
@@ -1,13 +1,18 @@
 from typing import Any
 
 
-def build_path_str(path: list[str]) -> str:
+def build_path_str(path: list[str], index: int | None = None) -> str:
     """Build a path string for validation issues
 
     We prepend $. on the front to mimic the format of
     the JSON Schema validation
     """
-    return ".".join(["$"] + path)
+    path_str = ".".join(["$"] + path)
+
+    if index is not None:
+        path_str += f"[{index}]"
+
+    return path_str
 
 
 def get_nested_value(data: dict, path: list[str]) -> Any:

--- a/api/tests/src/form_schema/rule_processing/test_json_rule_util.py
+++ b/api/tests/src/form_schema/rule_processing/test_json_rule_util.py
@@ -80,13 +80,18 @@ def test_get_nested_value(json_data, path, expected_value):
 
 
 @pytest.mark.parametrize(
-    "path,expected_str",
+    "path,index,expected_str",
     [
-        (["path", "to", "field"], "$.path.to.field"),
-        (["my_field"], "$.my_field"),
-        ([], "$"),
-        (["a", "b", "c", "d", "e"], "$.a.b.c.d.e"),
+        (["path", "to", "field"], None, "$.path.to.field"),
+        (["my_field"], None, "$.my_field"),
+        ([], None, "$"),
+        (["a", "b", "c", "d", "e"], None, "$.a.b.c.d.e"),
+        # With an index
+        (["path", "to", "field"], 4, "$.path.to.field[4]"),
+        (["my_field"], 0, "$.my_field[0]"),
+        (["hello", "darkness", "my", "old", "friend"], 12, "$.hello.darkness.my.old.friend[12]"),
+        (["a", "b", "c", "d", "e", "f"], 6, "$.a.b.c.d.e.f[6]"),
     ],
 )
-def test_build_path_str(path, expected_str):
-    assert build_path_str(path) == expected_str
+def test_build_path_str(path, index, expected_str):
+    assert build_path_str(path, index=index) == expected_str


### PR DESCRIPTION
## Summary

Fixes #5388

## Changes proposed
Modify the rule validator for validating attachment IDs to also handle the value we're validating being a list of attachment IDs

## Context for reviewers
Attachment ID questions in our forms can either be a single ID, or a list of IDs (ie. the question asks you to upload multiple files). This handles supporting that behavior, as well as building the path to include the index in the list. We know the SF424 that we're likely going to need to support has at least one question like this.
