### PR TITLE
[Issue #4281] add page anchor scroll offset

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -143,6 +143,8 @@ const nextConfig = {
   async headers() {
     return headers;
   },
+  // see https://nextjs.org/docs/messages/api-routes-response-size-limit
+  // warning about unrecognized key can be ignored
   api: {
     bodyParser: {
       sizeLimit: "2000mb",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "node": ">=22.13.0"
   },
   "scripts": {
-    "all-checks": "npm run lint && npm run ts:check && npm run test && npm run build -- --no-lint",
+    "all-checks": "npm run lint && npm run ts:check && npm run format-check && npm run test && npm run build -- --no-lint",
     "build": "next build",
     "dev": "NEW_RELIC_ENABLED=false next dev",
     "debug": "NODE_OPTIONS='--inspect' next dev",

--- a/frontend/src/app/[locale]/workspace/applications/application/[applicationId]/README.md
+++ b/frontend/src/app/[locale]/workspace/applications/application/[applicationId]/README.md
@@ -1,0 +1,29 @@
+## How to get here for local testing
+
+### obtain the id for an opportunity with an open competition
+
+In your local database, look in the `competition` table for any opportunity ID
+
+### visit the opportunity page
+
+Using this id, visit http://localhost:3000/opportunity/<your opportunity id>?\_ff=applyFormPrototypeOff:false
+
+The `_ff` param is to ensure that the correct feature flag is set to allow for starting and application
+
+### log in
+
+You need to be logged in in order to start an application
+
+### start an application (no organization required)
+
+Click "start new application", enter a name and you should be good
+
+### start an application (organization required)
+
+You'll need to associate your user with an existing organization.
+
+First find your user id by looking at the `user_token_session` table, there should only be one user id there.
+
+In the `organization_user` table, insert your user id in place of one of the existing `user_id`s in the table
+
+Now, when you click "start new application" the "who's applying" drop down should have an option in it, and you should be able to apply to competitions that are restricted to organizations only.

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -27,7 +27,7 @@ export default function Layout({ children, locale }: Props) {
         envFeatureFlags,
       )}
     >
-      <div className="display-flex flex-column minh-viewport simpler-page-anchor-offset">
+      <div className="display-flex flex-column minh-viewport">
         <a className="usa-skipnav" href="#main-content">
           {t("Layout.skipToMain")}
         </a>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -27,7 +27,7 @@ export default function Layout({ children, locale }: Props) {
         envFeatureFlags,
       )}
     >
-      <div className="display-flex flex-column minh-viewport">
+      <div className="display-flex flex-column minh-viewport simpler-page-anchor-offset">
         <a className="usa-skipnav" href="#main-content">
           {t("Layout.skipToMain")}
         </a>

--- a/frontend/src/components/application/ApplicationFormsTable.tsx
+++ b/frontend/src/components/application/ApplicationFormsTable.tsx
@@ -105,7 +105,7 @@ const ApplicationTable = ({
   const t = useTranslations("Application.competitionFormTable");
 
   return (
-    <Table className="width-full overflow-wrap">
+    <Table className="width-full overflow-wrap simpler-application-forms-table">
       <thead>
         <tr>
           <th scope="col" className="bg-base-lightest padding-y-205">

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -75,7 +75,7 @@ const ApplyForm = ({
   return (
     <>
       <form
-        className="flex-1 margin-top-2"
+        className="flex-1 margin-top-2 simpler-apply-form"
         action={formAction}
         // turns off html5 validation so all error displays are consistent
         noValidate

--- a/frontend/src/components/applyForm/ApplyFormMessage.tsx
+++ b/frontend/src/components/applyForm/ApplyFormMessage.tsx
@@ -44,7 +44,7 @@ export const ApplyFormMessage = ({
         <ul>
           {validationWarnings.map((warning, index) => (
             <li key={index}>
-              <a href={warning.field.replace("$.", "#")}>{warning.message}</a>
+              <a href={`#${warning.field}`}>{warning.message}</a>
             </li>
           ))}
         </ul>

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -395,7 +395,7 @@ export function getFieldsForNav(
       item.children.length > 0
     ) {
       if (item.name && item.label) {
-        results.push({ href: item.name, text: item.label });
+        results.push({ href: `form-section-${item.name}`, text: item.label });
       }
       if (
         Array.isArray(item.children) &&

--- a/frontend/src/components/applyForm/widgets/FieldsetWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/FieldsetWidget.tsx
@@ -11,7 +11,7 @@ export const FieldsetWidget = ({
   children: JSX.Element | undefined;
 }) => {
   return (
-    <Fieldset key={`${fieldName}-row`} id={fieldName}>
+    <Fieldset key={`${fieldName}-row`} id={`form-section-${fieldName}`}>
       <FormGroup key={`${fieldName}-group`} className="simpler-formgroup">
         <h4
           key={`${fieldName}-legend`}

--- a/frontend/src/components/opportunity/OpportunityDocuments.tsx
+++ b/frontend/src/components/opportunity/OpportunityDocuments.tsx
@@ -61,9 +61,13 @@ const OpportunityDocuments = ({
   const t = useTranslations("OpportunityListing.documents");
 
   return (
-    <Grid row className="margin-top-6">
+    <Grid
+      row
+      className="margin-top-6 simpler-page-anchor-offset"
+      id="opportunity-documents"
+    >
       <Grid col={8}>
-        <h2 id="opportunity_documents">{t("title")}</h2>
+        <h2>{t("title")}</h2>
       </Grid>
       {documents.length > 0 ? (
         <>

--- a/frontend/src/components/opportunity/OpportunityDownload.tsx
+++ b/frontend/src/components/opportunity/OpportunityDownload.tsx
@@ -21,7 +21,7 @@ const OpportunityDownload = ({ attachments }: OpportunityDownloadProps) => {
       className="margin-top-2 tablet:margin-top-0 flex-align-self-center"
     >
       <USWDSIcon name="arrow_downward" />
-      <Link className="flex-align-self-center" href={"#opportunity_documents"}>
+      <Link className="flex-align-self-center" href={"#opportunity-documents"}>
         {t("jumpToDocuments")}
       </Link>
     </Button>

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -681,3 +681,19 @@ iframe[id^="ethnio-screener-"] {
     scroll-margin-top: 6rem;
   }
 }
+
+.simpler-apply-form {
+  .usa-input, .usa-select, fieldset[id^=form-section] {
+    @include at-media("desktop") {
+      scroll-margin-top: 6rem;
+    }
+  }
+}
+
+.simpler-application-forms-table {
+  tr[id^=form] {
+    @include at-media("desktop") {
+      scroll-margin-top: 6rem;
+    }
+  }
+}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -675,3 +675,9 @@ iframe[id^="ethnio-screener-"] {
     margin-top: 0 !important;
   }
 }
+
+.simpler-page-anchor-offset {
+  @include at-media("desktop") {
+    scroll-margin-top: 6rem;
+  }
+}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -683,7 +683,9 @@ iframe[id^="ethnio-screener-"] {
 }
 
 .simpler-apply-form {
-  .usa-input, .usa-select, fieldset[id^=form-section] {
+  .usa-input,
+  .usa-select,
+  fieldset[id^="form-section"] {
     @include at-media("desktop") {
       scroll-margin-top: 6rem;
     }
@@ -691,7 +693,7 @@ iframe[id^="ethnio-screener-"] {
 }
 
 .simpler-application-forms-table {
-  tr[id^=form] {
+  tr[id^="form"] {
     @include at-media("desktop") {
       scroll-margin-top: 6rem;
     }

--- a/frontend/tests/components/opportunity/OpportunityDownload.test.tsx
+++ b/frontend/tests/components/opportunity/OpportunityDownload.test.tsx
@@ -13,7 +13,7 @@ describe("OpportunityDownload Component", () => {
     render(<OpportunityDownload attachments={[fakeOpportunityDocument]} />);
     const link = screen.getByRole("link");
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "#opportunity_documents");
+    expect(link).toHaveAttribute("href", "#opportunity-documents");
   });
 
   it("does not render link if no attachments are present", () => {


### PR DESCRIPTION
## Summary

Work for #4281 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes bug where internal anchor links were not taking the sticky header into account, and consequently putting the important linked stuff behind the header on scroll

I identified 4 places in the code where internal anchors were being used:
* the "jump to documents" link on opportunity detail
* application form validation warning links
* application form side nav links
* application submission validation warning links

If there are others, I missed them and they are not covered by this change

This also adds a readme file directing users how to access an application page, since that is a common path needed for validation, testing and development that is not very clear

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Note that any future anchor links we add that do not fit into any of the 4 categories described above will need to be handled on their own with custom css, as I've handled the current cases here.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


1. start a local server on this branch
2. visit an opportunity detail page for an opportunity with attachments
3. click "jump to documents" link
4. _VERIFY_: after scroll, the full documents table, including heading are displayed
5. start an application, following directions from the readme in this PR
6. click submit
7. click a link to a warning returned
8. _VERIFY_: page scrolls effectively to the form mentioned in the warning
9. click into a form
10. click save
11. click a link to a warning returned
8. _VERIFY_: page scrolls effectively to the input mentioned in the warning
9. click an item in the side nav
10. _VERIFY_: page scrolls effectively to the correct section