### PR TITLE
[Issue #5601] Setup SF424B form

### DIFF
--- a/api/src/form_schema/forms/sf424b.py
+++ b/api/src/form_schema/forms/sf424b.py
@@ -1,0 +1,76 @@
+import uuid
+
+from src.db.models.competition_models import Form
+
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    "required": ["signature", "title", "applicant_organization", "date_signed"],
+    "properties": {
+        "signature": {
+            "type": "string",
+            "title": "Signature of the Authorized Certifying Official",
+            "description": "Completed by Grants.gov upon submission.",
+            "minLength": 1,
+            "maxLength": 144,
+        },
+        "title": {
+            # FUTURE WORK: This gets copied from the SF-424's AuthorizedRepresentativeTitle field
+            "type": "string",
+            "title": "Title",
+            "description": "This should match the 'Authorized Representative Title' field from the SF-424 form",
+            "minLength": 1,
+            "maxLength": 45,
+        },
+        "applicant_organization": {
+            # FUTURE WORK: This gets copied from the SF-424's OrganizationName field (called Legal Name in the UI)
+            "type": "string",
+            "title": "Applicant Organization",
+            "description": "This should match the 'Legal Name' field from the SF-424 form",
+            "minLength": 1,
+            "maxLength": 60,
+        },
+        "date_signed": {
+            "type": "string",
+            "format": "date",
+            "title": "Date Signed",
+            "description": "Completed by Grants.gov upon submission.",
+        },
+    },
+}
+
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "1. Everything",
+        "name": "Everything",
+        "children": [
+            {"type": "field", "definition": "/properties/signature"},
+            {"type": "field", "definition": "/properties/title"},
+            {"type": "field", "definition": "/properties/applicant_organization"},
+            {"type": "field", "definition": "/properties/date_signed"},
+        ],
+    }
+]
+
+FORM_RULE_SCHEMA = {
+    ##### PRE-POPULATION RULES
+    # Note - we don't have pre-population enabled yet, so these
+    # won't run yet.
+    "signature": {"gg_pre_population": {"rule": "signature"}},
+    "date_signed": {"gg_post_population": {"rule": "current_date"}},
+}
+
+SF424b_v1_1 = Form(
+    # https://grants.gov/forms/form-items-description/fid/240
+    form_id=uuid.UUID("1d0681f8-26f9-4ff1-a75e-e33477668f73"),
+    legacy_form_id=240,
+    form_name="Assurances for Non-Construction Programs (SF-424B)",
+    short_form_name="SF424B",
+    form_version="1.1",
+    agency_code="SGG",
+    omb_number="4040-0007",
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    form_rule_schema=FORM_RULE_SCHEMA,
+    # No form instructions at the moment.
+)

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -13,6 +13,7 @@ from src.db.models.opportunity_models import Opportunity
 from src.form_schema.forms.project_abstract_summary import ProjectAbstractSummary_v2_0
 from src.form_schema.forms.sf424 import SF424_v4_0
 from src.form_schema.forms.sf424a import SF424a_v1_0
+from src.form_schema.forms.sf424b import SF424b_v1_1
 from src.form_schema.forms.sflll import SFLLL_v2_0
 from src.util.local import error_if_not_local
 from tests.lib.seed_agencies import _build_agencies
@@ -93,6 +94,11 @@ def _build_pilot_competition(db_session: db.Session) -> None:
     project_abstract_summary = db_session.merge(ProjectAbstractSummary_v2_0, load=True)
     factories.CompetitionFormFactory.create(
         competition=pilot_competition, form=project_abstract_summary, is_required=True
+    )
+
+    sf424b = db_session.merge(SF424b_v1_1, load=True)
+    factories.CompetitionFormFactory.create(
+        competition=pilot_competition, form=sf424b, is_required=True
     )
 
     sflll = db_session.merge(SFLLL_v2_0, load=True)

--- a/api/tests/src/form_schema/forms/test_sf424b.py
+++ b/api/tests/src/form_schema/forms/test_sf424b.py
@@ -1,0 +1,91 @@
+import pytest
+
+from src.form_schema.forms.sf424b import SF424b_v1_1
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+
+
+def validate_required(data: dict, expected_required_fields: list[str]):
+    validation_issues = validate_json_schema_for_form(data, SF424b_v1_1)
+
+    assert len(validation_issues) == len(expected_required_fields)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in expected_required_fields
+
+
+@pytest.fixture
+def minimal_valid_sf424b_v1_1() -> dict:
+    return {
+        "signature": "Bob Smith",
+        "title": "Mr.",
+        "applicant_organization": "Business Inc.",
+        "date_signed": "2025-01-01",
+    }
+
+
+def test_sf424b_v1_1_minimal_valid_json(minimal_valid_sf424b_v1_1):
+    validation_issues = validate_json_schema_for_form(minimal_valid_sf424b_v1_1, SF424b_v1_1)
+    assert len(validation_issues) == 0
+
+
+def test_sf424b_v1_1_empty_json():
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.signature",
+        "$.title",
+        "$.applicant_organization",
+        "$.date_signed",
+    ]
+
+    validate_required({}, EXPECTED_REQUIRED_FIELDS)
+
+
+def test_sf424b_v1_1_min_length():
+    data = {
+        "signature": "",
+        "title": "",
+        "applicant_organization": "",
+        "date_signed": "2025-01-01",
+    }
+    validation_issues = validate_json_schema_for_form(data, SF424b_v1_1)
+
+    EXPECTED_ERROR_FIELDS = [
+        "$.signature",
+        "$.title",
+        "$.applicant_organization",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_ERROR_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "minLength"
+        assert validation_issue.field in EXPECTED_ERROR_FIELDS
+
+
+def test_sf424b_v1_1_max_length():
+    data = {
+        "signature": "a" * 145,
+        "title": "b" * 46,
+        "applicant_organization": "c" * 61,
+        "date_signed": "2025-01-01",
+    }
+    validation_issues = validate_json_schema_for_form(data, SF424b_v1_1)
+
+    EXPECTED_ERROR_FIELDS = [
+        "$.signature",
+        "$.title",
+        "$.applicant_organization",
+    ]
+
+    assert len(validation_issues) == len(EXPECTED_ERROR_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "maxLength"
+        assert validation_issue.field in EXPECTED_ERROR_FIELDS
+
+
+def test_sf424b_v1_1_date_field(minimal_valid_sf424b_v1_1):
+    data = minimal_valid_sf424b_v1_1
+    data["date_signed"] = "not-a-date"
+    validation_issues = validate_json_schema_for_form(data, SF424b_v1_1)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "format"
+    assert validation_issues[0].message == "'not-a-date' is not a 'date'"


### PR DESCRIPTION
## Summary

Work for #5601

## Changes proposed
Add the SF424B form definition

## Context for reviewers
Another short form, nothing new here.

## Validation steps
`make db-seed-local` now has the form added, going to the competition it creates has a form that looks like this right now:
<img width="1166" height="682" alt="Screenshot 2025-07-18 at 1 02 11 PM" src="https://github.com/user-attachments/assets/9a884038-f8fc-44d7-92b8-a98a5b1e7547" />

