### PR TITLE
[Issue #5591] add and|or operator to frontend side saved searches

### DIFF
--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -754,6 +754,7 @@ export const messages = {
       closeDate: "Close date",
       costSharing: "Cost sharing",
       topLevelAgency: "Top level agency",
+      andOr: "Query and/or operator",
     },
     editModal: {
       loading: "Updating",

--- a/frontend/src/types/search/searchQueryTypes.ts
+++ b/frontend/src/types/search/searchQueryTypes.ts
@@ -19,6 +19,7 @@ export const validSearchQueryParamKeys = [
   ...searchFilterNames,
   "page",
   "sortby",
+  "andOr",
 ] as const;
 
 // an allow list for any paramaters we expect and would like to keep track of in New Relic or elsewhere

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -61,6 +61,7 @@ export type SavedSearchQuery = {
   filters: SearchFilterRequestBody;
   pagination: PaginationRequestBody;
   query: string;
+  query_operator: QueryOperator;
 };
 
 // relevant portions of the response payload from fetching a user's saved searches

--- a/frontend/src/utils/search/searchFormatUtils.ts
+++ b/frontend/src/utils/search/searchFormatUtils.ts
@@ -224,8 +224,14 @@ export const searchToQueryParams = (
       : {};
 
   const sortby = paginationToSortby(searchRecord?.pagination?.sort_order || []);
-
-  return { ...filters, query: searchRecord.query || "", ...sortby };
+  const withQueryAndSort = {
+    ...filters,
+    query: searchRecord.query || "",
+    ...sortby,
+  };
+  return searchRecord.query && searchRecord.query_operator
+    ? { ...withQueryAndSort, andOr: searchRecord.query_operator }
+    : withQueryAndSort;
 };
 
 // sort of the opposite of buildPagination - translates from backend search pagination object to "sortby" query param

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -9,6 +9,7 @@ import { ValidSearchQueryParamData } from "src/types/search/searchQueryTypes";
 import {
   PaginationOrderBy,
   PaginationSortDirection,
+  QueryOperator,
   QueryParamData,
   SearchAPIResponse,
   SearchFetcherActionType,
@@ -70,6 +71,7 @@ export const fakeSavedSearch = {
   filters: fakeSearchFilterRequestBody,
   pagination: arbitrarySearchPagination,
   query: "something to search for",
+  query_operator: "OR" as QueryOperator,
 };
 
 export const fakeSearchQueryParamData: ValidSearchQueryParamData = {

--- a/frontend/tests/components/workspace/SavedSearchesList.test.tsx
+++ b/frontend/tests/components/workspace/SavedSearchesList.test.tsx
@@ -56,6 +56,7 @@ const fakeParamDisplayMapping = {
   closeDate: "closeDate",
   costSharing: "costSharing",
   topLevelAgency: "topLevelAgency",
+  andOr: "andOr",
 };
 
 describe("SavedSearchesList", () => {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5591 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds support for recalling the "and/or" selection of a user's saved search when applying it from the dropdown or workspace page

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Since the operator only matters when there is a keyword term, we won't apply or show it to users unless the saved search contains a keyword

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search
3. log in
4. enter a keyword term and hit search
5. save your search
6. remove the keyword and select a filter
7. save your search
8. visit your saved searches page
9. _VERIFY_: you see your two saved searches, one with an entry for "Query and/or operator" and one without

### Screenshot

<img width="1186" height="708" alt="Screenshot 2025-08-01 at 3 11 39 PM" src="https://github.com/user-attachments/assets/68ebc024-a950-4fde-bf8e-2d5c97fe0934" />
