### PR TITLE
[Issue #5003] Suppress important dates fields update  

### DIFF
--- a/api/src/task/notifications/opportunity_notifcation.py
+++ b/api/src/task/notifications/opportunity_notifcation.py
@@ -435,15 +435,27 @@ class OpportunityNotificationTask(BaseNotificationTask):
             return NOT_SPECIFIED
         return value
 
-    def _build_important_dates_content(self, imp_dates_change: dict) -> str:
-        important_section = SECTION_STYLING.format("Important dates")
+    def _build_important_dates_content(
+        self, imp_dates_change: dict, opportunity_status: dict | None
+    ) -> str:
+        relevant_changes = []
         for field, change in imp_dates_change.items():
             before = self._normalize_date_field(change["before"])
             after = self._normalize_date_field(change["after"])
-            important_section += (
+            if field != "close_date":
+                if (
+                    opportunity_status
+                    and opportunity_status["before"] == OpportunityStatus.FORECASTED
+                ):
+                    continue
+            relevant_changes.append(
                 f"{BULLET_POINTS_STYLING} {IMPORTANT_DATE_FIELDS[field]} {before} to {after}.<br>"
             )
-        return important_section
+
+        if not relevant_changes:
+            return ""
+        important_section = SECTION_STYLING.format("Important dates")
+        return important_section + "".join(relevant_changes)
 
     def _build_opportunity_status_content(self, status_change: dict) -> str:
         before = status_change["before"]
@@ -475,7 +487,11 @@ class OpportunityNotificationTask(BaseNotificationTask):
         if "opportunity_status" in changes:
             sections.append(self._build_opportunity_status_content(changes["opportunity_status"]))
         if important_date_diffs := {k: changes[k] for k in IMPORTANT_DATE_FIELDS if k in changes}:
-            sections.append(self._build_important_dates_content(important_date_diffs))
+            sections.append(
+                self._build_important_dates_content(
+                    important_date_diffs, changes.get("opportunity_status", None)
+                )
+            )
         if award_fields_diffs := {k: changes[k] for k in AWARD_FIELDS if k in changes}:
             sections.append(self._build_award_fields_content(award_fields_diffs))
         if categorization_fields_diffs := {

--- a/api/tests/src/task/notifications/test_opportunity_notification.py
+++ b/api/tests/src/task/notifications/test_opportunity_notification.py
@@ -618,24 +618,28 @@ class TestOpportunityNotification:
         assert res == expected_html
 
     @pytest.mark.parametrize(
-        "imp_dates_diffs,expected_html",
+        "imp_dates_diffs,opportunity_status,expected_html",
         [
             # close_date
             (
                 {"close_date": {"before": "2035-10-10", "after": "2035-10-30"}},
+                None,
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The application due date changed from October 10, 2035 to October 30, 2035.<br>',
             ),
             (
                 {"close_date": {"before": "2025-10-10", "after": None}},
+                {"before": OpportunityStatus.POSTED, "after": OpportunityStatus.FORECASTED},
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The application due date changed from October 10, 2025 to not specified.<br>',
             ),
             # forecasted_award_date
             (
                 {"forecasted_award_date": {"before": "2030-1-6", "after": "2031-5-3"}},
+                None,
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The estimated award date changed from January 6, 2030 to May 3, 2031.<br>',
             ),
             (
                 {"forecasted_award_date": {"before": None, "after": "2026-9-11"}},
+                {"before": OpportunityStatus.POSTED, "after": OpportunityStatus.FORECASTED},
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The estimated award date changed from not specified to September 11, 2026.<br>',
             ),
             # forecasted_project_start_date
@@ -646,20 +650,47 @@ class TestOpportunityNotification:
                         "after": "2031-5-3",
                     }
                 },
+                None,
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The estimated project start date changed from January 7, 2027 to May 3, 2031.<br>',
             ),
             (
                 {"forecasted_project_start_date": {"before": None, "after": "2028-1-7"}},
+                {"before": OpportunityStatus.POSTED, "after": OpportunityStatus.FORECASTED},
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The estimated project start date changed from not specified to January 7, 2028.<br>',
             ),
             # fiscal_year
             (
                 {"fiscal_year": {"before": 2050, "after": 2051}},
+                None,
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The fiscal year changed from 2050 to 2051.<br>',
             ),
             (
                 {"fiscal_year": {"before": 2033, "after": None}},
+                None,
                 '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The fiscal year changed from 2033 to not specified.<br>',
+            ),
+            (
+                {"fiscal_year": {"before": 2033, "after": None}},
+                {"before": OpportunityStatus.FORECASTED, "after": OpportunityStatus.POSTED},
+                "",
+            ),
+            (
+                {"forecasted_project_start_date": {"before": "2028-1-7", "after": "2029-1-7"}},
+                {"before": OpportunityStatus.FORECASTED, "after": OpportunityStatus.CLOSED},
+                "",
+            ),
+            (
+                {"forecasted_award_date": {"before": "2025-10-7", "after": None}},
+                {"before": OpportunityStatus.FORECASTED, "after": OpportunityStatus.ARCHIVED},
+                "",
+            ),
+            (
+                {
+                    "forecasted_award_date": {"before": "2025-10-7", "after": None},
+                    "close_date": {"before": "2035-10-10", "after": "2035-10-30"},
+                },
+                {"before": OpportunityStatus.FORECASTED, "after": OpportunityStatus.POSTED},
+                '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The application due date changed from October 10, 2035 to October 30, 2035.<br>',
             ),
         ],
     )
