### PR TITLE
[Issue #5475] Add application list view endpoint

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -535,6 +535,55 @@ paths:
       summary: Form Get
       security:
       - ApiKeyAuth: []
+  /v1/users/{user_id}/applications:
+    post:
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserApplicationListResponse'
+          description: Successful response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Validation error
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Authentication error
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+      tags:
+      - User v1 - Internal Only
+      summary: Get all applications for a user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserApplicationListRequest'
+      security:
+      - ApiJwtAuth: []
   /v1/users/{user_id}/organizations:
     get:
       parameters:
@@ -3094,6 +3143,9 @@ components:
           type: integer
           description: The HTTP status code
           example: 200
+    UserApplicationListRequest:
+      type: object
+      properties: {}
     SamGovEntity:
       type: object
       properties:
@@ -3123,6 +3175,88 @@ components:
           anyOf:
           - $ref: '#/components/schemas/SamGovEntity'
           - type: 'null'
+    UserApplicationCompetition:
+      type: object
+      properties:
+        competition_id:
+          type: string
+          format: uuid
+          description: The competition ID
+          example: 123e4567-e89b-12d3-a456-426614174000
+        competition_title:
+          type: string
+          description: The title of the competition
+          example: Proposal for Advanced Research
+        opening_date:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: The opening date of the competition, the first day applications
+            are accepted
+        closing_date:
+          type:
+          - string
+          - 'null'
+          format: date
+          description: The closing date of the competition, the last day applications
+            are accepted
+        is_open:
+          type: boolean
+          description: Whether the competition is open and accepting applications
+    UserApplicationListItem:
+      type: object
+      properties:
+        application_id:
+          type: string
+          format: uuid
+          description: The application ID
+          example: 123e4567-e89b-12d3-a456-426614174000
+        application_name:
+          type:
+          - string
+          - 'null'
+          description: The name of the application
+          example: my app
+        application_status:
+          description: Status of the application
+          enum:
+          - in_progress
+          - submitted
+          - accepted
+          type:
+          - string
+        organization:
+          description: Organization associated with the application
+          type:
+          - object
+          - 'null'
+          anyOf:
+          - $ref: '#/components/schemas/UserOrganization'
+          - type: 'null'
+        competition:
+          description: Competition information
+          type:
+          - object
+          $ref: '#/components/schemas/UserApplicationCompetition'
+    UserApplicationListResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message to return
+          example: Success
+        data:
+          type: array
+          description: List of applications for the user
+          items:
+            type:
+            - object
+            $ref: '#/components/schemas/UserApplicationListItem'
+        status_code:
+          type: integer
+          description: The HTTP status code
+          example: 200
     UserOrganizationsResponse:
       type: object
       properties:

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -11,6 +11,8 @@ from src.api.route_utils import raise_flask_error
 from src.api.users import user_schemas
 from src.api.users.user_blueprint import user_blueprint
 from src.api.users.user_schemas import (
+    UserApplicationListRequestSchema,
+    UserApplicationListResponseSchema,
     UserDeleteSavedOpportunityResponseSchema,
     UserDeleteSavedSearchResponseSchema,
     UserGetResponseSchema,
@@ -39,6 +41,7 @@ from src.services.users.delete_saved_search import delete_saved_search
 from src.services.users.get_saved_opportunities import get_saved_opportunities
 from src.services.users.get_saved_searches import get_saved_searches
 from src.services.users.get_user import get_user
+from src.services.users.get_user_applications import get_user_applications
 from src.services.users.get_user_organizations import get_user_organizations
 from src.services.users.login_gov_callback_handler import (
     handle_login_gov_callback_request,
@@ -196,6 +199,38 @@ def user_get_organizations(db_session: db.Session, user_id: UUID) -> response.Ap
     )
 
     return response.ApiResponse(message="Success", data=organizations)
+
+
+@user_blueprint.post("/<uuid:user_id>/applications")
+@user_blueprint.input(UserApplicationListRequestSchema, location="json")
+@user_blueprint.output(UserApplicationListResponseSchema)
+@user_blueprint.doc(responses=[200, 401, 403])
+@user_blueprint.auth_required(api_jwt_auth)
+@flask_db.with_db_session()
+def user_get_applications(
+    db_session: db.Session, user_id: UUID, json_data: dict
+) -> response.ApiResponse:
+    """Get all applications for a user"""
+    logger.info("POST /v1/users/:user_id/applications")
+
+    user_token_session: UserTokenSession = api_jwt_auth.get_user_token_session()
+
+    # Verify the authenticated user matches the requested user_id
+    if user_token_session.user_id != user_id:
+        raise_flask_error(403, "Forbidden")
+
+    with db_session.begin():
+        applications = get_user_applications(db_session, user_id)
+
+    logger.info(
+        "Retrieved applications for user",
+        extra={
+            "user_id": user_id,
+            "application_count": len(applications),
+        },
+    )
+
+    return response.ApiResponse(message="Success", data=applications)
 
 
 @user_blueprint.post("/<uuid:user_id>/saved-opportunities")

--- a/api/src/api/users/user_schemas.py
+++ b/api/src/api/users/user_schemas.py
@@ -5,7 +5,7 @@ from src.api.opportunities_v1.opportunity_schemas import (
 )
 from src.api.schemas.extension import Schema, fields
 from src.api.schemas.response_schema import AbstractResponseSchema
-from src.constants.lookup_constants import ExternalUserType
+from src.constants.lookup_constants import ApplicationStatus, ExternalUserType
 from src.pagination.pagination_schema import generate_pagination_schema
 
 
@@ -195,4 +195,70 @@ class UserOrganizationsResponseSchema(AbstractResponseSchema):
     data = fields.List(
         fields.Nested(UserOrganizationSchema),
         metadata={"description": "List of organizations the user is associated with"},
+    )
+
+
+class UserApplicationListRequestSchema(Schema):
+    """Schema for application list request - currently empty but provided for future filtering"""
+
+    pass
+
+
+class UserApplicationCompetitionSchema(Schema):
+    """Schema for competition information in application list"""
+
+    competition_id = fields.UUID(metadata={"description": "The competition ID"})
+    competition_title = fields.String(
+        metadata={
+            "description": "The title of the competition",
+            "example": "Proposal for Advanced Research",
+        }
+    )
+    opening_date = fields.Date(
+        allow_none=True,
+        metadata={
+            "description": "The opening date of the competition, the first day applications are accepted"
+        },
+    )
+    closing_date = fields.Date(
+        allow_none=True,
+        metadata={
+            "description": "The closing date of the competition, the last day applications are accepted"
+        },
+    )
+    is_open = fields.Boolean(
+        metadata={"description": "Whether the competition is open and accepting applications"}
+    )
+
+
+class UserApplicationListItemSchema(Schema):
+    """Schema for individual application in the list"""
+
+    application_id = fields.UUID(metadata={"description": "The application ID"})
+    application_name = fields.String(
+        allow_none=True,
+        metadata={
+            "description": "The name of the application",
+            "example": "my app",
+        },
+    )
+    application_status = fields.Enum(
+        ApplicationStatus,
+        metadata={"description": "Status of the application"},
+    )
+    organization = fields.Nested(
+        UserOrganizationSchema,
+        allow_none=True,
+        metadata={"description": "Organization associated with the application"},
+    )
+    competition = fields.Nested(
+        UserApplicationCompetitionSchema,
+        metadata={"description": "Competition information"},
+    )
+
+
+class UserApplicationListResponseSchema(AbstractResponseSchema):
+    data = fields.List(
+        fields.Nested(UserApplicationListItemSchema),
+        metadata={"description": "List of applications for the user"},
     )

--- a/api/src/services/users/get_user_applications.py
+++ b/api/src/services/users/get_user_applications.py
@@ -15,13 +15,6 @@ logger = logging.getLogger(__name__)
 def get_user_applications(db_session: db.Session, user_id: UUID) -> list[Application]:
     """
     Get all applications for a user
-
-    Args:
-        db_session: Database session
-        user_id: The ID of the user to get applications for
-
-    Returns:
-        List of Application objects that the user has access to
     """
     logger.info(f"Getting applications for user {user_id}")
 

--- a/api/src/services/users/get_user_applications.py
+++ b/api/src/services/users/get_user_applications.py
@@ -1,0 +1,45 @@
+import logging
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+import src.adapters.db as db
+from src.db.models.competition_models import Application
+from src.db.models.entity_models import Organization
+from src.db.models.user_models import ApplicationUser
+
+logger = logging.getLogger(__name__)
+
+
+def get_user_applications(db_session: db.Session, user_id: UUID) -> list[Application]:
+    """
+    Get all applications for a user
+
+    Args:
+        db_session: Database session
+        user_id: The ID of the user to get applications for
+
+    Returns:
+        List of Application objects that the user has access to
+    """
+    logger.info(f"Getting applications for user {user_id}")
+
+    # Query for applications where the user is associated via ApplicationUser
+    result = db_session.execute(
+        select(Application)
+        .join(ApplicationUser, ApplicationUser.application_id == Application.application_id)
+        .where(ApplicationUser.user_id == user_id)
+        .options(
+            # Load the competition data
+            selectinload(Application.competition),
+            # Load organization and its sam_gov_entity
+            selectinload(Application.organization).selectinload(Organization.sam_gov_entity),
+        )
+    )
+
+    applications = list(result.scalars().all())
+
+    logger.info(f"Retrieved {len(applications)} applications for user {user_id}")
+
+    return applications

--- a/api/tests/src/api/users/test_user_application_routes.py
+++ b/api/tests/src/api/users/test_user_application_routes.py
@@ -1,0 +1,224 @@
+from src.api.users.user_schemas import UserApplicationListItemSchema
+from src.constants.lookup_constants import ApplicationStatus
+from tests.src.db.models.factories import (
+    ApplicationFactory,
+    ApplicationUserFactory,
+    CompetitionFactory,
+    OrganizationFactory,
+    SamGovEntityFactory,
+    UserFactory,
+)
+
+
+def test_user_get_applications_success(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test successful retrieval of applications for a user"""
+    # Create a competition
+    competition = CompetitionFactory.create(
+        competition_title="Test Competition",
+        opening_date=None,
+        closing_date=None,
+        is_simpler_grants_enabled=True,
+    )
+
+    # Create organization with SAM.gov entity
+    sam_gov_entity = SamGovEntityFactory.create(legal_business_name="Test Org LLC")
+    organization = OrganizationFactory.create(sam_gov_entity=sam_gov_entity)
+
+    # Create applications
+    application1 = ApplicationFactory.create(
+        competition=competition,
+        application_name="My First App",
+        application_status=ApplicationStatus.IN_PROGRESS,
+        organization=organization,
+    )
+    application2 = ApplicationFactory.create(
+        competition=competition,
+        application_name="My Second App",
+        application_status=ApplicationStatus.SUBMITTED,
+        organization=None,  # Individual application
+    )
+
+    # Associate user with applications
+    ApplicationUserFactory.create(user=user, application=application1, is_application_owner=True)
+    ApplicationUserFactory.create(user=user, application=application2, is_application_owner=True)
+
+    # Make the request
+    response = client.post(
+        f"/v1/users/{user.user_id}/applications",
+        json={},
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert "data" in response.json
+
+    # Check that we got both applications
+    applications = response.json["data"]
+    assert len(applications) == 2
+
+    # Sort by application name for consistent testing
+    applications.sort(key=lambda x: x["application_name"])
+
+    # Verify first application
+    app1_data = applications[0]
+    assert app1_data["application_id"] == str(application1.application_id)
+    assert app1_data["application_name"] == "My First App"
+    assert app1_data["application_status"] == ApplicationStatus.IN_PROGRESS.value
+
+    # Check organization data
+    assert app1_data["organization"] is not None
+    assert app1_data["organization"]["organization_id"] == str(organization.organization_id)
+    assert app1_data["organization"]["sam_gov_entity"]["legal_business_name"] == "Test Org LLC"
+
+    # Check competition data
+    assert app1_data["competition"]["competition_id"] == str(competition.competition_id)
+    assert app1_data["competition"]["competition_title"] == "Test Competition"
+    assert app1_data["competition"]["is_open"] is True
+
+    # Verify second application (individual)
+    app2_data = applications[1]
+    assert app2_data["application_id"] == str(application2.application_id)
+    assert app2_data["application_name"] == "My Second App"
+    assert app2_data["application_status"] == ApplicationStatus.SUBMITTED.value
+    assert app2_data["organization"] is None
+
+
+def test_user_get_applications_empty_list(
+    client, enable_factory_create, db_session, user_auth_token
+):
+    """Test when user has no applications"""
+    # Create a user with no applications
+    user = UserFactory.create()
+
+    response = client.post(
+        f"/v1/users/{user.user_id}/applications",
+        json={},
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 403  # User token doesn't match requested user
+
+
+def test_user_get_applications_empty_for_authenticated_user(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test when authenticated user has no applications"""
+    response = client.post(
+        f"/v1/users/{user.user_id}/applications",
+        json={},
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["message"] == "Success"
+    assert response.json["data"] == []
+
+
+def test_user_get_applications_forbidden_different_user(
+    client, enable_factory_create, db_session, user_auth_token
+):
+    """Test forbidden when requesting applications for a different user"""
+    other_user = UserFactory.create()
+
+    response = client.post(
+        f"/v1/users/{other_user.user_id}/applications",
+        json={},
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 403
+    assert "Forbidden" in response.json["message"]
+
+
+def test_user_get_applications_unauthorized(client, enable_factory_create, db_session, user):
+    """Test unauthorized when no auth token provided"""
+    response = client.post(
+        f"/v1/users/{user.user_id}/applications",
+        json={},
+        headers={"X-SGG-Token": "invalid-token"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_user_get_applications_multiple_competitions(
+    client, enable_factory_create, db_session, user, user_auth_token
+):
+    """Test user with applications across multiple competitions"""
+    # Create multiple competitions
+    competition1 = CompetitionFactory.create(
+        competition_title="Competition One", is_simpler_grants_enabled=True
+    )
+    competition2 = CompetitionFactory.create(
+        competition_title="Competition Two", is_simpler_grants_enabled=False
+    )
+
+    # Create applications for different competitions
+    application1 = ApplicationFactory.create(
+        competition=competition1,
+        application_name="App for Competition 1",
+        application_status=ApplicationStatus.IN_PROGRESS,
+    )
+    application2 = ApplicationFactory.create(
+        competition=competition2,
+        application_name="App for Competition 2",
+        application_status=ApplicationStatus.SUBMITTED,
+    )
+
+    # Associate user with applications
+    ApplicationUserFactory.create(user=user, application=application1)
+    ApplicationUserFactory.create(user=user, application=application2)
+
+    response = client.post(
+        f"/v1/users/{user.user_id}/applications",
+        json={},
+        headers={"X-SGG-Token": user_auth_token},
+    )
+
+    assert response.status_code == 200
+    applications = response.json["data"]
+    assert len(applications) == 2
+
+    # Check that we have applications from both competitions
+    competition_titles = {app["competition"]["competition_title"] for app in applications}
+    assert "Competition One" in competition_titles
+    assert "Competition Two" in competition_titles
+
+    # Check is_open values
+    comp1_app = next(
+        app for app in applications if app["competition"]["competition_title"] == "Competition One"
+    )
+    comp2_app = next(
+        app for app in applications if app["competition"]["competition_title"] == "Competition Two"
+    )
+
+    assert comp1_app["competition"]["is_open"] is True  # is_simpler_grants_enabled=True
+    assert comp2_app["competition"]["is_open"] is False  # is_simpler_grants_enabled=False
+
+
+def test_user_application_list_item_schema():
+    """Test that the schema can be instantiated and validated"""
+    schema = UserApplicationListItemSchema()
+
+    # Test data that matches the expected schema
+    test_data = {
+        "application_id": "123e4567-e89b-12d3-a456-426614174000",
+        "application_name": "Test Application",
+        "application_status": "in_progress",
+        "organization": None,
+        "competition": {
+            "competition_id": "123e4567-e89b-12d3-a456-426614174001",
+            "competition_title": "Test Competition",
+            "opening_date": None,
+            "closing_date": None,
+            "is_open": True,
+        },
+    }
+
+    # This should not raise any validation errors
+    result = schema.load(test_data)
+    assert result["application_name"] == "Test Application"
+    assert result["competition"]["competition_title"] == "Test Competition"

--- a/api/tests/src/services/users/test_get_user_applications.py
+++ b/api/tests/src/services/users/test_get_user_applications.py
@@ -1,0 +1,131 @@
+from src.constants.lookup_constants import ApplicationStatus
+from src.services.users.get_user_applications import get_user_applications
+from tests.src.db.models.factories import (
+    ApplicationFactory,
+    ApplicationUserFactory,
+    CompetitionFactory,
+    OrganizationFactory,
+    SamGovEntityFactory,
+    UserFactory,
+)
+
+
+def test_get_user_applications_success(enable_factory_create, db_session):
+    """Test successfully retrieving applications for a user"""
+    user = UserFactory.create()
+    competition = CompetitionFactory.create(competition_title="Test Competition")
+
+    # Create applications
+    application1 = ApplicationFactory.create(
+        competition=competition,
+        application_name="App 1",
+        application_status=ApplicationStatus.IN_PROGRESS,
+    )
+    application2 = ApplicationFactory.create(
+        competition=competition,
+        application_name="App 2",
+        application_status=ApplicationStatus.SUBMITTED,
+    )
+
+    # Associate user with applications
+    ApplicationUserFactory.create(user=user, application=application1)
+    ApplicationUserFactory.create(user=user, application=application2)
+
+    # Call the service
+    applications = get_user_applications(db_session, user.user_id)
+
+    # Verify results
+    assert len(applications) == 2
+    application_ids = {str(app.application_id) for app in applications}
+    assert str(application1.application_id) in application_ids
+    assert str(application2.application_id) in application_ids
+
+
+def test_get_user_applications_empty(enable_factory_create, db_session):
+    """Test retrieving applications for a user with no applications"""
+    user = UserFactory.create()
+
+    # Call the service
+    applications = get_user_applications(db_session, user.user_id)
+
+    # Should return empty list
+    assert len(applications) == 0
+
+
+def test_get_user_applications_with_organization(enable_factory_create, db_session):
+    """Test retrieving applications that have organizations"""
+    user = UserFactory.create()
+
+    # Create organization with SAM.gov entity
+    sam_gov_entity = SamGovEntityFactory.create(legal_business_name="Test Organization")
+    organization = OrganizationFactory.create(sam_gov_entity=sam_gov_entity)
+
+    competition = CompetitionFactory.create()
+    application = ApplicationFactory.create(
+        competition=competition,
+        organization=organization,
+        application_name="Org Application",
+    )
+
+    ApplicationUserFactory.create(user=user, application=application)
+
+    # Call the service
+    applications = get_user_applications(db_session, user.user_id)
+
+    # Verify results
+    assert len(applications) == 1
+    app = applications[0]
+    assert app.organization is not None
+    assert app.organization.sam_gov_entity.legal_business_name == "Test Organization"
+
+
+def test_get_user_applications_multiple_users(enable_factory_create, db_session):
+    """Test that we only get applications for the specified user"""
+    user1 = UserFactory.create()
+    user2 = UserFactory.create()
+
+    competition = CompetitionFactory.create()
+
+    # Create applications for different users
+    application1 = ApplicationFactory.create(competition=competition, application_name="User 1 App")
+    application2 = ApplicationFactory.create(competition=competition, application_name="User 2 App")
+
+    ApplicationUserFactory.create(user=user1, application=application1)
+    ApplicationUserFactory.create(user=user2, application=application2)
+
+    # Call the service for user1
+    applications = get_user_applications(db_session, user1.user_id)
+
+    # Should only get user1's application
+    assert len(applications) == 1
+    assert applications[0].application_name == "User 1 App"
+
+
+def test_get_user_applications_preloads_relationships(enable_factory_create, db_session):
+    """Test that the service properly preloads competition and organization relationships"""
+    user = UserFactory.create()
+
+    # Create organization with SAM.gov entity
+    sam_gov_entity = SamGovEntityFactory.create()
+    organization = OrganizationFactory.create(sam_gov_entity=sam_gov_entity)
+
+    competition = CompetitionFactory.create(competition_title="Test Competition")
+    application = ApplicationFactory.create(
+        competition=competition,
+        organization=organization,
+    )
+
+    ApplicationUserFactory.create(user=user, application=application)
+
+    # Call the service
+    applications = get_user_applications(db_session, user.user_id)
+
+    # Verify relationships are loaded (should not trigger additional queries)
+    app = applications[0]
+
+    # Competition should be loaded
+    assert app.competition.competition_title == "Test Competition"
+
+    # Organization and its SAM.gov entity should be loaded
+    assert app.organization is not None
+    assert app.organization.sam_gov_entity is not None


### PR DESCRIPTION
## Summary

Work for #5475

## Changes proposed

Add new Application List endpoint, associated schema objects
Add service to `get_user_applications`
Add unit tests

## Context for reviewers

In order to create an application list view, we need to create an endpoint to return all in-progress and completed applications.

## Validation steps

See attached unit tests