### PR TITLE
[Issue #5915] fix attachment field validations

### DIFF
--- a/frontend/src/components/applyForm/formDataToJson.ts
+++ b/frontend/src/components/applyForm/formDataToJson.ts
@@ -13,6 +13,23 @@ type FormDataToJsonOptions = {
   delimiter?: string;
 };
 
+const parseValue = (value: unknown): unknown => {
+  if (value === "false") return false;
+  if (value === "true") return true;
+  if (
+    value !== "" &&
+    value !== null &&
+    value !== undefined &&
+    !isNaN(Number(value))
+  )
+    return Number(value);
+  try {
+    return JSON.parse(value as string);
+  } catch (e) {
+    return value || undefined;
+  }
+};
+
 export function formDataToObject(
   formData = new FormData(),
   options?: FormDataToJsonOptions,
@@ -26,18 +43,7 @@ export function formDataToObject(
     const currentKey = parentKey ? `${parentKey}${delimiter}${key}` : key;
     const chunks = currentKey.split(delimiter);
     let current = result;
-    const parsedValue = (() => {
-      if (value === "false") return false;
-      if (value === "true") return true;
-      if (
-        value !== "" &&
-        value !== null &&
-        value !== undefined &&
-        !isNaN(Number(value))
-      )
-        return Number(value);
-      return value || undefined;
-    })();
+    const parsedValue = parseValue(value);
 
     const chunksLen = chunks.length;
     for (let chunkIdx = 0; chunkIdx < chunksLen; chunkIdx++) {
@@ -75,7 +81,7 @@ export function formDataToObject(
         }
       } else {
         if (chunkIdx === chunks.length - 1) {
-          current[chunkName] = parsedValue;
+          current[chunkName] = parsedValue as NestedObject;
         } else {
           current[chunkName] = current[chunkName] ?? {};
           current = current[chunkName] as NestedObject;

--- a/frontend/tests/utils/formDataToJson.test.ts
+++ b/frontend/tests/utils/formDataToJson.test.ts
@@ -33,6 +33,20 @@ describe("formDataToObject", () => {
 
     expect(result).toEqual(expected);
   });
+  it("handles json string values", () => {
+    const formData = new FormData();
+    formData.append("arrayLike", '["i am", "an array", 100]');
+    formData.append("complicated", '{"key": "value"}');
+
+    const expected = {
+      arrayLike: ["i am", "an array", 100],
+      complicated: { key: "value" },
+    };
+
+    const result = formDataToObject(formData);
+
+    expect(result).toEqual(expected);
+  });
   it("handles falsey values", () => {
     const formData = new FormData();
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5915 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes bug where properly completed attachment and multi attachment fields would come back with validation errors when saving a form

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The problem here was that the function we're using to translate formData into a properly serialized object did not account for the form data values being JSON strings. We now will try to parse any string values into JSON

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this brand with `npm run build -- --no-lint && npm start` or start with `npm run dev` and switch off `reactStrictMode`in your next.config
2. start an application following directions in the readme (https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. click into the "Project Narrative Attachment" form
4. upload file(s)
5. click save
6. _VERIFY_: no validation warnings are returned


### Screensho
<img width="1238" height="656" alt="Screenshot 2025-08-12 at 8 09 45 AM" src="https://github.com/user-attachments/assets/5e3e73d6-2301-4f88-8cbb-9df403be8b3b" />
ts
