### PR TITLE
[Issue #5634] Redirect prior int Opp ID to new UUID

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -8,7 +8,7 @@ import { OpportunityDetail } from "src/types/opportunity/opportunityResponseType
 import { WithFeatureFlagProps } from "src/types/uiTypes";
 
 import { getTranslations } from "next-intl/server";
-import { notFound, redirect } from "next/navigation";
+import { notFound, redirect, RedirectType } from "next/navigation";
 
 import BetaAlert from "src/components/BetaAlert";
 import Breadcrumbs from "src/components/Breadcrumbs";
@@ -112,6 +112,13 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
   opportunityData.summary = opportunityData?.summary
     ? opportunityData.summary
     : emptySummary();
+
+  if (id !== opportunityData.opportunity_id) {
+    redirect(
+      `/opportunity/${opportunityData.opportunity_id}`,
+      RedirectType.push,
+    );
+  }
 
   breadcrumbs.push({
     title: `${opportunityData.opportunity_title || ""}: ${opportunityData.opportunity_number}`,

--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -109,16 +109,16 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
     }
     throw error;
   }
-  opportunityData.summary = opportunityData?.summary
-    ? opportunityData.summary
-    : emptySummary();
-
   if (id !== opportunityData.opportunity_id) {
     redirect(
       `/opportunity/${opportunityData.opportunity_id}`,
       RedirectType.push,
     );
   }
+
+  opportunityData.summary = opportunityData?.summary
+    ? opportunityData.summary
+    : emptySummary();
 
   breadcrumbs.push({
     title: `${opportunityData.opportunity_title || ""}: ${opportunityData.opportunity_number}`,


### PR DESCRIPTION
## Summary

Work for #5634

## Changes proposed

If an Opportunity page is loaded using an Int ID, redirect to the same opportunity URL but with the new UUID

## Validation steps

1. Checkout the branch
2. Go to an int ID: https://localhost:3000/opportunity/3
3. Verify you're redirected to a UUID URL
4. Do a search
5. Click a search result
6. Verify the page loads without any redirect