### PR TITLE
Bug/Turn off email notification sync

### DIFF
--- a/api/src/task/notifications/config.py
+++ b/api/src/task/notifications/config.py
@@ -14,4 +14,4 @@ class EmailNotificationConfig(PydanticBaseEnvConfig):
     )
     enable_search_notifications: bool = Field(default=True, alias="ENABLE_SEARCH_NOTIFICATIONS")
     reset_emails_without_sending: bool = Field(default=True, alias="RESET_EMAILS_WITHOUT_SENDING")
-    sync_suppressed_emails: bool = Field(default=True, alias="SYNC_SUPPRESSED_EMAILS")
+    sync_suppressed_emails: bool = Field(default=False, alias="SYNC_SUPPRESSED_EMAILS")


### PR DESCRIPTION
## Summary

Temporary fix to turn off email sync until we apply infra changes to allow for hitting ses v2 suppression list endpoint

