### PR TITLE
[Unticketed] Fix XML vulnerabilities in Debian

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
         libtasn1-6 \
         libgnutls30 \
         systemd \
+        libxml2 \
     # Reduce the image size by clear apt cached lists
     # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
     && rm -fr /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary

## Changes proposed
Getting several vulnerability scans for a libxml2 Debian package. Forcing that to upgrade
