### PR TITLE
[Issue 5763] Update search alert w/ ethnio survey link

### DIFF
--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -74,7 +74,9 @@ function Search({ searchParams, params }: SearchPageProps) {
         heading={t("betaAlert.alertTitle")}
         alertMessage={t.rich("betaAlert.alert", {
           ethnioSurveyLink: (chunks) => (
-            <a href="https://ethn.io/16188" target="_blank">{chunks}</a>
+            <a href="https://ethn.io/16188" target="_blank">
+              {chunks}
+            </a>
           ),
         })}
       />

--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -73,18 +73,8 @@ function Search({ searchParams, params }: SearchPageProps) {
         containerClasses="margin-top-5"
         heading={t("betaAlert.alertTitle")}
         alertMessage={t.rich("betaAlert.alert", {
-          mailToGrants: (chunks) => (
-            <a href="mailto:simpler@grants.gov">{chunks}</a>
-          ),
-          bugReport: (chunks) => (
-            <a href="https://github.com/HHS/simpler-grants-gov/issues/new?template=1_bug_report.yml">
-              {chunks}
-            </a>
-          ),
-          featureRequest: (chunks) => (
-            <a href="https://github.com/HHS/simpler-grants-gov/issues/new?template=2_feature_request.yml">
-              {chunks}
-            </a>
+          ethnioSurveyLink: (chunks) => (
+            <a href="https://ethn.io/16188" target="_blank">{chunks}</a>
           ),
         })}
       />

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -59,18 +59,8 @@ export function SearchVersionTwo({
           containerClasses="padding-top-5"
           heading={t("betaAlert.alertTitle")}
           alertMessage={t.rich("betaAlert.alert", {
-            mailToGrants: (chunks) => (
-              <a href="mailto:simpler@grants.gov">{chunks}</a>
-            ),
-            bugReport: (chunks) => (
-              <a href="https://github.com/HHS/simpler-grants-gov/issues/new?template=1_bug_report.yml">
-                {chunks}
-              </a>
-            ),
-            featureRequest: (chunks) => (
-              <a href="https://github.com/HHS/simpler-grants-gov/issues/new?template=2_feature_request.yml">
-                {chunks}
-              </a>
+            ethnioSurveyLink: (chunks) => (
+              <a href="https://ethn.io/16188" target="_blank">{chunks}</a>
             ),
           })}
         />

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -60,7 +60,9 @@ export function SearchVersionTwo({
           heading={t("betaAlert.alertTitle")}
           alertMessage={t.rich("betaAlert.alert", {
             ethnioSurveyLink: (chunks) => (
-              <a href="https://ethn.io/16188" target="_blank">{chunks}</a>
+              <a href="https://ethn.io/16188" target="_blank">
+                {chunks}
+              </a>
             ),
           })}
         />

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -656,8 +656,7 @@ export const messages = {
       title: "Export results",
     },
     betaAlert: {
-      alertTitle:
-        "How can we build a simpler search experience?",
+      alertTitle: "How can we build a simpler search experience?",
       alert:
         "Fill out a <ethnioSurveyLink>1-minute survey</ethnioSurveyLink> and share your experience with Simpler and Classic Search.",
     },

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -657,9 +657,9 @@ export const messages = {
     },
     betaAlert: {
       alertTitle:
-        "We're actively building this search experience. Help us improve!",
+        "How can we build a simpler search experience?",
       alert:
-        "Send your feedback to <mailToGrants>simpler@grants.gov</mailToGrants>. GitHub users can file tickets to <bugReport>report a bug</bugReport> or <featureRequest>request a feature</featureRequest>.",
+        "Fill out a <ethnioSurveyLink>1-minute survey</ethnioSurveyLink> and share your experience with Simpler and Classic Search.",
     },
     saveSearch: {
       heading: "Current search query",


### PR DESCRIPTION
## Summary

Work for #5763 

## Changes proposed

- Edits the BetaAlert text on the /search page to link to an Ethnio survey (instead of contact us email or prompting GitHub issue submission) 

## Context for reviewers

See https://docs.google.com/document/d/1HPYT8YXcGfjoGFOAM06BN9OJ8swdegBzKisJ61OcT7o/edit?tab=t.0 

## Validation steps

- Load the search page
- Click the "1-minute survey" link in the alert
- It should open an Ethnio survey in a new tab