### PR TITLE
[Unticketed] Fix signature field to be post populated, not pre

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -740,8 +740,6 @@ FORM_UI_SCHEMA = [
 
 FORM_RULE_SCHEMA = {
     ##### PRE-POPULATION RULES
-    # Note - we don't have pre-population enabled yet, so these
-    # won't run yet.
     "sam_uei": {"gg_pre_population": {"rule": "uei"}},
     "agency_name": {"gg_pre_population": {"rule": "agency_name"}},
     "assistance_listing_number": {"gg_pre_population": {"rule": "assistance_listing_number"}},

--- a/api/src/form_schema/forms/sf424b.py
+++ b/api/src/form_schema/forms/sf424b.py
@@ -53,10 +53,8 @@ FORM_UI_SCHEMA = [
 ]
 
 FORM_RULE_SCHEMA = {
-    ##### PRE-POPULATION RULES
-    # Note - we don't have pre-population enabled yet, so these
-    # won't run yet.
-    "signature": {"gg_pre_population": {"rule": "signature"}},
+    ##### POST-POPULATION RULES
+    "signature": {"gg_post_population": {"rule": "signature"}},
     "date_signed": {"gg_post_population": {"rule": "current_date"}},
 }
 

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -578,8 +578,6 @@ FORM_UI_SCHEMA = [
 
 FORM_RULE_SCHEMA = {
     ##### PRE-POPULATION RULES
-    # Note - we don't have pre-population enabled yet, so these
-    # won't run yet.
     "federal_program_name": {"gg_pre_population": {"rule": "assistance_listing_program_title"}},
     "assistance_listing_number": {"gg_pre_population": {"rule": "assistance_listing_number"}},
     ##### POST-POPULATION RULES


### PR DESCRIPTION
## Summary

## Changes proposed
Was testing endpoints in dev, noticed a warning that a rule was misconfigured, signature is a post-populate, not a pre-populate.

<img width="1353" height="239" alt="Screenshot 2025-08-06 at 12 54 13 PM" src="https://github.com/user-attachments/assets/3def4df2-e010-435c-b084-d4ad47e87cbe" />

The details in New Relic pointed to this field.

Note that fixing this here doesn't actually change anything in dev/staging, that won't happen till I manually load the form data in again.