### PR TITLE
Remove "staging" deployment option for Nofo Builder

### DIFF
--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -18,7 +18,6 @@ on:
         type: choice
         options:
           - dev
-          - staging
           - prod
       version:
         description: "git reference to deploy (e.g., a branch, tag, or commit SHA)"


### PR DESCRIPTION

## Summary

The NOFO Builder is not using the staging environment, so let's remove this option from the GitHub Actions drop-down.

## Changes proposed

Removes "staging" option from "Environment to deploy to:" for the "Deploy NOFOs" action.

## Context for reviewers

<img width="1057" alt="Screenshot 2025-06-25 at 12 27 20" src="https://github.com/user-attachments/assets/a58cf1fd-514b-4ea3-9b80-c3c2c5a35146" />
