### PR TITLE
[Issue #5958] Sort the application forms when fetching an application

### DIFF
--- a/api/src/services/applications/get_application.py
+++ b/api/src/services/applications/get_application.py
@@ -75,6 +75,11 @@ def get_application(
     if not application:
         raise_flask_error(404, f"Application with ID {application_id} not found")
 
+    # To make sure the UI displays forms in a consistent order, sort the application_forms list
+    # NOTE: Trying to put this in an order_by in the relationship doesn't work as we can't sort on a joined value
+    #       Haven't found a way to sort this when querying above that doesn't break the query
+    application.application_forms.sort(key=lambda app_form: app_form.form.form_name)
+
     # Check if the user has access to the application (skip for internal users or when user is None)
     if not is_internal_user and user is not None:
         check_user_application_access(application, user)


### PR DESCRIPTION
## Summary
Fixes #5958 

## Changes proposed
Modified fetching an application to sort the application forms list by form name

## Context for reviewers
The order of app forms was random and could shuffle upon refreshing the application page which was confusing/annoying.

Ideally the right way to do this sorting is add `order_by` to the relationship, but we don't have the form name in that table and it doesn't let us do joins there. I couldn't find a way to sort a relationship during a query, so just do it in code on the DB record which should be fine.

## Validation steps
Going to the local apply page, we now consistently get a sorted order:

<img width="736" height="837" alt="Screenshot 2025-08-20 at 3 38 02 PM" src="https://github.com/user-attachments/assets/05056ee2-ee3e-4694-8164-a58ca0b3df9d" />
