### PR TITLE
[Isse #4495] revert next js metadata bug workarounds

### DIFF
--- a/frontend/.pa11yci-desktop.json
+++ b/frontend/.pa11yci-desktop.json
@@ -2,7 +2,7 @@
   "defaults": {
     "timeout": 240000,
     "runners": ["axe"],
-    "ignore": ["color-contrast", "document-title"],
+    "ignore": ["color-contrast"],
     "concurrency": 1,
     "chromeLaunchConfig": {
       "ignoreHTTPSErrors": true,

--- a/frontend/.pa11yci-mobile.json
+++ b/frontend/.pa11yci-mobile.json
@@ -2,7 +2,7 @@
   "defaults": {
     "timeout": 240000,
     "runners": ["axe"],
-    "ignore": ["color-contrast", "document-title"],
+    "ignore": ["color-contrast"],
     "concurrency": 1,
     "chromeLaunchConfig": {
       "ignoreHTTPSErrors": true,

--- a/frontend/tests/e2e/404.spec.ts
+++ b/frontend/tests/e2e/404.spec.ts
@@ -8,8 +8,7 @@ test.afterEach(async ({ context }) => {
   await context.close();
 });
 
-// see https://github.com/vercel/next.js/issues/77512 - unskip once this issue is resolved
-test.skip("has title", async ({ page }) => {
+test("has title", async ({ page }) => {
   await expect(page).toHaveTitle("Oops, we can't find that page.");
 });
 


### PR DESCRIPTION
## Summary

Fix for #4495 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Re-enables some tests that were skipped as a result of the next bug here, which has now been fixed https://github.com/vercel/next.js/issues/77512

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This bug has been fixed for a while, so the user facing issue (title and other metadata not showing on the 404 page) fixed itself - this is just clean up of related tests in our system

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. _VERIFY_: all tests pass in CI