### PR TITLE
[Unticketed] Add checkov skip for something that doesn't apply to us

### DIFF
--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -4,6 +4,8 @@
 
 # ALB for an app running in ECS
 resource "aws_lb" "alb" {
+  # checkov:skip=CKV2_AWS_76:No Java in our stack, with the intro of the mTLS and the SOAP it supports we likely won't put this behind a WAF ever
+
   # we need an identical alb, with mtls enabled
   # so we piggy back off existing and just spin up two when the api sets this true
   count      = var.enable_load_balancer ? var.enable_mtls_load_balancer ? 2 : 1 : 0


### PR DESCRIPTION
## Summary

A renovate PR I merged updated checkov so this started firing. It's for a Java vulnerability, so we're not affected, and we aren't finalized on whether to put the mTLS ALB behind a WAF given it's SOAP and we'd probably need to tune down the false positives a lot.