### PR TITLE
[Issue #6045] Update flatFormDataToArray and upload widget

### DIFF
--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -375,6 +375,7 @@ export const formatFieldWarnings = (
       },
       {} as Record<string, unknown>,
     );
+
     return flatFormDataToArray(name, warningMap) as unknown as [];
   }
   const warningsforField = getWarningsForField(name, required, warnings);
@@ -549,8 +550,12 @@ export const isFieldRequired = (
   return requiredFields.indexOf(path) > -1;
 };
 
-// arrays from the html look like field_[row]_item
-const flatFormDataToArray = (field: string, data: Record<string, unknown>) => {
+// arrays from the html look like field_[row]_item or are simply the field name
+export const flatFormDataToArray = (
+  field: string,
+  data: Record<string, unknown>,
+) => {
+  if (field in data) return [data[field]];
   return Object.entries(data).reduce(
     (values: Array<Record<string, unknown>>, [key, value]) => {
       const fieldSplit = key.split(/\[\d+\]\./);

--- a/frontend/src/components/applyForm/widgets/MultipleAttachmentUploadWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/MultipleAttachmentUploadWidget.tsx
@@ -25,7 +25,6 @@ import { getLabelTypeFromOptions } from "./getLabelTypeFromOptions";
 import { MultipleAttachmentUploadList } from "./MultiAttachmentUploadList";
 
 const MultipleAttachmentUploadWidget = ({
-  error,
   id,
   value: initialValue,
   required,
@@ -159,7 +158,7 @@ const MultipleAttachmentUploadWidget = ({
         labelType={labelType}
       />
 
-      {error && (
+      {hasError && (
         <ErrorMessage id={`error-for-${id}`}>
           {String(rawErrors[0])}
         </ErrorMessage>

--- a/frontend/tests/components/applyForm/utils.test.tsx
+++ b/frontend/tests/components/applyForm/utils.test.tsx
@@ -7,6 +7,7 @@ import {
   buildField,
   condenseFormSchemaProperties,
   determineFieldType,
+  flatFormDataToArray,
   formatFieldWarnings,
   getFieldName,
   getFieldSchema,
@@ -566,5 +567,54 @@ describe("formatFieldWarnings", () => {
         true,
       ),
     ).toEqual(["parent is required"]);
+  });
+});
+
+describe("flatFormDataToArray", () => {
+  it("returns array with single value if field exists directly", () => {
+    const data = { foo: "bar" };
+    expect(flatFormDataToArray("foo", data)).toEqual(["bar"]);
+  });
+
+  it("returns array of objects for indexed keys", () => {
+    const data = {
+      "tasks[0].title": "Task 1",
+      "tasks[1].title": "Task 2",
+    };
+    expect(flatFormDataToArray("tasks", data)).toEqual([
+      { title: "Task 1" },
+      { title: "Task 2" },
+    ]);
+  });
+
+  it("returns empty array if field not present", () => {
+    const data = { something: 123 };
+    expect(flatFormDataToArray("notfound", data)).toEqual([]);
+  });
+
+  it("handles sparse arrays", () => {
+    const data = {
+      "items[2].name": "third",
+      "items[0].name": "first",
+    };
+    expect(flatFormDataToArray("items", data)).toEqual([
+      { name: "first" },
+      undefined,
+      { name: "third" },
+    ]);
+  });
+
+  it("ignores falsy values", () => {
+    const data = {
+      "arr[0].val": null,
+      "arr[1].val": undefined,
+      "arr[2].val": "ok",
+    };
+
+    expect(flatFormDataToArray("arr", data)).toEqual([
+      undefined,
+      undefined,
+      { val: "ok" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6045 

## Changes proposed

Updates `flatFormDataToArray()` to return the correct errors for the upload widgets.

The updated form behavior:

<img width="842" height="650" alt="image" src="https://github.com/user-attachments/assets/9a9a9650-a687-40d0-859d-022bd60f8c76" />



## Context for reviewers

We have an issue with array support. Currently arrays are supported through the budget form and the upload widget. They both want data in a different form, so the `flatFormDataToArray()` function returns an array of objects for the budget form or a array of strings for the upload widget. 

We currently don't support generic arrays. I created #6092 to address this.

