### PR TITLE
[Unticketed] Fix inconsistent XML element ordering between different environments

### DIFF
--- a/api/src/legacy_soap_api/soap_payload_handler.py
+++ b/api/src/legacy_soap_api/soap_payload_handler.py
@@ -259,7 +259,8 @@ def _build_xml_elements(
     key_namespace_config: dict[str, str | None],
     namespaces: dict[str | None, str],
 ) -> None:
-    for key, value in xml_dict.items():
+    # Sort keys to ensure consistent XML element ordering across environments
+    for key, value in sorted(xml_dict.items()):
         # Get the namespace prefix for this element
         ns_prefix = key_namespace_config.get(key)
         ns_uri = namespaces.get(ns_prefix) if ns_prefix else None

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -218,8 +218,8 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
                 <ns5:ClosingDate>{closing_date}</ns5:ClosingDate>
                 <CompetitionID>{competition_id}</CompetitionID>
                 <CompetitionTitle>{competition_title}</CompetitionTitle>
-                <FundingOpportunityTitle>{funding_opportunity_title}</FundingOpportunityTitle>
                 <FundingOpportunityNumber>{funding_opportunity_number}</FundingOpportunityNumber>
+                <FundingOpportunityTitle>{funding_opportunity_title}</FundingOpportunityTitle>
                 <IsMultiProject>true</IsMultiProject>
                 <ns5:OpeningDate>{opening_date}</ns5:OpeningDate>
                 <PackageID>{legacy_package_id}</PackageID>


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes inconsistent XML element ordering between different environments, resulting in sporadic test failures.

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Sort XML keys, adjust tests to account for ordering.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We ran into [unreproducible test failures](https://github.com/HHS/simpler-grants-gov/actions/runs/17497241102/job/49701142555) in nonprod due to inconsistent XML key ordering. This resolves it.

## Validation steps

Ensure tests pass across deployment environments.