### PR TITLE
Infra 6106 - Attach additional ALB certs and tidy up gateway

### DIFF
--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -6,6 +6,7 @@ module "dev_config" {
   environment                     = "dev"
   network_name                    = "dev"
   domain_name                     = "api.dev.simpler.grants.gov"
+  secondary_domain_names          = ["alb.dev.simpler.grants.gov"]
   s3_cdn_domain_name              = "files.dev.simpler.grants.gov"
   mtls_domain_name                = "soap.dev.simpler.grants.gov"
   enable_https                    = true

--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -27,6 +27,7 @@ output "service_config" {
     instance_memory                 = var.instance_memory
     service_name                    = "${local.prefix}${var.app_name}-${var.environment}"
     domain_name                     = var.domain_name
+    secondary_domain_names          = var.secondary_domain_names
     s3_cdn_domain_name              = var.s3_cdn_domain_name
     mtls_domain_name                = var.mtls_domain_name
     enable_https                    = var.enable_https

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -185,3 +185,9 @@ variable "service_override_extra_environment_variables" {
   EOT
   default     = {}
 }
+
+variable "secondary_domain_names" {
+  type        = list(string)
+  description = "A list of domain names the ALB can also use"
+  default     = []
+}

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -6,6 +6,7 @@ module "prod_config" {
   environment                     = "prod"
   network_name                    = "prod"
   domain_name                     = "api.simpler.grants.gov"
+  secondary_domain_names          = ["alb.simpler.grants.gov"]
   enable_https                    = true
   s3_cdn_domain_name              = "files.simpler.grants.gov"
   mtls_domain_name                = "soap.simpler.grants.gov"

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -6,6 +6,7 @@ module "staging_config" {
   environment                     = "staging"
   network_name                    = "staging"
   domain_name                     = "api.staging.simpler.grants.gov"
+  secondary_domain_names          = ["alb.staging.simpler.grants.gov"]
   s3_cdn_domain_name              = "files.staging.simpler.grants.gov"
   mtls_domain_name                = "soap.staging.simpler.grants.gov"
   enable_https                    = true

--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -44,8 +44,8 @@ resource "aws_api_gateway_integration" "api_proxy_integration" {
 
   integration_http_method = aws_api_gateway_method.api_proxy_method[0].http_method
   type                    = "HTTP_PROXY"
-  # This will be changed to use a new ALB DNS and cert
-  uri = "https://${var.domain_name}/{proxy}"
+
+  uri = "https://${var.optional_extra_alb_domains[0]}/{proxy}"
 
   request_parameters = {
     "integration.request.path.proxy" = "method.request.path.proxy"
@@ -84,18 +84,16 @@ resource "aws_api_gateway_stage" "api_v1_stage" {
   rest_api_id   = aws_api_gateway_rest_api.api[0].id
   stage_name    = "v1"
 
-  # access_log_settings {
-  #   destination_arn = aws_cloudwatch_log_group.api_gateway_logs[0].arn
-  #   format          = "{ \"requestId\":\"$context.requestId\", \"extendedRequestId\":\"$context.extendedRequestId\",\"ip\": \"$context.identity.sourceIp\", \"caller\":\"$context.identity.caller\", \"apiKeyId\":\"$context.identity.apiKeyId\", \"requestTime\":\"$context.requestTime\", \"httpMethod\":\"$context.httpMethod\", \"resourcePath\":\"$context.resourcePath\", \"status\":\"$context.status\", \"protocol\":\"$context.protocol\", \"responseLength\":\"$context.responseLength\", \"responseLatency\": \"$context.responseLatency\" }"
-  # }
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_gateway_logs[0].arn
+    format          = "{ \"requestId\":\"$context.requestId\", \"extendedRequestId\":\"$context.extendedRequestId\",\"ip\": \"$context.identity.sourceIp\", \"caller\":\"$context.identity.caller\", \"apiKeyId\":\"$context.identity.apiKeyId\", \"requestTime\":\"$context.requestTime\", \"httpMethod\":\"$context.httpMethod\", \"resourcePath\":\"$context.resourcePath\", \"status\":\"$context.status\", \"protocol\":\"$context.protocol\", \"responseLength\":\"$context.responseLength\", \"responseLatency\": \"$context.responseLatency\" }"
+  }
 
   # checkov:skip=CKV_AWS_73:X-Ray can increase costs greatly, and aren't always necessary
   # checkov:skip=CKV2_AWS_29:WAF can be enabled at a later time if needed
   # checkov:skip=CKV2_AWS_51:Mutual TLS increases complexity for downstream systems
   # checkov:skip=CKV2_AWS_4:Log level and format is already set
   # checkov:skip=CKV_AWS_120:Cache disabled for now, will be followed up in a future ticket
-  # TEMP
-  # checkov:skip=CKV_AWS_76:Logging is dependent on a role being created in the infra/accounts playbook, but that isn't running first
 }
 
 resource "aws_cloudwatch_log_group" "api_gateway_logs" {
@@ -117,7 +115,7 @@ resource "aws_api_gateway_method_settings" "api_v1_stage_settings" {
 
   settings {
     metrics_enabled = true
-    # logging_level   = "INFO"
+    logging_level   = "INFO"
   }
   # checkov:skip=CKV2_AWS_4:Log level set to info
   # checkov:skip=CKV_AWS_225:Cache disabled for now, will be followed up in a future ticket

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -108,6 +108,14 @@ resource "aws_lb_listener" "alb_listener_https" {
   }
 }
 
+# Optional resource, used for if the ALB has multiple certificates
+resource "aws_lb_listener_certificate" "alb_listener_https_optional_extra_certs" {
+  for_each = toset(var.enable_load_balancer ? var.optional_extra_alb_certs : [])
+
+  listener_arn    = aws_lb_listener.alb_listener_https[1].arn
+  certificate_arn = each.value
+}
+
 resource "aws_lb_listener_rule" "app_https_forward" {
   # we need an identical https forward, with mtls enabled
   # so we piggy back off existing and just spin up two when the api sets this true

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -330,3 +330,15 @@ variable "mtls_certificate_arn" {
   type        = string
   default     = null
 }
+
+variable "optional_extra_alb_certs" {
+  description = "Optional: Stores the ARN for extra certs to attach to the ALB"
+  type        = list(string)
+  default     = []
+}
+
+variable "optional_extra_alb_domains" {
+  description = "Optional: Other domains the ALB is configured to accept traffic to. Requires optional_extra_alb_certs to be set"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6106

## Changes proposed

- Logic for optionally attaching extra certs to ALB
- Enable API gateway logging
- Point API gateway to secondary domain on ALB

## Context for reviewers

This PR has two main parts to it, adding logic for optionally attaching secondary certs to the ALB, and tidying up the API gateway setup. 

### ALB changes

For this part, I wanted to setup the ALB changes to be modular enough that it won't break in case we pass no extra domains to it, but allow it to take in more than a single extra domain in case more are added in the future. This is done in preparation for the cutover for the public DNS for the api.*.simpler... to point from the ALB to the API gateway. The DNS is already setup for alb.*.simpler..., so we can point the API gateway to that, and be ready for the cutover when it happens

### API Gateway changes

This part has a change for enabling logging, and a change to the logic for what domain the proxy forwards to. For the logging change, there was an issue from my first PR where I thought the accounts playbook would be deployed via terraform, but that didn't happen. I merged a second PR that disabled it until I got accounts deployed, which needed to be done manually and is now set. Now we can enable it again and have it log as expected. The other change is to point the gateway proxy from the main domain, `api...`, to the secondary, `alb...`, so that the cutover is only required to be done on the DNS side. This will let us test the cutover before going live

There might be another change to enable the domain association, which is currently commented out, but I'll have to test to make sure it won't break anything first. I'll edit the PR body if I can enable it with a blurb about it

## Validation steps

Validation will be done manually. I'll call out in Slack before testing, then deploy the changes and test. Once things are validated, I'll update the PR and revert the changes so that I don't introduce drift
