### PR TITLE
[ISSUE #6319] Adjust agency transform job to ignore review process enable field

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_agency.py
+++ b/api/src/data_migration/transformation/subtask/transform_agency.py
@@ -77,6 +77,8 @@ NOT_MAPPED_FIELDS = {
     "SAMValidation",
     # This was added in Jan 2025 in Grants.gov, we aren't using it yet
     "AllowSubmitWithExpSAM",
+    # Review process enable flag added in prod to test agencies
+    "ReviewProcessEnable",
 }
 
 REQUIRED_FIELDS = {

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
@@ -118,7 +118,7 @@ class TestTransformAgency(BaseTransformTestClass):
             "UPDATE-AGENCY-2",
             create_existing=True,
             deleted_fields={"AgencyContactEMail2", "ldapGp", "description", "SAMValidation"},
-            source_values={"SAMValidation": "1"},
+            source_values={"SAMValidation": "1", "ReviewProcessEnable": "Y"},
         )
         update_agency3 = setup_agency(
             "UPDATE-AGENCY-3",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6319  

## Changes proposed

- Added `ReviewProcessEnable` to the `NOT_MAPPED_FIELDS` set in `transform_agency.py`

## Context for reviewers

These changes handle a new field (ReviewProcessEnable) that was added to the production Grants.gov system for testing purposes. The transformation process is configured to ignore this field (not map it to the database)

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

```bash
make test args="-vv tests/src/data_migration/transformation/subtask/test_transform_agency.py"
```