### PR TITLE
Mikehgrantsgov/5727 add metrics to submission logic

### DIFF
--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -148,6 +148,7 @@ class CompetitionOpenToApplicant(StrEnum):
 
 class SubmissionIssue(StrEnum):
     """Submission issue types for metrics logging"""
+
     NOT_A_MEMBER_OF_ORG = "not_a_member_of_org"
     ORG_NO_SAM_GOV_ENTITY = "org_no_sam_gov_entity"
     ORG_INACTIVE_IN_SAM_GOV = "org_inactive_in_sam_gov"

--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -146,6 +146,27 @@ class CompetitionOpenToApplicant(StrEnum):
     ORGANIZATION = "organization"
 
 
+class SubmissionIssue(StrEnum):
+    """Submission issue types for metrics logging"""
+    NOT_A_MEMBER_OF_ORG = "not_a_member_of_org"
+    ORG_NO_SAM_GOV_ENTITY = "org_no_sam_gov_entity"
+    ORG_INACTIVE_IN_SAM_GOV = "org_inactive_in_sam_gov"
+    ORG_SAM_GOV_EXPIRED = "org_sam_gov_expired"
+    COMPETITION_NO_ORG_APPLICATIONS = "competition_no_org_applications"
+    COMPETITION_NO_INDIVIDUAL_APPLICATIONS = "competition_no_individual_applications"
+    COMPETITION_NOT_FOUND = "competition_not_found"
+    ORGANIZATION_NOT_FOUND = "organization_not_found"
+    APPLICATION_NOT_IN_PROGRESS = "application_not_in_progress"
+    COMPETITION_NOT_OPEN = "competition_not_open"
+    FORM_VALIDATION_ERRORS = "form_validation_errors"
+    UNAUTHORIZED_APPLICATION_ACCESS = "unauthorized_application_access"
+    NO_UPDATE_DATA_PROVIDED = "no_update_data_provided"
+    FORM_NOT_FOUND_OR_NOT_ATTACHED = "form_not_found_or_not_attached"
+    APPLICATION_FORM_NOT_FOUND_NO_RESPONSE = "application_form_not_found_no_response"
+    INVALID_FILE_NAME = "invalid_file_name"
+    ATTACHMENT_NOT_FOUND = "attachment_not_found"
+
+
 class SamGovExtractType(StrEnum):
     MONTHLY = "monthly"
     DAILY = "daily"

--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -242,10 +242,10 @@ def validate_forms(application: Application, action: ApplicationAction) -> None:
             extra={
                 "submission_issue": SubmissionIssue.FORM_VALIDATION_ERRORS,
                 "error_types": error_types,
-                "error_count": len(form_errors)
-            }
+                "error_count": len(form_errors),
+            },
         )
-        
+
         detail = {}
         if form_error_map:
             detail["form_validation_errors"] = form_error_map
