### PR TITLE
[Issue #5664] Pre-population for pilot forms

### DIFF
--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -172,9 +172,7 @@ def validate_application_form(
     form_validation_errors.extend(context.validation_issues)
 
     # Apply pre/post-populated changes back to the application form
-    # The context.json_data contains the updated values after rule processing
-    if context.json_data != application_form.application_response:
-        application_form.application_response = context.json_data
+    application_form.application_response = context.json_data
 
     # Check if the form is required
     is_required = is_form_required(application_form)

--- a/api/src/services/applications/application_validation.py
+++ b/api/src/services/applications/application_validation.py
@@ -22,7 +22,7 @@ class ApplicationAction(StrEnum):
 
 START_JSON_RULE_CONFIG = JsonRuleConfig(
     # When starting an application, we only do pre-population
-    do_pre_population=False,  # TODO - when we enable pre-population, flip this to True
+    do_pre_population=True,  # TODO - when we enable pre-population, flip this to True
     do_post_population=False,
     do_field_validation=False,
 )
@@ -39,7 +39,7 @@ UPDATE_JSON_RULE_CONFIG = JsonRuleConfig(
     # When updating, we do pre-population + validate. If a user
     # changed any values, we want to make sure any pre-populated fields
     # stay as the automatically generated ones.
-    do_pre_population=False,  # TODO - when we enable pre-population, flip this to True
+    do_pre_population=True,  # TODO - when we enable pre-population, flip this to True
     do_post_population=False,
     do_field_validation=True,
 )
@@ -171,7 +171,10 @@ def validate_application_form(
     process_rule_schema_for_context(context)
     form_validation_errors.extend(context.validation_issues)
 
-    # TODO pre/post-populate should update the value here
+    # Apply pre/post-populated changes back to the application form
+    # The context.json_data contains the updated values after rule processing
+    if context.json_data != application_form.application_response:
+        application_form.application_response = context.json_data
 
     # Check if the form is required
     is_required = is_form_required(application_form)

--- a/api/src/services/applications/create_application.py
+++ b/api/src/services/applications/create_application.py
@@ -17,6 +17,7 @@ from src.db.models.entity_models import Organization
 from src.db.models.user_models import ApplicationUser, OrganizationUser, User
 from src.services.applications.application_validation import (
     ApplicationAction,
+    validate_application_form,
     validate_competition_open,
 )
 from src.util.datetime_util import get_now_us_eastern_date
@@ -205,6 +206,9 @@ def create_application(
         )
 
         db_session.add(application_form)
+
+        # Validate the application form to trigger pre-population
+        validate_application_form(application_form, ApplicationAction.START)
 
     logger.info(
         "Created new application",


### PR DESCRIPTION
## Summary

Fixes / Work for #5664
 
## Changes proposed

Enable pre population in start/update.
Update tests

## Context for reviewers

Supports epic to enable auto-filling of form fields based on known information.

## Validation steps

See updated tests.