### PR TITLE
convert agency search results to filter options

### DIFF
--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -3,6 +3,7 @@
 import { debounce } from "lodash";
 import { agencySearch } from "src/services/fetch/fetchers/clientAgenciesFetcher";
 import { FilterOption } from "src/types/search/searchFilterTypes";
+import { agenciesToSortedAndNestedFilterOptions } from "src/utils/search/filterUtils";
 
 import { useState } from "react";
 import { TextInput } from "@trussworks/react-uswds";
@@ -36,7 +37,9 @@ export function AgencyFilterContent({
       }
       agencySearch(agencySearchTerm)
         .then((searchResults) => {
-          setAgencySearchResults(searchResults);
+          const searchResultsOptions =
+            agenciesToSortedAndNestedFilterOptions(searchResults);
+          setAgencySearchResults(searchResultsOptions);
         })
         .catch((e) => {
           console.error("Error fetching agency search results", e);

--- a/frontend/src/services/fetch/fetchers/clientAgenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientAgenciesFetcher.ts
@@ -1,4 +1,4 @@
-import { FilterOption } from "src/types/search/searchFilterTypes";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 
 export const agencySearch = async (searchKeyword: string) => {
   const response = await fetch("/api/agencies", {
@@ -8,7 +8,7 @@ export const agencySearch = async (searchKeyword: string) => {
     }),
   });
   if (response.ok && response.status === 200) {
-    const data = (await response.json()) as FilterOption[];
+    const data = (await response.json()) as RelevantAgencyRecord[];
     return data;
   }
   throw new Error(`Unable to fetch agencies search: ${response.status}`);

--- a/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
+++ b/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
@@ -37,7 +37,7 @@ const query = new Set<string>();
 describe("AgencyFilterContent", () => {
   beforeEach(() => {
     mockAgencySearch.mockResolvedValue([
-      { value: "agency1", label: "Agency 1", id: "1" },
+      { agency_code: "agency1", agency_name: "Agency 1", agency_id: "1" },
     ]);
   });
   afterEach(() => {
@@ -101,6 +101,8 @@ describe("AgencyFilterContent", () => {
         facetCounts={facetCounts}
       />,
     );
+    expect(screen.getByText("Agency 1")).toBeInTheDocument();
+    expect(screen.getByText("Agency 2")).toBeInTheDocument();
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "garbage" } });
 
@@ -115,11 +117,9 @@ describe("AgencyFilterContent", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Agency 1")).toBeInTheDocument();
-    });
-    await waitFor(() => {
       expect(screen.queryByText("Agency 2")).not.toBeInTheDocument();
     });
+    expect(screen.getByText("Agency 1")).toBeInTheDocument();
   });
 
   it("shows FilterSearchNoResults when agencySearch returns empty array", async () => {


### PR DESCRIPTION
## Summary

unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Properly converts agency search result data into filter option data

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Without this, searching for agencies results in unlabeled agency filter options

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch
2. visit http://localhost:3000/search
3. perform an agency search in the agency filter for a term that will give you results
4. _VERIFY_: results display with correct labels
5. selected displayed option
6. _VERIFY_: search updates as expected
