### PR TITLE
[Issue #5684] Update logging in SOAP endpoint to easily pull out various scenarios

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -9,6 +9,8 @@ from cryptography.x509 import load_pem_x509_certificate
 from pydantic import BaseModel
 from requests.adapters import HTTPAdapter
 
+from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
+
 logger = logging.getLogger(__name__)
 
 MTLS_CERT_HEADER_KEY = "X-Amzn-Mtls-Clientcert"
@@ -62,16 +64,23 @@ class SessionResumptionAdapter(HTTPAdapter):
 
 def get_soap_auth(mtls_cert: str | None) -> SOAPAuth | None:
     if not mtls_cert:
-        logger.info("soap_client_certificate: no certificate receieved from header")
+        logger.info(
+            "soap_client_certificate: no certificate received from header",
+            extra={"soap_api_event": LegacySoapApiEvent.NO_HEADER_CERT},
+        )
         return None
 
-    logger.info("soap_client_certificate: certificate receieved header")
+    logger.info("soap_client_certificate: certificate received header")
     auth = None
     try:
         auth = SOAPAuth(certificate=get_soap_client_certificate(mtls_cert))
         logger.info("soap_client_certificate: successfully extracted certificate and serial number")
     except Exception:
-        logger.info("soap_client_certificate: could not parse and extract serial number")
+        logger.info(
+            "soap_client_certificate: could not parse and extract serial number",
+            exc_info=True,
+            extra={"soap_api_event": LegacySoapApiEvent.UNPARSEABLE_CERT},
+        )
     return auth
 
 

--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -78,7 +78,10 @@ def get_soap_auth(mtls_cert: str | None) -> SOAPAuth | None:
     auth = None
     try:
         auth = SOAPAuth(certificate=get_soap_client_certificate(mtls_cert))
-        logger.info("soap_client_certificate: successfully extracted certificate and serial number")
+        logger.info(
+            "soap_client_certificate: successfully extracted certificate and serial number",
+            extra={"soap_api_event": LegacySoapApiEvent.PARSED_CERT},
+        )
     except Exception:
         logger.info(
             "soap_client_certificate: could not parse and extract serial number",

--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -127,13 +127,13 @@ class BaseSOAPClient:
                 "soap_api_diff complete",
                 extra={"soap_api_diff": diff_results, "soap_responses_match": diff_results == {}},
             )
-        except Exception as e:
+        except Exception:
             logger.info(
                 "soap_api_diff incomplete",
-                {
+                exc_info=True,
+                extra={
                     "soap_responses_match": False,
-                    "soap_api_error": "soap_response_diff",
-                    "soap_traceback": "".join(traceback.format_tb(e.__traceback__)),
+                    "soap_api_event": LegacySoapApiEvent.SOAP_DIFF_FAILED,
                 },
             )
 

--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from typing import Any
 
 from pydantic import ValidationError
@@ -8,6 +7,7 @@ import src.adapters.db as db
 from src.legacy_soap_api.applicants import schemas as applicants_schemas
 from src.legacy_soap_api.applicants.services import get_opportunity_list_response
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI
+from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPRequest, SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_utils import (
     SOAPFaultException,
@@ -72,7 +72,11 @@ class BaseSOAPClient:
         simpler_response_schema = self._get_simpler_soap_response_schema()
         if simpler_response_schema is None:
             logger.info(
-                "Unable to validate SOAP proxy response. No Simpler SOAP pydantic schema found."
+                "Unable to validate SOAP proxy response. No Simpler SOAP pydantic schema found.",
+                extra={
+                    "soap_api_event": LegacySoapApiEvent.NO_SIMPLER_SCHEMA_DEFINED,
+                    "response_operation_name": self.operation_config.response_operation_name,
+                },
             )
             return proxy_response_schema_data
 
@@ -95,12 +99,15 @@ class BaseSOAPClient:
             error_fields = {(err["type"], err["loc"]) for err in e.errors()}
             logger.info(
                 msg=f"{msg} {error_fields}",
-                extra={"simpler_soap_api_error": "proxy_response_validation"},
+                extra={
+                    "soap_api_event": LegacySoapApiEvent.PROXY_RESPONSE_VALIDATION_PROBLEM,
+                },
             )
-        except Exception as e:
+        except Exception:
             logger.info(
                 msg="Could not parse proxy response",
-                extra={"soap_traceback": "".join(traceback.format_tb(e.__traceback__))},
+                exc_info=True,
+                extra={"soap_api_event": LegacySoapApiEvent.UNPARSEABLE_SOAP_PROXY_RESPONSE},
             )
         return proxy_response_schema_data
 
@@ -127,7 +134,12 @@ class BaseSOAPClient:
             # parameters or data types. We can still compare the error data responses to the proxy
             # response.
             logger.info(
-                "simpler_soap_api: Fault", extra={"err": e.message, "fault": e.fault.model_dump()}
+                "simpler_soap_api: Fault",
+                exc_info=True,
+                extra={
+                    "soap_api_event": LegacySoapApiEvent.INVALID_REQUEST_RESPONSE_DATA,
+                    "fault": e.fault.model_dump(),
+                },
             )
             simpler_soap_response_payload = SOAPPayload(e.fault.to_xml().decode())
 

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -1,0 +1,21 @@
+from enum import StrEnum
+
+
+class LegacySoapApiEvent(StrEnum):
+
+    NO_HEADER_CERT = "no_header_cert"
+    UNPARSEABLE_CERT = "unparseable_cert"
+    UNKNOWN_INVALID_CLIENT_CERT = "unknown_invalid_client_cert"
+    NOT_CONFIGURED_CERT = "not_configured_cert"
+
+    NO_SIMPLER_SCHEMA_DEFINED = "no_simpler_schema_defined"
+
+    PROXY_RESPONSE_VALIDATION_PROBLEM = "proxy_response_validation_problem"
+    UNPARSEABLE_SOAP_PROXY_RESPONSE = "unparseable_soap_proxy_response"
+
+    INVALID_REQUEST_RESPONSE_DATA = "invalid_request_response_data"
+
+    INVALID_SOAP_AUTH_CONTENT_CONFIG = "invalid_soap_auth_content_config"
+
+    INVALID_REQUEST = "invalid_request"
+    UNKNOWN_ERROR = "unknown_error"

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -4,18 +4,30 @@ from enum import StrEnum
 class LegacySoapApiEvent(StrEnum):
 
     NO_HEADER_CERT = "no_header_cert"
+    PARSED_CERT = "parsed_cert"
     UNPARSEABLE_CERT = "unparseable_cert"
     UNKNOWN_INVALID_CLIENT_CERT = "unknown_invalid_client_cert"
     NOT_CONFIGURED_CERT = "not_configured_cert"
+    CALLING_WITHOUT_CERT = "calling_without_cert"
+    CALLING_WITH_CERT = "calling_with_cert"
 
     NO_SIMPLER_SCHEMA_DEFINED = "no_simpler_schema_defined"
 
     PROXY_RESPONSE_VALIDATION_PROBLEM = "proxy_response_validation_problem"
     UNPARSEABLE_SOAP_PROXY_RESPONSE = "unparseable_soap_proxy_response"
-
     INVALID_REQUEST_RESPONSE_DATA = "invalid_request_response_data"
 
     INVALID_SOAP_AUTH_CONTENT_CONFIG = "invalid_soap_auth_content_config"
 
+    SOAP_DIFF_FAILED = "soap_diff_failed"
+
+    UNKNOWN_SOAP_API = "unknown_soap_api"
+
     INVALID_REQUEST = "invalid_request"
     UNKNOWN_ERROR = "unknown_error"
+
+    ERROR_CALLING_LEGACY_SOAP = "error_call_legacy_soap"
+    ERROR_CALLING_SIMPLER = "error_calling_simpler"
+
+    RETURNING_SIMPLER_RESPONSE = "returning_simpler_response"
+    RETURNING_LEGACY_SOAP_RESPONSE = "returning_legacy_soap_response"

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -27,7 +27,7 @@ PROXY_TIMEOUT = 3600
 def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) -> SOAPResponse:
     config = get_soap_config()
 
-    # Use X-Gg-S2S-Uri header locally if passed, otherwise defualt to GRANTS_GOV_URI:GRANTS_GOV_PORT.
+    # Use X-Gg-S2S-Uri header locally if passed, otherwise default to GRANTS_GOV_URI:GRANTS_GOV_PORT.
     proxy_url = join(
         soap_request.headers.get(config.gg_s2s_proxy_header_key, config.gg_url),
         soap_request.full_path.lstrip("/"),

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -47,6 +47,7 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
             "soap_client_certificate: Sending soap request without client certificate",
             extra={"soap_api_event": LegacySoapApiEvent.CALLING_WITHOUT_CERT},
         )
+        print(_request.url)
         return _get_soap_response(_request, timeout=timeout)
 
     logger.info("soap_client_certificate: Processing client certificate")

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -47,7 +47,6 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
             "soap_client_certificate: Sending soap request without client certificate",
             extra={"soap_api_event": LegacySoapApiEvent.CALLING_WITHOUT_CERT},
         )
-        print(_request.url)
         return _get_soap_response(_request, timeout=timeout)
 
     logger.info("soap_client_certificate: Processing client certificate")

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -13,7 +13,11 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPRequest, SOAPResponse
-from src.legacy_soap_api.legacy_soap_api_utils import filter_headers, get_streamed_soap_response
+from src.legacy_soap_api.legacy_soap_api_utils import (
+    filter_headers,
+    get_soap_error_response,
+    get_streamed_soap_response,
+)
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 
 logger = logging.getLogger(__name__)
@@ -68,6 +72,9 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
                 "soap_client_certificate: Certificate validated but not configured",
                 exc_info=True,
                 extra={"soap_api_event": LegacySoapApiEvent.NOT_CONFIGURED_CERT},
+            )
+            return get_soap_error_response(
+                faultstring="Client certificate not configured for Simpler SOAP."
             )
 
         temp_cert_file.write(cert)

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -13,11 +13,7 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPRequest, SOAPResponse
-from src.legacy_soap_api.legacy_soap_api_utils import (
-    filter_headers,
-    get_soap_error_response,
-    get_streamed_soap_response,
-)
+from src.legacy_soap_api.legacy_soap_api_utils import filter_headers, get_streamed_soap_response
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 
 logger = logging.getLogger(__name__)
