### PR TITLE
[Issue #5721] some non-search related query params as custom new relic attributes

### DIFF
--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -3,7 +3,7 @@
 import { sendGAEvent } from "@next/third-parties/google";
 import { omit } from "lodash";
 import { OptionalStringDict } from "src/types/generalTypes";
-import { validSearchQueryParamKeys } from "src/types/search/searchQueryTypes";
+import { expectedQueryParamKeys } from "src/types/search/searchQueryTypes";
 import {
   setNewRelicCustomAttribute,
   unsetAllNewRelicQueryAttributes,
@@ -44,7 +44,7 @@ function SearchAnalytics({
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
         // only pass on valid query params to NR
-        if ((validSearchQueryParamKeys as readonly string[]).includes(key)) {
+        if ((expectedQueryParamKeys as readonly string[]).includes(key)) {
           setNewRelicCustomAttribute(key, value || "");
         }
       });

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -21,6 +21,13 @@ export const validSearchQueryParamKeys = [
   "sortby",
 ] as const;
 
+// an allow list for any paramaters we expect and would like to keep track of in New Relic or elsewhere
+export const expectedQueryParamKeys = [
+  ...validSearchQueryParamKeys,
+  "utm_source",
+  "savedSearch",
+];
+
 // Only a few defined keys possible
 // URL example => ?query=abcd&status=closed,archived
 export type ValidSearchQueryParam = (typeof validSearchQueryParamKeys)[number];


### PR DESCRIPTION
## Summary

Work for #5721

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->



## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

we're doing this to primarily track incoming links from grants.gov

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Could test this with NR locally but I didn't bother

1. after deploy, visit http://dev.simpler.grants.gov/search?utm_source=test
2. _VERIFY_: you see a hit for this query in new relic
```
FROM BrowserInteraction SELECT search_param_utm_source WHERE appName = 'frontend-dev' SINCE 1 day ago
```
