### PR TITLE
[Issue #6406] add form group and labels to attachment widget

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -452,7 +452,7 @@ FORM_JSON_SCHEMA = {
         "debt_explanation": {
             "allOf": [{"$ref": "#/$defs/attachment_field"}],
             "title": "Debt Explanation",
-            "description": "Debt Explanation is required.",
+            "description": "",
         },
         "certification_agree": {
             "type": "boolean",

--- a/frontend/src/components/applyForm/widgets/AttachmentUploadWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/AttachmentUploadWidget.tsx
@@ -10,12 +10,15 @@ import {
   Button,
   FileInput,
   FileInputRef,
+  FormGroup,
   ModalRef,
 } from "@trussworks/react-uswds";
 
 import { DeleteAttachmentModal } from "src/components/application/attachments/DeleteAttachmentModal";
 import { FieldErrors } from "src/components/applyForm/FieldErrors";
 import { UswdsWidgetProps } from "src/components/applyForm/types";
+import { DynamicFieldLabel } from "./DynamicFieldLabel";
+import { getLabelTypeFromOptions } from "./getLabelTypeFromOptions";
 
 const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
   const {
@@ -26,8 +29,11 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
     schema,
     rawErrors = [],
     disabled,
+    options,
   } = props;
-  const { contentMediaType, title } = schema;
+  const { contentMediaType, title, description } = schema;
+
+  const labelType = getLabelTypeFromOptions(options?.["widget-label"]);
 
   const attachments = useApplicationAttachments();
   const fileInputRef = useRef<FileInputRef | null>(null);
@@ -118,7 +124,14 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
   const isPreviouslyUploaded = fileName === "(Previously uploaded file)";
 
   return (
-    <React.Fragment key={`${id}-key`}>
+    <FormGroup key={`form-group__multi-file-upload--${id}`} error={error}>
+      <DynamicFieldLabel
+        idFor={id}
+        title={title}
+        required={required}
+        description={description as string}
+        labelType={labelType}
+      />
       <input type="hidden" name={id} value={attachmentId ?? ""} />
       {error && (
         <FieldErrors fieldName={id} rawErrors={rawErrors as string[]} />
@@ -160,7 +173,7 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
         modalRef={deleteModalRef}
         pendingDeleteName={deletePendingName ?? ""}
       />
-    </React.Fragment>
+    </FormGroup>
   );
 };
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6406 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds missing elements to attachment widget to ensure that the title and description assigned in the form schema and any error related styling are properly shown

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Also updates the description for the debt_explanation field on the sf424 since it is inaccurate when shown when delinquent_federal_debt == no

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. open the sf424
4. _VERIFY_: all attachment fields show description and title as expected
5. check "yes" on delinquent federal debt radio input
6. save
7. _VERIFY_: debt explanation shows proper error styling

## Screenshot
<img width="643" height="392" alt="Screenshot 2025-09-16 at 12 44 45 PM" src="https://github.com/user-attachments/assets/5b93fb9e-8471-4ea1-b542-7b19ff18a90a" />

