### PR TITLE
[Unticketed] Add form schema to app form API model

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -3806,6 +3806,10 @@ components:
           type: string
           format: uuid
           example: 123e4567-e89b-12d3-a456-426614174000
+        form:
+          type:
+          - object
+          $ref: '#/components/schemas/FormAlpha'
         application_response:
           type: object
           additionalProperties: {}

--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -1,4 +1,5 @@
 from src.api.competition_alpha.competition_schema import CompetitionAlphaSchema
+from src.api.form_alpha.form_schema import FormAlphaSchema
 from src.api.schemas.extension import Schema, fields
 from src.api.schemas.response_schema import (
     AbstractResponseSchema,
@@ -90,6 +91,7 @@ class ApplicationFormGetResponseDataSchema(Schema):
     application_form_id = fields.UUID()
     application_id = fields.UUID()
     form_id = fields.UUID()
+    form = fields.Nested(FormAlphaSchema())
     application_response = fields.Dict()
 
     application_form_status = fields.Enum(

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1163,18 +1163,38 @@ def test_application_get_success(client, enable_factory_create, db_session, user
     for application_form, application_form_response in zip(
         application_forms, response_application_forms, strict=True
     ):
-        assert application_form_response == {
-            "application_form_id": str(application_form.application_form_id),
-            "application_id": str(application.application_id),
-            "form_id": str(application_form.form_id),
-            "application_response": application_form.application_response,
-            "application_form_status": ApplicationFormStatus.IN_PROGRESS,
-            "created_at": application_form.created_at.isoformat(),
-            "updated_at": application_form.updated_at.isoformat(),
-            "is_required": True,
-            "is_included_in_submission": None,
-            "application_attachments": [],
-        }
+        assert application_form_response["application_form_id"] == str(
+            application_form.application_form_id
+        )
+        assert application_form_response["application_id"] == str(application.application_id)
+        assert application_form_response["form_id"] == str(application_form.form_id)
+        assert (
+            application_form_response["application_response"]
+            == application_form.application_response
+        )
+        assert (
+            application_form_response["application_form_status"]
+            == ApplicationFormStatus.IN_PROGRESS
+        )
+        assert application_form_response["created_at"] == application_form.created_at.isoformat()
+        assert application_form_response["updated_at"] == application_form.updated_at.isoformat()
+        assert application_form_response["is_required"] is True
+        assert application_form_response["is_included_in_submission"] is None
+        assert application_form_response["application_attachments"] == []
+        # Check the form
+        assert application_form_response["form"]["form_name"] == application_form.form.form_name
+        assert (
+            application_form_response["form"]["form_json_schema"]
+            == application_form.form.form_json_schema
+        )
+        assert (
+            application_form_response["form"]["form_ui_schema"]
+            == application_form.form.form_ui_schema
+        )
+        assert (
+            application_form_response["form"]["form_rule_schema"]
+            == application_form.form.form_rule_schema
+        )
 
 
 def test_application_get_with_attachments(


### PR DESCRIPTION
## Summary

## Changes proposed
Add form the the API schema for an application form

## Context for reviewers
I thought we already did this, but it turns out we don't return the form from the application form endpoint. When talking with @doug-s-nava - realized the frontend was having to do a roundabout way of getting the form's schema on the app form page, this should help fix that weird logic to get it via a competition.
