### PR TITLE
fix: adds addition text for state receive date and state application id

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -168,7 +168,7 @@ FORM_JSON_SCHEMA = {
             # A user will never fill this in, it's just on the form for agencies to use
             "type": "string",
             "title": "Date Received By State",
-            "description": "Enter the date received by the state, if applicable.",
+            "description": "Leave blank, to be filled out by state. Enter the date received by the state, if applicable.",
             "format": "date",
             "readOnly": True,
         },
@@ -176,7 +176,7 @@ FORM_JSON_SCHEMA = {
             # A user will never fill this in, it's just on the form for agencies to use
             "type": "string",
             "title": "State Application Identifier",
-            "description": "Enter the identifier assigned by the state, if applicable.",
+            "description": "Leave blank, to be filled out by state. Enter the identifier assigned by the state, if applicable.",
             "minLength": 0,
             "maxLength": 30,
             "readOnly": True,


### PR DESCRIPTION
## Summary

Fixes #6048 https://github.com/HHS/simpler-grants-gov/issues/6048

## Changes proposed

Added the text: "Leave blank, to be filled out by state." to fields **state receive date** and **state application id**

## Validation steps

1. to run locally, you would need to `run npm run build && npm start`
2. `make remake-backend && docker compose up`
3. navigate to `search`
4. search for `pilot`
5. you should see an opportunity called `Local Pilot-equivalent Opportunity`
6. sign in
7. start new application
8. navigate to form table of the application
9. navigate to form **Application for Federal Assistance (SF-424)**
