### PR TITLE
[Issue #6097]: Delinquent Federal Debt Radio button

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -975,6 +975,7 @@ FORM_UI_SCHEMA = [
             {
                 "type": "field",
                 "definition": "/properties/delinquent_federal_debt",
+                "widget": "Radio",
             },
             {
                 "type": "field",

--- a/frontend/src/components/applyForm/utils.tsx
+++ b/frontend/src/components/applyForm/utils.tsx
@@ -279,7 +279,7 @@ export const buildField = ({
   const disabled = fieldType === "null";
   let options = {};
 
- // Provide enumOptions for Select, MultiSelect, and Radio
+  // Provide enumOptions for Select, MultiSelect, and Radio
   if (type === "Select" || type === "MultiSelect" || type === "Radio") {
     let enums: string[] = [];
 

--- a/frontend/src/components/applyForm/widgets/RadioWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/RadioWidget.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   enumOptionsIsSelected,
   enumOptionsValueForIndex,
@@ -5,20 +7,64 @@ import {
   optionId,
   RJSFSchema,
   StrictRJSFSchema,
+  EnumOptionsType,
 } from "@rjsf/utils";
-
-import { FocusEvent, useCallback, useMemo } from "react";
+import React, { FocusEvent, useCallback, useMemo } from "react";
 import { ErrorMessage, FormGroup, Radio } from "@trussworks/react-uswds";
 
 import { TextTypes, UswdsWidgetProps } from "src/components/applyForm/types";
 import { DynamicFieldLabel } from "./DynamicFieldLabel";
 import { getLabelTypeFromOptions } from "./getLabelTypeFromOptions";
 
-/** The `RadioWidget` is a widget for rendering a radio group.
- *  It is typically used with a string property constrained with enum options.
- *
- * @param props - The `WidgetProps` for this component
+/**
+ * The portion of `options` we care about here, with safe typing.
+ * we shape our data since RJSF’s options are loosely typed.
  */
+type LocalOptions<S extends StrictRJSFSchema> = {
+  enumDisabled?: Array<string | number | boolean>;
+  emptyValue?: unknown;
+  enumOptions?: EnumOptionsType<S>[];
+  "widget-label"?: unknown;
+};
+
+/**
+ * normalizeForCompare
+ * 
+ * Given an option’s value and the current field value, we force the current value type
+ * so it compares correctly with the option's representation.
+ */
+function normalizeForCompare(optionValue: unknown, current: unknown): unknown {
+  const optionIsBoolString = optionValue === "true" || optionValue === "false";
+  if (optionIsBoolString) {
+    if (current === true) return "true";
+    if (current === false) return "false";
+    if (current === "true" || current === "false") return current;
+    return undefined;
+  }
+
+  return current;
+}
+
+/**
+ * parseFromInputValue
+ * 
+ * Convert an HTML input value (always a string) to the type we want to emit
+ * in events (`onChange`, `onBlur`, `onFocus`).
+ *
+ * If this radio group represents a boolean (options include "true"/"false"),
+ * return a *boolean* true/false.
+ * Otherwise, return the raw string value.
+ */
+function parseFromInputValue<S extends StrictRJSFSchema>(
+  raw: string,
+  enumOptions: ReadonlyArray<EnumOptionsType<S>>,
+): boolean | string {
+  const usesBoolStrings = enumOptions.some(
+    (option) => option.value === "true" || option.value === "false",
+  );
+  return usesBoolStrings ? raw === "true" : raw;
+}
+
 function RadioWidget<
   T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -34,50 +80,70 @@ function RadioWidget<
   autofocus = false,
   rawErrors = [],
   updateOnInput = false,
-  // passing on* functions made optional
   onChange = () => ({}),
   onBlur = () => ({}),
   onFocus = () => ({}),
 }: UswdsWidgetProps<T, S, F>) {
   const { title, enum: enumFromSchema, description } = schema;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { enumDisabled, emptyValue } = options;
+
+  // Extract and safely type the options we use
+  const { enumDisabled, emptyValue, enumOptions: uiEnumOptions } =
+    (options as LocalOptions<S>) ?? {};
+
   const labelType = getLabelTypeFromOptions(options?.["widget-label"]);
 
-  const enumOptions = useMemo(
-    () =>
-      (enumFromSchema ?? []).map((value) => ({
-        label: String(value),
-        value,
-      })),
-    [enumFromSchema],
-  );
+  /**
+   * Determine our list of options
+   */
+  const enumOptions: EnumOptionsType<S>[] = useMemo(() => {
+    if (Array.isArray(uiEnumOptions) && uiEnumOptions.length) {
+      return uiEnumOptions;
+    }
+    const fromSchema =
+      Array.isArray(enumFromSchema) && enumFromSchema.length
+        ? enumFromSchema.map((v) => ({ label: String(v), value: v }))
+        : [];
+    return fromSchema as EnumOptionsType<S>[];
+  }, [uiEnumOptions, enumFromSchema]);
 
+  /**
+   * Event helpers: 
+   * 
+   * convert the input string to a value 
+   * before passing to RJSF handlers.
+   */
   const handleBlur = useCallback(
-    ({ target }: FocusEvent<HTMLInputElement>) =>
-      onBlur(
-        id,
-        enumOptionsValueForIndex<S>(
-          target && target.value,
-          enumOptions,
-          emptyValue,
-        ),
-      ),
+    ({ target }: FocusEvent<HTMLInputElement>) => {
+      const next = enumOptionsValueForIndex<S>(
+        target?.value,
+        enumOptions,
+        emptyValue,
+      );
+      const coerced =
+        typeof next === "undefined"
+          ? (parseFromInputValue(String(target?.value ?? ""), enumOptions) as T)
+          : (next as T);
+      onBlur(id, coerced);
+    },
     [onBlur, id, enumOptions, emptyValue],
   );
 
   const handleFocus = useCallback(
-    ({ target }: FocusEvent<HTMLInputElement>) =>
-      onFocus(
-        id,
-        enumOptionsValueForIndex<S>(
-          target && target.value,
-          enumOptions,
-          emptyValue,
-        ),
-      ),
+    ({ target }: FocusEvent<HTMLInputElement>) => {
+      const next = enumOptionsValueForIndex<S>(
+        target?.value,
+        enumOptions,
+        emptyValue,
+      );
+      const coerced =
+        typeof next === "undefined"
+          ? (parseFromInputValue(String(target?.value ?? ""), enumOptions) as T)
+          : (next as T);
+      onFocus(id, coerced);
+    },
     [onFocus, id, enumOptions, emptyValue],
   );
+
   const error = rawErrors.length ? true : undefined;
   const describedby = error
     ? `error-for-${id}`
@@ -99,40 +165,55 @@ function RadioWidget<
         <ErrorMessage>
           {typeof rawErrors[0] === "string"
             ? rawErrors[0]
-            : Object.values(rawErrors[0])
-                .map((value) => value)
-                .join(",")}
+            : Object.values(rawErrors[0] as Record<string, string>).join(",")}
         </ErrorMessage>
       )}
-      {Array.isArray(enumOptions) &&
-        enumOptions.map((option, i) => {
-          const checked = enumOptionsIsSelected<S>(option.value, value);
-          const itemDisabled =
-            Array.isArray(enumDisabled) &&
-            enumDisabled.indexOf(option.value as TextTypes) !== -1;
 
-          const handleChange = () => onChange(option.value);
+      {enumOptions.map((option, index) => {
+        // Normalize the current value so 
+        // it can match "true"/"false" string options
+        const currentForCompare = normalizeForCompare(option.value, value);
 
-          return (
-            <Radio
-              label={option.label}
-              id={optionId(id, i)}
-              checked={updateOnInput ? checked : undefined}
-              defaultChecked={updateOnInput ? undefined : checked}
-              name={id}
-              required={required}
-              key={optionId(id, i)}
-              disabled={disabled || itemDisabled || readonly}
-              autoFocus={autofocus && i === 0}
-              defaultValue={updateOnInput ? undefined : String(option.value)}
-              value={updateOnInput ? String(option.value) : undefined}
-              onChange={updateOnInput ? handleChange : undefined}
-              onBlur={updateOnInput ? handleBlur : undefined}
-              onFocus={updateOnInput ? handleFocus : undefined}
-              aria-describedby={describedby}
-            />
-          );
-        })}
+        // Compute checked using RJSF helper 
+        // works for both strings and numbers
+        const checked = enumOptionsIsSelected<S>(option.value, currentForCompare);
+
+        const itemDisabled =
+          Array.isArray(enumDisabled) &&
+          enumDisabled.indexOf(option.value as TextTypes) !== -1;
+
+        const handleChange = () => {
+          const raw = String(option.value);
+          const toEmit = parseFromInputValue<S>(raw, enumOptions) as T;
+          onChange(toEmit);
+        };
+
+        return (
+          <Radio
+            label={option.label}
+            id={optionId(id, index)}
+            key={optionId(id, index)}
+            name={id}
+            required={required}
+            disabled={disabled || itemDisabled || readonly}
+            autoFocus={autofocus && index === 0}
+            aria-describedby={describedby}
+            checked={updateOnInput ? checked : undefined}
+            defaultChecked={updateOnInput ? undefined : checked}
+            /**
+             * Value handling:
+             * 
+             * Radios always submit a string value. We turn that string into a boolean (for
+             * "true"/"false") in our event handlers so the form data remains typed correctly.
+             */
+            value={updateOnInput ? String(option.value) : undefined}
+            defaultValue={updateOnInput ? undefined : String(option.value)}
+            onChange={updateOnInput ? handleChange : undefined}
+            onBlur={updateOnInput ? handleBlur : undefined}
+            onFocus={updateOnInput ? handleFocus : undefined}
+          />
+        );
+      })}
     </FormGroup>
   );
 }


### PR DESCRIPTION
## Summary

This is only a partial fix to: Delinquent Federal Debt [#6097](https://github.com/HHS/simpler-grants-gov/issues/6097)

## Changes proposed

I've added the Radio widget manually to the ui schema
it now displays, the YES / NO options
I tried to make it as type safe as possible
added some utils and helpers to work with the options that are returned/created 

## Context for reviewers

This does not contain the validation portion. That will come in a second PR-

## Validation steps

1. to run locally, you would need to `run npm run build && npm start`
2. `make remake-backend && docker compose up`
3. navigate to `search`
4. search for `pilot`
5. you should see an opportunity called `Local Pilot-equivalent Opportunity`
6. sign in
7. start new application
8. navigate to form table of the application
9. click Application for Federal Assistance (SF-424)
10. scroll down to Delinquent Federal Debt
11. when making no selection, and saving, you should not see any change to the radio and a validation error
12. when making a selection, for example, Yes, and saving, the value should remain Yes. same with No
13. Keep in mind validation is coming in a separate PR