### PR TITLE
[Issue #6016] fix conditional nested requires

### DIFF
--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -547,7 +547,6 @@ export const shapeFormData = <T extends object>(formData: FormData): T => {
     delimiter: "--",
   });
   return pruneEmptyNestedFields(structuredFormData) as T;
-  // return structuredFormData as T;
 };
 
 // arrays from the html look like field_[row]_item

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -502,19 +502,28 @@ const isBasicallyAnObject = (mightBeAnObject: unknown): boolean => {
   );
 };
 
+const isEmptyField = (mightBeEmpty: unknown): boolean => {
+  if (mightBeEmpty === undefined) {
+    return true;
+  }
+  return Object.values(mightBeEmpty as object).every((nestedValue) => {
+    if (isBasicallyAnObject(nestedValue)) {
+      return isEmptyField(nestedValue);
+    }
+    return !nestedValue;
+  });
+};
+
 // if a nested field contains no defined items, remove it from the data
 // this may not be necessary, as JSON.stringify probably does the same thing
 export const pruneEmptyNestedFields = (structuredFormData: object): object => {
   return Object.entries(structuredFormData).reduce(
     (acc, [key, value]) => {
-      if (!isBasicallyAnObject(value)) {
+      if (!isBasicallyAnObject(value) && value !== undefined) {
         acc[key] = value;
         return acc;
       }
-      const isEmptyObject = Object.values(value as object).every(
-        (nestedValue) => !nestedValue,
-      );
-      if (isEmptyObject) {
+      if (isEmptyField(value)) {
         return acc;
       }
       const pruned = pruneEmptyNestedFields(value as object);
@@ -538,6 +547,7 @@ export const shapeFormData = <T extends object>(formData: FormData): T => {
     delimiter: "--",
   });
   return pruneEmptyNestedFields(structuredFormData) as T;
+  // return structuredFormData as T;
 };
 
 // arrays from the html look like field_[row]_item

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -477,32 +477,34 @@ describe("getFieldSchema", () => {
 });
 
 describe("pruneEmptyNestedFields", () => {
-  it("returns flat object unchanged", () => {
+  it("returns flat object with undefined fields removed", () => {
     const flat = {
       thing: 1,
       another: "string",
-      bad: null,
+      bad: undefined,
       stuff: [2, "hi"],
     };
-    expect(pruneEmptyNestedFields(flat)).toEqual(flat);
+    expect(pruneEmptyNestedFields(flat)).toEqual({
+      thing: 1,
+      another: "string",
+      stuff: [2, "hi"],
+    });
   });
   it("returns empty object if passed an empty object or object with only undefined fields", () => {
     const empty = {};
     expect(pruneEmptyNestedFields(empty)).toEqual(empty);
   });
-  it("prunes only top level empty objects", () => {
+  it("prunes all empty objects and objects containing only undefined properties", () => {
     const undefinedFields = {
       whatever: {
         again: { something: undefined },
         another: undefined,
-        more: { stuff: undefined },
+        more: {},
       },
     };
-    expect(pruneEmptyNestedFields(undefinedFields)).toEqual({
-      whatever: { another: undefined },
-    });
+    expect(pruneEmptyNestedFields(undefinedFields)).toEqual({});
   });
-  it("removes nested objects containing only undefined properties", () => {
+  it("removes nested objects containing only undefined properties or objects with only undefined properties", () => {
     expect(
       pruneEmptyNestedFields({
         thing: "stuff",
@@ -522,7 +524,6 @@ describe("pruneEmptyNestedFields", () => {
       }),
     ).toEqual({
       thing: "stuff",
-      another: {},
       keepMe: {
         here: {
           ok: "sure",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6016

This is a bit of a prerequisite for https://github.com/HHS/simpler-grants-gov/issues/5832

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

An issue exists where validation of conditionally required fields were coming back with false positives. By making sure we do not pass any form data up for fields that do not have data we can ensure that these false validation failures occur.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->



1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. open the sf-LLL form
4. click save
5. _VALIDATE_: no validation errors are returned relating to the `prime_reporting_entity`
6. select "subawardee" as "entity type"
7. click save
5. _VALIDATE_: validation error is returned relating to the `prime_reporting_entity` as a required property

Note that this state is not ideal, and https://github.com/HHS/simpler-grants-gov/issues/5832 will address the situation from here