### PR TITLE
[Issue #6169] Attempt to bump jupyterlab version to address node vulns

### DIFF
--- a/analytics/poetry.lock
+++ b/analytics/poetry.lock
@@ -1885,20 +1885,20 @@ test = ["jupyter-server (>=2.0.0)", "pytest (>=7.0)", "pytest-jupyter[server] (>
 
 [[package]]
 name = "jupyterlab"
-version = "4.4.5"
+version = "4.4.6"
 description = "JupyterLab computational environment"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jupyterlab-4.4.5-py3-none-any.whl", hash = "sha256:e76244cceb2d1fb4a99341f3edc866f2a13a9e14c50368d730d75d8017be0863"},
-    {file = "jupyterlab-4.4.5.tar.gz", hash = "sha256:0bd6c18e6a3c3d91388af6540afa3d0bb0b2e76287a7b88ddf20ab41b336e595"},
+    {file = "jupyterlab-4.4.6-py3-none-any.whl", hash = "sha256:e877e930f46dde2e3ee9da36a935c6cd4fdb15aa7440519d0fde696f9fadb833"},
+    {file = "jupyterlab-4.4.6.tar.gz", hash = "sha256:e0b720ff5392846bdbc01745f32f29f4d001c071a4bff94d8b516ba89b5a4157"},
 ]
 
 [package.dependencies]
 async-lru = ">=1.0.0"
-httpx = ">=0.25.0"
-ipykernel = ">=6.5.0"
+httpx = ">=0.25.0,<1"
+ipykernel = ">=6.5.0,<6.30.0 || >6.30.0"
 jinja2 = ">=3.0.3"
 jupyter-core = "*"
 jupyter-lsp = ">=2.0.0"
@@ -4416,4 +4416,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13"
-content-hash = "ba4667f43d0101f949ddd12f443f9babfca5c36ce7638813ef31d528c870c7d0"
+content-hash = "90296abfacf9c3702d61a9226041056b5fed093076b501746df7c5709eb178e3"

--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -31,6 +31,7 @@ boto3-stubs = "^1.35.56"
 psycopg = "^3.2.3"
 smart-open = "^7.0.5"
 newrelic = "10.16.0"
+jupyterlab = "^4.4.6"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"


### PR DESCRIPTION
## Summary

Fixes #6169  

## Changes proposed

ECR is reporting Vulnerabilities for the node packages installed by the Python jupyterlab package. Bumping the python package version since that's the only influence we have on those installed node package versions.