### PR TITLE
[Issue #5582] add ethnio script for search launch survey

### DIFF
--- a/frontend/.pa11yci-desktop.json
+++ b/frontend/.pa11yci-desktop.json
@@ -6,7 +6,7 @@
       "color-contrast",
       "document-title",
       "frame-title",
-      "fram-tested"
+      "frame-tested"
     ],
     "concurrency": 1,
     "chromeLaunchConfig": {

--- a/frontend/.pa11yci-desktop.json
+++ b/frontend/.pa11yci-desktop.json
@@ -2,7 +2,12 @@
   "defaults": {
     "timeout": 240000,
     "runners": ["axe"],
-    "ignore": ["color-contrast", "document-title"],
+    "ignore": [
+      "color-contrast",
+      "document-title",
+      "frame-title",
+      "fram-tested"
+    ],
     "concurrency": 1,
     "chromeLaunchConfig": {
       "ignoreHTTPSErrors": true,

--- a/frontend/.pa11yci-mobile.json
+++ b/frontend/.pa11yci-mobile.json
@@ -6,7 +6,7 @@
       "color-contrast",
       "document-title",
       "frame-title",
-      "fram-tested"
+      "frame-tested"
     ],
     "concurrency": 1,
     "chromeLaunchConfig": {

--- a/frontend/.pa11yci-mobile.json
+++ b/frontend/.pa11yci-mobile.json
@@ -2,7 +2,12 @@
   "defaults": {
     "timeout": 240000,
     "runners": ["axe"],
-    "ignore": ["color-contrast", "document-title"],
+    "ignore": [
+      "color-contrast",
+      "document-title",
+      "frame-title",
+      "fram-tested"
+    ],
     "concurrency": 1,
     "chromeLaunchConfig": {
       "ignoreHTTPSErrors": true,

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,7 +15,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
 const appSassOptions = sassOptions(basePath);
 
 const cspHeader = `
-    default-src 'self' https://ethn.io http://ethn.io;
+    default-src 'self' https://ethn.io;
     script-src 'self' 'unsafe-eval' 'unsafe-inline';
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -25,7 +25,7 @@ const cspHeader = `
     base-uri 'self';
     media-src 'self';
     style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com/;
-    script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com/ https://fonts.googleapis.com/ https://js-agent.newrelic.com/;
+    script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com/ https://fonts.googleapis.com/ https://js-agent.newrelic.com/ https://ethn.io;
     form-action 'self';
     frame-ancestors 'none';
     upgrade-insecure-requests;

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -15,7 +15,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
 const appSassOptions = sassOptions(basePath);
 
 const cspHeader = `
-    default-src 'self';
+    default-src 'self' https://ethn.io http://ethn.io;
     script-src 'self' 'unsafe-eval' 'unsafe-inline';
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -78,6 +78,11 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
 
           dangerouslySetInnerHTML={{ __html: browserTimingHeader }}
         />
+        <Script
+          src="https://ethn.io/91732.js"
+          async={true}
+          type="text/javascript"
+        />
       </body>
     </html>
   );

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -67,22 +67,26 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
         <NextIntlClientProvider messages={messages}>
           <Layout locale={locale}>{children}</Layout>
         </NextIntlClientProvider>
-        <Script
-          id="nr-browser-agent"
-          // By setting the strategy to "beforeInteractive" we guarantee that
-          // the script will be added to the document's `head` element.
-          // However, we cannot add this because it needs to be in the Root Layout, outside of the [locale] directory
-          // And we cannot add beneath the local directory because our HTML tag needs to know about the locale
-          // Come back to this to see if we can find a solution later on
-          // strategy="beforeInteractive"
+        {environment.IS_CI !== "true" && (
+          <>
+            <Script
+              id="nr-browser-agent"
+              // By setting the strategy to "beforeInteractive" we guarantee that
+              // the script will be added to the document's `head` element.
+              // However, we cannot add this because it needs to be in the Root Layout, outside of the [locale] directory
+              // And we cannot add beneath the local directory because our HTML tag needs to know about the locale
+              // Come back to this to see if we can find a solution later on
+              // strategy="beforeInteractive"
 
-          dangerouslySetInnerHTML={{ __html: browserTimingHeader }}
-        />
-        <Script
-          src="https://ethn.io/91732.js"
-          async={true}
-          type="text/javascript"
-        />
+              dangerouslySetInnerHTML={{ __html: browserTimingHeader }}
+            />
+            <Script
+              src="https://ethn.io/91732.js"
+              async={true}
+              type="text/javascript"
+            />
+          </>
+        )}
       </body>
     </html>
   );

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -18,6 +18,7 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 
 import Layout from "src/components/Layout";
+import { ClientScriptInjector } from "src/components/ScriptInjector";
 
 const typedNewRelic = newrelic as NewRelicWithCorrectTypes;
 
@@ -80,11 +81,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
 
               dangerouslySetInnerHTML={{ __html: browserTimingHeader }}
             />
-            <Script
-              src="https://ethn.io/91732.js?page=search"
-              async={true}
-              type="text/javascript"
-            />
+            <ClientScriptInjector />
           </>
         )}
       </body>

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -81,7 +81,7 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
               dangerouslySetInnerHTML={{ __html: browserTimingHeader }}
             />
             <Script
-              src="https://ethn.io/91732.js"
+              src="https://ethn.io/91732.js?page=search"
               async={true}
               type="text/javascript"
             />

--- a/frontend/src/components/ScriptInjector.tsx
+++ b/frontend/src/components/ScriptInjector.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { environment } from "src/constants/environments";
+
+import { usePathname } from "next/navigation";
+import Script from "next/script";
+
+const scripts = {
+  ethnio: {
+    tag: (
+      <Script
+        src="https://ethn.io/91732.js"
+        async={true}
+        type="text/javascript"
+        key="ethnio"
+      />
+    ),
+    gate: (path: string, env: typeof environment) => {
+      return path.includes("/search") && env.IS_CI !== "true";
+    },
+  },
+};
+
+export function ClientScriptInjector() {
+  const path = usePathname();
+  const activeScripts = Object.values(scripts).map(({ tag, gate }) => {
+    return gate(path, environment) ? tag : "";
+  });
+  return <>{activeScripts}</>;
+}

--- a/frontend/src/components/ScriptInjector.tsx
+++ b/frontend/src/components/ScriptInjector.tsx
@@ -1,30 +1,16 @@
 "use client";
 
 import { environment } from "src/constants/environments";
+import { injectableScriptConfig } from "src/utils/injectableScripts";
 
 import { usePathname } from "next/navigation";
-import Script from "next/script";
-
-const scripts = {
-  ethnio: {
-    tag: (
-      <Script
-        src="https://ethn.io/91732.js"
-        async={true}
-        type="text/javascript"
-        key="ethnio"
-      />
-    ),
-    gate: (path: string, env: typeof environment) => {
-      return path.includes("/search") && env.IS_CI !== "true";
-    },
-  },
-};
 
 export function ClientScriptInjector() {
   const path = usePathname();
-  const activeScripts = Object.values(scripts).map(({ tag, gate }) => {
-    return gate(path, environment) ? tag : "";
-  });
+  const activeScripts = Object.values(injectableScriptConfig).map(
+    ({ tag, gate }) => {
+      return gate(path, environment) ? tag : "";
+    },
+  );
   return <>{activeScripts}</>;
 }

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -22,7 +22,10 @@ const {
   API_JWT_PUBLIC_KEY,
   NEW_RELIC_ENABLED,
   NEXT_RUNTIME,
+  CI,
 } = process.env;
+
+console.error("!!!", CI);
 
 export const featureFlags = {
   opportunityOff: FEATURE_OPPORTUNITY_OFF,
@@ -55,4 +58,5 @@ export const environment: { [key: string]: string } = {
   API_JWT_PUBLIC_KEY: API_JWT_PUBLIC_KEY || "",
   NEW_RELIC_ENABLED: NEW_RELIC_ENABLED || "false",
   NEXT_RUNTIME: NEXT_RUNTIME || "",
+  IS_CI: CI || "false",
 };

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -25,8 +25,6 @@ const {
   CI,
 } = process.env;
 
-console.error("!!!", CI);
-
 export const featureFlags = {
   opportunityOff: FEATURE_OPPORTUNITY_OFF,
   searchOff: FEATURE_SEARCH_OFF,

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -597,3 +597,7 @@ dl {
     background-color: color($theme-color-secondary-lightest);
   }
 }
+
+iframe[id^="ethnio-screener-"] {
+  position: fixed !important;
+}

--- a/frontend/src/utils/injectableScripts.tsx
+++ b/frontend/src/utils/injectableScripts.tsx
@@ -1,0 +1,19 @@
+import { environment } from "src/constants/environments";
+
+import Script from "next/script";
+
+export const injectableScriptConfig = {
+  ethnio: {
+    tag: (
+      <Script
+        src="https://ethn.io/91732.js"
+        async={true}
+        type="text/javascript"
+        key="ethnio"
+      />
+    ),
+    gate: (path: string, env: typeof environment) => {
+      return path.includes("/search") && env.IS_CI !== "true";
+    },
+  },
+};

--- a/frontend/tests/components/ScriptInjector.test.tsx
+++ b/frontend/tests/components/ScriptInjector.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+
+import { ClientScriptInjector } from "src/components/ScriptInjector";
+
+const usePathnameMock = jest.fn();
+const mockGate = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => usePathnameMock() as string,
+}));
+
+jest.mock("src/utils/injectableScripts", () => ({
+  injectableScriptConfig: {
+    test: {
+      tag: <a href="wherever">a link</a>,
+      gate: () => mockGate() as unknown,
+    },
+  },
+}));
+
+describe("ScriptInjector", () => {
+  afterEach(() => jest.resetAllMocks());
+  beforeEach(() => {
+    usePathnameMock.mockReturnValue("/fakepath");
+  });
+  it("inserts tag in config if gate function returns true", () => {
+    mockGate.mockReturnValue(true);
+    render(<ClientScriptInjector />);
+    expect(screen.getByRole("link", { name: "a link" })).toBeInTheDocument();
+  });
+  it("does not insert tag in config if gate function returns false", () => {
+    mockGate.mockReturnValue(false);
+    render(<ClientScriptInjector />);
+    expect(
+      screen.queryByRole("link", { name: "a link" }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Work for #5582

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds a from ethino to add a CSAT (customer satisfaction) survey on search pages. Since ethnio doesn't support the sort of page level targeting that need, this also adds a conditional script tag injector component.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Along with the 7/16 / 7/19 search launch we want to gauge user satisfaction. This survey should go out with the changes to enable the full search v2 experience.

Introduces a check for CI into the layout to avoid e2e or test failures due to script behavior that does not need to be covered by testing

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Note that ad blockers may block this script, I've had good luck using Chrome private windows for testing

1. start a local server on this branch
3. visit http://localhost:3000
4. _VERIFY_: a survey popup does not open
5. click "search" nav item
6. _VERIFY_: a survey popup opens

#### Screenshots

<img width="1329" height="733" alt="Screenshot 2025-07-11 at 11 00 12 AM" src="https://github.com/user-attachments/assets/c18af68c-32f4-4d6b-a2d0-bd2c414428ae" />


