### PR TITLE
[Unticketed] Adjust saved-opp query to fetch much less

### DIFF
--- a/api/src/services/users/get_saved_opportunities.py
+++ b/api/src/services/users/get_saved_opportunities.py
@@ -73,7 +73,11 @@ def get_saved_opportunities(
             CurrentOpportunitySummary.opportunity_summary_id
             == OpportunitySummary.opportunity_summary_id,
         )
-        .options(selectinload("*"))
+        .options(
+            selectinload(Opportunity.current_opportunity_summary).selectinload(
+                CurrentOpportunitySummary.opportunity_summary
+            )
+        )
     )
 
     stmt = add_sort_order(stmt, opportunity_params.pagination.sort_order)


### PR DESCRIPTION
## Summary

## Changes proposed
Instead of `selectinload("*")` when fetch saved opportunities, only fetch what we need.

## Context for reviewers
This endpoint suddenly has a lot of traffic as anyone logged in calls this on search. This highlighted the bad performance of this endpoint with the worst requests taking 3 seconds:
<img width="1732" height="785" alt="Screenshot 2025-08-11 at 3 48 23 PM" src="https://github.com/user-attachments/assets/bec85e17-d38c-47c1-bacf-7ed7cbf33af6" />

This is almost certainly due to fetching way too much in the query. The `*` approach fetches every relationship from an opportunity which means we're currently fetching almost every table record connected to an opportunity. The response model only needs the opportunity and its current opportunity summary. There isn't much info that needs to be returned for this endpoint to work. This should massively reduce how long these requests take.

