### PR TITLE
[Issue #3797] update saved opportunities page metadata description

### DIFF
--- a/frontend/src/app/[locale]/saved-opportunities/layout.tsx
+++ b/frontend/src/app/[locale]/saved-opportunities/layout.tsx
@@ -11,7 +11,7 @@ export async function generateMetadata({ params }: LocalizedPageProps) {
   const t = await getTranslations({ locale });
   const meta: Metadata = {
     title: t("SavedOpportunities.title"),
-    description: t("Index.metaDescription"),
+    description: t("SavedOpportunities.metaDescription"),
   };
   return meta;
 }

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -777,6 +777,7 @@ export const messages = {
     },
   },
   SavedOpportunities: {
+    metaDescription: "View your saved funding opportunities.",
     heading: "Saved opportunities",
     noSavedCTA:
       "To add an opportunity to your list, use the Save button next to its title on the listing's page.<br></br>Saved opportunities will be starred in your search results, but you can only save and un-save from the specific opportunity page",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #3797 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
update saved opportunities page metadata description

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch
2. visit http://localhost:3000
3. log in
4. click over to saved opportunities page
5. inspect page source
6. _VERIFY_: document head contains a meta tag looking like `<meta name="description" content="View your saved funding opportunities.">`

### Screenshot
<img width="813" height="548" alt="Screenshot 2025-08-01 at 10 26 54 AM" src="https://github.com/user-attachments/assets/0c156a2a-3845-46c6-bf09-7e39319be7d4" />

