### PR TITLE
[Issue #5608] Sample logs for /health

### DIFF
--- a/frontend/src/services/logger/simplerLogger.tsx
+++ b/frontend/src/services/logger/simplerLogger.tsx
@@ -50,13 +50,15 @@ export const logRequest = (request: NextRequest) => {
     headers.get("sec-fetch-dest") === "empty";
 
   if (!isPrefetch) {
-    logger.info({
-      url,
-      method,
-      userAgent: headers.get("user-agent"),
-      acceptLanguage: headers.get("accept-language"),
-      awsTraceId: headers.get("X-Amz-Cf-Id"),
-    });
+    if (!url.endsWith("/health") || Math.random() * 10 <= 1) {
+      logger.info({
+        url,
+        method,
+        userAgent: headers.get("user-agent"),
+        acceptLanguage: headers.get("accept-language"),
+        awsTraceId: headers.get("X-Amz-Cf-Id"),
+      });
+    }
   }
 };
 


### PR DESCRIPTION
## Summary

Work for #5608

## Changes proposed

If the middleware logger detects it's a request to /health, pull a random number to only log 1/10 actual hits to /health.

If my math is right, we're sending about 622MB of health check logs a month to NewRelic/CloudWatch.

## Validation steps
1. Checkout the branch
2. Run `npm run dev | grep "/health"`
3. Refresh http://localhost:3000/health multiple times
    a. Note that not every request logs the JSON info style log line
4. Validate that other URLs still log as expected 

<img width="804" alt="image" src="https://github.com/user-attachments/assets/e0a919dd-3792-4c38-95b9-c058d6ac035e" />
