### PR TITLE
[Issue #6013] Add perms for ListSuppresssedDestinations at the account level

### DIFF
--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -134,7 +134,7 @@ data "aws_iam_policy_document" "email_access" {
   statement {
     sid       = "ListSuppressedDestinations"
     actions   = ["ses:ListSuppressedDestinations"]
-    resources = ["arn:aws:ses:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6013 

## Changes proposed

Add permissions for the API Tasks user to call SES and get the Suppressed Email List content

## Validation steps

Will apply in Dev manually and then run the job to validate it fixes the issue.