### PR TITLE
[unticketed] correctly center maintenance text

### DIFF
--- a/frontend/src/app/[locale]/maintenance/page.tsx
+++ b/frontend/src/app/[locale]/maintenance/page.tsx
@@ -27,8 +27,8 @@ export default function Maintenance({ params }: LocalizedPageProps) {
   return (
     <GridContainer className="padding-y-1 tablet:padding-y-3 desktop-lg:padding-y-6 padding-x-5 tablet:padding-x-7 desktop-lg:padding-x-10 text-center">
       <h2 className="margin-bottom-0">{t("heading")}</h2>
-      <div>{body}</div>
-      <div>{t("signOff")}</div>
+      <p className="margin-x-auto">{body}</p>
+      <p className="margin-x-auto">{t("signOff")}</p>
     </GridContainer>
   );
 }

--- a/frontend/src/app/[locale]/maintenance/page.tsx
+++ b/frontend/src/app/[locale]/maintenance/page.tsx
@@ -27,8 +27,8 @@ export default function Maintenance({ params }: LocalizedPageProps) {
   return (
     <GridContainer className="padding-y-1 tablet:padding-y-3 desktop-lg:padding-y-6 padding-x-5 tablet:padding-x-7 desktop-lg:padding-x-10 text-center">
       <h2 className="margin-bottom-0">{t("heading")}</h2>
-      <p>{body}</p>
-      <p>{t("signOff")}</p>
+      <div>{body}</div>
+      <div>{t("signOff")}</div>
     </GridContainer>
   );
 }


### PR DESCRIPTION
## Summary

unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

fixes centering text on maintenance page

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server
2. visit http://localhost:3000/maintenance
3. _VERIFY_: looks ok

### Screenshots

#### Bad
<img width="1233" alt="Screenshot 2025-07-07 at 5 14 35 PM" src="https://github.com/user-attachments/assets/5628673b-ebe2-40b6-9015-4726157bbb79" />


#### Good
<img width="1213" alt="Screenshot 2025-07-07 at 5 14 58 PM" src="https://github.com/user-attachments/assets/9f7fe354-6dae-42c6-911d-2d9ce92b886b" />
