### PR TITLE
[Issue #5428] Enforce the applicant type in the create application endpoint

### DIFF
--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 
 from src.auth.api_jwt_auth import create_jwt_for_user
 from src.auth.internal_jwt_auth import create_jwt_for_internal_token
-from src.constants.lookup_constants import ApplicationFormStatus
+from src.constants.lookup_constants import ApplicationFormStatus, CompetitionOpenToApplicant
 from src.db.models.competition_models import Application, ApplicationForm, ApplicationStatus
 from src.db.models.user_models import ApplicationUser
 from src.util.datetime_util import get_now_us_eastern_date
@@ -2243,3 +2243,209 @@ def test_application_form_get_with_internal_jwt_nonexistent_application(
     )
     assert response.status_code == 404
     assert "Application with ID" in response.json["message"]
+
+
+def test_application_start_organization_not_allowed(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation fails when applying as organization but competition only allows individuals"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create organization and associate user with it
+    organization = OrganizationFactory.create()
+    OrganizationUserFactory.create(organization=organization, user=user)
+
+    # Create competition that only allows individual applicants
+    competition = CompetitionFactory.create(
+        opening_date=today,
+        closing_date=future_date,
+        open_to_applicants=[CompetitionOpenToApplicant.INDIVIDUAL],
+    )
+
+    competition_id = str(competition.competition_id)
+    organization_id = str(organization.organization_id)
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": organization_id,  # Applying as organization
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 422
+    assert "This competition does not allow organization applications" in response.json["message"]
+
+    # Verify no application was created
+    applications_count = (
+        db_session.execute(select(Application).where(Application.competition_id == competition_id))
+        .scalars()
+        .all()
+    )
+    assert len(applications_count) == 0
+
+
+def test_application_start_individual_not_allowed(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation fails when applying as individual but competition only allows organizations"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create competition that only allows organization applicants
+    competition = CompetitionFactory.create(
+        opening_date=today,
+        closing_date=future_date,
+        open_to_applicants=[CompetitionOpenToApplicant.ORGANIZATION],
+    )
+
+    competition_id = str(competition.competition_id)
+    request_data = {
+        "competition_id": competition_id,
+        # No organization_id - applying as individual
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 422
+    assert "This competition does not allow individual applications" in response.json["message"]
+
+    # Verify no application was created
+    applications_count = (
+        db_session.execute(select(Application).where(Application.competition_id == competition_id))
+        .scalars()
+        .all()
+    )
+    assert len(applications_count) == 0
+
+
+def test_application_start_organization_allowed(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation succeeds when applying as organization and competition allows organizations"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create organization and associate user with it
+    organization = OrganizationFactory.create()
+    OrganizationUserFactory.create(organization=organization, user=user)
+
+    # Create competition that allows organization applicants
+    competition = CompetitionFactory.create(
+        opening_date=today,
+        closing_date=future_date,
+        open_to_applicants=[CompetitionOpenToApplicant.ORGANIZATION],
+    )
+
+    competition_id = str(competition.competition_id)
+    organization_id = str(organization.organization_id)
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": organization_id,  # Applying as organization
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert "application_id" in response.json["data"]
+
+    # Verify application was created with organization
+    application_id = response.json["data"]["application_id"]
+    application = db_session.execute(
+        select(Application).where(Application.application_id == application_id)
+    ).scalar_one_or_none()
+
+    assert application is not None
+    assert str(application.organization_id) == organization_id
+
+
+def test_application_start_individual_allowed(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation succeeds when applying as individual and competition allows individuals"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create competition that allows individual applicants
+    competition = CompetitionFactory.create(
+        opening_date=today,
+        closing_date=future_date,
+        open_to_applicants=[CompetitionOpenToApplicant.INDIVIDUAL],
+    )
+
+    competition_id = str(competition.competition_id)
+    request_data = {
+        "competition_id": competition_id,
+        # No organization_id - applying as individual
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert "application_id" in response.json["data"]
+
+    # Verify application was created without organization
+    application_id = response.json["data"]["application_id"]
+    application = db_session.execute(
+        select(Application).where(Application.application_id == application_id)
+    ).scalar_one_or_none()
+
+    assert application is not None
+    assert application.organization_id is None
+
+
+def test_application_start_both_applicant_types_allowed(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test application creation succeeds when competition allows both individual and organization applicants"""
+    today = get_now_us_eastern_date()
+    future_date = today + timedelta(days=10)
+
+    # Create organization and associate user with it
+    organization = OrganizationFactory.create()
+    OrganizationUserFactory.create(organization=organization, user=user)
+
+    # Create competition that allows both applicant types (this is the new factory default)
+    competition = CompetitionFactory.create(
+        opening_date=today,
+        closing_date=future_date,
+        # open_to_applicants defaults to both individual and organization
+    )
+
+    competition_id = str(competition.competition_id)
+    organization_id = str(organization.organization_id)
+
+    # Test applying as organization
+    request_data = {
+        "competition_id": competition_id,
+        "organization_id": organization_id,
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+
+    # Test applying as individual
+    request_data = {
+        "competition_id": competition_id,
+        # No organization_id
+    }
+
+    response = client.post(
+        "/alpha/applications/start", json=request_data, headers={"X-SGG-Token": user_auth_token}
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -987,12 +987,12 @@ class CompetitionFactory(BaseFactory):
         size=lambda: random.randint(1, 2),
     )
 
-    open_to_applicants = factory.Faker(
-        "random_elements",
-        length=random.randint(1, 2),
-        elements=[a for a in CompetitionOpenToApplicant],
-        unique=True,
-    )
+    # Default to allowing both individual and organization applicants
+    # This can be overridden in tests by setting it explicitly
+    open_to_applicants = [
+        CompetitionOpenToApplicant.INDIVIDUAL,
+        CompetitionOpenToApplicant.ORGANIZATION,
+    ]
 
     is_simpler_grants_enabled = True
 


### PR DESCRIPTION
## Summary

Fixes #5428 

## Changes proposed

Add `_validate_applicant_type` in `create_application`.
Update factories
Add tests

## Context for reviewers

We want to add a rule to the create application endpoint to prevent someone from starting an application if the competition doesn't allow individuals/orgs and they're applying as that.

The open_to_applicants set on the competition record can have individual and/or organization in it. These dictate what types of applicants can apply.

We know whether someone is an individual or not when creating an application based on whether or not they pass in an organization ID when starting the application. The logic we add should be roughly:

if applying as an organization (org ID is set), error if organization isn't one of the allowed applicant types
if applying as an individual (org ID is not set), error if individual isn't one of the allowed types


## Validation steps

See updated unit tests