### PR TITLE
[unticketed] allow pills to correctly reference top level agenies

### DIFF
--- a/frontend/src/utils/search/filterUtils.ts
+++ b/frontend/src/utils/search/filterUtils.ts
@@ -173,7 +173,7 @@ export const formatPillLabels = (
 
       const queryParamKey = key as FrontendFilterNames;
       const availableOptions =
-        key === "agency"
+        key === "agency" || key === "topLevelAgency"
           ? agencyOptions
           : allFilterOptions[key as HardcodedFrontendFilterNames];
       const pillLabels = Array.from(values).map((value) => ({

--- a/frontend/tests/utils/Search/filterUtils.test.ts
+++ b/frontend/tests/utils/Search/filterUtils.test.ts
@@ -523,18 +523,20 @@ describe("formatPillLabel", () => {
 
 describe("formatPillLabels", () => {
   it("returns correctly formatted labels for all types of pills", () => {
-    expect(
-      formatPillLabels(
-        {
-          ...searchFetcherParams,
-          agency: new Set(["FAKE-SUB", "MOCK-SUB"]),
-        },
-        [
-          { id: "FAKE-SUB", label: "Fake sub", value: "FAKE-SUB" },
-          { id: "MOCK-SUB", label: "Mock sub", value: "MOCK-SUB" },
-        ],
-      ),
-    ).toEqual([
+    const result = formatPillLabels(
+      {
+        ...searchFetcherParams,
+        agency: new Set(["FAKE-SUB", "MOCK-SUB"]),
+        topLevelAgency: new Set(["FAKE", "MOCK"]),
+      },
+      [
+        { id: "FAKE-SUB", label: "Fake sub", value: "FAKE-SUB" },
+        { id: "MOCK-SUB", label: "Mock sub", value: "MOCK-SUB" },
+        { id: "FAKE", label: "Fake top", value: "FAKE" },
+        { id: "MOCK", label: "Mock top", value: "MOCK" },
+      ],
+    );
+    expect(result).toEqual([
       {
         label: "Forecasted",
         queryParamKey: "status",
@@ -564,6 +566,16 @@ describe("formatPillLabels", () => {
         label: "Mock sub",
         queryParamKey: "agency",
         queryParamValue: "MOCK-SUB",
+      },
+      {
+        label: "Fake top",
+        queryParamKey: "topLevelAgency",
+        queryParamValue: "FAKE",
+      },
+      {
+        label: "Mock top",
+        queryParamKey: "topLevelAgency",
+        queryParamValue: "MOCK",
       },
     ]);
   });


### PR DESCRIPTION
## Summary
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

fixes bug that crashed the app when trying to create a pill for a top level agency filter

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch
2. visit http://localhost:3000/search?_ff=searchDrawerOn:true&topLevelAgency=DOC&agency=
3. _VERIFY_: app doesn't crash
4. _VERIFY_: Department of Commerce pill is shown