### PR TITLE
[Issue #4940] search results table always full width

### DIFF
--- a/frontend/src/components/TableWithResponsiveHeader.tsx
+++ b/frontend/src/components/TableWithResponsiveHeader.tsx
@@ -71,7 +71,7 @@ export const TableWithResponsiveHeader = ({
                   {headerContent[j].cellData}
                 </div>
                 <div
-                  className="flex-2 tablet:flex-3"
+                  className="flex-2"
                   data-testid={`responsive-data-${i}-${j}`}
                 >
                   {tableCell.cellData}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -563,6 +563,7 @@ dl {
 }
 
 .simpler-responsive-table {
+  min-width: 100%;
   thead {
     @include at-media("tablet-lg") {
       display: table-header-group;


### PR DESCRIPTION
## Summary

Work for #4940

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

ensure search results table is always full width regardless of the size of contents

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on main
2. update local data so that one opportunity has very short agency name and opportunity title. I used `USDA-CSREE` for the agency
3. run `make populate-search-opportunities` in api
4. visit http://localhost:3000/search?_ff=searchTableOn:true
5. enter the name of your renamed opportunity from step 2
6. _VERIFY_: the table is not full width
7. restart server on this branch and refresh page
8. _VERIFY_: the table is full width

### Screenshots

#### Before
<img width="1315" height="674" alt="Screenshot 2025-07-11 at 10 47 17 AM" src="https://github.com/user-attachments/assets/59831b41-969d-43c4-b7d5-217277456307" />

#### After
<img width="1282" height="666" alt="Screenshot 2025-07-11 at 10 46 52 AM" src="https://github.com/user-attachments/assets/366b483d-806f-4c23-ae3f-97925b762d6d" />


