### PR TITLE
[Issue #5441] Update form to prevent lost changes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "newrelic": "^12.7.0",
         "next": "^15.4.7",
         "next-intl": "^3.2.1",
+        "next-navigation-guard": "^0.2.0",
         "pino": "^9.6.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -14750,6 +14751,16 @@
       "peerDependencies": {
         "next": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/next-navigation-guard": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/next-navigation-guard/-/next-navigation-guard-0.2.0.tgz",
+      "integrity": "sha512-EnQcqJi/bcHXnirnY0TGSFkQ3Rl9ID4BZWdU2ovoWAkA72mCofI2hTcaqUUOmlSBVZp4AvSGm1kQmkOJDLrEjg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "next": "^14 || ^15",
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/@img/sharp-darwin-arm64": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "newrelic": "^12.7.0",
     "next": "^15.4.7",
     "next-intl": "^3.2.1",
+    "next-navigation-guard": "^0.2.0",
     "pino": "^9.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/app/[locale]/(base)/workspace/applications/layout.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/applications/layout.tsx
@@ -1,0 +1,7 @@
+import { LayoutProps } from "src/types/generalTypes";
+
+import { NavigationGuardProvider } from "next-navigation-guard";
+
+export default function ApplicaitonsLayout({ children }: LayoutProps) {
+  return <NavigationGuardProvider>{children}</NavigationGuardProvider>;
+}

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -7,7 +7,8 @@ import { AttachmentsProvider } from "src/hooks/ApplicationAttachments";
 import { Attachment } from "src/types/attachmentTypes";
 
 import { useTranslations } from "next-intl";
-import { useActionState, useMemo } from "react";
+import { useNavigationGuard } from "next-navigation-guard";
+import { useActionState, useMemo, useState } from "react";
 import { Alert, Button, FormGroup } from "@trussworks/react-uswds";
 
 import { handleFormAction } from "./actions";
@@ -55,6 +56,15 @@ const ApplyForm = ({
     saved: false,
   });
 
+  const [formChanged, setFormChanged] = useState<boolean>(false);
+
+  useNavigationGuard({
+    enabled: formChanged,
+    confirm: () =>
+      // eslint-disable-next-line no-alert
+      window.confirm(t("unsavedChangesWarning")),
+  });
+
   const { formData, error, saved } = formState;
 
   const formObject = !isEmpty(formData) ? formData : savedFormData;
@@ -72,6 +82,9 @@ const ApplyForm = ({
     <form
       className="flex-1 margin-top-2 simpler-apply-form"
       action={formAction}
+      onChange={() => {
+        setFormChanged(true);
+      }}
       // turns off html5 validation so all error displays are consistent
       noValidate
     >
@@ -83,6 +96,7 @@ const ApplyForm = ({
           name="apply-form-button"
           className="margin-top-0"
           value="save"
+          onClick={() => setFormChanged(false)}
         >
           {pending ? "Saving..." : "Save"}
         </Button>

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -365,6 +365,7 @@ export const messages = {
         "Correct the following errors before submitting your application.",
       required: "A red asterisk <abr>*</abr> indicates a required field.",
       navTitle: "Sections in this form",
+      unsavedChangesWarning: "You have unsaved changes that will be lost.",
     },
   },
   Index: {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #5441

## Changes proposed

Adds https://github.com/LayerXcom/next-navigation-guard and wraps application forms in `NavigationGuardProvider`.

## Context for reviewers

I have a separate branch (https://github.com/HHS/simpler-grants-gov/tree/acouch/issue-5441-unsaved-form) that handled refresh and tab closing without this library, however the back button was more difficult. Adding the `popState` listener allowed intercepting the back button, but handling the "cancel" button in the dialog would mean intercepting the router which would have taken more custom logic. This library handles a lot of edge cases.

This only checks if a change is made to the form and the save button has not been pressed. Someone could add to a field, then remove what they added, returning to the original state. Deep comparing the formData for changes seems like outside of the scope of the ticket.

## Validation steps

Edit a form without saving, try and navigate away.
