### PR TITLE
[Isse #5243] fetch agencies the right way

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Start API Server for e2e tests
         run: |
           cd ../api
-          make init db-seed-local-with-agencies populate-search-opportunities start
+          make init db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
           echo "ENABLE_OPPORTUNITY_ATTACHMENT_PIPELINE=false" >> override.env
           cd ../frontend

--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -3,6 +3,7 @@
 import { debounce } from "lodash";
 import { agencySearch } from "src/services/fetch/fetchers/clientAgenciesFetcher";
 import { FilterOption } from "src/types/search/searchFilterTypes";
+import { agenciesToSortedAndNestedFilterOptions } from "src/utils/search/filterUtils";
 
 import { useState } from "react";
 import { TextInput } from "@trussworks/react-uswds";
@@ -36,7 +37,9 @@ export function AgencyFilterContent({
       }
       agencySearch(agencySearchTerm)
         .then((searchResults) => {
-          setAgencySearchResults(searchResults);
+          const searchResultsOptions =
+            agenciesToSortedAndNestedFilterOptions(searchResults);
+          setAgencySearchResults(searchResultsOptions);
         })
         .catch((e) => {
           console.error("Error fetching agency search results", e);

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -5,7 +5,10 @@ import {
   fundingOptions,
   statusOptions,
 } from "src/constants/searchFilterOptions";
-import { obtainAgencies } from "src/services/fetch/fetchers/agenciesFetcher";
+import {
+  obtainAgencies,
+  performAgencySearch,
+} from "src/services/fetch/fetchers/agenciesFetcher";
 import { SearchAPIResponse } from "src/types/search/searchRequestTypes";
 
 import { useTranslations } from "next-intl";
@@ -33,7 +36,10 @@ export default async function SearchFilters({
   searchResultsPromise: Promise<SearchAPIResponse>;
 }) {
   const t = useTranslations("Search");
-  const agenciesPromise = Promise.all([obtainAgencies(), searchResultsPromise]);
+  const agenciesPromise = Promise.all([
+    performAgencySearch(),
+    searchResultsPromise,
+  ]);
 
   let searchResults;
   try {

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -5,10 +5,7 @@ import {
   fundingOptions,
   statusOptions,
 } from "src/constants/searchFilterOptions";
-import {
-  obtainAgencies,
-  performAgencySearch,
-} from "src/services/fetch/fetchers/agenciesFetcher";
+import { performAgencySearch } from "src/services/fetch/fetchers/agenciesFetcher";
 import { SearchAPIResponse } from "src/types/search/searchRequestTypes";
 
 import { useTranslations } from "next-intl";

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -1,5 +1,8 @@
 import { environment } from "src/constants/environments";
-import { obtainAgencies } from "src/services/fetch/fetchers/agenciesFetcher";
+import {
+  obtainAgencies,
+  performAgencySearch,
+} from "src/services/fetch/fetchers/agenciesFetcher";
 import { searchForOpportunities } from "src/services/fetch/fetchers/searchFetcher";
 import QueryProvider from "src/services/search/QueryProvider";
 import { OptionalStringDict } from "src/types/generalTypes";
@@ -40,7 +43,7 @@ export function SearchVersionTwo({
   }
 
   const searchResultsPromise = searchForOpportunities(convertedSearchParams);
-  const agencyListPromise = obtainAgencies();
+  const agencyListPromise = performAgencySearch();
 
   return (
     <>

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -1,8 +1,5 @@
 import { environment } from "src/constants/environments";
-import {
-  obtainAgencies,
-  performAgencySearch,
-} from "src/services/fetch/fetchers/agenciesFetcher";
+import { performAgencySearch } from "src/services/fetch/fetchers/agenciesFetcher";
 import { searchForOpportunities } from "src/services/fetch/fetchers/searchFetcher";
 import QueryProvider from "src/services/search/QueryProvider";
 import { OptionalStringDict } from "src/types/generalTypes";

--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -62,13 +62,6 @@ export const toDynamicUsersEndpoint = (type: "POST" | "DELETE" | "PUT") => {
   };
 };
 
-export const fetchAgenciesEndpoint = {
-  basePath: environment.API_URL,
-  version: "v1",
-  namespace: "agencies",
-  method: "POST" as ApiMethod,
-};
-
 export const userRefreshEndpoint = {
   basePath: environment.API_URL,
   version: "v1",

--- a/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
@@ -1,14 +1,13 @@
 "server only";
 
 import { ApiRequestError } from "src/errors";
+import { JSONRequestBody } from "src/services/fetch/fetcherHelpers";
 import {
   fetchAgencies,
   searchAgencies,
 } from "src/services/fetch/fetchers/fetchers";
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import { flattenAgencies } from "src/utils/search/filterUtils";
-
-import { JSONRequestBody } from "../fetcherHelpers";
 
 // would have called this getAgencies, but technically it's a POST
 export const obtainAgencies = async (): Promise<RelevantAgencyRecord[]> => {
@@ -24,7 +23,6 @@ export const obtainAgencies = async (): Promise<RelevantAgencyRecord[]> => {
           },
         ],
       },
-      filters: { active: true },
     },
     nextOptions: {
       revalidate: 604800,
@@ -48,7 +46,11 @@ export const performAgencySearch = async (
         },
       ],
     },
-    filters: { active: true },
+    filters: {
+      opportunity_statuses: {
+        one_of: ["posted", "forecasted"],
+      },
+    },
   };
   if (keyword) {
     requestBody.query = keyword;

--- a/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
@@ -8,6 +8,8 @@ import {
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import { flattenAgencies } from "src/utils/search/filterUtils";
 
+import { JSONRequestBody } from "../fetcherHelpers";
+
 // would have called this getAgencies, but technically it's a POST
 export const obtainAgencies = async (): Promise<RelevantAgencyRecord[]> => {
   const response = await fetchAgencies({
@@ -35,21 +37,24 @@ export const obtainAgencies = async (): Promise<RelevantAgencyRecord[]> => {
 export const performAgencySearch = async (
   keyword?: string,
 ): Promise<RelevantAgencyRecord[]> => {
-  const response = await searchAgencies({
-    body: {
-      pagination: {
-        page_offset: 1,
-        page_size: 1500, // 969 agencies in prod as of 3/7/25
-        sort_order: [
-          {
-            order_by: "agency_code",
-            sort_direction: "ascending",
-          },
-        ],
-      },
-      filters: { active: true },
-      query: keyword || "",
+  const requestBody: JSONRequestBody = {
+    pagination: {
+      page_offset: 1,
+      page_size: 1500, // 969 agencies in prod as of 3/7/25
+      sort_order: [
+        {
+          order_by: "agency_code",
+          sort_direction: "ascending",
+        },
+      ],
     },
+    filters: { active: true },
+  };
+  if (keyword) {
+    requestBody.query = keyword;
+  }
+  const response = await searchAgencies({
+    body: requestBody,
   });
   if (!response || response.status !== 200) {
     throw new ApiRequestError(

--- a/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
@@ -2,35 +2,9 @@
 
 import { ApiRequestError } from "src/errors";
 import { JSONRequestBody } from "src/services/fetch/fetcherHelpers";
-import {
-  fetchAgencies,
-  searchAgencies,
-} from "src/services/fetch/fetchers/fetchers";
+import { searchAgencies } from "src/services/fetch/fetchers/fetchers";
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import { flattenAgencies } from "src/utils/search/filterUtils";
-
-// would have called this getAgencies, but technically it's a POST
-export const obtainAgencies = async (): Promise<RelevantAgencyRecord[]> => {
-  const response = await fetchAgencies({
-    body: {
-      pagination: {
-        page_offset: 1,
-        page_size: 1500, // 969 agencies in prod as of 3/7/25
-        sort_order: [
-          {
-            order_by: "created_at",
-            sort_direction: "ascending",
-          },
-        ],
-      },
-    },
-    nextOptions: {
-      revalidate: 604800,
-    },
-  });
-  const { data } = (await response.json()) as { data: RelevantAgencyRecord[] };
-  return data;
-};
 
 export const performAgencySearch = async (
   keyword?: string,

--- a/frontend/src/services/fetch/fetchers/clientAgenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientAgenciesFetcher.ts
@@ -1,4 +1,4 @@
-import { FilterOption } from "src/types/search/searchFilterTypes";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 
 export const agencySearch = async (searchKeyword: string) => {
   const response = await fetch("/api/agencies", {
@@ -8,7 +8,7 @@ export const agencySearch = async (searchKeyword: string) => {
     }),
   });
   if (response.ok && response.status === 200) {
-    const data = (await response.json()) as FilterOption[];
+    const data = (await response.json()) as RelevantAgencyRecord[];
     return data;
   }
   throw new Error(`Unable to fetch agencies search: ${response.status}`);

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -3,7 +3,6 @@ import "server-only";
 import { ApiRequestError } from "src/errors";
 import {
   EndpointConfig,
-  fetchAgenciesEndpoint,
   fetchCompetitionEndpoint,
   fetchFormEndpoint,
   fetchOpportunityEndpoint,
@@ -119,8 +118,6 @@ export const postUserLogout = requesterForEndpoint(userLogoutEndpoint);
 
 export const fetchUserWithMethod = (type: "POST" | "DELETE" | "PUT") =>
   requesterForEndpoint(toDynamicUsersEndpoint(type));
-
-export const fetchAgencies = requesterForEndpoint(fetchAgenciesEndpoint);
 
 export const postTokenRefresh = requesterForEndpoint(userRefreshEndpoint);
 

--- a/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
+++ b/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
@@ -37,7 +37,7 @@ const query = new Set<string>();
 describe("AgencyFilterContent", () => {
   beforeEach(() => {
     mockAgencySearch.mockResolvedValue([
-      { value: "agency1", label: "Agency 1", id: "1" },
+      { agency_code: "agency1", agency_name: "Agency 1", agency_id: "1" },
     ]);
   });
   afterEach(() => {
@@ -101,6 +101,8 @@ describe("AgencyFilterContent", () => {
         facetCounts={facetCounts}
       />,
     );
+    expect(screen.getByText("Agency 1")).toBeInTheDocument();
+    expect(screen.getByText("Agency 2")).toBeInTheDocument();
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "garbage" } });
 
@@ -115,11 +117,9 @@ describe("AgencyFilterContent", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Agency 1")).toBeInTheDocument();
-    });
-    await waitFor(() => {
       expect(screen.queryByText("Agency 2")).not.toBeInTheDocument();
     });
+    expect(screen.getByText("Agency 1")).toBeInTheDocument();
   });
 
   it("shows FilterSearchNoResults when agencySearch returns empty array", async () => {

--- a/frontend/tests/components/search/SearchFilters.test.tsx
+++ b/frontend/tests/components/search/SearchFilters.test.tsx
@@ -53,7 +53,7 @@ jest.mock(
 );
 
 jest.mock("src/services/fetch/fetchers/agenciesFetcher", () => ({
-  obtainAgencies: () => Promise.resolve(fakeAgencyResponseData),
+  performAgencySearch: () => Promise.resolve(fakeAgencyResponseData),
 }));
 
 jest.mock("react", () => ({

--- a/frontend/tests/services/fetch/fetchers/agenciesFetcher.test.ts
+++ b/frontend/tests/services/fetch/fetchers/agenciesFetcher.test.ts
@@ -1,5 +1,4 @@
 import {
-  obtainAgencies,
   performAgencySearch,
   searchAndFlattenAgencies,
 } from "src/services/fetch/fetchers/agenciesFetcher";
@@ -10,36 +9,9 @@ const fakeResponse = {
   status: 200,
 };
 
-// const fakeSortedOptions = [
-//   {
-//     id: "DOCNIST",
-//     label: "National Institute of Standards and Technology",
-//     value: "DOCNIST",
-//   },
-//   {
-//     id: "MOCKNIST",
-//     label: "Mational Institute",
-//     value: "MOCKNIST",
-//   },
-//   {
-//     id: "MOCKTRASH",
-//     label: "Mational TRASH",
-//     value: "MOCKTRASH",
-//   },
-//   {
-//     id: "FAKEORG",
-//     label: "Completely fake",
-//     value: "FAKEORG",
-//   },
-// ];
-
-// const mockSortFilterOptions = jest.fn();
 const mockFetchAgencies = jest.fn().mockResolvedValue(fakeResponse);
 const mockSearchAgencies = jest.fn().mockResolvedValue(fakeResponse);
 const mockFlattenAgencies = jest.fn().mockReturnValue(fakeAgencyResponseData);
-// const mockAgenciesToFilterOptions = jest
-//   .fn()
-//   .mockReturnValue(fakeSortedOptions);
 
 jest.mock("src/services/fetch/fetchers/fetchers", () => ({
   fetchAgencies: (arg: unknown): unknown => mockFetchAgencies(arg),
@@ -47,38 +19,8 @@ jest.mock("src/services/fetch/fetchers/fetchers", () => ({
 }));
 
 jest.mock("src/utils/search/filterUtils", () => ({
-  // sortFilterOptions: (arg: unknown): unknown => mockSortFilterOptions(arg),
-  // agenciesToFilterOptions: (arg: unknown): unknown =>
-  //   mockAgenciesToFilterOptions(arg),
   flattenAgencies: (arg: unknown): unknown => mockFlattenAgencies(arg),
 }));
-
-describe("obtainAgencies", () => {
-  it("calls request function with correct parameters", async () => {
-    const result = await obtainAgencies();
-
-    expect(mockFetchAgencies).toHaveBeenCalledWith({
-      body: {
-        filters: { active: true },
-        pagination: {
-          page_offset: 1,
-          page_size: 1500,
-          sort_order: [
-            {
-              order_by: "created_at",
-              sort_direction: "ascending",
-            },
-          ],
-        },
-      },
-      nextOptions: {
-        revalidate: 604800,
-      },
-    });
-
-    expect(result).toEqual(fakeAgencyResponseData);
-  });
-});
 
 describe("performAgencySearch", () => {
   it("calls request function with correct parameters", async () => {
@@ -86,7 +28,7 @@ describe("performAgencySearch", () => {
 
     expect(mockSearchAgencies).toHaveBeenCalledWith({
       body: {
-        filters: { active: true },
+        filters: { opportunity_statuses: { one_of: ["posted", "forecasted"] } },
         pagination: {
           page_offset: 1,
           page_size: 1500,
@@ -129,49 +71,10 @@ describe("searchAndFlattenAgencies", () => {
             },
           ],
         },
-        filters: { active: true },
+        filters: { opportunity_statuses: { one_of: ["posted", "forecasted"] } },
         query: "anything",
       },
     });
     expect(mockFlattenAgencies).toHaveBeenCalledWith(fakeAgencyResponseData);
   });
 });
-
-// describe("getAgenciesForFilterOptions", () => {
-//   beforeEach(() => {
-//     mockFetchAgencies.mockResolvedValue(fakeResponse);
-//     mockSearchAgencies.mockResolvedValue(fakeResponse);
-//     mockFlattenAgencies.mockReturnValue(fakeAgencyResponseData);
-//     mockAgenciesToFilterOptions.mockReturnValue(fakeSortedOptions);
-//   });
-//   afterEach(() => {
-//     jest.resetAllMocks();
-//   });
-//   it("calls fetch, transforms, and sorts", async () => {
-//     await getAgenciesForFilterOptions();
-
-//     expect(mockFetchAgencies).toHaveBeenCalledWith({
-//       body: {
-//         pagination: {
-//           page_offset: 1,
-//           page_size: 1500, // 969 agencies in prod as of 3/7/25
-//           sort_order: [
-//             {
-//               order_by: "created_at",
-//               sort_direction: "ascending",
-//             },
-//           ],
-//         },
-//         filters: { active: true },
-//       },
-//       nextOptions: {
-//         revalidate: 604800,
-//       },
-//     });
-//     expect(mockAgenciesToFilterOptions).toHaveBeenCalledWith(
-//       fakeAgencyResponseData,
-//     );
-
-//     expect(mockSortFilterOptions).toHaveBeenCalledWith(fakeSortedOptions);
-//   });
-// });


### PR DESCRIPTION
## Summary

Work for #5243 

## Changes proposed

* uses the agency search endpoint for all agency data fetches from the frontend
* pass correct filter params to limit agency response to agencies associated with at least one "posted" or "forecasted" opportunity

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This will fix a number of bugs with the current agency search behavior, caused by a mismatch between the initially fetched set of agencies (which were filtered for active agencies), and the agencies returned from results (which were not)

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. point your local environment at the dev api server
2. start a local server on this branch
3. visit http://localhost:3000/search?status=none
4. _VERIFY_: all agency options displayed have a > 0 facet count
5. search agencies for `"food and drug"`
6. _VERIFY_: no search results appear (for further verification test this out in dev, and you'll see "Food and Drug Administration" appear as a result with a 0 facet count)