@@ -667,12 +698,12 @@ class TestOpportunityNotification:
         self,
         db_session,
         imp_dates_diffs,
+        opportunity_status,
         expected_html,
         set_env_var_for_email_notification_config,
         notification_task,
     ):
-        res = notification_task._build_important_dates_content(imp_dates_diffs)
-
+        res = notification_task._build_important_dates_content(imp_dates_diffs, opportunity_status)
         assert res == expected_html
 
     @pytest.mark.parametrize(
@@ -1035,7 +1066,7 @@ class TestOpportunityNotification:
             revision_number=2,
             opportunity_title="Topaz 2025 Climate Research Grant",
             opportunity_status=OpportunityStatus.CLOSED,
-            close_date=date(2025, 12, 31),
+            close_date=None,
             forecasted_award_date=date(2026, 3, 15),
             forecasted_project_start_date=date(2026, 5, 1),
             fiscal_year=2026,
@@ -1064,10 +1095,7 @@ class TestOpportunityNotification:
             message=(
                 f"The following funding opportunity recently changed:<br><br><div>1. <a href='http://testhost:3000/opportunity/{TOPAZ.opportunity_id}' target='_blank'>Topaz 2025 Climate Research Grant</a><br><br>Here’s what changed:</div>"
                 '<p style="padding-left: 20px;">Status</p><p style="padding-left: 40px;">•  The status changed from Forecasted to Closed.<br><br>'
-                '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The application due date changed from November 30, 2025 to December 31, 2025.<br>'
-                '<p style="padding-left: 40px;">•  The estimated award date changed from February 1, 2026 to March 15, 2026.<br>'
-                '<p style="padding-left: 40px;">•  The estimated project start date changed from April 15, 2026 to May 1, 2026.<br>'
-                '<p style="padding-left: 40px;">•  The fiscal year changed from 2025 to 2026.<br><br>'
+                '<p style="padding-left: 20px;">Important dates</p><p style="padding-left: 40px;">•  The application due date changed from November 30, 2025 to not specified.<br><br>'
                 '<p style="padding-left: 20px;">Awards details</p><p style="padding-left: 40px;">•  Program funding changed from $10,000,000 to $12,000,000.<br>'
                 '<p style="padding-left: 40px;">•  The number of expected awards changed from 7 to 5.<br>'
                 '<p style="padding-left: 40px;">•  The award minimum changed from $100,000 to $200,000.<br>'


### PR DESCRIPTION
>> When Opportunity Status changes from Forecasted to any other status and there is an update to either of these Forecast Specific fields `forecasted_award_date`, `forecasted_project_start_date`, `fiscal_year` do not include in the email content. 
>> Add/Update tests tests