### PR TITLE
[Issue #6359] Skip sending to grants.gov if simpler formatted id

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_routes.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_routes.py
@@ -10,6 +10,7 @@ from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response
 from src.legacy_soap_api.legacy_soap_api_schemas import SimplerSoapAPI, SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
+    get_alternate_proxy_response,
     get_invalid_path_response,
     get_soap_error_response,
 )
@@ -60,7 +61,10 @@ def simpler_soap_api_route(
             auth=get_soap_auth(request.headers.get(MTLS_CERT_HEADER_KEY)),
             operation_name=operation_name,
         )
-        soap_proxy_response = get_proxy_response(soap_request)
+        if alternate_proxy_response := get_alternate_proxy_response(soap_request):
+            soap_proxy_response = alternate_proxy_response
+        else:
+            soap_proxy_response = get_proxy_response(soap_request)
     except Exception:
         logger.exception(
             msg="Error getting soap proxy response",

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -1,13 +1,17 @@
+import io
 import json
 import logging
 import uuid
+from enum import StrEnum
 from typing import Any, Callable
 
 import requests
 from defusedxml import minidom
+from lxml import etree
 
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
-from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage, SOAPResponse
+from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage, SOAPRequest, SOAPResponse
+from src.legacy_soap_api.soap_payload_handler import extract_soap_xml
 
 logger = logging.getLogger(__name__)
 
@@ -17,24 +21,61 @@ BASE_SOAP_API_RESPONSE_HEADERS = {
 HIDDEN_VALUE = "hidden"
 
 
-def format_local_soap_response(response_data: bytes) -> bytes:
+class AlternateSoapOperation(StrEnum):
+    GET_APPLICATION_ZIP = "GetApplicationZipRequest"
+    GET_APPLICATION = "GetApplicationRequest"
+
+
+def format_local_soap_response(response_data: bytes, boundary_id: str | None = None) -> bytes:
     # This is a format string for formatting local responses from the mock
     # soap server since it does not support manipulating the response.
     # The grants.gov SOAP API currently includes this data.
-    response_id = str(uuid.uuid4())
+    # Note: /r/n is how Windows encodes a newline
+    # /r symbolizes a Carriage Return which returns to the start of the current line (holdover from typewriters)
+    # Mac just uses /n
+    # This is used to ensure the correct Content-Length
+    # see: https://en.wikipedia.org/wiki/Newline
+    response_id = boundary_id if boundary_id else str(uuid.uuid4())
     return (
-        f"""
---uuid:{response_id}
-Content-Type: application/xop+xml; charset=UTF-8; type=\"text/xml\"
-Content-Transfer-Encoding: binary
-Content-ID: <root.message@cxf.apache.org>{response_data.decode()}
---uuid:{response_id}--
-        """.replace(
-            '<?xml version="1.0" encoding="UTF-8"?>', ""
+        (
+            f"--uuid:{response_id}\r\n"
+            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+            "Content-Transfer-Encoding: binary\r\n"
+            f"Content-ID: <root.message@cxf.apache.org>{response_data.decode()}\r\n"
+            f"--uuid:{response_id}--\r\n"
         )
+        .replace('<?xml version="1.0" encoding="UTF-8"?>', "")
         .strip()
         .encode("utf-8")
     )
+
+
+def get_soap_proxy_grant_application_not_found_response(
+    grants_gov_tracking_number: str, headers: dict, is_get_application_zip: bool = True
+) -> SOAPResponse:
+    data = (
+        '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body><soap:Fault><faultcode>soap:Server</faultcode><faultstring>"
+        f"Failed to get application{' zip' if is_get_application_zip else ''}."
+        f"(Grant Application not found for tracking number:{grants_gov_tracking_number})"
+        "</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    ).encode("utf-8")
+    boundary_id = str(uuid.uuid4())
+    response_data = format_local_soap_response(data, boundary_id=boundary_id)
+    response_headers = {
+        "Content-Type": (
+            "multipart/related;"
+            ' type="application/xop+xml";'
+            f' boundary="uuid:{boundary_id}";'
+            ' start="<root.message@cxf.apache.org>";'
+            ' start-info="text/xml"'
+        ),
+        "Set-Cookie": (f"{headers.get('Cookie')}; Path=/grantsws-agency; Secure; HttpOnly"),
+    }
+    return get_soap_response(response_data, 500, headers=response_headers)
 
 
 def get_soap_response(
@@ -262,3 +303,32 @@ def log_local(msg: str, data: Any | None = None, formatter: Callable | None = No
 
 def _hide_value(value: Any, hide: bool) -> Any:
     return HIDDEN_VALUE if hide else value
+
+
+def get_gov_grants_tracking_number(xml_bytes: bytes) -> str | None:
+    xml_file = io.BytesIO(xml_bytes)
+    value = None
+    try:
+        for event, elem in etree.iterparse(xml_file, events=("end",)):
+            if elem.tag.endswith("GrantsGovTrackingNumber") and event == "end":
+                value = elem.text
+                elem.clear()
+    except etree.XMLSyntaxError:
+        return None
+    return value
+
+
+def get_alternate_proxy_response(soap_request: SOAPRequest) -> SOAPResponse | None:
+    xml_bytes = extract_soap_xml(soap_request.data)
+    if not xml_bytes:
+        return None
+    if soap_request.operation_name in AlternateSoapOperation:
+        tracking_number = get_gov_grants_tracking_number(xml_bytes)
+        is_zip = soap_request.operation_name == AlternateSoapOperation.GET_APPLICATION_ZIP
+        if tracking_number and (
+            tracking_number.startswith("GRANT8") or tracking_number.startswith("GRANT9")
+        ):
+            return get_soap_proxy_grant_application_not_found_response(
+                tracking_number, headers=soap_request.headers, is_get_application_zip=is_zip
+            )
+    return None

--- a/api/tests/fixtures/legacy_soap_api/grantors/get_application_request.xml
+++ b/api/tests/fixtures/legacy_soap_api/grantors/get_application_request.xml
@@ -1,0 +1,8 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <agen:GetApplicationRequest>
+         <gran:GrantsGovTrackingNumber>GRANT00834688</gran:GrantsGovTrackingNumber>
+      </agen:GetApplicationRequest>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/api/tests/fixtures/legacy_soap_api/grantors/get_application_zip_request.xml
+++ b/api/tests/fixtures/legacy_soap_api/grantors/get_application_zip_request.xml
@@ -1,0 +1,8 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <agen:GetApplicationZipRequest>
+         <gran:GrantsGovTrackingNumber>GRANT00000008</gran:GrantsGovTrackingNumber>
+      </agen:GetApplicationZipRequest>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_utils.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_utils.py
@@ -20,7 +20,7 @@ from src.legacy_soap_api.legacy_soap_api_utils import (
 def test_format_local_soap_response() -> None:
     mock_uuid = "mockuuid4"
     mock_response = b"mockresponse"
-    expected = b'--uuid:mockuuid4\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>mockresponse\n--uuid:mockuuid4--'
+    expected = b'--uuid:mockuuid4\r\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>mockresponse\r\n--uuid:mockuuid4--'
 
     with patch.object(uuid, "uuid4", return_value=mock_uuid):
         given = format_local_soap_response(mock_response)


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->

If it is Simpler format, skip sending request to Grants.gov

## Changes proposed

Added a check to see if the incoming request meets the following criteria:
- It is either GetApplicationZip or GetApplication
- It has a GrantsGovTrackingNumber that starts with an 8 or a 9

If both those critera are met, do not forward the request on to grants.gov. 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Hitting grants.gov can be slow, so if we know for sure the data is not in grants.gov we won't bother actually making the request.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
