### PR TITLE
Dschrashun/4897 reduce login modal

### DIFF
--- a/frontend/src/components/LoginButton.tsx
+++ b/frontend/src/components/LoginButton.tsx
@@ -1,0 +1,48 @@
+import { LOGIN_URL } from "src/constants/auth";
+import SessionStorage from "src/services/sessionStorage/sessionStorage";
+
+import { PropsWithChildren } from "react";
+import { Button } from "@trussworks/react-uswds";
+
+import { USWDSIcon } from "./USWDSIcon";
+
+export function LoginLink({ children }: PropsWithChildren) {
+  return (
+    <a
+      href={LOGIN_URL}
+      key="login-link"
+      className="usa-button"
+      onClick={() => {
+        const startURL = `${location.pathname}${location.search}`;
+        if (startURL !== "") {
+          SessionStorage.setItem("login-redirect", startURL);
+        }
+      }}
+    >
+      {children}
+    </a>
+  );
+}
+
+export function LoginButton({
+  navLoginLinkText,
+}: {
+  navLoginLinkText: string;
+}) {
+  return (
+    <Button
+      type="button"
+      className="usa-nav__link font-sans-2xs display-flex text-normal border-0"
+      data-testid="sign-in-button"
+    >
+      <LoginLink>
+        <USWDSIcon
+          className="usa-icon margin-right-05 margin-left-neg-05"
+          name="login"
+          key="login-link-icon"
+        />
+        {navLoginLinkText}
+      </LoginLink>
+    </Button>
+  );
+}

--- a/frontend/src/components/LoginButton.tsx
+++ b/frontend/src/components/LoginButton.tsx
@@ -6,12 +6,12 @@ import { Button } from "@trussworks/react-uswds";
 
 import { USWDSIcon } from "./USWDSIcon";
 
