### PR TITLE
[Issue #5701] SF-LLL form

### DIFF
--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -134,18 +134,7 @@ FORM_JSON_SCHEMA = {
             "maxLength": 120,
         },
         "award_amount": {
-            # Represents a monetary amount. We use a string instead of number
-            # to avoid any floating point rounding issues.
-            "type": "string",
-            # Pattern here effectively says:
-            # * Any number of digits
-            # * An optional decimal point
-            # * Then exactly 2 digits - if there was a decimal
-            "pattern": r"^\d*([.]\d{2})?$",
-            # Limit the max amount based on the length (11-digits, allows up to 99 billion)
-            "maxLength": 14,
-            "title": "Award Amount",
-            "description": "For a covered Federal action where there has been an award or loan commitment by the Federal agency, enter the Federal amount of the award/loan commitment of the prime entity identified in item 4 or 5.",
+            "$ref": "#/$defs/budget_monetary_amount",
         },
         "lobbying_registrant": {
             "type": "object",
@@ -321,6 +310,20 @@ FORM_JSON_SCHEMA = {
                     "maxLength": 6,
                 },
             },
+        },
+        "budget_monetary_amount": {
+            # Represents a monetary amount. We use a string instead of number
+            # to avoid any floating point rounding issues.
+            "type": "string",
+            # Pattern here effectively says:
+            # * Any number of digits
+            # * An optional decimal point
+            # * Then exactly 2 digits - if there was a decimal
+            "pattern": r"^\d*([.]\d{2})?$",
+            # Limit the max amount based on the length (11-digits, allows up to 99 billion)
+            "maxLength": 14,
+            "title": "Award Amount",
+            "description": "For a covered Federal action where there has been an award or loan commitment by the Federal agency, enter the Federal amount of the award/loan commitment of the prime entity identified in item 4 or 5.",
         },
         "state_code": {
             "type": "string",

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -96,10 +96,10 @@ FORM_JSON_SCHEMA = {
                     "maximum": 99,
                 },
                 "applicant_reporting_entity": {
-                    "allOf": [{"$ref": "#/$defs/reporting_entity_awardee"}],
+                    "$ref": "#/$defs/reporting_entity_awardee",
                 },
                 "prime_reporting_entity": {
-                    "allOf": [{"$ref": "#/$defs/reporting_entity_awardee"}],
+                    "$ref": "#/$defs/reporting_entity_awardee",
                 },
             },
         },
@@ -134,7 +134,16 @@ FORM_JSON_SCHEMA = {
             "maxLength": 120,
         },
         "award_amount": {
-            "allOf": [{"$ref": "#/$defs/budget_monetary_amount"}],
+            # Represents a monetary amount. We use a string instead of number
+            # to avoid any floating point rounding issues.
+            "type": "string",
+            # Pattern here effectively says:
+            # * Any number of digits
+            # * An optional decimal point
+            # * Then exactly 2 digits - if there was a decimal
+            "pattern": r"^\d*([.]\d{2})?$",
+            # Limit the max amount based on the length (11-digits, allows up to 99 billion)
+            "maxLength": 14,
             "title": "Award Amount",
             "description": "For a covered Federal action where there has been an award or loan commitment by the Federal agency, enter the Federal amount of the award/loan commitment of the prime entity identified in item 4 or 5.",
         },
@@ -144,10 +153,10 @@ FORM_JSON_SCHEMA = {
             "required": ["individual"],
             "properties": {
                 "individual": {
-                    "allOf": [{"$ref": "#/$defs/person_name"}],
+                    "$ref": "#/$defs/person_name",
                 },
                 "address": {
-                    "allOf": [{"$ref": "#/$defs/simple_address"}],
+                    "$ref": "#/$defs/simple_address",
                 },
             },
         },
@@ -157,10 +166,10 @@ FORM_JSON_SCHEMA = {
             "required": ["individual"],
             "properties": {
                 "individual": {
-                    "allOf": [{"$ref": "#/$defs/person_name"}],
+                    "$ref": "#/$defs/person_name",
                 },
                 "address": {
-                    "allOf": [{"$ref": "#/$defs/simple_address"}],
+                    "$ref": "#/$defs/simple_address",
                 },
             },
         },
