### PR TITLE
[Issue #5859] Modify sam extract fetching to not refetch pending extracts

### DIFF
--- a/api/src/task/sam_extracts/fetch_sam_extracts.py
+++ b/api/src/task/sam_extracts/fetch_sam_extracts.py
@@ -63,7 +63,7 @@ class FetchSamExtractsTask(Task):
         stmt = select(SamExtractFile).where(
             SamExtractFile.extract_type == SamGovExtractType.MONTHLY,
             SamExtractFile.extract_date == target_date,
-            SamExtractFile.processing_status == SamGovProcessingStatus.COMPLETED,
+            SamExtractFile.processing_status != SamGovProcessingStatus.FAILED,
         )
         existing = self.db_session.execute(stmt).scalar_one_or_none()
 
@@ -125,7 +125,7 @@ class FetchSamExtractsTask(Task):
             stmt = select(SamExtractFile).where(
                 SamExtractFile.extract_type == SamGovExtractType.DAILY,
                 SamExtractFile.extract_date == date_to_process,
-                SamExtractFile.processing_status == SamGovProcessingStatus.COMPLETED,
+                SamExtractFile.processing_status != SamGovProcessingStatus.FAILED,
             )
             existing = self.db_session.execute(stmt).scalar_one_or_none()
 


### PR DESCRIPTION
## Summary
Work for #5859

## Changes proposed
When checking if we already fetched an extract, factor in pending extracts

## Context for reviewers
There are 3 extract status values with the following purpose:
* `pending` - We just downloaded this - the process extract task fetches everything in this status
* `completed` - We've processed this - the process extract task puts everything into this after running
* `failed` - Nothing sets this status, if we had an issue processing a file, we could move it to this status manually

Before this change it only considered a file in the `completed` status as valid for seeing if we already handled a file. But that means if we rerun the fetch process two times in a row, we end up creating duplicate records in our DB which would be bad as we'd then try to process every file twice. To protect against that, we want pending and completed processing statuses to both keep us from fetching an extract again. Only failed should be ignored and re-downloaded.
