### PR TITLE
[No issue] Update events page

### DIFF
--- a/frontend/src/app/[locale]/(base)/events/page.tsx
+++ b/frontend/src/app/[locale]/(base)/events/page.tsx
@@ -7,7 +7,6 @@ import { use } from "react";
 import EventsCoding from "./EventsCoding";
 import EventsDemo from "./EventsDemo";
 import EventsHero from "./EventsHero";
-import EventsUpcoming from "./EventsUpcoming";
 
 export async function generateMetadata({ params }: LocalizedPageProps) {
   const { locale } = await params;
@@ -26,11 +25,8 @@ export default function Events({ params }: LocalizedPageProps) {
   return (
     <>
       <EventsHero />
-      <EventsUpcoming />
-      <div className="bg-base-lightest">
-        <EventsDemo />
-        <EventsCoding />
-      </div>
+      <EventsDemo />
+      <EventsCoding />
     </>
   );
 }

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -71,7 +71,7 @@ export const messages = {
     demo: {
       title: "Simpler.Grants.gov Big Demo",
       description:
-        "Three times a year, the Simpler.Grants.gov team hosts a public demonstration of our newest features and functionality.  These virtual sessions highlight our progress, share user research insights, and showcase community engagement efforts. ",
+        "The Simpler.Grants.gov team hosts public demonstrations of our newest features and functionality.  These virtual sessions highlight our progress, share user research insights, and showcase community engagement efforts. ",
       watch: "Watch recordings of past Big Demos",
       watchLink: "January 15, 2025",
     },

--- a/frontend/tests/pages/events/__snapshots__/page.test.tsx.snap
+++ b/frontend/tests/pages/events/__snapshots__/page.test.tsx.snap
@@ -56,39 +56,92 @@ exports[`Events renders Events page unchanged 1`] = `
   </div>
   <div
     class="grid-container padding-y-4 tablet-lg:padding-y-6"
-    data-testid="events-upcoming-content"
+    data-testid="events-demo-content"
   >
     <div
       class="grid-row grid-gap"
       data-testid="grid"
     >
       <div
-        class="tablet:grid-col-4"
+        class="tablet:grid-col-5"
+        data-testid="grid"
+      >
+        <img
+          alt="events-img"
+          class="height-auto position-relative"
+          data-nimg="1"
+          decoding="async"
+          height="40"
+          loading="lazy"
+          src="/_next/image?url=%2Fimg.jpg&w=96&q=75"
+          srcset="/_next/image?url=%2Fimg.jpg&w=48&q=75 1x, /_next/image?url=%2Fimg.jpg&w=96&q=75 2x"
+          style="color: transparent;"
+          width="40"
+        />
+      </div>
+      <div
+        class="tablet:grid-col-7"
+        data-testid="grid"
+      >
+        <div
+          class=""
+          data-testid="grid"
+        >
+          <h2>
+            title
+          </h2>
+        </div>
+        <div
+          class=""
+          data-testid="grid"
+        >
+          <p
+            class="font-sans-md line-height-sans-4"
+          >
+            description
+          </p>
+          <h3>
+            watch
+          </h3>
+          <p>
+            <a
+              class="font-sans-md line-height-sans-4"
+              href="https://vimeo.com/1050177794/278fa78e0b?share=copy"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              watchLink
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="grid-container padding-y-4 tablet-lg:padding-y-6"
+    data-testid="events-coding-content"
+  >
+    <div
+      class="grid-row grid-gap"
+      data-testid="grid"
+    >
+      <div
+        class="tablet:grid-col-7"
         data-testid="grid"
       >
         <h2>
           title
         </h2>
-      </div>
-      <div
-        class="tablet:grid-col-8"
-        data-testid="grid"
-      >
-        <h3>
-          header
-        </h3>
-        <p
-          class="font-sans-md"
-        >
-          startDate
+        <p>
+          descriptionP1
         </p>
         <p>
-          description
+          descriptionP2
         </p>
         <p>
           <a
-            class="font-sans-md"
-            href="https://docs.google.com/forms/d/e/1FAIpQLSe3nyLxAIeky3bGydyvuZobrlEGdWrl0YaZBbVmsn7Pu6HhUw/viewform"
+            class="font-sans-md line-height-sans-4"
+            href="https://wiki.simpler.grants.gov/get-involved/community-events/spring-2025-collaborative-coding-challenge"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -96,123 +149,22 @@ exports[`Events renders Events page unchanged 1`] = `
           </a>
         </p>
       </div>
-    </div>
-  </div>
-  <div
-    class="bg-base-lightest"
-  >
-    <div
-      class="grid-container padding-y-4 tablet-lg:padding-y-6"
-      data-testid="events-demo-content"
-    >
       <div
-        class="grid-row grid-gap"
+        class="tablet:grid-col-5"
         data-testid="grid"
       >
-        <div
-          class="tablet:grid-col-5"
-          data-testid="grid"
-        >
-          <img
-            alt="events-img"
-            class="height-auto position-relative"
-            data-nimg="1"
-            decoding="async"
-            height="40"
-            loading="lazy"
-            src="/_next/image?url=%2Fimg.jpg&w=96&q=75"
-            srcset="/_next/image?url=%2Fimg.jpg&w=48&q=75 1x, /_next/image?url=%2Fimg.jpg&w=96&q=75 2x"
-            style="color: transparent;"
-            width="40"
-          />
-        </div>
-        <div
-          class="tablet:grid-col-7"
-          data-testid="grid"
-        >
-          <div
-            class=""
-            data-testid="grid"
-          >
-            <h2>
-              title
-            </h2>
-          </div>
-          <div
-            class=""
-            data-testid="grid"
-          >
-            <p
-              class="font-sans-md line-height-sans-4"
-            >
-              description
-            </p>
-            <h3>
-              watch
-            </h3>
-            <p>
-              <a
-                class="font-sans-md line-height-sans-4"
-                href="https://vimeo.com/1050177794/278fa78e0b?share=copy"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                watchLink
-              </a>
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="grid-container padding-y-4 tablet-lg:padding-y-6"
-      data-testid="events-coding-content"
-    >
-      <div
-        class="grid-row grid-gap"
-        data-testid="grid"
-      >
-        <div
-          class="tablet:grid-col-7"
-          data-testid="grid"
-        >
-          <h2>
-            title
-          </h2>
-          <p>
-            descriptionP1
-          </p>
-          <p>
-            descriptionP2
-          </p>
-          <p>
-            <a
-              class="font-sans-md line-height-sans-4"
-              href="https://wiki.simpler.grants.gov/get-involved/community-events/spring-2025-collaborative-coding-challenge"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              link
-            </a>
-          </p>
-        </div>
-        <div
-          class="tablet:grid-col-5"
-          data-testid="grid"
-        >
-          <img
-            alt="events-img"
-            class="height-auto position-relative padding-y-3 padding-left-6"
-            data-nimg="1"
-            decoding="async"
-            height="40"
-            loading="lazy"
-            src="/_next/image?url=%2Fimg.jpg&w=96&q=75"
-            srcset="/_next/image?url=%2Fimg.jpg&w=48&q=75 1x, /_next/image?url=%2Fimg.jpg&w=96&q=75 2x"
-            style="color: transparent;"
-            width="40"
-          />
-        </div>
+        <img
+          alt="events-img"
+          class="height-auto position-relative padding-y-3 padding-left-6"
+          data-nimg="1"
+          decoding="async"
+          height="40"
+          loading="lazy"
+          src="/_next/image?url=%2Fimg.jpg&w=96&q=75"
+          srcset="/_next/image?url=%2Fimg.jpg&w=48&q=75 1x, /_next/image?url=%2Fimg.jpg&w=96&q=75 2x"
+          style="color: transparent;"
+          width="40"
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

per https://betagrantsgov.slack.com/archives/C05TGEL3C6Q/p1756921734581869

## Changes proposed

- Remove upcoming events section ("Spring 2025 Collaborative Coding Challenge")
- Remove alternating white/gray page section background 
- Update "Big Demo" content about cadence 

Before / After: 

<img width="1432" height="1310" alt="image" src="https://github.com/user-attachments/assets/96ac0e99-3d0d-4afd-ae7d-e22625ced871" />

## Context for reviewers

The `EventsUpcoming` component is still there for if/when we need to add it back. 

## Validation steps

- View the events page
- Note the "Upcoming Events" and "Spring 2025 Collaborative Coding Challenge" content has been removed
- Note the page has only a white background (does not alternate between white and gray)