### PR TITLE
[Issue #5239] Allow users to skip validation for non-required forms

### DIFF
--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -174,21 +174,16 @@ def validate_application_form(
     if not is_required:
         # For non-required forms, check is_included_in_submission
         if application_form.is_included_in_submission is None:
-            # If the form has no content and is_included_in_submission is None,
-            # treat it as not included in submission (don't validate)
-            if len(application_form.application_response) == 0:
-                should_run_json_schema_validation = False
-            else:
-                # If form has content but is_included_in_submission is None, require explicit setting
-                inclusion_errors.append(
-                    ValidationErrorDetail(
-                        message="is_included_in_submission must be set on all non-required forms",
-                        type=ValidationErrorType.MISSING_INCLUDED_IN_SUBMISSION,
-                        field="is_included_in_submission",
-                        value=None,
-                    )
+            # If form hasn't set is_included_in_submission, it's always an error regardless of content
+            inclusion_errors.append(
+                ValidationErrorDetail(
+                    message="is_included_in_submission must be set on all non-required forms",
+                    type=ValidationErrorType.MISSING_INCLUDED_IN_SUBMISSION,
+                    field="is_included_in_submission",
+                    value=None,
                 )
-                should_run_json_schema_validation = False
+            )
+            should_run_json_schema_validation = False
         elif application_form.is_included_in_submission is False:
             # Don't run JSON schema validation if form is not included in submission
             should_run_json_schema_validation = False

--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -150,7 +150,7 @@ def validate_application_form(
     application_form: ApplicationForm, action: ApplicationAction
 ) -> tuple[list[ValidationErrorDetail], list[ValidationErrorDetail]]:
     """Validate an application form, and set the current application form status
-    
+
     Returns:
         tuple: (form_validation_errors, inclusion_errors)
             - form_validation_errors: errors that should be wrapped in APPLICATION_FORM_VALIDATION

--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -118,25 +118,6 @@ def get_application_form_errors(
             application_form, action
         )
 
-        is_app_form_required = is_form_required(application_form)
-
-        # If the user has not yet started, we don't want to put
-        # every error message and instead just want a "form is required error"
-        # If the form is not required, then if they haven't started it
-        # we effectively just want to ignore it.
-        if len(application_form.application_response) == 0:
-            if is_app_form_required:
-                form_errors.append(
-                    ValidationErrorDetail(
-                        message=f"Form {application_form.form.form_name} is required",
-                        type=ValidationErrorType.MISSING_REQUIRED_FORM,
-                        field="form_id",
-                        value=application_form.form_id,
-                    )
-                )
-            # Don't add the form validation errors below if they haven't started yet
-            continue
-
         if form_validation_errors:
             form_error_map[str(application_form.application_form_id)] = form_validation_errors
 

--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -168,7 +168,6 @@ def validate_application_form(
     """Validate an application form, and set the current application form status"""
     form_validation_errors: list[ValidationErrorDetail] = []
 
-    # Always run rule validation
     context = JsonRuleContext(application_form, config=_get_json_rule_config_for_action(action))
     process_rule_schema_for_context(context)
     form_validation_errors.extend(context.validation_issues)

--- a/api/src/services/applications/get_application_form.py
+++ b/api/src/services/applications/get_application_form.py
@@ -48,9 +48,11 @@ def get_application_form(
         raise_flask_error(404, f"Application form with ID {app_form_id} not found")
 
     # Get a list of validation warnings (also sets form status)
-    warnings: list[ValidationErrorDetail] = validate_application_form(
+    form_warnings, inclusion_warnings = validate_application_form(
         application_form, ApplicationAction.GET
     )
+    # Combine all warnings
+    warnings = form_warnings + inclusion_warnings
 
     # Set the is_required field on the application form object
     application_form.is_required = is_form_required(application_form)  # type: ignore[attr-defined]

--- a/api/src/services/applications/get_application_form.py
+++ b/api/src/services/applications/get_application_form.py
@@ -48,11 +48,7 @@ def get_application_form(
         raise_flask_error(404, f"Application form with ID {app_form_id} not found")
 
     # Get a list of validation warnings (also sets form status)
-    form_warnings, inclusion_warnings = validate_application_form(
-        application_form, ApplicationAction.GET
-    )
-    # Combine all warnings
-    warnings = form_warnings + inclusion_warnings
+    warnings = validate_application_form(application_form, ApplicationAction.GET)
 
     # Set the is_required field on the application form object
     application_form.is_required = is_form_required(application_form)  # type: ignore[attr-defined]

--- a/api/src/services/applications/update_application_form.py
+++ b/api/src/services/applications/update_application_form.py
@@ -104,9 +104,11 @@ def update_application_form(
 
     # Get a list of validation warnings (also sets form status)
     # Always validate because inclusion status affects validation requirements
-    warnings: list[ValidationErrorDetail] = validate_application_form(
+    form_warnings, inclusion_warnings = validate_application_form(
         application_form, ApplicationAction.MODIFY
     )
+    # Combine all warnings
+    warnings = form_warnings + inclusion_warnings
 
     operation_type = []
     if application_response is not None:

--- a/api/src/services/applications/update_application_form.py
+++ b/api/src/services/applications/update_application_form.py
@@ -104,11 +104,7 @@ def update_application_form(
 
     # Get a list of validation warnings (also sets form status)
     # Always validate because inclusion status affects validation requirements
-    form_warnings, inclusion_warnings = validate_application_form(
-        application_form, ApplicationAction.MODIFY
-    )
-    # Combine all warnings
-    warnings = form_warnings + inclusion_warnings
+    warnings = validate_application_form(application_form, ApplicationAction.MODIFY)
 
     operation_type = []
     if application_response is not None:

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -43,3 +43,5 @@ class ValidationErrorType(StrEnum):
     MISSING_APPLICATION_FORM = "missing_application_form"
 
     UNKNOWN_APPLICATION_ATTACHMENT = "unknown_application_attachment"
+
+    MISSING_INCLUDED_IN_SUBMISSION = "missing_included_in_submission"

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1765,7 +1765,7 @@ def test_application_submit_rule_validation_issue(
     ]
 
 
-def test_application_submit_missing_required_form(
+def test_application_submit_invalid_required_form(
     client, enable_factory_create, db_session, user, user_auth_token
 ):
     today = get_now_us_eastern_date()
@@ -1786,7 +1786,7 @@ def test_application_submit_missing_required_form(
     ApplicationUserFactory.create(application=application, user=user)
 
     # Setup an application form without any answers yet
-    ApplicationFormFactory.create(
+    application_form = ApplicationFormFactory.create(
         application=application, competition_form=competition_form, application_response={}
     )
 
@@ -1798,12 +1798,14 @@ def test_application_submit_missing_required_form(
     # Assert response
     assert response.status_code == 422
     assert response.json["message"] == "The application has issues in its form responses."
+    # With the new validation logic, empty required forms generate APPLICATION_FORM_VALIDATION errors
+    # instead of MISSING_REQUIRED_FORM errors
     assert response.json["errors"] == [
         {
-            "field": "form_id",
-            "message": "Form ExampleForm-ABC is required",
-            "type": "missing_required_form",
-            "value": str(form.form_id),
+            "field": "application_form_id",
+            "message": "The application form has outstanding errors.",
+            "type": "application_form_validation",
+            "value": str(application_form.application_form_id),
         }
     ]
 

--- a/api/tests/src/services/applications/test_application_validation.py
+++ b/api/tests/src/services/applications/test_application_validation.py
@@ -152,8 +152,10 @@ def test_validate_form_all_valid_not_started_optional_form(
         application_response=VALID_FORM_B_RESPONSE,
     )
     application_form_c = ApplicationFormFactory.build(
-        application=application, competition_form=competition_form_c, application_response={},
-        is_included_in_submission=False
+        application=application,
+        competition_form=competition_form_c,
+        application_response={},
+        is_included_in_submission=False,
     )
     application.application_forms = [application_form_a, application_form_b, application_form_c]
 

--- a/api/tests/src/services/applications/test_application_validation.py
+++ b/api/tests/src/services/applications/test_application_validation.py
@@ -125,7 +125,7 @@ def test_validate_form_all_valid(
         application=application,
         competition_form=competition_form_c,
         application_response=VALID_FORM_C_RESPONSE,
-        is_included_in_submission=True,  # Set to True for non-required forms to run validation
+        is_included_in_submission=True,
     )
     application.application_forms = [application_form_a, application_form_b, application_form_c]
     # TODO - add attachment stuff

--- a/api/tests/src/services/applications/test_application_validation.py
+++ b/api/tests/src/services/applications/test_application_validation.py
@@ -152,7 +152,8 @@ def test_validate_form_all_valid_not_started_optional_form(
         application_response=VALID_FORM_B_RESPONSE,
     )
     application_form_c = ApplicationFormFactory.build(
-        application=application, competition_form=competition_form_c, application_response={}
+        application=application, competition_form=competition_form_c, application_response={},
+        is_included_in_submission=False
     )
     application.application_forms = [application_form_a, application_form_b, application_form_c]
 
@@ -248,8 +249,8 @@ def test_validate_forms_not_started_all_forms(
 
     # With the new validation logic:
     # - Required forms (A & B) generate APPLICATION_FORM_VALIDATION errors due to JSON schema validation
-    # - Non-required form (C) with empty response and is_included_in_submission=None is treated as not included (no error)
-    assert len(validation_errors) == 2
+    # - Non-required form (C) with empty response and is_included_in_submission=None generates MISSING_INCLUDED_IN_SUBMISSION error
+    assert len(validation_errors) == 3
 
     # Check for APPLICATION_FORM_VALIDATION errors for required forms A and B
     app_form_validation_errors = [
@@ -259,13 +260,13 @@ def test_validate_forms_not_started_all_forms(
     ]
     assert len(app_form_validation_errors) == 2
 
-    # No MISSING_INCLUDED_IN_SUBMISSION errors since empty optional form is treated as not included
+    # Should have one MISSING_INCLUDED_IN_SUBMISSION error for the non-required form
     missing_inclusion_errors = [
         error
         for error in validation_errors
         if error.type == ValidationErrorType.MISSING_INCLUDED_IN_SUBMISSION
     ]
-    assert len(missing_inclusion_errors) == 0
+    assert len(missing_inclusion_errors) == 1
 
     # Should have error details for forms A and B due to JSON schema validation failures
     assert len(error_detail) == 2

--- a/api/tests/src/services/applications/test_application_validation.py
+++ b/api/tests/src/services/applications/test_application_validation.py
@@ -473,10 +473,7 @@ def test_validate_application_form_required_form_ignores_is_included_in_submissi
         is_included_in_submission=None,
     )
 
-    form_errors, inclusion_errors = validate_application_form(
-        application_form, ApplicationAction.GET
-    )
-    validation_errors = form_errors + inclusion_errors
+    validation_errors = validate_application_form(application_form, ApplicationAction.GET)
 
     # Should have JSON schema validation error (type error for str_a)
     assert len(validation_errors) == 1
@@ -485,10 +482,7 @@ def test_validate_application_form_required_form_ignores_is_included_in_submissi
 
     # Test with is_included_in_submission = False (should still validate for required forms)
     application_form.is_included_in_submission = False
-    form_errors, inclusion_errors = validate_application_form(
-        application_form, ApplicationAction.GET
-    )
-    validation_errors = form_errors + inclusion_errors
+    validation_errors = validate_application_form(application_form, ApplicationAction.GET)
 
     # Should still have JSON schema validation error
     assert len(validation_errors) == 1
@@ -511,20 +505,15 @@ def test_validate_application_form_non_required_form_null_is_included_in_submiss
         is_included_in_submission=None,
     )
 
-    form_errors, inclusion_errors = validate_application_form(
-        application_form, ApplicationAction.GET
-    )
+    validation_errors = validate_application_form(application_form, ApplicationAction.GET)
 
-    # Should have no form validation errors (JSON schema validation shouldn't run)
-    assert len(form_errors) == 0
-
-    # Should have exactly one inclusion error for missing is_included_in_submission
-    assert len(inclusion_errors) == 1
-    assert inclusion_errors[0].type == ValidationErrorType.MISSING_INCLUDED_IN_SUBMISSION
-    assert inclusion_errors[0].field == "is_included_in_submission"
-    assert inclusion_errors[0].value is None
+    # Should have exactly one validation error for missing is_included_in_submission
+    assert len(validation_errors) == 1
+    assert validation_errors[0].type == ValidationErrorType.MISSING_INCLUDED_IN_SUBMISSION
+    assert validation_errors[0].field == "is_included_in_submission"
+    assert validation_errors[0].value is None
     assert (
-        inclusion_errors[0].message
+        validation_errors[0].message
         == "is_included_in_submission must be set on all non-required forms"
     )
 
@@ -545,13 +534,10 @@ def test_validate_application_form_non_required_form_false_is_included_in_submis
         is_included_in_submission=False,
     )
 
-    form_errors, inclusion_errors = validate_application_form(
-        application_form, ApplicationAction.GET
-    )
+    validation_errors = validate_application_form(application_form, ApplicationAction.GET)
 
     # Should have no validation errors because JSON schema validation is skipped
-    assert len(form_errors) == 0
-    assert len(inclusion_errors) == 0
+    assert len(validation_errors) == 0
 
 
 def test_validate_application_form_non_required_form_true_is_included_in_submission(form_c):
@@ -570,17 +556,12 @@ def test_validate_application_form_non_required_form_true_is_included_in_submiss
         is_included_in_submission=True,
     )
 
-    form_errors, inclusion_errors = validate_application_form(
-        application_form, ApplicationAction.GET
-    )
+    validation_errors = validate_application_form(application_form, ApplicationAction.GET)
 
-    # Should have JSON schema validation error in form_errors
-    assert len(form_errors) == 1
-    assert form_errors[0].type == "type"
-    assert "$.str_c" in form_errors[0].field
-
-    # Should have no inclusion errors
-    assert len(inclusion_errors) == 0
+    # Should have JSON schema validation error
+    assert len(validation_errors) == 1
+    assert validation_errors[0].type == "type"
+    assert "$.str_c" in validation_errors[0].field
 
 
 def test_validate_application_form_non_required_form_valid_response_true_is_included_in_submission(
@@ -601,13 +582,10 @@ def test_validate_application_form_non_required_form_valid_response_true_is_incl
         is_included_in_submission=True,
     )
 
-    form_errors, inclusion_errors = validate_application_form(
-        application_form, ApplicationAction.GET
-    )
+    validation_errors = validate_application_form(application_form, ApplicationAction.GET)
 
     # Should have no validation errors
-    assert len(form_errors) == 0
-    assert len(inclusion_errors) == 0
+    assert len(validation_errors) == 0
 
 
 def test_get_application_form_errors_with_is_included_in_submission_validation(

--- a/api/tests/src/services/applications/test_application_validation.py
+++ b/api/tests/src/services/applications/test_application_validation.py
@@ -246,11 +246,11 @@ def test_validate_forms_not_started_all_forms(
         application, ApplicationAction.GET
     )
 
-        # With the new validation logic:
+    # With the new validation logic:
     # - Required forms (A & B) generate APPLICATION_FORM_VALIDATION errors due to JSON schema validation
     # - Non-required form (C) with empty response and is_included_in_submission=None is treated as not included (no error)
     assert len(validation_errors) == 2
-    
+
     # Check for APPLICATION_FORM_VALIDATION errors for required forms A and B
     app_form_validation_errors = [
         error
@@ -258,7 +258,7 @@ def test_validate_forms_not_started_all_forms(
         if error.type == ValidationErrorType.APPLICATION_FORM_VALIDATION
     ]
     assert len(app_form_validation_errors) == 2
-    
+
     # No MISSING_INCLUDED_IN_SUBMISSION errors since empty optional form is treated as not included
     missing_inclusion_errors = [
         error
@@ -288,9 +288,9 @@ def test_validate_forms_optional_form_with_content_missing_inclusion_flag(
     )
     # Optional form C has content but is_included_in_submission is None
     application_form_c = ApplicationFormFactory.build(
-        application=application, 
-        competition_form=competition_form_c, 
-        application_response={"str_c": "some content"}
+        application=application,
+        competition_form=competition_form_c,
+        application_response={"str_c": "some content"},
     )
     application.application_forms = [application_form_a, application_form_b, application_form_c]
 
@@ -301,7 +301,10 @@ def test_validate_forms_optional_form_with_content_missing_inclusion_flag(
     # Should have 1 MISSING_INCLUDED_IN_SUBMISSION error for the optional form with content
     assert len(validation_errors) == 1
     assert validation_errors[0].type == ValidationErrorType.MISSING_INCLUDED_IN_SUBMISSION
-    assert validation_errors[0].message == "is_included_in_submission must be set on all non-required forms"
+    assert (
+        validation_errors[0].message
+        == "is_included_in_submission must be set on all non-required forms"
+    )
 
     # No error details since the forms with content are valid
     assert len(error_detail) == 0
@@ -467,7 +470,9 @@ def test_validate_application_form_required_form_ignores_is_included_in_submissi
         is_included_in_submission=None,
     )
 
-    form_errors, inclusion_errors = validate_application_form(application_form, ApplicationAction.GET)
+    form_errors, inclusion_errors = validate_application_form(
+        application_form, ApplicationAction.GET
+    )
     validation_errors = form_errors + inclusion_errors
 
     # Should have JSON schema validation error (type error for str_a)
@@ -477,7 +482,9 @@ def test_validate_application_form_required_form_ignores_is_included_in_submissi
 
     # Test with is_included_in_submission = False (should still validate for required forms)
     application_form.is_included_in_submission = False
-    form_errors, inclusion_errors = validate_application_form(application_form, ApplicationAction.GET)
+    form_errors, inclusion_errors = validate_application_form(
+        application_form, ApplicationAction.GET
+    )
     validation_errors = form_errors + inclusion_errors
 
     # Should still have JSON schema validation error
@@ -501,11 +508,13 @@ def test_validate_application_form_non_required_form_null_is_included_in_submiss
         is_included_in_submission=None,
     )
 
-    form_errors, inclusion_errors = validate_application_form(application_form, ApplicationAction.GET)
+    form_errors, inclusion_errors = validate_application_form(
+        application_form, ApplicationAction.GET
+    )
 
     # Should have no form validation errors (JSON schema validation shouldn't run)
     assert len(form_errors) == 0
-    
+
     # Should have exactly one inclusion error for missing is_included_in_submission
     assert len(inclusion_errors) == 1
     assert inclusion_errors[0].type == ValidationErrorType.MISSING_INCLUDED_IN_SUBMISSION
@@ -533,7 +542,9 @@ def test_validate_application_form_non_required_form_false_is_included_in_submis
         is_included_in_submission=False,
     )
 
-    form_errors, inclusion_errors = validate_application_form(application_form, ApplicationAction.GET)
+    form_errors, inclusion_errors = validate_application_form(
+        application_form, ApplicationAction.GET
+    )
 
     # Should have no validation errors because JSON schema validation is skipped
     assert len(form_errors) == 0
@@ -556,13 +567,15 @@ def test_validate_application_form_non_required_form_true_is_included_in_submiss
         is_included_in_submission=True,
     )
 
-    form_errors, inclusion_errors = validate_application_form(application_form, ApplicationAction.GET)
+    form_errors, inclusion_errors = validate_application_form(
+        application_form, ApplicationAction.GET
+    )
 
     # Should have JSON schema validation error in form_errors
     assert len(form_errors) == 1
     assert form_errors[0].type == "type"
     assert "$.str_c" in form_errors[0].field
-    
+
     # Should have no inclusion errors
     assert len(inclusion_errors) == 0
 
@@ -585,7 +598,9 @@ def test_validate_application_form_non_required_form_valid_response_true_is_incl
         is_included_in_submission=True,
     )
 
-    form_errors, inclusion_errors = validate_application_form(application_form, ApplicationAction.GET)
+    form_errors, inclusion_errors = validate_application_form(
+        application_form, ApplicationAction.GET
+    )
 
     # Should have no validation errors
     assert len(form_errors) == 0

--- a/api/tests/src/services/applications/test_submit_application.py
+++ b/api/tests/src/services/applications/test_submit_application.py
@@ -91,7 +91,7 @@ def test_submit_application_with_missing_required_form(enable_factory_create, db
     )
 
 
-def test_submit_application_with_not_started_required_form(enable_factory_create, db_session, user):
+def test_submit_application_with_invalid_required_form(enable_factory_create, db_session, user):
     competition = CompetitionFactory.create(competition_forms=[])
     form = FormFactory.create(form_json_schema=SIMPLE_JSON_SCHEMA)
     competition_form = CompetitionFormFactory.create(competition=competition, form=form)
@@ -112,9 +112,11 @@ def test_submit_application_with_not_started_required_form(enable_factory_create
 
     assert excinfo.value.status_code == 422
     assert excinfo.value.message == "The application has issues in its form responses."
+    # With the new validation logic, empty required forms generate APPLICATION_FORM_VALIDATION errors
+    # instead of MISSING_REQUIRED_FORM errors
     assert (
         excinfo.value.extra_data["validation_issues"][0].type
-        == ValidationErrorType.MISSING_REQUIRED_FORM
+        == ValidationErrorType.APPLICATION_FORM_VALIDATION
     )
 
 


### PR DESCRIPTION
## Summary

Work for #5239

## Changes proposed

Added new validation logic for `is_included_in_submission` flag on application forms
Added new validation error type `MISSING_INCLUDED_IN_SUBMISSION`
Updated `validate_application_form` to implement conditional validation logic based on form requirement status / inclusion flag
Add tests

## Context for reviewers

Gives users explicit control over validation for non-required forms. Previously, all forms (required and non-required) would always run JSON schema validation

## Validation steps

See updated unit tests