### PR TITLE
[Issue #4934] fetch agencies by status

### DIFF
--- a/api/tests/lib/seed_agencies.py
+++ b/api/tests/lib/seed_agencies.py
@@ -445,6 +445,16 @@ AGENCIES_TO_CREATE = [
         "agency_name": "Office for Victims of Crime",
         "top_level_agency_id": "63a027ef-7d10-4b3b-b8d6-290e0b8e681a",
     },
+    {
+        "agency_code": "CLOSED",
+        "agency_id": "add4b8ff-e895-4ca9-92f4-38ed34055247",
+        "agency_name": "Agency of closed opportunities",
+    },
+    {
+        "agency_code": "ARCHIVED",
+        "agency_id": "add4bfff-e895-4ca9-92f4-38ed34055247",
+        "agency_name": "Agency of archived opportunities",
+    },
 ]
 
 

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -42,8 +42,12 @@ def _build_opportunities(
         factories.OpportunityFactory.create_batch(
             size=2, is_posted_summary=True, has_long_descriptions=True
         )
-        factories.OpportunityFactory.create_batch(size=2, agency_code="CLOSED", is_closed_summary=True)
-        factories.OpportunityFactory.create_batch(size=2, agency_code="ARCHIVED", is_archived_non_forecast_summary=True)
+        factories.OpportunityFactory.create_batch(
+            size=2, agency_code="CLOSED", is_closed_summary=True
+        )
+        factories.OpportunityFactory.create_batch(
+            size=2, agency_code="ARCHIVED", is_archived_non_forecast_summary=True
+        )
 
         # generate a few opportunities with mostly null values
         all_null_opportunities = factories.OpportunityFactory.create_batch(

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -42,6 +42,8 @@ def _build_opportunities(
         factories.OpportunityFactory.create_batch(
             size=2, is_posted_summary=True, has_long_descriptions=True
         )
+        factories.OpportunityFactory.create_batch(size=2, agency_code="CLOSED", is_closed_summary=True)
+        factories.OpportunityFactory.create_batch(size=2, agency_code="ARCHIVED", is_archived_non_forecast_summary=True)
 
         # generate a few opportunities with mostly null values
         all_null_opportunities = factories.OpportunityFactory.create_batch(

--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -80,7 +80,6 @@ function Search({ searchParams, params }: SearchPageProps) {
               >
                 <SaveSearchPanel />
                 <SearchFilters
-                  rawStatus={resolvedSearchParams?.status?.split(",") || []}
                   opportunityStatus={status}
                   eligibility={eligibility}
                   category={category}

--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -80,6 +80,7 @@ function Search({ searchParams, params }: SearchPageProps) {
               >
                 <SaveSearchPanel />
                 <SearchFilters
+                  rawStatus={resolvedSearchParams?.status?.split(",") || []}
                   opportunityStatus={status}
                   eligibility={eligibility}
                   category={category}

--- a/frontend/src/app/api/agencies/handler.ts
+++ b/frontend/src/app/api/agencies/handler.ts
@@ -5,14 +5,20 @@ import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import { NextRequest } from "next/server";
 
 export async function searchForAgencies(request: NextRequest) {
-  const { keyword } = (await request.json()) as { keyword: string | undefined };
+  const { keyword, selectedStatuses } = (await request.json()) as {
+    keyword?: string;
+    selectedStatuses?: string[];
+  };
 
   let agencySearchResults: RelevantAgencyRecord[] = [];
   try {
     if (!keyword) {
       throw new Error("No agency search keyword provided");
     }
-    agencySearchResults = await searchAndFlattenAgencies(keyword);
+    agencySearchResults = await searchAndFlattenAgencies(
+      keyword,
+      selectedStatuses,
+    );
   } catch (e) {
     const { status, message } = readError(e as Error, 500);
     console.error(e);

--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -5,7 +5,6 @@ import { agencySearch } from "src/services/fetch/fetchers/clientAgenciesFetcher"
 import { FilterOption } from "src/types/search/searchFilterTypes";
 import { agenciesToSortedAndNestedFilterOptions } from "src/utils/search/filterUtils";
 
-import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { TextInput } from "@trussworks/react-uswds";
 
@@ -26,9 +25,8 @@ export function AgencyFilterContent({
   allAgencies: FilterOption[];
   facetCounts: { [key: string]: number };
   topLevelQuery: Set<string>;
-  selectedStatuses?: Set<string>;
+  selectedStatuses?: string[];
 }) {
-  // const searchParams = useSearchParams();
   const [agencySearchResults, setAgencySearchResults] =
     useState<FilterOption[]>();
   const [searchTerm, setSearchTerm] = useState<string>();
@@ -39,12 +37,7 @@ export function AgencyFilterContent({
         setAgencySearchResults(allAgencies);
         return;
       }
-      // const selectedStatuses = searchParams.get("status");
-      agencySearch(
-        agencySearchTerm,
-        // selectedStatuses ? selectedStatuses.split(",") : undefined,
-        selectedStatuses ? Array.from(selectedStatuses) : undefined,
-      )
+      agencySearch(agencySearchTerm, selectedStatuses || undefined)
         .then((searchResults) => {
           const searchResultsOptions =
             agenciesToSortedAndNestedFilterOptions(searchResults);

--- a/frontend/src/components/search/Filters/AgencyFilterContent.tsx
+++ b/frontend/src/components/search/Filters/AgencyFilterContent.tsx
@@ -5,6 +5,7 @@ import { agencySearch } from "src/services/fetch/fetchers/clientAgenciesFetcher"
 import { FilterOption } from "src/types/search/searchFilterTypes";
 import { agenciesToSortedAndNestedFilterOptions } from "src/utils/search/filterUtils";
 
+import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { TextInput } from "@trussworks/react-uswds";
 
@@ -18,13 +19,16 @@ export function AgencyFilterContent({
   allAgencies,
   facetCounts,
   topLevelQuery,
+  selectedStatuses,
 }: {
   query: Set<string>;
   title: string;
   allAgencies: FilterOption[];
   facetCounts: { [key: string]: number };
   topLevelQuery: Set<string>;
+  selectedStatuses?: Set<string>;
 }) {
+  // const searchParams = useSearchParams();
   const [agencySearchResults, setAgencySearchResults] =
     useState<FilterOption[]>();
   const [searchTerm, setSearchTerm] = useState<string>();
@@ -35,7 +39,12 @@ export function AgencyFilterContent({
         setAgencySearchResults(allAgencies);
         return;
       }
-      agencySearch(agencySearchTerm)
+      // const selectedStatuses = searchParams.get("status");
+      agencySearch(
+        agencySearchTerm,
+        // selectedStatuses ? selectedStatuses.split(",") : undefined,
+        selectedStatuses ? Array.from(selectedStatuses) : undefined,
+      )
         .then((searchResults) => {
           const searchResultsOptions =
             agenciesToSortedAndNestedFilterOptions(searchResults);

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -111,7 +111,7 @@ export async function SearchDrawerFilters({
           agencyOptionsPromise={agenciesPromise}
           topLevelQuery={topLevelAgency}
           className="width-100 padding-right-5"
-          selectedStatuses={status}
+          selectedStatuses={Array.from(status)}
         />
       </Suspense>
       <CheckboxFilter

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -111,6 +111,7 @@ export async function SearchDrawerFilters({
           agencyOptionsPromise={agenciesPromise}
           topLevelQuery={topLevelAgency}
           className="width-100 padding-right-5"
+          selectedStatuses={status}
         />
       </Suspense>
       <CheckboxFilter

--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -18,7 +18,7 @@ export async function AgencyFilterAccordion({
   agencyOptionsPromise: Promise<[RelevantAgencyRecord[], SearchAPIResponse]>;
   topLevelQuery: Set<string>;
   className?: string;
-  selectedStatuses?: Set<string>;
+  selectedStatuses?: string[];
 }) {
   const t = useTranslations("Search");
 

--- a/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
+++ b/frontend/src/components/search/SearchFilterAccordion/AgencyFilterAccordion.tsx
@@ -12,12 +12,13 @@ export async function AgencyFilterAccordion({
   agencyOptionsPromise,
   topLevelQuery,
   className,
+  selectedStatuses,
 }: {
   query: Set<string>;
-
   agencyOptionsPromise: Promise<[RelevantAgencyRecord[], SearchAPIResponse]>;
   topLevelQuery: Set<string>;
   className?: string;
+  selectedStatuses?: Set<string>;
 }) {
   const t = useTranslations("Search");
 
@@ -48,6 +49,7 @@ export async function AgencyFilterAccordion({
         allAgencies={agencyOptions}
         facetCounts={facetCounts}
         topLevelQuery={topLevelQuery}
+        selectedStatuses={selectedStatuses}
       />
     </BasicSearchFilterAccordion>
   );

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -23,6 +23,7 @@ export default async function SearchFilters({
   opportunityStatus,
   topLevelAgency,
   searchResultsPromise,
+  rawStatus,
 }: {
   fundingInstrument: Set<string>;
   eligibility: Set<string>;
@@ -31,11 +32,12 @@ export default async function SearchFilters({
   opportunityStatus: Set<string>;
   topLevelAgency: Set<string>;
   searchResultsPromise: Promise<SearchAPIResponse>;
+  rawStatus: string[];
 }) {
   const t = useTranslations("Search");
   const agenciesPromise = Promise.all([
     performAgencySearch({
-      selectedStatuses: Array.from(opportunityStatus),
+      selectedStatuses: rawStatus,
     }),
     searchResultsPromise,
   ]);
@@ -89,7 +91,7 @@ export default async function SearchFilters({
           query={agency}
           agencyOptionsPromise={agenciesPromise}
           topLevelQuery={topLevelAgency}
-          selectedStatuses={opportunityStatus}
+          selectedStatuses={rawStatus}
         />
       </Suspense>
       <SearchFilterAccordion

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -23,7 +23,6 @@ export default async function SearchFilters({
   opportunityStatus,
   topLevelAgency,
   searchResultsPromise,
-  rawStatus,
 }: {
   fundingInstrument: Set<string>;
   eligibility: Set<string>;
@@ -32,12 +31,11 @@ export default async function SearchFilters({
   opportunityStatus: Set<string>;
   topLevelAgency: Set<string>;
   searchResultsPromise: Promise<SearchAPIResponse>;
-  rawStatus: string[];
 }) {
   const t = useTranslations("Search");
   const agenciesPromise = Promise.all([
     performAgencySearch({
-      selectedStatuses: rawStatus,
+      selectedStatuses: Array.from(opportunityStatus),
     }),
     searchResultsPromise,
   ]);
@@ -91,7 +89,7 @@ export default async function SearchFilters({
           query={agency}
           agencyOptionsPromise={agenciesPromise}
           topLevelQuery={topLevelAgency}
-          selectedStatuses={rawStatus}
+          selectedStatuses={Array.from(opportunityStatus)}
         />
       </Suspense>
       <SearchFilterAccordion

--- a/frontend/src/components/search/SearchFilters.tsx
+++ b/frontend/src/components/search/SearchFilters.tsx
@@ -34,7 +34,9 @@ export default async function SearchFilters({
 }) {
   const t = useTranslations("Search");
   const agenciesPromise = Promise.all([
-    performAgencySearch(),
+    performAgencySearch({
+      selectedStatuses: Array.from(opportunityStatus),
+    }),
     searchResultsPromise,
   ]);
 
@@ -87,6 +89,7 @@ export default async function SearchFilters({
           query={agency}
           agencyOptionsPromise={agenciesPromise}
           topLevelQuery={topLevelAgency}
+          selectedStatuses={opportunityStatus}
         />
       </Suspense>
       <SearchFilterAccordion

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -41,7 +41,7 @@ export function SearchVersionTwo({
 
   const searchResultsPromise = searchForOpportunities(convertedSearchParams);
   const agencyListPromise = performAgencySearch({
-    selectedStatuses: Array.from(convertedSearchParams.status),
+    selectedStatuses: Array.from(resolvedSearchParams.status || []),
   });
 
   return (

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -41,7 +41,7 @@ export function SearchVersionTwo({
 
   const searchResultsPromise = searchForOpportunities(convertedSearchParams);
   const agencyListPromise = performAgencySearch({
-    selectedStatuses: Array.from(resolvedSearchParams.status || []),
+    selectedStatuses: Array.from(convertedSearchParams.status),
   });
 
   return (

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -40,7 +40,9 @@ export function SearchVersionTwo({
   }
 
   const searchResultsPromise = searchForOpportunities(convertedSearchParams);
-  const agencyListPromise = performAgencySearch();
+  const agencyListPromise = performAgencySearch({
+    selectedStatuses: Array.from(convertedSearchParams.status),
+  });
 
   return (
     <>

--- a/frontend/src/constants/search.ts
+++ b/frontend/src/constants/search.ts
@@ -2,8 +2,8 @@ import { FrontendFilterNames } from "src/types/search/searchFilterTypes";
 
 // Show all values status for search.
 export const SEARCH_NO_STATUS_VALUE = "none";
-export const SEARCH_DEFAULT_VALUES = ["forecasted", "posted"];
+export const STATUS_FILTER_DEFAULT_VALUES = ["forecasted", "posted"];
 export const defaultFilterValues: { [key in FrontendFilterNames]?: string[] } =
   {
-    status: SEARCH_DEFAULT_VALUES,
+    status: STATUS_FILTER_DEFAULT_VALUES,
   };

--- a/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
@@ -14,9 +14,6 @@ export const performAgencySearch = async ({
   keyword?: string;
   selectedStatuses?: string[];
 } = {}): Promise<RelevantAgencyRecord[]> => {
-  const statuses = getStatusValueForAgencySearch(selectedStatuses);
-
-  console.log("!!! statuses", statuses);
   const requestBody: JSONRequestBody = {
     pagination: {
       page_offset: 1,
@@ -30,7 +27,7 @@ export const performAgencySearch = async ({
     },
     filters: {
       opportunity_statuses: {
-        one_of: statuses,
+        one_of: getStatusValueForAgencySearch(selectedStatuses),
       },
     },
   };
@@ -58,15 +55,13 @@ export const performAgencySearch = async ({
 
 export const searchAndFlattenAgencies = async (
   keyword: string,
-  selectedStatuses?: Set<string>,
+  selectedStatuses?: string[],
 ): Promise<RelevantAgencyRecord[]> => {
   let agencies = [];
   try {
     agencies = await performAgencySearch({
       keyword,
-      selectedStatuses: selectedStatuses
-        ? Array.from(selectedStatuses)
-        : undefined,
+      selectedStatuses: selectedStatuses || undefined,
     });
   } catch (e) {
     console.error("Error searching agency options");

--- a/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
@@ -1,13 +1,11 @@
 "server only";
 
-import { uniq } from "lodash";
-import { STATUS_FILTER_DEFAULT_VALUES } from "src/constants/search";
-import { statusOptions } from "src/constants/searchFilterOptions";
 import { ApiRequestError } from "src/errors";
 import { JSONRequestBody } from "src/services/fetch/fetcherHelpers";
 import { searchAgencies } from "src/services/fetch/fetchers/fetchers";
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import { flattenAgencies } from "src/utils/search/filterUtils";
+import { getStatusValueForAgencySearch } from "src/utils/search/searchUtils";
 
 export const performAgencySearch = async ({
   keyword,
@@ -16,14 +14,7 @@ export const performAgencySearch = async ({
   keyword?: string;
   selectedStatuses?: string[];
 } = {}): Promise<RelevantAgencyRecord[]> => {
-  // this works but need to adjust callers to send in blanks when we want ANY rather than blanks when we want DEFAULT
-  const statuses = selectedStatuses?.length
-    ? uniq(selectedStatuses.concat(STATUS_FILTER_DEFAULT_VALUES))
-    : statusOptions.map(({ value }) => value);
-
-  // const statuses = selectedStatuses?.length
-  //   ? uniq(selectedStatuses.concat(STATUS_FILTER_DEFAULT_VALUES))
-  //   : STATUS_FILTER_DEFAULT_VALUES;
+  const statuses = getStatusValueForAgencySearch(selectedStatuses);
 
   console.log("!!! statuses", statuses);
   const requestBody: JSONRequestBody = {

--- a/frontend/src/services/fetch/fetchers/clientAgenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/clientAgenciesFetcher.ts
@@ -1,10 +1,14 @@
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 
-export const agencySearch = async (searchKeyword: string) => {
+export const agencySearch = async (
+  keyword: string,
+  selectedStatuses?: string[],
+) => {
   const response = await fetch("/api/agencies", {
     method: "POST",
     body: JSON.stringify({
-      keyword: searchKeyword,
+      keyword,
+      selectedStatuses,
     }),
   });
   if (response.ok && response.status === 200) {

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -1,7 +1,9 @@
+import { uniq } from "lodash";
 import {
   SEARCH_NO_STATUS_VALUE,
   STATUS_FILTER_DEFAULT_VALUES,
 } from "src/constants/search";
+import { statusOptions } from "src/constants/searchFilterOptions";
 import { OptionalStringDict } from "src/types/generalTypes";
 import { FilterOption } from "src/types/search/searchFilterTypes";
 import { QuerySetParam } from "src/types/search/searchQueryTypes";
@@ -107,4 +109,16 @@ export const getSiblingOptionValues = (
         return acc;
       }, [] as string[])
     : [];
+};
+
+export const getStatusValueForAgencySearch = (statuses?: string[]) => {
+  // if empty - apply defaults
+  if (!statuses?.length) {
+    return STATUS_FILTER_DEFAULT_VALUES;
+  }
+  // if "none" - apply any / all
+  if (statuses.includes(SEARCH_NO_STATUS_VALUE)) {
+    return statusOptions.map(({ value }) => value);
+  }
+  return uniq(statuses.concat(STATUS_FILTER_DEFAULT_VALUES));
 };

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -111,14 +111,12 @@ export const getSiblingOptionValues = (
     : [];
 };
 
+// defaults will already have been applied upstream
 export const getStatusValueForAgencySearch = (statuses?: string[]) => {
-  // if empty - apply defaults
+  // if empty - apply any / all
   if (!statuses?.length) {
-    return STATUS_FILTER_DEFAULT_VALUES;
-  }
-  // if "none" - apply any / all
-  if (statuses.includes(SEARCH_NO_STATUS_VALUE)) {
     return statusOptions.map(({ value }) => value);
   }
+  // always include posted and forecasted
   return uniq(statuses.concat(STATUS_FILTER_DEFAULT_VALUES));
 };

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -1,6 +1,6 @@
 import {
-  SEARCH_DEFAULT_VALUES,
   SEARCH_NO_STATUS_VALUE,
+  STATUS_FILTER_DEFAULT_VALUES,
 } from "src/constants/search";
 import { OptionalStringDict } from "src/types/generalTypes";
 import { FilterOption } from "src/types/search/searchFilterTypes";
@@ -47,7 +47,7 @@ export function convertSearchParamsToProperTypes(
 // and to reset that status params none if status=none is set
 function paramToSet(param: QuerySetParam, type?: string): Set<string> {
   if (!param && type === "status") {
-    return new Set(SEARCH_DEFAULT_VALUES);
+    return new Set(STATUS_FILTER_DEFAULT_VALUES);
   }
 
   if (!param || (type === "status" && param === SEARCH_NO_STATUS_VALUE)) {

--- a/frontend/tests/api/agencies/route.test.ts
+++ b/frontend/tests/api/agencies/route.test.ts
@@ -32,10 +32,16 @@ describe("POST request", () => {
     await searchForAgencies(
       new NextRequest("http://simpler.grants.gov", {
         method: "POST",
-        body: JSON.stringify({ keyword: "anything" }),
+        body: JSON.stringify({
+          keyword: "anything",
+          selectedStatuses: ["forecasted", "posted"],
+        }),
       }),
     );
-    expect(mockSearchAndFlattenAgencies).toHaveBeenCalledWith("anything");
+    expect(mockSearchAndFlattenAgencies).toHaveBeenCalledWith("anything", [
+      "forecasted",
+      "posted",
+    ]);
   });
   it("responds with return value of searchAndFlattenAgencies", async () => {
     mockSearchAndFlattenAgencies.mockResolvedValue(initialFilterOptions);

--- a/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
+++ b/frontend/tests/components/search/Filters/AgencyFilterContent.test.tsx
@@ -33,6 +33,7 @@ const allAgencies: FilterOption[] = [
 
 const facetCounts = { agency1: 5, agency2: 2 };
 const query = new Set<string>();
+const selectedStatuses = ["posted", "closed"];
 
 describe("AgencyFilterContent", () => {
   beforeEach(() => {
@@ -52,6 +53,7 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
     const results = await axe(container);
@@ -66,6 +68,7 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
     expect(screen.getByRole("textbox")).toBeInTheDocument();
@@ -81,13 +84,14 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
     const input = screen.getByRole("textbox");
     fireEvent.change(input, { target: { value: "NASA" } });
 
     await waitFor(() => {
-      expect(mockAgencySearch).toHaveBeenCalledWith("NASA");
+      expect(mockAgencySearch).toHaveBeenCalledWith("NASA", selectedStatuses);
     });
   });
 
@@ -99,6 +103,7 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
     expect(screen.getByText("Agency 1")).toBeInTheDocument();
@@ -113,6 +118,7 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
 
@@ -131,6 +137,7 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
     const input = screen.getByRole("textbox");
@@ -149,13 +156,17 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
     const input = screen.getByRole("textbox");
 
     fireEvent.change(input, { target: { value: "garbage" } });
     await waitFor(() => {
-      expect(mockAgencySearch).toHaveBeenCalledWith("garbage");
+      expect(mockAgencySearch).toHaveBeenCalledWith(
+        "garbage",
+        selectedStatuses,
+      );
     });
 
     fireEvent.change(input, { target: { value: "" } });
@@ -177,6 +188,7 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
     const input = screen.getByRole("textbox");
@@ -189,6 +201,7 @@ describe("AgencyFilterContent", () => {
         title="Agencies"
         allAgencies={allAgencies}
         facetCounts={facetCounts}
+        selectedStatuses={selectedStatuses}
       />,
     );
 

--- a/frontend/tests/services/fetch/fetchers/agenciesFetcher.test.ts
+++ b/frontend/tests/services/fetch/fetchers/agenciesFetcher.test.ts
@@ -12,6 +12,9 @@ const fakeResponse = {
 const mockFetchAgencies = jest.fn().mockResolvedValue(fakeResponse);
 const mockSearchAgencies = jest.fn().mockResolvedValue(fakeResponse);
 const mockFlattenAgencies = jest.fn().mockReturnValue(fakeAgencyResponseData);
+const mockGetStatusValueForAgencySearch = jest
+  .fn()
+  .mockReturnValue(["forecasted"]);
 
 jest.mock("src/services/fetch/fetchers/fetchers", () => ({
   fetchAgencies: (arg: unknown): unknown => mockFetchAgencies(arg),
@@ -20,6 +23,11 @@ jest.mock("src/services/fetch/fetchers/fetchers", () => ({
 
 jest.mock("src/utils/search/filterUtils", () => ({
   flattenAgencies: (arg: unknown): unknown => mockFlattenAgencies(arg),
+}));
+
+jest.mock("src/utils/search/searchUtils", () => ({
+  getStatusValueForAgencySearch: (arg: unknown) =>
+    mockGetStatusValueForAgencySearch(arg) as unknown,
 }));
 
 describe("performAgencySearch", () => {
@@ -31,7 +39,7 @@ describe("performAgencySearch", () => {
 
     expect(mockSearchAgencies).toHaveBeenCalledWith({
       body: {
-        filters: { opportunity_statuses: { one_of: ["forecasted", "posted"] } },
+        filters: { opportunity_statuses: { one_of: ["forecasted"] } },
         pagination: {
           page_offset: 1,
           page_size: 1500,
@@ -73,7 +81,7 @@ describe("searchAndFlattenAgencies", () => {
             },
           ],
         },
-        filters: { opportunity_statuses: { one_of: ["forecasted", "posted"] } },
+        filters: { opportunity_statuses: { one_of: ["forecasted"] } },
         query: "anything",
       },
     });

--- a/frontend/tests/services/fetch/fetchers/agenciesFetcher.test.ts
+++ b/frontend/tests/services/fetch/fetchers/agenciesFetcher.test.ts
@@ -24,11 +24,14 @@ jest.mock("src/utils/search/filterUtils", () => ({
 
 describe("performAgencySearch", () => {
   it("calls request function with correct parameters", async () => {
-    const result = await performAgencySearch("anything");
+    const result = await performAgencySearch({
+      keyword: "anything",
+      selectedStatuses: ["forecasted"],
+    });
 
     expect(mockSearchAgencies).toHaveBeenCalledWith({
       body: {
-        filters: { opportunity_statuses: { one_of: ["posted", "forecasted"] } },
+        filters: { opportunity_statuses: { one_of: ["forecasted", "posted"] } },
         pagination: {
           page_offset: 1,
           page_size: 1500,
@@ -52,13 +55,12 @@ describe("searchAndFlattenAgencies", () => {
     mockFetchAgencies.mockResolvedValue(fakeResponse);
     mockSearchAgencies.mockResolvedValue(fakeResponse);
     mockFlattenAgencies.mockReturnValue(fakeAgencyResponseData);
-    // mockAgenciesToFilterOptions.mockReturnValue(fakeSortedOptions);
   });
   afterEach(() => {
     jest.resetAllMocks();
   });
   it("calls fetch, and flattens", async () => {
-    await searchAndFlattenAgencies("anything");
+    await searchAndFlattenAgencies("anything", ["forecasted"]);
     expect(mockSearchAgencies).toHaveBeenCalledWith({
       body: {
         pagination: {
@@ -71,7 +73,7 @@ describe("searchAndFlattenAgencies", () => {
             },
           ],
         },
-        filters: { opportunity_statuses: { one_of: ["posted", "forecasted"] } },
+        filters: { opportunity_statuses: { one_of: ["forecasted", "posted"] } },
         query: "anything",
       },
     });

--- a/frontend/tests/utils/search/searchUtils.test.ts
+++ b/frontend/tests/utils/search/searchUtils.test.ts
@@ -8,6 +8,7 @@ import {
   convertSearchParamsToProperTypes,
   getAgencyParent,
   getSiblingOptionValues,
+  getStatusValueForAgencySearch,
   paramsToFormattedQuery,
   paramToDateRange,
 } from "src/utils/search/searchUtils";
@@ -143,5 +144,23 @@ describe("getSiblingOptionValues", () => {
         },
       ]),
     ).toEqual(["parent-sibling", "parent-another-sibling"]);
+  });
+});
+
+describe("getStatusValueForAgencySearch", () => {
+  it("returns all options if passed empty status array", () => {
+    expect(getStatusValueForAgencySearch([])).toEqual([
+      "forecasted",
+      "posted",
+      "closed",
+      "archived",
+    ]);
+  });
+  it("returns default options plus any passed options", () => {
+    expect(getStatusValueForAgencySearch(["closed"])).toEqual([
+      "closed",
+      "forecasted",
+      "posted",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Work for #4934


## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Allows agency search calls to filter agencies based on opportunity statuses. All responses should include agencies with at least one opportunity with a "posted" or "forecasted" status. If the current opportunity search includes "archived" or "closed" opportunities as well, the agency search should also return agencies that have "archived" or "closed" opportunities respectively.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

* adds two agencies and some opportunities to the seed in order to test situations specific to agencies that contain only closed or archived opportunities

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch
2. visit http://localhost:3000/search
3. _VERIFY_: "Agency of closed opportunities" and "Agency of archived opportunities" do not appear in the list of agencies in the agency filter
4. select the "archived" status option
5. _VERIFY_: "Agency of archived opportunities" appears in the list of agencies in the agency filter
6. select the "closed" status option
5. _VERIFY_: "Agency of closed opportunities" appears in the list of agencies in the agency filter
6. uncheck all status options
7. _VERIFY_: "Agency of closed opportunities" and "Agency of archived opportunities" appear in the list of agencies in the agency filter
8. repeat steps 3 - 9 using search filter drawer with searchDrawerOn:true param
