### PR TITLE
[Unticketed] Fix issue with sam.gov extracts flagging expected scenario

### DIFF
--- a/api/src/task/sam_extracts/process_sam_extracts.py
+++ b/api/src/task/sam_extracts/process_sam_extracts.py
@@ -66,6 +66,7 @@ class ProcessSamExtractsTask(Task):
 
         ROWS_PROCESSED_COUNT = "rows_processed_count"
         ROWS_SKIPPED_COUNT = "rows_skipped_count"
+        DEACTIVATED_SKIPPED_COUNT = "deactivated_skipped_count"
         DEACTIVATED_ROWS_COUNT = "deactivated_rows_count"
         EXPIRED_ROWS_COUNT = "expired_rows_count"
         ROWS_CONVERTED_COUNT = "rows_converted_count"
@@ -237,6 +238,19 @@ class ProcessSamExtractsTask(Task):
             # These records are separated by the "EFT Indicator" and we will
             # assume that every UEI has one null/empty EFT indicator record that we'll use.
             if len(eft_indicator) > 0:
+                # If the extract_code is to deactivate a record, AND has an eft indicator
+                # then it's saying to deactivate that particular EFT indicator record on a UEI
+                # Since we don't consume any non-empty EFT indicator records, we have nothing
+                # to deactivate and shouldn't expect it to be present.
+                # If the entire UEI was deactivated, we'd receive the empty EFT indicator record itself
+                if extract_code == "1":
+                    logger.info(
+                        "EFT Indicator is not empty, but record is marked for deactivation, skipping entirely",
+                        extra=log_extra,
+                    )
+                    self.increment(self.Metrics.DEACTIVATED_SKIPPED_COUNT)
+                    continue
+
                 logger.info(
                     "EFT Indicator is not empty, skipping assuming to be a duplicate",
                     extra=log_extra,

--- a/api/tests/src/task/sam_extracts/test_process_sam_extracts.py
+++ b/api/tests/src/task/sam_extracts/test_process_sam_extracts.py
@@ -50,10 +50,13 @@ def build_sam_extract_row(
     return "|".join(raw_data) + "!end"
 
 
-def build_sam_extract_row_deactivated_or_expired(uei: str, extract_code: str = "1"):
+def build_sam_extract_row_deactivated_or_expired(
+    uei: str, extract_code: str = "1", eft_indicator: str = ""
+):
     return build_sam_extract_row(
         uei=uei,
         extract_code=extract_code,
+        entity_eft_indicator=eft_indicator,
         # All of the below won't be set for deactivated/expired rows
         legal_business_name="",
         registration_expiration_date="",
@@ -62,7 +65,6 @@ def build_sam_extract_row_deactivated_or_expired(uei: str, extract_code: str = "
         ebiz_last_name="",
         debt_subject_to_offset="",
         exclusion_status_flag="",
-        entity_eft_indicator="",
         initial_registration_date="",
         last_update_date="",
     )
@@ -162,7 +164,11 @@ class TestProcessSamExtracts:
             extract_code="4",
         )
 
-        rows = [row1, row2, row3, row4, row5, row6, row7, row8]
+        row9 = build_sam_extract_row_deactivated_or_expired(
+            uei="III999", extract_code="1", eft_indicator="1234"
+        )
+
+        rows = [row1, row2, row3, row4, row5, row6, row7, row8, row9]
 
         s3_path = f"s3://{mock_s3_bucket}/extracts/SAM_FOUO_MONTHLY_1234.zip"
         make_zip_on_s3(s3_path, build_sam_extract_contents(rows))
@@ -264,8 +270,9 @@ class TestProcessSamExtracts:
         assert len(entity6.import_records) == 0
 
         metrics = task.metrics
-        assert metrics[task.Metrics.ROWS_PROCESSED_COUNT] == 8
+        assert metrics[task.Metrics.ROWS_PROCESSED_COUNT] == 9
         assert metrics[task.Metrics.ROWS_CONVERTED_COUNT] == 4
+        assert metrics[task.Metrics.DEACTIVATED_SKIPPED_COUNT] == 1
         assert metrics[task.Metrics.DEACTIVATED_ROWS_COUNT] == 1
         assert metrics[task.Metrics.EXPIRED_ROWS_COUNT] == 1
         assert metrics[task.Metrics.ROWS_SKIPPED_COUNT] == 0


### PR DESCRIPTION
<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->

## Changes proposed
When a sam.gov extract row is marked as deactivated and has an EFT indicator, don't expect to see the primary non-eft indicator row

## Context for reviewers
The very short version of the EFT indicator logic is that we can receive multiple rows for a given UEI from sam.gov, but anything that has the EFT indicator set is duplicate data as far as we're concerned (it's used to add more bank account info to an entity, something we don't look at). We only want the primary record, but added logic to flag if we saw any non-primary records without the primary. This fixes a case where we can get a non-primary record without the primary (deleting one of those EFT indicator records). This doesn't adjust any meaningful processing logic, just our alert to ourselves that the data was in an odd state.