### PR TITLE
[Issue #6404] Fix prepopulation when value is null

### DIFF
--- a/api/src/form_schema/rule_processing/README.md
+++ b/api/src/form_schema/rule_processing/README.md
@@ -123,14 +123,6 @@ NOTE: If you had data like `{"my_array": [{"x": 4}, {"x": 5}]}` and ran a rule o
 that would work as we can change the values in the objects within an array uneventfully. We just don't
 want to be adding or removing items themselves from the array. This would result in `{"my_array": [{}, {}]}`
 
----
-Due to how our pre-population rules are setup, we'll still create the path to a value,
-even if we don't create the value itself. For example, if you had data of `{}` and
-a rule to pre-populate `x.y.z` with a null value, the result would be: `{"x": {"y": {}}}`.
-We may be able to work around this issue in the future.
-
-TODO - can I fix this?
-
 ## Monetary Summation
 We support the ability to sum monetary amounts together. This rule requires that you
 specify which fields to sum together like so:

--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -11,23 +11,48 @@ logger = logging.getLogger(__name__)
 INDIVIDUAL_UEI = "00000000INDV"
 ZERO_DECIMAL = Decimal("0.00")  # For formatting and defining 0 for decimal/monetary
 EXCLUDE_VALUE = "exclude_value"
+UNKNOWN_VALUE = "unknown"
 
-def get_opportunity_number(context: JsonRuleContext, json_rule: JsonRule) -> str | None:
+def get_opportunity_number(context: JsonRuleContext, json_rule: JsonRule) -> str:
     """Get the opportunity number"""
-    return context.opportunity.opportunity_number
+    opportunity_number = context.opportunity.opportunity_number
+    if opportunity_number is None:
+        # The data model lets opportunity number be null, but in prod
+        # there are no null opportunity numbers, this is just a safety net
+        # so we always populate something
+        logger.error("Opportunity with null opportunity_number run through pre-population", extra=context.get_log_context())
+        return UNKNOWN_VALUE
+
+    return opportunity_number
 
 
-def get_opportunity_title(context: JsonRuleContext, json_rule: JsonRule) -> str | None:
+def get_opportunity_title(context: JsonRuleContext, json_rule: JsonRule) -> str:
     """Get the opportunity title"""
-    return context.opportunity.opportunity_title
+    opportunity_title = context.opportunity.opportunity_title
+    if opportunity_title is None:
+        # The data model lets opportunity title be null, but in prod
+        # there are no null opportunity titles, this is just a safety net
+        # so we always populate something
+        logger.error("Opportunity with null opportunity_title run through pre-population", extra=context.get_log_context())
+        return UNKNOWN_VALUE
+
+    return opportunity_title
 
 
-def get_agency_name(context: JsonRuleContext, json_rule: JsonRule) -> str | None:
+def get_agency_name(context: JsonRuleContext, json_rule: JsonRule) -> str:
     """Get the agency's name, falling back to agency code if no agency name"""
-    if context.opportunity.agency_name is None:
+    agency_name = context.opportunity.agency_name
+    if context.opportunity.agency_name is not None:
+        return context.opportunity.agency_name
+
+    if context.opportunity.agency_code is not None:
         return context.opportunity.agency_code
 
-    return context.opportunity.agency_name
+    # There are a handful of very old opportunities in prod without an agency
+    # attached to them, so this is technically possible, but we shouldn't expect
+    # it on anything new with an active competition
+    logger.error("Opportunity with null agency_code run through pre-population", extra=context.get_log_context())
+    return UNKNOWN_VALUE
 
 
 def get_current_date(context: JsonRuleContext, json_rule: JsonRule) -> str:
@@ -62,6 +87,7 @@ def get_assistance_listing_number(context: JsonRuleContext, json_rule: JsonRule)
     """Get the assistance listing number attached to the competition"""
     competition = context.application_form.application.competition
 
+    # These can be null, not every competition has an assistance listing number attached
     if competition.opportunity_assistance_listing is None:
         return None
 
@@ -74,6 +100,7 @@ def get_assistance_listing_program_title(
     """Get the assistance listing program title attached to the competition"""
     competition = context.application_form.application.competition
 
+    # These can be null, not every competition has an assistance listing number attached
     if competition.opportunity_assistance_listing is None:
         return None
 
@@ -100,7 +127,7 @@ def get_signature(context: JsonRuleContext, json_rule: JsonRule) -> str | None:
     if len(app_users) > 0:
         return app_users[0].user.email
 
-    return "unknown"
+    return UNKNOWN_VALUE
 
 
 def _convert_monetary_field(value: Any) -> Decimal:

--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 INDIVIDUAL_UEI = "00000000INDV"
 ZERO_DECIMAL = Decimal("0.00")  # For formatting and defining 0 for decimal/monetary
-
+EXCLUDE_VALUE = "exclude_value"
 
 def get_opportunity_number(context: JsonRuleContext, json_rule: JsonRule) -> str | None:
     """Get the opportunity number"""
@@ -179,6 +179,7 @@ def handle_field_population(
 ) -> None:
 
     rule_code: str | None = json_rule.rule.get("rule", None)
+    remove_null_fields = json_rule.rule.get("null_population", EXCLUDE_VALUE) == EXCLUDE_VALUE
     log_extra = context.get_log_context() | json_rule.get_log_context()
 
     # If the rule code isn't configured right, log a warning to alert us, but
@@ -193,7 +194,7 @@ def handle_field_population(
     rule_func = mapper[rule_code]
     try:
         value = rule_func(context, json_rule)
-        context.json_data = populate_nested_value(context.json_data, json_rule.path, value)
+        context.json_data = populate_nested_value(context.json_data, json_rule.path, value, remove_null_fields=remove_null_fields)
     except ValueError:
         # If a value error occurred, something unexpected happened with the data/config
         # we don't want to fail, so instead we'll proceed on. This will only be blocking

--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -13,6 +13,7 @@ ZERO_DECIMAL = Decimal("0.00")  # For formatting and defining 0 for decimal/mone
 EXCLUDE_VALUE = "exclude_value"
 UNKNOWN_VALUE = "unknown"
 
+
 def get_opportunity_number(context: JsonRuleContext, json_rule: JsonRule) -> str:
     """Get the opportunity number"""
     opportunity_number = context.opportunity.opportunity_number
@@ -20,7 +21,10 @@ def get_opportunity_number(context: JsonRuleContext, json_rule: JsonRule) -> str
         # The data model lets opportunity number be null, but in prod
         # there are no null opportunity numbers, this is just a safety net
         # so we always populate something
-        logger.error("Opportunity with null opportunity_number run through pre-population", extra=context.get_log_context())
+        logger.error(
+            "Opportunity with null opportunity_number run through pre-population",
+            extra=context.get_log_context(),
+        )
         return UNKNOWN_VALUE
 
     return opportunity_number
@@ -33,7 +37,10 @@ def get_opportunity_title(context: JsonRuleContext, json_rule: JsonRule) -> str:
         # The data model lets opportunity title be null, but in prod
         # there are no null opportunity titles, this is just a safety net
         # so we always populate something
-        logger.error("Opportunity with null opportunity_title run through pre-population", extra=context.get_log_context())
+        logger.error(
+            "Opportunity with null opportunity_title run through pre-population",
+            extra=context.get_log_context(),
+        )
         return UNKNOWN_VALUE
 
     return opportunity_title
@@ -41,7 +48,6 @@ def get_opportunity_title(context: JsonRuleContext, json_rule: JsonRule) -> str:
 
 def get_agency_name(context: JsonRuleContext, json_rule: JsonRule) -> str:
     """Get the agency's name, falling back to agency code if no agency name"""
-    agency_name = context.opportunity.agency_name
     if context.opportunity.agency_name is not None:
         return context.opportunity.agency_name
 
@@ -51,7 +57,10 @@ def get_agency_name(context: JsonRuleContext, json_rule: JsonRule) -> str:
     # There are a handful of very old opportunities in prod without an agency
     # attached to them, so this is technically possible, but we shouldn't expect
     # it on anything new with an active competition
-    logger.error("Opportunity with null agency_code run through pre-population", extra=context.get_log_context())
+    logger.error(
+        "Opportunity with null agency_code run through pre-population",
+        extra=context.get_log_context(),
+    )
     return UNKNOWN_VALUE
 
 
@@ -221,7 +230,9 @@ def handle_field_population(
     rule_func = mapper[rule_code]
     try:
         value = rule_func(context, json_rule)
-        context.json_data = populate_nested_value(context.json_data, json_rule.path, value, remove_null_fields=remove_null_fields)
+        context.json_data = populate_nested_value(
+            context.json_data, json_rule.path, value, remove_null_fields=remove_null_fields
+        )
     except ValueError:
         # If a value error occurred, something unexpected happened with the data/config
         # we don't want to fail, so instead we'll proceed on. This will only be blocking

--- a/api/src/form_schema/rule_processing/json_rule_util.py
+++ b/api/src/form_schema/rule_processing/json_rule_util.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from os import remove
 from typing import Any
 
 import jsonpath_ng
@@ -156,7 +157,7 @@ def get_nested_value(data: dict, path: list[str]) -> Any:
 
 
 def _populate_nested_value_for_array(
-    json_data: dict, curr_node: str, sub_path: list[str], raw_index: str, value: Any
+    json_data: dict, curr_node: str, sub_path: list[str], raw_index: str, value: Any, remove_null_fields: bool = True
 ) -> dict:
     """Handle the case where we need to populate a nested value
     for an array field.
@@ -194,7 +195,7 @@ def _populate_nested_value_for_array(
         if len(sub_path) == 0:
             array_value[index] = value
         else:
-            result = _populate_nested_value(array_value[index], sub_path, value)
+            result = _populate_nested_value(array_value[index], sub_path, value, remove_null_fields=remove_null_fields)
             array_value[index] = result
     return json_data
 
@@ -219,7 +220,7 @@ def _get_index_from_str(text: str) -> str | None:
     return match.group(1)
 
 
-def _populate_nested_value(json_data: dict, path: list[str], value: Any) -> dict:
+def _populate_nested_value(json_data: dict, path: list[str], value: Any, remove_null_fields: bool = True) -> dict:
     """Populate a value in a series of nested dictionaries
 
     For example, if your path is ["path", "to", "field"]
@@ -253,13 +254,27 @@ def _populate_nested_value(json_data: dict, path: list[str], value: Any) -> dict
             sub_path=sub_path,
             raw_index=raw_index,
             value=value,
+            remove_null_fields=remove_null_fields
         )
 
     # If we're at the end of the path, populate
     # the value in the json_data and return, we're
     # done with recursion down this path.
     if len(path) == 1:
+        # TODO - document / add extra variable
+        if value is None and remove_null_fields:
+            if json_data.get(curr_node, None) is not None:
+                del json_data[curr_node]
+
+            return json_data
+
         json_data[curr_node] = value
+        return json_data
+
+    # If the value is None, and we want to remove null fields
+    # Don't create a nested object if the value is just going to be removed
+    # This prevents us from creating a path to an object and then doing nothing with it
+    if value is None and remove_null_fields and json_data.get(curr_node, None) is None:
         return json_data
 
     # If the value doesn't exist, make it a dictionary
@@ -273,17 +288,18 @@ def _populate_nested_value(json_data: dict, path: list[str], value: Any) -> dict
             f"Unable to populate nested value, value in path is not a dictionary: {curr_node}"
         )
 
-    result = _populate_nested_value(json_data[curr_node], sub_path, value)
+    result = _populate_nested_value(json_data[curr_node], sub_path, value, remove_null_fields=remove_null_fields)
     json_data[curr_node] = result
     return json_data
 
 
-def populate_nested_value(json_data: dict, path: list[str], value: Any) -> dict:
+# TODO - adjust the function params, assuming logic as I implement
+def populate_nested_value(json_data: dict, path: list[str], value: Any, remove_null_fields: bool = True) -> dict:
     """Handle populating a nested value, just a wrapper around _populate_nested_value
     to add a convenient error log message for debugging
     """
     try:
-        return _populate_nested_value(json_data, path, value)
+        return _populate_nested_value(json_data, path, value, remove_null_fields)
     except Exception:
         logger.exception("Failed to populate nested value", extra={"path": build_path_str(path)})
         raise

--- a/api/src/form_schema/rule_processing/json_rule_util.py
+++ b/api/src/form_schema/rule_processing/json_rule_util.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from os import remove
 from typing import Any
 
 import jsonpath_ng
@@ -157,7 +156,12 @@ def get_nested_value(data: dict, path: list[str]) -> Any:
 
 
 def _populate_nested_value_for_array(
-    json_data: dict, curr_node: str, sub_path: list[str], raw_index: str, value: Any, remove_null_fields: bool = True
+    json_data: dict,
+    curr_node: str,
+    sub_path: list[str],
+    raw_index: str,
+    value: Any,
+    remove_null_fields: bool = True,
 ) -> dict:
     """Handle the case where we need to populate a nested value
     for an array field.
@@ -195,7 +199,9 @@ def _populate_nested_value_for_array(
         if len(sub_path) == 0:
             array_value[index] = value
         else:
-            result = _populate_nested_value(array_value[index], sub_path, value, remove_null_fields=remove_null_fields)
+            result = _populate_nested_value(
+                array_value[index], sub_path, value, remove_null_fields=remove_null_fields
+            )
             array_value[index] = result
     return json_data
 
@@ -220,7 +226,9 @@ def _get_index_from_str(text: str) -> str | None:
     return match.group(1)
 
 
-def _populate_nested_value(json_data: dict, path: list[str], value: Any, remove_null_fields: bool = True) -> dict:
+def _populate_nested_value(
+    json_data: dict, path: list[str], value: Any, remove_null_fields: bool = True
+) -> dict:
     """Populate a value in a series of nested dictionaries
 
     For example, if your path is ["path", "to", "field"]
@@ -254,7 +262,7 @@ def _populate_nested_value(json_data: dict, path: list[str], value: Any, remove_
             sub_path=sub_path,
             raw_index=raw_index,
             value=value,
-            remove_null_fields=remove_null_fields
+            remove_null_fields=remove_null_fields,
         )
 
     # If we're at the end of the path, populate
@@ -288,13 +296,17 @@ def _populate_nested_value(json_data: dict, path: list[str], value: Any, remove_
             f"Unable to populate nested value, value in path is not a dictionary: {curr_node}"
         )
 
-    result = _populate_nested_value(json_data[curr_node], sub_path, value, remove_null_fields=remove_null_fields)
+    result = _populate_nested_value(
+        json_data[curr_node], sub_path, value, remove_null_fields=remove_null_fields
+    )
     json_data[curr_node] = result
     return json_data
 
 
 # TODO - adjust the function params, assuming logic as I implement
-def populate_nested_value(json_data: dict, path: list[str], value: Any, remove_null_fields: bool = True) -> dict:
+def populate_nested_value(
+    json_data: dict, path: list[str], value: Any, remove_null_fields: bool = True
+) -> dict:
     """Handle populating a nested value, just a wrapper around _populate_nested_value
     to add a convenient error log message for debugging
     """

--- a/api/src/form_schema/rule_processing/json_rule_util.py
+++ b/api/src/form_schema/rule_processing/json_rule_util.py
@@ -269,8 +269,11 @@ def _populate_nested_value(
     # the value in the json_data and return, we're
     # done with recursion down this path.
     if len(path) == 1:
-        # TODO - document / add extra variable
+        # If a value is None and we want to remove null fields
+        # then we want to skip populating the field will null
         if value is None and remove_null_fields:
+            # If the field already exists, remove it rather
+            # than leave some lingering value
             if json_data.get(curr_node, None) is not None:
                 del json_data[curr_node]
 
@@ -303,7 +306,6 @@ def _populate_nested_value(
     return json_data
 
 
-# TODO - adjust the function params, assuming logic as I implement
 def populate_nested_value(
     json_data: dict, path: list[str], value: Any, remove_null_fields: bool = True
 ) -> dict:

--- a/api/tests/lib/data_factories.py
+++ b/api/tests/lib/data_factories.py
@@ -3,11 +3,25 @@
 To help simplify setup when we need many factories repeatedly
 with only a few alterations.
 """
+
 from src.db.models.competition_models import ApplicationForm
-from tests.src.db.models.factories import AgencyFactory, OpportunityFactory, OpportunityAssistanceListingFactory, CompetitionFactory, OrganizationFactory, ApplicationFactory, ApplicationFormFactory, \
-    FormFactory, CompetitionFormFactory, ApplicationAttachmentFactory, ApplicationUserFactory, LinkExternalUserFactory
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    ApplicationAttachmentFactory,
+    ApplicationFactory,
+    ApplicationFormFactory,
+    ApplicationUserFactory,
+    CompetitionFactory,
+    CompetitionFormFactory,
+    FormFactory,
+    LinkExternalUserFactory,
+    OpportunityAssistanceListingFactory,
+    OpportunityFactory,
+    OrganizationFactory,
+)
 
 DEFAULT_VALUE = object()
+
 
 def setup_application_for_form_validation(
     json_data: dict,

--- a/api/tests/lib/data_factories.py
+++ b/api/tests/lib/data_factories.py
@@ -18,7 +18,7 @@ def setup_application_for_form_validation(
     opportunity_number: str | None = DEFAULT_VALUE,
     opportunity_title: str | None = DEFAULT_VALUE,
     has_agency: bool = True,
-    agency_name: str | None = None,
+    agency_name: str | None = DEFAULT_VALUE,
     agency_code: str | None = None,
     user_email: str | None = None,
     attachment_ids: list[str] | None = None,
@@ -93,4 +93,3 @@ def setup_application_for_form_validation(
         LinkExternalUserFactory.create(email=user_email, user=app_user.user)
 
     return application_form
-

--- a/api/tests/lib/data_factories.py
+++ b/api/tests/lib/data_factories.py
@@ -1,0 +1,96 @@
+"""Factories for setting up data for specific scenarios
+
+To help simplify setup when we need many factories repeatedly
+with only a few alterations.
+"""
+from src.db.models.competition_models import ApplicationForm
+from tests.src.db.models.factories import AgencyFactory, OpportunityFactory, OpportunityAssistanceListingFactory, CompetitionFactory, OrganizationFactory, ApplicationFactory, ApplicationFormFactory, \
+    FormFactory, CompetitionFormFactory, ApplicationAttachmentFactory, ApplicationUserFactory, LinkExternalUserFactory
+
+DEFAULT_VALUE = object()
+
+def setup_application_for_form_validation(
+    json_data: dict,
+    json_schema: dict,
+    rule_schema: dict | None,
+    # These are various params that be set in the application
+    # if the value is None, we'll just leave it to the factory to set.
+    opportunity_number: str | None = DEFAULT_VALUE,
+    opportunity_title: str | None = DEFAULT_VALUE,
+    has_agency: bool = True,
+    agency_name: str | None = None,
+    agency_code: str | None = None,
+    user_email: str | None = None,
+    attachment_ids: list[str] | None = None,
+    has_organization: bool = False,
+    uei: str | None = None,
+    has_assistance_listing_number: bool = True,
+    assistance_listing_number: str | None = None,
+    assistance_listing_program_title: str | None = None,
+    public_competition_id: str | None = None,
+    competition_title: str | None = None,
+) -> ApplicationForm:
+    opp_params = {}
+    agency_params = {}
+    if has_agency:
+        if agency_name is not DEFAULT_VALUE:
+            agency_params["agency_name"] = agency_name
+        agency = AgencyFactory.create(**agency_params)
+        opp_params["agency_code"] = agency.agency_code
+    else:
+        opp_params["agency_code"] = agency_code
+
+    if opportunity_number is not DEFAULT_VALUE:
+        opp_params["opportunity_number"] = opportunity_number
+    if opportunity_title is not DEFAULT_VALUE:
+        opp_params["opportunity_title"] = opportunity_title
+
+    opportunity = OpportunityFactory.create(**opp_params)
+
+    opportunity_assistance_listing = None
+    if has_assistance_listing_number:
+        params = {
+            "opportunity": opportunity,
+            "assistance_listing_number": assistance_listing_number,
+            "program_title": assistance_listing_program_title,
+        }
+        opportunity_assistance_listing = OpportunityAssistanceListingFactory.create(**params)
+
+    competition_params = {
+        "opportunity": opportunity,
+        "competition_forms": [],
+        "competition_title": competition_title,
+        "public_competition_id": public_competition_id,
+        "opportunity_assistance_listing": opportunity_assistance_listing,
+    }
+
+    competition = CompetitionFactory.create(**competition_params)
+    form = FormFactory.create(form_json_schema=json_schema, form_rule_schema=rule_schema)
+    competition_form = CompetitionFormFactory.create(competition=competition, form=form)
+
+    organization = None
+    if has_organization:
+        organization_params = {}
+        if uei is not None:
+            organization_params["sam_gov_entity__uei"] = uei
+        else:
+            organization_params["sam_gov_entity"] = None
+        organization = OrganizationFactory(**organization_params)
+
+    application = ApplicationFactory.create(competition=competition, organization=organization)
+    application_form = ApplicationFormFactory.create(
+        application=application, competition_form=competition_form, application_response=json_data
+    )
+
+    if attachment_ids is not None:
+        for attachment_id in attachment_ids:
+            ApplicationAttachmentFactory.create(
+                application_attachment_id=attachment_id, application=application
+            )
+
+    if user_email is not None:
+        app_user = ApplicationUserFactory.create(application=application, is_application_owner=True)
+        LinkExternalUserFactory.create(email=user_email, user=app_user.user)
+
+    return application_form
+

--- a/api/tests/src/form_schema/forms/test_sf424.py
+++ b/api/tests/src/form_schema/forms/test_sf424.py
@@ -2,6 +2,9 @@ import pytest
 
 from src.form_schema.forms.sf424 import SF424_v4_0
 from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+from src.services.applications.application_validation import validate_application_form, ApplicationAction
+from tests.lib.data_factories import setup_application_for_form_validation
+from tests.src.db.models.factories import ApplicationFormFactory, CompetitionFactory, CompetitionFormFactory, ApplicationFactory
 
 
 @pytest.fixture()
@@ -367,3 +370,77 @@ def test_sf424_v4_0_conditionally_required_fields(
     for validation_issue in validation_issues:
         assert validation_issue.type == "required"
         assert validation_issue.field in required_fields
+
+
+
+
+def test_sf424_v4_0_pre_population_with_all_non_null_values(enable_factory_create, valid_json_v4_0):
+    application_form = setup_application_for_form_validation(
+        valid_json_v4_0,
+        json_schema=SF424_v4_0.form_json_schema,
+        rule_schema=SF424_v4_0.form_rule_schema,
+        opportunity_number="ABC-123-XYZ",
+        opportunity_title="My Example Opportunity",
+        has_agency=True,
+        agency_name="Example Agency XYZ",
+        agency_code="ABC-XYZ-123-456-789",
+        attachment_ids=["4943c20b-57cc-4611-9d10-582144de726d"],
+        has_organization=True,
+        uei="TESTUEI98765",
+        has_assistance_listing_number=True,
+        assistance_listing_number="12.345",
+        assistance_listing_program_title="Example Program Title",
+        public_competition_id="COMP-ABC-XYZ-123",
+        competition_title="Competition for Research Funding",
+    )
+
+    issues = validate_application_form(application_form, ApplicationAction.MODIFY)
+
+    assert len(issues) == 0
+    # Verify prepopulation rules ran
+    app_json = application_form.application_response
+    assert app_json["sam_uei"] == "TESTUEI98765"
+    assert app_json["agency_name"] == "Example Agency XYZ"
+    assert app_json["assistance_listing_number"] == "12.345"
+    assert app_json["assistance_listing_program_title"] == "Example Program Title"
+    assert app_json["funding_opportunity_number"] == "ABC-123-XYZ"
+    assert app_json["funding_opportunity_title"] == "My Example Opportunity"
+    assert app_json["competition_identification_number"] == "COMP-ABC-XYZ-123"
+    assert app_json["competition_identification_title"] == "Competition for Research Funding"
+    # Post-populated fields not present
+    assert "date_received" not in app_json
+    assert "date_signed" not in app_json
+    assert "aor_signature" not in app_json
+
+def test_sf424_v4_0_pre_population_with_all_null_values(enable_factory_create, valid_json_v4_0):
+    application_form = setup_application_for_form_validation(
+        valid_json_v4_0,
+        json_schema=SF424_v4_0.form_json_schema,
+        rule_schema=SF424_v4_0.form_rule_schema,
+        opportunity_number=None,
+        opportunity_title=None,
+        has_agency=False,
+        agency_code="NO-AGENCY-THIS-CONNECTS-TO",
+        has_organization=False,
+        has_assistance_listing_number=False,
+        public_competition_id=None,
+        competition_title=None,
+    )
+
+    issues = validate_application_form(application_form, ApplicationAction.MODIFY)
+
+    assert len(issues) == 0
+    # Verify prepopulation rules ran
+    app_json = application_form.application_response
+    assert app_json["sam_uei"] == "00000000INDV"
+    assert app_json["agency_name"] == "NO-AGENCY-THIS-CONNECTS-TO"
+    assert "assistance_listing_number" not in app_json
+    assert "assistance_listing_program_title" not in app_json
+    assert "funding_opportunity_number" not in app_json
+    assert "funding_opportunity_title" not in app_json
+    assert "competition_identification_number" not in app_json
+    assert "competition_identification_title" not in app_json
+    # Post-populated fields not present
+    assert "date_received" not in app_json
+    assert "date_signed" not in app_json
+    assert "aor_signature" not in app_json

--- a/api/tests/src/form_schema/forms/test_sf424.py
+++ b/api/tests/src/form_schema/forms/test_sf424.py
@@ -1,10 +1,14 @@
+import freezegun
 import pytest
 
 from src.form_schema.forms.sf424 import SF424_v4_0
 from src.form_schema.jsonschema_validator import validate_json_schema_for_form
-from src.services.applications.application_validation import validate_application_form, ApplicationAction
+from src.services.applications.application_validation import (
+    ApplicationAction,
+    validate_application_form,
+)
 from tests.lib.data_factories import setup_application_for_form_validation
-import freezegun
+
 
 @pytest.fixture()
 def sf424_v4_0():
@@ -371,8 +375,6 @@ def test_sf424_v4_0_conditionally_required_fields(
         assert validation_issue.field in required_fields
 
 
-
-
 def test_sf424_v4_0_pre_population_with_all_non_null_values(enable_factory_create, valid_json_v4_0):
     application_form = setup_application_for_form_validation(
         valid_json_v4_0,
@@ -411,6 +413,7 @@ def test_sf424_v4_0_pre_population_with_all_non_null_values(enable_factory_creat
     assert "date_signed" not in app_json
     assert "aor_signature" not in app_json
 
+
 def test_sf424_v4_0_pre_population_with_all_null_values(enable_factory_create, valid_json_v4_0):
     application_form = setup_application_for_form_validation(
         valid_json_v4_0,
@@ -442,6 +445,7 @@ def test_sf424_v4_0_pre_population_with_all_null_values(enable_factory_create, v
     assert "date_received" not in app_json
     assert "date_signed" not in app_json
     assert "aor_signature" not in app_json
+
 
 @freezegun.freeze_time("2023-02-20 12:00:00", tz_offset=0)
 def test_sf424_post_population(enable_factory_create, valid_json_v4_0):

--- a/api/tests/src/form_schema/rule_processing/conftest.py
+++ b/api/tests/src/form_schema/rule_processing/conftest.py
@@ -2,6 +2,7 @@ from src.form_schema.rule_processing.json_rule_context import JsonRuleConfig
 from src.form_schema.rule_processing.json_rule_processor import JsonRuleContext
 from tests.lib.data_factories import setup_application_for_form_validation
 
+
 def setup_context(
     json_data: dict,
     rule_schema: dict | None,
@@ -11,7 +12,9 @@ def setup_context(
     do_field_validation: bool = True,
     **kwargs: dict
 ):
-    application_form = setup_application_for_form_validation(json_data=json_data, json_schema={}, rule_schema=rule_schema, **kwargs)
+    application_form = setup_application_for_form_validation(
+        json_data=json_data, json_schema={}, rule_schema=rule_schema, **kwargs
+    )
 
     return JsonRuleContext(
         application_form,

--- a/api/tests/src/form_schema/rule_processing/conftest.py
+++ b/api/tests/src/form_schema/rule_processing/conftest.py
@@ -1,106 +1,17 @@
 from src.form_schema.rule_processing.json_rule_context import JsonRuleConfig
 from src.form_schema.rule_processing.json_rule_processor import JsonRuleContext
-from tests.src.db.models.factories import (
-    AgencyFactory,
-    ApplicationAttachmentFactory,
-    ApplicationFactory,
-    ApplicationFormFactory,
-    ApplicationUserFactory,
-    CompetitionFactory,
-    CompetitionFormFactory,
-    FormFactory,
-    LinkExternalUserFactory,
-    OpportunityAssistanceListingFactory,
-    OpportunityFactory,
-    OrganizationFactory,
-)
-
+from tests.lib.data_factories import setup_application_for_form_validation
 
 def setup_context(
     json_data: dict,
     rule_schema: dict | None,
-    # These are various params that be set in the application
-    # if the value is None, we'll just leave it to the factory to set.
-    opportunity_number: str | None = None,
-    opportunity_title: str | None = None,
-    has_agency: bool = True,
-    agency_name: str | None = None,
-    agency_code: str | None = None,
-    user_email: str | None = None,
-    attachment_ids: list[str] | None = None,
-    has_organization: bool = False,
-    uei: str | None = None,
-    has_assistance_listing_number: bool = True,
-    assistance_listing_number: str | None = None,
-    assistance_listing_program_title: str | None = None,
-    public_competition_id: str | None = None,
-    competition_title: str | None = None,
     # Configurational params
     do_pre_population: bool = True,
     do_post_population: bool = True,
     do_field_validation: bool = True,
+    **kwargs: dict
 ):
-    opp_params = {}
-    agency_params = {}
-    if has_agency:
-        if agency_name is not None:
-            agency_params["agency_name"] = agency_name
-        agency = AgencyFactory.create(**agency_params)
-        opp_params["agency_code"] = agency.agency_code
-    elif agency_code is not None:
-        opp_params["agency_code"] = agency_code
-
-    if opportunity_number is not None:
-        opp_params["opportunity_number"] = opportunity_number
-    if opportunity_title is not None:
-        opp_params["opportunity_title"] = opportunity_title
-
-    opportunity = OpportunityFactory.create(**opp_params)
-
-    opportunity_assistance_listing = None
-    if has_assistance_listing_number:
-        params = {
-            "opportunity": opportunity,
-            "assistance_listing_number": assistance_listing_number,
-            "program_title": assistance_listing_program_title,
-        }
-        opportunity_assistance_listing = OpportunityAssistanceListingFactory.create(**params)
-
-    competition_params = {
-        "opportunity": opportunity,
-        "competition_forms": [],
-        "competition_title": competition_title,
-        "public_competition_id": public_competition_id,
-        "opportunity_assistance_listing": opportunity_assistance_listing,
-    }
-
-    competition = CompetitionFactory.create(**competition_params)
-    form = FormFactory.create(form_rule_schema=rule_schema)
-    competition_form = CompetitionFormFactory.create(competition=competition, form=form)
-
-    organization = None
-    if has_organization:
-        organization_params = {}
-        if uei is not None:
-            organization_params["sam_gov_entity__uei"] = uei
-        else:
-            organization_params["sam_gov_entity"] = None
-        organization = OrganizationFactory(**organization_params)
-
-    application = ApplicationFactory.create(competition=competition, organization=organization)
-    application_form = ApplicationFormFactory.create(
-        application=application, competition_form=competition_form, application_response=json_data
-    )
-
-    if attachment_ids is not None:
-        for attachment_id in attachment_ids:
-            ApplicationAttachmentFactory.create(
-                application_attachment_id=attachment_id, application=application
-            )
-
-    if user_email is not None:
-        app_user = ApplicationUserFactory.create(application=application, is_application_owner=True)
-        LinkExternalUserFactory.create(email=user_email, user=app_user.user)
+    application_form = setup_application_for_form_validation(json_data=json_data, json_schema={}, rule_schema=rule_schema, **kwargs)
 
     return JsonRuleContext(
         application_form,

--- a/api/tests/src/form_schema/rule_processing/test_json_rule_util.py
+++ b/api/tests/src/form_schema/rule_processing/test_json_rule_util.py
@@ -112,33 +112,56 @@ COMPLEX_ARRAY_DATA = {
 def test_populate_nested_value(existing_json, path, value, expected_json):
     assert populate_nested_value(existing_json, path, value) == expected_json
 
-@pytest.mark.parametrize("existing_json,path,expected_json", [
-    ({"my_field": {"x": 4}}, ["my_field", "x"], {"my_field": {}}),
-    ({}, ["my_field", "x"], {}),
-    ({}, ["x", "y", "z"], {}),
-    ({}, ["my_field"], {}),
-    ({"my_field": [{"a": 1, "x": 10}, {"x": 4}]}, ["my_field[*]", "x"], {"my_field": [{"a": 1}, {}]}),
-    ({"my_field": [{"a": 1, "x": 10}, {"x": 4}]}, ["my_field[0]", "x"], {"my_field": [{"a": 1}, {"x": 4}]}),
-    # Deleting values in an array is not supported at this time
-    # so these cases will just be changed to None unlike the above cases
-    # See the README.md in the rule_processing folder for further details
-    ({"my_field": [1, 2, 3]}, ["my_field[*]"], {"my_field": [None, None, None]}),
-    ({"my_field": [1, 2, 3]}, ["my_field[1]"], {"my_field": [1, None, 3]}),
-])
+
+@pytest.mark.parametrize(
+    "existing_json,path,expected_json",
+    [
+        ({"my_field": {"x": 4}}, ["my_field", "x"], {"my_field": {}}),
+        ({}, ["my_field", "x"], {}),
+        ({}, ["x", "y", "z"], {}),
+        ({}, ["my_field"], {}),
+        (
+            {"my_field": [{"a": 1, "x": 10}, {"x": 4}]},
+            ["my_field[*]", "x"],
+            {"my_field": [{"a": 1}, {}]},
+        ),
+        (
+            {"my_field": [{"a": 1, "x": 10}, {"x": 4}]},
+            ["my_field[0]", "x"],
+            {"my_field": [{"a": 1}, {"x": 4}]},
+        ),
+        # Deleting values in an array is not supported at this time
+        # so these cases will just be changed to None unlike the above cases
+        # See the README.md in the rule_processing folder for further details
+        ({"my_field": [1, 2, 3]}, ["my_field[*]"], {"my_field": [None, None, None]}),
+        ({"my_field": [1, 2, 3]}, ["my_field[1]"], {"my_field": [1, None, 3]}),
+    ],
+)
 def test_populate_nested_value_null_exclude_value(existing_json, path, expected_json):
     assert populate_nested_value(existing_json, path, None) == expected_json
 
-@pytest.mark.parametrize("existing_json,path,expected_json", [
-    ({"my_field": {"x": 4}}, ["my_field", "x"], {"my_field": {"x": None}}),
-    ({}, ["my_field", "x"], {"my_field": {"x": None}}),
-    ({}, ["x", "y", "z"], {"x": {"y": {"z": None}}}),
-    ({}, ["my_field"], {"my_field": None}),
-    ({"my_field": [{"a": 1, "x": 10}, {"x": 4}]}, ["my_field[*]", "x"], {"my_field": [{"a": 1, "x": None}, {"x": None}]}),
-    ({"my_field": [1, 2, 3]}, ["my_field[*]"], {"my_field": [None, None, None]}),
-    ({"my_field": [1, 2, 3]}, ["my_field[1]"], {"my_field": [1, None, 3]}),
-])
+
+@pytest.mark.parametrize(
+    "existing_json,path,expected_json",
+    [
+        ({"my_field": {"x": 4}}, ["my_field", "x"], {"my_field": {"x": None}}),
+        ({}, ["my_field", "x"], {"my_field": {"x": None}}),
+        ({}, ["x", "y", "z"], {"x": {"y": {"z": None}}}),
+        ({}, ["my_field"], {"my_field": None}),
+        (
+            {"my_field": [{"a": 1, "x": 10}, {"x": 4}]},
+            ["my_field[*]", "x"],
+            {"my_field": [{"a": 1, "x": None}, {"x": None}]},
+        ),
+        ({"my_field": [1, 2, 3]}, ["my_field[*]"], {"my_field": [None, None, None]}),
+        ({"my_field": [1, 2, 3]}, ["my_field[1]"], {"my_field": [1, None, 3]}),
+    ],
+)
 def test_populate_nested_value_null_set_as_null(existing_json, path, expected_json):
-    assert populate_nested_value(existing_json, path, None, remove_null_fields=False) == expected_json
+    assert (
+        populate_nested_value(existing_json, path, None, remove_null_fields=False) == expected_json
+    )
+
 
 def test_populate_nested_value_non_dict_in_path():
     with pytest.raises(

--- a/api/tests/src/form_schema/rule_processing/test_json_rule_util.py
+++ b/api/tests/src/form_schema/rule_processing/test_json_rule_util.py
@@ -112,6 +112,33 @@ COMPLEX_ARRAY_DATA = {
 def test_populate_nested_value(existing_json, path, value, expected_json):
     assert populate_nested_value(existing_json, path, value) == expected_json
 
+@pytest.mark.parametrize("existing_json,path,expected_json", [
+    ({"my_field": {"x": 4}}, ["my_field", "x"], {"my_field": {}}),
+    ({}, ["my_field", "x"], {}),
+    ({}, ["x", "y", "z"], {}),
+    ({}, ["my_field"], {}),
+    ({"my_field": [{"a": 1, "x": 10}, {"x": 4}]}, ["my_field[*]", "x"], {"my_field": [{"a": 1}, {}]}),
+    ({"my_field": [{"a": 1, "x": 10}, {"x": 4}]}, ["my_field[0]", "x"], {"my_field": [{"a": 1}, {"x": 4}]}),
+    # Deleting values in an array is not supported at this time
+    # so these cases will just be changed to None unlike the above cases
+    # See the README.md in the rule_processing folder for further details
+    ({"my_field": [1, 2, 3]}, ["my_field[*]"], {"my_field": [None, None, None]}),
+    ({"my_field": [1, 2, 3]}, ["my_field[1]"], {"my_field": [1, None, 3]}),
+])
+def test_populate_nested_value_null_exclude_value(existing_json, path, expected_json):
+    assert populate_nested_value(existing_json, path, None) == expected_json
+
+@pytest.mark.parametrize("existing_json,path,expected_json", [
+    ({"my_field": {"x": 4}}, ["my_field", "x"], {"my_field": {"x": None}}),
+    ({}, ["my_field", "x"], {"my_field": {"x": None}}),
+    ({}, ["x", "y", "z"], {"x": {"y": {"z": None}}}),
+    ({}, ["my_field"], {"my_field": None}),
+    ({"my_field": [{"a": 1, "x": 10}, {"x": 4}]}, ["my_field[*]", "x"], {"my_field": [{"a": 1, "x": None}, {"x": None}]}),
+    ({"my_field": [1, 2, 3]}, ["my_field[*]"], {"my_field": [None, None, None]}),
+    ({"my_field": [1, 2, 3]}, ["my_field[1]"], {"my_field": [1, None, 3]}),
+])
+def test_populate_nested_value_null_set_as_null(existing_json, path, expected_json):
+    assert populate_nested_value(existing_json, path, None, remove_null_fields=False) == expected_json
 
 def test_populate_nested_value_non_dict_in_path():
     with pytest.raises(


### PR DESCRIPTION
## Summary
Fixes  #6404

## Changes proposed
Adjust behavior of prepopulation when a value is null, by default the field should not be populated AND any existing value is removed.

Adjust some of our prepopulation logic to not let a field be null (opportunity number, opportunity title, and agency name) to avoid issues where a required field can't be populated

Add some additional tests to the SF424 validation pre-population behavior

## Context for reviewers
Some prepopulation fields can be null as the field is not required, for example the competition title is a commonly nullable field. But our JSON schema doesn't like those fields being null, even if they're not required. Null != missing, missing is fine, null would require we change the type from `string` to `["string", "null"]` which is a much bigger change. Instead we'll change the default to not include the field. Additionally, it will delete an existing value, this is because an API user could pass in any value for it, and we want to make sure it's unset (there are a few very specific edge cases still unhandled, but not needed any time soon).

For the fields I made not be able to prepopulate to null, they do have nullable columns but in prod opportunity number and title are never actually null. Agency is only null on about 40 opportunities, most of those from before 2010. We should eventually fix the schema to not let those fields be null, but that's not something we should worry about yet.