### PR TITLE
[Issue #6103] Update permissions for Co-planning sync Fider to GitHub

### DIFF
--- a/.github/workflows/coplanning-sync-fider-to-gh.yml
+++ b/.github/workflows/coplanning-sync-fider-to-gh.yml
@@ -10,7 +10,7 @@ on:
     - cron: "0 0 * * *" # run daily at midnight
 
 permissions:
-  issues: read
+  issues: write
 
 defaults:
   run:


### PR DESCRIPTION
## Summary

Updates permissions for "Co-planning sync Fider to GitHub". This action updates the issue body, so we need `issue: write` permissions instead of `issue: read`

Fixes #6103 

## Changes proposed

Changes permissions for the GitHub token in [`coplanning-sync-fider-to-gh.yml`](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/coplanning-sync-fider-to-gh.yml) from `issue: read` to `issue: write` because we need to update the issue body.

## Context for reviewers

This wasn't caught by the CI previously because we only run the script in `--dry-run` mode which logs the issues that will be updated but doesn't actually attempt to update the issue body.

Now that the GitHub action exists on `main` I can test an actual run from the branch.

## Validation steps

I was able to trigger a `workflow_dispatch` [run from this branch](https://github.com/HHS/simpler-grants-gov/actions/runs/17464455888/job/49596610183) with the updated permissions and the workflow ran successfully:

<img width="1440" height="900" alt="Screenshot 2025-09-04 at 8 52 30 AM" src="https://github.com/user-attachments/assets/f7659dd1-c3a1-4821-a02a-8fab89e03ebd" />
