### PR TITLE
[Issue #5314] Adjust sam.gov extract parsing based on testing

### DIFF
--- a/api/src/task/sam_extracts/process_sam_extracts.py
+++ b/api/src/task/sam_extracts/process_sam_extracts.py
@@ -302,6 +302,7 @@ class ProcessSamExtractsTask(Task):
         sam_extract_file: SamExtractFile,
         extract_log_extra: dict,
     ) -> None:
+        """Load sam.gov entities to the DB"""
         total_to_process = len(sam_gov_entity_container.processed_entities)
         total_processed = 0
         for batch in itertools.batched(

--- a/api/src/task/sam_extracts/process_sam_extracts.py
+++ b/api/src/task/sam_extracts/process_sam_extracts.py
@@ -1,12 +1,15 @@
+import itertools
 import logging
+import time
 import zipfile
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from enum import StrEnum
-from typing import Sequence
+from typing import IO, Sequence
 
 from sqlalchemy import select
 
+import src.adapters.db as db
 from src.constants.lookup_constants import (
     SamGovExtractType,
     SamGovImportType,
@@ -16,6 +19,7 @@ from src.db.models.entity_models import SamGovEntity, SamGovEntityImportType
 from src.db.models.sam_extract_models import SamExtractFile
 from src.task.task import Task
 from src.util import file_util
+from src.util.env_config import PydanticBaseEnvConfig
 
 logger = logging.getLogger(__name__)
 
@@ -42,16 +46,26 @@ class ExtractIndex:
 @dataclass
 class SamGovEntityContainer:
     processed_entities: list[SamGovEntity] = field(default_factory=list)
+    ueis_skipped: set[str] = field(default_factory=set)
 
     deactivated_ueis: list[str] = field(default_factory=list)
     expired_ueis: list[str] = field(default_factory=list)
 
 
+class ProcessSamExtractsConfig(PydanticBaseEnvConfig):
+    process_sam_extracts_upsert_batch_size: int = 10000
+
+
 class ProcessSamExtractsTask(Task):
+
+    def __init__(self, db_session: db.Session):
+        super().__init__(db_session)
+        self.config = ProcessSamExtractsConfig()
 
     class Metrics(StrEnum):
 
         ROWS_PROCESSED_COUNT = "rows_processed_count"
+        ROWS_SKIPPED_COUNT = "rows_skipped_count"
         DEACTIVATED_ROWS_COUNT = "deactivated_rows_count"
         EXPIRED_ROWS_COUNT = "expired_rows_count"
         ROWS_CONVERTED_COUNT = "rows_converted_count"
@@ -68,6 +82,8 @@ class ProcessSamExtractsTask(Task):
         ENTITY_EXPIRED_COUNT = "entity_expired_count"
         ENTITY_EXPIRED_MISSING_COUNT = "entity_expired_missing_count"
         ENTITY_EXPIRED_MISMATCH_COUNT = "entity_expired_mismatch_count"
+
+        SKIPPED_UEI_NOT_PROCESSED_COUNT = "skipped_uei_not_processed_count"
 
         EXTRACTS_PROCESSED_COUNT = "extracts_processed_count"
         MONTHLY_EXTRACT_PROCESSED_COUNT = "monthly_extract_processed_count"
@@ -90,39 +106,19 @@ class ProcessSamExtractsTask(Task):
                 "extract_date": sam_extract_file.extract_date,
                 "extract_type": sam_extract_file.extract_type,
             }
+            start = time.perf_counter()
             with self.db_session.begin():
-                # process the extract
-                sam_gov_entity_container = self.process_extract(sam_extract_file, extract_log_extra)
+                self.process_extract(sam_extract_file, extract_log_extra)
 
-                # Fetch all existing sam.gov records, this is several magnitudes
-                # faster than individually fetching them as we process them below.
-                all_entities = self.db_session.execute(select(SamGovEntity)).scalars()
-                entity_map = {}
-                for entity in all_entities:
-                    entity_map[entity.uei] = entity
-
-                # Process updated/new sam.gov entity records
-                for sam_gov_entity in sam_gov_entity_container.processed_entities:
-                    self.load_sam_gov_entity_to_db(
-                        sam_gov_entity, entity_map, sam_extract_file.extract_type, extract_log_extra
-                    )
-
-                # Handle deactivated sam.gov entity records
-                for uei in sam_gov_entity_container.deactivated_ueis:
-                    self.handle_deactivated_entity(
-                        uei, entity_map, sam_extract_file, extract_log_extra
-                    )
-
-                # Handle expired sam.gov entity records
-                for uei in sam_gov_entity_container.expired_ueis:
-                    self.handle_expired_entity(uei, entity_map, sam_extract_file, extract_log_extra)
-
-                logger.info(
-                    "Finished loading records to DB for Sam.gov extract", extra=extract_log_extra
-                )
-
-                # Mark extract as processed
-                sam_extract_file.processing_status = SamGovProcessingStatus.COMPLETED
+            # Record the time that extract took to complete
+            # We do this after the with db_session.begin block
+            # so that we count the time it takes the commit to occur
+            end = time.perf_counter()
+            duration = round((end - start), 3)
+            logger.info(
+                "Finished processing sam.gov extract",
+                extra=extract_log_extra | {"extract_process_duration_sec": duration},
+            )
 
     def get_extracts_to_process(self) -> Sequence[SamExtractFile]:
         """Fetch all the sam.gov extract files in ascending order"""
@@ -136,11 +132,46 @@ class ProcessSamExtractsTask(Task):
             .all()
         )
 
