### PR TITLE
[Unticketed] Fix a flaky test after the UUID work

### DIFF
--- a/api/tests/src/task/opportunities/test_store_opportunity_version_task.py
+++ b/api/tests/src/task/opportunities/test_store_opportunity_version_task.py
@@ -79,8 +79,10 @@ class TestStoreOpportunityVersionTask(BaseTestClass):
             ]
             == 2
         )
-        assert opp_vers[0].opportunity_id == oca_1.opportunity_id
-        assert opp_vers[1].opportunity_id == oca_2.opportunity_id
+        assert {opp_vers[0].opportunity_id, opp_vers[1].opportunity_id} == {
+            oca_1.opportunity_id,
+            oca_2.opportunity_id,
+        }
 
     def test_with_existing_opportunity_saved_version_no_diff(
         self, db_session, enable_factory_create, store_opportunity_version_task
@@ -119,8 +121,10 @@ class TestStoreOpportunityVersionTask(BaseTestClass):
             ]
             == 1
         )
-        assert opp_vers[0].opportunity_id == opp_ver_existing.opportunity_id
-        assert opp_vers[1].opportunity_id == opp_ver_existing.opportunity_id
+        assert [opp_vers[0].opportunity_id, opp_vers[1].opportunity_id] == [
+            opp_ver_existing.opportunity_id,
+            opp_ver_existing.opportunity_id,
+        ]
 
         # run with a second update
         oca.opportunity.current_opportunity_summary = None
@@ -137,4 +141,4 @@ class TestStoreOpportunityVersionTask(BaseTestClass):
             ]
             == 1
         )
-        assert opp_vers[2].opportunity_id == opp_ver_existing.opportunity_id
+        assert set([o.opportunity_id for o in opp_vers]) == {opp_ver_existing.opportunity_id}


### PR DESCRIPTION
## Summary

## Changes proposed
Fix a few tests that were flaky, likely due to the UUID issue causing the ordering to change (going from int primary key to uuid)
