### PR TITLE
[Issue #6050] Rename analytics user table

### DIFF
--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0013_rename_user_table.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0013_rename_user_table.sql
@@ -1,0 +1,5 @@
+-- Migration to rename the user table to user_data
+-- This addresses potential conflicts with reserved keywords in some SQL contexts
+
+-- Rename the table from "user" to user_data
+ALTER TABLE "user" RENAME TO user_data;

--- a/analytics/src/analytics/integrations/extracts/constants.py
+++ b/analytics/src/analytics/integrations/extracts/constants.py
@@ -13,7 +13,7 @@ class OpportunityTables(StrEnum):
     CURRENT_OPPORTUNITY_SUMMARY = "current_opportunity_summary"
     USER_SAVED_OPPORTUNITY = "user_saved_opportunity"
     USER_SAVED_SEARCH = "user_saved_search"
-    USER = "user"
+    USER_DATA = "user_data"
 
 
 LK_OPPORTUNITY_STATUS_COLS = (
@@ -129,5 +129,11 @@ MAP_TABLES_TO_COLS: dict[OpportunityTables, tuple[str, ...]] = {
     OpportunityTables.CURRENT_OPPORTUNITY_SUMMARY: CURRENT_OPPORTUNITY_SUMMARY_COLS,
     OpportunityTables.USER_SAVED_OPPORTUNITY: USER_SAVED_OPPORTUNITY_COLS,
     OpportunityTables.USER_SAVED_SEARCH: USER_SAVED_SEARCH_COLS,
-    OpportunityTables.USER: USER_COLS,
+    OpportunityTables.USER_DATA: USER_COLS,
+}
+
+# Optional mapping for cases where file name differs from table name
+# If a table is not in this mapping, the file name will be the same as the table name
+MAP_TABLE_TO_FILE_NAME: dict[OpportunityTables, str] = {
+    OpportunityTables.USER_DATA: "user",
 }

--- a/analytics/src/analytics/integrations/extracts/load_opportunity_data.py
+++ b/analytics/src/analytics/integrations/extracts/load_opportunity_data.py
@@ -12,6 +12,7 @@ from sqlalchemy import Connection
 
 from analytics.integrations.etldb.etldb import EtlDb
 from analytics.integrations.extracts.constants import (
+    MAP_TABLE_TO_FILE_NAME,
     MAP_TABLES_TO_COLS,
     OpportunityTables,
 )
@@ -64,10 +65,13 @@ def _fetch_insert_opportunity_data(conn: Connection) -> None:
                        FROM STDIN WITH (FORMAT CSV, DELIMITER ',', QUOTE '"', HEADER)
                     """
 
+        # Use custom file name if mapping exists, otherwise use table name
+        file_name = MAP_TABLE_TO_FILE_NAME.get(table, table)
+
         with ExitStack() as stack:
             file = stack.enter_context(
                 smart_open.open(
-                    f"{s3_config.load_opportunity_data_file_path}/{table}.csv",
+                    f"{s3_config.load_opportunity_data_file_path}/{file_name}.csv",
                     "r",
                 ),
             )

--- a/analytics/tests/conftest.py
+++ b/analytics/tests/conftest.py
@@ -402,6 +402,7 @@ def _create_opportunity_table(conn: EtlDb.connection, schema: str) -> None:
             "0010_add_user_saved_opportunity_and_search_tables.sql",
             "0011_update_to_uuid_primary_keys.sql",
             "0012_add_user_tables.sql",
+            "0013_rename_user_table.sql",
         ]
 
         for filename in sql_files:

--- a/analytics/tests/integrations/extracts/test_load_opportunity_data.py
+++ b/analytics/tests/integrations/extracts/test_load_opportunity_data.py
@@ -113,7 +113,7 @@ def test_extract_copy_opportunity_data(
 
         assert (
             conn.execute(
-                text('SELECT COUNT(*) FROM "user" ;'),
+                text("SELECT COUNT(*) FROM user_data ;"),
             ).fetchone()[0]
             == 7
         )


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6050 

## Changes proposed

- Added migration `0013_rename_user_table.sql` to rename the `user` table to `user_data`
- Updated `OpportunityTables` enum to use `USER_DATA` instead of `USER` 
- Introduced `MAP_TABLE_TO_FILE_NAME` mapping to handle cases where database table names differ from CSV file names
- Updated `load_opportunity_data.py` to use the new table-to-filename mapping system

## Context for reviewers

This change addresses potential conflicts with the reserved keyword "user" in SQL contexts by renaming the table to `user_data`. The migration is straightforward - it simply renames the existing table.

## Validation steps

`make test-audit`