-    def process_extract(
+    def process_extract(self, sam_extract_file: SamExtractFile, extract_log_extra: dict) -> None:
+        """Process a sam.gov FOUO entity extract file, parsing and loading the file to our sam.gov entity table"""
+        # process the extract
+        sam_gov_entity_container = self.parse_extract_file(sam_extract_file, extract_log_extra)
+
+        self.load_sam_gov_entities_to_db(
+            sam_gov_entity_container, sam_extract_file, extract_log_extra
+        )
+
+        # Handle deactivated sam.gov entity records
+        existing_deactivated_entities = self.get_existing_entities(
+            sam_gov_entity_container.deactivated_ueis
+        )
+        for uei in sam_gov_entity_container.deactivated_ueis:
+            self.handle_deactivated_entity(
+                uei, existing_deactivated_entities, sam_extract_file, extract_log_extra
+            )
+
+        # Handle expired sam.gov entity records
+        existing_expired_entities = self.get_existing_entities(
+            sam_gov_entity_container.expired_ueis
+        )
+        for uei in sam_gov_entity_container.expired_ueis:
+            self.handle_expired_entity(
+                uei, existing_expired_entities, sam_extract_file, extract_log_extra
+            )
+
+        # Verify that the records we skipped due to non-empty EFT indicator all got processed
+        # in one of the above sections.
+        self.verify_skipped_entities_have_processed_row(sam_gov_entity_container, extract_log_extra)
+
+        logger.info("Finished loading records to DB for Sam.gov extract", extra=extract_log_extra)
+
+        # Mark extract as processed
+        sam_extract_file.processing_status = SamGovProcessingStatus.COMPLETED
+
+    def parse_extract_file(
         self, sam_extract_file: SamExtractFile, extract_log_extra: dict
     ) -> SamGovEntityContainer:
         """Process an extract file from sam.gov, pulling all entities out of it"""
-
         logger.info("Processing sam.gov extract file", extra=extract_log_extra)
         self.increment(self.Metrics.EXTRACTS_PROCESSED_COUNT)
         if sam_extract_file.extract_type == SamGovExtractType.MONTHLY:
@@ -157,27 +188,58 @@ class ProcessSamExtractsTask(Task):
                         f"Expected exactly one file in sam.gov extract zip, found: {','.join(files_in_zip)}"
                     )
 
-                file_bytes = extract_zip.read(files_in_zip[0])
-                return self.process_dat(file_bytes.decode("utf-8"), extract_log_extra)
+                with extract_zip.open(files_in_zip[0]) as dat_file:
+                    return self.process_dat(dat_file, extract_log_extra)
 
