### PR TITLE
[Issue #5253] Setup a CLI command for running sam.gov tasks

### DIFF
--- a/api/src/task/__init__.py
+++ b/api/src/task/__init__.py
@@ -6,7 +6,6 @@ import src.task.notifications.generate_notifications  # noqa: F401 E402 isort:sk
 import src.task.opportunities.export_opportunity_data_task  # noqa: F401 E402 isort:skip
 import src.task.analytics.create_analytics_db_csvs  # noqa: F401 E402 isort:skip
 import src.task.notifications.email_notification  # noqa: F401 E402 isort:skip
-import src.task.sam_extracts.process_sam_extracts  # noqa: F401 E402 isort:skip
-import src.task.sam_extracts.fetch_sam_extracts  # noqa: F401 E402 isort:skip
+import src.task.sam_extracts.sam_extract_cli  # noqa: F401 E402 isort:skip
 
 __all__ = ["task_blueprint"]

--- a/api/src/task/sam_extracts/process_sam_extracts.py
+++ b/api/src/task/sam_extracts/process_sam_extracts.py
@@ -7,8 +7,6 @@ from typing import Sequence
 
 from sqlalchemy import select
 
-import src.adapters.db as db
-from src.adapters.db import flask_db
 from src.constants.lookup_constants import (
     SamGovExtractType,
     SamGovImportType,
@@ -16,9 +14,7 @@ from src.constants.lookup_constants import (
 )
 from src.db.models.entity_models import SamGovEntity, SamGovEntityImportType
 from src.db.models.sam_extract_models import SamExtractFile
-from src.task.ecs_background_task import ecs_background_task
 from src.task.task import Task
-from src.task.task_blueprint import task_blueprint
 from src.util import file_util
 
 logger = logging.getLogger(__name__)
@@ -463,11 +459,3 @@ def convert_exclusion_status_flag(value_str: str) -> bool:
         return True
 
     return False
-
-
-@task_blueprint.cli.command("process-sam-extracts", help="Process sam.gov extracts")
-@ecs_background_task("process-sam-extracts")
-@flask_db.with_db_session()
-def run_process_sam_extracts_task(db_session: db.Session) -> None:
-    # Initialize and run the task
-    ProcessSamExtractsTask(db_session).run()

--- a/api/src/task/sam_extracts/sam_extract_cli.py
+++ b/api/src/task/sam_extracts/sam_extract_cli.py
@@ -1,0 +1,47 @@
+import logging
+
+import click
+
+import src.adapters.db as db
+from src.adapters.db import flask_db
+from src.adapters.sam_gov import create_sam_gov_client
+from src.task.ecs_background_task import ecs_background_task
+from src.task.sam_extracts.create_orgs_from_sam_entity import CreateOrgsFromSamEntityTask
+from src.task.sam_extracts.fetch_sam_extracts import FetchSamExtractsTask
+from src.task.sam_extracts.process_sam_extracts import ProcessSamExtractsTask
+from src.task.task_blueprint import task_blueprint
+
+logger = logging.getLogger(__name__)
+
+
+@task_blueprint.cli.command(
+    "sam-extracts", help="Fetch SAM.gov daily and monthly extracts, and process them in our system"
+)
+@click.option("--fetch-extracts/--no-fetch-extracts", default=True, help="run FetchSamExtractsTask")
+@click.option(
+    "--process-extracts/--no-process-extracts", default=True, help="run ProcessSamExtractsTask"
+)
+@click.option(
+    "--create-orgs/--no-create-orgs", default=True, help="run CreateOrgsFromSamEntityTask"
+)
+@ecs_background_task("sam-extracts")
+@flask_db.with_db_session()
+def run_sam_extracts(
+    db_session: db.Session, fetch_extracts: bool, process_extracts: bool, create_orgs: bool
+) -> None:
+    """Run the SAM.gov extracts task"""
+    logger.info("Starting sam-extracts task")
+
+    if fetch_extracts:
+        # Create the SAM.gov client using the factory
+        sam_gov_client = create_sam_gov_client()
+        # Initialize and run the task
+        FetchSamExtractsTask(db_session, sam_gov_client).run()
+
+    if process_extracts:
+        ProcessSamExtractsTask(db_session).run()
+
+    if create_orgs:
+        CreateOrgsFromSamEntityTask(db_session).run()
+
+    logger.info("Completed sam-extracts task")

--- a/api/tests/src/task/sam_extracts/test_fetch_sam_extracts.py
+++ b/api/tests/src/task/sam_extracts/test_fetch_sam_extracts.py
@@ -12,7 +12,7 @@ from src.adapters.sam_gov.models import SamExtractResponse
 from src.constants.lookup_constants import SamGovExtractType, SamGovProcessingStatus
 from src.db.models.sam_extract_models import SamExtractFile
 from src.task.sam_extracts.fetch_sam_extracts import (
-    SamExtractsTask,
+    FetchSamExtractsTask,
     get_first_sunday_of_month,
     get_monthly_extract_date,
 )
@@ -57,7 +57,7 @@ class TestSamExtractsTask(BaseTestClass):
         monkeypatch.setenv("DRAFT_FILES_BUCKET", mock_s3_bucket)
         monkeypatch.setenv("SAM_GOV_BASE_URL", "https://api.sam.gov")
 
-        task = SamExtractsTask(db_session, mock_sam_gov_client)
+        task = FetchSamExtractsTask(db_session, mock_sam_gov_client)
         # Add mock for increment method to track metric calls
         task.increment = MagicMock()
         return task
@@ -68,7 +68,7 @@ class TestSamExtractsTask(BaseTestClass):
         monkeypatch.setenv("DRAFT_FILES_BUCKET", mock_s3_bucket)
         monkeypatch.setenv("SAM_GOV_BASE_URL", "https://api.sam.gov")
 
-        task = SamExtractsTask(db_session, mock_sam_gov_client)
+        task = FetchSamExtractsTask(db_session, mock_sam_gov_client)
 
         # Verify the task has the expected attributes
         assert task.db_session == db_session


### PR DESCRIPTION
## Summary

Fixes #5253

## Changes proposed
Make a CLI command for running the sam.gov extract ECS tasks

## Context for reviewers
We'll run these 3 tasks together every day much like our transformation code. The jobs fetch, process, and do some post-processing on the sam.gov data.

I renamed the `SamExtractsTask` to `FetchSamExtractsTask` as we originally planned one task, not 3, and even the files had been renamed already. Better to be more specific.

## Validation steps
You can test that the command works locally with `make cmd args="task sam-extracts"` which will fail due to needing files setup. Setting up the files takes a bit of work as it'll expect to fetch every extract between June 1st and today.

I did sorta set it up to verify it's working. First, download the FOUO zip from https://open.gsa.gov/api/sam-entity-extracts-api/#sample-extract-files - rename the ZIP to exactly `SAM_FOUO_MONTHLY_V2_20250601.ZIP`.

In your `override.env` file, set the following environment variables, pointing to the folder you downloaded the file - make sure to create the draft file folder:
```
SAM_GOV_MOCK_EXTRACT_DIR=~/workspace/data
DRAFT_FILES_BUCKET=~/workspace/data/destination
```
In order to workaround needing files for every single day - instead in the Sam.gov extract task, comment out `self._fetch_daily_extracts(monthly_extract_date)` in the run_task method (so it doesn't get daily extracts that don't exist).

You can then run the above command. Note that the 3rd task to create orgs won't do anything as we have no users setup with matching emails.