### PR TITLE
Infra 5775 - Fix API Gateway timeout length

### DIFF
--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -51,7 +51,7 @@ resource "aws_api_gateway_integration" "api_proxy_integration" {
     "integration.request.path.proxy" = "method.request.path.proxy"
   }
 
-  timeout_milliseconds = 180000
+  timeout_milliseconds = 29000
 }
 
 resource "aws_api_gateway_deployment" "api_deployment" {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5775 

## Changes proposed

- Set timeout length to max allowed

## Context for reviewers

The previous PR setup the API Gateway, but we changed the timeout to match what's on the ALB and didn't test it. This PR drops the timeout to the [max allowed](https://github.com/HHS/simpler-grants-gov/actions/runs/17080242780/job/48432945359#step:5:1898)

## Validation steps

I can deploy this manually to test, I'll post the results here once tested
