### PR TITLE
[Issue #5699] ui for project narrative attachment form

### DIFF
--- a/api/src/form_schema/forms/project_narrative_attachment.py
+++ b/api/src/form_schema/forms/project_narrative_attachment.py
@@ -12,20 +12,20 @@ FORM_JSON_SCHEMA = {
             "description": "At least one file must be attached",
             "minItems": 1,
             "maxItems": 100,
-            "items": {"allOf": [{"$ref": "#/$defs/attachment_field"}]},
+            "items": {"$ref": "#/$defs/attachment_field"},
         }
     },
     "$defs": {
         # Just defining this separately so it's easier to refactor when we have a shared schema
-        "attachment_field": {"type": "string", "format": "uuid"},
+        "attachment_field": {"type": "string", "format": "uuid", "title": "Attachment"},
     },
 }
 
 FORM_UI_SCHEMA = [
     {
         "type": "section",
-        "label": "1. Everything",
-        "name": "Everything",
+        "label": "1. Project Narrative File(s)",
+        "name": "projectNarrativeFiles",
         "children": [
             {"type": "field", "definition": "/properties/attachments"},
         ],

--- a/api/src/form_schema/forms/project_narrative_attachment.py
+++ b/api/src/form_schema/forms/project_narrative_attachment.py
@@ -12,7 +12,7 @@ FORM_JSON_SCHEMA = {
             "description": "At least one file must be attached",
             "minItems": 1,
             "maxItems": 100,
-            "items": {"$ref": "#/$defs/attachment_field"},
+            "items": {"allOf": [{"$ref": "#/$defs/attachment_field"}]},
         }
     },
     "$defs": {
@@ -27,7 +27,7 @@ FORM_UI_SCHEMA = [
         "label": "1. Project Narrative File(s)",
         "name": "projectNarrativeFiles",
         "children": [
-            {"type": "field", "definition": "/properties/attachments"},
+            {"type": "field", "definition": "/properties/attachments", "widget": "AttachmentArray"},
         ],
     }
 ]


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5699 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Gets the project narrative attachment form basically working

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Note that there are still problems with validation and keeping track of uploaded documents that will be resolved later.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local frontend server on this branch
2. run `make volume-recreate db-seed-local populate-search-opportunities populate-search-agencies start` on /api
3. start an application as described in the readme (https://github.com/HHS/simpler-grants-gov/blob/16f5ca621c3ce1469d0a5b250efe52d6718ae28e/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
4. open the project narrative attachment form
5. click save
6. _VERIFY_: validation errors are returned
7. add multiple attachments
8. click save
9. _VERIFY_: it saves (validation errors are expected at this point)
10. return to the application page
11. _VERIFY_: your uploaded files appear in the attachment section

### Screenshot
<img width="1238" height="656" alt="Screenshot 2025-08-12 at 8 09 45 AM" src="https://github.com/user-attachments/assets/1e19c1f7-951f-4dbe-a8ea-0da611d1636c" />


