### PR TITLE
[Unticketed] Update to latest template pattern for post apt-get install cleanup

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     libgnutls30 \
   # Reduce the image size by clear apt cached lists
   # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
+  && apt-get clean \
   && rm -fr /var/lib/apt/lists/* \
   && rm /etc/ssl/private/ssl-cert-snakeoil.key
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
         libgnutls30 \
     # Reduce the image size by clear apt cached lists
     # Complies with https://github.com/codacy/codacy-hadolint/blob/master/codacy-hadolint/docs/description/DL3009.md
+    && apt-get clean \
     && rm -fr /var/lib/apt/lists/* \
     && rm /etc/ssl/private/ssl-cert-snakeoil.key
 
@@ -55,7 +56,9 @@ ARG RUN_USER
 # If there is anything that needs to be ran as root, this is the spot
 
 # Install graphviz which is used to generate ERD diagrams
-RUN apt-get update && apt-get install --no-install-recommends --yes graphviz
+RUN apt-get update && apt-get install --no-install-recommends --yes graphviz \ 
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 USER ${RUN_USER}
 WORKDIR /api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -75,7 +75,8 @@ RUN apt-get update \
   # Install wget, required for health checks
   wget \
   # Reduce the image size by clearing apt cached lists
-  && rm -fr /var/lib/apt/lists/*
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Remove dev dependencies after build
 RUN npm prune --production


### PR DESCRIPTION
## Changes proposed

Recent Platform template updates note that we should be doing both apt-get clean and deleting the lists (which we were already doing).