### PR TITLE
[Issue #6294] Add training option to manual deploy drop down

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -21,6 +21,7 @@ on:
         options:
           - dev
           - staging
+          - training
           - prod
       version:
         required: true

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -21,6 +21,7 @@ on:
         options:
           - dev
           - staging
+          - training
           - prod
       version:
         required: true

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -21,6 +21,7 @@ on:
         options:
           - dev
           - staging
+          - training
           - prod
       version:
         required: true


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6294 

## Changes proposed

Include training in the drop down list for manual deploys via the CD Workflows in GitHub Actions