@@ -43,7 +39,10 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
     _request = Request(method="POST", url=proxy_url, headers=proxy_headers, data=soap_request.data)
 
     if not soap_request.auth or config.soap_auth_map == {}:
-        logger.info("soap_client_certificate: Sending soap request without client certificate")
+        logger.info(
+            "soap_client_certificate: Sending soap request without client certificate",
+            extra={"soap_api_event": LegacySoapApiEvent.CALLING_WITHOUT_CERT},
+        )
         return _get_soap_response(_request, timeout=timeout)
 
     logger.info("soap_client_certificate: Processing client certificate")
@@ -75,7 +74,10 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
         temp_cert_file.flush()
 
         add_extra_data_to_current_request_logs({"cert_id": cert_id})
-        logger.info("soap_client_certificate: Sending soap request with client certificate")
+        logger.info(
+            "soap_client_certificate: Sending soap request with client certificate",
+            extra={"soap_api_event": LegacySoapApiEvent.CALLING_WITH_CERT},
+        )
         return _get_soap_response(_request, cert=temp_file_path, timeout=timeout)
 
 

--- a/api/src/legacy_soap_api/legacy_soap_api_routes.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_routes.py
@@ -6,6 +6,7 @@ import src.adapters.db as db
 import src.adapters.db.flask_db as flask_db
 from src.legacy_soap_api.legacy_soap_api_auth import MTLS_CERT_HEADER_KEY, get_soap_auth
 from src.legacy_soap_api.legacy_soap_api_blueprint import legacy_soap_api_blueprint
