### PR TITLE
[Issue #5697 & #5698] Add Budget & Project Narrative Attachment Forms

### DIFF
--- a/api/src/form_schema/forms/budget_narrative_attachment.py
+++ b/api/src/form_schema/forms/budget_narrative_attachment.py
@@ -1,0 +1,53 @@
+import uuid
+
+from src.db.models.competition_models import Form
+
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    "required": ["attachments"],
+    "properties": {
+        "attachments": {
+            "type": "array",
+            "title": "Budget Narrative Files",
+            "description": "At least one file must be attached",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {"allOf": [{"$ref": "#/$defs/attachment_field"}]},
+        }
+    },
+    "$defs": {
+        # Just defining this separately so it's easier to refactor when we have a shared schema
+        "attachment_field": {"type": "string", "format": "uuid"},
+    },
+}
+
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "1. Everything",
+        "name": "Everything",
+        "children": [
+            {"type": "field", "definition": "/properties/attachments"},
+        ],
+    }
+]
+
+FORM_RULE_SCHEMA = {
+    ##### VALIDATION RULES
+    "attachments": {"gg_validation": {"rule": "attachment"}},
+}
+
+BudgetNarrativeAttachment_v1_2 = Form(
+    # https://grants.gov/forms/form-items-description/fid/543
+    form_id=uuid.UUID("66092260-d3c2-4427-8fd2-bb14e1590aff"),
+    legacy_form_id=543,
+    form_name="Budget Narrative Attachment Form",
+    short_form_name="BudgetNarrativeAttachments_1_2",
+    form_version="1.2",
+    agency_code="SGG",
+    omb_number=None,
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    form_rule_schema=FORM_RULE_SCHEMA,
+    # No form instructions at the moment.
+)

--- a/api/src/form_schema/forms/project_narrative_attachment.py
+++ b/api/src/form_schema/forms/project_narrative_attachment.py
@@ -1,0 +1,53 @@
+import uuid
+
+from src.db.models.competition_models import Form
+
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    "required": ["attachments"],
+    "properties": {
+        "attachments": {
+            "type": "array",
+            "title": "Project Narrative Files",
+            "description": "At least one file must be attached",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {"allOf": [{"$ref": "#/$defs/attachment_field"}]},
+        }
+    },
+    "$defs": {
+        # Just defining this separately so it's easier to refactor when we have a shared schema
+        "attachment_field": {"type": "string", "format": "uuid"},
+    },
+}
+
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "1. Everything",
+        "name": "Everything",
+        "children": [
+            {"type": "field", "definition": "/properties/attachments"},
+        ],
+    }
+]
+
+FORM_RULE_SCHEMA = {
+    ##### VALIDATION RULES
+    "attachments": {"gg_validation": {"rule": "attachment"}},
+}
+
+ProjectNarrativeAttachment_v1_2 = Form(
+    # https://grants.gov/forms/form-items-description/fid/539
+    form_id=uuid.UUID("32165da2-354d-42c0-a986-cf4f2f350039"),
+    legacy_form_id=539,
+    form_name="Project Narrative Attachment Form",
+    short_form_name="ProjectNarrativeAttachments_1_2",
+    form_version="1.2",
+    agency_code="SGG",
+    omb_number=None,
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    form_rule_schema=FORM_RULE_SCHEMA,
+    # No form instructions at the moment.
+)

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -10,7 +10,9 @@ import src.util.datetime_util as datetime_util
 import tests.src.db.models.factories as factories
 from src.adapters.db import PostgresDBClient
 from src.db.models.opportunity_models import Opportunity
+from src.form_schema.forms.budget_narrative_attachment import BudgetNarrativeAttachment_v1_2
 from src.form_schema.forms.project_abstract_summary import ProjectAbstractSummary_v2_0
+from src.form_schema.forms.project_narrative_attachment import ProjectNarrativeAttachment_v1_2
 from src.form_schema.forms.sf424 import SF424_v4_0
 from src.form_schema.forms.sf424a import SF424a_v1_0
 from src.form_schema.forms.sflll import SFLLL_v2_0
@@ -93,6 +95,16 @@ def _build_pilot_competition(db_session: db.Session) -> None:
     project_abstract_summary = db_session.merge(ProjectAbstractSummary_v2_0, load=True)
     factories.CompetitionFormFactory.create(
         competition=pilot_competition, form=project_abstract_summary, is_required=True
+    )
+
+    project_narrative_attachment = db_session.merge(ProjectNarrativeAttachment_v1_2, load=True)
+    factories.CompetitionFormFactory.create(
+        competition=pilot_competition, form=project_narrative_attachment, is_required=True
+    )
+
+    budget_narrative_attachment = db_session.merge(BudgetNarrativeAttachment_v1_2, load=True)
+    factories.CompetitionFormFactory.create(
+        competition=pilot_competition, form=budget_narrative_attachment, is_required=True
     )
 
     sflll = db_session.merge(SFLLL_v2_0, load=True)