-export function LoginLink({ children }: PropsWithChildren) {
+export function LoginLink({ children, className }: PropsWithChildren) {
   return (
     <a
       href={LOGIN_URL}
       key="login-link"
-      className="usa-button"
+      className={className}
       onClick={() => {
         const startURL = `${location.pathname}${location.search}`;
         if (startURL !== "") {
@@ -35,7 +35,7 @@ export function LoginButton({
       className="usa-nav__link font-sans-2xs display-flex text-normal border-0"
       data-testid="sign-in-button"
     >
-      <LoginLink>
+      <LoginLink className="padding-0 text-no-underline text-primary-dark display-flex">
         <USWDSIcon
           className="usa-icon margin-right-05 margin-left-neg-05"
           name="login"

--- a/frontend/src/components/LoginButton.tsx
+++ b/frontend/src/components/LoginButton.tsx
@@ -6,7 +6,10 @@ import { Button } from "@trussworks/react-uswds";
 
 import { USWDSIcon } from "./USWDSIcon";
 
-export function LoginLink({ children, className }: PropsWithChildren) {
+export function LoginLink({
+  children,
+  className,
+}: { className?: string } & PropsWithChildren) {
   return (
     <a
       href={LOGIN_URL}
@@ -30,19 +33,19 @@ export function LoginButton({
   navLoginLinkText: string;
 }) {
   return (
-    <Button
-      type="button"
-      className="usa-nav__link font-sans-2xs display-flex text-normal border-0"
-      data-testid="sign-in-button"
-    >
-      <LoginLink className="padding-0 text-no-underline text-primary-dark display-flex">
+    <LoginLink className="padding-0 text-no-underline text-primary-dark display-flex">
+      <Button
+        type="button"
+        className="usa-nav__link font-sans-2xs display-flex text-normal border-0"
+        data-testid="sign-in-button"
+      >
         <USWDSIcon
           className="usa-icon margin-right-05 margin-left-neg-05"
           name="login"
           key="login-link-icon"
         />
         {navLoginLinkText}
-      </LoginLink>
-    </Button>
+      </Button>
+    </LoginLink>
   );
 }

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -66,7 +66,7 @@ export const LoginModalBody = ({
       <p className="font-sans-2xs margin-y-4">{descriptionText}</p>
       <ModalFooter>
         <ButtonGroup>
-          <LoginLink>
+          <LoginLink className="usa-button">
             {buttonText}
             <USWDSIcon
               className="usa-icon margin-right-05 margin-left-neg-05"

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -1,7 +1,5 @@
 "use-client";
 
-import SessionStorage from "src/services/sessionStorage/sessionStorage";
-
 import { RefObject } from "react";
 import {
   ButtonGroup,
@@ -11,9 +9,8 @@ import {
 } from "@trussworks/react-uswds";
 
 import { USWDSIcon } from "src/components/USWDSIcon";
+import { LoginLink } from "./LoginButton";
 import { SimplerModal } from "./SimplerModal";
-
-export const LOGIN_URL = "/api/auth/login";
 
 export const LoginModal = ({
   modalRef,
@@ -69,24 +66,14 @@ export const LoginModalBody = ({
       <p className="font-sans-2xs margin-y-4">{descriptionText}</p>
       <ModalFooter>
         <ButtonGroup>
-          <a
-            href={LOGIN_URL}
-            key="login-link"
-            className="usa-button"
-            onClick={() => {
-              const startURL = `${location.pathname}${location.search}`;
-              if (startURL !== "") {
-                SessionStorage.setItem("login-redirect", startURL);
-              }
-            }}
-          >
+          <LoginLink>
             {buttonText}
             <USWDSIcon
               className="usa-icon margin-right-05 margin-left-neg-05"
               name="launch"
               key="login-gov-link-icon"
             />
-          </a>
+          </LoginLink>
           <ModalToggleButton
             modalRef={modalRef}
             closer

--- a/frontend/src/components/user/UserControl.tsx
+++ b/frontend/src/components/user/UserControl.tsx
@@ -12,7 +12,7 @@ import {
   NavDropDownButton,
 } from "@trussworks/react-uswds";
 
-import { LoginButtonModal } from "src/components/LoginButtonModal";
+import { LoginButton } from "src/components/LoginButton";
 import { USWDSIcon } from "src/components/USWDSIcon";
 
 // used in three different places
@@ -137,9 +137,7 @@ export const UserControl = () => {
 
   return (
     <>
-      {!user?.token && (
-        <LoginButtonModal navLoginLinkText={t("navLinks.login")} />
-      )}
+      {!user?.token && <LoginButton navLoginLinkText={t("navLinks.login")} />}
       {!!user?.token && (
         <UserDropdown
           user={user}

--- a/frontend/src/constants/auth.ts
+++ b/frontend/src/constants/auth.ts
@@ -3,3 +3,5 @@ export const clientTokenRefreshInterval = 10 * 60 * 1000;
 
 // 15 minutes
 export const clientTokenExpirationInterval = 15 * 60 * 1000;
+
+export const LOGIN_URL = "/api/auth/login";

--- a/frontend/tests/components/LoginButton.test.tsx
+++ b/frontend/tests/components/LoginButton.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { LoginButton, LoginLink } from "src/components/LoginButton";
+
+const mockSetItem = jest.fn<void, [string, string]>();
+
+jest.mock("src/services/sessionStorage/sessionStorage", () => {
+  return {
+    __esModule: true,
+    default: {
+      setItem: (key: string, value: string): void => mockSetItem(key, value),
+    },
+  };
+});
+
+const mockLocation = {
+  pathname: "/test-path",
+  search: "?param=value",
+};
+
+// Save the original location
+const originalLocation = global.location;
+
+describe("LoginButton", () => {
+  it("matches snapshot", () => {
+    const { container } = render(<LoginButton navLoginLinkText="whatever" />);
+
+    expect(container).toMatchSnapshot();
+  });
+});
+
+describe("LoginLink", () => {
+  beforeEach(() => {
+    Object.defineProperty(global, "location", {
+      configurable: true,
+      value: { ...mockLocation },
+      writable: true,
+    });
+
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(global, "location", {
+      configurable: true,
+      value: originalLocation,
+      writable: true,
+    });
+  });
+  it("matches snapshot", () => {
+    const { container } = render(
+      <LoginLink>
+        <span>hi</span>
+      </LoginLink>,
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+  it("should store the current URL in session storage when clicking sign in", async () => {
+    render(
+      <LoginLink>
+        <span>hi</span>
+      </LoginLink>,
+    );
+
+    const signInButton = screen.getByText("hi");
+    await userEvent.click(signInButton);
+
+    expect(mockSetItem).toHaveBeenCalledWith(
+      "login-redirect",
+      "/test-path?param=value",
+    );
+  });
+
+  it("should not store URL in session storage if pathname and search are empty", async () => {
+    Object.defineProperty(global, "location", {
+      value: { pathname: "", search: "" },
+    });
+
+    render(
+      <LoginLink>
+        <span>hi</span>
+      </LoginLink>,
+    );
+
+    const loginButton = screen.getByText("hi");
+    await userEvent.click(loginButton);
+
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/LoginButtonModal.test.tsx
+++ b/frontend/tests/components/LoginButtonModal.test.tsx
@@ -1,9 +1,9 @@
 import userEvent from "@testing-library/user-event";
+import { LOGIN_URL } from "src/constants/auth";
 import { render, screen } from "tests/react-utils";
 
 import Header from "src/components/Header";
 import { LoginButtonModal } from "src/components/LoginButtonModal";
-import { LOGIN_URL } from "src/components/LoginModal";
 
 const usePathnameMock = jest.fn().mockReturnValue("/fakepath");
 

--- a/frontend/tests/components/LoginButtonModal.test.tsx
+++ b/frontend/tests/components/LoginButtonModal.test.tsx
@@ -2,7 +2,6 @@ import userEvent from "@testing-library/user-event";
 import { LOGIN_URL } from "src/constants/auth";
 import { render, screen } from "tests/react-utils";
 
-import Header from "src/components/Header";
 import { LoginButtonModal } from "src/components/LoginButtonModal";
 
 const usePathnameMock = jest.fn().mockReturnValue("/fakepath");
@@ -39,7 +38,7 @@ describe("LoginButtonModal", () => {
   });
 
   it("displays modal when clicked", async () => {
-    render(<Header />);
+    render(<LoginButtonModal navLoginLinkText="Sign in" />);
 
     const loginButton = screen.getByRole("button", { name: /Sign in/i });
     expect(loginButton).toBeInTheDocument();

--- a/frontend/tests/components/LoginModal.test.tsx
+++ b/frontend/tests/components/LoginModal.test.tsx
@@ -1,28 +1,9 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import { RefObject } from "react";
 import { ModalRef } from "@trussworks/react-uswds/lib/components/Modal/Modal";
 
 import { LoginModal } from "src/components/LoginModal";
-
-const mockSetItem = jest.fn<void, [string, string]>();
-
-jest.mock("src/services/sessionStorage/sessionStorage", () => {
-  return {
-    __esModule: true,
-    default: {
-      setItem: (key: string, value: string): void => mockSetItem(key, value),
-    },
-  };
-});
-
-const mockLocation = {
-  pathname: "/test-path",
-  search: "?param=value",
-};
-
-// Save the original location
-const originalLocation = global.location;
 
 describe("LoginModal", () => {
   const createModalRef = (): RefObject<ModalRef> => ({
@@ -35,21 +16,7 @@ describe("LoginModal", () => {
   });
 
   beforeEach(() => {
-    Object.defineProperty(global, "location", {
-      configurable: true,
-      value: { ...mockLocation },
-      writable: true,
-    });
-
     jest.clearAllMocks();
-  });
-
-  afterAll(() => {
-    Object.defineProperty(global, "location", {
-      configurable: true,
-      value: originalLocation,
-      writable: true,
-    });
   });
 
   it("should render the login modal", () => {
@@ -87,53 +54,5 @@ describe("LoginModal", () => {
     );
 
     expect(screen.getByText(customButtonText)).toBeInTheDocument();
-  });
-
-  it("should store the current URL in session storage when clicking sign in", () => {
-    const modalRef = createModalRef();
-    render(
-      <LoginModal
-        modalRef={modalRef}
-        helpText="Help text"
-        titleText="Login"
-        descriptionText="Please login"
-        buttonText="Sign In"
-        closeText="Close"
-        modalId="login-modal"
-      />,
-    );
-
-    const signInButton = screen.getByText("Sign In");
-    fireEvent.click(signInButton);
-
-    expect(mockSetItem).toHaveBeenCalledWith(
-      "login-redirect",
-      "/test-path?param=value",
-    );
-  });
-
-  it("should not store URL in session storage if pathname and search are empty", () => {
-    Object.defineProperty(global, "location", {
-      value: { pathname: "", search: "" },
-    });
-
-    const modalRef = createModalRef();
-
-    render(
-      <LoginModal
-        modalRef={modalRef}
-        helpText="Help text"
-        titleText="Login"
-        descriptionText="Please login"
-        buttonText="Sign In"
-        closeText="Close"
-        modalId="login-modal"
-      />,
-    );
-
-    const loginButton = screen.getByText("Sign In");
-    fireEvent.click(loginButton);
-
-    expect(mockSetItem).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/components/__snapshots__/LoginButton.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/LoginButton.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoginButton matches snapshot 1`] = `
+<div>
+  <a
+    class="padding-0 text-no-underline text-primary-dark display-flex"
+    href="/api/auth/login"
+  >
+    <button
+      class="usa-button usa-nav__link font-sans-2xs display-flex text-normal border-0"
+      data-testid="sign-in-button"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="usa-icon usa-icon margin-right-05 margin-left-neg-05"
+        role="img"
+      >
+        <use
+          href="/img.jpg#login"
+        />
+      </svg>
+      whatever
+    </button>
+  </a>
+</div>
+`;
+
+exports[`LoginLink matches snapshot 1`] = `
+<div>
+  <a
+    href="/api/auth/login"
+  >
+    <span>
+      hi
+    </span>
+  </a>
+</div>
+`;


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #4897

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

The main nav link to "sign in" will now direct directly to the login page rather than opening a modal

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Since we now have two places where we're using a link directly to the login page, split out that functionality into its own component

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000
3. click "sign in"
4. _VALIDATE_: you are taken directly to the login page without opening a modal
5. complete sign in
6. _VALIDATE_: sign in works as expected, and logged in nav looks right
7. navigate to an opportunity
8. log out
9. click to save opportunity
10. _VERIFY_: modal appears, and you can log in through that as usual