### PR TITLE
[Issue #5976] Setup a schedule for the application zip creation job

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -85,5 +85,11 @@ locals {
       schedule_expression = "cron(0 13 * * ? *)"
       state               = "DISABLED"
     }
+    create-application-submission = {
+      task_command = ["poetry", "run", "flask", "task", "create-application-submission"]
+      # Every day at 2am Eastern Time during DST. 3am during non-DST.
+      schedule_expression = "cron(0 7 * * ? *)"
+      state               = "ENABLED"
+    }
   }
 }


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #5976

## Changes proposed

Add terraform config to call `create-application-submission` nightly at 2AM EDT.

## Context for reviewers

Is there a preference for what time of night this runs?

## Validation steps

See TF applied once merged.