@@ -272,7 +272,7 @@ def validate_application_in_progress(application: Application, action: Applicati
                 "action": action,
                 "application_status": application.application_status,
                 "application_action": action,
-                "submission_issue": SubmissionIssue.APPLICATION_NOT_IN_PROGRESS
+                "submission_issue": SubmissionIssue.APPLICATION_NOT_IN_PROGRESS,
             },
         )
         raise_flask_error(
@@ -302,7 +302,7 @@ def validate_competition_open(competition: Competition, action: ApplicationActio
                 "closing_date": competition.closing_date,
                 "grace_period": competition.grace_period,
                 "application_action": action,
-                "submission_issue": SubmissionIssue.COMPETITION_NOT_OPEN
+                "submission_issue": SubmissionIssue.COMPETITION_NOT_OPEN,
             },
         )
         raise_flask_error(

--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
-from src.constants.lookup_constants import ApplicationFormStatus, ApplicationStatus
+from src.constants.lookup_constants import ApplicationFormStatus, ApplicationStatus, SubmissionIssue
 from src.db.models.competition_models import Application, ApplicationForm, Competition
 from src.form_schema.jsonschema_validator import validate_json_schema_for_form
 from src.form_schema.rule_processing.json_rule_context import JsonRuleConfig, JsonRuleContext
@@ -235,6 +235,17 @@ def validate_forms(application: Application, action: ApplicationAction) -> None:
     form_errors, form_error_map = get_application_form_errors(application, action)
 
     if len(form_errors) > 0:
+        # Log the specific validation issues for metrics
+        error_types = [error.type for error in form_errors]
+        logger.info(
+            "Application has form validation issues preventing submission",
+            extra={
+                "submission_issue": SubmissionIssue.FORM_VALIDATION_ERRORS,
+                "error_types": error_types,
+                "error_count": len(form_errors)
+            }
+        )
+        
         detail = {}
         if form_error_map:
             detail["form_validation_errors"] = form_error_map
@@ -261,6 +272,7 @@ def validate_application_in_progress(application: Application, action: Applicati
                 "action": action,
                 "application_status": application.application_status,
                 "application_action": action,
+                "submission_issue": SubmissionIssue.APPLICATION_NOT_IN_PROGRESS
             },
         )
         raise_flask_error(
@@ -290,6 +302,7 @@ def validate_competition_open(competition: Competition, action: ApplicationActio
                 "closing_date": competition.closing_date,
                 "grace_period": competition.grace_period,
                 "application_action": action,
+                "submission_issue": SubmissionIssue.COMPETITION_NOT_OPEN
             },
         )
         raise_flask_error(

--- a/api/src/services/applications/auth_utils.py
+++ b/api/src/services/applications/auth_utils.py
@@ -1,6 +1,7 @@
 import logging
 
 from src.api.route_utils import raise_flask_error
+from src.constants.lookup_constants import SubmissionIssue
 from src.db.models.competition_models import Application
 from src.db.models.user_models import User
 
@@ -21,6 +22,7 @@ def check_user_application_access(application: Application, user: User) -> None:
             extra={
                 "user_id": user.user_id,
                 "application_id": application.application_id,
+                "submission_issue": SubmissionIssue.UNAUTHORIZED_APPLICATION_ACCESS
             },
         )
         raise_flask_error(403, "Unauthorized")

--- a/api/src/services/applications/auth_utils.py
+++ b/api/src/services/applications/auth_utils.py
@@ -22,7 +22,7 @@ def check_user_application_access(application: Application, user: User) -> None:
             extra={
                 "user_id": user.user_id,
                 "application_id": application.application_id,
-                "submission_issue": SubmissionIssue.UNAUTHORIZED_APPLICATION_ACCESS
+                "submission_issue": SubmissionIssue.UNAUTHORIZED_APPLICATION_ACCESS,
             },
         )
         raise_flask_error(403, "Unauthorized")

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -7,7 +7,11 @@ from sqlalchemy.orm import selectinload
 
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
-from src.constants.lookup_constants import ApplicationStatus, CompetitionOpenToApplicant, SubmissionIssue
+from src.constants.lookup_constants import (
+    ApplicationStatus,
+    CompetitionOpenToApplicant,
+    SubmissionIssue,
+)
 from src.db.models.competition_models import Application, ApplicationForm, Competition
 from src.db.models.entity_models import Organization
 from src.db.models.user_models import ApplicationUser, OrganizationUser, User