+from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response
 from src.legacy_soap_api.legacy_soap_api_schemas import SimplerSoapAPI, SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
@@ -34,7 +35,10 @@ def simpler_soap_api_route(
 
     api_name = SimplerSoapAPI.get_soap_api(service_name, service_port_name)
     if not api_name:
-        logger.info("Could not determine Simpler SOAP API from service_name and service_port_name")
+        logger.info(
+            "Could not determine Simpler SOAP API from service_name and service_port_name",
+            extra={"soap_api_event": LegacySoapApiEvent.UNKNOWN_SOAP_API},
+        )
         return get_invalid_path_response().to_flask_response()
 
     operation_name = get_soap_operation_name(request.data)
@@ -62,6 +66,7 @@ def simpler_soap_api_route(
             msg="Error getting soap proxy response",
             extra={
                 "used_simpler_response": False,
+                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_LEGACY_SOAP,
             },
         )
         return get_soap_error_response().to_flask_response()
@@ -76,6 +81,7 @@ def simpler_soap_api_route(
             msg=msg,
             extra={
                 "used_simpler_response": False,
+                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },
         )
         return soap_proxy_response.to_flask_response()

--- a/api/src/legacy_soap_api/legacy_soap_api_routes.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_routes.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 
 from flask import request
 
@@ -71,7 +70,7 @@ def simpler_soap_api_route(
         return get_simpler_soap_response(
             soap_request, soap_proxy_response, db_session
         ).to_flask_response()
-    except Exception as e:
+    except Exception:
         msg = "Unable to process Simpler SOAP proxy response"
         logger.exception(
             msg=msg,

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -1,11 +1,11 @@
 import logging
-import traceback
 
 import src.adapters.db as db
 from src.legacy_soap_api.legacy_soap_api_client import (
     SimplerApplicantsS2SClient,
     SimplerGrantorsS2SClient,
 )
+from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import (
     SimplerSoapAPI,
     SOAPInvalidEnvelope,
@@ -43,20 +43,21 @@ def get_simpler_soap_response(
     except (SOAPInvalidEnvelope, SOAPInvalidRequestOperationName, SOAPOperationNotSupported) as e:
         logger.info(
             f"simpler_soap_api: {e}",
+            exc_info=True,
             extra={
-                "simpler_soap_api_error": e,
+                "soap_api_event": LegacySoapApiEvent.INVALID_REQUEST,
                 "used_simpler_response": use_simpler,
             },
         )
         return soap_proxy_response
-    except Exception as e:
+    except Exception:
         err = "Unable to initialize Simpler SOAP client: Unknown error"
         logger.info(
             f"simpler_soap_api: {err}",
+            exc_info=True,
             extra={
-                "simpler_soap_api_error": err,
+                "soap_api_event": LegacySoapApiEvent.UNKNOWN_ERROR,
                 "used_simpler_response": use_simpler,
-                "soap_traceback": "".join(traceback.format_tb(e.__traceback__)),
             },
         )
         return soap_proxy_response

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -69,12 +69,18 @@ def get_simpler_soap_response(
     if simpler_soap_response is not None and use_simpler:
         logger.info(
             "simpler_soap_api: Successfully processed request and returning Simpler SOAP response",
-            extra={"used_simpler_response": use_simpler},
+            extra={
+                "soap_api_event": LegacySoapApiEvent.RETURNING_SIMPLER_RESPONSE,
+                "used_simpler_response": use_simpler,
+            },
         )
         return simpler_soap_response
 
     logger.info(
         "simpler_soap_api: Successfully processed request and returning SOAP proxy response",
-        extra={"used_simpler_response": use_simpler},
+        extra={
+            "soap_api_event": LegacySoapApiEvent.RETURNING_LEGACY_SOAP_RESPONSE,
+            "used_simpler_response": use_simpler,
+        },
     )
     return soap_proxy_response

--- a/api/src/logging/flask_logger.py
+++ b/api/src/logging/flask_logger.py
@@ -223,6 +223,10 @@ def _add_error_info_to_log_record(record: logging.LogRecord) -> bool:
     exc_info = getattr(record, "exc_info", None)
     # exc_info is a 3-part tuple with the class, error obj, and traceback
     if exc_info and len(exc_info) == 3:
+        # Add the exception class name to the logs, check that it
+        # is a class just in case there is some code path that sets this different.
+        if isinstance(exc_info[0], type):
+            record.__dict__["exc_info_cls"] = exc_info[0].__name__
         # If the error were `raise ValueError("example")`, the
         # value of this would be "ValueError('example')"
         record.__dict__["exc_info_short"] = repr(exc_info[1])


### PR DESCRIPTION
## Summary
Fixes #5684

## Changes proposed
Add a `soap_api_event` to most logs in the SOAP API to easily get metrics for various scenarios.

Adjusted API-wide logging to always put the class whenever an exception is logged.

## Context for reviewers
The soap api events are just to make graphs and metrics easy in New Relic.

A few other miscellaneous changes:
* Removed uses of `traceback` in favor of `exc_info=True` to keep how errors get formatted in logs consistent.
* Either use exception or info logs
* Added a few additional values to all logs at the start of the request.

No logic behavior should have been changed by this, just a bunch of log additions/adjustments.

## Validation steps
Hard to test every scenario since I'm not sure how we'd even cause some of them locally, but at least in some cases it logs:
<img width="1427" height="127" alt="Screenshot 2025-07-29 at 1 17 35 PM" src="https://github.com/user-attachments/assets/7ff4a86d-c8a4-419c-9705-99574a2c6f49" />


