### PR TITLE
[Issue #5729] Fix up links to Grants.gov

### DIFF
--- a/frontend/src/components/ReturnToGrantsNotification.tsx
+++ b/frontend/src/components/ReturnToGrantsNotification.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { environment } from "src/constants/environments";
 import SessionStorage from "src/services/sessionStorage/sessionStorage";
 
 import { useTranslations } from "next-intl";
@@ -10,7 +11,7 @@ export function ReturnToGrantsNotification() {
   const searchParams = useSearchParams();
   const GrantsLink = (
     <div className="display-flex flex-1 tablet:text-right tablet:margin-bottom-0 margin-bottom-3 tablet:padding-top-3 tablet:flex-justify-end">
-      <a href="https://grants.gov">{t("message")}</a>
+      <a href={environment.LEGACY_HOST}>{t("message")}</a>
     </div>
   );
   if (searchParams.get("utm_source") === "Grants.gov") {

--- a/frontend/src/constants/environments.ts
+++ b/frontend/src/constants/environments.ts
@@ -36,10 +36,24 @@ export const featureFlags = {
   searchTableOn: FEATURE_SEARCH_TABLE_ON,
 };
 
+const legacyHost = (): string => {
+  switch (ENVIRONMENT) {
+    case "prod":
+      return "https://www.grants.gov";
+    case "training":
+      return "https://training.grants.gov";
+    case "staging":
+      return "https://staging.grants.gov";
+    case "test":
+      return "https://test.grants.gov";
+    default:
+      return "https://dev.grants.gov";
+  }
+};
+
 // home for all interpreted server side environment variables
 export const environment: { [key: string]: string } = {
-  LEGACY_HOST:
-    ENVIRONMENT === "prod" ? "https://grants.gov" : "https://test.grants.gov",
+  LEGACY_HOST: legacyHost(),
   NEXT_PUBLIC_BASE_PATH: NEXT_PUBLIC_BASE_PATH ?? "",
   USE_SEARCH_MOCK_DATA: USE_SEARCH_MOCK_DATA || "",
   SENDY_API_URL: SENDY_API_URL || "",


### PR DESCRIPTION
## Summary

Work for #5729

## Changes proposed

Make the links to Grants.gov use full www.grants.gov in Prod and make it more aware of other environments.

## Validation steps

1. Checkout the branch
2. Load http://localhost:3000/search?utm_source=Grants.gov
3. Validate that the link for "Return to Grants.gov" is to "dev.grants.gov" (previously it would have been to "grants.gov"
