### PR TITLE
[Issue #6224] Static Site Content Update for Co-planning

### DIFF
--- a/frontend/src/components/homepage/IconInfoSection.tsx
+++ b/frontend/src/components/homepage/IconInfoSection.tsx
@@ -8,8 +8,8 @@ import { USWDSIcon } from "src/components/USWDSIcon";
 type Props = {
   description: string;
   iconName: UswdsIconNames;
-  link: string;
-  linkText: string;
+  link?: string;
+  linkText?: string;
   title: string;
 };
 
@@ -29,9 +29,10 @@ export default function IconInfo({
       />
       <h3 className="margin-top-2">{title}</h3>
       <p>{description}</p>
-      <p>
-        <Link href={link}>{linkText}</Link>
-      </p>
+      {link && (<p>
+          <Link href={link}>{linkText}</Link>
+        </p>
+      )}
     </>
   );
 }

--- a/frontend/src/components/roadmap/sections/RoadmapProcess.tsx
+++ b/frontend/src/components/roadmap/sections/RoadmapProcess.tsx
@@ -1,7 +1,7 @@
 import { UswdsIconNames } from "src/types/generalTypes";
 
 import { useTranslations } from "next-intl";
-
+import IconInfo from "src/components/homepage/IconInfoSection";
 import RoadmapPageSection from "src/components/roadmap/RoadmapPageSection";
 import { USWDSIcon } from "src/components/USWDSIcon";
 
@@ -9,6 +9,8 @@ type RoadmapProcessSectionContentProps = {
   content: string;
   title: string;
   iconName: UswdsIconNames;
+  link?: string;
+  linkText?: string;
 };
 
 type RoadmapProcessGrid = RoadmapProcessSectionContentProps[][];
@@ -34,7 +36,14 @@ export default function RoadmapProcess() {
         content: t(`contentItems.${2}.content`),
         iconName: "construction",
       },
-    ],
+      {
+        title: t(`contentItems.${3}.title`),
+        content: t(`contentItems.${3}.content`),
+        iconName: "star_half",
+        link: "https://simplergrants.fider.io",
+        linkText: "Vote on our proposals board",
+      },
+    ]
   ];
 
   return (
@@ -63,14 +72,18 @@ const RoadmapProcessSectionContent = ({
   title,
   content,
   iconName,
+  link,
+  linkText,
 }: RoadmapProcessSectionContentProps) => {
   return (
     <div className="margin-top-4">
-      {iconName && (
-        <USWDSIcon className="usa-icon--size-4 text-middle" name={iconName} />
-      )}
-      <h3 className="margin-top-2">{title}</h3>
-      <p>{content}</p>
+      <IconInfo
+        title={title}
+        description={content}
+        iconName={iconName}
+        link={link}
+        linkText={linkText}
+      />
     </div>
   );
 };

--- a/frontend/src/components/roadmap/sections/RoadmapProcess.tsx
+++ b/frontend/src/components/roadmap/sections/RoadmapProcess.tsx
@@ -35,13 +35,15 @@ export default function RoadmapProcess() {
         title: t(`contentItems.${2}.title`),
         content: t(`contentItems.${2}.content`),
         iconName: "construction",
+        link: t(`contentItems.${2}.link`),
+        linkText: t(`contentItems.${2}.linkText`),
       },
       {
         title: t(`contentItems.${3}.title`),
         content: t(`contentItems.${3}.content`),
         iconName: "star_half",
-        link: "https://simplergrants.fider.io",
-        linkText: "Vote on our proposals board",
+        link: t(`contentItems.${3}.link`),
+        linkText: t(`contentItems.${3}.linkText`),
       },
     ]
   ];

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1041,6 +1041,10 @@ export const messages = {
             content:
               "We swiftly adapt to changing priorities and requirements based on the feedback we receive.",
           },
+          {
+            title: "Co-planning",
+            content: "We prioritize improvements to align with user needs through public ranking. Let us know what’s important to you.",
+          }
         ],
       },
       timeline: {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1039,9 +1039,9 @@ export const messages = {
           {
             title: "Iterative",
             content:
-              "We continuously release features, refining the product with each cycle based on public input.",
+              "We continuously release features, refining the product with each cycle based on public input. Send us your feedback and suggestions.",
             link: "mailto:simpler@grants.gov",
-            linkText: "Send feedback and suggestions to simpler@grants.gov.",
+            linkText: "Contact us at simpler@grants.gov.",
             },
           {
             title: "Co-planning",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1032,18 +1032,22 @@ export const messages = {
               "We're building a simpler Grants.gov in the open. All of the code we're writing is open source and our roadmap is public.",
           },
           {
-            title: "Iterative",
-            content:
-              "We continuously release features, refining the product with each cycle based on public input. Email your feedback and suggestions to simpler@grants.gov.",
-          },
-          {
             title: "Agile",
             content:
               "We swiftly adapt to changing priorities and requirements based on the feedback we receive.",
           },
           {
+            title: "Iterative",
+            content:
+              "We continuously release features, refining the product with each cycle based on public input.",
+            link: "mailto:simpler@grants.gov",
+            linkText: "Send feedback and suggestions to simpler@grants.gov.",
+            },
+          {
             title: "Co-planning",
             content: "We prioritize improvements to align with user needs through public ranking. Let us know what’s important to you.",
+            link: "https://simplergrants.fider.io",
+            linkText: "Vote on our proposals board",
           }
         ],
       },


### PR DESCRIPTION
## Summary

Work for #6224 

## Changes proposed

- Updated the static site to add co-planning content
- Made changes to the <LinkInfo /> component and updated the functionality of the roadmap page to use the pattern
- [Figma Link](https://www.figma.com/design/sgKE2z5uFU6R6HVxpt224Y/Simpler.Grants.gov-Coplanning-Roadmap-Changes?node-id=8119-853&t=8qofzHvX088drKha-0)
- Made a minor change to the email us to make the link clickable instead of plaintext. 

## Context for reviewers

- Updates made to <LinkInfo /> component to make link optional for use on pages where we have an Icon, Title and Text but no link. 

## Validation steps

<img width="1393" height="699" alt="Screenshot 2025-09-17 at 11 17 11 AM" src="https://github.com/user-attachments/assets/82844620-6b4e-497a-982d-56dcd866a08c" />