@@ -176,7 +185,7 @@ FORM_JSON_SCHEMA = {
                     "maxLength": 144,
                 },
                 "name": {
-                    "allOf": [{"$ref": "#/$defs/person_name"}],
+                    "$ref": "#/$defs/person_name",
                 },
                 "title": {
                     "type": "string",
@@ -239,7 +248,7 @@ FORM_JSON_SCHEMA = {
                 },
                 "suffix": {
                     "type": "string",
-                    "title": "suffix",
+                    "title": "Suffix",
                     "description": "Select the suffix from the provided list or enter a new suffix not provided on the list.",
                     "minLength": 1,
                     "maxLength": 10,
@@ -258,28 +267,28 @@ FORM_JSON_SCHEMA = {
             "properties": {
                 "street1": {
                     "type": "string",
-                    "title": "street1",
+                    "title": "Street 1",
                     "description": "Enter the first line of the Street Address.",
                     "minLength": 1,
                     "maxLength": 55,
                 },
                 "street2": {
                     "type": "string",
-                    "title": "street2",
+                    "title": "Street 2",
                     "description": "Enter the second line of the Street Address.",
                     "minLength": 1,
                     "maxLength": 55,
                 },
                 "city": {
                     "type": "string",
-                    "title": "city",
+                    "title": "City",
                     "description": "Enter the city.",
                     "minLength": 1,
                     "maxLength": 35,
                 },
                 "state": {
                     "allOf": [{"$ref": "#/$defs/state_code"}],
-                    "title": "state",
+                    "title": "State",
                     "description": "Enter the state.",
                 },
                 "zip_code": {
@@ -302,7 +311,7 @@ FORM_JSON_SCHEMA = {
                     "maxLength": 60,
                 },
                 "address": {
-                    "allOf": [{"$ref": "#/$defs/simple_address"}],
+                    "$ref": "#/$defs/simple_address",
                 },
                 "congressional_district": {
                     "type": "string",
@@ -312,18 +321,6 @@ FORM_JSON_SCHEMA = {
                     "maxLength": 6,
                 },
             },
-        },
-        "budget_monetary_amount": {
-            # Represents a monetary amount. We use a string instead of number
-            # to avoid any floating point rounding issues.
-            "type": "string",
-            # Pattern here effectively says:
-            # * Any number of digits
-            # * An optional decimal point
-            # * Then exactly 2 digits - if there was a decimal
-            "pattern": r"^\d*([.]\d{2})?$",
-            # Limit the max amount based on the length (11-digits, allows up to 99 billion)
-            "maxLength": 14,
         },
         "state_code": {
             "type": "string",
@@ -343,149 +340,237 @@ FORM_JSON_SCHEMA = {
 FORM_UI_SCHEMA = [
     {
         "type": "section",
-        "label": "1. Everything",
-        "name": "Everything",
+        "label": "1. Background",
+        "name": "Background",
         "children": [
             {"type": "field", "definition": "/properties/federal_action_type"},
             {"type": "field", "definition": "/properties/federal_action_status"},
             {"type": "field", "definition": "/properties/report_type"},
+        ],
+    },
+    {
+        "type": "section",
+        "label": "2. For Material Change Only",
+        "name": "For Material Change Only",
+        "children": [
             # Material Change
             {"type": "field", "definition": "/properties/material_change_year"},
             {"type": "field", "definition": "/properties/material_change_quarter"},
             {"type": "field", "definition": "/properties/last_report_date"},
+        ],
+    },
+    {
+        "type": "section",
+        "label": "3. Name and Address of Reporting Entity",
+        "name": "Name and Address of Reporting Entity",
+        "children": [
             # Reporting Entity
-            {"type": "field", "definition": "/properties/reporting_entity/entity_type"},
-            {"type": "field", "definition": "/properties/reporting_entity/tier"},
+            {"type": "field", "definition": "/properties/reporting_entity/properties/entity_type"},
+            {"type": "field", "definition": "/properties/reporting_entity/properties/tier"},
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/applicant_reporting_entity/organization_name",
+                "definition": "/properties/reporting_entity/properties/applicant_reporting_entity/properties/organization_name",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/applicant_reporting_entity/address/street1",
+                "definition": "/properties/reporting_entity/properties/applicant_reporting_entity/properties/address/properties/street1",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/applicant_reporting_entity/address/street2",
+                "definition": "/properties/reporting_entity/properties/applicant_reporting_entity/properties/address/properties/street2",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/applicant_reporting_entity/address/city",
+                "definition": "/properties/reporting_entity/properties/applicant_reporting_entity/properties/address/properties/city",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/applicant_reporting_entity/address/state",
+                "definition": "/properties/reporting_entity/properties/applicant_reporting_entity/properties/address/properties/state",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/applicant_reporting_entity/address/zip_code",
+                "definition": "/properties/reporting_entity/properties/applicant_reporting_entity/properties/address/properties/zip_code",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/applicant_reporting_entity/congressional_district",
+                "definition": "/properties/reporting_entity/properties/applicant_reporting_entity/properties/congressional_district",
+            },
+        ],
+    },
+    {
+        "type": "section",
+        "label": "4. If Reporting Entity in No.3 is Subawardee, Enter Name and Address of Prime",
+        "name": "If Reporting Entity in No.3 is Subawardee, Enter Name and Address of Prime",
+        "children": [
+            {
+                "type": "field",
+                "definition": "/properties/reporting_entity/properties/prime_reporting_entity/properties/organization_name",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/prime_reporting_entity/organization_name",
+                "definition": "/properties/reporting_entity/properties/prime_reporting_entity/properties/address/properties/street1",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/prime_reporting_entity/address/street1",
+                "definition": "/properties/reporting_entity/properties/prime_reporting_entity/properties/address/properties/street2",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/prime_reporting_entity/address/street2",
+                "definition": "/properties/reporting_entity/properties/prime_reporting_entity/properties/address/properties/city",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/prime_reporting_entity/address/city",
+                "definition": "/properties/reporting_entity/properties/prime_reporting_entity/properties/address/properties/state",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/prime_reporting_entity/address/state",
+                "definition": "/properties/reporting_entity/properties/prime_reporting_entity/properties/address/properties/zip_code",
             },
             {
                 "type": "field",
-                "definition": "/properties/reporting_entity/prime_reporting_entity/address/zip_code",
+                "definition": "/properties/reporting_entity/properties/prime_reporting_entity/properties/congressional_district",
             },
-            {
-                "type": "field",
-                "definition": "/properties/reporting_entity/prime_reporting_entity/congressional_district",
-            },
+        ],
+    },
+    {
+        "type": "section",
+        "label": "5. Details",
+        "name": "Details",
+        "children": [
             # Various fields in middle
             {"type": "field", "definition": "/properties/federal_agency_department"},
             {"type": "field", "definition": "/properties/federal_program_name"},
             {"type": "field", "definition": "/properties/assistance_listing_number"},
             {"type": "field", "definition": "/properties/federal_action_number"},
             {"type": "field", "definition": "/properties/award_amount"},
+        ],
+    },
+    {
+        "type": "section",
+        "label": "6. Name and Address of Lobbying Registrant",
+        "name": "Name and Address of Lobbying Registrant",
+        "children": [
             # Lobbying Registrant
             {
                 "type": "field",
-                "definition": "/properties/lobbying_registrant/individual/first_name",
+                "definition": "/properties/lobbying_registrant/properties/individual/properties/first_name",
             },
             {
                 "type": "field",
-                "definition": "/properties/lobbying_registrant/individual/middle_name",
+                "definition": "/properties/lobbying_registrant/properties/individual/properties/middle_name",
             },
-            {"type": "field", "definition": "/properties/lobbying_registrant/individual/last_name"},
-            {"type": "field", "definition": "/properties/lobbying_registrant/individual/prefix"},
-            {"type": "field", "definition": "/properties/lobbying_registrant/individual/suffix"},
-            {"type": "field", "definition": "/properties/lobbying_registrant/address/street1"},
-            {"type": "field", "definition": "/properties/lobbying_registrant/address/street2"},
-            {"type": "field", "definition": "/properties/lobbying_registrant/address/city"},
-            {"type": "field", "definition": "/properties/lobbying_registrant/address/state"},
-            {"type": "field", "definition": "/properties/lobbying_registrant/address/zip_code"},
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/individual/properties/last_name",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/individual/properties/prefix",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/individual/properties/suffix",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/address/properties/street1",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/address/properties/street2",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/address/properties/city",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/address/properties/state",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/lobbying_registrant/properties/address/properties/zip_code",
+            },
+        ],
+    },
+    {
+        "type": "section",
+        "label": "7. Individual Performing Services (including address if different from No. 6)",
+        "name": "Individual Performing Services (including address if different from No. 6)",
+        "children": [
             # Individual performing services
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/individual/first_name",
+                "definition": "/properties/individual_performing_service/properties/individual/properties/first_name",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/individual/middle_name",
+                "definition": "/properties/individual_performing_service/properties/individual/properties/middle_name",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/individual/last_name",
+                "definition": "/properties/individual_performing_service/properties/individual/properties/last_name",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/individual/prefix",
+                "definition": "/properties/individual_performing_service/properties/individual/properties/prefix",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/individual/suffix",
+                "definition": "/properties/individual_performing_service/properties/individual/properties/suffix",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/address/street1",
+                "definition": "/properties/individual_performing_service/properties/address/properties/street1",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/address/street2",
+                "definition": "/properties/individual_performing_service/properties/address/properties/street2",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/address/city",
+                "definition": "/properties/individual_performing_service/properties/address/properties/city",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/address/state",
+                "definition": "/properties/individual_performing_service/properties/address/properties/state",
             },
             {
                 "type": "field",
-                "definition": "/properties/individual_performing_service/address/zip_code",
+                "definition": "/properties/individual_performing_service/properties/address/properties/zip_code",
             },
-            # Signature block
-            {"type": "field", "definition": "/properties/signature_block/signature"},
-            {"type": "field", "definition": "/properties/signature_block/name/first_name"},
-            {"type": "field", "definition": "/properties/signature_block/name/middle_name"},
-            {"type": "field", "definition": "/properties/signature_block/name/last_name"},
-            {"type": "field", "definition": "/properties/signature_block/name/prefix"},
-            {"type": "field", "definition": "/properties/signature_block/name/suffix"},
-            {"type": "field", "definition": "/properties/signature_block/signed_date"},
         ],
-    }
+    },
+    {
+        "type": "section",
+        "label": "8. Signature",
+        "name": "Signature",
+        "children": [
+            # Signature block
+            {"type": "field", "definition": "/properties/signature_block/properties/signature"},
+            {
+                "type": "field",
+                "definition": "/properties/signature_block/properties/name/properties/first_name",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/signature_block/properties/name/properties/middle_name",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/signature_block/properties/name/properties/last_name",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/signature_block/properties/name/properties/prefix",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/signature_block/properties/name/properties/suffix",
+            },
+            {"type": "field", "definition": "/properties/signature_block/properties/signed_date"},
+        ],
+    },
 ]
 
 FORM_RULE_SCHEMA = {

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -15,18 +15,24 @@ FORM_JSON_SCHEMA = {
         "individual_performing_service",
         "signature_block",
     ],
-    # Conditionally required
+    # If report_type is MaterialChange, the 3 material change fields become required
+    # Unfortunately, "required" seems to conflict with other validators here, so enforcing on formatting
     "allOf": [
-        # If report_type is MaterialChange, the 3 material change fields become required
         {
             "if": {
+                "required": ["report_type"],
                 "properties": {"report_type": {"const": "MaterialChange"}},
-                "required": ["report_type"],  # Only run rule if report_type is set
             },
             "then": {
-                "required": ["material_change_year", "material_change_quarter", "last_report_date"]
+                "properties": {
+                    "material_change_quarter": {
+                        "allOf": [{"type": "integer"}, {"maximum": 4}, {"minimum": 1}]
+                    },
+                    "material_change_year": {"allOf": [{"pattern": "^[1-9][0-9]{3}$"}]},
+                    "last_report_date": {"allOf": [{"format": "date"}]},
+                }
             },
-        },
+        }
     ],
     "properties": {
         "federal_action_type": {
@@ -50,22 +56,19 @@ FORM_JSON_SCHEMA = {
         "material_change_year": {
             "type": "string",
             "title": "Material Change Year",
+            "anyOf": [{"pattern": "^[1-9][0-9]{3}$"}, {"maxLength": 0}],
             "description": "If this is a follow up report caused by a material change to the information previously reported, enter the year in which the change occurred.",
-            # Allow all years 1000-9999
-            "pattern": r"^[1-9][0-9]{3}$",
         },
         "material_change_quarter": {
-            "type": "integer",
             "title": "Material Change Quarter",
+            "anyOf": [{"allOf": [{"maximum": 4}, {"minimum": 1}]}, {"maxLength": 0}],
             "description": "If this is a follow up report caused by a material change to the information previously reported, enter the quarter in which the change occurred.",
-            "minimum": 1,
-            "maximum": 4,
         },
         "last_report_date": {
             "type": "string",
+            "allOf": [{"anyOf": [{"format": "date"}, {"maxLength": 0}]}],
             "title": "Material Change Date of Last Report",
             "description": "Enter the date of the previously submitted report by this reporting entity for this covered Federal action.",
-            "format": "date",
         },
         "reporting_entity": {
             "type": "object",

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -15,24 +15,18 @@ FORM_JSON_SCHEMA = {
         "individual_performing_service",
         "signature_block",
     ],
-    # If report_type is MaterialChange, the 3 material change fields become required
-    # Unfortunately, "required" seems to conflict with other validators here, so enforcing on formatting
+    # Conditionally required
     "allOf": [
+        # If report_type is MaterialChange, the 3 material change fields become required
         {
             "if": {
-                "required": ["report_type"],
                 "properties": {"report_type": {"const": "MaterialChange"}},
+                "required": ["report_type"],  # Only run rule if report_type is set
             },
             "then": {
-                "properties": {
-                    "material_change_quarter": {
-                        "allOf": [{"type": "integer"}, {"maximum": 4}, {"minimum": 1}]
-                    },
-                    "material_change_year": {"allOf": [{"pattern": "^[1-9][0-9]{3}$"}]},
-                    "last_report_date": {"allOf": [{"format": "date"}]},
-                }
+                "required": ["material_change_year", "material_change_quarter", "last_report_date"]
             },
-        }
+        },
     ],
     "properties": {
         "federal_action_type": {
@@ -56,19 +50,22 @@ FORM_JSON_SCHEMA = {
         "material_change_year": {
             "type": "string",
             "title": "Material Change Year",
-            "anyOf": [{"pattern": "^[1-9][0-9]{3}$"}, {"maxLength": 0}],
             "description": "If this is a follow up report caused by a material change to the information previously reported, enter the year in which the change occurred.",
+            # Allow all years 1000-9999
+            "pattern": r"^[1-9][0-9]{3}$",
         },
         "material_change_quarter": {
+            "type": "integer",
             "title": "Material Change Quarter",
-            "anyOf": [{"allOf": [{"maximum": 4}, {"minimum": 1}]}, {"maxLength": 0}],
             "description": "If this is a follow up report caused by a material change to the information previously reported, enter the quarter in which the change occurred.",
+            "minimum": 1,
+            "maximum": 4,
         },
         "last_report_date": {
             "type": "string",
-            "allOf": [{"anyOf": [{"format": "date"}, {"maxLength": 0}]}],
             "title": "Material Change Date of Last Report",
             "description": "Enter the date of the previously submitted report by this reporting entity for this covered Federal action.",
+            "format": "date",
         },
         "reporting_entity": {
             "type": "object",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,6 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "focus-trap-react": "^10.2.3",
-    "formdata2json": "^1.0.8",
     "isomorphic-dompurify": "^2.15.0",
     "jose": "^5.9.6",
     "js-cookie": "^3.0.5",

--- a/frontend/src/components/applyForm/actions.ts
+++ b/frontend/src/components/applyForm/actions.ts
@@ -19,10 +19,10 @@ type ApplyFormResponse = {
 };
 
 export async function handleFormAction(
-  _prevState: ApplyFormResponse,
+  prevState: ApplyFormResponse,
   formData: FormData,
 ) {
-  const { formId, applicationId } = _prevState;
+  const { formId, applicationId } = prevState;
   const session = await getSession();
   if (!session || !session.token) {
     return {

--- a/frontend/src/components/applyForm/actions.ts
+++ b/frontend/src/components/applyForm/actions.ts
@@ -45,6 +45,7 @@ export async function handleFormAction(
     };
   }
 
+  // this generic typing isn't correct - we'll end up with a nested object
   const applicationFormData =
     shapeFormData<ApplicationResponseDetail>(formData);
 

--- a/frontend/src/components/applyForm/formDataToJson.ts
+++ b/frontend/src/components/applyForm/formDataToJson.ts
@@ -35,7 +35,7 @@ export function formDataToObject(
         !isNaN(Number(value))
       )
         return Number(value);
-      return value;
+      return value || undefined;
     })();
 
     const chunksLen = chunks.length;

--- a/frontend/src/components/applyForm/formDataToJson.ts
+++ b/frontend/src/components/applyForm/formDataToJson.ts
@@ -1,0 +1,87 @@
+// based on https://github.com/ArturKot95/FormData2Json/blob/main/src/formDataToObject.ts
+
+type NestedObject = {
+  [key: string]:
+    | NestedObject
+    | NestedObject[]
+    | (object | string | boolean | number | null);
+};
+
+type FormDataToJsonOptions = {
+  parentKey?: string;
+  delimiter?: string;
+};
+
+export function formDataToObject(
+  formData = new FormData(),
+  options?: FormDataToJsonOptions,
+): NestedObject {
+  const delimiter = options?.delimiter || ".";
+  const { parentKey } = options ?? { parentKey: "" };
+  const result: NestedObject = {};
+  const entries = formData.entries();
+
+  for (const [key, value] of entries) {
+    const currentKey = parentKey ? `${parentKey}${delimiter}${key}` : key;
+    const chunks = currentKey.split(delimiter);
+    let current = result;
+    const parsedValue = (() => {
+      if (value === "false") return false;
+      if (value === "true") return true;
+      if (
+        value !== "" &&
+        value !== null &&
+        value !== undefined &&
+        !isNaN(Number(value))
+      )
+        return Number(value);
+      return value;
+    })();
+
+    const chunksLen = chunks.length;
+    for (let chunkIdx = 0; chunkIdx < chunksLen; chunkIdx++) {
+      const chunkName = chunks[chunkIdx];
+      const isArray = chunkName.endsWith("]");
+
+      if (isArray) {
+        const indexStart = chunkName.indexOf("[");
+        const indexEnd = chunkName.indexOf("]");
+
+        const arrayIndex = parseInt(
+          chunkName.substring(indexStart + 1, indexEnd),
+        );
+
+        if (isNaN(arrayIndex)) {
+          throw new Error(
+            `wrong form data - cannot retrieve array index ${arrayIndex}`,
+          );
+        }
+
+        const actualChunkName = chunkName.substring(0, indexStart);
+        const currentValue =
+          (current[actualChunkName] as NestedObject[]) ??
+          ([] as NestedObject[]);
+
+        current[actualChunkName] = currentValue;
+
+        // const currentChunk: NestedObject[] = current[actualChunkName];
+        if (chunkIdx === chunks.length - 1) {
+          current[actualChunkName][arrayIndex] = parsedValue;
+        } else {
+          current[actualChunkName][arrayIndex] =
+            current[actualChunkName][arrayIndex] ?? {};
+          current = current[actualChunkName][arrayIndex] as NestedObject;
+        }
+      } else {
+        if (chunkIdx === chunks.length - 1) {
+          current[chunkName] = parsedValue;
+        } else {
+          current[chunkName] = current[chunkName] ?? {};
+          current = current[chunkName] as NestedObject;
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/frontend/src/components/applyForm/formDataToJson.ts
+++ b/frontend/src/components/applyForm/formDataToJson.ts
@@ -58,19 +58,20 @@ export function formDataToObject(
         }
 
         const actualChunkName = chunkName.substring(0, indexStart);
-        const currentValue =
-          (current[actualChunkName] as NestedObject[]) ??
-          ([] as NestedObject[]);
+        current[actualChunkName] =
+          (current[actualChunkName] as unknown[]) ?? ([] as unknown[]);
 
-        current[actualChunkName] = currentValue;
-
-        // const currentChunk: NestedObject[] = current[actualChunkName];
+        // const currentChunk: unknown[] = current[actualChunkName];
+        const currentChunk = current[actualChunkName] as unknown[];
         if (chunkIdx === chunks.length - 1) {
-          current[actualChunkName][arrayIndex] = parsedValue;
+          currentChunk[arrayIndex] = parsedValue;
         } else {
-          current[actualChunkName][arrayIndex] =
-            current[actualChunkName][arrayIndex] ?? {};
-          current = current[actualChunkName][arrayIndex] as NestedObject;
+          // this is here to satisfy the TS, would love to find a way to remove this check
+          if (Array.isArray(current[actualChunkName])) {
+            current[actualChunkName][arrayIndex] =
+              currentChunk[arrayIndex] ?? {};
+            current = currentChunk[arrayIndex] as NestedObject;
+          }
         }
       } else {
         if (chunkIdx === chunks.length - 1) {

--- a/frontend/src/components/applyForm/formDataToJson.ts
+++ b/frontend/src/components/applyForm/formDataToJson.ts
@@ -61,7 +61,6 @@ export function formDataToObject(
         current[actualChunkName] =
           (current[actualChunkName] as unknown[]) ?? ([] as unknown[]);
 
-        // const currentChunk: unknown[] = current[actualChunkName];
         const currentChunk = current[actualChunkName] as unknown[];
         if (chunkIdx === chunks.length - 1) {
           currentChunk[arrayIndex] = parsedValue;

--- a/frontend/src/components/applyForm/formDataToJson.ts
+++ b/frontend/src/components/applyForm/formDataToJson.ts
@@ -1,10 +1,11 @@
 // based on https://github.com/ArturKot95/FormData2Json/blob/main/src/formDataToObject.ts
 
+// like, this is basically anything lol - DWS
 type NestedObject = {
   [key: string]:
     | NestedObject
     | NestedObject[]
-    | (object | string | boolean | number | null);
+    | (object | string | boolean | number | null | undefined);
 };
 
 type FormDataToJsonOptions = {

--- a/frontend/src/components/applyForm/types.ts
+++ b/frontend/src/components/applyForm/types.ts
@@ -92,39 +92,6 @@ export type TextTypes =
   | "tel"
   | "url";
 
-// extends the WidgetProps type from rjsf for USWDS and this project implementation
-// export interface UswdsWidgetProps<
-//   T = unknown,
-//   S extends StrictRJSFSchema = RJSFSchema,
-//   F extends FormContextType = never,
-// > extends GenericObjectType,
-//     Pick<
-//       HTMLAttributes<HTMLElement>,
-//       Exclude<keyof HTMLAttributes<HTMLElement>, "onBlur" | "onFocus">
-//     > {
-//   id: string;
-//   value?: string | Array<T> | unknown;
-//   type?: string;
-//   minLength?: number;
-//   schema: RJSFSchema;
-//   maxLength?: number;
-//   required?: boolean;
-//   disabled?: boolean;
-//   readonly?: boolean;
-//   hideError?: boolean;
-//   autofocus?: boolean;
-//   placeholder?: string;
-//   options?: NonNullable<UIOptionsType<T, S, F>>;
-//   hideLabel?: boolean;
-//   multiple?: boolean;
-//   rawErrors?: string[] | [Record<string, unknown>] | undefined;
-//   // whether or not to use value + onChange
-//   updateOnInput?: boolean;
-//   onChange?: (value: unknown) => void;
-//   onBlur?: (id: string, value: unknown) => void;
-//   onFocus?: (id: string, value: unknown) => void;
-// }
-
 export interface UswdsWidgetProps<
   T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,

--- a/frontend/src/components/applyForm/types.ts
+++ b/frontend/src/components/applyForm/types.ts
@@ -93,6 +93,38 @@ export type TextTypes =
   | "url";
 
 // extends the WidgetProps type from rjsf for USWDS and this project implementation
+// export interface UswdsWidgetProps<
+//   T = unknown,
+//   S extends StrictRJSFSchema = RJSFSchema,
+//   F extends FormContextType = never,
+// > extends GenericObjectType,
+//     Pick<
+//       HTMLAttributes<HTMLElement>,
+//       Exclude<keyof HTMLAttributes<HTMLElement>, "onBlur" | "onFocus">
+//     > {
+//   id: string;
+//   value?: string | Array<T> | unknown;
+//   type?: string;
+//   minLength?: number;
+//   schema: RJSFSchema;
+//   maxLength?: number;
+//   required?: boolean;
+//   disabled?: boolean;
+//   readonly?: boolean;
+//   hideError?: boolean;
+//   autofocus?: boolean;
+//   placeholder?: string;
+//   options?: NonNullable<UIOptionsType<T, S, F>>;
+//   hideLabel?: boolean;
+//   multiple?: boolean;
+//   rawErrors?: string[] | [Record<string, unknown>] | undefined;
+//   // whether or not to use value + onChange
+//   updateOnInput?: boolean;
+//   onChange?: (value: unknown) => void;
+//   onBlur?: (id: string, value: unknown) => void;
+//   onFocus?: (id: string, value: unknown) => void;
+// }
+
 export interface UswdsWidgetProps<
   T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -175,17 +175,20 @@ export const getNameFromDef = ({
 };
 
 // new, not used in multifield
-export const getFieldName = (
-  definition?: string,
-  schema?: SchemaField,
-): string => {
+export const getFieldName = ({
+  definition,
+  schema,
+}: {
+  definition?: string;
+  schema?: SchemaField;
+}): string => {
   if (definition) {
     const definitionParts = definition.split("/");
     return definitionParts
       .filter((part) => part && part !== "properties")
       .join("--"); // using hyphens since that will work better for html attributes than slashes and will have less conflict with other characters
   }
-  return (schema?.title ?? "untitled").replace(" ", "-");
+  return (schema?.title ?? "untitled").replace(/\s/g, "-");
 };
 
 export const getFieldPath = (fieldName: string) =>
@@ -268,7 +271,7 @@ export const buildField = ({
   } else if (typeof definition === "string") {
     fieldSchema = getFieldSchema({ definition, schema, formSchema });
 
-    name = getFieldName(definition, schema);
+    name = getFieldName({ definition, schema });
     const path = getFieldPath(name);
     value = getByPointer(formData, path) as string | number | undefined;
   }

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -215,6 +215,11 @@ const getByPointer = (target: object, path: string): unknown => {
   try {
     return getSchemaObjectFromPointer(target, path);
   } catch (e) {
+    // this is not ideal, but it seems like the desired behavior is to return undefined if the
+    // path is not found on the target, and the library throws an error instead
+    if ((e as Error).message.includes("Invalid reference token:")) {
+      return undefined;
+    }
     console.error("error referencing schema path", e, target, path);
     throw e;
   }

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -174,6 +174,20 @@ export const getNameFromDef = ({
       : "untitled";
 };
 
+// new, not used in multifield
+export const getFieldName = (
+  definition?: string,
+  schema?: SchemaField,
+): string => {
+  if (definition) {
+    const definitionParts = definition.split("/");
+    return definitionParts
+      .filter((part) => part && part !== "properties")
+      .join("."); // using hyphens since that will work better for html attributes than slashes and will have less conflict with other characters
+  }
+  return (schema?.title ?? "untitled").replace(" ", "-");
+};
+
 const widgetComponents: Record<
   WidgetTypes,
   (widgetProps: UswdsWidgetProps) => JSX.Element
@@ -228,7 +242,7 @@ export const buildField = ({
   } else if (typeof definition === "string") {
     fieldSchema = getFieldSchema({ definition, schema, formSchema });
 
-    name = getNameFromDef({ definition, schema });
+    name = getFieldName(definition, schema);
     value = get(formData, name) as string | number | undefined;
   }
   if (!name || !fieldSchema) {
@@ -368,8 +382,10 @@ export const shapeFormData = <T extends object>(formData: FormData): T => {
   formData.delete("$ACTION_REF_1");
   formData.delete("$ACTION_KEY");
   formData.delete("apply-form-button");
-
-  return formDataToObject(formData) as T;
+  // const preStructuredFormData = Array.from(formData.entries()).reduc
+  // const formattedFormData = formDataToObject(restructuredFormData) as T;
+  const formattedFormData = formDataToObject(formData) as T;
+  return formattedFormData;
 };
 
 // arrays from the html look like field_[row]_item

--- a/frontend/src/components/applyForm/validate.ts
+++ b/frontend/src/components/applyForm/validate.ts
@@ -32,13 +32,13 @@ export const UiJsonSchema: RJSFSchema = {
           oneOf: [
             {
               type: "string",
-              pattern: "^/properties/[a-zA-Z0-9_]+$",
+              pattern: "^/(properties|\\$defs)(/[a-zA-Z0-9_]+)+$",
             },
             {
               type: "array",
               items: {
                 type: "string",
-                pattern: "^/properties/[a-zA-Z0-9_]+$",
+                pattern: "^/(properties|\\$defs)(/[a-zA-Z0-9_]+)+$",
               },
             },
           ],

--- a/frontend/src/components/applyForm/widgets/CheckboxWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/CheckboxWidget.tsx
@@ -51,7 +51,7 @@ function CheckboxWidget<
     (event: FocusEvent<HTMLInputElement>) => onFocus(id, event.target.checked),
     [onFocus, id],
   );
-  const description = options.description ?? schema.description;
+  const description = options?.description ?? schema.description;
 
   const label = required ? (
     <>

--- a/frontend/src/components/applyForm/widgets/RadioWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/RadioWidget.tsx
@@ -25,7 +25,7 @@ function RadioWidget<
 >({
   id,
   disabled,
-  options,
+  options = {},
   schema,
   required,
   readonly,
@@ -91,7 +91,15 @@ function RadioWidget<
         required={required}
         description={description}
       />
-      {error && <ErrorMessage>{rawErrors[0]}</ErrorMessage>}
+      {error && (
+        <ErrorMessage>
+          {typeof rawErrors[0] === "string"
+            ? rawErrors[0]
+            : Object.values(rawErrors[0])
+                .map((value) => value)
+                .join(",")}
+        </ErrorMessage>
+      )}
       {Array.isArray(enumOptions) &&
         enumOptions.map((option, i) => {
           const checked = enumOptionsIsSelected<S>(option.value, value);

--- a/frontend/src/components/applyForm/widgets/SelectWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/SelectWidget.tsx
@@ -46,7 +46,7 @@ function SelectWidget<
 >({
   id,
   disabled,
-  options,
+  options = {},
   readonly,
   required,
   schema,
@@ -125,7 +125,15 @@ function SelectWidget<
         description={description}
       />
 
-      {error && <ErrorMessage>{rawErrors[0]}</ErrorMessage>}
+      {error && (
+        <ErrorMessage>
+          {typeof rawErrors[0] === "string"
+            ? rawErrors[0]
+            : Object.values(rawErrors[0])
+                .map((value) => value)
+                .join(",")}
+        </ErrorMessage>
+      )}
 
       <Widget
         // necessary due to react 19 bug https://github.com/facebook/react/issues/30580

--- a/frontend/src/components/applyForm/widgets/TextAreaWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/TextAreaWidget.tsx
@@ -63,7 +63,16 @@ function TextAreaWidget<
     <FormGroup error={error} key={`wrapper-for-${id}`}>
       <FieldLabel idFor={id} title={title} required={required} />
 
-      {error && <ErrorMessage>{rawErrors[0]}</ErrorMessage>}
+      {error && (
+        <ErrorMessage>
+          {" "}
+          {typeof rawErrors[0] === "string"
+            ? rawErrors[0]
+            : Object.values(rawErrors[0])
+                .map((value) => value)
+                .join(",")}
+        </ErrorMessage>
+      )}
       <Textarea
         minLength={(minLength as number) ?? undefined}
         maxLength={(maxLength as number) ?? undefined}

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -121,7 +121,7 @@ export const handleUpdateApplicationForm = async (
   };
   const response = await fetchApplicationWithMethod("PUT")({
     subPath: `${applicationId}/forms/${applicationFormId}`,
-    body: { application_response: values },
+    body: { application_response: values, is_included_in_submission: true },
     additionalHeaders: ssgToken,
   });
 

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -10,6 +10,7 @@ import {
   filterUnfilledNestedFields,
   getApplicationResponse,
   getFieldSchema,
+  pruneEmptyNestedFields,
   shapeFormData,
 } from "src/components/applyForm/utils";
 
@@ -529,7 +530,7 @@ describe("getFieldSchema", () => {
   });
 });
 
-describe("filterUnfilledNestedFields", () => {
+describe("pruneEmptyNestedFields", () => {
   it("returns flat object unchanged", () => {
     const flat = {
       thing: 1,
@@ -537,11 +538,11 @@ describe("filterUnfilledNestedFields", () => {
       bad: null,
       stuff: [2, "hi"],
     };
-    expect(filterUnfilledNestedFields(flat)).toEqual(flat);
+    expect(pruneEmptyNestedFields(flat)).toEqual(flat);
   });
   it("returns undefined if passed an empty object or object with only undefined fields", () => {
     const empty = {};
-    expect(filterUnfilledNestedFields(empty)).toEqual(undefined);
+    expect(pruneEmptyNestedFields(empty)).toEqual(empty);
 
     const undefinedFields = {
       whatever: {
@@ -550,11 +551,11 @@ describe("filterUnfilledNestedFields", () => {
         more: { stuff: undefined },
       },
     };
-    expect(filterUnfilledNestedFields(undefinedFields)).toEqual(undefined);
+    expect(pruneEmptyNestedFields(undefinedFields)).toEqual(empty);
   });
-  it("removes nested objects containing only undefined properties", () => {
+  it.only("removes nested objects containing only undefined properties", () => {
     expect(
-      filterUnfilledNestedFields({
+      pruneEmptyNestedFields({
         thing: "stuff",
         another: {
           nested: {
@@ -572,6 +573,7 @@ describe("filterUnfilledNestedFields", () => {
       }),
     ).toEqual({
       thing: "stuff",
+      another: {},
       keepMe: {
         here: {
           ok: "sure",

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -7,7 +7,6 @@ import {
   buildField,
   buildFormTreeRecursive,
   determineFieldType,
-  filterUnfilledNestedFields,
   getApplicationResponse,
   getFieldSchema,
   pruneEmptyNestedFields,
@@ -21,16 +20,16 @@ jest.mock("react", () => ({
 
 describe("shapeFormData", () => {
   it("should shape form data to the form schema", () => {
-    const formSchema: RJSFSchema = {
-      title: "test schema",
-      properties: {
-        name: { type: "string", title: "test name", maxLength: 60 },
-        dob: { type: "string", format: "date", title: "Date of birth" },
-        address: { type: "string", title: "test address" },
-        state: { type: "string", title: "test state" },
-      },
-      required: ["name"],
-    };
+    // const formSchema: RJSFSchema = {
+    //   title: "test schema",
+    //   properties: {
+    //     name: { type: "string", title: "test name", maxLength: 60 },
+    //     dob: { type: "string", format: "date", title: "Date of birth" },
+    //     address: { type: "string", title: "test address" },
+    //     state: { type: "string", title: "test state" },
+    //   },
+    //   required: ["name"],
+    // };
 
     const shapedFormData = {
       name: "test",
@@ -45,63 +44,63 @@ describe("shapeFormData", () => {
     formData.append("name", "test");
     formData.append("state", "PA");
 
-    const data = shapeFormData(formData, formSchema);
+    const data = shapeFormData(formData);
 
     expect(data).toMatchObject(shapedFormData);
   });
   it("should shape nested form data", () => {
-    const formSchema: RJSFSchema = {
-      type: "object",
-      title: "test schema",
-      properties: {
-        name: { type: "string", title: "test name", maxLength: 60 },
-        dob: { type: "string", format: "date", title: "Date of birth" },
-        address: {
-          type: "object",
-          properties: {
-            street: { type: "string", title: "street" },
-            zip: { type: "number", title: "zip code" },
-            state: { type: "string", title: "test state" },
-            question: {
-              type: "object",
-              properties: {
-                own: { type: "string", title: "own" },
-                rent: { type: "string", title: "rent" },
-                other: { type: "string", title: "other" },
-              },
-            },
-          },
-        },
-        tasks: {
-          type: "array",
-          title: "Tasks",
-          items: {
-            type: "object",
-            required: ["title"],
-            properties: {
-              title: {
-                type: "string",
-                title: "Important task",
-              },
-              done: {
-                type: "boolean",
-                title: "Done?",
-                default: false,
-              },
-            },
-          },
-        },
-        todos: {
-          type: "array",
-          title: "Tasks",
-          items: {
-            type: "string",
-            title: "Reminder",
-          },
-        },
-      },
-      required: ["name"],
-    };
+    // const formSchema: RJSFSchema = {
+    //   type: "object",
+    //   title: "test schema",
+    //   properties: {
+    //     name: { type: "string", title: "test name", maxLength: 60 },
+    //     dob: { type: "string", format: "date", title: "Date of birth" },
+    //     address: {
+    //       type: "object",
+    //       properties: {
+    //         street: { type: "string", title: "street" },
+    //         zip: { type: "number", title: "zip code" },
+    //         state: { type: "string", title: "test state" },
+    //         question: {
+    //           type: "object",
+    //           properties: {
+    //             own: { type: "string", title: "own" },
+    //             rent: { type: "string", title: "rent" },
+    //             other: { type: "string", title: "other" },
+    //           },
+    //         },
+    //       },
+    //     },
+    //     tasks: {
+    //       type: "array",
+    //       title: "Tasks",
+    //       items: {
+    //         type: "object",
+    //         required: ["title"],
+    //         properties: {
+    //           title: {
+    //             type: "string",
+    //             title: "Important task",
+    //           },
+    //           done: {
+    //             type: "boolean",
+    //             title: "Done?",
+    //             default: false,
+    //           },
+    //         },
+    //       },
+    //     },
+    //     todos: {
+    //       type: "array",
+    //       title: "Tasks",
+    //       items: {
+    //         type: "string",
+    //         title: "Reminder",
+    //       },
+    //     },
+    //   },
+    //   required: ["name"],
+    // };
 
     const shapedFormData = {
       name: "test",
@@ -147,7 +146,7 @@ describe("shapeFormData", () => {
     formData.append("todos[0]", "email");
     formData.append("todos[1]", "write");
 
-    const data = shapeFormData(formData, formSchema);
+    const data = shapeFormData(formData);
     expect(data).toMatchObject(shapedFormData);
   });
 });
@@ -495,12 +494,14 @@ describe("getFieldSchema", () => {
       },
     };
 
-    const uiFieldObject: UiSchemaField = {
-      type: "field",
-      definition: "/properties/name",
-    };
+    // const uiFieldObject: UiSchemaField = {
+    //   type: "field",
+    //   definition: "/properties/name",
+    // };
 
-    const result = getFieldSchema({ uiFieldObject, formSchema });
+    const definition = "/properties/name";
+
+    const result = getFieldSchema({ schema: {}, definition, formSchema });
     expect(result).toEqual({ type: "string", title: "Name", maxLength: 50 });
   });
 
@@ -512,13 +513,15 @@ describe("getFieldSchema", () => {
       },
     };
 
-    const uiFieldObject: UiSchemaField = {
-      type: "field",
-      definition: "/properties/name",
-      schema: { title: "Custom Name", minLength: 5 },
-    };
+    // const uiFieldObject: UiSchemaField = {
+    //   type: "field",
+    //   definition: "/properties/name",
+    //   schema: { title: "Custom Name", minLength: 5 },
+    // };
 
-    const result = getFieldSchema({ uiFieldObject, formSchema });
+    const definition = "/properties/name";
+
+    const result = getFieldSchema({ schema: {}, definition, formSchema });
     expect(result).toEqual({
       type: "string",
       // overridden the beh uiFieldObject schema
@@ -553,7 +556,7 @@ describe("pruneEmptyNestedFields", () => {
     };
     expect(pruneEmptyNestedFields(undefinedFields)).toEqual(empty);
   });
-  it.only("removes nested objects containing only undefined properties", () => {
+  it("removes nested objects containing only undefined properties", () => {
     expect(
       pruneEmptyNestedFields({
         thing: "stuff",

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -21,17 +21,6 @@ jest.mock("react", () => ({
 
 describe("shapeFormData", () => {
   it("should shape form data to the form schema", () => {
-    // const formSchema: RJSFSchema = {
-    //   title: "test schema",
-    //   properties: {
-    //     name: { type: "string", title: "test name", maxLength: 60 },
-    //     dob: { type: "string", format: "date", title: "Date of birth" },
-    //     address: { type: "string", title: "test address" },
-    //     state: { type: "string", title: "test state" },
-    //   },
-    //   required: ["name"],
-    // };
-
     const shapedFormData = {
       name: "test",
       dob: "01/01/1900",

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -7,6 +7,7 @@ import {
   buildField,
   buildFormTreeRecursive,
   determineFieldType,
+  filterUnfilledNestedFields,
   getApplicationResponse,
   getFieldSchema,
   shapeFormData,
@@ -525,5 +526,17 @@ describe("getFieldSchema", () => {
       // added from the uiFieldObject schema
       minLength: 5,
     });
+  });
+});
+
+describe("filterUnfilledNestedFields", () => {
+  it.only("returns flat object unchanged", () => {
+    const flat = {
+      thing: 1,
+      another: "string",
+      bad: null,
+      stuff: [2, "hi"],
+    };
+    expect(filterUnfilledNestedFields(flat)).toEqual(flat);
   });
 });

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -8,6 +8,7 @@ import {
   buildFormTreeRecursive,
   determineFieldType,
   getApplicationResponse,
+  getFieldName,
   getFieldSchema,
   pruneEmptyNestedFields,
   shapeFormData,
@@ -485,5 +486,31 @@ describe("pruneEmptyNestedFields", () => {
         },
       },
     });
+  });
+});
+
+describe("getFieldName", () => {
+  it("returns correct field name based on definition, removing properties and adding delimiter", () => {
+    expect(
+      getFieldName({
+        definition: "/properties/something/properties/somethingElse",
+      }),
+    ).toEqual("something--somethingElse");
+  });
+  // this may not actually work
+  it("returns correct field name based on schema", () => {
+    expect(
+      getFieldName({
+        schema: {
+          title: "a bunch of stuff",
+        },
+      }),
+    ).toEqual("a-bunch-of-stuff");
+
+    expect(
+      getFieldName({
+        schema: {},
+      }),
+    ).toEqual("untitled");
   });
 });

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -530,7 +530,7 @@ describe("getFieldSchema", () => {
 });
 
 describe("filterUnfilledNestedFields", () => {
-  it.only("returns flat object unchanged", () => {
+  it("returns flat object unchanged", () => {
     const flat = {
       thing: 1,
       another: "string",
@@ -538,5 +538,45 @@ describe("filterUnfilledNestedFields", () => {
       stuff: [2, "hi"],
     };
     expect(filterUnfilledNestedFields(flat)).toEqual(flat);
+  });
+  it("returns undefined if passed an empty object or object with only undefined fields", () => {
+    const empty = {};
+    expect(filterUnfilledNestedFields(empty)).toEqual(undefined);
+
+    const undefinedFields = {
+      whatever: {
+        again: { something: undefined },
+        another: undefined,
+        more: { stuff: undefined },
+      },
+    };
+    expect(filterUnfilledNestedFields(undefinedFields)).toEqual(undefined);
+  });
+  it("removes nested objects containing only undefined properties", () => {
+    expect(
+      filterUnfilledNestedFields({
+        thing: "stuff",
+        another: {
+          nested: {
+            bad: undefined,
+          },
+        },
+        keepMe: {
+          here: {
+            ok: "sure",
+          },
+          remove: {
+            me: undefined,
+          },
+        },
+      }),
+    ).toEqual({
+      thing: "stuff",
+      keepMe: {
+        here: {
+          ok: "sure",
+        },
+      },
+    });
   });
 });

--- a/frontend/tests/components/applyForm/validate.test.ts
+++ b/frontend/tests/components/applyForm/validate.test.ts
@@ -20,7 +20,7 @@ describe("validateFormData", () => {
       required: ["name"],
     };
 
-    const data = shapeFormData(formData, schema);
+    const data = shapeFormData(formData);
 
     expect(validateJsonBySchema(data, schema)).toBe(false);
   });
@@ -103,13 +103,12 @@ describe("validateFormData", () => {
         "/0/definition",
       );
       expect(schemaErrors && schemaErrors[0]?.message).toMatch(
-        'must match pattern "^/properties/[a-zA-Z0-9_]+$"',
+        // eslint-disable-next-line
+        `must match pattern \"^/(properties|\\$defs)(/[a-zA-Z0-9_]+)+$\"`,
       );
-      expect(schemaErrors && schemaErrors[7]?.instancePath).toMatch(
-        "/1/definition",
-      );
+      expect(schemaErrors && schemaErrors[7]?.instancePath).toMatch("/0/type");
       expect(schemaErrors && schemaErrors[7]?.message).toMatch(
-        'must match pattern "^/properties/[a-zA-Z0-9_]+$"',
+        "must be equal to one of the allowed values",
       );
     });
   });

--- a/frontend/tests/utils/formDataToJson.test.ts
+++ b/frontend/tests/utils/formDataToJson.test.ts
@@ -18,14 +18,14 @@ describe("formDataToObject", () => {
       user: {
         age: 30,
         name: "Alice",
-        emptyString: "",
+        emptyString: undefined,
         skills: ["JavaScript", "TypeScript", { surprise: "more stuff" }],
         deeper: {
           value: "hello",
         },
       },
       nonUser: false,
-      empty: "",
+      empty: undefined,
       numeral: 100,
     };
 

--- a/frontend/tests/utils/formDataToJson.test.ts
+++ b/frontend/tests/utils/formDataToJson.test.ts
@@ -1,5 +1,3 @@
-import { isNull } from "node:util";
-
 import { formDataToObject } from "src/components/applyForm/formDataToJson";
 
 describe("formDataToObject", () => {
@@ -43,6 +41,8 @@ describe("formDataToObject", () => {
     const result = formDataToObject(formData);
 
     expect(result.any).toEqual(undefined);
+    // eslint-disable-next-line
+    // @ts-ignore
     expect(result.something.somethingElse).toEqual(undefined);
   });
 });

--- a/frontend/tests/utils/formDataToJson.test.ts
+++ b/frontend/tests/utils/formDataToJson.test.ts
@@ -1,0 +1,48 @@
+import { isNull } from "node:util";
+
+import { formDataToObject } from "src/components/applyForm/formDataToJson";
+
+describe("formDataToObject", () => {
+  it("correctly converts formData to object", () => {
+    const formData = new FormData();
+    formData.append("user.name", "Alice");
+    formData.append("user.age", "30");
+    formData.append("user.emptyString", "");
+    formData.append("user.deeper.value", "hello");
+    formData.append("user.skills[0]", "JavaScript");
+    formData.append("user.skills[1]", "TypeScript");
+    formData.append("user.skills[2].surprise", "more stuff");
+    formData.append("nonUser", "false");
+    formData.append("empty", "");
+    formData.append("numeral", "100");
+
+    const expected = {
+      user: {
+        age: 30,
+        name: "Alice",
+        emptyString: "",
+        skills: ["JavaScript", "TypeScript", { surprise: "more stuff" }],
+        deeper: {
+          value: "hello",
+        },
+      },
+      nonUser: false,
+      empty: "",
+      numeral: 100,
+    };
+
+    const result = formDataToObject(formData);
+
+    expect(result).toEqual(expected);
+  });
+  it("handles falsey values", () => {
+    const formData = new FormData();
+
+    formData.append("something.whatever", "a value");
+
+    const result = formDataToObject(formData);
+
+    expect(result.any).toEqual(undefined);
+    expect(result.something.somethingElse).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5701 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds UI implementation for the "Disclosure of Lobbying Activities (SF-LLL)" form

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This relies on some changes from https://github.com/HHS/simpler-grants-gov/pull/5717, and is based off of that branch. This PR will merge into that branch rather than main.

Other than form implementation, this PR handles:
* properly referencing nested json schema properties. HTML input ids will now reflect the nested nature of the schema, using `--` as a delimiter for nested paths.
* transforming a flat set of form data into a properly nested format. This draws on the library here, but required some customization for our use case, so copy pasted it over and made the necessary changes https://github.com/ArturKot95/FormData2Json

### Not implemented

* proper validation indicators for some nested fields. Address/city and Address/street1 are always required in "Name and Address of Reporting Entity", but will not be indicated as such in the UI. Same situation with signatureBlock/name/firstName and lastName
* proper "required" indicators for any nested or conditionally required fields
* postpopulation stuff for signature and signed date has not been implemented. Those fields should not be editable but currently look like they are

## Validation steps

### Required fields

Since parsing the schema is a little difficult, this is is how the required fields break down for this form

```

- "federal_action_type",
- "federal_action_status",
- "report_type",
- federal dept or agency

- reporting entity / entity type
- reporting entity / applicant reporting entity / organization name
- reporting entity / applicant reporting entity / address / city
- reporting entity / applicant reporting entity / address / street 1

- lobbying registrant / first name
- lobbying registrant / last name

- individual performing service / first name
- individual performing service / last name

- signature / first name
- signature / last name

- if report type == material change
- - material change year
- - material change quarter
- - (material change) last report date

- if reporting entity / entity type == subawardee
- - reporting entity / tier
- - reporting entity / prime reporting entity / organization name
- - reporting entity / prime reporting entity / address / city
- - reporting entity / prime reporting entity / address / street 1
```

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Reference for the form (PDF, DAT file) can be found here https://grants.gov/forms/form-items-description/fid/670

1. on this branch, run `make db-seed-local` from /api in order to pull in form changes to the DB
2. on this branch start a local fronted server with `npm run dev`
3. find the local "pilot type" opportunity in your local db. reference your local "competition" table, the opportunity id will match up with the competition that has more forms in the "competition_form" table
4. visit http://localhost:3000/opportunity/<opportunity id from 3>?_ff=applyFormPrototypeOff:false
5. log in
6. start a new application
7. click on the sf-LLL form in the list
8. _VERIFY_: form matches screenshot with all forms present and matching the definitions from the PDF / DAT file
9. click save
10. _VERIFY_: validation warnings returned largely match the required fields as mentioned above, with the caveats mentioned further above
11. enter "materialChange" as the "Report type" and save
12. _VERIFY_: all 3 material change fields are now failing validation
13. enter "subawardee" as "Entity Type"
14. _VERIFY: "tier" and section 4 "organization_name" are now failing validation
15. fill in all fields and save
16. _VERIFY_: no validation warnings

### Outstanding work and questions

- should state be a select?
- how to represent proper award amount and zip as strings?

### Screenshot
<img width="2640" height="18564" alt="Screenshot 2025-07-31 at 11-57-38 Form test for form React JSON Schema" src="https://github.com/user-attachments/assets/96f5e040-3524-40b1-97e4-515951d89dcc" />

