### PR TITLE
Add a new env var (AWS_STORAGE_BUCKET_NAME) to NOFOs app container

### DIFF
--- a/infra/nofos/app-config/env-config/environment_variables.tf
+++ b/infra/nofos/app-config/env-config/environment_variables.tf
@@ -26,5 +26,10 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/nofos/${var.environment}/secret-key"
     }
+
+    AWS_STORAGE_BUCKET_NAME = {
+      manage_method     = "manual"
+      secret_store_name = "/nofos/${var.environment}/aws-storage-bucket-name"
+    }
   }
 }


### PR DESCRIPTION
## Summary

This is prep work for an upcoming task to build an image uploading feature.

## Changes proposed

Add this new env var to the NOFOs app container task definition: `AWS_STORAGE_BUCKET_NAME`

Should be self-evident what it is for.