-    def process_dat(self, dat_text: str, extract_log_extra: dict) -> SamGovEntityContainer:
-        """Process the text of the dat file from the sam.gov extract"""
+    def process_dat(self, dat_file: IO[bytes], extract_log_extra: dict) -> SamGovEntityContainer:
+        """Process the dat file from the sam.gov extract"""
         container = SamGovEntityContainer()
-        lines = dat_text.split("\n")
 
-        # We need at least two lines (header/footer) for the file to be valid
-        if len(lines) < 2:
-            raise Exception("Invalid DAT file, doesn't contain any records")
+        for raw_line in dat_file:
+            line = raw_line.decode("utf-8")
+            # The header and footer are formatted as
+            # BOF/EOF FOUO V2 STARTDATE ENDDATE RECORD_COUNT SEQUENCE_NUMBER
+            # For example:
+            # BOF FOUO V2 20250726 20250726 0001234 0001000
+            #
+            # The start date seems to always match the end date for daily extracts
+            # For monthly extracts the start date is all zeroes
+            #
+            # Sequence number just increments by 1 every day
+            if line.startswith("BOF") or line.startswith("EOF"):
+                tokens = line.split()
+                if len(tokens) != 7:
+                    raise Exception("Unexpected format for header/footer")
+                sequence_num, record_count = tokens[-1], tokens[-2]
+                logger.info(
+                    "Processing header/footer of dat file",
+                    extra=extract_log_extra
+                    | {"sequence_number": sequence_num, "record_count": record_count},
+                )
+                continue
 
-        # The first and last line of the file are a header + footer
-        # with some counts - so skip those and parse the others.
-        for line in lines[1:-1]:
-            self.increment(self.Metrics.ROWS_PROCESSED_COUNT)
             tokens = line.split("|")
+            self.increment(self.Metrics.ROWS_PROCESSED_COUNT)
 
             uei = get_token_value(tokens, ExtractIndex.UEI)
+            eft_indicator = get_token_value(tokens, ExtractIndex.ENTITY_EFT_INDICATOR)
             extract_code = get_token_value(tokens, ExtractIndex.SAM_EXTRACT_CODE)
             log_extra = {"uei": uei, "extract_code": extract_code} | extract_log_extra
