### PR TITLE
[Issue #6084] disable sf424b postpopulated fields

### DIFF
--- a/api/src/form_schema/forms/sf424b.py
+++ b/api/src/form_schema/forms/sf424b.py
@@ -52,7 +52,7 @@ FORM_JSON_SCHEMA = {
     "required": ["title", "applicant_organization"],
     "properties": {
         "signature": {
-            "type": "string",
+            "type": "null",
             "title": "Signature of the Authorized Certifying Official",
             "description": "Completed by Grants.gov upon submission.",
             "minLength": 1,
@@ -75,7 +75,7 @@ FORM_JSON_SCHEMA = {
             "maxLength": 60,
         },
         "date_signed": {
-            "type": "string",
+            "type": "null",
             "format": "date",
             "title": "Date Signed",
             "description": "Completed by Grants.gov upon submission.",

--- a/frontend/src/components/application/ApplicationFormsTable.tsx
+++ b/frontend/src/components/application/ApplicationFormsTable.tsx
@@ -246,8 +246,6 @@ const CompetitionStatus = ({
         {t("complete")}
       </div>
     );
-  } else {
-    return <>-</>;
   }
 };
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6084

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Disables postpopulated signature and signed date fields in sf424b

Also minor bug fix of unnecessary character in forms table

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. open the sf424b
4. _VERIFY_: signature and signed date fields are disabled