### PR TITLE
[unticketed] strip cruft from valdation field path

### DIFF
--- a/frontend/src/components/applyForm/ApplyFormMessage.tsx
+++ b/frontend/src/components/applyForm/ApplyFormMessage.tsx
@@ -3,6 +3,9 @@ import { Alert } from "@trussworks/react-uswds";
 
 import { FormValidationWarning } from "./types";
 
+const removeLeadingFieldPathCruft = (fieldName: string): string =>
+  fieldName.replace(/^\$\./, "");
+
 export const ApplyFormMessage = ({
   error,
   validationWarnings,
@@ -44,7 +47,9 @@ export const ApplyFormMessage = ({
         <ul>
           {validationWarnings.map((warning, index) => (
             <li key={index}>
-              <a href={`#${warning.field}`}>{warning.message}</a>
+              <a href={`#${removeLeadingFieldPathCruft(warning.field)}`}>
+                {warning.message}
+              </a>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes bug related to incorrect anchor links being set in form validation warnings

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This bug may originate here, though I'm not positive https://github.com/HHS/simpler-grants-gov/pull/6070/files

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. open the sf424
4. click save
5. click the first validation warning link
6. _VERIFY_: link takes you to the correct field