### PR TITLE
[Issue #5489] Run post-population during submit flow

### DIFF
--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -171,9 +171,7 @@ def validate_application_form(
     process_rule_schema_for_context(context)
     form_validation_errors.extend(context.validation_issues)
 
-    # Apply post-population changes to the application form during submit
-    if action == ApplicationAction.SUBMIT and context.config.do_post_population:
-        application_form.application_response = context.json_data
+    application_form.application_response = context.json_data
 
     # Check if the form is required
     is_required = is_form_required(application_form)

--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -48,7 +48,7 @@ SUBMISSION_JSON_RULE_CONFIG = JsonRuleConfig(
     # During submission, we do post-population (the only place we ever do)
     # and field validation
     do_pre_population=False,
-    do_post_population=False,  # TODO - when we enable post-population, flip this to True
+    do_post_population=True,  # Post-population enabled for submit flow
     do_field_validation=True,
 )
 
@@ -171,7 +171,9 @@ def validate_application_form(
     process_rule_schema_for_context(context)
     form_validation_errors.extend(context.validation_issues)
 
-    # TODO pre/post-populate should update the value here
+    # Apply post-population changes to the application form during submit
+    if action == ApplicationAction.SUBMIT and context.config.do_post_population:
+        application_form.application_response = context.json_data
 
     # Check if the form is required
     is_required = is_form_required(application_form)

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -46,6 +46,21 @@ SIMPLE_ATTACHMENT_JSON_SCHEMA = {
 
 SIMPLE_ATTACHMENT_RULE_SCHEMA = {"attachment_field": {"gg_validation": {"rule": "attachment"}}}
 
+# Test schemas for post-population
+POST_POPULATION_JSON_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "signature_field": {"type": "string"},
+        "date_field": {"type": "string"},
+        "existing_field": {"type": "string"},
+    },
+}
+
+POST_POPULATION_RULE_SCHEMA = {
+    "signature_field": {"gg_post_population": {"rule": "signature"}},
+    "date_field": {"gg_post_population": {"rule": "current_date"}},
+}
+
 
 def test_application_start_success(
     client, enable_factory_create, db_session, user, user_auth_token

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -46,21 +46,6 @@ SIMPLE_ATTACHMENT_JSON_SCHEMA = {
 
 SIMPLE_ATTACHMENT_RULE_SCHEMA = {"attachment_field": {"gg_validation": {"rule": "attachment"}}}
 
-# Test schemas for post-population
-POST_POPULATION_JSON_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "signature_field": {"type": "string"},
-        "date_field": {"type": "string"},
-        "existing_field": {"type": "string"},
-    },
-}
-
-POST_POPULATION_RULE_SCHEMA = {
-    "signature_field": {"gg_post_population": {"rule": "signature"}},
-    "date_field": {"gg_post_population": {"rule": "current_date"}},
-}
-
 
 def test_application_start_success(
     client, enable_factory_create, db_session, user, user_auth_token


### PR DESCRIPTION
## Summary

Fixes / Work for #5489 

## Changes proposed

Set `do_post_population=True`
Set `application_form.application_response = context.json_data` in validate
Update tests

## Context for reviewers

Signature and current date would be disabled while filling out the application, and then we would auto-populate them upon submission.

## Validation steps

See updated unit tests