### PR TITLE
[Unticketed] Fix values to ensure more deterministic behvior

### DIFF
--- a/api/src/legacy_soap_api/soap_payload_handler.py
+++ b/api/src/legacy_soap_api/soap_payload_handler.py
@@ -259,7 +259,8 @@ def _build_xml_elements(
     key_namespace_config: dict[str, str | None],
     namespaces: dict[str | None, str],
 ) -> None:
-    for key, value in xml_dict.items():
+    # Sort keys to ensure consistent XML element ordering across environments
+    for key, value in sorted(xml_dict.items()):
         # Get the namespace prefix for this element
         ns_prefix = key_namespace_config.get(key)
         ns_uri = namespaces.get(ns_prefix) if ns_prefix else None

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -164,6 +164,8 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
             opportunity=OpportunityFactory.build(
                 opportunity_title=funding_opportunity_title,
                 opportunity_number=funding_opportunity_number,
+                agency_code="TEST",
+                agency_record=None,
             ),
         )
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -218,8 +218,8 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
                 <ns5:ClosingDate>{closing_date}</ns5:ClosingDate>
                 <CompetitionID>{competition_id}</CompetitionID>
                 <CompetitionTitle>{competition_title}</CompetitionTitle>
-                <FundingOpportunityTitle>{funding_opportunity_title}</FundingOpportunityTitle>
                 <FundingOpportunityNumber>{funding_opportunity_number}</FundingOpportunityNumber>
+                <FundingOpportunityTitle>{funding_opportunity_title}</FundingOpportunityTitle>
                 <IsMultiProject>true</IsMultiProject>
                 <ns5:OpeningDate>{opening_date}</ns5:OpeningDate>
                 <PackageID>{legacy_package_id}</PackageID>


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes issue of test failures for suspected nondeterministic factory behavior.

## Changes proposed

Fix factory values to have a more consistent SOAP payload in tests.

## Context for reviewers

Another build failure was reported with a new issue: https://github.com/HHS/simpler-grants-gov/actions/runs/17503840148/job/49722918675#step:8:216
This is difficult to reproduce locally, but fairly sure the root cause is a factory populating an `agency_record` value which results in new XML entries in the SOAP payload tests.

## Validation steps

See passing unit tests post deploy.
