### PR TITLE
[Issue #5379] Hook up MTLS ceritificates to MTLS ALBs

### DIFF
--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -7,6 +7,7 @@ module "dev_config" {
   network_name                    = "dev"
   domain_name                     = "api.dev.simpler.grants.gov"
   s3_cdn_domain_name              = "files.dev.simpler.grants.gov"
+  mtls_domain_name                = "soap.dev.simpler.grants.gov"
   enable_https                    = true
   has_database                    = local.has_database
   database_enable_http_endpoint   = true

--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -28,6 +28,7 @@ output "service_config" {
     service_name                    = "${local.prefix}${var.app_name}-${var.environment}"
     domain_name                     = var.domain_name
     s3_cdn_domain_name              = var.s3_cdn_domain_name
+    mtls_domain_name                = var.mtls_domain_name
     enable_https                    = var.enable_https
     region                          = var.default_region
     cpu                             = var.instance_cpu

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -30,6 +30,11 @@ variable "s3_cdn_domain_name" {
   default     = null
 }
 
+variable "mtls_domain_name" {
+  type        = string
+  description = "The domain name for the mTLS side-by-side ALB for the API"
+  default     = null
+}
 variable "enable_command_execution" {
   type        = bool
   description = "Enables the ability to manually execute commands on running service containers using AWS ECS Exec"

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -8,6 +8,7 @@ module "prod_config" {
   domain_name                     = "api.simpler.grants.gov"
   enable_https                    = true
   s3_cdn_domain_name              = "files.simpler.grants.gov"
+  mtls_domain_name                = "soap.simpler.grants.gov"
   has_database                    = local.has_database
   database_enable_http_endpoint   = true
   has_incident_management_service = local.has_incident_management_service

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -7,6 +7,7 @@ module "staging_config" {
   network_name                    = "staging"
   domain_name                     = "api.staging.simpler.grants.gov"
   s3_cdn_domain_name              = "files.staging.simpler.grants.gov"
+  mtls_domain_name                = "soap.staging.simpler.grants.gov"
   enable_https                    = true
   has_database                    = local.has_database
   database_enable_http_endpoint   = true

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -87,8 +87,7 @@ resource "aws_lb_listener" "alb_listener_https" {
   load_balancer_arn = aws_lb.alb[count.index].arn
   port              = 443
   protocol          = "HTTPS"
-  #TODO: figure out how we get soap. certificate here for false option
-  certificate_arn = count.index == 0 ? var.certificate_arn : var.certificate_arn
+  certificate_arn   = count.index == 0 ? var.certificate_arn : var.mtls_certificate_arn
   mutual_authentication {
     mode = count.index == 1 ? "passthrough" : "off"
   }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -318,3 +318,9 @@ variable "mtls_domain_name" {
   description = "The fully qualified domain name for the mTLS-enabled load balancer"
   default     = null
 }
+
+variable "mtls_certificate_arn" {
+  description = "The ARN of the certificate to use for the mTLS LB for the API"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

Work for #5379 

## Changes proposed

Following the process for CDN domain names and certificate references, hook up the mtls domain and certificate for the soap.<env>.simpler.grants.gov URLs.

## Validation steps

Manually deployed branch to Dev using terraform apply and tested successfully.