### PR TITLE
[Issue #5812] Exclude suppressed emails form email notifications

### DIFF
--- a/api/src/task/notifications/closing_date_notification.py
+++ b/api/src/task/notifications/closing_date_notification.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm import selectinload
 
 from src.adapters import db
 from src.db.models.opportunity_models import Opportunity, OpportunitySummary
-from src.db.models.user_models import UserOpportunityNotificationLog, UserSavedOpportunity
+from src.db.models.user_models import (
+    LinkExternalUser,
+    SuppressedEmail,
+    UserOpportunityNotificationLog,
+    UserSavedOpportunity,
+)
 from src.task.notifications.base_notification import BaseNotificationTask
 from src.task.notifications.config import EmailNotificationConfig
 from src.task.notifications.constants import NotificationReason, UserEmailNotification
@@ -73,6 +78,7 @@ class ClosingDateNotificationTask(BaseNotificationTask):
                         # == NotificationReason.CLOSING_DATE_REMINDER
                     )
                 ),
+                ~exists().where(SuppressedEmail.email == LinkExternalUser.email),
             )
         )
 

--- a/api/src/task/notifications/search_notification.py
+++ b/api/src/task/notifications/search_notification.py
@@ -2,7 +2,7 @@ import logging
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import select, update
+from sqlalchemy import exists, select, update
 from sqlalchemy.orm import selectinload
 
 import src.adapters.db as db
@@ -12,7 +12,7 @@ from src.db.models.opportunity_models import (
     Opportunity,
     OpportunitySummary,
 )
-from src.db.models.user_models import UserSavedSearch
+from src.db.models.user_models import LinkExternalUser, SuppressedEmail, UserSavedSearch
 from src.services.opportunities_v1.search_opportunities import search_opportunities_id
 from src.task.notifications.base_notification import BaseNotificationTask
 from src.task.notifications.config import EmailNotificationConfig
@@ -48,7 +48,10 @@ class SearchNotificationTask(BaseNotificationTask):
             select(UserSavedSearch)
             .options(selectinload(UserSavedSearch.user))
             .where(UserSavedSearch.last_notified_at < datetime_util.utcnow())
-            .where(UserSavedSearch.is_deleted.isnot(True))
+            .where(
+                UserSavedSearch.is_deleted.isnot(True),
+                ~exists().where(SuppressedEmail.email == LinkExternalUser.email),
+            )
         )
 
         saved_searches = self.db_session.execute(stmt).scalars().all()

--- a/api/tests/src/task/notifications/test_opportunity_notification.py
+++ b/api/tests/src/task/notifications/test_opportunity_notification.py
@@ -14,7 +14,7 @@ from src.constants.lookup_constants import (
     OpportunityStatus,
 )
 from src.db.models.opportunity_models import Opportunity, OpportunityVersion
-from src.db.models.user_models import UserNotificationLog, UserSavedOpportunity
+from src.db.models.user_models import SuppressedEmail, UserNotificationLog, UserSavedOpportunity
 from src.task.notifications.config import EmailNotificationConfig
 from src.task.notifications.constants import (
     Metrics,
@@ -191,6 +191,7 @@ class TestOpportunityNotification:
         cascade_delete_from_db_table(db_session, UserNotificationLog)
         cascade_delete_from_db_table(db_session, Opportunity)
         cascade_delete_from_db_table(db_session, UserSavedOpportunity)
+        cascade_delete_from_db_table(db_session, SuppressedEmail)
 
     @pytest.fixture(autouse=True)
     def user_with_email(self, db_session, user):
@@ -1126,3 +1127,29 @@ class TestOpportunityNotification:
             ]
         )
         assert res == expected
+
+    def test_get_latest_opportunity_versions_suppressed(
+        self,
+        db_session,
+        enable_factory_create,
+        set_env_var_for_email_notification_config,
+        notification_task,
+        user,
+    ):
+        """Test that the user notification does not pick up user on suppression_list"""
+        # create a suppressed email
+        user_1 = factories.LinkExternalUserFactory.create().user
+        factories.SuppressedEmailFactory(email=user_1.email)
+
+        # create opportunity
+        opp = factories.OpportunityFactory.create(is_posted_summary=True)
+        factories.UserSavedOpportunityFactory.create(
+            user=user,
+            opportunity=opp,
+        )
+        factories.OpportunityVersionFactory.create(opportunity=opp)
+
+        # Instantiate the task
+        results = notification_task._get_latest_opportunity_versions()
+
+        assert len(results) == 0

--- a/api/tests/src/task/notifications/test_search_notification.py
+++ b/api/tests/src/task/notifications/test_search_notification.py
@@ -9,7 +9,7 @@ from src.adapters.aws.pinpoint_adapter import _clear_mock_responses, _get_mock_r
 from src.api.opportunities_v1.opportunity_schemas import OpportunityV1Schema
 from src.constants.lookup_constants import OpportunityStatus
 from src.db.models.opportunity_models import Opportunity
-from src.db.models.user_models import UserNotificationLog, UserSavedSearch
+from src.db.models.user_models import SuppressedEmail, UserNotificationLog, UserSavedSearch
 from src.task.notifications.config import EmailNotificationConfig
 from src.task.notifications.constants import NotificationReason
 from src.task.notifications.email_notification import EmailNotificationTask
@@ -53,6 +53,7 @@ def clear_data(db_session):
     cascade_delete_from_db_table(db_session, UserNotificationLog)
     cascade_delete_from_db_table(db_session, Opportunity)
     cascade_delete_from_db_table(db_session, UserSavedSearch)
+    cascade_delete_from_db_table(db_session, SuppressedEmail)
 
 
 @pytest.fixture()
@@ -646,4 +647,46 @@ def test_search_notification_deleted_search(
     results = notification_task.collect_email_notifications()
 
     # assert deleted saved search is not picked up
+    assert len(results) == 0
+
+
+def test_search_notification_suppressed_email(
+    cli_runner,
+    db_session,
+    setup_opensearch_data,
+    enable_factory_create,
+    user_with_email,
+    search_client,
+    notification_task,
+):
+    """Test that the user notification does not pick up users on suppression_list"""
+    # create a suppressed email
+    factories.SuppressedEmailFactory(email=user_with_email.email)
+
+    opp = factories.OpportunityFactory.create(
+        opportunity_id=OPPORTUNITIES[0].opportunity_id,
+        no_current_summary=True,
+        legacy_opportunity_id=4,
+        opportunity_title="Scholarship Program",
+    )
+    summary = factories.OpportunitySummaryFactory.create(
+        opportunity=opp, post_date=date.fromisoformat("2020-01-01")
+    )
+    factories.CurrentOpportunitySummaryFactory.create(
+        opportunity=opp,
+        opportunity_summary=summary,
+        opportunity_status=OpportunityStatus.POSTED,
+    )
+
+    # Create saved searches
+    factories.UserSavedSearchFactory.create(
+        search_query={"keywords": "test"},
+        user=user_with_email,
+        searched_opportunity_ids=[OPPORTUNITIES[1].opportunity_id],
+        last_notified_at=datetime_util.utcnow() - timedelta(days=1),
+    )
+
+    results = notification_task.collect_email_notifications()
+
+    # assert saved search is not picked up
     assert len(results) == 0


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #5812  

## Changes proposed

Update email sending logic to exclude any users whose email exists in the suppressed_email table.

