### PR TITLE
[Issue #5959] Add Application Status to Get Application Form endpoint

### DIFF
--- a/api/src/db/models/competition_models.py
+++ b/api/src/db/models/competition_models.py
@@ -326,6 +326,10 @@ class ApplicationForm(ApiSchemaTable, TimestampMixin):
     def application_name(self) -> str | None:
         return self.application.application_name
 
+    @property
+    def application_status(self) -> "ApplicationStatus | None":
+        return self.application.application_status
+
 
 class ApplicationAttachment(ApiSchemaTable, TimestampMixin):
     __tablename__ = "application_attachment"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #5959

## Changes proposed

Add Application Status to Get Application Form endpoint
Update unit tests

## Context for reviewers

In order to hide the Save button on all forms after an application has been submitted, we need to pass the Application Status back to the front end.

## Validation steps

See unit tests