### PR TITLE
[Issue #5502] allow form left nav to scroll

### DIFF
--- a/frontend/src/components/applyForm/ApplyFormNav.tsx
+++ b/frontend/src/components/applyForm/ApplyFormNav.tsx
@@ -21,7 +21,7 @@ const ApplyFormNav = ({
   return (
     fields.length > 0 && (
       <aside
-        className="usa-in-page-nav maxw-card order-1 margin-left-0 desktop:margin-right-5"
+        className="usa-in-page-nav maxw-card order-1 margin-left-0 desktop:margin-right-5 overflow-auto"
         aria-label={title}
         data-testid="InPageNavigation"
       >

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -701,6 +701,9 @@ dl {
       scroll-margin-top: 6rem;
     }
   }
+  aside {
+    max-height: calc(100vh - 2rem);
+  }
 }
 
 .simpler-application-forms-table {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #5502 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Allows left hand form nav to scroll when contents are larger than viewport height

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. open the sf 424
4. scroll down the page, and attempt to scroll the left hand nav to see the bottom of the nav list
5. _VERIFY_: left hand nav scrolls and you are able to see the full list of nav items without scrolling the page