### PR TITLE
[ISSUE #6367] Adjust agency transform job to ignore ReviewProcessGoLive, EnableReviewProcess and ReviewProcessPeriod and fields

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_agency.py
+++ b/api/src/data_migration/transformation/subtask/transform_agency.py
@@ -80,6 +80,8 @@ NOT_MAPPED_FIELDS = {
     # Review process flags added in prod to test agencies
     "ReviewProcessEnable",
     "ReviewProcessGoLive",
+    "EnableReviewProcess",
+    "ReviewProcessPeriod",
 }
 
 REQUIRED_FIELDS = {

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
@@ -146,6 +146,24 @@ class TestTransformAgency(BaseTransformTestClass):
                 "AgencyName": "Agency with Review Process Go Live",
             },
         )
+        # Test agency with EnableReviewProcess field to ensure it's properly ignored
+        update_agency_with_enable_review_process = setup_agency(
+            "UPDATE-AGENCY-ENABLE-REVIEW-PROCESS",
+            create_existing=True,
+            source_values={
+                "EnableReviewProcess": "Y",
+                "AgencyName": "Agency with Enable Review Process",
+            },
+        )
+        # Test agency with ReviewProcessPeriod field to ensure it's properly ignored
+        update_agency_with_review_process_period = setup_agency(
+            "UPDATE-AGENCY-REVIEW-PROCESS-PERIOD",
+            create_existing=True,
+            source_values={
+                "ReviewProcessPeriod": "30",
+                "AgencyName": "Agency with Review Process Period",
+            },
+        )
         update_test_agency = setup_agency("SECSCAN", create_existing=True)
 
         already_processed1 = setup_agency(
@@ -194,6 +212,10 @@ class TestTransformAgency(BaseTransformTestClass):
         validate_agency(db_session, update_agency_with_review_process)
         # Validate that the agency with ReviewProcessGoLive was processed successfully
         validate_agency(db_session, update_agency_with_review_process_go_live)
+        # Validate that the agency with EnableReviewProcess was processed successfully
+        validate_agency(db_session, update_agency_with_enable_review_process)
+        # Validate that the agency with ReviewProcessPeriod was processed successfully
+        validate_agency(db_session, update_agency_with_review_process_period)
         validate_agency(db_session, update_test_agency, is_test_agency=True)
 
         validate_agency(db_session, already_processed1, expect_values_to_match=False)
@@ -205,9 +227,9 @@ class TestTransformAgency(BaseTransformTestClass):
         validate_agency(db_session, update_error2, expect_values_to_match=False)
 
         metrics = transform_agency.metrics
-        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_PROCESSED] == 15
+        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_PROCESSED] == 17
         assert metrics[transform_constants.Metrics.TOTAL_RECORDS_INSERTED] == 6
-        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_UPDATED] == 6
+        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_UPDATED] == 8
         assert metrics[transform_constants.Metrics.TOTAL_ERROR_COUNT] == 3
 
         # Rerunning does mostly nothing, it will attempt to re-process the three that errored
@@ -215,9 +237,9 @@ class TestTransformAgency(BaseTransformTestClass):
         db_session.commit()  # commit to end any existing transactions as run_subtask starts a new one
         transform_agency.run_subtask()
 
-        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_PROCESSED] == 18
+        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_PROCESSED] == 20
         assert metrics[transform_constants.Metrics.TOTAL_RECORDS_INSERTED] == 6
-        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_UPDATED] == 6
+        assert metrics[transform_constants.Metrics.TOTAL_RECORDS_UPDATED] == 8
         assert metrics[transform_constants.Metrics.TOTAL_ERROR_COUNT] == 6
 
     def test_process_tgroups_missing_fields_for_insert(self, db_session, transform_agency):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6367 

## Changes proposed

Added ReviewProcessGoLive,  EnableReviewProcess and ReviewProcessPeriod to the NOT_MAPPED_FIELDS set in transform_agency.py

## Context for reviewers

These changes handle new fields `ReviewProcessGoLive`, `EnableReviewProcess` and `ReviewProcessPeriod` that was added to the production Grants.gov system for testing purposes. The transformation process is configured to ignore this field (not map it to the database)


## Validation steps

make test args="-vv tests/src/data_migration/transformation/subtask/test_transform_agency.py"
