### PR TITLE
[Unticketed] Add application name to app form API model

### DIFF
--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -114,6 +114,7 @@ class ApplicationFormGetResponseDataSchema(Schema):
     )
 
     application_attachments = fields.List(fields.Nested(ApplicationAttachmentNoLinkSchema()))
+    application_name = fields.String()
 
 
 class ApplicationFormUpdateResponseSchema(AbstractResponseSchema, WarningMixinSchema):

--- a/api/src/db/models/competition_models.py
+++ b/api/src/db/models/competition_models.py
@@ -322,6 +322,10 @@ class ApplicationForm(ApiSchemaTable, TimestampMixin):
         """Property function to access application attachments"""
         return self.application.application_attachments
 
+    @property
+    def application_name(self) -> str | None:
+        return self.application.application_name
+
 
 class ApplicationAttachment(ApiSchemaTable, TimestampMixin):
     __tablename__ = "application_attachment"

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -1019,6 +1019,9 @@ def test_application_form_get_success(
     assert response.json["data"]["application_response"] == {"name": "John Doe"}
     # Verify application_attachments field exists (empty list in this case)
     assert response.json["data"]["application_attachments"] == []
+    assert (
+        response.json["data"]["application_name"] == application_form.application.application_name
+    )
 
 
 def test_application_form_get_application_not_found(
@@ -1181,6 +1184,7 @@ def test_application_get_success(client, enable_factory_create, db_session, user
         assert application_form_response["is_required"] is True
         assert application_form_response["is_included_in_submission"] is None
         assert application_form_response["application_attachments"] == []
+        assert application_form_response["application_name"] == application.application_name
         # Check the form
         assert application_form_response["form"]["form_name"] == application_form.form.form_name
         assert (


### PR DESCRIPTION
## Summary

## Changes proposed
Pipe the application name through to the app form API model for the frontend who wants app name when fetching app form