@@ -36,7 +40,7 @@ def _validate_organization_membership(
     if not is_member:
         logger.info(
             "User is not a member of the organization",
-            extra={"submission_issue": SubmissionIssue.NOT_A_MEMBER_OF_ORG}
+            extra={"submission_issue": SubmissionIssue.NOT_A_MEMBER_OF_ORG},
         )
         raise_flask_error(403, "User is not a member of the organization")
 
@@ -55,7 +59,7 @@ def _validate_organization_expiration(organization: Organization) -> None:
     if not organization.sam_gov_entity:
         logger.info(
             "Organization has no SAM.gov entity record",
-            extra={"submission_issue": SubmissionIssue.ORG_NO_SAM_GOV_ENTITY}
+            extra={"submission_issue": SubmissionIssue.ORG_NO_SAM_GOV_ENTITY},
         )
         raise_flask_error(
             422,
@@ -69,7 +73,7 @@ def _validate_organization_expiration(organization: Organization) -> None:
     if sam_gov_entity.is_inactive is True:
         logger.info(
             "Organization is inactive in SAM.gov",
-            extra={"submission_issue": SubmissionIssue.ORG_INACTIVE_IN_SAM_GOV}
+            extra={"submission_issue": SubmissionIssue.ORG_INACTIVE_IN_SAM_GOV},
         )
         raise_flask_error(
             422,
@@ -80,7 +84,7 @@ def _validate_organization_expiration(organization: Organization) -> None:
     if sam_gov_entity.expiration_date < current_date:
         logger.info(
             "Organization SAM.gov registration has expired",
-            extra={"submission_issue": SubmissionIssue.ORG_SAM_GOV_EXPIRED}
+            extra={"submission_issue": SubmissionIssue.ORG_SAM_GOV_EXPIRED},
         )
         raise_flask_error(
             422,
@@ -103,7 +107,7 @@ def _validate_applicant_type(competition: Competition, organization_id: UUID | N
         if CompetitionOpenToApplicant.ORGANIZATION not in allowed_applicant_types:
             logger.info(
                 "Competition does not allow organization applications",
-                extra={"submission_issue": SubmissionIssue.COMPETITION_NO_ORG_APPLICATIONS}
+                extra={"submission_issue": SubmissionIssue.COMPETITION_NO_ORG_APPLICATIONS},
             )
             raise_flask_error(
                 422,
@@ -114,7 +118,7 @@ def _validate_applicant_type(competition: Competition, organization_id: UUID | N
         if CompetitionOpenToApplicant.INDIVIDUAL not in allowed_applicant_types:
             logger.info(
                 "Competition does not allow individual applications",
-                extra={"submission_issue": SubmissionIssue.COMPETITION_NO_INDIVIDUAL_APPLICATIONS}
+                extra={"submission_issue": SubmissionIssue.COMPETITION_NO_INDIVIDUAL_APPLICATIONS},
             )
             raise_flask_error(
                 422,
@@ -142,7 +146,7 @@ def create_application(
     if not competition:
         logger.info(
             "Competition not found",
-            extra={"submission_issue": SubmissionIssue.COMPETITION_NOT_FOUND}
+            extra={"submission_issue": SubmissionIssue.COMPETITION_NOT_FOUND},
         )
         raise_flask_error(404, "Competition not found")
 
@@ -167,7 +171,7 @@ def create_application(
         if not organization:
             logger.info(
                 "Organization not found",
-                extra={"submission_issue": SubmissionIssue.ORGANIZATION_NOT_FOUND}
+                extra={"submission_issue": SubmissionIssue.ORGANIZATION_NOT_FOUND},
             )
             raise_flask_error(404, "Organization not found")
 

--- a/api/src/services/applications/create_application_attachment.py
+++ b/api/src/services/applications/create_application_attachment.py
@@ -51,7 +51,7 @@ def upsert_application_attachment(
     if file_attachment.filename is None:
         logger.info(
             "Invalid file name, cannot parse",
-            extra={"submission_issue": SubmissionIssue.INVALID_FILE_NAME}
+            extra={"submission_issue": SubmissionIssue.INVALID_FILE_NAME},
         )
         raise_flask_error(422, "Invalid file name, cannot parse")
 

--- a/api/src/services/applications/create_application_attachment.py
+++ b/api/src/services/applications/create_application_attachment.py
@@ -8,6 +8,7 @@ import src.adapters.db as db
 import src.util.file_util as file_util
 from src.adapters.aws import S3Config
 from src.api.route_utils import raise_flask_error
+from src.constants.lookup_constants import SubmissionIssue
 from src.db.models.competition_models import Application, ApplicationAttachment
 from src.db.models.user_models import User
 from src.services.applications.get_application import get_application
@@ -48,6 +49,10 @@ def upsert_application_attachment(
     # This should only ever happen if someone had a filename that Werkzeug could
     # not parse or interpreted as a file stream.
     if file_attachment.filename is None:
+        logger.info(
+            "Invalid file name, cannot parse",
+            extra={"submission_issue": SubmissionIssue.INVALID_FILE_NAME}
+        )
         raise_flask_error(422, "Invalid file name, cannot parse")
 
     # secure_filename makes the file safe in path operations and removes non-ascii characters

--- a/api/src/services/applications/get_application_attachment.py
+++ b/api/src/services/applications/get_application_attachment.py
@@ -5,6 +5,7 @@ from sqlalchemy import select
 
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
+from src.constants.lookup_constants import SubmissionIssue
 from src.db.models.competition_models import ApplicationAttachment
 from src.db.models.user_models import User
 from src.services.applications.get_application import get_application
@@ -32,6 +33,10 @@ def get_application_attachment(
 
     # 404 if not found
     if not application_attachment:
+        logger.info(
+            "Application attachment not found",
+            extra={"submission_issue": SubmissionIssue.ATTACHMENT_NOT_FOUND}
+        )
         raise_flask_error(
             404, f"Application attachment with ID {application_attachment_id} not found"
         )

--- a/api/src/services/applications/get_application_attachment.py
+++ b/api/src/services/applications/get_application_attachment.py
@@ -35,7 +35,7 @@ def get_application_attachment(
     if not application_attachment:
         logger.info(
             "Application attachment not found",
-            extra={"submission_issue": SubmissionIssue.ATTACHMENT_NOT_FOUND}
+            extra={"submission_issue": SubmissionIssue.ATTACHMENT_NOT_FOUND},
         )
         raise_flask_error(
             404, f"Application attachment with ID {application_attachment_id} not found"

--- a/api/src/services/applications/update_application_form.py
+++ b/api/src/services/applications/update_application_form.py
@@ -50,7 +50,7 @@ def update_application_form(
     if application_response is None and is_included_in_submission is None:
         logger.info(
             "Neither application_response nor is_included_in_submission provided",
-            extra={"submission_issue": SubmissionIssue.NO_UPDATE_DATA_PROVIDED}
+            extra={"submission_issue": SubmissionIssue.NO_UPDATE_DATA_PROVIDED},
         )
         raise_flask_error(
             400,
@@ -74,7 +74,7 @@ def update_application_form(
     if not competition_form:
         logger.info(
             "Form not found or not attached to competition",
-            extra={"submission_issue": SubmissionIssue.FORM_NOT_FOUND_OR_NOT_ATTACHED}
+            extra={"submission_issue": SubmissionIssue.FORM_NOT_FOUND_OR_NOT_ATTACHED},
         )
         raise_flask_error(
             404,
@@ -100,7 +100,7 @@ def update_application_form(
         if application_response is None:
             logger.info(
                 "Application form not found and no response data provided",
-                extra={"submission_issue": SubmissionIssue.APPLICATION_FORM_NOT_FOUND_NO_RESPONSE}
+                extra={"submission_issue": SubmissionIssue.APPLICATION_FORM_NOT_FOUND_NO_RESPONSE},
             )
             raise_flask_error(
                 404,

--- a/api/src/services/applications/update_application_form.py
+++ b/api/src/services/applications/update_application_form.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 import src.adapters.db as db
 from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
+from src.constants.lookup_constants import SubmissionIssue
 from src.db.models.competition_models import ApplicationForm, CompetitionForm
 from src.db.models.user_models import User
 from src.services.applications.application_validation import (
@@ -47,6 +48,10 @@ def update_application_form(
     """
     # Validate that at least one update is being made
     if application_response is None and is_included_in_submission is None:
+        logger.info(
+            "Neither application_response nor is_included_in_submission provided",
+            extra={"submission_issue": SubmissionIssue.NO_UPDATE_DATA_PROVIDED}
+        )
         raise_flask_error(
             400,
             "Either application_response or is_included_in_submission must be provided",
@@ -67,6 +72,10 @@ def update_application_form(
     ).scalar_one_or_none()
 
     if not competition_form:
+        logger.info(
+            "Form not found or not attached to competition",
+            extra={"submission_issue": SubmissionIssue.FORM_NOT_FOUND_OR_NOT_ATTACHED}
+        )
         raise_flask_error(
             404,
             f"Form with ID {form_id} not found or not attached to this application's competition",
@@ -89,6 +98,10 @@ def update_application_form(
     else:
         # Create new application form (requires application_response)
         if application_response is None:
+            logger.info(
+                "Application form not found and no response data provided",
+                extra={"submission_issue": SubmissionIssue.APPLICATION_FORM_NOT_FOUND_NO_RESPONSE}
+            )
             raise_flask_error(
                 404,
                 f"Application form not found for application {application_id} and form {form_id}",


### PR DESCRIPTION
## Summary

Work for #5727

## Changes proposed

Add `SubmissionIssue` class to capture new logging message types
Add logging in strategic places across application logic to capture reasons for specific actions, which can later go into NR.

## Context for reviewers

Before adding visualizations in New Relic (https://github.com/HHS/simpler-grants-gov/issues/5612), we want to add a few more metrics to the API, such as "why wasn’t the submission allowed”?

Anywhere in our application logic (submit, update, start) where we would error and prevent a user from proceeding, add some level of detail of what error was encountered to the logs as an extra object. We should have the key for this be consistent so we can easily make graphs.

## Validation steps

Unit tests not updated since we are just adding logging and augmenting existing logging. Visual review.