+
+            # We can receive multiple rows for a given UEI in an extract
+            # In sam.gov if your UEI has multiple bank accounts associated
+            # then each comes through as a separate record, BUT as the FOUO
+            # information doesn't have that, they are for our purposes duplicates.
+            # These records are separated by the "EFT Indicator" and we will
+            # assume that every UEI has one null/empty EFT indicator record that we'll use.
+            if len(eft_indicator) > 0:
+                logger.info(
+                    "EFT Indicator is not empty, skipping assuming to be a duplicate",
+                    extra=log_extra,
+                )
+                container.ueis_skipped.add(uei)
+                self.increment(self.Metrics.ROWS_SKIPPED_COUNT)
+                continue
 
             """
             The SAM Extract code can have a few different values depending on whether
@@ -222,6 +284,44 @@ class ProcessSamExtractsTask(Task):
                 self.increment(self.Metrics.ENTITY_ERROR_COUNT)
 
         return container
+
+    def get_existing_entities(self, ueis: list[str]) -> dict[str, SamGovEntity]:
+        """Fetch all passed in sam.gov entities by UEI"""
+        all_entities = self.db_session.execute(
+            select(SamGovEntity).where(SamGovEntity.uei.in_(ueis))
+        ).scalars()
+        entity_map = {}
+        for entity in all_entities:
+            entity_map[entity.uei] = entity
+
+        return entity_map
+
+    def load_sam_gov_entities_to_db(
+        self,
+        sam_gov_entity_container: SamGovEntityContainer,
+        sam_extract_file: SamExtractFile,
+        extract_log_extra: dict,
+    ) -> None:
+        total_to_process = len(sam_gov_entity_container.processed_entities)
+        total_processed = 0
+        for batch in itertools.batched(
+            sam_gov_entity_container.processed_entities,
+            n=self.config.process_sam_extracts_upsert_batch_size,
+            strict=False,
+        ):
+            logger.info(
+                f"Processing a batch, processed {total_processed} / {total_to_process}",
+                extra=extract_log_extra,
+            )
+            entity_map = self.get_existing_entities([entity.uei for entity in batch])
+
+            # Process updated/new sam.gov entity records
+            for sam_gov_entity in batch:
+                self.load_sam_gov_entity_to_db(
+                    sam_gov_entity, entity_map, sam_extract_file.extract_type, extract_log_extra
+                )
+
+            total_processed += len(batch)
 
     def load_sam_gov_entity_to_db(
         self,
@@ -362,6 +462,34 @@ class ProcessSamExtractsTask(Task):
         # If it's just expired, we'll note it, but do nothing for now
         self.increment(self.Metrics.ENTITY_EXPIRED_COUNT)
         logger.info("Sam.gov entity is marked as expired", extra=log_extra)
+
+    def verify_skipped_entities_have_processed_row(
+        self, sam_gov_entity_container: SamGovEntityContainer, extract_log_extra: dict
+    ) -> None:
+        """Verify that any entities skipped for having the EFT indicator set
+        had a row that we actually processed
+
+        This is just validating an assumption that we have in the data
+        that if an entity receives an update and has multiple EFT indicators,
+        we'll always receive all of the different EFT indicators, including an "empty" one.
+        """
+        logger.info("Validating that skipped UEIs were processed", extra=extract_log_extra)
+        ueis_processed = {entity.uei for entity in sam_gov_entity_container.processed_entities}
+        ueis_processed.update(sam_gov_entity_container.deactivated_ueis)
+        ueis_processed.update(sam_gov_entity_container.expired_ueis)
+
+        unprocessed_ueis = sam_gov_entity_container.ueis_skipped.difference(ueis_processed)
+        for unprocessed_uei in unprocessed_ueis:
+            logger.error(
+                "A UEI we skipped did not have a non-empty EFT indicator in extract file",
+                extra=extract_log_extra | {"uei": unprocessed_uei},
+            )
+            self.increment(self.Metrics.SKIPPED_UEI_NOT_PROCESSED_COUNT)
+
+        if len(unprocessed_ueis) == 0:
+            logger.info(
+                "All UEIs we skipped were processed via another row", extra=extract_log_extra
+            )
 
 
 def build_sam_gov_entity(tokens: list[str]) -> SamGovEntity:

--- a/api/tests/src/task/sam_extracts/test_process_sam_extracts.py
+++ b/api/tests/src/task/sam_extracts/test_process_sam_extracts.py
@@ -70,6 +70,7 @@ def build_sam_extract_row_deactivated_or_expired(uei: str, extract_code: str = "
 
 def build_sam_extract_contents(rows):
     contents = []
+
     header = "BOF FOUO V2 00000000 20200414 0084875 0005510"
     footer = "EOF FOUO V2 00000000 20200414 0084875 0005510"
 
@@ -107,7 +108,7 @@ class TestProcessSamExtracts:
             ebiz_last_name="Smith",
             debt_subject_to_offset="Y",
             exclusion_status_flag="D",
-            entity_eft_indicator="0001",
+            entity_eft_indicator="",
             initial_registration_date="20200101",
             last_update_date="20241225",
         )
@@ -135,7 +136,7 @@ class TestProcessSamExtracts:
             ebiz_last_name="Jones",
             debt_subject_to_offset="",
             exclusion_status_flag="",
-            entity_eft_indicator="789",
+            entity_eft_indicator="",
             initial_registration_date="20200101",
             last_update_date="20210203",
         )
@@ -200,7 +201,7 @@ class TestProcessSamExtracts:
         assert entity1.ebiz_poc_last_name == "Smith"
         assert entity1.has_debt_subject_to_offset is True
         assert entity1.has_exclusion_status is True
-        assert entity1.eft_indicator == "0001"
+        assert entity1.eft_indicator is None
         assert entity1.initial_registration_date == date(2020, 1, 1)
         assert entity1.last_update_date == date(2024, 12, 25)
         assert len(entity1.import_records) == 1
@@ -228,7 +229,7 @@ class TestProcessSamExtracts:
         assert entity3.ebiz_poc_last_name == "Jones"
         assert entity3.has_debt_subject_to_offset is False
         assert entity3.has_exclusion_status is False
-        assert entity3.eft_indicator == "789"
+        assert entity3.eft_indicator is None
         assert entity3.initial_registration_date == date(2020, 1, 1)
         assert entity3.last_update_date == date(2021, 2, 3)
         assert len(entity3.import_records) == 1
@@ -258,6 +259,7 @@ class TestProcessSamExtracts:
         assert metrics[task.Metrics.ROWS_CONVERTED_COUNT] == 4
         assert metrics[task.Metrics.DEACTIVATED_ROWS_COUNT] == 1
         assert metrics[task.Metrics.EXPIRED_ROWS_COUNT] == 1
+        assert metrics[task.Metrics.ROWS_SKIPPED_COUNT] == 0
         assert metrics[task.Metrics.ENTITY_ERROR_COUNT] == 2
 
         assert metrics[task.Metrics.ENTITY_INSERTED_COUNT] == 1
@@ -271,6 +273,8 @@ class TestProcessSamExtracts:
         assert metrics[task.Metrics.ENTITY_EXPIRED_COUNT] == 1
         assert metrics[task.Metrics.ENTITY_EXPIRED_MISSING_COUNT] == 0
         assert metrics[task.Metrics.ENTITY_EXPIRED_MISMATCH_COUNT] == 0
+
+        assert metrics[task.Metrics.SKIPPED_UEI_NOT_PROCESSED_COUNT] == 0
 
         assert metrics[task.Metrics.EXTRACTS_PROCESSED_COUNT] == 1
 
@@ -368,6 +372,90 @@ class TestProcessSamExtracts:
         assert metrics[task.Metrics.ENTITY_NO_OP_COUNT] == 1
 
         assert metrics[task.Metrics.EXTRACTS_PROCESSED_COUNT] == 3
+
+    def test_run_task_skipped_records(
+        self, db_session, enable_factory_create, mock_s3_bucket, caplog
+    ):
+        row1 = build_sam_extract_row(
+            uei="AAA111",
+            extract_code="A",
+            legal_business_name="Sara's Sweets",
+            registration_expiration_date="20250101",
+            ebiz_poc_email="sara@example.com",
+            ebiz_first_name="Sara",
+            ebiz_last_name="Smith",
+            debt_subject_to_offset="Y",
+            exclusion_status_flag="D",
+            entity_eft_indicator="",
+            initial_registration_date="20200101",
+            last_update_date="20241225",
+        )
+        row1_dupe = build_sam_extract_row(
+            uei="AAA111",
+            extract_code="A",
+            legal_business_name="Sara's Sweets",
+            registration_expiration_date="20250101",
+            ebiz_poc_email="sara@example.com",
+            ebiz_first_name="Sara",
+            ebiz_last_name="Smith",
+            debt_subject_to_offset="Y",
+            exclusion_status_flag="D",
+            entity_eft_indicator="0001",  # The only difference from the above
+            initial_registration_date="20200101",
+            last_update_date="20241225",
+        )
+
+        # This should get flagged as an issue because
+        # there is ONLY a row with an entity EFT indicator which is not expected
+        row2_dupe = build_sam_extract_row(
+            uei="BBB222",
+            extract_code="A",
+            legal_business_name="Steve's Shovels",
+            registration_expiration_date="20250101",
+            ebiz_poc_email="steve@example.com",
+            ebiz_first_name="Steve",
+            ebiz_last_name="Shovelman",
+            debt_subject_to_offset="Y",
+            exclusion_status_flag="D",
+            entity_eft_indicator="0001",
+            initial_registration_date="20200101",
+            last_update_date="20241225",
+        )
+
+        rows = [row1, row1_dupe, row2_dupe]
+
+        s3_path = f"s3://{mock_s3_bucket}/extracts/SAM_FOUO_MONTHLY_1234.zip"
+        make_zip_on_s3(s3_path, build_sam_extract_contents(rows))
+
+        SamExtractFileFactory.create(s3_path=s3_path, extract_date=date(2025, 1, 1))
+
+        task = ProcessSamExtractsTask(db_session)
+        task.run()
+
+        sam_gov_entities = db_session.execute(select(SamGovEntity)).scalars().all()
+        # Only the first UEI was made, the second was skipped and alerted
+        assert len(sam_gov_entities) == 1
+
+        entity1 = sam_gov_entities[0]
+        assert entity1.uei == "AAA111"
+        assert entity1.legal_business_name == "Sara's Sweets"
+        assert entity1.eft_indicator is None
+
+        # For the second record, verify we did flag that there was an issue
+        record = next(
+            record
+            for record in caplog.records
+            if record.message
+            == "A UEI we skipped did not have a non-empty EFT indicator in extract file"
+        )
+        assert record.uei == "BBB222"
+
+        metrics = task.metrics
+        assert metrics[task.Metrics.ROWS_PROCESSED_COUNT] == 3
+        assert metrics[task.Metrics.ROWS_CONVERTED_COUNT] == 1
+        assert metrics[task.Metrics.ROWS_SKIPPED_COUNT] == 2
+
+        assert metrics[task.Metrics.SKIPPED_UEI_NOT_PROCESSED_COUNT] == 1
 
     def test_run_task_deactivated_records(
         self, db_session, enable_factory_create, mock_s3_bucket, caplog
@@ -507,16 +595,14 @@ class TestProcessSamExtracts:
         with pytest.raises(Exception, match="Expected exactly one file in sam.gov extract zip"):
             task.run()
 
-    def test_run_task_invalid_file_contents(
-        self, db_session, enable_factory_create, mock_s3_bucket
-    ):
+    def test_run_task_invalid_header(self, db_session, enable_factory_create, mock_s3_bucket):
         s3_path = f"s3://{mock_s3_bucket}/extracts/SAM_FOUO_MONTHLY_12345678.zip"
-        make_zip_on_s3(s3_path, "this isn't a valid file")
+        make_zip_on_s3(s3_path, "BOF bad header")
 
         SamExtractFileFactory.create(s3_path=s3_path)
 
         task = ProcessSamExtractsTask(db_session)
-        with pytest.raises(Exception, match="Invalid DAT file, doesn't contain any records"):
+        with pytest.raises(Exception, match="Unexpected format for header/footer"):
             task.run()
 
     def test_run_task_invalid_file_contents_bad_lines(


### PR DESCRIPTION
## Summary

Fixes / Work for #5314 

## Changes proposed
Modified sam.gov extract parsing to account for duplicate UEIs in a given extract file (see below for context)

Modified extract processing to use a bit less memory, not loading entire entity table into memory, and processing file line-by-line instead of as a big text blob.

A few other refactors for simplifying logic.

## Context for reviewers
I assumed that we would only receive a single row in a given extract file for a UEI, but it turns out that was wrong. If a given entity has multiple "EFT Indicators" then each of those will be a separate row in the data we receive. This indicator is related to bank account information according to the docs, and is for the most part irrelevant to us. From validating the monthly extract, I verified that the only two fields that ever differ across these duplicate records are EFT indicator and cage code (a value we do not use). I also verified that every UEI has at least one record where the EFT indicator is blank, which is the one we will use, and skip the others (I added validation/logging in the job to catch if this is ever not true).

Additionally, I changed some of the parsing logic because the way it was written, we'd load the entire file, and the entire set of sam.gov entities into the processes memory, and I know that is going to break when we try to run it for real. Instead we fetch 10k entities at a time (note that the monthly extract has just shy of 900k records) and the file processing logic was restructured a bit to use proper file parsing instead of loading the text of the file fully into memory all at once.

## Validation steps
For verifying the changes I made, I actually used extract files from production running locally, and that data is sensitive, so can't quite share how you can do it, but here's what I did.

I downloaded all extract files we fetched (one monthly file, 16 daily files over the entirety of July), setup my DB to have all of them loaded in, pointing to the files on disk. Running locally, this takes ~10 minutes, about 7.5 of which are the monthly extract. I expect it'll take a bit longer non-locally, but we are fine with that.

I ran just the processing part, and skipped setting up files since I did that manually.
`make cmd args="task sam-extracts --no-fetch-extracts --no-create-orgs"`

From running locally, I had zero errors processing rows, and none of the bad scenarios occurred with data, so the assumptions I've made seem to at least be fairly valid.