### PR TITLE
[Issue #6430] Lowercase emails for sam.gov and login

### DIFF
--- a/api/src/services/users/login_gov_callback_handler.py
+++ b/api/src/services/users/login_gov_callback_handler.py
@@ -152,7 +152,9 @@ def _process_token(db_session: db.Session, token: str, nonce: str) -> LoginGovCa
         external_user = _create_login_gov_user(login_gov_user.user_id, db_session)
 
     # Update fields on the external user table
-    external_user.email = login_gov_user.email
+    # Store the email as lowercase, this should be how it's returned already
+    # but just to make email comparisons easier elsewhere we doubly make sure.
+    external_user.email = login_gov_user.email.lower()
 
     # Flush the records to the DB so any auto-generated IDs and similar are populated
     # prior to us trying to work with the user further.

--- a/api/src/task/sam_extracts/create_orgs_from_sam_entity.py
+++ b/api/src/task/sam_extracts/create_orgs_from_sam_entity.py
@@ -26,6 +26,10 @@ class CreateOrgsFromSamEntityTask(Task):
             sam_gov_entities = self.db_session.execute(
                 select(SamGovEntity, LinkExternalUser)
                 .join(LinkExternalUser, SamGovEntity.ebiz_poc_email == LinkExternalUser.email)
+                # There can be blank email fields in the Sam.gov data
+                # just in case a user ever ends up with a blank email
+                # we want to avoid them becoming the org owner of 500 random orgs
+                .where(SamGovEntity.ebiz_poc_email != "")
                 .options(selectinload(SamGovEntity.organization))
                 .options(selectinload(LinkExternalUser.user).selectinload(User.organizations))
             )

--- a/api/src/task/sam_extracts/process_sam_extracts.py
+++ b/api/src/task/sam_extracts/process_sam_extracts.py
@@ -526,7 +526,9 @@ def build_sam_gov_entity(tokens: list[str]) -> SamGovEntity:
         tokens, ExtractIndex.REGISTRATION_EXPIRATION_DATE, can_be_blank=False
     )
     # NOTE: Email can be null in rare cases
-    ebiz_poc_email = get_token_value(tokens, ExtractIndex.EBIZ_POC_EMAIL)
+    # We lowercase the email so it can later be joined with our user table
+    # to setup organizations. Sam.gov stores emails with whatever case the user entered.
+    ebiz_poc_email = get_token_value(tokens, ExtractIndex.EBIZ_POC_EMAIL).lower()
     ebiz_first_name = get_token_value(tokens, ExtractIndex.EBIZ_POC_FIRST_NAME)
     ebiz_last_name = get_token_value(tokens, ExtractIndex.EBIZ_POC_LAST_NAME)
     debt_subject_to_offset = get_token_value(tokens, ExtractIndex.DEBT_SUBJECT_TO_OFFSET)

--- a/api/tests/src/services/users/test_organization_from_ebiz_poc.py
+++ b/api/tests/src/services/users/test_organization_from_ebiz_poc.py
@@ -57,6 +57,16 @@ def test_handle_ebiz_poc_organization_during_login_not_ebiz_poc(db_session, enab
     assert result is None
 
 
+def test_handle_ebiz_poc_organization_during_login_blank_email(db_session, enable_factory_create):
+    """Test that we return None when user email is blank"""
+    SamGovEntityFactory.create(ebiz_poc_email="")
+    external_user = LinkExternalUserFactory.create(email="")
+
+    result = handle_ebiz_poc_organization_during_login(db_session, external_user.user)
+
+    assert result is None
+
+
 def test_handle_ebiz_poc_organization_during_login_creates_organization(
     db_session, enable_factory_create
 ):

--- a/api/tests/src/task/sam_extracts/test_process_sam_extracts.py
+++ b/api/tests/src/task/sam_extracts/test_process_sam_extracts.py
@@ -105,7 +105,7 @@ class TestProcessSamExtracts:
             extract_code="A",
             legal_business_name="Sara's Sweets",
             registration_expiration_date="20250101",
-            ebiz_poc_email="sara@example.com",
+            ebiz_poc_email="SARA@example.com",  # will be lowercased when processed
             ebiz_first_name="Sara",
             ebiz_last_name="Smith",
             debt_subject_to_offset="Y",


### PR DESCRIPTION
## Summary
Fixes #6430

## Changes proposed
When loading sam.gov data, lowercase the email.
When receiving login.gov data, lowercase the email.

When joining sam.gov data for creating orgs, skip all blank emails

## Context for reviewers
The sam.gov extract doesn't store emails in a consistent case, we might receive an email of `ABC@mail.com` but login.gov looks like it always lowercases it to `abc@mail.com`. This means the join wouldn't actually work, and we're probably missing some orgs. This fixes the emails when we import them.

Also we have a few hundred sam.gov entities without an email, just in case, we don't want that to join with a blank email in the external table.
