### PR TITLE
[Issue #5195] Various small adjustments to transform attachment

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
+++ b/api/src/data_migration/transformation/subtask/transform_opportunity_attachment.py
@@ -54,6 +54,7 @@ class TransformOpportunityAttachment(AbstractTransformSubTask):
             # to avoid running out of memory.
             batch_size=self.attachment_config.transform_opportunity_attachment_batch_size,
             limit=self.attachment_config.transform_opportunity_attachment_batch_size,
+            order_by=TsynopsisAttachment.created_at.desc(),
         )
 
         records_processed = self.process_opportunity_attachment_group(records)
@@ -243,5 +244,7 @@ def write_file(
     if source_attachment.file_lob is None:
         raise ValueError("Attachment is null, cannot copy")
 
-    with file_util.open_stream(destination_attachment.file_location, "wb") as outfile:
+    with file_util.open_stream(
+        destination_attachment.file_location, "wb", content_type=destination_attachment.mime_type
+    ) as outfile:
         outfile.write(source_attachment.file_lob)


### PR DESCRIPTION
## Summary

Fixes #5195

## Changes proposed
When creating an opportunity attachment, set the content-type

When processing opportunity attachments, process from newest to oldest

When processing opportunity attachments, allow for making the batch count larger

## Context for reviewers
These are all small miscellaneous fixes to the transform opportunity attachment work in preparation of the opportunity ID reload work where we're going to need to rerun this job for all attachments again. Setting the content-type makes it so when you click on a link for it, it can open in the browser if it's an appropriate type. Processing newest to oldest makes it so we'll process what appears on search at the top first and then slowly backfill stuff from many years ago instead of it randomly choosing the order (which ended up being oldest to newest roughly). And the batch count work makes it so we can just run the job with a lot of batches and let it go for a day.

## Validation steps
None of this really made sense to add to tests, so I manually verified it worked by loading some attachments locally and adjusting the batch count size - it worked, things got loaded, and batch counts were changed. It did process newest first.
