### PR TITLE
[Issue #5759] Add ability to save opportunities from search results table

### DIFF
--- a/frontend/src/app/[locale]/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/opportunity/[id]/page.tsx
@@ -139,6 +139,7 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
         <div className="padding-y-3 display-flex">
           <OpportunitySaveUserControl
             opportunityId={opportunityData.opportunity_id}
+            type="button"
           />
           {opportunityData.competitions &&
             opportunityData.opportunity_title && (

--- a/frontend/src/components/SaveIcon.tsx
+++ b/frontend/src/components/SaveIcon.tsx
@@ -1,0 +1,56 @@
+import clsx from "clsx";
+
+import Spinner from "./Spinner";
+import { USWDSIcon } from "./USWDSIcon";
+
+interface SaveIconProps {
+  onClick?: () => void;
+  loading?: boolean;
+  saved?: boolean;
+  className?: string;
+}
+
+const SaveIcon = ({
+  onClick,
+  loading = false,
+  saved = false,
+  className,
+}: SaveIconProps) => {
+  if (loading) {
+    return (
+      <Spinner
+        className={clsx("height-105 width-105 button-icon-large", className)}
+      />
+    );
+  }
+
+  const iconElement = (
+    <USWDSIcon
+      className={clsx(
+        "button-icon-large",
+        {
+          "icon-active": saved,
+        },
+        className,
+      )}
+      name={saved ? "star" : "star_outline"}
+    />
+  );
+
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        className="usa-button--unstyled cursor-pointer"
+        onClick={onClick}
+        aria-label={saved ? "Remove from saved" : "Save opportunity"}
+      >
+        {iconElement}
+      </button>
+    );
+  }
+
+  return iconElement;
+};
+
+export default SaveIcon;

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -117,13 +117,7 @@ const toSearchResultsTableRow = (
       stackOrder: 1,
     },
     {
-      cellData: (
-        <TitleDisplay
-          opportunity={result}
-          page={page}
-          index={index}
-        />
-      ),
+      cellData: <TitleDisplay opportunity={result} page={page} index={index} />,
       stackOrder: 0,
     },
     {
@@ -167,11 +161,7 @@ export const SearchResultsTable = ({
     { cellData: t("headings.awardMax") },
   ];
   const tableRowData = searchResults.map((result, index) =>
-    toSearchResultsTableRow(
-      result,
-      page,
-      index,
-    ),
+    toSearchResultsTableRow(result, page, index),
   );
   return (
     <TableWithResponsiveHeader

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -72,7 +72,7 @@ const TitleDisplay = ({
         <span className="text-bold">{t("number")}:</span>{" "}
         {opportunity.opportunity_number}
       </div>
-      <div className="margin-top-2">
+      <div className="margin-top-2 search-table-save-wrapper">
         <OpportunitySaveUserControl
           opportunityId={opportunity.opportunity_id}
         />

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -61,26 +61,26 @@ const TitleDisplay = ({
   return (
     <>
       <div className="display-flex">
-        <div className="margin-right-1 margin-y-auto flex-1">
+        <div className="margin-y-auto grid-col-auto minw-4">
           <OpportunitySaveUserControl
             opportunityId={opportunity.opportunity_id}
             type="icon"
           />
         </div>
-
-        <div className="font-sans-md text-bold flex-11">
-          <a
-            href={getOpportunityUrl(opportunity.opportunity_id)}
-            id={`search-result-link-${page}-${index + 1}`}
-          >
-            {opportunity.opportunity_title}
-          </a>
+        <div className="grid-col-fill">
+          <div className="font-sans-md text-bold line-height-sans-3">
+            <a
+              href={getOpportunityUrl(opportunity.opportunity_id)}
+              id={`search-result-link-${page}-${index + 1}`}
+            >
+              {opportunity.opportunity_title}
+            </a>
+          </div>
+          <div className="display-none tablet-lg:display-block font-sans-xs">
+            <span className="text-bold">{t("number")}:</span>{" "}
+            {opportunity.opportunity_number}
+          </div>
         </div>
-      </div>
-
-      <div className="display-none tablet-lg:display-block font-sans-xs">
-        <span className="text-bold">{t("number")}:</span>{" "}
-        {opportunity.opportunity_number}
       </div>
     </>
   );

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
 import { isNil } from "lodash";
-import { fetchSavedOpportunities } from "src/services/fetch/fetchers/savedOpportunityFetcher";
 import {
   BaseOpportunity,
   OpportunityStatus,
@@ -16,7 +15,7 @@ import {
   TableCellData,
   TableWithResponsiveHeader,
 } from "src/components/TableWithResponsiveHeader";
-import { USWDSIcon } from "src/components/USWDSIcon";
+import { OpportunitySaveUserControl } from "src/components/user/OpportunitySaveUserControl";
 import { FilterSearchNoResults } from "./Filters/FilterSearchNoResults";
 
 const statusColorClasses = {
@@ -51,12 +50,10 @@ const CloseDateDisplay = ({ closeDate }: { closeDate: string }) => {
 
 const TitleDisplay = ({
   opportunity,
-  saved,
   page,
   index,
 }: {
   opportunity: BaseOpportunity;
-  saved: boolean;
   page: number;
   index: number;
 }) => {
@@ -75,17 +72,11 @@ const TitleDisplay = ({
         <span className="text-bold">{t("number")}:</span>{" "}
         {opportunity.opportunity_number}
       </div>
-      {saved && (
-        <div className="margin-top-2 display-inline-block">
-          <span className="display-flex flex-align-center font-sans-2xs">
-            <USWDSIcon
-              name="star"
-              className="text-accent-warm-dark button-icon-md padding-right-05"
-            />
-            {t("saved")}
-          </span>
-        </div>
-      )}
+      <div className="margin-top-2">
+        <OpportunitySaveUserControl
+          opportunityId={opportunity.opportunity_id}
+        />
+      </div>
     </>
   );
 };
@@ -111,7 +102,6 @@ const AgencyDisplay = ({ opportunity }: { opportunity: BaseOpportunity }) => {
 
 const toSearchResultsTableRow = (
   result: BaseOpportunity,
-  saved: boolean,
   page: number,
   index: number,
 ): TableCellData[] => {
@@ -130,7 +120,6 @@ const toSearchResultsTableRow = (
       cellData: (
         <TitleDisplay
           opportunity={result}
-          saved={saved}
           page={page}
           index={index}
         />
@@ -169,11 +158,6 @@ export const SearchResultsTable = async ({
     return <FilterSearchNoResults useHeading={true} />;
   }
 
-  const savedOpportunities = await fetchSavedOpportunities();
-  const savedOpportunityIds = savedOpportunities.map(
-    (opportunity) => opportunity.opportunity_id,
-  );
-
   const headerContent: TableCellData[] = [
     { cellData: t("headings.closeDate") },
     { cellData: t("headings.status") },
@@ -185,7 +169,6 @@ export const SearchResultsTable = async ({
   const tableRowData = searchResults.map((result, index) =>
     toSearchResultsTableRow(
       result,
-      savedOpportunityIds.includes(result.opportunity_id),
       page,
       index,
     ),

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -60,22 +60,27 @@ const TitleDisplay = ({
   const t = useTranslations("Search.table");
   return (
     <>
-      <div className="font-sans-lg text-bold">
-        <a
-          href={getOpportunityUrl(opportunity.opportunity_id)}
-          id={`search-result-link-${page}-${index + 1}`}
-        >
-          {opportunity.opportunity_title}
-        </a>
+      <div className="display-flex">
+        <div className="margin-right-1 margin-y-auto flex-1">
+          <OpportunitySaveUserControl
+            opportunityId={opportunity.opportunity_id}
+            type="icon"
+          />
+        </div>
+
+        <div className="font-sans-md text-bold flex-11">
+          <a
+            href={getOpportunityUrl(opportunity.opportunity_id)}
+            id={`search-result-link-${page}-${index + 1}`}
+          >
+            {opportunity.opportunity_title}
+          </a>
+        </div>
       </div>
+
       <div className="display-none tablet-lg:display-block font-sans-xs">
         <span className="text-bold">{t("number")}:</span>{" "}
         {opportunity.opportunity_number}
-      </div>
-      <div className="margin-top-2 search-table-save-wrapper">
-        <OpportunitySaveUserControl
-          opportunityId={opportunity.opportunity_id}
-        />
       </div>
     </>
   );

--- a/frontend/src/components/search/SearchResultsTable.tsx
+++ b/frontend/src/components/search/SearchResultsTable.tsx
@@ -145,7 +145,7 @@ const toSearchResultsTableRow = (
   ];
 };
 
-export const SearchResultsTable = async ({
+export const SearchResultsTable = ({
   searchResults,
   page,
 }: {

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -102,7 +102,9 @@ export const OpportunitySaveUserControl = ({
       <>
         {user?.token ? (
           <SaveIcon
-            onClick={userSavedOppCallback}
+            onClick={() => {
+              userSavedOppCallback().catch(console.error);
+            }}
             loading={loading}
             saved={saved}
           />

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -12,14 +12,17 @@ import { ModalRef, ModalToggleButton } from "@trussworks/react-uswds";
 
 import { LoginModal } from "src/components/LoginModal";
 import SaveButton from "src/components/SaveButton";
+import SaveIcon from "src/components/SaveIcon";
 import { USWDSIcon } from "src/components/USWDSIcon";
 
 const SAVED_OPPS_PAGE_LINK = "/saved-opportunities";
 
 export const OpportunitySaveUserControl = ({
   opportunityId,
+  type = "button",
 }: {
   opportunityId: string;
+  type?: "button" | "icon";
 }) => {
   const t = useTranslations("OpportunityListing");
   const modalRef = useRef<ModalRef>(null);
@@ -93,6 +96,40 @@ export const OpportunitySaveUserControl = ({
 
   const { checkFeatureFlag } = useFeatureFlags();
   if (!checkFeatureFlag("savedOpportunitiesOn")) return null;
+
+  if (type === "icon") {
+    return (
+      <>
+        {user?.token ? (
+          <SaveIcon
+            onClick={userSavedOppCallback}
+            loading={loading}
+            saved={saved}
+          />
+        ) : (
+          <>
+            <ModalToggleButton
+              modalRef={modalRef}
+              opener
+              className="usa-button--unstyled"
+            >
+              <SaveIcon saved={false} />
+            </ModalToggleButton>
+            <LoginModal
+              modalRef={modalRef as React.RefObject<ModalRef>}
+              helpText={t("saveloginModal.help")}
+              buttonText={t("saveloginModal.button")}
+              closeText={t("saveloginModal.close")}
+              descriptionText={t("saveloginModal.description")}
+              titleText={t("saveloginModal.title")}
+              modalId="opp-save-login-modal"
+            />
+          </>
+        )}
+      </>
+    );
+  }
+
   return (
     <>
       {user?.token ? (

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -633,29 +633,3 @@ iframe[id^="ethnio-screener-"] {
     transform-origin: left bottom;
   }
 }
-
-// Search Table Save Button Responsive Layout
-.search-table-save-wrapper {
-  .display-flex.flex-align-start {
-    flex-direction: column;
-    align-items: flex-start;
-    .usa-alert {
-      margin-left: 0px !important;
-    }
-    .usa-alert__body {
-      height: auto !important;
-    }
-    button {
-      margin-bottom: 1rem;
-      text-wrap: nowrap;
-    }
-    @include at-media("widescreen") {
-      flex-direction: row;
-      align-items: flex-start;
-
-      button {
-        margin-bottom: 0;
-      }
-    }
-  }
-}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -652,11 +652,10 @@ iframe[id^="ethnio-screener-"] {
     @include at-media("widescreen") {
       flex-direction: row;
       align-items: flex-start;
-      
+
       button {
         margin-bottom: 0;
       }
     }
   }
 }
-

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -633,3 +633,25 @@ iframe[id^="ethnio-screener-"] {
     transform-origin: left bottom;
   }
 }
+
+// Search Table Save Button Responsive Layout
+.search-table-save-wrapper {
+  .display-flex.flex-align-start {
+    flex-direction: column;
+    align-items: flex-start;
+    
+    button {
+      margin-bottom: 1rem;
+      text-wrap: nowrap;
+    }
+    
+    @include at-media("tablet-lg") {
+      flex-direction: row;
+      align-items: flex-start;
+      
+      button {
+        margin-bottom: 0;
+      }
+    }
+  }
+}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -639,13 +639,17 @@ iframe[id^="ethnio-screener-"] {
   .display-flex.flex-align-start {
     flex-direction: column;
     align-items: flex-start;
-    
+    .usa-alert {
+      margin-left: 0px !important;
+    }
+    .usa-alert__body {
+      height: auto !important;
+    }
     button {
       margin-bottom: 1rem;
       text-wrap: nowrap;
     }
-    
-    @include at-media("tablet-lg") {
+    @include at-media("widescreen") {
       flex-direction: row;
       align-items: flex-start;
       
@@ -655,3 +659,4 @@ iframe[id^="ethnio-screener-"] {
     }
   }
 }
+

--- a/frontend/tests/components/SaveIcon.test.tsx
+++ b/frontend/tests/components/SaveIcon.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "tests/react-utils";
+import { fireEvent, render, screen } from "tests/react-utils";
 
 import SaveIcon from "src/components/SaveIcon";
 
@@ -90,4 +90,4 @@ describe("SaveIcon", () => {
       expect(icon).toBeInTheDocument();
     });
   });
-}); 
+});

--- a/frontend/tests/components/SaveIcon.test.tsx
+++ b/frontend/tests/components/SaveIcon.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from "tests/react-utils";
+
+import SaveIcon from "src/components/SaveIcon";
+
+describe("SaveIcon", () => {
+  it("renders without errors", () => {
+    render(<SaveIcon />);
+    const icon = screen.getByRole("img", { hidden: true });
+    expect(icon).toBeInTheDocument();
+  });
+
+  it("shows star_outline icon when not saved", () => {
+    render(<SaveIcon saved={false} />);
+    const icon = screen.getByRole("img", { hidden: true });
+    expect(icon).toHaveClass("usa-icon");
+  });
+
+  it("shows star icon when saved", () => {
+    render(<SaveIcon saved={true} />);
+    const icon = screen.getByRole("img", { hidden: true });
+    expect(icon).toHaveClass("usa-icon");
+  });
+
+  it("applies icon-active class when saved", () => {
+    render(<SaveIcon saved={true} />);
+    const icon = screen.getByRole("img", { hidden: true });
+    expect(icon).toHaveClass("icon-active");
+  });
+
+  it("shows spinner when loading", () => {
+    render(<SaveIcon loading={true} />);
+    const spinner = screen.getByRole("progressbar");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("does not show icon when loading", () => {
+    render(<SaveIcon loading={true} />);
+    expect(screen.queryByRole("img", { hidden: true })).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(<SaveIcon className="custom-class" />);
+    const icon = screen.getByRole("img", { hidden: true });
+    expect(icon).toHaveClass("custom-class");
+  });
+
+  describe("when clickable", () => {
+    it("renders as button when onClick is provided", () => {
+      const onClick = jest.fn();
+      render(<SaveIcon onClick={onClick} />);
+      const button = screen.getByRole("button");
+      expect(button).toBeInTheDocument();
+    });
+
+    it("calls onClick when clicked", () => {
+      const onClick = jest.fn();
+      render(<SaveIcon onClick={onClick} />);
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("has proper aria-label when not saved", () => {
+      const onClick = jest.fn();
+      render(<SaveIcon onClick={onClick} saved={false} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-label", "Save opportunity");
+    });
+
+    it("has proper aria-label when saved", () => {
+      const onClick = jest.fn();
+      render(<SaveIcon onClick={onClick} saved={true} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("aria-label", "Remove from saved");
+    });
+
+    it("applies cursor pointer style to button", () => {
+      const onClick = jest.fn();
+      render(<SaveIcon onClick={onClick} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("cursor-pointer");
+    });
+  });
+
+  describe("when not clickable", () => {
+    it("renders icon directly without button wrapper", () => {
+      render(<SaveIcon />);
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+      const icon = screen.getByRole("img", { hidden: true });
+      expect(icon).toBeInTheDocument();
+    });
+  });
+}); 

--- a/frontend/tests/components/search/SearchResultsTable.test.tsx
+++ b/frontend/tests/components/search/SearchResultsTable.test.tsx
@@ -13,13 +13,14 @@ jest.mock("next-intl", () => ({
 jest.mock("src/components/user/OpportunitySaveUserControl", () => ({
   OpportunitySaveUserControl: jest
     .fn()
-    .mockImplementation(({ opportunityId }: { opportunityId: string }) => {
+    .mockImplementation(({ opportunityId, type }: { opportunityId: string; type?: string }) => {
       return (
         <div
           data-testid={`opportunity-save-control-${opportunityId}`}
           data-opportunity-id={opportunityId}
+          data-type={type || "button"}
         >
-          {`Mocked Save Control for ${opportunityId}`}
+          {`Mocked Save Control for ${opportunityId} (${type || "button"})`}
         </div>
       );
     }),
@@ -72,30 +73,30 @@ describe("SearchResultsTable", () => {
     // Verify the mock component was called for each opportunity
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledTimes(2);
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: mockOpportunity.opportunity_id },
+      { opportunityId: mockOpportunity.opportunity_id, type: "icon" },
       undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: "second-opportunity-id" },
+      { opportunityId: "second-opportunity-id", type: "icon" },
       undefined,
     );
   });
 
-  it("applies search-table-save-wrapper CSS class to save control containers", () => {
+  it("renders save control in correct layout structure", () => {
     const component = SearchResultsTable({
       searchResults: [mockOpportunity],
       page: 1,
     });
     const { container } = render(component);
 
-    // Check that the wrapper div with search-table-save-wrapper class exists
+    // Check that the wrapper div with new layout classes exists
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector(".search-table-save-wrapper");
+    const wrapper = container.querySelector(".margin-right-1.margin-y-auto.flex-1");
     expect(wrapper).toBeInTheDocument();
 
     // Verify the mock was called
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: mockOpportunity.opportunity_id },
+      { opportunityId: mockOpportunity.opportunity_id, type: "icon" },
       undefined,
     );
   });
@@ -160,7 +161,7 @@ describe("SearchResultsTable", () => {
 
     // Verify that the save control component was called for this opportunity
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: mockOpportunity.opportunity_id },
+      { opportunityId: mockOpportunity.opportunity_id, type: "icon" },
       undefined,
     );
 
@@ -253,20 +254,20 @@ describe("SearchResultsTable", () => {
 
     // Verify correct number of wrapper divs
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrappers = container.querySelectorAll(".search-table-save-wrapper");
+    const wrappers = container.querySelectorAll(".margin-right-1.margin-y-auto.flex-1");
     expect(wrappers).toHaveLength(3);
 
     // Verify each opportunity ID was called
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: "opp-1" },
+      { opportunityId: "opp-1", type: "icon" },
       undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: "opp-2" },
+      { opportunityId: "opp-2", type: "icon" },
       undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: "opp-3" },
+      { opportunityId: "opp-3", type: "icon" },
       undefined,
     );
   });
@@ -288,12 +289,27 @@ describe("SearchResultsTable", () => {
 
     // Check that the mock was called with the correct opportunity IDs
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: "unique-id-1" },
+      { opportunityId: "unique-id-1", type: "icon" },
       undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
-      { opportunityId: "unique-id-2" },
+      { opportunityId: "unique-id-2", type: "icon" },
+      undefined,
+    );
+  });
+
+  it("passes type='icon' to OpportunitySaveUserControl components", () => {
+    const component = SearchResultsTable({
+      searchResults: [mockOpportunity],
+      page: 1,
+    });
+    render(component);
+
+    // Verify that type="icon" was passed to the component
+    expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
+      { opportunityId: mockOpportunity.opportunity_id, type: "icon" },
       undefined,
     );
   });
 });
+

--- a/frontend/tests/components/search/SearchResultsTable.test.tsx
+++ b/frontend/tests/components/search/SearchResultsTable.test.tsx
@@ -13,17 +13,19 @@ jest.mock("next-intl", () => ({
 jest.mock("src/components/user/OpportunitySaveUserControl", () => ({
   OpportunitySaveUserControl: jest
     .fn()
-    .mockImplementation(({ opportunityId, type }: { opportunityId: string; type?: string }) => {
-      return (
-        <div
-          data-testid={`opportunity-save-control-${opportunityId}`}
-          data-opportunity-id={opportunityId}
-          data-type={type || "button"}
-        >
-          {`Mocked Save Control for ${opportunityId} (${type || "button"})`}
-        </div>
-      );
-    }),
+    .mockImplementation(
+      ({ opportunityId, type }: { opportunityId: string; type?: string }) => {
+        return (
+          <div
+            data-testid={`opportunity-save-control-${opportunityId}`}
+            data-opportunity-id={opportunityId}
+            data-type={type || "button"}
+          >
+            {`Mocked Save Control for ${opportunityId} (${type || "button"})`}
+          </div>
+        );
+      },
+    ),
 }));
 
 // this does not directly test responsive aspects of the component, that should be done in e2e tests
@@ -91,7 +93,9 @@ describe("SearchResultsTable", () => {
 
     // Check that the wrapper div with new layout classes exists
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector(".margin-right-1.margin-y-auto.flex-1");
+    const wrapper = container.querySelector(
+      ".margin-right-1.margin-y-auto.flex-1",
+    );
     expect(wrapper).toBeInTheDocument();
 
     // Verify the mock was called
@@ -254,7 +258,9 @@ describe("SearchResultsTable", () => {
 
     // Verify correct number of wrapper divs
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrappers = container.querySelectorAll(".margin-right-1.margin-y-auto.flex-1");
+    const wrappers = container.querySelectorAll(
+      ".margin-right-1.margin-y-auto.flex-1",
+    );
     expect(wrappers).toHaveLength(3);
 
     // Verify each opportunity ID was called
@@ -312,4 +318,3 @@ describe("SearchResultsTable", () => {
     );
   });
 });
-

--- a/frontend/tests/components/search/SearchResultsTable.test.tsx
+++ b/frontend/tests/components/search/SearchResultsTable.test.tsx
@@ -11,25 +11,29 @@ jest.mock("next-intl", () => ({
 }));
 
 jest.mock("src/components/user/OpportunitySaveUserControl", () => ({
-  OpportunitySaveUserControl: jest.fn().mockImplementation(({ opportunityId }: { opportunityId: string }) => {
-    return (
-      <div 
-        data-testid={`opportunity-save-control-${opportunityId}`}
-        data-opportunity-id={opportunityId}
-      >
-        {`Mocked Save Control for ${opportunityId}`}
-      </div>
-    );
-  }),
+  OpportunitySaveUserControl: jest
+    .fn()
+    .mockImplementation(({ opportunityId }: { opportunityId: string }) => {
+      return (
+        <div
+          data-testid={`opportunity-save-control-${opportunityId}`}
+          data-opportunity-id={opportunityId}
+        >
+          {`Mocked Save Control for ${opportunityId}`}
+        </div>
+      );
+    }),
 }));
 
 // this does not directly test responsive aspects of the component, that should be done in e2e tests
 // see https://github.com/HHS/simpler-grants-gov/issues/5414
 describe("SearchResultsTable", () => {
-  const mockOpportunitySaveUserControl = jest.mocked(OpportunitySaveUserControl);
-  
+  const mockOpportunitySaveUserControl = jest.mocked(
+    OpportunitySaveUserControl,
+  );
+
   afterEach(() => jest.resetAllMocks());
-  
+
   it("passes accessibility test", async () => {
     const component = SearchResultsTable({
       searchResults: [mockOpportunity],
@@ -69,11 +73,11 @@ describe("SearchResultsTable", () => {
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledTimes(2);
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: mockOpportunity.opportunity_id },
-      undefined
+      undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: "second-opportunity-id" },
-      undefined
+      undefined,
     );
   });
 
@@ -86,13 +90,13 @@ describe("SearchResultsTable", () => {
 
     // Check that the wrapper div with search-table-save-wrapper class exists
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrapper = container.querySelector('.search-table-save-wrapper');
+    const wrapper = container.querySelector(".search-table-save-wrapper");
     expect(wrapper).toBeInTheDocument();
-    
+
     // Verify the mock was called
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: mockOpportunity.opportunity_id },
-      undefined
+      undefined,
     );
   });
 
@@ -148,18 +152,18 @@ describe("SearchResultsTable", () => {
         name: "headings.status statuses.posted",
       }),
     ).toBeInTheDocument();
-    
+
     const titleCell = within(results[1]).getByRole("cell", {
       name: /headings\.title Test Opportunity number: OPP-12345/,
     });
     expect(titleCell).toBeInTheDocument();
-    
+
     // Verify that the save control component was called for this opportunity
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: mockOpportunity.opportunity_id },
-      undefined
+      undefined,
     );
-    
+
     expect(
       within(results[1]).getByRole("cell", {
         name: "headings.agency published : Jan 15, 2023 expectedAwards: 1",
@@ -246,24 +250,24 @@ describe("SearchResultsTable", () => {
 
     // Verify correct number of mock calls
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledTimes(3);
-    
+
     // Verify correct number of wrapper divs
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-    const wrappers = container.querySelectorAll('.search-table-save-wrapper');
+    const wrappers = container.querySelectorAll(".search-table-save-wrapper");
     expect(wrappers).toHaveLength(3);
-    
+
     // Verify each opportunity ID was called
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: "opp-1" },
-      undefined
+      undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: "opp-2" },
-      undefined
+      undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: "opp-3" },
-      undefined
+      undefined,
     );
   });
 
@@ -281,15 +285,15 @@ describe("SearchResultsTable", () => {
 
     // Check that the mock was called with the correct parameters
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledTimes(2);
-    
+
     // Check that the mock was called with the correct opportunity IDs
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: "unique-id-1" },
-      undefined
+      undefined,
     );
     expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
       { opportunityId: "unique-id-2" },
-      undefined
+      undefined,
     );
   });
 });

--- a/frontend/tests/components/search/SearchResultsTable.test.tsx
+++ b/frontend/tests/components/search/SearchResultsTable.test.tsx
@@ -5,25 +5,29 @@ import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import { SearchResultsTable } from "src/components/search/SearchResultsTable";
 
-const mockFetchSavedOpportunities = jest.fn();
+// Mock the OpportunitySaveUserControl component
+const mockOpportunitySaveUserControl = jest.fn(({ opportunityId }) => (
+  <div 
+    data-testid={`opportunity-save-control-${opportunityId}`}
+    data-opportunity-id={opportunityId}
+  >
+    Mocked Save Control
+  </div>
+));
 
 jest.mock("next-intl", () => ({
   useTranslations: () => useTranslationsMock(),
 }));
 
-jest.mock("src/services/fetch/fetchers/savedOpportunityFetcher", () => ({
-  fetchSavedOpportunities: () => mockFetchSavedOpportunities() as unknown,
+jest.mock("src/components/user/OpportunitySaveUserControl", () => ({
+  OpportunitySaveUserControl: mockOpportunitySaveUserControl,
 }));
 
 // this does not directly test responsive aspects of the component, that should be done in e2e tests
 // see https://github.com/HHS/simpler-grants-gov/issues/5414
 describe("SearchResultsTable", () => {
-  beforeEach(() =>
-    mockFetchSavedOpportunities.mockResolvedValue([
-      { opportunity_id: "0bfdd67c-e58a-4005-bfd1-12cfe592b17e" },
-    ]),
-  );
   afterEach(() => jest.resetAllMocks());
+  
   it("passes accessibility test", async () => {
     const component = await SearchResultsTable({
       searchResults: [mockOpportunity],
@@ -33,6 +37,7 @@ describe("SearchResultsTable", () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
   it("matches snapshot", async () => {
     const component = await SearchResultsTable({
       searchResults: [mockOpportunity],
@@ -41,24 +46,59 @@ describe("SearchResultsTable", () => {
     const { container } = render(component);
     expect(container).toMatchSnapshot();
   });
-  it("displays saved search indicator when applicable", async () => {
+
+  it("renders OpportunitySaveUserControl for each opportunity", async () => {
+    const opportunities = [
+      mockOpportunity,
+      {
+        ...mockOpportunity,
+        opportunity_id: "second-opportunity-id",
+        opportunity_title: "Second Test Opportunity",
+      },
+    ];
+
     const component = await SearchResultsTable({
-      searchResults: [
-        mockOpportunity,
-        {
-          ...mockOpportunity,
-          opportunity_id: "0bfdd67c-e58a-4005-bfd1-12cfe592b17e",
-        },
-      ],
+      searchResults: opportunities,
       page: 1,
     });
     render(component);
 
-    const results = screen.getAllByRole("row");
-    expect(results).toHaveLength(3); // first is the header row
-    expect(within(results[1]).queryByText("saved")).not.toBeInTheDocument();
-    expect(within(results[2]).getByText("saved")).toBeInTheDocument();
+    // Verify OpportunitySaveUserControl is rendered for each opportunity
+    expect(mockOpportunitySaveUserControl).toHaveBeenCalledTimes(2);
+    
+    // Check first opportunity
+    expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
+      { opportunityId: mockOpportunity.opportunity_id },
+      {}
+    );
+    
+    // Check second opportunity
+    expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
+      { opportunityId: "second-opportunity-id" },
+      {}
+    );
+
+    // Verify the components are rendered in the DOM
+    expect(screen.getByTestId(`opportunity-save-control-${mockOpportunity.opportunity_id}`)).toBeInTheDocument();
+    expect(screen.getByTestId("opportunity-save-control-second-opportunity-id")).toBeInTheDocument();
   });
+
+  it("applies search-table-save-wrapper CSS class to save control containers", async () => {
+    const component = await SearchResultsTable({
+      searchResults: [mockOpportunity],
+      page: 1,
+    });
+    const { container } = render(component);
+
+    // Check that the search-table-save-wrapper class is applied
+    const saveWrappers = container.querySelectorAll('.search-table-save-wrapper');
+    expect(saveWrappers).toHaveLength(1);
+    
+    // Verify the save control is within the wrapper
+    const saveWrapper = saveWrappers[0];
+    expect(within(saveWrapper as HTMLElement).getByTestId(`opportunity-save-control-${mockOpportunity.opportunity_id}`)).toBeInTheDocument();
+  });
+
   it("displays headings for all columns as expected", async () => {
     const component = await SearchResultsTable({
       searchResults: [mockOpportunity],
@@ -85,6 +125,7 @@ describe("SearchResultsTable", () => {
       screen.getByRole("columnheader", { name: "headings.awardMax" }),
     ).toBeInTheDocument();
   });
+
   // note that values for this test also include the header value - this is a remnant of the responsive experience,
   // Jest doesn't know that these header values should be hidden :shrug:
   it("displays data for all columns as expected", async () => {
@@ -110,11 +151,14 @@ describe("SearchResultsTable", () => {
         name: "headings.status statuses.posted",
       }),
     ).toBeInTheDocument();
-    expect(
-      within(results[1]).getByRole("cell", {
-        name: "headings.title Test Opportunity number: OPP-12345",
-      }),
-    ).toBeInTheDocument();
+    
+    // Updated to include the save control in the title cell
+    const titleCell = within(results[1]).getByRole("cell", {
+      name: /headings\.title Test Opportunity number: OPP-12345/,
+    });
+    expect(titleCell).toBeInTheDocument();
+    expect(within(titleCell).getByTestId(`opportunity-save-control-${mockOpportunity.opportunity_id}`)).toBeInTheDocument();
+    
     expect(
       within(results[1]).getByRole("cell", {
         name: "headings.agency published : Jan 15, 2023 expectedAwards: 1",
@@ -171,6 +215,7 @@ describe("SearchResultsTable", () => {
       }),
     ).toBeInTheDocument();
   });
+
   it("displays a proper message when there are no results", async () => {
     const component = await SearchResultsTable({
       searchResults: [],
@@ -183,5 +228,52 @@ describe("SearchResultsTable", () => {
         name: "title",
       }),
     ).toBeInTheDocument();
+  });
+
+  it("renders save controls for multiple opportunities with different IDs", async () => {
+    const opportunities = [
+      { ...mockOpportunity, opportunity_id: "opp-1" },
+      { ...mockOpportunity, opportunity_id: "opp-2" },
+      { ...mockOpportunity, opportunity_id: "opp-3" },
+    ];
+
+    const component = await SearchResultsTable({
+      searchResults: opportunities,
+      page: 1,
+    });
+    render(component);
+
+    // Verify all save controls are rendered with unique opportunity IDs
+    expect(screen.getByTestId("opportunity-save-control-opp-1")).toBeInTheDocument();
+    expect(screen.getByTestId("opportunity-save-control-opp-2")).toBeInTheDocument();
+    expect(screen.getByTestId("opportunity-save-control-opp-3")).toBeInTheDocument();
+
+    // Verify all have the search-table-save-wrapper class
+    const { container } = render(component);
+    const saveWrappers = container.querySelectorAll('.search-table-save-wrapper');
+    expect(saveWrappers).toHaveLength(3);
+  });
+
+  it("passes correct opportunity ID to each save control component", async () => {
+    const opportunities = [
+      { ...mockOpportunity, opportunity_id: "unique-id-1" },
+      { ...mockOpportunity, opportunity_id: "unique-id-2" },
+    ];
+
+    const component = await SearchResultsTable({
+      searchResults: opportunities,
+      page: 1,
+    });
+    render(component);
+
+    // Verify that each OpportunitySaveUserControl received the correct opportunity ID
+    expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
+      { opportunityId: "unique-id-1" },
+      {}
+    );
+    expect(mockOpportunitySaveUserControl).toHaveBeenCalledWith(
+      { opportunityId: "unique-id-2" },
+      {}
+    );
   });
 });

--- a/frontend/tests/components/search/SearchResultsTable.test.tsx
+++ b/frontend/tests/components/search/SearchResultsTable.test.tsx
@@ -94,7 +94,7 @@ describe("SearchResultsTable", () => {
     // Check that the wrapper div with new layout classes exists
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const wrapper = container.querySelector(
-      ".margin-right-1.margin-y-auto.flex-1",
+      ".margin-y-auto.grid-col-auto.minw-4",
     );
     expect(wrapper).toBeInTheDocument();
 
@@ -259,7 +259,7 @@ describe("SearchResultsTable", () => {
     // Verify correct number of wrapper divs
     // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
     const wrappers = container.querySelectorAll(
-      ".margin-right-1.margin-y-auto.flex-1",
+      ".margin-y-auto.grid-col-auto.minw-4",
     );
     expect(wrappers).toHaveLength(3);
 

--- a/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
+++ b/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
@@ -114,30 +114,34 @@ exports[`SearchResultsTable matches snapshot 1`] = `
                 class="display-flex"
               >
                 <div
-                  class="margin-right-1 margin-y-auto flex-1"
+                  class="margin-y-auto grid-col-auto minw-4"
                 />
                 <div
-                  class="font-sans-md text-bold flex-11"
+                  class="grid-col-fill"
                 >
-                  <a
-                    href="/opportunity/63588df8-f2d1-44ed-a201-5804abba696a"
-                    id="search-result-link-1-1"
+                  <div
+                    class="font-sans-md text-bold line-height-sans-3"
                   >
-                    Test Opportunity
-                  </a>
+                    <a
+                      href="/opportunity/63588df8-f2d1-44ed-a201-5804abba696a"
+                      id="search-result-link-1-1"
+                    >
+                      Test Opportunity
+                    </a>
+                  </div>
+                  <div
+                    class="display-none tablet-lg:display-block font-sans-xs"
+                  >
+                    <span
+                      class="text-bold"
+                    >
+                      number
+                      :
+                    </span>
+                     
+                    OPP-12345
+                  </div>
                 </div>
-              </div>
-              <div
-                class="display-none tablet-lg:display-block font-sans-xs"
-              >
-                <span
-                  class="text-bold"
-                >
-                  number
-                  :
-                </span>
-                 
-                OPP-12345
               </div>
             </div>
           </div>

--- a/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
+++ b/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
@@ -111,14 +111,21 @@ exports[`SearchResultsTable matches snapshot 1`] = `
               data-testid="responsive-data-0-2"
             >
               <div
-                class="font-sans-lg text-bold"
+                class="display-flex"
               >
-                <a
-                  href="/opportunity/63588df8-f2d1-44ed-a201-5804abba696a"
-                  id="search-result-link-1-1"
+                <div
+                  class="margin-right-1 margin-y-auto flex-1"
+                />
+                <div
+                  class="font-sans-md text-bold flex-11"
                 >
-                  Test Opportunity
-                </a>
+                  <a
+                    href="/opportunity/63588df8-f2d1-44ed-a201-5804abba696a"
+                    id="search-result-link-1-1"
+                  >
+                    Test Opportunity
+                  </a>
+                </div>
               </div>
               <div
                 class="display-none tablet-lg:display-block font-sans-xs"
@@ -132,9 +139,6 @@ exports[`SearchResultsTable matches snapshot 1`] = `
                  
                 OPP-12345
               </div>
-              <div
-                class="margin-top-2 search-table-save-wrapper"
-              />
             </div>
           </div>
         </td>

--- a/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
+++ b/frontend/tests/components/search/__snapshots__/SearchResultsTable.test.tsx.snap
@@ -132,6 +132,9 @@ exports[`SearchResultsTable matches snapshot 1`] = `
                  
                 OPP-12345
               </div>
+              <div
+                class="margin-top-2 search-table-save-wrapper"
+              />
             </div>
           </div>
         </td>

--- a/frontend/tests/components/user/OpportunitySaveUserControl.test.tsx
+++ b/frontend/tests/components/user/OpportunitySaveUserControl.test.tsx
@@ -17,4 +17,4 @@ describe("OpportunitySaveUserControl", () => {
     const component = OpportunitySaveUserControl;
     expect(component).toBeDefined();
   });
-}); 
+});

--- a/frontend/tests/components/user/OpportunitySaveUserControl.test.tsx
+++ b/frontend/tests/components/user/OpportunitySaveUserControl.test.tsx
@@ -1,0 +1,20 @@
+import { OpportunitySaveUserControl } from "src/components/user/OpportunitySaveUserControl";
+
+describe("OpportunitySaveUserControl", () => {
+  it("exports the component correctly", () => {
+    expect(typeof OpportunitySaveUserControl).toBe("function");
+  });
+
+  it("accepts the required opportunityId prop", () => {
+    // This is a basic test to ensure the component interface is correct
+    const component = OpportunitySaveUserControl;
+    expect(component).toBeDefined();
+  });
+
+  it("accepts the optional type prop with correct types", () => {
+    // TypeScript compilation would catch type errors, so this test
+    // is mainly to document the expected interface
+    const component = OpportunitySaveUserControl;
+    expect(component).toBeDefined();
+  });
+}); 


### PR DESCRIPTION
## Summary

Work for #5759 

## Changes proposed

Added ability to opportunities from search results table. 

## Context for reviewers

Had to manually implement CSS classes to change how button was displayed in this context without impacting how the button is used on the opportunity page. 

## Validation steps
<img width="1256" height="747" alt="Screenshot 2025-07-30 at 4 06 34 PM" src="https://github.com/user-attachments/assets/b375b999-5a26-4075-bf5c-7782eac1f81f" />

