### PR TITLE
[Issue #5518] Enable transform competition to ECS task.

### DIFF
--- a/api/src/data_migration/transformation/transform_oracle_data_task.py
+++ b/api/src/data_migration/transformation/transform_oracle_data_task.py
@@ -50,7 +50,7 @@ class TransformOracleDataTaskConfig(PydanticBaseEnvConfig):
     enable_opportunity_attachment: bool = (
         True  # TRANSFORM_ORACLE_DATA_ENABLE_OPPORTUNITY_ATTACHMENT
     )
-    enable_competition: bool = False  # TRANSFORM_ORACLE_DATA_ENABLE_COMPETITION
+    enable_competition: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_COMPETITION
 
 
 class TransformOracleDataTask(Task):


### PR DESCRIPTION
## Summary

Fixes #5518

## Changes proposed

This pr enables the transform ecs task to run the transform competition automatically in all environments.

## Context for reviewers

This is required for syncing competition data from grants.gov into simpler.

## Validation steps

This is validated as part of [this](https://github.com/HHS/simpler-grants-gov/issues/4483)