### PR TITLE
[Issue #5818] add pagination beneath search results

### DIFF
--- a/frontend/src/components/search/SearchResultsView.tsx
+++ b/frontend/src/components/search/SearchResultsView.tsx
@@ -122,6 +122,13 @@ const SearchResultsTableView = ({
         totalPages={totalPages}
       />
       <SearchResultsTable searchResults={searchResults.data} page={page} />
+      <SearchPagination
+        totalPages={totalPages}
+        page={page}
+        query={query}
+        totalResults={totalResults}
+        paginationClassName="flex-justify-start tablet:flex-justify-end border-top-0"
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5818

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds pagination beneath search results table

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch
2. visit http://localhost:3000/search?_ff=searchDrawerOn:true
3. _VERIFY_: pagination appears at bottom of page beneath search results table


### Screenshot
<img width="1288" height="668" alt="Screenshot 2025-08-07 at 9 27 20 AM" src="https://github.com/user-attachments/assets/78f86d11-eac2-445f-8b1e-b41d541b16f4" />

