### PR TITLE
[Issue #5859] Small fixes/adjustments to sam.gov processing

### DIFF
--- a/api/src/adapters/sam_gov/client.py
+++ b/api/src/adapters/sam_gov/client.py
@@ -111,8 +111,10 @@ class SamGovClient(BaseSamGovClient):
         try:
             headers = self._build_headers()
 
-            logging.info(f"Downloading SAM.gov extract from {url}")
-            logging.debug(f"Request parameters: {params}")
+            logging.info(
+                f"Downloading SAM.gov extract from {url}",
+                extra={"extract_file_name": extract_request.file_name},
+            )
 
             response = requests.get(url, params=params, headers=headers, stream=True, timeout=30)
 

--- a/api/src/task/sam_extracts/process_sam_extracts.py
+++ b/api/src/task/sam_extracts/process_sam_extracts.py
@@ -168,6 +168,8 @@ class ProcessSamExtractsTask(Task):
             )
 
             # Mark extract as processed
+            # Have to add to the session as it was fetched in a different transaction
+            self.db_session.add(sam_extract_file)
             sam_extract_file.processing_status = SamGovProcessingStatus.COMPLETED
 
     def parse_extract_file(


### PR DESCRIPTION
## Summary
Fixes for #5859

## Changes proposed
* Add a little more logging to extract file download to say which file it is downloading
* Fix logic for setting the processing status of a sam.gov extract so it actually gets set

## Context for reviewers
Processing status wasn't getting set when run because we fetch the extract files in one transaction, and update it in a different one, so they aren't associated with the DB session in the latter case so the update doesn't do anything. Adding them to the DB session fixes this.