--- a/api/tests/src/form_schema/forms/test_budget_narrative_attachment.py
+++ b/api/tests/src/form_schema/forms/test_budget_narrative_attachment.py
@@ -1,0 +1,57 @@
+import pytest
+
+from src.form_schema.forms.budget_narrative_attachment import BudgetNarrativeAttachment_v1_2
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+
+
+def validate_required(data: dict, expected_required_fields: list[str]):
+    validation_issues = validate_json_schema_for_form(data, BudgetNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == len(expected_required_fields)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in expected_required_fields
+
+
+@pytest.fixture
+def minimal_valid_budget_narrative_v1_2():
+    return {"attachments": ["00b9001b-6ca8-4c0c-9328-46f39e9ff14b"]}
+
+
+def test_budget_narrative_v1_2_minimal_valid_json(minimal_valid_budget_narrative_v1_2):
+    validation_issues = validate_json_schema_for_form(
+        minimal_valid_budget_narrative_v1_2, BudgetNarrativeAttachment_v1_2
+    )
+    assert len(validation_issues) == 0
+
+
+def test_budget_narrative_v1_2_empty_json():
+    validate_required({}, ["$.attachments"])
+
+
+def test_budget_narrative_v1_2_empty_attachments():
+    data = {"attachments": []}
+    validation_issues = validate_json_schema_for_form(data, BudgetNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minItems"
+    assert validation_issues[0].message == "[] should be non-empty"
+
+
+def test_budget_narrative_v1_2_too_many_attachments():
+    data = {"attachments": ["c8eebbcc-a6ec-4b20-9bfa-e6bcc5abb6d5" for _ in range(101)]}
+    validation_issues = validate_json_schema_for_form(data, BudgetNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxItems"
+    assert validation_issues[0].message == "The array is too long, expected a maximum length of 100"
+
+
+def test_budget_narrative_v1_2_attachment_type():
+    data = {"attachments": ["c8eebbcc-a6ec-4b20-9bfa-e6bcc5abb6d5", "my_attachment"]}
+    validation_issues = validate_json_schema_for_form(data, BudgetNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "format"
+    assert validation_issues[0].message == "'my_attachment' is not a 'uuid'"
+    assert validation_issues[0].field == "$.attachments[1]"

--- a/api/tests/src/form_schema/forms/test_project_narrative_attachment.py
+++ b/api/tests/src/form_schema/forms/test_project_narrative_attachment.py
@@ -1,0 +1,57 @@
+import pytest
+
+from src.form_schema.forms.project_narrative_attachment import ProjectNarrativeAttachment_v1_2
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+
+
+def validate_required(data: dict, expected_required_fields: list[str]):
+    validation_issues = validate_json_schema_for_form(data, ProjectNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == len(expected_required_fields)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in expected_required_fields
+
+
+@pytest.fixture
+def minimal_valid_project_narrative_v1_2():
+    return {"attachments": ["00b9001b-6ca8-4c0c-9328-46f39e9ff14b"]}
+
+
+def test_project_narrative_v1_2_minimal_valid_json(minimal_valid_project_narrative_v1_2):
+    validation_issues = validate_json_schema_for_form(
+        minimal_valid_project_narrative_v1_2, ProjectNarrativeAttachment_v1_2
+    )
+    assert len(validation_issues) == 0
+
+
+def test_project_narrative_v1_2_empty_json():
+    validate_required({}, ["$.attachments"])
+
+
+def test_project_narrative_v1_2_empty_attachments():
+    data = {"attachments": []}
+    validation_issues = validate_json_schema_for_form(data, ProjectNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minItems"
+    assert validation_issues[0].message == "[] should be non-empty"
+
+
+def test_project_narrative_v1_2_too_many_attachments():
+    data = {"attachments": ["c8eebbcc-a6ec-4b20-9bfa-e6bcc5abb6d5" for _ in range(101)]}
+    validation_issues = validate_json_schema_for_form(data, ProjectNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxItems"
+    assert validation_issues[0].message == "The array is too long, expected a maximum length of 100"
+
+
+def test_project_narrative_v1_2_attachment_type():
+    data = {"attachments": ["c8eebbcc-a6ec-4b20-9bfa-e6bcc5abb6d5", "my_attachment"]}
+    validation_issues = validate_json_schema_for_form(data, ProjectNarrativeAttachment_v1_2)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "format"
+    assert validation_issues[0].message == "'my_attachment' is not a 'uuid'"
+    assert validation_issues[0].field == "$.attachments[1]"


### PR DESCRIPTION
## Summary

Work for #5697
Work for #5698 

## Changes proposed
Add JSON schema for Budget Narrative Attachment Form
Add JSON schema for Project Narrative Attachment Form

## Context for reviewers
These two forms are identical as far as the schemas go with just a minor difference in file name and some of the text a user will see.

Note that in the current PDF the attachment is setup as two fields a "required" attachment and then an "optional" list of attachments. But in the underlying data schema, it's a list like what I've done here.

## Validation steps
`make db-seed-local` will create an opportunity+competition with these attached. They don't quite render right because the attachment logic isn't fully implemented on the frontend / UI schema would need to be updated too.

<img width="1087" height="277" alt="Screenshot 2025-07-18 at 1 38 42 PM" src="https://github.com/user-attachments/assets/2dcbd40e-b06c-425d-8d37-41714e7fe252" />
<img width="1387" height="455" alt="Screenshot 2025-07-18 at 1 51 58 PM" src="https://github.com/user-attachments/assets/5c65ae58-1f09-43b1-970b-4acf1f5f3c64" />

