### PR TITLE
[Issue #6330] Update required fields on SF424A and support negative numbers

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -626,10 +626,11 @@ FORM_JSON_SCHEMA = {
             # to avoid any floating point rounding issues.
             "type": "string",
             # Pattern here effectively says:
+            # * An optional negative sign
             # * Any number of digits
             # * An optional decimal point
             # * Then exactly 2 digits - if there was a decimal
-            "pattern": r"^\d*([.]\d{2})?$",
+            "pattern": r"^(-)?\d*([.]\d{2})?$",
             # Limit the max amount based on the length (11-digits, allows up to 99 billion)
             "maxLength": 14,
         },

--- a/api/src/form_schema/forms/sf424a.py
+++ b/api/src/form_schema/forms/sf424a.py
@@ -6,11 +6,6 @@ FORM_JSON_SCHEMA = {
     "type": "object",
     "required": [
         "activity_line_items",
-        "total_budget_summary",
-        "total_budget_categories",
-        "total_non_federal_resources",
-        "forecasted_cash_needs",
-        "total_federal_fund_estimates",
         "confirmation",
     ],
     "properties": {
@@ -20,14 +15,7 @@ FORM_JSON_SCHEMA = {
             "maxItems": 4,
             "items": {
                 "type": "object",
-                "required": [
-                    "activity_title",
-                    "assistance_listing_number",
-                    "budget_summary",
-                    "budget_categories",
-                    "non_federal_resources",
-                    "federal_fund_estimates",
-                ],
+                "required": ["activity_title"],
                 "properties": {
                     "activity_title": {
                         # Activity title appears in multiple places on the form
@@ -68,15 +56,6 @@ FORM_JSON_SCHEMA = {
         "total_budget_summary": {
             # Section A - Total Row (Column 5)
             "allOf": [{"$ref": "#/$defs/budget_summary"}],
-            # In the total budget summary, all fields are required
-            "required": [
-                "federal_estimated_unobligated_amount",
-                "non_federal_estimated_unobligated_amount",
-                "federal_new_or_revised_amount",
-                "non_federal_new_or_revised_amount",
-                # total_amount is already required in the base definition
-                # don't include it again or it gets added as an error twice.
-            ],
         },
         "total_budget_categories": {
             # Section B - Total Column (Column 5)
@@ -85,23 +64,12 @@ FORM_JSON_SCHEMA = {
         "total_non_federal_resources": {
             # Section C - Total Row (Line 12)
             "allOf": [{"$ref": "#/$defs/non_federal_resources"}],
-            # In the total non-federal resources, all fields are required
-            "required": [
-                "applicant_amount",
-                "state_amount",
-                "other_amount",
-                # total_amount is already required in the base definition
-                # don't include it again or it gets added as an error twice.
-            ],
         },
         "forecasted_cash_needs": {
             # Section D
             "type": "object",
-            "required": [
-                "federal_forecasted_cash_needs",
-                "non_federal_forecasted_cash_needs",
-                "total_forecasted_cash_needs",
-            ],
+            # No required fields
+            "required": [],
             "properties": {
                 "federal_forecasted_cash_needs": {
                     # Section D - Line 13
@@ -120,13 +88,7 @@ FORM_JSON_SCHEMA = {
         "total_federal_fund_estimates": {
             # Section E - Total Row (Line 20)
             "allOf": [{"$ref": "#/$defs/federal_fund_estimates"}],
-            # In the total federal fund estimates, all fields are required
-            "required": [
-                "first_year_amount",
-                "second_year_amount",
-                "third_year_amount",
-                "fourth_year_amount",
-            ],
+            # No required fields
         },
         "direct_charges_explanation": {
             # Line 21
@@ -165,17 +127,17 @@ FORM_JSON_SCHEMA = {
             # to avoid any floating point rounding issues.
             "type": "string",
             # Pattern here effectively says:
+            # * An optional negative sign
             # * Any number of digits
             # * An optional decimal point
             # * Then exactly 2 digits - if there was a decimal
-            "pattern": r"^\d*([.]\d{2})?$",
+            "pattern": r"^(-)?\d*([.]\d{2})?$",
             # Limit the max amount based on the length (11-digits, allows up to 99 billion)
             "maxLength": 14,
         },
         "budget_summary": {
             # Represents a row from Section A
             "type": "object",
-            "required": ["total_amount"],
             "properties": {
                 "federal_estimated_unobligated_amount": {
                     # Column C
@@ -202,7 +164,8 @@ FORM_JSON_SCHEMA = {
         "budget_categories": {
             # Represents a column from Section B
             "type": "object",
-            "required": ["total_direct_charge_amount", "total_amount"],
+            # No required fields
+            "required": [],
             "properties": {
                 "personnel_amount": {
                     # Row A
@@ -257,7 +220,8 @@ FORM_JSON_SCHEMA = {
         "non_federal_resources": {
             # Represents a row from Section C
             "type": "object",
-            "required": ["total_amount"],
+            # No required fields
+            "required": [],
             "properties": {
                 "applicant_amount": {
                     # Column B
@@ -280,7 +244,7 @@ FORM_JSON_SCHEMA = {
         "federal_fund_estimates": {
             # Represents a row from Section E
             "type": "object",
-            # By default, nothing is required
+            # No required fields
             "required": [],
             "properties": {
                 "first_year_amount": {
@@ -304,7 +268,8 @@ FORM_JSON_SCHEMA = {
         "forecasted_cash_needs": {
             # Represents a row from Section D
             "type": "object",
-            "required": ["total_amount"],
+            # No required fields
+            "required": [],
             "properties": {
                 "first_quarter_amount": {
                     # Column 1st Quarter

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -326,10 +326,11 @@ FORM_JSON_SCHEMA = {
             # to avoid any floating point rounding issues.
             "type": "string",
             # Pattern here effectively says:
+            # * An optional negative sign
             # * Any number of digits
             # * An optional decimal point
             # * Then exactly 2 digits - if there was a decimal
-            "pattern": r"^\d*([.]\d{2})?$",
+            "pattern": r"^(-)?\d*([.]\d{2})?$",
             # Limit the max amount based on the length (11-digits, allows up to 99 billion)
             "maxLength": 14,
         },

--- a/api/tests/src/form_schema/forms/test_sf424.py
+++ b/api/tests/src/form_schema/forms/test_sf424.py
@@ -244,14 +244,16 @@ def test_sf424_v_4_0_applicant_type_length(sf424_v4_0, valid_json_v4_0, value, e
     assert validation_issues[0].message == expected_error
 
 
-@pytest.mark.parametrize("value", ["-123.45", "123.4", "$123.45", "123..45", "12.345"])
+@pytest.mark.parametrize("value", ["123.4", "$123.45", "123..45", "12.345"])
 def test_sf424_v4_0_monetary_amount_format(sf424_v4_0, valid_json_v4_0, value):
     data = valid_json_v4_0
     data["federal_estimated_funding"] = value
 
     validation_issues = validate_json_schema_for_form(data, sf424_v4_0)
     assert len(validation_issues) == 1
-    assert validation_issues[0].message == f"'{value}' does not match '^\\\\d*([.]\\\\d{{2}})?$'"
+    assert (
+        validation_issues[0].message == f"'{value}' does not match '^(-)?\\\\d*([.]\\\\d{{2}})?$'"
+    )
 
 
 @pytest.mark.parametrize(

--- a/api/tests/src/form_schema/forms/test_sf424a.py
+++ b/api/tests/src/form_schema/forms/test_sf424a.py
@@ -6,61 +6,13 @@ from src.form_schema.jsonschema_validator import validate_json_schema_for_form
 
 @pytest.fixture
 def minimal_valid_activity_line_item_v1_0():
-    return {
-        "activity_title": "My full activity",
-        "assistance_listing_number": "12.345",
-        "budget_summary": {
-            "total_amount": "0.00",
-        },
-        "budget_categories": {
-            "total_direct_charge_amount": "0.00",
-            "total_amount": "0.00",
-        },
-        "non_federal_resources": {
-            "total_amount": "0.00",
-        },
-        "federal_fund_estimates": {},
-    }
+    return {"activity_title": "My full activity"}
 
 
 @pytest.fixture
 def minimal_valid_json_v1_0(minimal_valid_activity_line_item_v1_0):
     return {
         "activity_line_items": [minimal_valid_activity_line_item_v1_0],
-        "total_budget_summary": {
-            "federal_estimated_unobligated_amount": "0.00",
-            "non_federal_estimated_unobligated_amount": "0.00",
-            "federal_new_or_revised_amount": "0.00",
-            "non_federal_new_or_revised_amount": "0.00",
-            "total_amount": "0.00",
-        },
-        "total_budget_categories": {
-            "total_direct_charge_amount": "0.00",
-            "total_amount": "0.00",
-        },
-        "total_non_federal_resources": {
-            "applicant_amount": "0.00",
-            "state_amount": "0.00",
-            "other_amount": "0.00",
-            "total_amount": "0.00",
-        },
-        "forecasted_cash_needs": {
-            "federal_forecasted_cash_needs": {
-                "total_amount": "0.00",
-            },
-            "non_federal_forecasted_cash_needs": {
-                "total_amount": "0.00",
-            },
-            "total_forecasted_cash_needs": {
-                "total_amount": "0.00",
-            },
-        },
-        "total_federal_fund_estimates": {
-            "first_year_amount": "0.00",
-            "second_year_amount": "0.00",
-            "third_year_amount": "0.00",
-            "fourth_year_amount": "0.00",
-        },
         "confirmation": True,
     }
 
@@ -188,11 +140,6 @@ def test_sf424a_v1_0_empty_json():
 
     EXPECTED_REQUIRED_FIELDS = [
         "$.activity_line_items",
-        "$.total_budget_summary",
-        "$.total_budget_categories",
-        "$.total_non_federal_resources",
-        "$.forecasted_cash_needs",
-        "$.total_federal_fund_estimates",
         "$.confirmation",
     ]
 
@@ -207,71 +154,7 @@ def test_sf424a_v1_0_empty_line_item(full_valid_json_v1_0):
     data["activity_line_items"] = [{}]
     validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
 
-    EXPECTED_REQUIRED_FIELDS = [
-        "$.activity_line_items[0].activity_title",
-        "$.activity_line_items[0].assistance_listing_number",
-        "$.activity_line_items[0].budget_summary",
-        "$.activity_line_items[0].budget_categories",
-        "$.activity_line_items[0].non_federal_resources",
-        "$.activity_line_items[0].federal_fund_estimates",
-    ]
-
-    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
-    for validation_issue in validation_issues:
-        assert validation_issue.type == "required"
-        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
-
-
-def test_sf424a_v1_0_empty_line_item_budget_summary(
-    full_valid_json_v1_0, minimal_valid_activity_line_item_v1_0
-):
-    line_item_data = minimal_valid_activity_line_item_v1_0
-    line_item_data["budget_summary"] = {}
-
-    data = full_valid_json_v1_0
-    data["activity_line_items"] = [line_item_data]
-    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
-
-    EXPECTED_REQUIRED_FIELDS = ["$.activity_line_items[0].budget_summary.total_amount"]
-
-    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
-    for validation_issue in validation_issues:
-        assert validation_issue.type == "required"
-        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
-
-
-def test_sf424a_v1_0_empty_line_item_budget_categories(
-    full_valid_json_v1_0, minimal_valid_activity_line_item_v1_0
-):
-    line_item_data = minimal_valid_activity_line_item_v1_0
-    line_item_data["budget_categories"] = {}
-
-    data = full_valid_json_v1_0
-    data["activity_line_items"] = [line_item_data]
-    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
-
-    EXPECTED_REQUIRED_FIELDS = [
-        "$.activity_line_items[0].budget_categories.total_direct_charge_amount",
-        "$.activity_line_items[0].budget_categories.total_amount",
-    ]
-
-    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
-    for validation_issue in validation_issues:
-        assert validation_issue.type == "required"
-        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
-
-
-def test_sf424a_v1_0_empty_line_item_non_federal_resources(
-    full_valid_json_v1_0, minimal_valid_activity_line_item_v1_0
-):
-    line_item_data = minimal_valid_activity_line_item_v1_0
-    line_item_data["non_federal_resources"] = {}
-
-    data = full_valid_json_v1_0
-    data["activity_line_items"] = [line_item_data]
-    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
-
-    EXPECTED_REQUIRED_FIELDS = ["$.activity_line_items[0].non_federal_resources.total_amount"]
+    EXPECTED_REQUIRED_FIELDS = ["$.activity_line_items[0].activity_title"]
 
     assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
     for validation_issue in validation_issues:
@@ -300,63 +183,6 @@ def test_sf424a_v1_0_too_many_line_items(full_valid_json_v1_0, full_valid_activi
     assert validation_issues[0].field == "$.activity_line_items"
 
 
-def test_sf424a_v1_0_empty_totals(full_valid_json_v1_0):
-    data = full_valid_json_v1_0
-    data["total_budget_summary"] = {}
-    data["total_budget_categories"] = {}
-    data["total_non_federal_resources"] = {}
-    data["forecasted_cash_needs"] = {}
-    data["total_federal_fund_estimates"] = {}
-    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
-
-    EXPECTED_REQUIRED_FIELDS = [
-        "$.total_budget_summary.federal_estimated_unobligated_amount",
-        "$.total_budget_summary.non_federal_estimated_unobligated_amount",
-        "$.total_budget_summary.federal_new_or_revised_amount",
-        "$.total_budget_summary.non_federal_new_or_revised_amount",
-        "$.total_budget_summary.total_amount",
-        "$.total_budget_categories.total_direct_charge_amount",
-        "$.total_budget_categories.total_amount",
-        "$.total_non_federal_resources.applicant_amount",
-        "$.total_non_federal_resources.state_amount",
-        "$.total_non_federal_resources.other_amount",
-        "$.total_non_federal_resources.total_amount",
-        "$.forecasted_cash_needs.federal_forecasted_cash_needs",
-        "$.forecasted_cash_needs.non_federal_forecasted_cash_needs",
-        "$.forecasted_cash_needs.total_forecasted_cash_needs",
-        "$.total_federal_fund_estimates.first_year_amount",
-        "$.total_federal_fund_estimates.second_year_amount",
-        "$.total_federal_fund_estimates.third_year_amount",
-        "$.total_federal_fund_estimates.fourth_year_amount",
-    ]
-
-    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
-    for validation_issue in validation_issues:
-        assert validation_issue.type == "required"
-        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
-
-
-def test_sf424a_v1_0_empty_forecasted_cash_needs(full_valid_json_v1_0):
-    data = full_valid_json_v1_0
-    data["forecasted_cash_needs"] = {
-        "federal_forecasted_cash_needs": {},
-        "non_federal_forecasted_cash_needs": {},
-        "total_forecasted_cash_needs": {},
-    }
-    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
-
-    EXPECTED_REQUIRED_FIELDS = [
-        "$.forecasted_cash_needs.federal_forecasted_cash_needs.total_amount",
-        "$.forecasted_cash_needs.non_federal_forecasted_cash_needs.total_amount",
-        "$.forecasted_cash_needs.total_forecasted_cash_needs.total_amount",
-    ]
-
-    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
-    for validation_issue in validation_issues:
-        assert validation_issue.type == "required"
-        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
-
-
 def test_sf424_confirmation_must_be_true(full_valid_json_v1_0):
     data = full_valid_json_v1_0
     data["confirmation"] = False
@@ -366,3 +192,51 @@ def test_sf424_confirmation_must_be_true(full_valid_json_v1_0):
     assert validation_issues[0].type == "enum"
     assert validation_issues[0].field == "$.confirmation"
     assert validation_issues[0].message == "False is not one of [True]"
+
+
+def test_sf424_allowed_monetary_formats(full_valid_json_v1_0):
+    """Test the regex for the monetary formats"""
+    data = full_valid_json_v1_0
+    # All of these are valid formats
+    data["total_budget_categories"] = {
+        "personnel_amount": "10000000.00",
+        "fringe_benefits_amount": "-10.00",
+        "travel_amount": "-43560",
+        "equipment_amount": "0",
+        "supplies_amount": "999.99",
+        "contractual_amount": "-1.01",
+        "construction_amount": "-100000000.00",
+        "other_amount": "3",
+        "total_direct_charge_amount": "0.00",
+        "total_indirect_charge_amount": "123456789.10",
+        "total_amount": "9999.99",
+        "program_income_amount": "4243244.23",
+    }
+
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+    assert len(validation_issues) == 0
+
+
+def test_sf424_disallowed_monetary_formats(full_valid_json_v1_0):
+    """Test the regex for the monetary formats"""
+    data = full_valid_json_v1_0
+    # All of these are valid formats
+    data["total_budget_categories"] = {
+        "personnel_amount": "1-0.00",
+        "fringe_benefits_amount": "1-1",
+        "travel_amount": "hello",
+        "equipment_amount": "1.1",
+        "supplies_amount": "-1.2",
+        "contractual_amount": "10000.000",
+        "construction_amount": "-1000.0000",
+        "other_amount": "+12",
+        "total_direct_charge_amount": "!@!@$!#",
+        "total_indirect_charge_amount": "1e12",
+        "total_amount": "3.",
+        "program_income_amount": "4.x",
+    }
+
+    validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
+    assert len(validation_issues) == 12
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "pattern"


### PR DESCRIPTION
## Summary
Work for #6330

## Changes proposed
Remove most required fields from the SF424A leaving only:
* The activity line items list
* The activity title in the line items
* The confirmation question

Modify the monetary amount regex to allow an optional negative sign

## Context for reviewers
We want to make the form a bit less complex to fill out, the existing grants.gov equivalent only requires the activity title, so this is as close as we can get with JSON schema.
