### PR TITLE
[Issue #5737] Remove email test disclaimer from subjects

### DIFF
--- a/api/src/task/notifications/closing_date_notification.py
+++ b/api/src/task/notifications/closing_date_notification.py
@@ -120,9 +120,9 @@ class ClosingDateNotificationTask(BaseNotificationTask):
                     extra={"user_id": user_id, "closing_opp_count": len(closing_opportunities)},
                 )
                 subject = (
-                    "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Applications for your bookmarked funding opportunity are due soon"
+                    "Applications for your bookmarked funding opportunity are due soon"
                     if len(closing_opportunities) == 1
-                    else "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Applications for your bookmarked funding opportunities are due soon"
+                    else "Applications for your bookmarked funding opportunities are due soon"
                 )
                 users_email_notifications.append(
                     UserEmailNotification(

--- a/api/src/task/notifications/opportunity_notifcation.py
+++ b/api/src/task/notifications/opportunity_notifcation.py
@@ -564,9 +564,9 @@ class OpportunityNotificationTask(BaseNotificationTask):
             else "The following funding opportunity recently changed:<br><br>"
         )
         subject = (
-            "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunities changed on "
+            "Your saved funding opportunities changed on "
             if updated_opp_count > 1
-            else "[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunity changed on "
+            else "Your saved funding opportunity changed on "
         )
         subject += "Simpler.Grants.gov"
 

--- a/api/src/task/notifications/search_notification.py
+++ b/api/src/task/notifications/search_notification.py
@@ -137,9 +137,9 @@ class SearchNotificationTask(BaseNotificationTask):
 
             formatted_date = datetime_util.utcnow().strftime("%-m/%-d/%Y")
             subject = (
-                f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] New Grant Published on {formatted_date}"
+                f"New Grant Published on {formatted_date}"
                 if len(opportunities) == 1
-                else f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] {len(opportunities)} New Grants Published on {formatted_date}"
+                else f"{len(opportunities)} New Grants Published on {formatted_date}"
             )
             users_email_notifications.append(
                 UserEmailNotification(

--- a/api/tests/src/task/notifications/test_opportunity_notification.py
+++ b/api/tests/src/task/notifications/test_opportunity_notification.py
@@ -998,7 +998,7 @@ class TestOpportunityNotification:
                     ),
                 ],
                 UserOpportunityUpdateContent(
-                    subject="[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunities changed on Simpler.Grants.gov",
+                    subject="Your saved funding opportunities changed on Simpler.Grants.gov",
                     message=(
                         f"The following funding opportunities recently changed:<br><br><div>1. <a href='http://testhost:3000/opportunity/{OPAL.opportunity_id}' target='_blank'>Opal 2025 Awards</a><br><br>Here’s what changed:</div>"
                         '<p style="padding-left: 20px;">Status</p><p style="padding-left: 40px;">•  The status changed from Open to Closed.<br>'
@@ -1022,7 +1022,7 @@ class TestOpportunityNotification:
                     ),
                 ],
                 UserOpportunityUpdateContent(
-                    subject="[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunity changed on Simpler.Grants.gov",
+                    subject="Your saved funding opportunity changed on Simpler.Grants.gov",
                     message=(
                         f"The following funding opportunity recently changed:<br><br><div>1. <a href='http://testhost:3000/opportunity/{TOPAZ.opportunity_id}' target='_blank'>Topaz 2025 Climate Research Grant</a><br><br>Here’s what changed:</div>"
                         '<p style="padding-left: 20px;">Status</p><p style="padding-left: 40px;">•  The status changed from Forecasted to Closed.<br>'
@@ -1091,7 +1091,7 @@ class TestOpportunityNotification:
         )
 
         expected = UserOpportunityUpdateContent(
-            subject="[This is a test email from the Simpler.Grants.gov alert system. No action is required] Your saved funding opportunity changed on Simpler.Grants.gov",
+            subject="Your saved funding opportunity changed on Simpler.Grants.gov",
             message=(
                 f"The following funding opportunity recently changed:<br><br><div>1. <a href='http://testhost:3000/opportunity/{TOPAZ.opportunity_id}' target='_blank'>Topaz 2025 Climate Research Grant</a><br><br>Here’s what changed:</div>"
                 '<p style="padding-left: 20px;">Status</p><p style="padding-left: 40px;">•  The status changed from Forecasted to Closed.<br><br>'

--- a/api/tests/src/task/notifications/test_search_notification.py
+++ b/api/tests/src/task/notifications/test_search_notification.py
@@ -400,7 +400,7 @@ def test_search_notification_email_format_single_opportunity(
         mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
             "SimpleEmail"
         ]["Subject"]["Data"]
-        == f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] New Grant Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
+        == f"New Grant Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
     )
 
     email_content = mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
@@ -579,7 +579,7 @@ def test_search_notification_email_format_multiple_opportunities(
         mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][
             "SimpleEmail"
         ]["Subject"]["Data"]
-        == f"[This is a test email from the Simpler.Grants.gov alert system. No action is required] 2 New Grants Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
+        == f"2 New Grants Published on {datetime_util.utcnow().strftime("%-m/%-d/%Y")}"
     )
 
     email_content = mock_responses[0][0]["MessageRequest"]["MessageConfiguration"]["EmailMessage"][


### PR DESCRIPTION
## Summary

Work for #5737 

## Changes proposed

Remove the temporary language that flagged the first batch of email notification emails as testing while we validated the content and recipients.