### PR TITLE
add attachments provider to form print view

### DIFF
--- a/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
@@ -63,7 +63,13 @@ export default async function FormPage({ params }: FormPageProps) {
     return <TopLevelError />;
   }
 
-  const { applicationResponse, formName, formSchema, formUiSchema } = data;
+  const {
+    applicationResponse,
+    formName,
+    formSchema,
+    formUiSchema,
+    applicationAttachments,
+  } = data;
 
   return (
     <>
@@ -72,6 +78,7 @@ export default async function FormPage({ params }: FormPageProps) {
         savedFormData={applicationResponse}
         formSchema={formSchema}
         uiSchema={formUiSchema}
+        attachments={applicationAttachments}
       />
     </>
   );

--- a/frontend/src/components/applyForm/PrintForm.tsx
+++ b/frontend/src/components/applyForm/PrintForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { RJSFSchema } from "@rjsf/utils";
+import { AttachmentsProvider } from "src/hooks/ApplicationAttachments";
+import { Attachment } from "src/types/attachmentTypes";
 
 import { FormFields } from "./FormFields";
 import { UiSchema } from "./types";
@@ -9,17 +11,21 @@ export default function PrintForm({
   formSchema,
   savedFormData,
   uiSchema,
+  attachments,
 }: {
   formSchema: RJSFSchema;
   savedFormData: object;
   uiSchema: UiSchema;
+  attachments: Attachment[];
 }) {
   return (
-    <FormFields
-      errors={null}
-      formData={savedFormData}
-      schema={formSchema}
-      uiSchema={uiSchema}
-    />
+    <AttachmentsProvider value={attachments ?? []}>
+      <FormFields
+        errors={null}
+        formData={savedFormData}
+        schema={formSchema}
+        uiSchema={uiSchema}
+      />
+    </AttachmentsProvider>
   );
 }


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes bug where the print route for forms that have attachments fails due to lack of an AttachmentsProvider

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. visit a form page for a form with attachments
2. generate an internal api token
3. add the internal api token as X-SGG-Internal-Token header using mod header
4. load up something like this http://localhost:3000/print/application/2ddc1e3d-1c7f-45b3-a1a8-f7083220570a/form/6d0795bc-e733-4031-a063-b49417c759a0
5. _VERIFY_: page loads