### PR TITLE
[unticketed] fix weird scroll when clicking radio button in drawer

### DIFF
--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -525,6 +525,9 @@ button.usa-pagination__button.usa-button {
   .usa-modal__content {
     height: 100%;
   }
+  .usa-radio__input {
+    width: 0;
+  }
 }
 
 // make modal close "X" use normal style rather than simpler button styline


### PR DESCRIPTION
## Summary

unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes scroll bug in filter drawer related to trussworks radio input implementation

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The truss radio component implements it's radio looking button aspect with a `:before` while hiding the browser input UI by absolutely positioning it and moving out of the viewport. Unfortunately when this is implemented in a modal which should not scroll, clicking one of this buttons will sometimes result in the modal doing a weird scrolling behavior. Adding the width 0 here fixes the issue by making the ui buttons take up no space in the DOM. This should still be accessible

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on main using `npm run dev`
2. visit http://localhost:3000/search?_ff=searchDrawerOn:true
3. open the drawer, select a "cost sharing" radio button
4. _VERIFY_: drawer moves upwards, potentially out of viewport
5. repeat 1 - 4 on this branch]
6. _VERIFY_: drawer content does not move when radio button is clicked

### Video of bug


https://github.com/user-attachments/assets/2817d1bf-e041-4808-aa40-dcab641b3e62

