### PR TITLE
[Issue #4994] Drop redirect when not in maintenance mode for now

### DIFF
--- a/frontend/src/app/[locale]/maintenance/page.tsx
+++ b/frontend/src/app/[locale]/maintenance/page.tsx
@@ -5,8 +5,6 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { use } from "react";
 import { GridContainer } from "@trussworks/react-uswds";
 
-import ClientMaintenanceCheck from "src/components/ClientMaintenanceCheck";
-
 export async function generateMetadata({ params }: LocalizedPageProps) {
   const { locale } = await params;
   const t = await getTranslations({ locale });
@@ -28,7 +26,8 @@ export default function Maintenance({ params }: LocalizedPageProps) {
 
   return (
     <>
-      <ClientMaintenanceCheck />
+      {/* This piece does not seem reliable, maybe due to re-render or rehyrdrate cylces where we redirect away before the actual client live feature flag is set */}
+      {/* <ClientMaintenanceCheck /> */}
       <GridContainer className="padding-y-1 tablet:padding-y-3 desktop-lg:padding-y-6 padding-x-5 tablet:padding-x-7 desktop-lg:padding-x-10 text-center">
         <h2 className="margin-bottom-0">{t("heading")}</h2>
         <p className="margin-x-auto">{body}</p>

--- a/frontend/src/components/ClientMaintenanceCheck.tsx
+++ b/frontend/src/components/ClientMaintenanceCheck.tsx
@@ -2,7 +2,6 @@
 
 import { useFeatureFlags } from "src/hooks/useFeatureFlags";
 
-import { redirect, RedirectType } from "next/navigation";
 import { useEffect } from "react";
 
 /**
@@ -19,7 +18,8 @@ export default function ClientMaintenanceCheck() {
       !checkFeatureFlag("opportunityOff") &&
       checkFeatureFlag("authOn")
     ) {
-      redirect("/", RedirectType.push);
+      // This piece does not seem reliable, maybe due to re-render or rehyrdrate cylces where we redirect away before the actual client live feature flag is set
+      // redirect("/", RedirectType.push);
     }
   }, [checkFeatureFlag]);
 

--- a/frontend/tests/pages/maintenance/page.test.tsx
+++ b/frontend/tests/pages/maintenance/page.test.tsx
@@ -58,7 +58,7 @@ describe("Maintenance", () => {
     expect(content).toBeInTheDocument();
   });
 
-  it("redirects when not in maintenance", () => {
+  it.skip("redirects when not in maintenance", () => {
     // set a major feature offline so we don't redirect to homepage
     render(
       <UserContext


### PR DESCRIPTION
## Summary
Work for #4994

## Changes proposed

Stop redirecting from /maintenance to the home page if no "major" features are off. This wasn't working reliably and we've seen from past downtime that folks don't seem to end up "stuck" on the maintenance page.