### PR TITLE
[Issue #5733] Restore Click Thru Tracking metadata

### DIFF
--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -52,15 +52,22 @@ const CloseDateDisplay = ({ closeDate }: { closeDate: string }) => {
 const TitleDisplay = ({
   opportunity,
   saved,
+  page,
+  index,
 }: {
   opportunity: BaseOpportunity;
   saved: boolean;
+  page: number;
+  index: number;
 }) => {
   const t = useTranslations("Search.table");
   return (
     <>
       <div className="font-sans-lg text-bold">
-        <a href={getOpportunityUrl(opportunity.opportunity_id)}>
+        <a
+          href={getOpportunityUrl(opportunity.opportunity_id)}
+          id={`search-result-link-${page}-${index + 1}`}
+        >
           {opportunity.opportunity_title}
         </a>
       </div>
@@ -105,6 +112,8 @@ const AgencyDisplay = ({ opportunity }: { opportunity: BaseOpportunity }) => {
 const toSearchResultsTableRow = (
   result: BaseOpportunity,
   saved: boolean,
+  page: number,
+  index: number,
 ): TableCellData[] => {
   return [
     {
@@ -118,7 +127,14 @@ const toSearchResultsTableRow = (
       stackOrder: 1,
     },
     {
-      cellData: <TitleDisplay opportunity={result} saved={saved} />,
+      cellData: (
+        <TitleDisplay
+          opportunity={result}
+          saved={saved}
+          page={page}
+          index={index}
+        />
+      ),
       stackOrder: 0,
     },
     {
@@ -142,8 +158,10 @@ const toSearchResultsTableRow = (
 
 export const SearchResultsTable = async ({
   searchResults,
+  page,
 }: {
   searchResults: SearchResponseData;
+  page: number;
 }) => {
   const t = useTranslations("Search.table");
 
@@ -164,10 +182,12 @@ export const SearchResultsTable = async ({
     { cellData: t("headings.awardMin") },
     { cellData: t("headings.awardMax") },
   ];
-  const tableRowData = searchResults.map((result) =>
+  const tableRowData = searchResults.map((result, index) =>
     toSearchResultsTableRow(
       result,
       savedOpportunityIds.includes(result.opportunity_id),
+      page,
+      index,
     ),
   );
   return (

--- a/frontend/src/components/search/SearchResultsView.tsx
+++ b/frontend/src/components/search/SearchResultsView.tsx
@@ -121,7 +121,7 @@ const SearchResultsTableView = ({
         totalResults={totalResults}
         totalPages={totalPages}
       />
-      <SearchResultsTable searchResults={searchResults.data} />
+      <SearchResultsTable searchResults={searchResults.data} page={page} />
     </>
   );
 };

--- a/frontend/tests/components/search/SearchResultsTable.test.tsx
+++ b/frontend/tests/components/search/SearchResultsTable.test.tsx
@@ -35,6 +35,7 @@ describe("SearchResultsTable", () => {
   it("matches snapshot", async () => {
     const component = await SearchResultsTable({
       searchResults: [mockOpportunity],
+      page: 1,
     });
     const { container } = render(component);
     expect(container).toMatchSnapshot();
@@ -48,6 +49,7 @@ describe("SearchResultsTable", () => {
           opportunity_id: "0bfdd67c-e58a-4005-bfd1-12cfe592b17e",
         },
       ],
+      page: 1,
     });
     render(component);
 
@@ -59,6 +61,7 @@ describe("SearchResultsTable", () => {
   it("displays headings for all columns as expected", async () => {
     const component = await SearchResultsTable({
       searchResults: [mockOpportunity],
+      page: 1,
     });
     render(component);
 

--- a/frontend/tests/components/search/SearchResultsTable.test.tsx
+++ b/frontend/tests/components/search/SearchResultsTable.test.tsx
@@ -27,6 +27,7 @@ describe("SearchResultsTable", () => {
   it("passes accessibility test", async () => {
     const component = await SearchResultsTable({
       searchResults: [mockOpportunity],
+      page: 1,
     });
     const { container } = render(component);
     const results = await axe(container);
@@ -94,6 +95,7 @@ describe("SearchResultsTable", () => {
           summary: { ...mockOpportunity.summary, expected_number_of_awards: 1 },
         },
       ],
+      page: 1,
     });
     render(component);
 
@@ -143,6 +145,7 @@ describe("SearchResultsTable", () => {
           },
         },
       ],
+      page: 1,
     });
     render(component);
 
@@ -171,6 +174,7 @@ describe("SearchResultsTable", () => {
   it("displays a proper message when there are no results", async () => {
     const component = await SearchResultsTable({
       searchResults: [],
+      page: 1,
     });
     render(component);
     expect(screen.queryAllByRole("row")).toHaveLength(0);

--- a/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
+++ b/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
@@ -115,6 +115,7 @@ exports[`SearchResultsTable matches snapshot 1`] = `
               >
                 <a
                   href="/opportunity/63588df8-f2d1-44ed-a201-5804abba696a"
+                  id="search-result-link-1-1"
                 >
                   Test Opportunity
                 </a>


### PR DESCRIPTION
## Summary

Work for #5733

## Changes proposed

The non-table view had ids on the Links (now a tags) so that we could report on how often users click on the top 3 Opportunities in the Search Results.  This adds that id to the Table layout so we can continue reporting on that.
