### PR TITLE
[Issue #6375] remove application attachment file type filter

### DIFF
--- a/frontend/src/components/application/attachments/AttachmentsCardForm.tsx
+++ b/frontend/src/components/application/attachments/AttachmentsCardForm.tsx
@@ -21,7 +21,6 @@ export const AttachmentsCardForm = ({
         id="application-attachment-upload"
         name="application-attachment-upload"
         errorText={errorText}
-        accept=".pdf,.xlsx"
         onChange={(e) => {
           const files = e.currentTarget.files;
           e.preventDefault();


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6375 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Removes list of accepted file types for application attachments uploader

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The `accept` attribute does not do much to prevent uploading any file you want, since there are workarounds in each browser, and it was causing confusion with users.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. attempt to upload all kinds of files to the application
4. _VERIFY_: no impediment to uploading whatever you want