### PR TITLE
[Issue #5857] fix bug with empty pills by maintaining list of all agencies

### DIFF
--- a/frontend/src/components/search/SearchVersionTwo.tsx
+++ b/frontend/src/components/search/SearchVersionTwo.tsx
@@ -44,9 +44,18 @@ export function SearchVersionTwo({
   }
 
   const searchResultsPromise = searchForOpportunities(convertedSearchParams);
-  const agencyListPromise = performAgencySearch({
+
+  // this represents the list of agencies as filtered based on the user's selected opportunity status
+  // to be used to form the list of agencies available from the agency filter
+  const filteredAgencyListPromise = performAgencySearch({
     selectedStatuses: Array.from(convertedSearchParams.status),
   });
+
+  // this represents the list of ALL agencies regardless of the user's selected opportunity status
+  // since a user may have agencies selected in a filter that only have archived / close opportunities
+  // and may then alter the list of agency options by deselecting archived / closed status
+  // this full list ensures that filter pills will always have labels regardless of opportunity status selection
+  const agencyListPromise = performAgencySearch();
 
   return (
     <QueryProvider>
@@ -96,7 +105,7 @@ export function SearchVersionTwo({
                   <SearchDrawerFilters
                     searchParams={convertedSearchParams}
                     searchResultsPromise={searchResultsPromise}
-                    agencyListPromise={agencyListPromise}
+                    agencyListPromise={filteredAgencyListPromise}
                   />
                 </DrawerUnit>
               </div>


### PR DESCRIPTION

## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5857

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Bug exists where pills can end up without labels when messing around with opportunity statuses and agencies / top level agencies

Fixes bug by passing full list of agencies to pill list to ensure pills always have labels

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Note that I was not reliably able to reproduce without messing with opportunity status, I was able to reproduce at least once. Not sure how / why, but this fix should handle whatever case that represents regardless

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on main
2. visit http://localhost:3000/search?_ff=filterDrawerOn:true
3. select "archived" opportunity status filter
4. select "CDC ATSDR" agency filter
5. deselect "archived" opportunity status filter
6. _VERIFY_: an empty pill is present
7. restart local server on this branch
8. repeat steps 2 - 5
9. _VERIFY_: no empty pill is present