### PR TITLE
[Unticketed] Fix debian vulnerability

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
         libgnutls30 \
         systemd \
         libxml2 \
+        libicu72 \
     # Reduce the image size by clear apt cached lists
     # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
     && rm -fr /var/lib/apt/lists/* \


### PR DESCRIPTION
## Summary

Fixes #ISSUE

## Changes proposed
Force upgrade libicu72 which has a vulnerability

## Context for reviewers

Vulnerabilities we have right now (python one is low and won't block):
```
NAME      INSTALLED  FIXED-IN        TYPE    VULNERABILITY  SEVERITY  EPSS%  RISK  
python    3.13.5     3.14.0          binary  CVE-2024-3220  Low       32.21  < 0.1  
libicu72  72.1-3     72.1-3+deb12u1  deb     CVE-2025-5222  High       4.39  < 0.1 
```

## Validation steps
After rebuilding locally, I checked the /var/lib/dpkg/status file and it says libicu72 is now on the right version.
