### PR TITLE
[Issue #5383] opportunity detail margins

### DIFF
--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -47,6 +47,9 @@ def _build_opportunities(
             size=2, is_posted_summary=True, has_long_descriptions=True
         )
         factories.OpportunityFactory.create_batch(
+            size=2, is_posted_summary=True, has_long_descriptions=True, has_attachments=True
+        )
+        factories.OpportunityFactory.create_batch(
             size=2, agency_code="CLOSED", is_closed_summary=True
         )
         factories.OpportunityFactory.create_batch(

--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -148,7 +148,10 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
               />
             )}
         </div>
-        <div className="grid-row grid-gap margin-top-2">
+        <div
+          className="grid-row grid-gap margin-top-2"
+          id="opportunity-detail-content"
+        >
           <div className="desktop:grid-col-8 tablet:grid-col-12 tablet:order-1 desktop:order-first">
             <OpportunityIntro opportunityData={opportunityData} />
             <OpportunityDescription

--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -152,7 +152,7 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
           className="grid-row grid-gap margin-top-2"
           id="opportunity-detail-content"
         >
-          <div className="desktop:grid-col-8 tablet:grid-col-12 tablet:order-1 desktop:order-first">
+          <div className="desktop:grid-col-8 grid-col-12 order-1 desktop:order-first">
             <OpportunityIntro opportunityData={opportunityData} />
             <OpportunityDescription
               summary={opportunityData.summary}
@@ -165,7 +165,7 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
             <OpportunityLink opportunityData={opportunityData} />
           </div>
 
-          <div className="desktop:grid-col-4 tablet:grid-col-12 tablet:order-0">
+          <div className="desktop:grid-col-4 grid-col-12 order-0">
             <OpportunityStatusWidget opportunityData={opportunityData} />
             <OpportunityCTA legacyId={opportunityData.legacy_opportunity_id} />
             <OpportunityAwardInfo opportunityData={opportunityData} />

--- a/frontend/src/components/opportunity/OpportunityAwardGridRow.tsx
+++ b/frontend/src/components/opportunity/OpportunityAwardGridRow.tsx
@@ -22,7 +22,7 @@ const OpportunityAwardGridRow = ({ title, content }: Props) => {
       <p className="font-sans-sm text-bold margin-bottom-0">
         {content || defaultContentByType(title)}
       </p>
-      <p className="desktop-lg:font-sans-sm margin-top-0">{t(`${title}`)}</p>
+      <p className="desktop-lg:font-sans-sm">{t(`${title}`)}</p>
     </div>
   );
 };

--- a/frontend/src/components/opportunity/OpportunityAwardInfo.tsx
+++ b/frontend/src/components/opportunity/OpportunityAwardInfo.tsx
@@ -96,7 +96,7 @@ const OpportunityAwardInfo = ({ opportunityData }: Props) => {
             {t(`${title as TranslationKeys}`)}
             {":"}
           </p>
-          <div className={"margin-top-0"}>{formatSubContent(content)}</div>
+          <div>{formatSubContent(content)}</div>
         </div>
       ))}
     </div>

