### PR TITLE
[Issue #5605] Include links to Opportuntiy page in Saved Search emails 

### DIFF
--- a/api/src/task/notifications/search_notification.py
+++ b/api/src/task/notifications/search_notification.py
@@ -186,8 +186,7 @@ class SearchNotificationTask(BaseNotificationTask):
                 continue
 
             # Add opportunity title (empty line before title)
-            message += f"{opportunity.opportunity_title}\n\n"
-
+            message += f"<b><a href='{self.notification_config.frontend_base_url}/opportunity/{opportunity.opportunity_id}' target='_blank'>{opportunity.opportunity_title}</a></b><br/>"
             # Add status
             status = (
                 str(opportunity.opportunity_status).capitalize()

--- a/api/tests/src/task/notifications/test_search_notification.py
+++ b/api/tests/src/task/notifications/test_search_notification.py
@@ -368,8 +368,7 @@ def test_search_notification_email_format_single_opportunity(
     # Test single opportunity format
     expected_single = """A funding opportunity matching your saved search query was recently published.
 
-2025 Port Infrastructure Development Program
-
+<b><a href='http://localhost:8080/opportunity/2' target='_blank'>2025 Port Infrastructure Development Program</a></b>
 Status: Posted
 Submission period: 1/31/2025–4/30/2025
 Award range: $1,000,000-$112,500,000
@@ -439,8 +438,7 @@ def test_search_notification_email_format_no_close_date(
     # Test opportunity with no close date format
     expected_content = """A funding opportunity matching your saved search query was recently published.
 
-Ongoing Research Grant Program
-
+<b><a href='http://localhost:8080/opportunity/3' target='_blank'>Ongoing Research Grant Program</a></b>
 Status: Posted
 Submission period: 2/15/2025-(To be determined)
 Award range: $50,000-$500,000
@@ -537,16 +535,14 @@ def test_search_notification_email_format_multiple_opportunities(
     # Test single opportunity format
     expected_single = """The following funding opportunities matching your saved search queries were recently published.
 
-2025 Port Infrastructure Development Program
-
+<b><a href='http://localhost:8080/opportunity/1' target='_blank'>2025 Port Infrastructure Development Program</a></b>
 Status: Posted
 Submission period: 1/31/2025–4/30/2025
 Award range: $1,000,000-$112,500,000
 Expected awards: 40
 Cost sharing: Yes
 
-Cooperative Agreement for affiliated Partner with Rocky Mountains Cooperative Ecosystem Studies Unit (CESU)
-
+<b><a href='http://localhost:8080/opportunity/2' target='_blank'>Cooperative Agreement for affiliated Partner with Rocky Mountains Cooperative Ecosystem Studies Unit (CESU)</a></b>
 Status: Forecasted
 Submission period: To be announced.
 Award range: $1-$30,000


### PR DESCRIPTION
## Summary

Work for #5605

## Changes proposed

We noticed in testing that of the 3 email notifications, the saved search one wasn't linking the user to the Opportunity page. So we added that.
