### PR TITLE
Give API ECS role API Gateway permissions

### DIFF
--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -180,7 +180,7 @@ resource "aws_iam_policy" "runtime_logs" {
 }
 
 resource "aws_iam_policy" "api_gateway_access" {
-  count = var.enable_api_gateway ? 1 : 0
+  count  = var.enable_api_gateway ? 1 : 0
   name   = "${var.service_name}-api-gateway-access-role-policy"
   policy = data.aws_iam_policy_document.api_gateway_access[0].json
 }

--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -141,17 +141,14 @@ data "aws_iam_policy_document" "email_access" {
 data "aws_iam_policy_document" "api_gateway_access" {
   count = var.enable_api_gateway ? 1 : 0
 
-  # Will be locked down once base functionality is confirmed to work
-
   # Only allows running the GET /apikeys request
   statement {
     sid     = "AllowGetApiKeys"
     actions = ["apigateway:GET"]
     resources = [
+      # Must be wildcarded for this to work. Someone using a dev key in prod would not work
+      # because the dev key's usage plan doesn't allow it to access other env's gateways
       "arn:aws:apigateway:${data.aws_region.current.name}::/apikeys/*", # GetApiKey
-      # Not sure if we need this?
-      # Gives permissions for the API gateway and all sub resources
-      # "${aws_api_gateway_rest_api.api[0].arn}/*"
     ]
   }
 
@@ -160,10 +157,9 @@ data "aws_iam_policy_document" "api_gateway_access" {
     sid     = "AllowImportApiKeys"
     actions = ["apigateway:POST"]
     resources = [
+      # Must be wildcarded for this to work. Someone using a dev key in prod would not work
+      # because the dev key's usage plan doesn't allow it to access other env's gateways
       "arn:aws:apigateway:${data.aws_region.current.name}::/apikeys", # ImportApiKeys
-      # Not sure if we need this?
-      # Gives permissions for the API gateway and all sub resources
-      # "${aws_api_gateway_rest_api.api[0].arn}/*"
     ]
   }
 }

--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -138,6 +138,35 @@ data "aws_iam_policy_document" "email_access" {
   }
 }
 
+data "aws_iam_policy_document" "api_gateway_access" {
+  count = var.enable_api_gateway ? 1 : 0
+
+  # Will be locked down once base functionality is confirmed to work
+
+  # Only allows running the GET /apikeys request
+  statement {
+    sid     = "AllowGetApiKeys"
+    actions = ["apigateway:GET"]
+    resources = [
+      "arn:aws:apigateway:${data.aws_region.current.name}::/apikeys/*", # GetApiKey
+      # Not sure if we need this?
+      # Gives permissions for the API gateway and all sub resources
+      # "${aws_api_gateway_rest_api.api[0].arn}/*"
+    ]
+  }
+
+  # Only allows running the POST /apikeys request
+  statement {
+    sid     = "AllowImportApiKeys"
+    actions = ["apigateway:POST"]
+    resources = [
+      "arn:aws:apigateway:${data.aws_region.current.name}::/apikeys", # ImportApiKeys
+      # Not sure if we need this?
+      # Gives permissions for the API gateway and all sub resources
+      # "${aws_api_gateway_rest_api.api[0].arn}/*"
+    ]
+  }
+}
 
 resource "aws_iam_role_policy" "task_executor" {
   name   = "${var.service_name}-task-executor-role-policy"
@@ -148,6 +177,12 @@ resource "aws_iam_role_policy" "task_executor" {
 resource "aws_iam_policy" "runtime_logs" {
   name   = "${var.service_name}-task-executor-role-policy"
   policy = data.aws_iam_policy_document.runtime_logs.json
+}
+
+resource "aws_iam_policy" "api_gateway_access" {
+  count = var.enable_api_gateway ? 1 : 0
+  name   = "${var.service_name}-api-gateway-access-role-policy"
+  policy = data.aws_iam_policy_document.api_gateway_access[0].json
 }
 
 resource "aws_iam_policy" "email_access" {
@@ -173,4 +208,11 @@ resource "aws_iam_role_policy_attachment" "email_access" {
 
   role       = aws_iam_role.app_service.name
   policy_arn = aws_iam_policy.email_access[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "api_gateway_access" {
+  count = var.enable_api_gateway ? 1 : 0
+
+  role       = aws_iam_role.app_service.name
+  policy_arn = aws_iam_policy.api_gateway_access[0].arn
 }


### PR DESCRIPTION
## Summary

Gives API ECS service permissions to hit API Gateway internal API

## Changes proposed

- New IAM policy attached to API ECS role

## Context for reviewers

This PR provides the API ECS service the required permissions to hit the [internal API for API gateway](https://docs.aws.amazon.com/apigateway/latest/api/API_Operations.html)

## Validation steps

This will be tested manually once the API code side PR is merged. We'll use an inline policy so it won't require this to be merged for it to work
