### PR TITLE
[Unticketed] Update `update_opportunity_search_queue ` explicitly to api schema

### DIFF
--- a/api/src/db/migrations/constants.py
+++ b/api/src/db/migrations/constants.py
@@ -1,5 +1,5 @@
 opportunity_search_index_queue_trigger_function = """
-CREATE OR REPLACE FUNCTION update_opportunity_search_queue()
+CREATE OR REPLACE FUNCTION api.update_opportunity_search_queue()
 RETURNS TRIGGER AS $$
 DECLARE
     opp_id bigint;

--- a/api/src/db/migrations/versions/2024_10_28_add_opportunity_table_triggers.py
+++ b/api/src/db/migrations/versions/2024_10_28_add_opportunity_table_triggers.py
@@ -15,7 +15,7 @@ branch_labels = None
 depends_on = None
 
 create_trigger_function = """
-CREATE OR REPLACE FUNCTION update_opportunity_search_queue()
+CREATE OR REPLACE FUNCTION api.update_opportunity_search_queue()
 RETURNS TRIGGER AS $$
 DECLARE
     opp_id bigint;
@@ -69,7 +69,7 @@ def upgrade():
             f"""
             CREATE TRIGGER {table}_queue_trigger
             AFTER INSERT OR UPDATE ON api.{table}
-            FOR EACH ROW EXECUTE FUNCTION update_opportunity_search_queue();
+            FOR EACH ROW EXECUTE FUNCTION api.update_opportunity_search_queue();
         """
         )
 
@@ -80,4 +80,4 @@ def downgrade():
         op.execute(f"DROP TRIGGER IF EXISTS {table}_queue_trigger ON api.{table};")
 
     # Drop the trigger function
-    op.execute("DROP FUNCTION IF EXISTS update_opportunity_search_queue();")
+    op.execute("DROP FUNCTION IF EXISTS api.update_opportunity_search_queue();")

--- a/api/src/db/migrations/versions/2024_10_31_remove_has_update_column_from_.py
+++ b/api/src/db/migrations/versions/2024_10_31_remove_has_update_column_from_.py
@@ -17,7 +17,7 @@ depends_on = None
 
 
 create_old_trigger_function = """
-CREATE OR REPLACE FUNCTION update_opportunity_search_queue()
+CREATE OR REPLACE FUNCTION api.update_opportunity_search_queue()
 RETURNS TRIGGER AS $$
 DECLARE
     opp_id bigint;
@@ -49,7 +49,7 @@ $$ LANGUAGE plpgsql;
 """
 
 create_trigger_function = """
-CREATE OR REPLACE FUNCTION update_opportunity_search_queue()
+CREATE OR REPLACE FUNCTION api.update_opportunity_search_queue()
 RETURNS TRIGGER AS $$
 DECLARE
     opp_id bigint;

--- a/api/src/db/migrations/versions/2025_01_16_rename_tables_and_create_job_table.py
+++ b/api/src/db/migrations/versions/2025_01_16_rename_tables_and_create_job_table.py
@@ -19,7 +19,7 @@ depends_on = None
 
 
 create_trigger_function = """
-CREATE OR REPLACE FUNCTION update_opportunity_search_queue()
+CREATE OR REPLACE FUNCTION api.update_opportunity_search_queue()
 RETURNS TRIGGER AS $$
 DECLARE
     opp_id bigint;


### PR DESCRIPTION
## Changes proposed

Somewhere along the way the `make db-init` command broke due to schema not properly being declared in some migrations. Update this to resolve.

## Context for reviewers

<img width="577" alt="Screenshot 2025-06-26 at 4 22 12 PM" src="https://github.com/user-attachments/assets/bd480427-0803-4a25-a873-23d330fd33b7" />

## Validation steps

See passing ci/cd, local `make init-db` should succeed.