### PR TITLE
[Issue #5906] reuse login modal

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -33,10 +33,12 @@ export default function Layout({ children, locale }: Props) {
         <a className="usa-skipnav" href="#main-content">
           {t("Layout.skipToMain")}
         </a>
-        <Header locale={locale} />
-        <main id="main-content" className="border-top-0">
-          {children}
-        </main>
+        <LoginModalProvider>
+          <Header locale={locale} />
+          <main id="main-content" className="border-top-0">
+            {children}
+          </main>
+        </LoginModalProvider>
         <Footer />
         <GrantsIdentifier />
       </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { defaultFeatureFlags } from "src/constants/defaultFeatureFlags";
 import { envFeatureFlags } from "src/constants/environments";
+import { LoginModalProvider } from "src/services/auth/LoginModalProvider";
 import UserProvider from "src/services/auth/UserProvider";
 import { assignBaseFlags } from "src/services/featureFlags/featureFlagHelpers";
 

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -66,23 +66,6 @@ export const OpportunitySaveUserControl = ({
     }
   };
 
-  // // fetch user's saved opportunities
-  // useEffect(() => {
-  //   if (!user?.token) return;
-  //   setLoading(true);
-  //   fetchSaved(`/api/user/saved-opportunities/${opportunityId}`)
-  //     .then((data) => {
-  //       data && setSaved(true);
-  //     })
-  //     .catch((e) => {
-  //       console.error(e);
-  //     })
-  //     .finally(() => {
-  //       setLoading(false);
-  //     });
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [opportunityId, user?.token]);
-
   const messageText = displayAsSaved
     ? savedError
       ? t("saveMessage.errorUnsave")

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -9,7 +9,7 @@ import { useUser } from "src/services/auth/useUser";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { Button, ModalToggleButton } from "@trussworks/react-uswds";
+import { ModalToggleButton } from "@trussworks/react-uswds";
 
 import SaveButton from "src/components/SaveButton";
 import SaveIcon from "src/components/SaveIcon";
@@ -108,7 +108,7 @@ export const OpportunitySaveUserControl = ({
             saved={displayAsSaved}
           />
         ) : isSSR ? (
-          <Button type="button">dummy ssr button</Button>
+          <SaveIcon saved={false} />
         ) : (
           <ModalToggleButton
             id={`save-search-result-${opportunityId}`}
@@ -147,7 +147,7 @@ export const OpportunitySaveUserControl = ({
           savedText={t("saveButton.saved")}
         />
       ) : isSSR ? (
-        <Button type="button">dummy ssr button</Button>
+        <SaveIcon saved={false} />
       ) : (
         <ModalToggleButton
           modalRef={loginModalRef}

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -2,13 +2,14 @@
 
 import { useClientFetch } from "src/hooks/useClientFetch";
 import { useFeatureFlags } from "src/hooks/useFeatureFlags";
+import { useIsSSR } from "src/hooks/useIsSSR";
 import { useLoginModal } from "src/services/auth/LoginModalProvider";
 import { useUser } from "src/services/auth/useUser";
 
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useMemo, useState } from "react";
-import { ModalToggleButton } from "@trussworks/react-uswds";
+import { Button, ModalToggleButton } from "@trussworks/react-uswds";
 
 import SaveButton from "src/components/SaveButton";
 import SaveIcon from "src/components/SaveIcon";
@@ -35,6 +36,11 @@ export const OpportunitySaveUserControl = ({
     setHelpText,
     setTitleText,
   } = useLoginModal();
+
+  // Next will try to render this server side without a ref for the login modal,
+  // which causes a hydration error. To work around this, we'll render a dummy button server side
+  // instead
+  const isSSR = useIsSSR();
 
   const { clientFetch: updateSaved } = useClientFetch<{ type: string }>(
     "Error updating saved opportunity",
@@ -101,24 +107,24 @@ export const OpportunitySaveUserControl = ({
             loading={loading}
             saved={displayAsSaved}
           />
+        ) : isSSR ? (
+          <Button type="button">dummy ssr button</Button>
         ) : (
-          <>
-            <ModalToggleButton
-              id={`save-search-result-${opportunityId}`}
-              modalRef={loginModalRef}
-              opener
-              className="usa-button--unstyled"
-              onClick={() => {
-                setHelpText(t("saveloginModal.help"));
-                setButtonText(t("saveloginModal.button"));
-                setCloseText(t("saveloginModal.close"));
-                setDescriptionText(t("saveloginModal.description"));
-                setTitleText(t("saveloginModal.title"));
-              }}
-            >
-              <SaveIcon saved={false} />
-            </ModalToggleButton>
-          </>
+          <ModalToggleButton
+            id={`save-search-result-${opportunityId}`}
+            modalRef={loginModalRef}
+            opener
+            className="usa-button--unstyled"
+            onClick={() => {
+              setHelpText(t("saveloginModal.help"));
+              setButtonText(t("saveloginModal.button"));
+              setCloseText(t("saveloginModal.close"));
+              setDescriptionText(t("saveloginModal.description"));
+              setTitleText(t("saveloginModal.title"));
+            }}
+          >
+            <SaveIcon saved={false} />
+          </ModalToggleButton>
         )}
       </>
     );
@@ -140,24 +146,24 @@ export const OpportunitySaveUserControl = ({
           saved={displayAsSaved}
           savedText={t("saveButton.saved")}
         />
+      ) : isSSR ? (
+        <Button type="button">dummy ssr button</Button>
       ) : (
-        <>
-          <ModalToggleButton
-            modalRef={loginModalRef}
-            opener
-            className="usa-button usa-button--outline"
-            onClick={() => {
-              setHelpText(t("saveloginModal.help"));
-              setButtonText(t("saveloginModal.button"));
-              setCloseText(t("saveloginModal.close"));
-              setDescriptionText(t("saveloginModal.description"));
-              setTitleText(t("saveloginModal.title"));
-            }}
-          >
-            <USWDSIcon name="star_outline" className="button-icon-large" />
-            {t("saveButton.save")}
-          </ModalToggleButton>
-        </>
+        <ModalToggleButton
+          modalRef={loginModalRef}
+          opener
+          className="usa-button usa-button--outline"
+          onClick={() => {
+            setHelpText(t("saveloginModal.help"));
+            setButtonText(t("saveloginModal.button"));
+            setCloseText(t("saveloginModal.close"));
+            setDescriptionText(t("saveloginModal.description"));
+            setTitleText(t("saveloginModal.title"));
+          }}
+        >
+          <USWDSIcon name="star_outline" className="button-icon-large" />
+          {t("saveButton.save")}
+        </ModalToggleButton>
       )}
     </>
   );

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -38,9 +38,10 @@ export const OpportunitySaveUserControl = ({
   const [savedError, setSavedError] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const displayAsSaved = useMemo(() => {
-    return locallySaved === null ? opportunitySaved : locallySaved;
-  }, [locallySaved, opportunitySaved]);
+  const displayAsSaved = useMemo(
+    () => (locallySaved === null ? opportunitySaved : locallySaved),
+    [locallySaved, opportunitySaved],
+  );
 
   const closeMessage = () => {
     setshowMessage(false);
@@ -64,6 +65,23 @@ export const OpportunitySaveUserControl = ({
       setLoading(false);
     }
   };
+
+  // // fetch user's saved opportunities
+  // useEffect(() => {
+  //   if (!user?.token) return;
+  //   setLoading(true);
+  //   fetchSaved(`/api/user/saved-opportunities/${opportunityId}`)
+  //     .then((data) => {
+  //       data && setSaved(true);
+  //     })
+  //     .catch((e) => {
+  //       console.error(e);
+  //     })
+  //     .finally(() => {
+  //       setLoading(false);
+  //     });
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [opportunityId, user?.token]);
 
   const messageText = displayAsSaved
     ? savedError

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -38,10 +38,9 @@ export const OpportunitySaveUserControl = ({
   const [savedError, setSavedError] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const displayAsSaved = useMemo(
-    () => (locallySaved === null ? opportunitySaved : locallySaved),
-    [locallySaved, opportunitySaved],
-  );
+  const displayAsSaved = useMemo(() => {
+    return locallySaved === null ? opportunitySaved : locallySaved;
+  }, [locallySaved, opportunitySaved]);
 
   const closeMessage = () => {
     setshowMessage(false);

--- a/frontend/src/components/user/OpportunitySaveUserControl.tsx
+++ b/frontend/src/components/user/OpportunitySaveUserControl.tsx
@@ -2,14 +2,14 @@
 
 import { useClientFetch } from "src/hooks/useClientFetch";
 import { useFeatureFlags } from "src/hooks/useFeatureFlags";
+import { useLoginModal } from "src/services/auth/LoginModalProvider";
 import { useUser } from "src/services/auth/useUser";
 
 import { useTranslations } from "next-intl";
 import Link from "next/link";
-import { useMemo, useRef, useState } from "react";
-import { ModalRef, ModalToggleButton } from "@trussworks/react-uswds";
+import { useMemo, useState } from "react";
+import { ModalToggleButton } from "@trussworks/react-uswds";
 
-import { LoginModal } from "src/components/LoginModal";
 import SaveButton from "src/components/SaveButton";
 import SaveIcon from "src/components/SaveIcon";
 import { USWDSIcon } from "src/components/USWDSIcon";
@@ -26,7 +26,15 @@ export const OpportunitySaveUserControl = ({
   opportunitySaved: boolean;
 }) => {
   const t = useTranslations("OpportunityListing");
-  const modalRef = useRef<ModalRef>(null);
+
+  const {
+    loginModalRef,
+    setButtonText,
+    setCloseText,
+    setDescriptionText,
+    setHelpText,
+    setTitleText,
+  } = useLoginModal();
 
   const { clientFetch: updateSaved } = useClientFetch<{ type: string }>(
     "Error updating saved opportunity",
@@ -97,21 +105,19 @@ export const OpportunitySaveUserControl = ({
           <>
             <ModalToggleButton
               id={`save-search-result-${opportunityId}`}
-              modalRef={modalRef}
+              modalRef={loginModalRef}
               opener
               className="usa-button--unstyled"
+              onClick={() => {
+                setHelpText(t("saveloginModal.help"));
+                setButtonText(t("saveloginModal.button"));
+                setCloseText(t("saveloginModal.close"));
+                setDescriptionText(t("saveloginModal.description"));
+                setTitleText(t("saveloginModal.title"));
+              }}
             >
               <SaveIcon saved={false} />
             </ModalToggleButton>
-            <LoginModal
-              modalRef={modalRef as React.RefObject<ModalRef>}
-              helpText={t("saveloginModal.help")}
-              buttonText={t("saveloginModal.button")}
-              closeText={t("saveloginModal.close")}
-              descriptionText={t("saveloginModal.description")}
-              titleText={t("saveloginModal.title")}
-              modalId={`opp-save-login-modal-${opportunityId}`}
-            />
           </>
         )}
       </>
@@ -137,22 +143,20 @@ export const OpportunitySaveUserControl = ({
       ) : (
         <>
           <ModalToggleButton
-            modalRef={modalRef}
+            modalRef={loginModalRef}
             opener
             className="usa-button usa-button--outline"
+            onClick={() => {
+              setHelpText(t("saveloginModal.help"));
+              setButtonText(t("saveloginModal.button"));
+              setCloseText(t("saveloginModal.close"));
+              setDescriptionText(t("saveloginModal.description"));
+              setTitleText(t("saveloginModal.title"));
+            }}
           >
             <USWDSIcon name="star_outline" className="button-icon-large" />
             {t("saveButton.save")}
           </ModalToggleButton>
-          <LoginModal
-            modalRef={modalRef as React.RefObject<ModalRef>}
-            helpText={t("saveloginModal.help")}
-            buttonText={t("saveloginModal.button")}
-            closeText={t("saveloginModal.close")}
-            descriptionText={t("saveloginModal.description")}
-            titleText={t("saveloginModal.title")}
-            modalId={`opp-save-login-modal-${opportunityId}`}
-          />
         </>
       )}
     </>

--- a/frontend/src/services/auth/LoginModalProvider.tsx
+++ b/frontend/src/services/auth/LoginModalProvider.tsx
@@ -15,6 +15,11 @@ import { LoginModal } from "src/components/LoginModal";
 
 type LoginModalContextValue = {
   loginModalRef: RefObject<ModalRef | null>;
+  setHelpText: (text: string) => void;
+  setTitleText: (text: string) => void;
+  setDescriptionText: (text: string) => void;
+  setButtonText: (text: string) => void;
+  setCloseText: (text: string) => void;
 };
 
 const LoginModalContext = createContext<LoginModalContextValue | null>(null);

--- a/frontend/src/services/auth/LoginModalProvider.tsx
+++ b/frontend/src/services/auth/LoginModalProvider.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  createContext,
+  PropsWithChildren,
+  RefObject,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { ModalRef } from "@trussworks/react-uswds";
+
+import { LoginModal } from "src/components/LoginModal";
+
+type LoginModalContextValue = {
+  loginModalRef: RefObject<ModalRef | null>;
+};
+
+const LoginModalContext = createContext<LoginModalContextValue | null>(null);
+
+export const useLoginModal = () => {
+  const ctx = useContext(LoginModalContext);
+  if (ctx === null) {
+    throw new Error("useLoginModal must be used within <LoginModalProvider>");
+  }
+  return ctx;
+};
+
+export function LoginModalProvider({ children }: PropsWithChildren) {
+  const loginModalRef = useRef<ModalRef | null>(null);
+
+  const [helpText, setHelpText] = useState<string>("");
+  const [titleText, setTitleText] = useState<string>("");
+  const [descriptionText, setDescriptionText] = useState<string>("");
+  const [buttonText, setButtonText] = useState<string>("");
+  const [closeText, setCloseText] = useState<string>("");
+
+  const contextValue = useMemo(
+    () => ({
+      loginModalRef,
+      setHelpText,
+      setTitleText,
+      setDescriptionText,
+      setButtonText,
+      setCloseText,
+    }),
+    [
+      loginModalRef,
+      setHelpText,
+      setTitleText,
+      setDescriptionText,
+      setButtonText,
+      setCloseText,
+    ],
+  );
+
+  return (
+    <>
+      <LoginModal
+        modalRef={loginModalRef as RefObject<ModalRef>}
+        helpText={helpText}
+        titleText={titleText}
+        descriptionText={descriptionText}
+        buttonText={buttonText}
+        closeText={closeText}
+        modalId={"simpler-login-modal"}
+      />
+      <LoginModalContext.Provider value={contextValue}>
+        {children}
+      </LoginModalContext.Provider>
+    </>
+  );
+}

--- a/frontend/tests/components/user/OpportunitySaveUserControl.test.tsx
+++ b/frontend/tests/components/user/OpportunitySaveUserControl.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { noop } from "lodash";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
+
+import { createRef } from "react";
 
 import { OpportunitySaveUserControl } from "src/components/user/OpportunitySaveUserControl";
 
@@ -28,6 +31,17 @@ jest.mock("next-intl", () => ({
 jest.mock("src/hooks/useFeatureFlags", () => ({
   useFeatureFlags: () => ({
     checkFeatureFlag: () => true,
+  }),
+}));
+
+jest.mock("src/services/auth/LoginModalProvider", () => ({
+  useLoginModal: () => ({
+    loginModalRef: createRef(),
+    setButtonText: noop,
+    setCloseText: noop,
+    setDescriptionText: noop,
+    setHelpText: noop,
+    setTitleText: noop,
   }),
 }));
 

--- a/frontend/tests/services/auth/LoginModalProvider.test.tsx
+++ b/frontend/tests/services/auth/LoginModalProvider.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  LoginModalProvider,
+  useLoginModal,
+} from "src/services/auth/LoginModalProvider";
+
+import { ModalToggleButton } from "@trussworks/react-uswds";
+
+describe("LoginModalProvider", () => {
+  it("renders a login modal", () => {
+    render(<LoginModalProvider />);
+    expect(screen.getByTestId("modalWindow")).toBeInTheDocument();
+  });
+  it("allows for setting text values", () => {
+    const Consumer = () => {
+      const {
+        setHelpText,
+        setTitleText,
+        setDescriptionText,
+        setButtonText,
+        setCloseText,
+      } = useLoginModal();
+
+      setHelpText("help");
+      setTitleText("title");
+      setDescriptionText("description");
+      setButtonText("button");
+      setCloseText("close");
+      return <></>;
+    };
+    render(
+      <LoginModalProvider>
+        <Consumer />
+      </LoginModalProvider>,
+    );
+    expect(screen.getByText("help")).toBeInTheDocument();
+    expect(screen.getByText("title")).toBeInTheDocument();
+    expect(screen.getByText("description")).toBeInTheDocument();
+    expect(screen.getByText("button")).toBeInTheDocument();
+    expect(screen.getByText("close")).toBeInTheDocument();
+  });
+  it("sets up a situation where a button child can control the modal", async () => {
+    const Consumer = () => {
+      const { loginModalRef } = useLoginModal();
+
+      // setHelpText("help");
+      return (
+        <ModalToggleButton data-testid="modal-toggle" modalRef={loginModalRef}>
+          click me
+        </ModalToggleButton>
+      );
+    };
+    render(
+      <LoginModalProvider>
+        <Consumer />
+      </LoginModalProvider>,
+    );
+
+    // expect(screen.getByText("help")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toHaveClass("is-hidden");
+    const modalToggle = screen.getByTestId("modal-toggle");
+    await userEvent.click(modalToggle);
+
+    expect(screen.getByRole("dialog")).not.toHaveClass("is-hidden");
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Partial Work for #5906 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds the ability for the site to reuse a single login modal with multiple triggers

This solves an issue where a page, such as the current search page, will load a separate modal for each trigger on the page

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This:
* creates a context that can be used to control a single login modal
* implements that context on the search and opportunity pages

As the main reason to do this work now was to clean up the main modals on the search page, this doesn't implement the context for use across all usages of the login modal, that can be done in a later ticket.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/search?_ff=applyFormPrototypeOff:false
3. open developer console and search DOM for `.usa-modal`
4. _VERIFY_: you find 2 or maybe 3 instances (down from the 20+ on main)
5. click a star to save an opportunity
6. _VERIFY_: login modal appears with correct language
7. go to an opportunity detail page
3. click a star to save the opportunity
4. _VERIFY_: login modal appears with correct language
5. go back to search and search for `pilot`
8. visit the pilot opportunity detail page
9. click button to start application
4. _VERIFY_: login modal appears with correct language
10. 