### PR TITLE
[Issue #4412] fix unstable saved search select state

### DIFF
--- a/frontend/src/components/search/SaveSearchSelector.tsx
+++ b/frontend/src/components/search/SaveSearchSelector.tsx
@@ -88,7 +88,7 @@ export const SaveSearchSelector = ({
         }
         const searchQueryParams = searchToQueryParams(searchToApply);
         setApplyingSavedSearch(true);
-        replaceQueryParams(searchQueryParams);
+        replaceQueryParams({ ...searchQueryParams, savedSearch: selectedId });
         updateQueryTerm(searchQueryParams.query || "");
       }
     },
@@ -116,28 +116,58 @@ export const SaveSearchSelector = ({
         // this works now but may not if once we introduce token refreshes.
         // if a token changes without clearing the newSavedSearches list on the parent
         // we could accidentally select a saved search on token refresh
-        setApplyingSavedSearch(true);
+        // setApplyingSavedSearch(true);
         setSelectedSavedSearch(savedSearchToSetInSelectAfterFetch);
-        if (savedSearchQueryValue) {
-          removeQueryParam("savedSearch");
-        }
+        // if (savedSearchQueryValue) {
+        //   removeQueryParam("savedSearch");
+        // }
       }
       setRunPostFetchActions(false);
     }
   }, [runPostFetchActions, searchParams, newSavedSearches, removeQueryParam]);
 
-  // reset saved search selector on search change
+  // I think this works...
   useEffect(() => {
-    // we want to display the name of selected saved search on selection, so opt out of clearing during apply
-    if (!applyingSavedSearch && searchParams !== prevSearchParams) {
+    console.log(
+      "####",
+      searchParams !== prevSearchParams,
+      searchParams.get("savedSearch"),
+      prevSearchParams?.get("savedSearch"),
+    );
+    if (
+      searchParams !== prevSearchParams &&
+      searchParams.get("savedSearch") &&
+      prevSearchParams?.get("savedSearch")
+    ) {
       setSelectedSavedSearch("");
+      removeQueryParam("savedSearch");
     }
-  }, [searchParams, prevSearchParams, applyingSavedSearch]);
+  }, [searchParams, prevSearchParams, removeQueryParam]);
 
-  // clear applying saved flag when searchParams change
-  useEffect(() => {
-    setApplyingSavedSearch(false);
-  }, [searchParams]);
+  // // reset saved search selector on search change
+  // useEffect(() => {
+  //   // we want to display the name of selected saved search on selection, so opt out of clearing during apply
+  //   console.log(
+  //     "!!!",
+  //     !applyingSavedSearch,
+  //     searchParams !== prevSearchParams,
+  //     searchParams,
+  //     prevSearchParams,
+  //   );
+  //   // if (selectedSavedSearch && searchParams !== prevSearchParams) {
+  //   if (!applyingSavedSearch && searchParams !== prevSearchParams) {
+  //     setSelectedSavedSearch("");
+  //   }
+  //   if (applyingSavedSearch) {
+  //     setApplyingSavedSearch(false);
+  //   }
+  // }, [searchParams, prevSearchParams, applyingSavedSearch]);
+  // // }, [searchParams, prevSearchParams, selectedSavedSearch]);
+
+  // // clear applying saved flag when searchParams change
+  // useEffect(() => {
+  //   setApplyingSavedSearch(false);
+  // }, [searchParams]);
 
   if (apiError) {
     return (

--- a/frontend/src/hooks/useSearchParamUpdater.ts
+++ b/frontend/src/hooks/useSearchParamUpdater.ts
@@ -57,7 +57,9 @@ export function useSearchParamUpdater() {
     router.push(`${pathname}${paramsToFormattedQuery(params)}`, { scroll });
   };
 
-  const replaceQueryParams = (params: ValidSearchQueryParamData) => {
+  const replaceQueryParams = (
+    params: ValidSearchQueryParamData | { savedSearch?: string },
+  ) => {
     router.push(`${pathname}${queryParamsToQueryString(params)}`);
   };
 

--- a/frontend/src/utils/injectableScripts.tsx
+++ b/frontend/src/utils/injectableScripts.tsx
@@ -13,7 +13,11 @@ export const injectableScriptConfig = {
       />
     ),
     gate: (path: string, env: typeof environment) => {
-      return path.includes("/search") && env.IS_CI !== "true";
+      return (
+        path.includes("/search") &&
+        env.IS_CI !== "true" &&
+        env.ENVIRONMENT !== "dev"
+      );
     },
   },
 };


### PR DESCRIPTION
## Summary

Work for #4412

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Changes logic for resetting selected saved search state that was not airtight, and resulted in the state not being reset when search paramters were updated after applying a saved search

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch
2. visit http://localhost:3000/search
3. log in
4. set up a search to save with a keyword and various filters selected
5. save the search
6. _VERIFY_: correct saved search appears in saved search drop down
7. update filters
8. _VERIFY_: saved search drop down resets to default state
9. select saved search from drop down
10. _VERIFY_: correct saved search appears in saved search drop down
11. update keyword term
8. _VERIFY_: saved search drop down resets to default state
9. visit http://localhost:3000/saved-search-queries
10. click on a saved search
10. _VERIFY_: correct saved search appears in saved search drop down