### PR TITLE
[Unticketed] Allow version_number to be null in search response

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -2769,7 +2769,9 @@ components:
           description: The text for the link to the agency email address
           example: Click me to email the agency
         version_number:
-          type: integer
+          type:
+          - integer
+          - 'null'
           description: The version number of the opportunity summary
           example: 1
         funding_instruments:

--- a/api/src/api/opportunities_v1/opportunity_schemas.py
+++ b/api/src/api/opportunities_v1/opportunity_schemas.py
@@ -203,7 +203,8 @@ class OpportunitySummaryV1Schema(Schema):
     )
 
     version_number = fields.Integer(
-        metadata={"description": "The version number of the opportunity summary", "example": 1}
+        allow_none=True,
+        metadata={"description": "The version number of the opportunity summary", "example": 1},
     )
 
     funding_instruments = fields.List(fields.Enum(FundingInstrument))

--- a/api/tests/src/task/notifications/test_opportunity_notification.py
+++ b/api/tests/src/task/notifications/test_opportunity_notification.py
@@ -306,8 +306,7 @@ class TestOpportunityNotification:
             .all()
         )
         assert len(notification_logs) == 2
-        assert notification_logs[0].user_id == user.user_id
-        assert notification_logs[1].user_id == user_2.user_id
+        assert {n.user_id for n in notification_logs} == {user.user_id, user_2.user_id}
 
         # Verify the log contains the correct metrics
         log_records = [


### PR DESCRIPTION
## Summary

## Changes proposed
Allow `version_number` to be null in search response schema

## Context for reviewers
I setup an opportunity manually in dev/staging for our apply pilot and set this to null in the DB, but when search tries to return it, it errors because the schema validation. This just makes it work.

## Validation steps
Create an opportunity locally like this via `make console`
```py
x = f.OpportunityFactory()
x.current_opportunity_summary.opportunity_summary.version_number = None
dbs.commit()
```
Run `make populate-search-opportunities`

Go to localhost:3000/search and it shouldn't error.