--- a/frontend/src/components/opportunity/OpportunityDownload.tsx
+++ b/frontend/src/components/opportunity/OpportunityDownload.tsx
@@ -15,9 +15,13 @@ const OpportunityDownload = ({ attachments }: OpportunityDownloadProps) => {
   const t = useTranslations("OpportunityListing.description");
 
   return attachments.length > 0 ? (
-    <Button type="button" unstyled>
+    <Button
+      type="button"
+      unstyled
+      className="margin-top-2 tablet:margin-top-0 flex-align-self-center"
+    >
       <USWDSIcon name="arrow_downward" />
-      <Link className="flex-align-self-center" href={"#opportunity_documents"}>
+      <Link className="flex-align-self-center " href={"#opportunity_documents"}>
         {t("jumpToDocuments")}
       </Link>
     </Button>

--- a/frontend/src/components/opportunity/OpportunityDownload.tsx
+++ b/frontend/src/components/opportunity/OpportunityDownload.tsx
@@ -21,7 +21,7 @@ const OpportunityDownload = ({ attachments }: OpportunityDownloadProps) => {
       className="margin-top-2 tablet:margin-top-0 flex-align-self-center"
     >
       <USWDSIcon name="arrow_downward" />
-      <Link className="flex-align-self-center " href={"#opportunity_documents"}>
+      <Link className="flex-align-self-center" href={"#opportunity_documents"}>
         {t("jumpToDocuments")}
       </Link>
     </Button>

--- a/frontend/src/components/opportunity/OpportunityEligibility.tsx
+++ b/frontend/src/components/opportunity/OpportunityEligibility.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { upperFirst } from "lodash";
 import { eligbilityValueToGroup } from "src/constants/opportunity";
 import { eligibilityOptions } from "src/constants/searchFilterOptions";
@@ -41,8 +42,15 @@ export const OpportunityEligibility = ({
             <div key={`eligibility-group${groupName}`}>
               <h4>{upperFirst(groupName)}</h4>
               <ul>
-                {applicantTypes.map((display) => (
-                  <li key={display}>{display}</li>
+                {applicantTypes.map((display, i) => (
+                  <li
+                    key={display}
+                    className={clsx({
+                      "margin-bottom-2": i === applicantTypes.length - 1,
+                    })}
+                  >
+                    {display}
+                  </li>
                 ))}
               </ul>
             </div>

--- a/frontend/src/components/opportunity/OpportunityHistory.tsx
+++ b/frontend/src/components/opportunity/OpportunityHistory.tsx
@@ -23,7 +23,7 @@ export const OpportunityHistoryItem = ({
         {title}
         {":"}
       </p>
-      <p className={"margin-top-0"}>{content}</p>
+      <p>{content}</p>
     </div>
   );
 };

--- a/frontend/src/components/opportunity/OpportunityIntro.tsx
+++ b/frontend/src/components/opportunity/OpportunityIntro.tsx
@@ -57,7 +57,7 @@ const OpportunityIntro = ({ opportunityData }: Props) => {
 
   return (
     <>
-      <p className="usa-intro line-height-sans-5 tablet-lg:font-sans-lg margin-top-0">{`${t("agency")} ${agencyName}`}</p>
+      <p className="usa-intro line-height-sans-5 tablet-lg:font-sans-lg">{`${t("agency")} ${agencyName}`}</p>
       <AssistanceListingsDisplay
         assistanceListings={opportunityData.opportunity_assistance_listings}
         assistanceListingsText={t("assistanceListings")}

--- a/frontend/src/components/opportunity/OpportunityStatusWidget.tsx
+++ b/frontend/src/components/opportunity/OpportunityStatusWidget.tsx
@@ -23,7 +23,7 @@ const CloseDateDescriptionDisplay = ({
 
   if (closeDateDescription?.length < 150) {
     return (
-      <div className="border radius-md border-base-lighter padding-x-2 margin-top-0">
+      <div className="border radius-md border-base-lighter padding-x-2">
         <p className="line-height-sans-5">{closeDateDescription}</p>
       </div>
     );
@@ -35,7 +35,7 @@ const CloseDateDescriptionDisplay = ({
   const postSplit = closeDateDescription.substring(splitAt + 1);
 
   return (
-    <div className="border radius-md border-base-lighter padding-x-2 margin-top-0">
+    <div className="border radius-md border-base-lighter padding-x-2">
       <p className="line-height-sans-5">{preSplit}...</p>
       <ContentDisplayToggle
         showCallToAction={t("showDescription")}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -631,5 +631,15 @@ iframe[id^="ethnio-screener-"] {
     border-bottom: 2px solid color("base-darkest");
     transform: rotate(-45deg);
     transform-origin: left bottom;
+
+  }
+}
+
+#opportunity-detail-content {
+  p:first-child {
+    margin-top: 1rem;
+  }
+  p:last-child {
+    margin-bottom: 1rem;
   }
 }

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -631,7 +631,6 @@ iframe[id^="ethnio-screener-"] {
     border-bottom: 2px solid color("base-darkest");
     transform: rotate(-45deg);
     transform-origin: left bottom;
-
   }
 }
 

--- a/frontend/tests/components/opportunity/OpportunityAwardGridRow.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityAwardGridRow.test.tsx
@@ -39,7 +39,7 @@ describe("OpportunityAwardGridRow", () => {
 
     const titleElement = screen.getByText(mockTranslations.programFunding);
     expect(titleElement).toBeInTheDocument();
-    expect(titleElement).toHaveClass("desktop-lg:font-sans-sm margin-top-0");
+    expect(titleElement).toHaveClass("desktop-lg:font-sans-sm");
   });
 
   it("accepts number value for content", () => {


### PR DESCRIPTION
## Summary

Work for #5383

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Improves spacing on opportunity detail page

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Looks like some vertical spacing related to first and last <p> tag children was lost during the typography refactor. This adds it back

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. find your local opportunity that has a long description and attachments
2. start a local server on this branch
3. visit http://localhost:3000/opportunity/<your complete opportunity id>
4. _VERIFY_: spacing matches screenshot, mobile an desktop views look correct

### Screenshots

<img width="2880" height="6534" alt="Screenshot 2025-07-15 at 09-50-21 Opportunity Listing - Julie Schmidt Foundation Grant for extend B2B convergence" src="https://github.com/user-attachments/assets/ecaf4897-8f60-4456-83a7-fe31db2a1f16" />
