### PR TITLE
[Issue #5798] Add service to rename API keys from logged in user in DB

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -1156,6 +1156,66 @@ paths:
               $ref: '#/components/schemas/UserSavedOpportunitiesRequest'
       security:
       - ApiJwtAuth: []
+  /v1/users/{user_id}/api-keys/{api_key_id}:
+    patch:
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: api_key_id
+        schema:
+          type: string
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserApiKeyRenameResponse'
+          description: Successful response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Validation error
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Authentication error
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Not found
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Bad Request
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Forbidden
+      tags:
+      - User v1 - Internal Only
+      summary: Rename an existing API key for the authenticated user
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserApiKeyRenameRequest'
+      security:
+      - ApiJwtAuth: []
   /alpha/applications/{application_id}/attachments:
     post:
       parameters:
@@ -4343,6 +4403,33 @@ components:
             type:
             - object
             $ref: '#/components/schemas/SavedOpportunityResponseV1'
+        status_code:
+          type: integer
+          description: The HTTP status code
+          example: 200
+    UserApiKeyRenameRequest:
+      type: object
+      properties:
+        key_name:
+          type: string
+          minLength: 1
+          maxLength: 255
+          description: New human-readable name for the API key
+          example: Updated Production API Key
+      required:
+      - key_name
+    UserApiKeyRenameResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message to return
+          example: Success
+        data:
+          description: The renamed API key
+          type:
+          - object
+          $ref: '#/components/schemas/UserApiKey'
         status_code:
           type: integer
           description: The HTTP status code

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -1206,7 +1206,7 @@ paths:
       security:
       - ApiJwtAuth: []
   /v1/users/{user_id}/api-keys/{api_key_id}:
-    patch:
+    put:
       parameters:
       - in: path
         name: user_id

--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -4414,8 +4414,8 @@ components:
           type: string
           minLength: 1
           maxLength: 255
-          description: New human-readable name for the API key
-          example: Updated Production API Key
+          description: New name for the API key
+          example: Production API Key
       required:
       - key_name
     UserApiKeyRenameResponse:

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -13,10 +13,10 @@ from src.api.users.user_blueprint import user_blueprint
 from src.api.users.user_schemas import (
     UserApiKeyCreateRequestSchema,
     UserApiKeyCreateResponseSchema,
-    UserApiKeyRenameRequestSchema,
-    UserApiKeyRenameResponseSchema,
     UserApiKeyListRequestSchema,
     UserApiKeyListResponseSchema,
+    UserApiKeyRenameRequestSchema,
+    UserApiKeyRenameResponseSchema,
     UserApplicationListRequestSchema,
     UserApplicationListResponseSchema,
     UserDeleteSavedOpportunityResponseSchema,
@@ -529,8 +529,9 @@ def user_rename_api_key(
     )
 
     return response.ApiResponse(message="Success", data=api_key)
-  
-  @user_blueprint.post("/<uuid:user_id>/api-keys/list")
+
+
+@user_blueprint.post("/<uuid:user_id>/api-keys/list")
 @user_blueprint.input(UserApiKeyListRequestSchema, location="json")
 @user_blueprint.output(UserApiKeyListResponseSchema)
 @user_blueprint.doc(responses=[200, 401, 403])

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -519,15 +519,6 @@ def user_rename_api_key(
     with db_session.begin():
         api_key = rename_api_key(db_session, user_id, api_key_id, json_data)
 
-    logger.info(
-        "Renamed API key for user",
-        extra={
-            "user_id": user_id,
-            "api_key_id": api_key.api_key_id,
-            "key_name": api_key.key_name,
-        },
-    )
-
     return response.ApiResponse(message="Success", data=api_key)
 
 

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -13,6 +13,8 @@ from src.api.users.user_blueprint import user_blueprint
 from src.api.users.user_schemas import (
     UserApiKeyCreateRequestSchema,
     UserApiKeyCreateResponseSchema,
+    UserApiKeyRenameRequestSchema,
+    UserApiKeyRenameResponseSchema,
     UserApplicationListRequestSchema,
     UserApplicationListResponseSchema,
     UserDeleteSavedOpportunityResponseSchema,
@@ -51,6 +53,7 @@ from src.services.users.login_gov_callback_handler import (
     handle_login_gov_callback_request,
     handle_login_gov_token,
 )
+from src.services.users.rename_api_key import rename_api_key
 from src.services.users.update_saved_searches import update_saved_search
 
 logger = logging.getLogger(__name__)
@@ -482,6 +485,39 @@ def user_create_api_key(
 
     logger.info(
         "Created API key for user",
+        extra={
+            "user_id": user_id,
+            "api_key_id": api_key.api_key_id,
+            "key_name": api_key.key_name,
+        },
+    )
+
+    return response.ApiResponse(message="Success", data=api_key)
+
+
+@user_blueprint.patch("/<uuid:user_id>/api-keys/<uuid:api_key_id>")
+@user_blueprint.input(UserApiKeyRenameRequestSchema, location="json")
+@user_blueprint.output(UserApiKeyRenameResponseSchema)
+@user_blueprint.doc(responses=[200, 400, 401, 403, 404])
+@user_blueprint.auth_required(api_jwt_auth)
+@flask_db.with_db_session()
+def user_rename_api_key(
+    db_session: db.Session, user_id: UUID, api_key_id: UUID, json_data: dict
+) -> response.ApiResponse:
+    """Rename an existing API key for the authenticated user"""
+    add_extra_data_to_current_request_logs({"user_id": user_id, "api_key_id": api_key_id})
+    logger.info("PATCH /v1/users/:user_id/api-keys/:api_key_id")
+
+    user_token_session: UserTokenSession = api_jwt_auth.get_user_token_session()
+
+    if user_token_session.user_id != user_id:
+        raise_flask_error(403, "Forbidden")
+
+    with db_session.begin():
+        api_key = rename_api_key(db_session, user_id, api_key_id, json_data)
+
+    logger.info(
+        "Renamed API key for user",
         extra={
             "user_id": user_id,
             "api_key_id": api_key.api_key_id,

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -498,7 +498,7 @@ def user_create_api_key(
     return response.ApiResponse(message="Success", data=api_key)
 
 
-@user_blueprint.patch("/<uuid:user_id>/api-keys/<uuid:api_key_id>")
+@user_blueprint.put("/<uuid:user_id>/api-keys/<uuid:api_key_id>")
 @user_blueprint.input(UserApiKeyRenameRequestSchema, location="json")
 @user_blueprint.output(UserApiKeyRenameResponseSchema)
 @user_blueprint.doc(responses=[200, 400, 401, 403, 404])
@@ -509,7 +509,7 @@ def user_rename_api_key(
 ) -> response.ApiResponse:
     """Rename an existing API key for the authenticated user"""
     add_extra_data_to_current_request_logs({"user_id": user_id, "api_key_id": api_key_id})
-    logger.info("PATCH /v1/users/:user_id/api-keys/:api_key_id")
+    logger.info("PUT /v1/users/:user_id/api-keys/:api_key_id")
 
     user_token_session: UserTokenSession = api_jwt_auth.get_user_token_session()
 

--- a/api/src/api/users/user_schemas.py
+++ b/api/src/api/users/user_schemas.py
@@ -313,7 +313,6 @@ class UserApiKeyCreateResponseSchema(AbstractResponseSchema):
     data = fields.Nested(UserApiKeySchema, metadata={"description": "The newly created API key"})
 
 
-
 class UserApiKeyRenameRequestSchema(Schema):
     key_name = fields.String(
         required=True,
@@ -328,6 +327,7 @@ class UserApiKeyRenameRequestSchema(Schema):
 class UserApiKeyRenameResponseSchema(AbstractResponseSchema):
     data = fields.Nested(UserApiKeySchema, metadata={"description": "The renamed API key"})
 
+
 class UserApiKeyListRequestSchema(Schema):
     # Future filtering fields can be added here
     pass
@@ -338,4 +338,3 @@ class UserApiKeyListResponseSchema(AbstractResponseSchema):
         fields.Nested(UserApiKeySchema),
         metadata={"description": "List of API keys for the user"},
     )
-

--- a/api/src/api/users/user_schemas.py
+++ b/api/src/api/users/user_schemas.py
@@ -311,3 +311,18 @@ class UserApiKeySchema(Schema):
 
 class UserApiKeyCreateResponseSchema(AbstractResponseSchema):
     data = fields.Nested(UserApiKeySchema, metadata={"description": "The newly created API key"})
+
+
+class UserApiKeyRenameRequestSchema(Schema):
+    key_name = fields.String(
+        required=True,
+        validate=validators.Length(min=1, max=255),
+        metadata={
+            "description": "New name for the API key",
+            "example": "Production API Key",
+        },
+    )
+
+
+class UserApiKeyRenameResponseSchema(AbstractResponseSchema):
+    data = fields.Nested(UserApiKeySchema, metadata={"description": "The renamed API key"})

--- a/api/src/services/users/rename_api_key.py
+++ b/api/src/services/users/rename_api_key.py
@@ -33,7 +33,6 @@ def rename_api_key(
     if api_key is None:
         raise_flask_error(404, "API key not found")
 
-    old_key_name = api_key.key_name
     api_key.key_name = params.key_name
 
     logger.info(

--- a/api/src/services/users/rename_api_key.py
+++ b/api/src/services/users/rename_api_key.py
@@ -1,0 +1,49 @@
+import logging
+from uuid import UUID
+
+from sqlalchemy import select
+
+from src.adapters import db
+from src.api.route_utils import raise_flask_error
+from src.db.models.user_models import UserApiKey
+
+logger = logging.getLogger(__name__)
+
+
+class RenameApiKeyParams:
+    """Simple parameter extraction for API key renaming"""
+
+    def __init__(self, json_data: dict):
+        self.key_name = json_data["key_name"]
+
+
+def rename_api_key(
+    db_session: db.Session, user_id: UUID, api_key_id: UUID, json_data: dict
+) -> UserApiKey:
+    """Rename an existing API key for a user"""
+    params = RenameApiKeyParams(json_data)
+
+    api_key = db_session.execute(
+        select(UserApiKey).filter(
+            UserApiKey.api_key_id == api_key_id,
+            UserApiKey.user_id == user_id,
+        )
+    ).scalar_one_or_none()
+
+    if api_key is None:
+        raise_flask_error(404, "API key not found")
+
+    old_key_name = api_key.key_name
+    api_key.key_name = params.key_name
+
+    logger.info(
+        "Renamed API key",
+        extra={
+            "api_key_id": api_key.api_key_id,
+            "user_id": user_id,
+            "old_key_name": old_key_name,
+            "new_key_name": params.key_name,
+        },
+    )
+
+    return api_key

--- a/api/src/services/users/rename_api_key.py
+++ b/api/src/services/users/rename_api_key.py
@@ -41,8 +41,6 @@ def rename_api_key(
         extra={
             "api_key_id": api_key.api_key_id,
             "user_id": user_id,
-            "old_key_name": old_key_name,
-            "new_key_name": params.key_name,
         },
     )
 

--- a/api/tests/src/api/users/test_user_rename_api_key.py
+++ b/api/tests/src/api/users/test_user_rename_api_key.py
@@ -9,7 +9,7 @@ def test_rename_api_key_success(enable_factory_create, db_session, client, user,
     api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name", last_used=None)
     json_data = {"key_name": "Updated API Key Name"}
 
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,
@@ -44,7 +44,7 @@ def test_rename_api_key_validation_error_missing_key_name(
     api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
     json_data = {}
 
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,
@@ -64,7 +64,7 @@ def test_rename_api_key_validation_error_long_key_name(
     api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
     json_data = {"key_name": "a" * 256}  # Exceeds 255 character limit
 
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,
@@ -84,7 +84,7 @@ def test_rename_api_key_validation_error_empty_key_name(
     api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
     json_data = {"key_name": ""}
 
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,
@@ -105,7 +105,7 @@ def test_rename_api_key_unauthorized_different_user(
     api_key = UserApiKeyFactory.create(user=other_user, key_name="Original Key Name")
     json_data = {"key_name": "Updated API Key Name"}
 
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{other_user.user_id}/api-keys/{api_key.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,
@@ -126,7 +126,7 @@ def test_rename_api_key_unauthorized_wrong_user_owns_key(
     api_key = UserApiKeyFactory.create(user=other_user, key_name="Original Key Name")
     json_data = {"key_name": "Updated API Key Name"}
 
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,
@@ -144,7 +144,7 @@ def test_rename_api_key_no_authentication(enable_factory_create, db_session, cli
     api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
     json_data = {"key_name": "Updated API Key Name"}
 
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
         json=json_data,
     )
@@ -165,7 +165,7 @@ def test_rename_api_key_multiple_keys_same_user(
 
     # Rename the second key
     json_data = {"key_name": "Renamed Second API Key"}
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key2.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,
@@ -201,7 +201,7 @@ def test_rename_api_key_preserves_other_fields(
     original_created_at = api_key.created_at
 
     json_data = {"key_name": "Updated Key Name"}
-    response = client.patch(
+    response = client.put(
         f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
         headers={"X-SGG-Token": user_auth_token},
         json=json_data,

--- a/api/tests/src/api/users/test_user_rename_api_key.py
+++ b/api/tests/src/api/users/test_user_rename_api_key.py
@@ -26,7 +26,7 @@ def test_rename_api_key_success(enable_factory_create, db_session, client, user,
     assert "created_at" in response_data
 
     db_session.expunge(api_key)
-    
+
     updated_api_key = db_session.execute(
         select(UserApiKey).where(UserApiKey.api_key_id == api_key.api_key_id)
     ).scalar_one_or_none()

--- a/api/tests/src/api/users/test_user_rename_api_key.py
+++ b/api/tests/src/api/users/test_user_rename_api_key.py
@@ -25,6 +25,8 @@ def test_rename_api_key_success(enable_factory_create, db_session, client, user,
     assert response_data["last_used"] is None
     assert "created_at" in response_data
 
+    db_session.expunge(api_key)
+    
     updated_api_key = db_session.execute(
         select(UserApiKey).where(UserApiKey.api_key_id == api_key.api_key_id)
     ).scalar_one_or_none()

--- a/api/tests/src/api/users/test_user_rename_api_key.py
+++ b/api/tests/src/api/users/test_user_rename_api_key.py
@@ -6,7 +6,7 @@ from tests.src.db.models.factories import UserApiKeyFactory
 
 def test_rename_api_key_success(enable_factory_create, db_session, client, user, user_auth_token):
     """Test successful API key renaming"""
-    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name", last_used=None)
     json_data = {"key_name": "Updated API Key Name"}
 
     response = client.patch(

--- a/api/tests/src/api/users/test_user_rename_api_key.py
+++ b/api/tests/src/api/users/test_user_rename_api_key.py
@@ -1,0 +1,221 @@
+from sqlalchemy import select
+
+from src.db.models.user_models import UserApiKey
+from tests.src.db.models.factories import UserApiKeyFactory
+
+
+def test_rename_api_key_success(enable_factory_create, db_session, client, user, user_auth_token):
+    """Test successful API key renaming"""
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {"key_name": "Updated API Key Name"}
+
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 200
+
+    response_data = response.json["data"]
+    assert str(response_data["api_key_id"]) == str(api_key.api_key_id)
+    assert response_data["key_name"] == "Updated API Key Name"
+    assert response_data["key_id"] == api_key.key_id
+    assert response_data["is_active"] == api_key.is_active
+    assert response_data["last_used"] is None
+    assert "created_at" in response_data
+
+    updated_api_key = db_session.execute(
+        select(UserApiKey).where(UserApiKey.api_key_id == api_key.api_key_id)
+    ).scalar_one_or_none()
+
+    assert updated_api_key is not None
+    assert updated_api_key.key_name == "Updated API Key Name"
+    assert updated_api_key.user_id == user.user_id
+    assert updated_api_key.key_id == api_key.key_id
+
+
+def test_rename_api_key_validation_error_missing_key_name(
+    enable_factory_create, db_session, client, user, user_auth_token
+):
+    """Test validation error when key_name is missing"""
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {}
+
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 422
+    assert response.json["message"] == "Validation error"
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Original Key Name"
+
+
+def test_rename_api_key_validation_error_long_key_name(
+    enable_factory_create, db_session, client, user, user_auth_token
+):
+    """Test validation error when key_name exceeds maximum length"""
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {"key_name": "a" * 256}  # Exceeds 255 character limit
+
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 422
+    assert response.json["message"] == "Validation error"
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Original Key Name"
+
+
+def test_rename_api_key_validation_error_empty_key_name(
+    enable_factory_create, db_session, client, user, user_auth_token
+):
+    """Test validation error when key_name is empty"""
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {"key_name": ""}
+
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 422
+    assert response.json["message"] == "Validation error"
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Original Key Name"
+
+
+def test_rename_api_key_unauthorized_different_user(
+    enable_factory_create, db_session, client, user, user_auth_token
+):
+    """Test that users cannot rename API keys for other users"""
+    other_user = UserApiKeyFactory.create().user
+    api_key = UserApiKeyFactory.create(user=other_user, key_name="Original Key Name")
+    json_data = {"key_name": "Updated API Key Name"}
+
+    response = client.patch(
+        f"/v1/users/{other_user.user_id}/api-keys/{api_key.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 403
+    assert response.json["message"] == "Forbidden"
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Original Key Name"
+
+
+def test_rename_api_key_unauthorized_wrong_user_owns_key(
+    enable_factory_create, db_session, client, user, user_auth_token
+):
+    """Test that users cannot rename API keys that belong to other users even with correct user_id in path"""
+    other_user = UserApiKeyFactory.create().user
+    api_key = UserApiKeyFactory.create(user=other_user, key_name="Original Key Name")
+    json_data = {"key_name": "Updated API Key Name"}
+
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 404
+    assert response.json["message"] == "API key not found"
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Original Key Name"
+
+
+def test_rename_api_key_no_authentication(enable_factory_create, db_session, client, user):
+    """Test that the endpoint requires authentication"""
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {"key_name": "Updated API Key Name"}
+
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
+        json=json_data,
+    )
+
+    assert response.status_code == 401
+    assert response.json["message"] == "Unable to process token"
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Original Key Name"
+
+
+def test_rename_api_key_multiple_keys_same_user(
+    enable_factory_create, db_session, client, user, user_auth_token
+):
+    """Test that renaming one API key doesn't affect other API keys for the same user"""
+    api_key1 = UserApiKeyFactory.create(user=user, key_name="First API Key")
+    api_key2 = UserApiKeyFactory.create(user=user, key_name="Second API Key")
+
+    # Rename the second key
+    json_data = {"key_name": "Renamed Second API Key"}
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key2.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 200
+
+    response_data = response.json["data"]
+    assert response_data["key_name"] == "Renamed Second API Key"
+    assert str(response_data["api_key_id"]) == str(api_key2.api_key_id)
+
+    db_session.refresh(api_key1)
+    assert api_key1.key_name == "First API Key"
+
+    db_session.refresh(api_key2)
+    assert api_key2.key_name == "Renamed Second API Key"
+
+
+def test_rename_api_key_preserves_other_fields(
+    enable_factory_create, db_session, client, user, user_auth_token
+):
+    """Test that renaming only changes the key_name and preserves other fields"""
+    api_key = UserApiKeyFactory.create(
+        user=user,
+        key_name="Original Key Name",
+        is_active=False,
+        last_used=None,
+    )
+
+    original_key_id = api_key.key_id
+    original_is_active = api_key.is_active
+    original_last_used = api_key.last_used
+    original_created_at = api_key.created_at
+
+    json_data = {"key_name": "Updated Key Name"}
+    response = client.patch(
+        f"/v1/users/{user.user_id}/api-keys/{api_key.api_key_id}",
+        headers={"X-SGG-Token": user_auth_token},
+        json=json_data,
+    )
+
+    assert response.status_code == 200
+
+    response_data = response.json["data"]
+    assert response_data["key_name"] == "Updated Key Name"
+    assert response_data["key_id"] == original_key_id
+    assert response_data["is_active"] == original_is_active
+    assert response_data["last_used"] == original_last_used
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Updated Key Name"
+    assert api_key.key_id == original_key_id
+    assert api_key.is_active == original_is_active
+    assert api_key.last_used == original_last_used
+    assert api_key.created_at == original_created_at

--- a/api/tests/src/services/users/test_rename_api_key.py
+++ b/api/tests/src/services/users/test_rename_api_key.py
@@ -1,7 +1,7 @@
+import apiflask.exceptions
 import pytest
 
 from src.adapters import db
-from src.api.route_utils import FlaskError
 from src.services.users.rename_api_key import rename_api_key
 from tests.src.db.models.factories import UserApiKeyFactory, UserFactory
 
@@ -38,7 +38,7 @@ def test_rename_api_key_wrong_user(enable_factory_create, db_session: db.Session
     api_key = UserApiKeyFactory.create(user=user1, key_name="Original Key Name")
     json_data = {"key_name": "New Key Name"}
 
-    with pytest.raises(FlaskError) as exc_info:
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
         rename_api_key(
             db_session=db_session,
             user_id=user2.user_id,  # Different user
@@ -126,10 +126,6 @@ def test_rename_api_key_logging_success(enable_factory_create, db_session: db.Se
     assert str(log_record.api_key_id) == str(api_key.api_key_id)
     assert hasattr(log_record, "user_id")
     assert str(log_record.user_id) == str(user.user_id)
-    assert hasattr(log_record, "old_key_name")
-    assert log_record.old_key_name == "Original Key Name"
-    assert hasattr(log_record, "new_key_name")
-    assert log_record.new_key_name == "New Key Name"
 
 
 def test_rename_api_key_multiple_keys_same_user(enable_factory_create, db_session: db.Session):

--- a/api/tests/src/services/users/test_rename_api_key.py
+++ b/api/tests/src/services/users/test_rename_api_key.py
@@ -1,0 +1,189 @@
+import pytest
+
+from src.adapters import db
+from src.api.route_utils import FlaskError
+from src.services.users.rename_api_key import rename_api_key
+from tests.src.db.models.factories import UserApiKeyFactory, UserFactory
+
+
+def test_rename_api_key_success(enable_factory_create, db_session: db.Session):
+    """Test that rename_api_key successfully renames an existing API key."""
+    user = UserFactory.create()
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {"key_name": "New Key Name"}
+
+    renamed_api_key = rename_api_key(
+        db_session=db_session,
+        user_id=user.user_id,
+        api_key_id=api_key.api_key_id,
+        json_data=json_data,
+    )
+
+    assert renamed_api_key.api_key_id == api_key.api_key_id
+    assert renamed_api_key.user_id == user.user_id
+    assert renamed_api_key.key_name == "New Key Name"
+    assert renamed_api_key.key_id == api_key.key_id  # key_id should remain unchanged
+    assert renamed_api_key.is_active == api_key.is_active
+    assert renamed_api_key.last_used == api_key.last_used
+
+    db_session.commit()
+    db_session.refresh(renamed_api_key)
+    assert renamed_api_key.key_name == "New Key Name"
+
+
+def test_rename_api_key_wrong_user(enable_factory_create, db_session: db.Session):
+    """Test that rename_api_key raises 404 error when API key belongs to different user."""
+    user1 = UserFactory.create()
+    user2 = UserFactory.create()
+    api_key = UserApiKeyFactory.create(user=user1, key_name="Original Key Name")
+    json_data = {"key_name": "New Key Name"}
+
+    with pytest.raises(FlaskError) as exc_info:
+        rename_api_key(
+            db_session=db_session,
+            user_id=user2.user_id,  # Different user
+            api_key_id=api_key.api_key_id,
+            json_data=json_data,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.message == "API key not found"
+
+    db_session.refresh(api_key)
+    assert api_key.key_name == "Original Key Name"
+
+
+def test_rename_api_key_same_name(enable_factory_create, db_session: db.Session):
+    """Test that rename_api_key works when setting the same name."""
+    user = UserFactory.create()
+    api_key = UserApiKeyFactory.create(user=user, key_name="Same Key Name")
+    json_data = {"key_name": "Same Key Name"}
+
+    renamed_api_key = rename_api_key(
+        db_session=db_session,
+        user_id=user.user_id,
+        api_key_id=api_key.api_key_id,
+        json_data=json_data,
+    )
+
+    assert renamed_api_key.key_name == "Same Key Name"
+    assert renamed_api_key.api_key_id == api_key.api_key_id
+
+
+def test_rename_api_key_preserves_other_fields(enable_factory_create, db_session: db.Session):
+    """Test that rename_api_key only changes the key_name and preserves all other fields."""
+    user = UserFactory.create()
+    api_key = UserApiKeyFactory.create(
+        user=user,
+        key_name="Original Key Name",
+        is_active=False,
+        last_used=None,
+    )
+
+    original_api_key_id = api_key.api_key_id
+    original_key_id = api_key.key_id
+    original_user_id = api_key.user_id
+    original_is_active = api_key.is_active
+    original_last_used = api_key.last_used
+    original_created_at = api_key.created_at
+
+    json_data = {"key_name": "Updated Key Name"}
+
+    renamed_api_key = rename_api_key(
+        db_session=db_session,
+        user_id=user.user_id,
+        api_key_id=api_key.api_key_id,
+        json_data=json_data,
+    )
+
+    assert renamed_api_key.key_name == "Updated Key Name"
+    assert renamed_api_key.api_key_id == original_api_key_id
+    assert renamed_api_key.key_id == original_key_id
+    assert renamed_api_key.user_id == original_user_id
+    assert renamed_api_key.is_active == original_is_active
+    assert renamed_api_key.last_used == original_last_used
+    assert renamed_api_key.created_at == original_created_at
+
+
+def test_rename_api_key_logging_success(enable_factory_create, db_session: db.Session, caplog):
+    """Test that rename_api_key logs appropriate success messages."""
+    user = UserFactory.create()
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {"key_name": "New Key Name"}
+
+    with caplog.at_level("INFO"):
+        rename_api_key(
+            db_session=db_session,
+            user_id=user.user_id,
+            api_key_id=api_key.api_key_id,
+            json_data=json_data,
+        )
+
+    assert any("Renamed API key" in record.message for record in caplog.records)
+
+    log_record = next(record for record in caplog.records if "Renamed API key" in record.message)
+    assert hasattr(log_record, "api_key_id")
+    assert str(log_record.api_key_id) == str(api_key.api_key_id)
+    assert hasattr(log_record, "user_id")
+    assert str(log_record.user_id) == str(user.user_id)
+    assert hasattr(log_record, "old_key_name")
+    assert log_record.old_key_name == "Original Key Name"
+    assert hasattr(log_record, "new_key_name")
+    assert log_record.new_key_name == "New Key Name"
+
+
+def test_rename_api_key_multiple_keys_same_user(enable_factory_create, db_session: db.Session):
+    """Test that rename_api_key correctly identifies the right key when user has multiple keys."""
+    user = UserFactory.create()
+    api_key1 = UserApiKeyFactory.create(user=user, key_name="Key 1")
+    api_key2 = UserApiKeyFactory.create(user=user, key_name="Key 2")
+
+    json_data = {"key_name": "Renamed Key 2"}
+
+    renamed_api_key = rename_api_key(
+        db_session=db_session,
+        user_id=user.user_id,
+        api_key_id=api_key2.api_key_id,
+        json_data=json_data,
+    )
+
+    assert renamed_api_key.api_key_id == api_key2.api_key_id
+    assert renamed_api_key.key_name == "Renamed Key 2"
+
+    db_session.refresh(api_key1)
+    assert api_key1.key_name == "Key 1"
+
+
+def test_rename_api_key_long_name(enable_factory_create, db_session: db.Session):
+    """Test that rename_api_key handles long key names correctly."""
+    user = UserFactory.create()
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+
+    long_name = "A" * 255
+    json_data = {"key_name": long_name}
+
+    renamed_api_key = rename_api_key(
+        db_session=db_session,
+        user_id=user.user_id,
+        api_key_id=api_key.api_key_id,
+        json_data=json_data,
+    )
+
+    assert renamed_api_key.key_name == long_name
+    assert len(renamed_api_key.key_name) == 255
+
+
+def test_rename_api_key_empty_name_handled_by_schema(enable_factory_create, db_session: db.Session):
+    """Test that empty key names are handled by schema validation (not by the service)."""
+    user = UserFactory.create()
+    api_key = UserApiKeyFactory.create(user=user, key_name="Original Key Name")
+    json_data = {"key_name": ""}
+
+    renamed_api_key = rename_api_key(
+        db_session=db_session,
+        user_id=user.user_id,
+        api_key_id=api_key.api_key_id,
+        json_data=json_data,
+    )
+
+    assert renamed_api_key.key_name == ""


### PR DESCRIPTION
## Summary

Fixes #5798
 

## Changes proposed

Added endpoint and utilities to rename an API key

