### PR TITLE
[Issue #5851] Create script for generating internal token

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -296,6 +296,9 @@ setup-foreign-tables:
 seed-local-legacy-tables:
 	$(PY_RUN_CMD) python3 -m tests.lib.seed_local_legacy_tables
 
+generate-internal-token:
+	$(FLASK_CMD) task generate-internal-token $(args)
+
 ##################################################
 # Tasks/Jobs
 ##################################################

--- a/api/src/task/__init__.py
+++ b/api/src/task/__init__.py
@@ -7,5 +7,6 @@ import src.task.analytics.create_analytics_db_csvs  # noqa: F401 E402 isort:skip
 import src.task.notifications.email_notification  # noqa: F401 E402 isort:skip
 import src.task.sam_extracts.sam_extract_cli  # noqa: F401 E402 isort:skip
 import src.task.apply.create_application_submission_task  # noqa: F401 E402 isort:skip
+import src.task.generate_internal_token  # noqa: F401 E402 isort:skip
 
 __all__ = ["task_blueprint"]

--- a/api/src/task/generate_internal_token.py
+++ b/api/src/task/generate_internal_token.py
@@ -1,0 +1,98 @@
+"""
+This CLI command creates an internal JWT token that can be used to authenticate
+with endpoints that accept internal authentication (e.g., for PDF generation).
+
+Usage:
+    flask task generate-internal-token [--expiration-minutes MINUTES] [--quiet]
+
+The token will be printed to stdout and can be used with the X-SGG-Internal-Token header.
+
+Example:
+    make cmd args="task generate-internal-token"
+    make cmd args="task generate-internal-token --expiration-minutes 60"
+    make cmd args="task generate-internal-token --quiet"
+"""
+
+import logging
+from datetime import timedelta
+
+import click
+
+import src.adapters.db as db
+import src.util.datetime_util as datetime_util
+from src.adapters.db import flask_db
+from src.auth.api_jwt_auth import initialize_jwt_auth
+from src.auth.internal_jwt_auth import create_jwt_for_internal_token
+from src.task.task_blueprint import task_blueprint
+from src.util.local import error_if_not_local
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EXPIRATION_MINUTES = 30
+
+
+@task_blueprint.cli.command(
+    "generate-internal-token",
+    help="Generate an internal JWT token for testing purposes"
+)
+@click.option(
+    "--expiration-minutes",
+    type=int,
+    default=DEFAULT_EXPIRATION_MINUTES,
+    help=f"Number of minutes until the token expires (default: {DEFAULT_EXPIRATION_MINUTES})"
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Only output the token, no additional messages"
+)
+@flask_db.with_db_session()
+def generate_internal_token_cli(
+    db_session: db.Session, 
+    expiration_minutes: int, 
+    quiet: bool
+) -> None:
+    """Generate an internal JWT token for testing purposes."""
+    # Ensure we're running in a local environment
+    error_if_not_local()
+    
+    # Initialize JWT auth configuration (should already be done by Flask app)
+    initialize_jwt_auth()
+    
+    # Calculate expiration time
+    current_time = datetime_util.utcnow()
+    expires_at = current_time + timedelta(minutes=expiration_minutes)
+    
+    # Generate the token
+    with db_session.begin():
+        jwt_token, short_lived_token = create_jwt_for_internal_token(
+            expires_at=expires_at,
+            db_session=db_session
+        )
+        
+        logger.info(
+            "Generated internal JWT token",
+            extra={
+                "short_lived_internal_token_id": str(short_lived_token.short_lived_internal_token_id),
+                "expires_at": expires_at.isoformat(),
+                "expiration_minutes": expiration_minutes,
+            }
+        )
+    
+    if quiet:
+        # Only print the token for easy copy/paste
+        click.echo(jwt_token)
+    else:
+        # Print with helpful information
+        click.echo("=" * 80)
+        click.echo("INTERNAL JWT TOKEN GENERATED")
+        click.echo("=" * 80)
+        click.echo(f"Expiration: {expiration_minutes} minutes")
+        click.echo(f"Header: X-SGG-Internal-Token")
+        click.echo("-" * 80)
+        click.echo("Token:")
+        click.echo(jwt_token)
+        click.echo("-" * 80)
+        click.echo("Example usage:")
+        click.echo(f'curl -H "X-SGG-Internal-Token: {jwt_token}" http://localhost:5000/alpha/applications/<application_id>/application_form/<form_id>')
+        click.echo("=" * 80) 

--- a/documentation/api/auth/short-lived-auth.md
+++ b/documentation/api/auth/short-lived-auth.md
@@ -108,6 +108,40 @@ def generate_pdf_token(db_session: db.Session) -> str:
     return jwt_token
 ```
 
+### Generate Tokens for Testing (CLI Command)
+
+For local development and testing, you can use the provided Flask CLI command to generate internal tokens:
+
+```bash
+# Generate a token with default 30-minute expiration
+make generate-internal-token
+
+# Generate a token with custom expiration (60 minutes)
+make generate-internal-token args="--expiration-minutes 60"
+
+# Generate a token quietly (just output the token for copy/paste)
+make generate-internal-token args="--quiet"
+
+# Alternative: Use the Flask CLI directly
+make cmd args="task generate-internal-token --help"
+make cmd args="task generate-internal-token --expiration-minutes 120"
+```
+
+**Implementation Location**: `api/src/task/generate_internal_token.py`
+
+**Usage in API calls**:
+```bash
+# Example: Get application form using the generated token
+curl -H "X-SGG-Internal-Token: <generated-token>" \
+     http://localhost:5000/alpha/applications/<application_id>/application_form/<form_id>
+```
+
+This CLI command is particularly useful for:
+- Frontend developers testing PDF generation endpoints
+- Internal service integration testing
+- Local development workflow automation
+- Testing endpoints that require internal authentication
+
 ### Revoking Tokens
 
 ```python


### PR DESCRIPTION
## Summary

Fixes #5851

## Changes proposed

Create docs, makefile command, and utility to create an internal JWT token that can be used to authenticate with endpoints that accept internal authentication.

## Context for reviewers

We want to create a local-only script that calls our [internal jwt auth](https://github.com/HHS/simpler-grants-gov/blob/main/api/src/auth/internal_jwt_auth.py) code and can generate a token. This is needed to allow the frontend folks to test/build an endpoint for PDF generation.

The script should be runnable via make, and we should put it in the test/lib folder. It just needs to generate a token that someone could copy paste to call the GET application form endpoint (which can take this token in).

## Validation steps

See docs and screenshot of local usage.
<img width="1043" height="874" alt="Screenshot 2025-08-06 at 5 16 42 PM" src="https://github.com/user-attachments/assets/92862cf5-278e-40a8-ae83-06b7d8313c18" />

