### PR TITLE
[Issue #4393] Temporary disable auto deploy to dev

### DIFF
--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -2,13 +2,13 @@ name: Deploy API
 run-name: Deploy ${{ inputs.version || 'main' }} to API ${{ inputs.environment || (github.event_name == 'release' && 'prod') || 'nonprod' }}
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - "api/**"
-      - "infra/api/**"
-      - "infra/modules/**"
+  # push:
+  #   branches:
+  #     - "main"
+  #   paths:
+  #     - "api/**"
+  #     - "infra/api/**"
+  #     - "infra/modules/**"
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -2,13 +2,13 @@ name: Deploy frontend
 run-name: Deploy ${{ inputs.version || 'main' }} to Frontend ${{ inputs.environment || (github.event_name == 'release' && 'prod') || 'nonprod' }}
 
 on:
-  push:
-    branches:
-      - "main"
-    paths:
-      - "frontend/**"
-      - "infra/frontend/**"
-      - "infra/modules/**"
+  # push:
+  #   branches:
+  #     - "main"
+  #   paths:
+  #     - "frontend/**"
+  #     - "infra/frontend/**"
+  #     - "infra/modules/**"
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Work for #4393

## Changes proposed

Commented out the push trigger in the cd-api and cd-frontend workflows


## Context for reviewers

Testing UUID migration in dev first. We want control over the environment and when the deploy happens so turning off auto deploy.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
