### PR TITLE
[Issue #5520] Create the JSON schema for a SF424A

### DIFF
--- a/api/src/form_schema/forms/sf424a.py
+++ b/api/src/form_schema/forms/sf424a.py
@@ -2,7 +2,6 @@ import uuid
 
 from src.db.models.competition_models import Form
 
-# TODO - pluralization of values
 FORM_JSON_SCHEMA = {
     "type": "object",
     "required": [
@@ -10,9 +9,9 @@ FORM_JSON_SCHEMA = {
         "total_budget_summary",
         "total_budget_categories",
         "total_non_federal_resources",
+        "forecasted_cash_needs",
         "total_federal_fund_estimates",
         "confirmation",
-
     ],
     "properties": {
         "activity_line_items": {
@@ -21,7 +20,14 @@ FORM_JSON_SCHEMA = {
             "maxItems": 4,
             "items": {
                 "type": "object",
-                "required": ["activity_title", "assistance_listing_number", "budget_summary", "budget_categories", "non_federal_resources", "federal_fund_estimates"],
+                "required": [
+                    "activity_title",
+                    "assistance_listing_number",
+                    "budget_summary",
+                    "budget_categories",
+                    "non_federal_resources",
+                    "federal_fund_estimates",
+                ],
                 "properties": {
                     "activity_title": {
                         # Activity title appears in multiple places on the form
@@ -63,7 +69,14 @@ FORM_JSON_SCHEMA = {
             # Section A - Total Row (Column 5)
             "allOf": [{"$ref": "#/$defs/budget_summary"}],
             # In the total budget summary, all fields are required
-            "required": ["federal_estimated_unobligated_amount", "non_federal_estimated_unobligated_amount", "federal_new_or_revised_amount", "non_federal_new_or_revised_amount", "total_amount"]
+            "required": [
+                "federal_estimated_unobligated_amount",
+                "non_federal_estimated_unobligated_amount",
+                "federal_new_or_revised_amount",
+                "non_federal_new_or_revised_amount",
+                # total_amount is already required in the base definition
+                # don't include it again or it gets added as an error twice.
+            ],
         },
         "total_budget_categories": {
             # Section B - Total Column (Column 5)
@@ -73,12 +86,22 @@ FORM_JSON_SCHEMA = {
             # Section C - Total Row (Line 12)
             "allOf": [{"$ref": "#/$defs/non_federal_resources"}],
             # In the total non-federal resources, all fields are required
-            "required": ["applicant_amount", "state_amount", "other_amount", "total_amount"]
+            "required": [
+                "applicant_amount",
+                "state_amount",
+                "other_amount",
+                # total_amount is already required in the base definition
+                # don't include it again or it gets added as an error twice.
+            ],
         },
         "forecasted_cash_needs": {
             # Section D
             "type": "object",
-            "required": [],
+            "required": [
+                "federal_forecasted_cash_needs",
+                "non_federal_forecasted_cash_needs",
+                "total_forecasted_cash_needs",
+            ],
             "properties": {
                 "federal_forecasted_cash_needs": {
                     # Section D - Line 13
@@ -98,7 +121,12 @@ FORM_JSON_SCHEMA = {
             # Section E - Total Row (Line 20)
             "allOf": [{"$ref": "#/$defs/federal_fund_estimates"}],
             # In the total federal fund estimates, all fields are required
-            "required": ["first_year_amount", "second_year_amount", "third_year_amount", "fourth_year_amount"]
+            "required": [
+                "first_year_amount",
+                "second_year_amount",
+                "third_year_amount",
+                "fourth_year_amount",
+            ],
         },
         "direct_charges_explanation": {
             # Line 21
@@ -125,10 +153,10 @@ FORM_JSON_SCHEMA = {
             "maxLength": 250,
         },
         "confirmation": {
-            # TODO - can I make sure this is only ever True?
             "type": "boolean",
-            "title": "TODO",
-            "description": "TODO",
+            "title": "Confirmation",
+            "description": "Is this form complete?",
+            "enum": [True],
         },
     },
     "$defs": {
@@ -303,8 +331,22 @@ FORM_JSON_SCHEMA = {
     },
 }
 
-
-FORM_UI_SCHEMA = []
+# I have no idea what the frontend needs for the UI schema as it's
+# likely quite different from anything prior, so just going to leave
+# this blank for now.
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "1. Everything",
+        "name": "Everything",
+        "children": [
+            {"type": "field", "definition": "/properties/direct_charges_explanation"},
+            {"type": "field", "definition": "/properties/indirect_charges_explanation"},
+            {"type": "field", "definition": "/properties/remarks"},
+            {"type": "field", "definition": "/properties/confirmation"},
+        ],
+    }
+]
 
 
 SF424a_v1_0 = Form(
@@ -313,10 +355,11 @@ SF424a_v1_0 = Form(
     form_id=uuid.UUID("08e6603f-d197-4a60-98cd-d49acb1fc1fd"),
     form_name="Budget Information for Non-Construction Programs (SF-424A)",
     form_version="1.0",
-    agency_code="SGG",  # TODO - Do we want to add Simpler Grants.gov as an "Agency"?
+    agency_code="SGG",
     omb_number="4040-0006",
     form_json_schema=FORM_JSON_SCHEMA,
     form_ui_schema=FORM_UI_SCHEMA,
+    # No rule schema yet, we'll likely but automated sums in this
     form_rule_schema=None,
     # No form instructions at the moment.
 )

--- a/api/src/form_schema/forms/sf424a.py
+++ b/api/src/form_schema/forms/sf424a.py
@@ -1,0 +1,322 @@
+import uuid
+
+from src.db.models.competition_models import Form
+
+# TODO - pluralization of values
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    "required": [
+        "activity_line_items",
+        "total_budget_summary",
+        "total_budget_categories",
+        "total_non_federal_resources",
+        "total_federal_fund_estimates",
+        "confirmation",
+
+    ],
+    "properties": {
+        "activity_line_items": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 4,
+            "items": {
+                "type": "object",
+                "required": ["activity_title", "assistance_listing_number", "budget_summary", "budget_categories", "non_federal_resources", "federal_fund_estimates"],
+                "properties": {
+                    "activity_title": {
+                        # Activity title appears in multiple places on the form
+                        # as a sort of header that is shared between several tables.
+                        # * Section A - Column A
+                        # * Section B - Row 6
+                        # * Section C - Column A
+                        # * Section E - Column A
+                        "type": "string",
+                        "minLength": 0,
+                        "maxLength": 120,
+                    },
+                    "assistance_listing_number": {
+                        # Section A - Column B
+                        "type": "string",
+                        "minLength": 0,
+                        "maxLength": 15,
+                    },
+                    "budget_summary": {
+                        # Section A
+                        "allOf": [{"$ref": "#/$defs/budget_summary"}],
+                    },
+                    "budget_categories": {
+                        # Section B
+                        "allOf": [{"$ref": "#/$defs/budget_categories"}],
+                    },
+                    "non_federal_resources": {
+                        # Section C
+                        "allOf": [{"$ref": "#/$defs/non_federal_resources"}],
+                    },
+                    "federal_fund_estimates": {
+                        # Section E
+                        "allOf": [{"$ref": "#/$defs/federal_fund_estimates"}],
+                    },
+                },
+            },
+        },
+        "total_budget_summary": {
+            # Section A - Total Row (Column 5)
+            "allOf": [{"$ref": "#/$defs/budget_summary"}],
+            # In the total budget summary, all fields are required
+            "required": ["federal_estimated_unobligated_amount", "non_federal_estimated_unobligated_amount", "federal_new_or_revised_amount", "non_federal_new_or_revised_amount", "total_amount"]
+        },
+        "total_budget_categories": {
+            # Section B - Total Column (Column 5)
+            "allOf": [{"$ref": "#/$defs/budget_categories"}],
+        },
+        "total_non_federal_resources": {
+            # Section C - Total Row (Line 12)
+            "allOf": [{"$ref": "#/$defs/non_federal_resources"}],
+            # In the total non-federal resources, all fields are required
+            "required": ["applicant_amount", "state_amount", "other_amount", "total_amount"]
+        },
+        "forecasted_cash_needs": {
+            # Section D
+            "type": "object",
+            "required": [],
+            "properties": {
+                "federal_forecasted_cash_needs": {
+                    # Section D - Line 13
+                    "allOf": [{"$ref": "#/$defs/forecasted_cash_needs"}],
+                },
+                "non_federal_forecasted_cash_needs": {
+                    # Section D - Line 14
+                    "allOf": [{"$ref": "#/$defs/forecasted_cash_needs"}],
+                },
+                "total_forecasted_cash_needs": {
+                    # Section D - Line 15
+                    "allOf": [{"$ref": "#/$defs/forecasted_cash_needs"}],
+                },
+            },
+        },
+        "total_federal_fund_estimates": {
+            # Section E - Total Row (Line 20)
+            "allOf": [{"$ref": "#/$defs/federal_fund_estimates"}],
+            # In the total federal fund estimates, all fields are required
+            "required": ["first_year_amount", "second_year_amount", "third_year_amount", "fourth_year_amount"]
+        },
+        "direct_charges_explanation": {
+            # Line 21
+            "type": "string",
+            "title": "Direct Charges",
+            "description": "Use this space to explain amounts for individual direct object class cost categories that may appear to be out of the ordinary or to explain the details as required by the Federal grantor agency.",
+            "minLength": 0,
+            "maxLength": 50,
+        },
+        "indirect_charges_explanation": {
+            # Line 22
+            "type": "string",
+            "title": "Indirect Charges",
+            "description": "Enter the type of indirect rate (provisional, predetermined, final or fixed) that will be in effect during the funding period, the estimated amount of the base to which the rate is applied, and the total indirect expense.",
+            "minLength": 0,
+            "maxLength": 50,
+        },
+        "remarks": {
+            # Line 23
+            "type": "string",
+            "title": "Remarks",
+            "description": "Provide any other explanations or comments deemed necessary.",
+            "minLength": 0,
+            "maxLength": 250,
+        },
+        "confirmation": {
+            # TODO - can I make sure this is only ever True?
+            "type": "boolean",
+            "title": "TODO",
+            "description": "TODO",
+        },
+    },
+    "$defs": {
+        "budget_monetary_amount": {
+            # Represents a monetary amount. We use a string instead of number
+            # to avoid any floating point rounding issues.
+            "type": "string",
+            # Pattern here effectively says:
+            # * Any number of digits
+            # * An optional decimal point
+            # * Then exactly 2 digits - if there was a decimal
+            "pattern": r"^\d*([.]\d{2})?$",
+            # Limit the max amount based on the length (11-digits, allows up to 99 billion)
+            "maxLength": 14,
+        },
+        "budget_summary": {
+            # Represents a row from Section A
+            "type": "object",
+            "required": ["total_amount"],
+            "properties": {
+                "federal_estimated_unobligated_amount": {
+                    # Column C
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "non_federal_estimated_unobligated_amount": {
+                    # Column D
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "federal_new_or_revised_amount": {
+                    # Column E
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "non_federal_new_or_revised_amount": {
+                    # Column F
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "total_amount": {
+                    # Column G
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+            },
+        },
+        "budget_categories": {
+            # Represents a column from Section B
+            "type": "object",
+            "required": ["total_direct_charge_amount", "total_amount"],
+            "properties": {
+                "personnel_amount": {
+                    # Row A
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "fringe_benefits_amount": {
+                    # Row B
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "travel_amount": {
+                    # Row C
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "equipment_amount": {
+                    # Row D
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "supplies_amount": {
+                    # Row E
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "contractual_amount": {
+                    # Row F
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "construction_amount": {
+                    # Row G
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "other_amount": {
+                    # Row H
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "total_direct_charge_amount": {
+                    # Row I
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "total_indirect_charge_amount": {
+                    # Row J
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "total_amount": {
+                    # Row K
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "program_income_amount": {
+                    # Line 7
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+            },
+        },
+        "non_federal_resources": {
+            # Represents a row from Section C
+            "type": "object",
+            "required": ["total_amount"],
+            "properties": {
+                "applicant_amount": {
+                    # Column B
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "state_amount": {
+                    # Column C
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "other_amount": {
+                    # Column D
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "total_amount": {
+                    # Column E
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+            },
+        },
+        "federal_fund_estimates": {
+            # Represents a row from Section E
+            "type": "object",
+            # By default, nothing is required
+            "required": [],
+            "properties": {
+                "first_year_amount": {
+                    # Column B
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "second_year_amount": {
+                    # Column C
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "third_year_amount": {
+                    # Column D
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "fourth_year_amount": {
+                    # Column E
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+            },
+        },
+        "forecasted_cash_needs": {
+            # Represents a row from Section D
+            "type": "object",
+            "required": ["total_amount"],
+            "properties": {
+                "first_quarter_amount": {
+                    # Column 1st Quarter
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "second_quarter_amount": {
+                    # Column 2nd Quarter
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "third_quarter_amount": {
+                    # Column 3rd Quarter
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "fourth_quarter_amount": {
+                    # Column 4th Quarter
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+                "total_amount": {
+                    # Column Total for 1st Year
+                    "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+                },
+            },
+        },
+    },
+}
+
+
+FORM_UI_SCHEMA = []
+
+
+SF424a_v1_0 = Form(
+    # legacy form ID - 241
+    # https://grants.gov/forms/form-items-description/fid/241
+    form_id=uuid.UUID("08e6603f-d197-4a60-98cd-d49acb1fc1fd"),
+    form_name="Budget Information for Non-Construction Programs (SF-424A)",
+    form_version="1.0",
+    agency_code="SGG",  # TODO - Do we want to add Simpler Grants.gov as an "Agency"?
+    omb_number="4040-0006",
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    form_rule_schema=None,
+    # No form instructions at the moment.
+)

--- a/api/src/form_schema/jsonschema_validator.py
+++ b/api/src/form_schema/jsonschema_validator.py
@@ -31,7 +31,10 @@ def _required(
                 f"{field_name!r} is a required property", path=[field_name]
             )
 
-def _maxItems(validator: jsonschema.Draft202012Validator, mI: typing.Any, instance: typing.Any, _: typing.Any) -> typing.Generator[jsonschema.ValidationError]:
+
+def _maxItems(
+    validator: jsonschema.Draft202012Validator, mI: typing.Any, instance: typing.Any, _: typing.Any
+) -> typing.Generator[jsonschema.ValidationError]:
     """Handle a maxItems field validator in the JSON Schema validation
 
     This is identical to the maxItems validator, but we adjusted the message
@@ -42,11 +45,13 @@ def _maxItems(validator: jsonschema.Draft202012Validator, mI: typing.Any, instan
         message = "is expected to be empty" if mI == 0 else "is too long"
         yield jsonschema.ValidationError(f"The array {message}, expected a maximum length of {mI}")
 
+
 OUR_VALIDATOR = jsonschema.validators.extend(
-    validator=jsonschema.Draft202012Validator, validators={
+    validator=jsonschema.Draft202012Validator,
+    validators={
         "required": _required,
         "maxItems": _maxItems,
-    }
+    },
 )
 
 

--- a/api/src/form_schema/jsonschema_validator.py
+++ b/api/src/form_schema/jsonschema_validator.py
@@ -31,9 +31,22 @@ def _required(
                 f"{field_name!r} is a required property", path=[field_name]
             )
 
+def _maxItems(validator: jsonschema.Draft202012Validator, mI: typing.Any, instance: typing.Any, _: typing.Any) -> typing.Generator[jsonschema.ValidationError]:
+    """Handle a maxItems field validator in the JSON Schema validation
+
+    This is identical to the maxItems validator, but we adjusted the message
+    to not contain the entire array that is too long. In some cases this was
+    an incredibly large list of objects which was not helpful.
+    """
+    if validator.is_type(instance, "array") and len(instance) > mI:
+        message = "is expected to be empty" if mI == 0 else "is too long"
+        yield jsonschema.ValidationError(f"The array {message}, expected a maximum length of {mI}")
 
 OUR_VALIDATOR = jsonschema.validators.extend(
-    validator=jsonschema.Draft202012Validator, validators={"required": _required}
+    validator=jsonschema.Draft202012Validator, validators={
+        "required": _required,
+        "maxItems": _maxItems,
+    }
 )
 
 

--- a/api/tests/lib/seed_form.py
+++ b/api/tests/lib/seed_form.py
@@ -1,4 +1,4 @@
-FORM_NAME = "Application For Federal Assistance SFS 424 - Individual"
+FORM_NAME = "(Prototype) Application For Federal Assistance SF 424 - Individual"
 
 UI_SCHEMA = [
     {

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -1,16 +1,14 @@
 import logging
-import uuid
 
 import click
-from sqlalchemy import select
 
 import src.adapters.db as db
 import src.logging
 import src.util.datetime_util as datetime_util
 import tests.src.db.models.factories as factories
 from src.adapters.db import PostgresDBClient
-from src.db.models.competition_models import Competition
 from src.form_schema.forms.sf424 import SF424_v4_0
+from src.form_schema.forms.sf424a import SF424a_v1_0
 from src.util.local import error_if_not_local
 from tests.lib.seed_agencies import _build_agencies
 from tests.lib.seed_form import FORM_NAME, JSON_SCHEMA_FORM, UI_SCHEMA
@@ -62,28 +60,7 @@ def _build_opportunities(
     logger.info("Finished creating opportunities")
 
 
-def _build_competitions(db_session: db.Session) -> None:
-    logger.info("Creating competitions")
-
-    # Statically create a competition with exactly one of our default forms
-    # Static to make development for frontend folks easier so they don't need
-    # to keep looking up the UUID
-    static_competition_id = uuid.UUID("fd7f5921-9585-48a5-ab0f-e726f4d1ef94")
-    static_competition = db_session.execute(
-        select(Competition).where(Competition.competition_id == static_competition_id)
-    ).scalar_one_or_none()
-    if static_competition is None:
-        competition = factories.CompetitionFactory.create(
-            competition_id=static_competition_id, competition_forms=[]
-        )
-        factories.CompetitionFormFactory.create(competition=competition)
-        big_form = factories.FormFactory.create(
-            form_json_schema=JSON_SCHEMA_FORM, form_name=FORM_NAME, form_ui_schema=UI_SCHEMA
-        )
-        factories.CompetitionFormFactory.create(competition=competition, form=big_form)
-
-    logger.info(f"Static competition for development exists with ID {str(static_competition_id)}")
-
+def _build_pilot_competition(db_session: db.Session) -> None:
     logger.info("Creating an opportunity setup like our pilot")
     pilot_competition = factories.CompetitionFactory.create(
         opportunity__opportunity_title="Local Pilot-equivalent Opportunity",
@@ -91,14 +68,51 @@ def _build_competitions(db_session: db.Session) -> None:
         with_instruction=True,
     )
 
-    # Create/update the sf424 form if it doesn't already exist
-    form_obj = db_session.merge(SF424_v4_0, load=True)
+    # Create/update the forms if they don't already exist
+    sf424 = db_session.merge(SF424_v4_0, load=True)
     factories.CompetitionFormFactory.create(
-        competition=pilot_competition, form=form_obj, is_required=True
+        competition=pilot_competition, form=sf424, is_required=True
     )
+
+    sf424a = db_session.merge(SF424a_v1_0, load=True)
+    factories.CompetitionFormFactory.create(
+        competition=pilot_competition, form=sf424a, is_required=True
+    )
+
     logger.info(
         f"Created a pilot-like opportunity - http://localhost:3000/opportunity/{pilot_competition.opportunity_id}"
     )
+
+
+def _build_simple_competition():
+    logger.info("Creating a very simple competition for local development")
+
+    simple_competition = factories.CompetitionFactory.create(
+        opportunity__opportunity_title="Local Very Simple Opportunity",
+        competition_forms=[],
+        with_instruction=True,
+    )
+
+    factories.CompetitionFormFactory.create(
+        competition=simple_competition, is_required=True, form__with_instruction=True
+    )
+    factories.CompetitionFormFactory.create(
+        competition=simple_competition,
+        is_required=False,
+        form__form_name=FORM_NAME,
+        form__form_json_schema=JSON_SCHEMA_FORM,
+        form__form_ui_schema=UI_SCHEMA,
+    )
+
+    logger.info(
+        f"Created a very simple local opportunity - http://localhost:3000/opportunity/{simple_competition.opportunity_id}"
+    )
+
+
+def _build_competitions(db_session: db.Session) -> None:
+    logger.info("Creating competitions")
+    _build_simple_competition()
+    _build_pilot_competition(db_session)
 
 
 @click.command()

--- a/api/tests/src/form_schema/forms/test_sf424.py
+++ b/api/tests/src/form_schema/forms/test_sf424.py
@@ -233,8 +233,7 @@ def test_sf424_v4_0_applicant_type_other(sf424_v4_0, valid_json_v4_0, value):
                 "C: city or Township Government",
                 "D: Special District Government",
             ],
-            "['A: state Government', 'B: county Government', 'C: city or Township "
-            "Government', 'D: Special District Government'] is too long",
+            "The array is too long, expected a maximum length of 3",
         ),
     ],
 )

--- a/api/tests/src/form_schema/forms/test_sf424a.py
+++ b/api/tests/src/form_schema/forms/test_sf424a.py
@@ -1,0 +1,159 @@
+import pytest
+
+from src.form_schema.forms.sf424a import SF424a_v1_0
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+
+@pytest.fixture
+def minimal_valid_activity_line_item_v1_0():
+    return {
+        "activity_title": "My full activity",
+        "assistance_listing_number": "12.345",
+        "budget_summary": {
+            "total_budget_amount": "0.00",
+        },
+        "budget_categories": {
+            "total_direct_charge_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "non_federal_resources": {
+            "total_amount": "0.00",
+        },
+        "federal_fund_estimates": {},
+    }
+
+@pytest.fixture
+def minimal_valid_json_v1_0(minimal_valid_activity_line_item_v1_0):
+    return {
+        "activity_line_items": [minimal_valid_activity_line_item_v1_0],
+        "confirmation": True
+    }
+
+@pytest.fixture
+def full_valid_activity_line_item_v1_0():
+    return {
+        "activity_title": "My full activity",
+        "assistance_listing_number": "12.345",
+        "budget_summary": {
+            "federal_estimated_unobligated_amount": "0.00",
+            "non_federal_estimated_unobligated_amount": "0.00",
+            "federal_new_or_revised_amount": "0.00",
+            "non_federal_new_or_revised_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "budget_categories": {
+            "personnel_amount": "0.00",
+            "fringe_benefits_amount": "0.00",
+            "travel_amount": "0.00",
+            "equipment_amount": "0.00",
+            "supplies_amount": "0.00",
+            "contractual_amount": "0.00",
+            "construction_amount": "0.00",
+            "other_amount": "0.00",
+            "total_direct_charge_amount": "0.00",
+            "total_indirect_charge_amount": "0.00",
+            "total_amount": "0.00",
+            "program_income_amount": "0.00",
+        },
+        "non_federal_resources": {
+            "applicant_amount": "0.00",
+            "state_amount": "0.00",
+            "other_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "federal_fund_estimates": {
+            "first_year_amount": "0.00",
+            "second_year_amount": "0.00",
+            "third_year_amount": "0.00",
+            "fourth_year_amount": "0.00",
+        },
+    }
+
+
+@pytest.fixture
+def full_valid_json_v1_0(full_valid_activity_line_item_v1_0):
+    return {
+        "activity_line_items": [full_valid_activity_line_item_v1_0],
+        "total_budget_summary": {
+            "federal_estimated_unobligated_amount": "0.00",
+            "non_federal_estimated_unobligated_amount": "0.00",
+            "federal_new_or_revised_amount": "0.00",
+            "non_federal_new_or_revised_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "total_budget_categories": {
+            "personnel_amount": "0.00",
+            "fringe_benefits_amount": "0.00",
+            "travel_amount": "0.00",
+            "equipment_amount": "0.00",
+            "supplies_amount": "0.00",
+            "contractual_amount": "0.00",
+            "construction_amount": "0.00",
+            "other_amount": "0.00",
+            "total_direct_charge_amount": "0.00",
+            "total_indirect_charge_amount": "0.00",
+            "total_amount": "0.00",
+            "program_income_amount": "0.00",
+        },
+        "total_non_federal_resources": {
+            "applicant_amount": "0.00",
+            "state_amount": "0.00",
+            "other_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "forecasted_cash_needs": {
+            "federal_forecasted_cash_needs": {
+                "first_quarter_amount": "0.00",
+                "second_quarter_amount": "0.00",
+                "third_quarter_amount": "0.00",
+                "fourth_quarter_amount": "0.00",
+                "total_amount": "0.00",
+            },
+            "non_federal_forecasted_cash_needs": {
+                "first_quarter_amount": "0.00",
+                "second_quarter_amount": "0.00",
+                "third_quarter_amount": "0.00",
+                "fourth_quarter_amount": "0.00",
+                "total_amount": "0.00",
+            },
+            "total_forecasted_cash_needs": {
+                "first_quarter_amount": "0.00",
+                "second_quarter_amount": "0.00",
+                "third_quarter_amount": "0.00",
+                "fourth_quarter_amount": "0.00",
+                "total_amount": "0.00",
+            },
+        },
+        "total_federal_fund_estimates": {
+            "first_year_amount": "0.00",
+            "second_year_amount": "0.00",
+            "third_year_amount": "0.00",
+            "fourth_year_amount": "0.00",
+        },
+        "direct_charges_explanation": "",
+        "indirect_charges_explanation": "",
+        "remarks": "",
+        "confirmation": True,
+    }
+
+def test_sf424a_v1_0_minimal_valid_json(minimal_valid_json_v1_0):
+    validation_issues = validate_json_schema_for_form(minimal_valid_json_v1_0, SF424a_v1_0)
+    assert len(validation_issues) == 0
+
+def test_sf424a_v1_0_full_valid_json(full_valid_json_v1_0):
+    validation_issues = validate_json_schema_for_form(full_valid_json_v1_0, SF424a_v1_0)
+    assert len(validation_issues) == 0
+
+def test_sf424a_v1_0_too_many_line_items(full_valid_json_v1_0, full_valid_activity_line_item_v1_0):
+    data = full_valid_json_v1_0
+    data["activity_line_items"] = [full_valid_activity_line_item_v1_0] * 5
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxItems"
+    assert validation_issues[0].message == "The array is too long, expected a maximum length of 4"
+
+# TODO
+# Partial
+# Zero in list
+# Required in various places
+# * Total sections versus line item

--- a/api/tests/src/form_schema/forms/test_sf424a.py
+++ b/api/tests/src/form_schema/forms/test_sf424a.py
@@ -3,13 +3,14 @@ import pytest
 from src.form_schema.forms.sf424a import SF424a_v1_0
 from src.form_schema.jsonschema_validator import validate_json_schema_for_form
 
+
 @pytest.fixture
 def minimal_valid_activity_line_item_v1_0():
     return {
         "activity_title": "My full activity",
         "assistance_listing_number": "12.345",
         "budget_summary": {
-            "total_budget_amount": "0.00",
+            "total_amount": "0.00",
         },
         "budget_categories": {
             "total_direct_charge_amount": "0.00",
@@ -21,12 +22,48 @@ def minimal_valid_activity_line_item_v1_0():
         "federal_fund_estimates": {},
     }
 
+
 @pytest.fixture
 def minimal_valid_json_v1_0(minimal_valid_activity_line_item_v1_0):
     return {
         "activity_line_items": [minimal_valid_activity_line_item_v1_0],
-        "confirmation": True
+        "total_budget_summary": {
+            "federal_estimated_unobligated_amount": "0.00",
+            "non_federal_estimated_unobligated_amount": "0.00",
+            "federal_new_or_revised_amount": "0.00",
+            "non_federal_new_or_revised_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "total_budget_categories": {
+            "total_direct_charge_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "total_non_federal_resources": {
+            "applicant_amount": "0.00",
+            "state_amount": "0.00",
+            "other_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "forecasted_cash_needs": {
+            "federal_forecasted_cash_needs": {
+                "total_amount": "0.00",
+            },
+            "non_federal_forecasted_cash_needs": {
+                "total_amount": "0.00",
+            },
+            "total_forecasted_cash_needs": {
+                "total_amount": "0.00",
+            },
+        },
+        "total_federal_fund_estimates": {
+            "first_year_amount": "0.00",
+            "second_year_amount": "0.00",
+            "third_year_amount": "0.00",
+            "fourth_year_amount": "0.00",
+        },
+        "confirmation": True,
     }
+
 
 @pytest.fixture
 def full_valid_activity_line_item_v1_0():
@@ -135,13 +172,122 @@ def full_valid_json_v1_0(full_valid_activity_line_item_v1_0):
         "confirmation": True,
     }
 
+
 def test_sf424a_v1_0_minimal_valid_json(minimal_valid_json_v1_0):
     validation_issues = validate_json_schema_for_form(minimal_valid_json_v1_0, SF424a_v1_0)
     assert len(validation_issues) == 0
 
+
 def test_sf424a_v1_0_full_valid_json(full_valid_json_v1_0):
     validation_issues = validate_json_schema_for_form(full_valid_json_v1_0, SF424a_v1_0)
     assert len(validation_issues) == 0
+
+
+def test_sf424a_v1_0_empty_json():
+    validation_issues = validate_json_schema_for_form({}, SF424a_v1_0)
+
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.activity_line_items",
+        "$.total_budget_summary",
+        "$.total_budget_categories",
+        "$.total_non_federal_resources",
+        "$.forecasted_cash_needs",
+        "$.total_federal_fund_estimates",
+        "$.confirmation",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424a_v1_0_empty_line_item(full_valid_json_v1_0):
+    data = full_valid_json_v1_0
+    data["activity_line_items"] = [{}]
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.activity_line_items[0].activity_title",
+        "$.activity_line_items[0].assistance_listing_number",
+        "$.activity_line_items[0].budget_summary",
+        "$.activity_line_items[0].budget_categories",
+        "$.activity_line_items[0].non_federal_resources",
+        "$.activity_line_items[0].federal_fund_estimates",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424a_v1_0_empty_line_item_budget_summary(
+    full_valid_json_v1_0, minimal_valid_activity_line_item_v1_0
+):
+    line_item_data = minimal_valid_activity_line_item_v1_0
+    line_item_data["budget_summary"] = {}
+
+    data = full_valid_json_v1_0
+    data["activity_line_items"] = [line_item_data]
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    EXPECTED_REQUIRED_FIELDS = ["$.activity_line_items[0].budget_summary.total_amount"]
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424a_v1_0_empty_line_item_budget_categories(
+    full_valid_json_v1_0, minimal_valid_activity_line_item_v1_0
+):
+    line_item_data = minimal_valid_activity_line_item_v1_0
+    line_item_data["budget_categories"] = {}
+
+    data = full_valid_json_v1_0
+    data["activity_line_items"] = [line_item_data]
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.activity_line_items[0].budget_categories.total_direct_charge_amount",
+        "$.activity_line_items[0].budget_categories.total_amount",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424a_v1_0_empty_line_item_non_federal_resources(
+    full_valid_json_v1_0, minimal_valid_activity_line_item_v1_0
+):
+    line_item_data = minimal_valid_activity_line_item_v1_0
+    line_item_data["non_federal_resources"] = {}
+
+    data = full_valid_json_v1_0
+    data["activity_line_items"] = [line_item_data]
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    EXPECTED_REQUIRED_FIELDS = ["$.activity_line_items[0].non_federal_resources.total_amount"]
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424a_v1_0_no_line_items(full_valid_json_v1_0):
+    data = full_valid_json_v1_0
+    data["activity_line_items"] = []
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minItems"
+    assert validation_issues[0].message == "[] should be non-empty"
+    assert validation_issues[0].field == "$.activity_line_items"
+
 
 def test_sf424a_v1_0_too_many_line_items(full_valid_json_v1_0, full_valid_activity_line_item_v1_0):
     data = full_valid_json_v1_0
@@ -151,9 +297,72 @@ def test_sf424a_v1_0_too_many_line_items(full_valid_json_v1_0, full_valid_activi
     assert len(validation_issues) == 1
     assert validation_issues[0].type == "maxItems"
     assert validation_issues[0].message == "The array is too long, expected a maximum length of 4"
+    assert validation_issues[0].field == "$.activity_line_items"
 
-# TODO
-# Partial
-# Zero in list
-# Required in various places
-# * Total sections versus line item
+
+def test_sf424a_v1_0_empty_totals(full_valid_json_v1_0):
+    data = full_valid_json_v1_0
+    data["total_budget_summary"] = {}
+    data["total_budget_categories"] = {}
+    data["total_non_federal_resources"] = {}
+    data["forecasted_cash_needs"] = {}
+    data["total_federal_fund_estimates"] = {}
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.total_budget_summary.federal_estimated_unobligated_amount",
+        "$.total_budget_summary.non_federal_estimated_unobligated_amount",
+        "$.total_budget_summary.federal_new_or_revised_amount",
+        "$.total_budget_summary.non_federal_new_or_revised_amount",
+        "$.total_budget_summary.total_amount",
+        "$.total_budget_categories.total_direct_charge_amount",
+        "$.total_budget_categories.total_amount",
+        "$.total_non_federal_resources.applicant_amount",
+        "$.total_non_federal_resources.state_amount",
+        "$.total_non_federal_resources.other_amount",
+        "$.total_non_federal_resources.total_amount",
+        "$.forecasted_cash_needs.federal_forecasted_cash_needs",
+        "$.forecasted_cash_needs.non_federal_forecasted_cash_needs",
+        "$.forecasted_cash_needs.total_forecasted_cash_needs",
+        "$.total_federal_fund_estimates.first_year_amount",
+        "$.total_federal_fund_estimates.second_year_amount",
+        "$.total_federal_fund_estimates.third_year_amount",
+        "$.total_federal_fund_estimates.fourth_year_amount",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424a_v1_0_empty_forecasted_cash_needs(full_valid_json_v1_0):
+    data = full_valid_json_v1_0
+    data["forecasted_cash_needs"] = {
+        "federal_forecasted_cash_needs": {},
+        "non_federal_forecasted_cash_needs": {},
+        "total_forecasted_cash_needs": {},
+    }
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.forecasted_cash_needs.federal_forecasted_cash_needs.total_amount",
+        "$.forecasted_cash_needs.non_federal_forecasted_cash_needs.total_amount",
+        "$.forecasted_cash_needs.total_forecasted_cash_needs.total_amount",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424_confirmation_must_be_true(full_valid_json_v1_0):
+    data = full_valid_json_v1_0
+    data["confirmation"] = False
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "enum"
+    assert validation_issues[0].field == "$.confirmation"
+    assert validation_issues[0].message == "False is not one of [True]"


### PR DESCRIPTION
## Summary

Fixes #5520

## Changes proposed
Setup the JSON schema for an SF424A budget form

Slightly adjustment to the error message for maxItems

Adjustments to DB seed script to add this form to the local competition + adjusted how we setup the other competition that uses more generic forms.

## Context for reviewers
This is the complex budget form that has a whole bunch of tables, but the data structure works a bit differently internally as line items cross tables. I've tried my best to label the fields and where they appear.

I adjusted the maxItems validator because the message dumped the entire array into the message which if something like the activity line items exceeded was just unreadable due to the size.

## Validation steps
Something wasn't working on the frontend for me to view the forms (not just these forms, but any), this form has almost nothing in it yet for the UI schema as it will be very custom, so there wouldn't be anything to view anyways.