### PR TITLE
[Issue #4515] Add unique ID to certs in SOAP calls

### DIFF
--- a/api/bin/setup-soap.sh
+++ b/api/bin/setup-soap.sh
@@ -53,7 +53,7 @@ for file in $applicantspub $applicantspk $grantorspub $grantorspk; do
   fi
 done
 
-soap_auth_content=$(printf '{"%s": "%s\n\n%s","%s": "%s\n\n%s"}' \
+soap_auth_content=$(printf '{"%s": {"id": "applicant_cert", "cert": "%s\n\n%s"},"%s": {"id": "grantor_cert", "cert": "%s\n\n%s"}}' \
 "`openssl x509 -in $applicantspub -noout -fingerprint -sha256 | sed 's/://g' | cut -d'=' -f2 | tr '[:upper:]' '[:lower:]'`" "`cat ${applicantspk}`" "`cat ${applicantspub}`" \
 "`openssl x509 -in $grantorspub -noout -fingerprint -sha256 | sed 's/://g' | cut -d'=' -f2 | tr '[:upper:]' '[:lower:]'`" "`cat ${grantorspk}`" "`cat ${grantorspub}`")
 

--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -27,13 +27,17 @@ class SOAPClientCertificate(BaseModel):
     serial_number: int
     fingerprint: str
 
-    def get_pem(self, key_map: dict) -> str:
+    def get_pem(self, key_map: dict) -> tuple[str, str]:
         """Note that this auth mechanism will only be configured in lower environments
 
         There will be no prod configurations for this auth mechanism.
+        TODO - is the above true? I think this happens for prod as well?
         """
         try:
-            return f"{key_map[self.fingerprint]}\n\n{self.cert}"
+            value = key_map[self.fingerprint]
+            pem = f"{value['cert']}\n\n{self.cert}"
+            pem_id = value.get("id", "unknown")
+            return pem, pem_id
         except KeyError:
             raise SOAPClientCertificateNotConfigured("cert is not configured") from None
         except Exception:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
@@ -5,13 +5,14 @@ import pytest
 from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPAuth,
     SOAPClientCertificate,
+    SOAPClientCertificateLookupError,
     SOAPClientCertificateNotConfigured,
     get_soap_auth,
 )
 
 MOCK_FINGERPRINT = "123"
 MOCK_CERT = "456"
-MOCK_KEYMAP = {MOCK_FINGERPRINT: MOCK_CERT}
+MOCK_KEYMAP = {MOCK_FINGERPRINT: {"id": "XYZ", "cert": MOCK_CERT}}
 MOCK_CERT_STR = "certstr"
 MOCK_CLIENT_CERT = SOAPClientCertificate(
     cert=MOCK_CERT_STR,
@@ -29,12 +30,20 @@ def test_get_soap_auth(mock_get_soap_client_certificate):
 
 def test_client_auth():
     auth = SOAPAuth(certificate=MOCK_CLIENT_CERT)
-    assert auth.certificate.get_pem(MOCK_KEYMAP) == f"{MOCK_CERT}\n\n{MOCK_CERT_STR}"
+    cert, id = auth.certificate.get_pem(MOCK_KEYMAP)
+    assert cert == f"{MOCK_CERT}\n\n{MOCK_CERT_STR}"
+    assert id == "XYZ"
 
 
 def test_client_auth_exceptions():
     auth = SOAPAuth(certificate=MOCK_CLIENT_CERT)
-    with pytest.raises(SOAPClientCertificateNotConfigured):
+    with pytest.raises(SOAPClientCertificateNotConfigured, match="cert is not configured"):
         auth.certificate.get_pem({})
-    with pytest.raises(SOAPClientCertificateNotConfigured):
+    with pytest.raises(SOAPClientCertificateNotConfigured, match="cert is not configured"):
         auth.certificate.get_pem({"dne": "dne"})
+    with pytest.raises(SOAPClientCertificateNotConfigured, match="cert is not configured"):
+        auth.certificate.get_pem({MOCK_FINGERPRINT: {"id": "abc"}})
+    with pytest.raises(
+        SOAPClientCertificateLookupError, match="could not retrieve client cert for serial number"
+    ):
+        auth.certificate.get_pem({MOCK_FINGERPRINT: "not-an-object"})


### PR DESCRIPTION
## Summary

Fixes #4515

## Changes proposed
Adjust how we define certs to include an ID that we can log

## Context for reviewers
We want to have an ID for each cert that isn't secret. Now the env var JSON will have an ID in it alongside the cert for logging. 

Before we can merge this, we'll need to update the env var in dev/staging/prod in parameter store, but holding on that until right before I merge to avoid breaking things / confirm this approach.

## Validation steps
Delete your existing soap-api.env file and run `make setup-soap-proxy` to generate the env var in the same format.

Testing using the example SOAP call in the cert secret from 1password you'll now see the logs have the ID value of that cert:
<img width="1443" height="85" alt="Screenshot 2025-07-24 at 2 30 20 PM" src="https://github.com/user-attachments/assets/c8c0e4c0-9aec-41eb-90d8-a1adccfa8244" />

