### PR TITLE
Temp fully proxy API Gateway

### DIFF
--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -9,16 +9,17 @@ resource "aws_api_gateway_rest_api" "api" {
   body = jsonencode({
     "openapi" : "3.0.1",
     "paths" : {
-      "/health" : {
-        "get" : {
-          "x-amazon-apigateway-integration" : {
-            "type" : "http_proxy",
-            "httpMethod" : "GET",
-            "uri" : "https://${var.optional_extra_alb_domains[0]}/health",
-            "passthroughBehavior" : "when_no_match"
-          }
-        }
-      },
+      # Temp disable as we work on fully testing this out
+      # "/health" : {
+      #   "get" : {
+      #     "x-amazon-apigateway-integration" : {
+      #       "type" : "http_proxy",
+      #       "httpMethod" : "GET",
+      #       "uri" : "https://${var.optional_extra_alb_domains[0]}/health",
+      #       "passthroughBehavior" : "when_no_match"
+      #     }
+      #   }
+      # },
       "/{proxy+}" : {
         "x-amazon-apigateway-any-method" : {
           "parameters" : [
@@ -32,84 +33,88 @@ resource "aws_api_gateway_rest_api" "api" {
             }
           ],
           "security" : [
-            {
-              "api_key" : []
-            }
+            # Temp disable as we work on fully testing this out
+            # {
+            #   "api_key" : []
+            # }
           ],
           "x-amazon-apigateway-integration" : {
             "type" : "http_proxy",
             "httpMethod" : "ANY",
             "uri" : "https://${var.optional_extra_alb_domains[0]}/{proxy}",
             "requestParameters" : {
-              "integration.request.path.proxy" : "method.request.path.proxy"
+              "integration.request.path.proxy" : "method.request.path.proxy",
+              # Might not be needed, but adding for testing
+              "integration.request.header.Host" : "'${var.domain_name}'"
             },
             "passthroughBehavior" : "when_no_match",
             "timeoutInMillis" : 29000
           }
         }
       },
-      "/v1/users/login" : {
-        "get" : {
-          "x-amazon-apigateway-integration" : {
-            "type" : "http_proxy",
-            "httpMethod" : "GET",
-            "uri" : "https://${var.optional_extra_alb_domains[0]}/v1/users/login",
-            "requestParameters" : {
-              "integration.request.header.Host" : "'${var.domain_name}'"
-            },
-            "passthroughBehavior" : "when_no_match"
-          }
-        }
-      },
-      "/v1/users/login/callback" : {
-        "get" : {
-          "x-amazon-apigateway-integration" : {
-            "type" : "http_proxy",
-            "httpMethod" : "GET",
-            "uri" : "https://${var.optional_extra_alb_domains[0]}/v1/users/login/callback",
-            "requestParameters" : {
-              "integration.request.header.Host" : "'${var.domain_name}'"
-            },
-            "passthroughBehavior" : "when_no_match"
-          }
-        }
-      },
-      "/docs" : {
-        "get" : {
-          "x-amazon-apigateway-integration" : {
-            "type" : "http_proxy",
-            "httpMethod" : "GET",
-            "uri" : "https://${var.optional_extra_alb_domains[0]}/docs",
-            "passthroughBehavior" : "when_no_match"
-          }
-        }
-      },
-      "/static/{proxy+}" : {
-        "get" : {
-          "parameters" : [
-            {
-              "name" : "proxy",
-              "in" : "path",
-              "required" : true,
-              "schema" : {
-                "type" : "string"
-              }
-            }
-          ],
-          "x-amazon-apigateway-integration" : {
-            "type" : "http_proxy",
-            "httpMethod" : "GET",
-            "uri" : "https://${var.optional_extra_alb_domains[0]}/static/{proxy}",
-            "requestParameters" : {
-              "integration.request.path.proxy" : "method.request.path.proxy"
-            },
-            "passthroughBehavior" : "when_no_match",
-            "cacheKeyParameters" : [
-              "method.request.path.proxy"
-            ]
-          }
-        }
-      }
+      # Temp disable as we work on fully testing this out
+      # "/v1/users/login" : {
+      #   "get" : {
+      #     "x-amazon-apigateway-integration" : {
+      #       "type" : "http_proxy",
+      #       "httpMethod" : "GET",
+      #       "uri" : "https://${var.optional_extra_alb_domains[0]}/v1/users/login",
+      #       "requestParameters" : {
+      #         "integration.request.header.Host" : "'${var.domain_name}'"
+      #       },
+      #       "passthroughBehavior" : "when_no_match"
+      #     }
+      #   }
+      # },
+      # "/v1/users/login/callback" : {
+      #   "get" : {
+      #     "x-amazon-apigateway-integration" : {
+      #       "type" : "http_proxy",
+      #       "httpMethod" : "GET",
+      #       "uri" : "https://${var.optional_extra_alb_domains[0]}/v1/users/login/callback",
+      #       "requestParameters" : {
+      #         "integration.request.header.Host" : "'${var.domain_name}'"
+      #       },
+      #       "passthroughBehavior" : "when_no_match"
+      #     }
+      #   }
+      # },
+      # "/docs" : {
+      #   "get" : {
+      #     "x-amazon-apigateway-integration" : {
+      #       "type" : "http_proxy",
+      #       "httpMethod" : "GET",
+      #       "uri" : "https://${var.optional_extra_alb_domains[0]}/docs",
+      #       "passthroughBehavior" : "when_no_match"
+      #     }
+      #   }
+      # },
+      # "/static/{proxy+}" : {
+      #   "get" : {
+      #     "parameters" : [
+      #       {
+      #         "name" : "proxy",
+      #         "in" : "path",
+      #         "required" : true,
+      #         "schema" : {
+      #           "type" : "string"
+      #         }
+      #       }
+      #     ],
+      #     "x-amazon-apigateway-integration" : {
+      #       "type" : "http_proxy",
+      #       "httpMethod" : "GET",
+      #       "uri" : "https://${var.optional_extra_alb_domains[0]}/static/{proxy}",
+      #       "requestParameters" : {
+      #         "integration.request.path.proxy" : "method.request.path.proxy"
+      #       },
+      #       "passthroughBehavior" : "when_no_match",
+      #       "cacheKeyParameters" : [
+      #         "method.request.path.proxy"
+      #       ]
+      #     }
+      #   }
+      # }
     }
   })
   # checkov:skip=CKV_AWS_237: Create before destroy is defined in deployment below


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #ISSUE 

## Changes proposed

- Temp comment out full proxy requirement for API token
- Temp comment out other endpoints since they are redundant right now

## Context for reviewers

This PR will comment out the majority of the logic for the API gateway so that it acts like a full proxy to the underlying ECS service. This will allow us to change the DNS from the ALB to the gateway, but not turn the gateway on, so that we can test the functionality and have a fast way to revert back in case any issues arise. Otherwise, we'd need to change the DNS, which can take time due to it being a long process

## Validation steps

Validation would be to hit the API gateway URL and see if things work as expected. I'm tempted to deploy the proxy as the none stage so we can test fully functionality before the dev DNS change occurs
