### PR TITLE
[Issue: #5763] Follow-up: Add external link icon to ethnio survey

### DIFF
--- a/frontend/src/app/[locale]/search/page.tsx
+++ b/frontend/src/app/[locale]/search/page.tsx
@@ -74,7 +74,11 @@ function Search({ searchParams, params }: SearchPageProps) {
         heading={t("betaAlert.alertTitle")}
         alertMessage={t.rich("betaAlert.alert", {
           ethnioSurveyLink: (chunks) => (
-            <a href="https://ethn.io/16188" target="_blank" className="usa-link--external">
+            <a
+              href="https://ethn.io/16188"
+              target="_blank"
+              className="usa-link--external"
+            >
               {chunks}
             </a>
           ),

--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -60,7 +60,11 @@ export function SearchVersionTwo({
           heading={t("betaAlert.alertTitle")}
           alertMessage={t.rich("betaAlert.alert", {
             ethnioSurveyLink: (chunks) => (
-              <a href="https://ethn.io/16188" target="_blank" className="usa-link--external">
+              <a
+                href="https://ethn.io/16188"
+                target="_blank"
+                className="usa-link--external"
+              >
                 {chunks}
               </a>
             ),


### PR DESCRIPTION
## Summary

Work for #5763 

## Changes proposed

- Add `className="usa-link--external"` to the Ethnio link in the Alert on /search

<img width="763" height="297" alt="image" src="https://github.com/user-attachments/assets/c0ea111d-7fe7-453e-8094-8775aa0a47b1" />

## Context for reviewers

Missed this in previous design/PR

## Validation steps

- Go to the /search page
- Make sure the external link icon indicates that the "1-minute survey" link is not a SGG URL