### PR TITLE
[Issue #5524] Add flag on email subjects to convey to users we're testing new emails

### DIFF
--- a/api/src/task/notifications/closing_date_notification.py
+++ b/api/src/task/notifications/closing_date_notification.py
@@ -121,9 +121,9 @@ class ClosingDateNotificationTask(BaseNotificationTask):
                     extra={"user_id": user_id, "closing_opp_count": len(closing_opportunities)},
                 )
                 subject = (
-                    "[Test email] Applications for your bookmarked funding opportunity are due soon"
+                    "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Applications for your bookmarked funding opportunity are due soon"
                     if len(closing_opportunities) == 1
-                    else "[Test email] Applications for your bookmarked funding opportunities are due soon"
+                    else "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Applications for your bookmarked funding opportunities are due soon"
                 )
                 users_email_notifications.append(
                     UserEmailNotification(

--- a/api/src/task/notifications/opportunity_notifcation.py
+++ b/api/src/task/notifications/opportunity_notifcation.py
@@ -525,9 +525,9 @@ class OpportunityNotificationTask(BaseNotificationTask):
             else "The following funding opportunity recently changed:<br><br>"
         )
         subject = (
-            "[Test email] Your saved funding opportunities changed on "
+            "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunities changed on "
             if updated_opp_count > 1
-            else "[Test email] Your saved funding opportunity changed on "
+            else "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunity changed on "
         )
         subject += "Simpler.Grants.gov"
 

--- a/api/src/task/notifications/search_notification.py
+++ b/api/src/task/notifications/search_notification.py
@@ -133,9 +133,9 @@ class SearchNotificationTask(BaseNotificationTask):
 
             formatted_date = datetime_util.utcnow().strftime("%-m/%-d/%Y")
             subject = (
-                f"[Test email] New Grant Published on {formatted_date}"
+                f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] New Grant Published on {formatted_date}"
                 if len(opportunities) == 1
-                else f"[Test email] {len(opportunities)} New Grants Published on {formatted_date}"
+                else f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] {len(opportunities)} New Grants Published on {formatted_date}"
             )
             users_email_notifications.append(
                 UserEmailNotification(

--- a/api/tests/src/task/notifications/test_opportunity_notification.py
+++ b/api/tests/src/task/notifications/test_opportunity_notification.py
@@ -833,7 +833,7 @@ class TestOpportunityNotification:
                     ),
                 ],
                 UserOpportunityUpdateContent(
-                    subject="[Test email] Your saved funding opportunities changed on Simpler.Grants.gov",
+                    subject="[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunities changed on Simpler.Grants.gov",
                     message=(
                         f"The following funding opportunities recently changed:<br><br><div>1. <a href='http://testhost:3000/opportunity/{OPAL.opportunity_id}' target='_blank'>Opal 2025 Awards</a><br><br>Here’s what changed:</div>"
                         '<p style="padding-left: 20px;">Status</p><p style="padding-left: 40px;">•  The status changed from Open to Closed.<br>'
@@ -857,7 +857,7 @@ class TestOpportunityNotification:
                     ),
                 ],
                 UserOpportunityUpdateContent(
-                    subject="[Test email] Your saved funding opportunity changed on Simpler.Grants.gov",
+                    subject="[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunity changed on Simpler.Grants.gov",
                     message=(
                         f"The following funding opportunity recently changed:<br><br><div>1. <a href='http://testhost:3000/opportunity/{TOPAZ.opportunity_id}' target='_blank'>Topaz 2025 Climate Research Grant</a><br><br>Here’s what changed:</div>"
                         '<p style="padding-left: 20px;">Status</p><p style="padding-left: 40px;">•  The status changed from Forecasted to Closed.<br>'
@@ -885,7 +885,7 @@ class TestOpportunityNotification:
                     )
                 ],
                 UserOpportunityUpdateContent(
-                    subject="[Test email] Your saved funding opportunity changed on Simpler.Grants.gov",
+                    subject="[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunity changed on Simpler.Grants.gov",
                     message=(
                         f"The following funding opportunity recently changed:<br><br><div>1. <a href='http://testhost:3000/opportunity/{TOPAZ.opportunity_id}' target='_blank'>Topaz 2025 Climate Research Grant</a><br><br>Here’s what changed:</div>"
                         '<p style="padding-left: 20px;">Status</p><p style="padding-left: 40px;">•  The status changed from Forecasted to Closed.<br><br>'

--- a/api/tests/src/task/notifications/test_search_notification.py
+++ b/api/tests/src/task/notifications/test_search_notification.py
@@ -358,7 +358,7 @@ def test_search_notification_email_format_single_opportunity(
         mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
             "SimpleEmail"
         ]["Subject"]["Data"]
-        == f"[Test email] New Grant Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
+        == f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] New Grant Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
     )
 
     email_content = mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
@@ -527,7 +527,7 @@ def test_search_notification_email_format_multiple_opportunities(
         mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
             "SimpleEmail"
         ]["Subject"]["Data"]
-        == f"[Test email] 2 New Grants Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
+        == f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] 2 New Grants Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
     )
 
     email_content = mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][


### PR DESCRIPTION
## Changes proposed

Per Product/Design add prefix of "[Test email]" to each of the outgoing emails until we're more stable and solid on the email contents and they are sending regularly.

## Validation steps

Will test as part of larger email testing in Dev/Stage after deploy.