### PR TITLE
[Unticketed] Make all post-populated fields non-required

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -8,7 +8,6 @@ FORM_JSON_SCHEMA = {
     "required": [
         "submission_type",
         "application_type",
-        "date_received",
         "organization_name",
         "employer_taxpayer_identification_number",
         "sam_uei",
@@ -38,8 +37,6 @@ FORM_JSON_SCHEMA = {
         "authorized_representative",
         "authorized_representative_phone_number",
         "authorized_representative_email",
-        "aor_signature",
-        "date_signed",
     ],
     # Conditional validation rules for SF424
     "allOf": [

--- a/api/src/form_schema/forms/sf424b.py
+++ b/api/src/form_schema/forms/sf424b.py
@@ -4,7 +4,7 @@ from src.db.models.competition_models import Form
 
 FORM_JSON_SCHEMA = {
     "type": "object",
-    "required": ["signature", "title", "applicant_organization", "date_signed"],
+    "required": ["signature", "title", "applicant_organization"],
     "properties": {
         "signature": {
             "type": "string",

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -166,7 +166,7 @@ FORM_JSON_SCHEMA = {
         },
         "signature_block": {
             "type": "object",
-            "required": ["signature", "name", "signed_date"],
+            "required": ["name"],
             "properties": {
                 "signature": {
                     "type": "string",

--- a/api/tests/src/form_schema/forms/test_sf424.py
+++ b/api/tests/src/form_schema/forms/test_sf424.py
@@ -14,7 +14,6 @@ def valid_json_v4_0():
     return {
         "submission_type": "Application",
         "application_type": "New",
-        "date_received": "2025-01-01",
         "organization_name": "Example Org",
         "employer_taxpayer_identification_number": "123-456-7890",
         "sam_uei": "UEI123123123",
@@ -56,8 +55,6 @@ def valid_json_v4_0():
         },
         "authorized_representative_phone_number": "123-456-7890",
         "authorized_representative_email": "example@mail.com",
-        "aor_signature": "Bob Smith",
-        "date_signed": "2025-06-01",
     }
 
 
@@ -70,6 +67,7 @@ def full_valid_json_v4_0(valid_json_v4_0):
         "application_type": "Revision",
         "revision_type": "E: Other (specify)",
         "revision_other_specify": "I am redoing it",
+        "date_received": "2025-01-01",
         "applicant_id": "ABC123",
         "federal_entity_identifier": "XYZ456",
         "federal_award_identifier": "1234567890",
@@ -121,6 +119,8 @@ def full_valid_json_v4_0(valid_json_v4_0):
             "title": "Agent",
         },
         "authorized_representative_fax": "333-333-3333",
+        "aor_signature": "Bob Smith",
+        "date_signed": "2025-06-01",
     }
 
 
@@ -140,7 +140,6 @@ def test_sf424_v4_0_empty_json(sf424_v4_0):
     EXPECTED_REQUIRED_FIELDS = {
         "$.submission_type",
         "$.application_type",
-        "$.date_received",
         "$.organization_name",
         "$.employer_taxpayer_identification_number",
         "$.sam_uei",
@@ -170,8 +169,6 @@ def test_sf424_v4_0_empty_json(sf424_v4_0):
         "$.authorized_representative",
         "$.authorized_representative_phone_number",
         "$.authorized_representative_email",
-        "$.aor_signature",
-        "$.date_signed",
     }
 
     assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)

--- a/api/tests/src/form_schema/forms/test_sf424b.py
+++ b/api/tests/src/form_schema/forms/test_sf424b.py
@@ -19,12 +19,21 @@ def minimal_valid_sf424b_v1_1() -> dict:
         "signature": "Bob Smith",
         "title": "Mr.",
         "applicant_organization": "Business Inc.",
-        "date_signed": "2025-01-01",
     }
+
+
+@pytest.fixture
+def full_valid_sf424b_v1_1(minimal_valid_sf424b_v1_1) -> dict:
+    return minimal_valid_sf424b_v1_1 | {"date_signed": "2025-01-01"}
 
 
 def test_sf424b_v1_1_minimal_valid_json(minimal_valid_sf424b_v1_1):
     validation_issues = validate_json_schema_for_form(minimal_valid_sf424b_v1_1, SF424b_v1_1)
+    assert len(validation_issues) == 0
+
+
+def test_sf424b_v1_1_full_valid_json(full_valid_sf424b_v1_1):
+    validation_issues = validate_json_schema_for_form(full_valid_sf424b_v1_1, SF424b_v1_1)
     assert len(validation_issues) == 0
 
 
@@ -33,7 +42,6 @@ def test_sf424b_v1_1_empty_json():
         "$.signature",
         "$.title",
         "$.applicant_organization",
-        "$.date_signed",
     ]
 
     validate_required({}, EXPECTED_REQUIRED_FIELDS)

--- a/api/tests/src/form_schema/forms/test_sflll.py
+++ b/api/tests/src/form_schema/forms/test_sflll.py
@@ -40,12 +40,10 @@ def minimal_valid_sflll_v2_0() -> dict:
             }
         },
         "signature_block": {
-            "signature": "Bob",
             "name": {
                 "first_name": "Bob",
                 "last_name": "Brown",
             },
-            "signed_date": "2025-01-01",
         },
     }
 
@@ -186,9 +184,7 @@ def test_sflll_2_0_empty_objects(minimal_valid_sflll_v2_0):
         "$.reporting_entity.applicant_reporting_entity",
         "$.lobbying_registrant.individual",
         "$.individual_performing_service.individual",
-        "$.signature_block.signature",
         "$.signature_block.name",
-        "$.signature_block.signed_date",
     ]
     validate_required(data, EXPECTED_REQUIRED_FIELDS)
 


### PR DESCRIPTION
## Summary

## Changes proposed
Make all fields that are going to be post-populated non-required.

## Context for reviewers
This doesn't technically change what fields will be populated when submission occurs, but will remove error messages complaining about "missing a required field" for a field that a user can't fill in. We know the field will be set by our post-population (when that gets enabled in the next few days) so giving a user an error they can't do anything about is just noise.

