### PR TITLE
[Issue #5419] Add more prepopulation rules

### DIFF
--- a/api/src/db/models/competition_models.py
+++ b/api/src/db/models/competition_models.py
@@ -256,7 +256,7 @@ class Application(ApiSchemaTable, TimestampMixin):
     organization_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID, ForeignKey(Organization.organization_id)
     )
-    organization: Mapped[Organization] = relationship(
+    organization: Mapped[Organization | None] = relationship(
         Organization, uselist=False, back_populates="applications"
     )
 

--- a/api/src/form_schema/forms/project_abstract_summary.py
+++ b/api/src/form_schema/forms/project_abstract_summary.py
@@ -69,8 +69,6 @@ FORM_RULE_SCHEMA = {
     ##### PRE-POPULATION RULES
     # Note - we don't have pre-population enabled yet, so these
     # won't run yet.
-    # TODO - before we can enable prepopulation we need the following rules:
-    #   * assistance listing number
     "funding_opportunity_number": {"gg_pre_population": {"rule": "opportunity_number"}},
     "assistance_listing_number": {"gg_pre_population": {"rule": "assistance_listing_number"}},
 }

--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -745,12 +745,6 @@ FORM_RULE_SCHEMA = {
     ##### PRE-POPULATION RULES
     # Note - we don't have pre-population enabled yet, so these
     # won't run yet.
-    # TODO - before we can enable prepopulation we need the following rules:
-    #   * uei
-    #   * assistance listing number
-    #   * assistance listing program title
-    #   * public competition ID
-    #   * competition title
     "sam_uei": {"gg_pre_population": {"rule": "uei"}},
     "agency_name": {"gg_pre_population": {"rule": "agency_name"}},
     "assistance_listing_number": {"gg_pre_population": {"rule": "assistance_listing_number"}},
@@ -780,7 +774,7 @@ SF424_v4_0 = Form(
     form_name="Application for Federal Assistance (SF-424)",
     short_form_name="SF424_4_0",
     form_version="4.0",
-    agency_code="SGG",  # TODO - Do we want to add Simpler Grants.gov as an "Agency"?
+    agency_code="SGG",
     omb_number="4040-0004",
     form_json_schema=FORM_JSON_SCHEMA,
     form_ui_schema=FORM_UI_SCHEMA,

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -492,9 +492,6 @@ FORM_RULE_SCHEMA = {
     ##### PRE-POPULATION RULES
     # Note - we don't have pre-population enabled yet, so these
     # won't run yet.
-    # TODO - before we can enable prepopulation we need the following rules:
-    #   * assistance listing number
-    #   * assistance listing program title
     "federal_program_name": {"gg_pre_population": {"rule": "assistance_listing_program_title"}},
     "assistance_listing_number": {"gg_pre_population": {"rule": "assistance_listing_number"}},
     ##### POST-POPULATION RULES

--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 INDIVIDUAL_UEI = "000000000INDV"
 
+
 def get_opportunity_number(context: JsonRuleContext) -> str | None:
     return context.opportunity.opportunity_number
 
@@ -27,6 +28,7 @@ def get_agency_name(context: JsonRuleContext) -> str | None:
 def get_current_date(context: JsonRuleContext) -> str:
     return get_now_us_eastern_date().isoformat()
 
+
 def get_uei(context: JsonRuleContext) -> str:
     organization = context.application_form.application.organization
     if organization is None:
@@ -35,10 +37,14 @@ def get_uei(context: JsonRuleContext) -> str:
     # This shouldn't happen during our pilot as all orgs should be created
     # from sam.gov entity data in the first place, but just as a safety net
     if organization.sam_gov_entity is None:
-        logger.error("Organization does not have a sam.gov entity, cannot determine UEI", extra={"organization_id": organization.organization_id})
+        logger.error(
+            "Organization does not have a sam.gov entity, cannot determine UEI",
+            extra={"organization_id": organization.organization_id},
+        )
         return INDIVIDUAL_UEI
 
     return organization.sam_gov_entity.uei
+
 
 def get_assistance_listing_number(context: JsonRuleContext) -> str | None:
     competition = context.application_form.application.competition
@@ -48,6 +54,7 @@ def get_assistance_listing_number(context: JsonRuleContext) -> str | None:
 
     return competition.opportunity_assistance_listing.assistance_listing_number
 
+
 def get_assistance_listing_program_title(context: JsonRuleContext) -> str | None:
     competition = context.application_form.application.competition
 
@@ -56,13 +63,16 @@ def get_assistance_listing_program_title(context: JsonRuleContext) -> str | None
 
     return competition.opportunity_assistance_listing.program_title
 
+
 def get_public_competition_id(context: JsonRuleContext) -> str | None:
     competition = context.application_form.application.competition
     return competition.public_competition_id
 
+
 def get_competition_title(context: JsonRuleContext) -> str | None:
     competition = context.application_form.application.competition
     return competition.competition_title
+
 
 def get_signature(context: JsonRuleContext) -> str | None:
     # TODO - we don't yet have users names, so this arbitrarily grabs

--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -11,14 +11,17 @@ INDIVIDUAL_UEI = "000000000INDV"
 
 
 def get_opportunity_number(context: JsonRuleContext) -> str | None:
+    """Get the opportunity number"""
     return context.opportunity.opportunity_number
 
 
 def get_opportunity_title(context: JsonRuleContext) -> str | None:
+    """Get the opportunity title"""
     return context.opportunity.opportunity_title
 
 
 def get_agency_name(context: JsonRuleContext) -> str | None:
+    """Get the agency's name, falling back to agency code if no agency name"""
     if context.opportunity.agency_name is None:
         return context.opportunity.agency_code
 
@@ -26,10 +29,17 @@ def get_agency_name(context: JsonRuleContext) -> str | None:
 
 
 def get_current_date(context: JsonRuleContext) -> str:
+    """Get the current date"""
     return get_now_us_eastern_date().isoformat()
 
 
 def get_uei(context: JsonRuleContext) -> str:
+    """Get a UEI from an application's organization
+
+    If the application does not have an organization,
+    defaults to a static one representing an individual
+    like Grants.gov did.
+    """
     organization = context.application_form.application.organization
     if organization is None:
         return INDIVIDUAL_UEI
@@ -47,6 +57,7 @@ def get_uei(context: JsonRuleContext) -> str:
 
 
 def get_assistance_listing_number(context: JsonRuleContext) -> str | None:
+    """Get the assistance listing number attached to the competition"""
     competition = context.application_form.application.competition
 
     if competition.opportunity_assistance_listing is None:
@@ -56,6 +67,7 @@ def get_assistance_listing_number(context: JsonRuleContext) -> str | None:
 
 
 def get_assistance_listing_program_title(context: JsonRuleContext) -> str | None:
+    """Get the assistance listing program title attached to the competition"""
     competition = context.application_form.application.competition
 
     if competition.opportunity_assistance_listing is None:
@@ -65,16 +77,19 @@ def get_assistance_listing_program_title(context: JsonRuleContext) -> str | None
 
 
 def get_public_competition_id(context: JsonRuleContext) -> str | None:
+    """Get the public competition ID from the competition"""
     competition = context.application_form.application.competition
     return competition.public_competition_id
 
 
 def get_competition_title(context: JsonRuleContext) -> str | None:
+    """Get the competition title from the competition"""
     competition = context.application_form.application.competition
     return competition.competition_title
 
 
 def get_signature(context: JsonRuleContext) -> str | None:
+    """Get the name of the owner of the application"""
     # TODO - we don't yet have users names, so this arbitrarily grabs
     # one users email attached to the app - not ideal, will fix when we can.
     app_users = context.application_form.application.application_users

--- a/api/tests/src/form_schema/rule_processing/conftest.py
+++ b/api/tests/src/form_schema/rule_processing/conftest.py
@@ -1,0 +1,112 @@
+from src.form_schema.rule_processing.json_rule_context import JsonRuleConfig
+from src.form_schema.rule_processing.json_rule_processor import JsonRuleContext
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    ApplicationAttachmentFactory,
+    ApplicationFactory,
+    ApplicationFormFactory,
+    ApplicationUserFactory,
+    CompetitionFactory,
+    CompetitionFormFactory,
+    FormFactory,
+    LinkExternalUserFactory,
+    OpportunityAssistanceListingFactory,
+    OpportunityFactory,
+    OrganizationFactory,
+)
+
+
+def setup_context(
+    json_data: dict,
+    rule_schema: dict | None,
+    # These are various params that be set in the application
+    # if the value is None, we'll just leave it to the factory to set.
+    opportunity_number: str | None = None,
+    opportunity_title: str | None = None,
+    has_agency: bool = True,
+    agency_name: str | None = None,
+    agency_code: str | None = None,
+    user_email: str | None = None,
+    attachment_ids: list[str] | None = None,
+    has_organization: bool = False,
+    uei: str | None = None,
+    has_assistance_listing_number: bool = True,
+    assistance_listing_number: str | None = None,
+    assistance_listing_program_title: str | None = None,
+    public_competition_id: str | None = None,
+    competition_title: str | None = None,
+    # Configurational params
+    do_pre_population: bool = True,
+    do_post_population: bool = True,
+    do_field_validation: bool = True,
+):
+    opp_params = {}
+    agency_params = {}
+    if has_agency:
+        if agency_name is not None:
+            agency_params["agency_name"] = agency_name
+        agency = AgencyFactory.create(**agency_params)
+        opp_params["agency_code"] = agency.agency_code
+    elif agency_code is not None:
+        opp_params["agency_code"] = agency_code
+
+    if opportunity_number is not None:
+        opp_params["opportunity_number"] = opportunity_number
+    if opportunity_title is not None:
+        opp_params["opportunity_title"] = opportunity_title
+
+    opportunity = OpportunityFactory.create(**opp_params)
+
+    opportunity_assistance_listing = None
+    if has_assistance_listing_number:
+        params = {
+            "opportunity": opportunity,
+            "assistance_listing_number": assistance_listing_number,
+            "program_title": assistance_listing_program_title,
+        }
+        opportunity_assistance_listing = OpportunityAssistanceListingFactory.create(**params)
+
+    competition_params = {
+        "opportunity": opportunity,
+        "competition_forms": [],
+        "competition_title": competition_title,
+        "public_competition_id": public_competition_id,
+        "opportunity_assistance_listing": opportunity_assistance_listing,
+    }
+
+    competition = CompetitionFactory.create(**competition_params)
+    form = FormFactory.create(form_rule_schema=rule_schema)
+    competition_form = CompetitionFormFactory.create(competition=competition, form=form)
+
+    organization = None
+    if has_organization:
+        organization_params = {}
+        if uei is not None:
+            organization_params["sam_gov_entity__uei"] = uei
+        else:
+            organization_params["sam_gov_entity"] = None
+        organization = OrganizationFactory(**organization_params)
+
+    application = ApplicationFactory.create(competition=competition, organization=organization)
+    application_form = ApplicationFormFactory.create(
+        application=application, competition_form=competition_form, application_response=json_data
+    )
+
+    if attachment_ids is not None:
+        for attachment_id in attachment_ids:
+            ApplicationAttachmentFactory.create(
+                application_attachment_id=attachment_id, application=application
+            )
+
+    if user_email is not None:
+        app_user = ApplicationUserFactory.create(application=application, is_application_owner=True)
+        LinkExternalUserFactory.create(email=user_email, user=app_user.user)
+
+    return JsonRuleContext(
+        application_form,
+        JsonRuleConfig(
+            do_pre_population=do_pre_population,
+            do_post_population=do_post_population,
+            do_field_validation=do_field_validation,
+        ),
+    )

--- a/api/tests/src/form_schema/rule_processing/test_json_rule_field_population.py
+++ b/api/tests/src/form_schema/rule_processing/test_json_rule_field_population.py
@@ -1,0 +1,78 @@
+import pytest
+
+from src.form_schema.rule_processing.json_rule_field_population import (
+    POST_POPULATION_MAPPER,
+    PRE_POPULATION_MAPPER,
+    handle_field_population,
+)
+from src.util.datetime_util import get_now_us_eastern_date
+from tests.src.form_schema.rule_processing.conftest import setup_context
+
+
+@pytest.mark.parametrize(
+    "rule,setup_params,expected_value",
+    [
+        ({"rule": "opportunity_number"}, {"opportunity_number": "ABC-XYZ"}, "ABC-XYZ"),
+        (
+            {"rule": "opportunity_title"},
+            {"opportunity_title": "My opportunity title"},
+            "My opportunity title",
+        ),
+        ({"rule": "agency_name"}, {"agency_name": "My Research Agency"}, "My Research Agency"),
+        # Agency name falls back to agency code if no agency
+        ({"rule": "agency_name"}, {"has_agency": False, "agency_code": "XYZ-ABC"}, "XYZ-ABC"),
+        # No organization get a generic INDV UEI
+        ({"rule": "uei"}, {"has_organization": False}, "000000000INDV"),
+        # Having an organization gets the UEI
+        ({"rule": "uei"}, {"has_organization": True, "uei": "123456789"}, "123456789"),
+        ({"rule": "assistance_listing_number"}, {"has_assistance_listing_number": False}, None),
+        (
+            {"rule": "assistance_listing_number"},
+            {"has_assistance_listing_number": True, "assistance_listing_number": "00.123"},
+            "00.123",
+        ),
+        (
+            {"rule": "assistance_listing_program_title"},
+            {"has_assistance_listing_number": False},
+            None,
+        ),
+        (
+            {"rule": "assistance_listing_program_title"},
+            {
+                "has_assistance_listing_number": True,
+                "assistance_listing_program_title": "My program title",
+            },
+            "My program title",
+        ),
+        ({"rule": "public_competition_id"}, {"public_competition_id": None}, None),
+        ({"rule": "public_competition_id"}, {"public_competition_id": "ABC123456"}, "ABC123456"),
+        ({"rule": "competition_title"}, {"competition_title": None}, None),
+        (
+            {"rule": "competition_title"},
+            {"competition_title": "Research Competition"},
+            "Research Competition",
+        ),
+    ],
+)
+def test_handle_field_population_pre_population(
+    rule, setup_params, expected_value, enable_factory_create
+):
+    context = setup_context({}, {"my_field": rule}, **setup_params)
+    handle_field_population(context, rule, ["my_field"], PRE_POPULATION_MAPPER)
+    assert context.json_data == {"my_field": expected_value}
+
+
+@pytest.mark.parametrize(
+    "rule,setup_params,expected_value",
+    [
+        ({"rule": "current_date"}, {}, get_now_us_eastern_date().isoformat()),
+        ({"rule": "signature"}, {"user_email": "example@mail.com"}, "example@mail.com"),
+        ({"rule": "signature"}, {"user_email": None}, "unknown"),
+    ],
+)
+def test_handle_field_population_post_population(
+    rule, setup_params, expected_value, enable_factory_create
+):
+    context = setup_context({}, {"my_field": rule}, **setup_params)
+    handle_field_population(context, rule, ["my_field"], POST_POPULATION_MAPPER)
+    assert context.json_data == {"my_field": expected_value}

--- a/api/tests/src/form_schema/rule_processing/test_json_rule_processor.py
+++ b/api/tests/src/form_schema/rule_processing/test_json_rule_processor.py
@@ -4,92 +4,33 @@ import freezegun
 import pytest
 
 from src.api.response import ValidationErrorDetail
-from src.form_schema.rule_processing.json_rule_context import JsonRuleConfig
-from src.form_schema.rule_processing.json_rule_processor import (
-    JsonRuleContext,
-    process_rule_schema_for_context,
-)
+from src.form_schema.rule_processing.json_rule_processor import process_rule_schema_for_context
 from src.validation.validation_constants import ValidationErrorType
-from tests.src.db.models.factories import (
-    AgencyFactory,
-    ApplicationAttachmentFactory,
-    ApplicationFactory,
-    ApplicationFormFactory,
-    ApplicationUserFactory,
-    CompetitionFactory,
-    CompetitionFormFactory,
-    FormFactory,
-    LinkExternalUserFactory,
-    OpportunityFactory,
-)
-
-
-def setup_context(
-    json_data: dict,
-    rule_schema: dict | None,
-    # These are various params that be set in the application
-    # if the value is None, we'll just leave it to the factory to set.
-    opportunity_number: str | None = None,
-    opportunity_title: str | None = None,
-    agency_name: str | None = None,
-    user_email: str | None = None,
-    attachment_ids: list[str] | None = None,
-    # Configurational params
-    do_pre_population: bool = True,
-    do_post_population: bool = True,
-    do_field_validation: bool = True,
-):
-    agency_params = {}
-    if agency_name is not None:
-        agency_params["agency_name"] = agency_name
-    agency = AgencyFactory.create(**agency_params)
-
-    opp_params = {"agency_code": agency.agency_code}
-    if opportunity_number is not None:
-        opp_params["opportunity_number"] = opportunity_number
-    if opportunity_title is not None:
-        opp_params["opportunity_title"] = opportunity_title
-
-    opportunity = OpportunityFactory.create(**opp_params)
-    competition = CompetitionFactory.create(opportunity=opportunity, competition_forms=[])
-    form = FormFactory.create(form_rule_schema=rule_schema)
-    competition_form = CompetitionFormFactory.create(competition=competition, form=form)
-
-    application = ApplicationFactory.create(competition=competition)
-    application_form = ApplicationFormFactory.create(
-        application=application, competition_form=competition_form, application_response=json_data
-    )
-
-    if attachment_ids is not None:
-        for attachment_id in attachment_ids:
-            ApplicationAttachmentFactory.create(
-                application_attachment_id=attachment_id, application=application
-            )
-
-    if user_email is not None:
-        link_user = LinkExternalUserFactory.create(email=user_email)
-        ApplicationUserFactory.create(application=application, user=link_user.user)
-
-    return JsonRuleContext(
-        application_form,
-        JsonRuleConfig(
-            do_pre_population=do_pre_population,
-            do_post_population=do_post_population,
-            do_field_validation=do_field_validation,
-        ),
-    )
+from tests.src.form_schema.rule_processing.conftest import setup_context
 
 
 @freezegun.freeze_time("2023-02-20 12:00:00", tz_offset=0)
 def test_process_rule_schema_flat(enable_factory_create):
     rule_schema = {
+        # Pre populated
         "opp_number_field": {
             "gg_pre_population": {"rule": "opportunity_number"},
         },
         "opp_title_field": {"gg_pre_population": {"rule": "opportunity_title"}},
         "agency_name_field": {"gg_pre_population": {"rule": "agency_name"}},
+        "uei_field": {"gg_pre_population": {"rule": "uei"}},
+        "assistance_listing_number_field": {
+            "gg_pre_population": {"rule": "assistance_listing_number"}
+        },
+        "assistance_listing_program_title_field": {
+            "gg_pre_population": {"rule": "assistance_listing_program_title"}
+        },
+        "public_competition_id_field": {"gg_pre_population": {"rule": "public_competition_id"}},
+        "competition_title_field": {"gg_pre_population": {"rule": "competition_title"}},
+        # Post populated
         "date_field": {"gg_post_population": {"rule": "current_date"}},
         "signature_field": {"gg_post_population": {"rule": "signature"}},
+        # Validation
         "attachment_id_field": {"gg_validation": {"rule": "attachment"}},
         "attachment_id_list_field": {"gg_validation": {"rule": "attachment"}},
         "missing_attachment_id_field": {"gg_validation": {"rule": "attachment"}},
@@ -122,6 +63,13 @@ def test_process_rule_schema_flat(enable_factory_create):
             "d97253ea-d512-4aa8-b3dc-bf75834e1e90",
             "b27b22d0-0dfe-4e85-a509-045e6a447824",
         ],
+        has_organization=True,
+        uei="UEI12345",
+        has_assistance_listing_number=True,
+        assistance_listing_number="12.345",
+        assistance_listing_program_title="My example program title",
+        public_competition_id="4567",
+        competition_title="My competition title",
     )
 
     process_rule_schema_for_context(context)
@@ -163,6 +111,11 @@ def test_process_rule_schema_flat(enable_factory_create):
             "d97253ea-d512-4aa8-b3dc-bf75834e1e90",
             "1d532d43-ac3f-4b28-bdaa-b5afa04640c1",
         ],
+        "uei_field": "UEI12345",
+        "assistance_listing_number_field": "12.345",
+        "assistance_listing_program_title_field": "My example program title",
+        "public_competition_id_field": "4567",
+        "competition_title_field": "My competition title",
     }
 
     assert len(context.validation_issues) == 3


### PR DESCRIPTION
## Summary

Fixes #5419

## Changes proposed
This adds additional prepopulation rules that we can configure.

## Context for reviewers
All of the newly added rules are pretty straightforward, UEI is a bit odd for applications without orgs because they have to get a UEI still, which is that odd `000000000INDV` one which is copied from how grants.gov handles this.

I reworked tests and added dedicated tests for these to minimize the complexity of the test setup a bit.
