### PR TITLE
[Unticketed] Explicitly mark updated rows as not-deleted in load-oracle logic

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -200,7 +200,14 @@ class LoadOracleDataTask(src.task.task.Task):
         ):
             update_sql = sql.build_update_sql(
                 foreign_table, staging_table, batch_of_update_ids, excluded_columns
-            ).values(transformed_at=None)
+            ).values(
+                transformed_at=None,
+                # Explicitly mark the updated row as not-deleted so that if
+                # a row is deleted and recreated with the same primary key
+                # we'll process the update
+                is_deleted=False,
+                deleted_at=None,
+            )
 
             with self.db_session.begin():
                 self.db_session.execute(update_sql)

--- a/api/tests/src/data_migration/load/test_load_oracle_data_task.py
+++ b/api/tests/src/data_migration/load/test_load_oracle_data_task.py
@@ -32,6 +32,9 @@ def validate_copied_value(
         assert destination_record.transformed_at is None
         assert destination_record.deleted_at is not None
         return
+    else:
+        assert destination_record.is_deleted is False
+        assert destination_record.deleted_at is None
 
     mismatches = []
 
@@ -104,7 +107,12 @@ class TestLoadOracleData(BaseTestClass):
             opportunity_id=4, oppnumber="A-4", cfdas=[], last_upd_date=time1
         )
         StagingTopportunityFactory.create(
-            opportunity_id=6, oppnumber="A-6", cfdas=[], last_upd_date=None
+            opportunity_id=6,
+            oppnumber="A-6",
+            cfdas=[],
+            last_upd_date=None,
+            deleted_at=time1,
+            is_deleted=True,
         )
         # delete:
         StagingTopportunityFactory.create(


### PR DESCRIPTION
## Summary

## Changes proposed
When doing an update from the Oracle DB, set is_deleted and deleted_at back to default (undeleted) values

## Context for reviewers
Had an opportunity synopsis not get updated in prod because the synopsis was deleted and later recreated. The primary key is just the opportunity ID, so our logic saw them as the same row. It did properly update the row, but the `is_deleted` flag was not changed so it left it deleted.
