### PR TITLE
[Issue #5600] Setup form for Project Abstract Summary

### DIFF
--- a/api/src/form_schema/forms/project_abstract_summary.py
+++ b/api/src/form_schema/forms/project_abstract_summary.py
@@ -1,0 +1,90 @@
+import uuid
+
+from src.db.models.competition_models import Form
+
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    "required": [
+        "funding_opportunity_number",
+        "applicant_name",
+        "project_title",
+        "project_abstract",
+    ],
+    "properties": {
+        "funding_opportunity_number": {
+            "type": "string",
+            "title": "Funding Opportunity Number",
+            "minLength": 1,
+            "maxLength": 40,
+        },
+        "assistance_listing_number": {
+            "type": "string",
+            "title": "Assistance Listing Number",
+            "minLength": 1,
+            "maxLength": 15,
+        },
+        "applicant_name": {
+            # NOTE: This is named OrganizationName in the XSD, but
+            # the UI calls it an applicant name.
+            # FUTURE WORK: This gets copied from the SF-424's OrganizationName field (called Legal Name in the UI)
+            "type": "string",
+            "title": "Applicant Name",
+            "description": "This should match the 'Legal Name' field from the SF-424 form",
+            "minLength": 1,
+            "maxLength": 60,
+        },
+        "project_title": {
+            # FUTURE WORK: This gets copied from the SF-424's ProjectTitle field
+            "type": "string",
+            "title": "Descriptive Title of Applicant's Project",
+            "description": "This should match the 'Project Title' field from the SF-424 form",
+            "minLength": 1,
+            "maxLength": 250,
+        },
+        "project_abstract": {
+            "type": "string",
+            "title": "Project Abstract",
+            "minLength": 1,
+            "maxLength": 4000,
+        },
+    },
+}
+
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "1. Everything",
+        "name": "Everything",
+        "children": [
+            {"type": "field", "definition": "/properties/funding_opportunity_number"},
+            {"type": "field", "definition": "/properties/assistance_listing_number"},
+            {"type": "field", "definition": "/properties/applicant_name"},
+            {"type": "field", "definition": "/properties/project_title"},
+            {"type": "field", "definition": "/properties/project_abstract"},
+        ],
+    }
+]
+
+FORM_RULE_SCHEMA = {
+    ##### PRE-POPULATION RULES
+    # Note - we don't have pre-population enabled yet, so these
+    # won't run yet.
+    # TODO - before we can enable prepopulation we need the following rules:
+    #   * assistance listing number
+    "funding_opportunity_number": {"gg_pre_population": {"rule": "opportunity_number"}},
+    "assistance_listing_number": {"gg_pre_population": {"rule": "assistance_listing_number"}},
+}
+
+ProjectAbstractSummary_v2_0 = Form(
+    # legacy form ID - 591
+    # https://grants.gov/forms/form-items-description/fid/591
+    form_id=uuid.UUID("bf683068-23a4-43fa-ac7a-0f046b83cb14"),
+    form_name="Project Abstract Summary",
+    form_version="2.0",
+    agency_code="SGG",
+    omb_number="4040-0019",
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    form_rule_schema=FORM_RULE_SCHEMA,
+    # No form instructions at the moment.
+)

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -489,8 +489,6 @@ FORM_UI_SCHEMA = [
 ]
 
 FORM_RULE_SCHEMA = {
-    # Pre-populate should have federal program name and assistance listing number
-    # Post-populate should have signature, signature date
     ##### PRE-POPULATION RULES
     # Note - we don't have pre-population enabled yet, so these
     # won't run yet.
@@ -516,7 +514,6 @@ SFLLL_v2_0 = Form(
     omb_number="4040-0013",
     form_json_schema=FORM_JSON_SCHEMA,
     form_ui_schema=FORM_UI_SCHEMA,
-    # No rule schema yet, we'll likely but automated sums in this
     form_rule_schema=FORM_RULE_SCHEMA,
     # No form instructions at the moment.
 )

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -10,6 +10,7 @@ import src.util.datetime_util as datetime_util
 import tests.src.db.models.factories as factories
 from src.adapters.db import PostgresDBClient
 from src.db.models.opportunity_models import Opportunity
+from src.form_schema.forms.project_abstract_summary import ProjectAbstractSummary_v2_0
 from src.form_schema.forms.sf424 import SF424_v4_0
 from src.form_schema.forms.sf424a import SF424a_v1_0
 from src.form_schema.forms.sflll import SFLLL_v2_0
@@ -81,6 +82,11 @@ def _build_pilot_competition(db_session: db.Session) -> None:
     sf424a = db_session.merge(SF424a_v1_0, load=True)
     factories.CompetitionFormFactory.create(
         competition=pilot_competition, form=sf424a, is_required=True
+    )
+
+    project_abstract_summary = db_session.merge(ProjectAbstractSummary_v2_0, load=True)
+    factories.CompetitionFormFactory.create(
+        competition=pilot_competition, form=project_abstract_summary, is_required=True
     )
 
     sflll = db_session.merge(SFLLL_v2_0, load=True)

--- a/api/tests/src/form_schema/forms/test_project_abstract_summary.py
+++ b/api/tests/src/form_schema/forms/test_project_abstract_summary.py
@@ -1,0 +1,107 @@
+import pytest
+
+from src.form_schema.forms.project_abstract_summary import ProjectAbstractSummary_v2_0
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+
+
+def validate_required(data: dict, expected_required_fields: list[str]):
+    validation_issues = validate_json_schema_for_form(data, ProjectAbstractSummary_v2_0)
+
+    assert len(validation_issues) == len(expected_required_fields)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in expected_required_fields
+
+
+@pytest.fixture
+def minimal_valid_summary_v2_0() -> dict:
+    return {
+        "funding_opportunity_number": "ABC-123",
+        "applicant_name": "My Company LLC",
+        "project_title": "Research into Science",
+        "project_abstract": "We plan to do research on science",
+    }
+
+
+@pytest.fixture
+def full_valid_summary_v2_0() -> dict:
+    return {
+        "funding_opportunity_number": "XYZ-456",
+        "assistance_listing_number": "12.345",
+        "applicant_name": "My Business Inc",
+        "project_title": "Space Exploration",
+        "project_abstract": "We are going to Pluto",
+    }
+
+
+def test_summary_v2_0_minimal_valid_json(minimal_valid_summary_v2_0):
+    validation_issues = validate_json_schema_for_form(
+        minimal_valid_summary_v2_0, ProjectAbstractSummary_v2_0
+    )
+    assert len(validation_issues) == 0
+
+
+def test_summary_v2_0_full_valid_json(full_valid_summary_v2_0):
+    validation_issues = validate_json_schema_for_form(
+        full_valid_summary_v2_0, ProjectAbstractSummary_v2_0
+    )
+    assert len(validation_issues) == 0
+
+
+def test_summary_v2_0_empty_json():
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.funding_opportunity_number",
+        "$.applicant_name",
+        "$.project_title",
+        "$.project_abstract",
+    ]
+
+    validate_required({}, EXPECTED_REQUIRED_FIELDS)
+
+
+def test_summary_v2_0_min_length():
+    data = {
+        "funding_opportunity_number": "",
+        "assistance_listing_number": "",
+        "applicant_name": "",
+        "project_title": "",
+        "project_abstract": "",
+    }
+    validation_issues = validate_json_schema_for_form(data, ProjectAbstractSummary_v2_0)
+
+    EXPECTED_ERROR_FIELDS = [
+        "$.funding_opportunity_number",
+        "$.assistance_listing_number",
+        "$.applicant_name",
+        "$.project_title",
+        "$.project_abstract",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_ERROR_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "minLength"
+        assert validation_issue.field in EXPECTED_ERROR_FIELDS
+
+
+def test_summary_v2_0_max_length():
+    data = {
+        "funding_opportunity_number": "a" * 41,
+        "assistance_listing_number": "b" * 16,
+        "applicant_name": "c" * 61,
+        "project_title": "d" * 251,
+        "project_abstract": "e" * 4001,
+    }
+    validation_issues = validate_json_schema_for_form(data, ProjectAbstractSummary_v2_0)
+
+    EXPECTED_ERROR_FIELDS = [
+        "$.funding_opportunity_number",
+        "$.assistance_listing_number",
+        "$.applicant_name",
+        "$.project_title",
+        "$.project_abstract",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_ERROR_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "maxLength"
+        assert validation_issue.field in EXPECTED_ERROR_FIELDS


### PR DESCRIPTION
## Summary

Work for #5600 

## Changes proposed
Create the form for the Project Abstract Summary

## Context for reviewers
This is a very simple form, 5 text questions. There are two fields that in the automation that exists in grants.gov get copied from the SF424, we don't have anything to support that planned yet, so I just noted them down for later. Likely we can do something with our rule schema to handle this, but that will require an entirely new rule setup to do.

## Validation steps
`make db-seed-local` will create an opportunity+competition with this attached to it. If you navigate to it via the frontend, it looks like this right now:

<img width="1137" height="865" alt="Screenshot 2025-07-11 at 1 37 45 PM" src="https://github.com/user-attachments/assets/4e035ba4-4dd2-4e8c-a1ef-eedd4702fe28" />

