### PR TITLE
[Issue #6313] Implement configurable XML namespaces [DRAFT]

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -1066,7 +1066,10 @@ FORM_XML_TRANSFORM_RULES = {
         "description": "XML transformation rules for converting Simpler SF-424 JSON to Grants.gov XML format",
         "version": "1.0",
         "form_name": "SF424_4_0",
-        "namespaces": {"default": "http://apply.grants.gov/forms/SF424_4_0-V4.0", "prefix": ""},
+        "namespaces": {
+            "default": "http://apply.grants.gov/forms/SF424_4_0-V4.0",
+            "globLib": "http://apply.grants.gov/system/GlobalLibrary-V2.0",
+        },
         "xml_structure": {"root_element": "SF424_4_0", "version": "4.0"},
         "null_handling_options": {
             "exclude": "Default - exclude field entirely from XML (recommended)",
@@ -1092,13 +1095,13 @@ FORM_XML_TRANSFORM_RULES = {
     # Address information - nested structure
     "applicant_address": {
         "xml_transform": {"target": "Applicant", "type": "nested_object"},
-        "address_line_1": {"xml_transform": {"target": "Street1"}},
-        "address_line_2": {"xml_transform": {"target": "Street2"}},
-        "city": {"xml_transform": {"target": "City"}},
-        "county": {"xml_transform": {"target": "County"}},
-        "state_code": {"xml_transform": {"target": "State"}},
-        "country_code": {"xml_transform": {"target": "Country"}},
-        "zip_code": {"xml_transform": {"target": "ZipPostalCode"}},
+        "street1": {"xml_transform": {"target": "Street1", "namespace": "globLib"}},
+        "street2": {"xml_transform": {"target": "Street2", "namespace": "globLib"}},
+        "city": {"xml_transform": {"target": "City", "namespace": "globLib"}},
+        "county": {"xml_transform": {"target": "County", "namespace": "globLib"}},
+        "state": {"xml_transform": {"target": "State", "namespace": "globLib"}},
+        "country": {"xml_transform": {"target": "Country", "namespace": "globLib"}},
+        "zip_postal_code": {"xml_transform": {"target": "ZipPostalCode", "namespace": "globLib"}},
     },
     # Contact information - direct field mappings
     "phone_number": {"xml_transform": {"target": "PhoneNumber"}},
@@ -1183,6 +1186,26 @@ FORM_XML_TRANSFORM_RULES = {
             "target": "CertificationAgree",
             "value_transform": {"type": "boolean_to_yes_no"},
         }
+    },
+    # Authorized representative - nested structure for name fields
+    "authorized_representative": {
+        "xml_transform": {"target": "AuthorizedRepresentative", "type": "nested_object"},
+        "first_name": {
+            "xml_transform": {
+                "target": "FirstName",
+                "namespace": "globLib",
+                "null_handling": "default_value",
+                "default_value": "John",
+            }
+        },
+        "last_name": {
+            "xml_transform": {
+                "target": "LastName",
+                "namespace": "globLib",
+                "null_handling": "default_value",
+                "default_value": "Doe",
+            }
+        },
     },
     # Authorized representative - direct field mappings
     "authorized_representative_title": {

--- a/api/src/services/xml_generation/service.py
+++ b/api/src/services/xml_generation/service.py
@@ -4,6 +4,8 @@ import logging
 import xml.etree.ElementTree as ET
 from typing import Any
 
+from lxml import etree as lxml_etree
+
 from .config import load_xml_transform_config
 from .models import XMLGenerationRequest, XMLGenerationResponse
 from .transformers.base_transformer import RecursiveXMLTransformer
@@ -66,11 +68,72 @@ class XMLGenerationService:
         namespace_config = xml_config.get("namespaces", {})
         default_namespace = namespace_config.get("default", "")
 
-        # Create root element
-        if default_namespace:
-            root = ET.Element(root_element_name, xmlns=default_namespace)
+        # Extract namespace field mappings
+        namespace_fields = self._extract_namespace_fields(transform_config)
+
+        # Use lxml for proper namespace handling if namespaces are configured
+        if namespace_fields or default_namespace:
+            return self._generate_xml_with_namespaces(
+                data, root_element_name, namespace_config, namespace_fields, pretty_print
+            )
         else:
-            root = ET.Element(root_element_name)
+            # Fallback to simple ElementTree for backward compatibility
+            return self._generate_simple_xml(data, root_element_name, pretty_print)
+
+    def _generate_xml_with_namespaces(
+        self,
+        data: dict,
+        root_element_name: str,
+        namespace_config: dict,
+        namespace_fields: dict,
+        pretty_print: bool = True,
+    ) -> str:
+        """Generate XML with namespace support using lxml."""
+        default_namespace = namespace_config.get("default", "")
+
+        # Create namespace map for lxml with all required namespaces
+        nsmap = {
+            "SF424_4_0": default_namespace,  # SF424 namespace with prefix
+        }
+
+        # Add additional namespaces
+        for prefix, uri in namespace_config.items():
+            if prefix != "default":
+                nsmap[prefix] = uri
+
+        # Add globLib namespace if any fields use it
+        if any(ns == "globLib" for ns in namespace_fields.values()):
+            nsmap["globLib"] = "http://apply.grants.gov/system/GlobalLibrary-V2.0"
+
+        # Create root element with proper namespace prefix
+        if default_namespace:
+            root_element_with_namespace = f"{{{default_namespace}}}{root_element_name}"
+            root = lxml_etree.Element(root_element_with_namespace, nsmap=nsmap)
+
+            # Add FormVersion attribute with proper namespace prefix
+            root.set(f"{{{default_namespace}}}FormVersion", "4.0")
+        else:
+            root = lxml_etree.Element(root_element_name, nsmap=nsmap)
+
+        # Add data elements with namespace support
+        for field_name, value in data.items():
+            self._add_lxml_element_to_parent(root, field_name, value, nsmap, namespace_fields)
+
+        # Generate XML string
+        if pretty_print:
+            xml_bytes = lxml_etree.tostring(
+                root, encoding="utf-8", xml_declaration=True, pretty_print=True
+            )
+        else:
+            xml_bytes = lxml_etree.tostring(root, encoding="utf-8", xml_declaration=True)
+
+        return xml_bytes.decode("utf-8").strip()
+
+    def _generate_simple_xml(
+        self, data: dict, root_element_name: str, pretty_print: bool = True
+    ) -> str:
+        """Generate simple XML without namespace support (backward compatibility)."""
+        root = ET.Element(root_element_name)
 
         # Add data elements
         for field_name, value in data.items():
@@ -82,6 +145,94 @@ class XMLGenerationService:
         xml_string = ET.tostring(root, encoding="unicode", xml_declaration=True)
 
         return xml_string
+
+    def _extract_namespace_fields(self, transform_config: dict) -> dict[str, str]:
+        """Extract namespace configuration from transform rules.
+
+        Args:
+            transform_config: The transformation configuration dictionary
+
+        Returns:
+            Dictionary mapping field names to their namespace prefixes
+        """
+        namespace_fields = {}
+
+        def extract_from_rules(rules: dict, path: str = "") -> None:
+            """Recursively extract namespace information from rules."""
+            for key, value in rules.items():
+                if key.startswith("_"):  # Skip metadata keys
+                    continue
+
+                if isinstance(value, dict):
+                    # Check if this field has XML transform with namespace
+                    if "xml_transform" in value:
+                        xml_transform = value["xml_transform"]
+                        if "namespace" in xml_transform and "target" in xml_transform:
+                            target_name = xml_transform["target"]
+                            namespace = xml_transform["namespace"]
+                            namespace_fields[target_name] = namespace
+
+                    # Recursively check nested fields
+                    extract_from_rules(value, f"{path}.{key}" if path else key)
+
+        extract_from_rules(transform_config)
+        return namespace_fields
+
+    def _add_lxml_element_to_parent(
+        self, parent: Any, field_name: str, value: Any, nsmap: dict, namespace_fields: dict
+    ) -> None:
+        """Add an element to a parent using lxml with proper namespace handling."""
+        if isinstance(value, dict):
+            # Create nested element for dictionary values
+            if field_name in namespace_fields:
+                # Use configured namespace
+                namespace_prefix = namespace_fields[field_name]
+                namespace_uri = nsmap.get(namespace_prefix, "")
+                element_name = f"{{{namespace_uri}}}{field_name}"
+                nested_element = lxml_etree.SubElement(parent, element_name)
+            else:
+                # Use default namespace (SF424_4_0)
+                default_namespace = nsmap.get("SF424_4_0", "")
+                if default_namespace:
+                    element_name = f"{{{default_namespace}}}{field_name}"
+                    nested_element = lxml_etree.SubElement(parent, element_name)
+                else:
+                    nested_element = lxml_etree.SubElement(parent, field_name)
+
+            for nested_field, nested_value in value.items():
+                if nested_value is not None:
+                    self._add_lxml_element_to_parent(
+                        nested_element, nested_field, nested_value, nsmap, namespace_fields
+                    )
+        elif value is None:
+            # Create empty element for None values (when include_null is configured)
+            if field_name in namespace_fields:
+                namespace_prefix = namespace_fields[field_name]
+                namespace_uri = nsmap.get(namespace_prefix, "")
+                element_name = f"{{{namespace_uri}}}{field_name}"
+                lxml_etree.SubElement(parent, element_name)
+            else:
+                default_namespace = nsmap.get("SF424_4_0", "")
+                if default_namespace:
+                    element_name = f"{{{default_namespace}}}{field_name}"
+                    lxml_etree.SubElement(parent, element_name)
+                else:
+                    lxml_etree.SubElement(parent, field_name)
+        else:
+            # Simple value - create element with text content
+            if field_name in namespace_fields:
+                namespace_prefix = namespace_fields[field_name]
+                namespace_uri = nsmap.get(namespace_prefix, "")
+                element_name = f"{{{namespace_uri}}}{field_name}"
+                element = lxml_etree.SubElement(parent, element_name)
+            else:
+                default_namespace = nsmap.get("SF424_4_0", "")
+                if default_namespace:
+                    element_name = f"{{{default_namespace}}}{field_name}"
+                    element = lxml_etree.SubElement(parent, element_name)
+                else:
+                    element = lxml_etree.SubElement(parent, field_name)
+            element.text = str(value)
 
     def _add_element_to_parent(self, parent: ET.Element, field_name: str, value: Any) -> None:
         """Add an element to a parent, handling both simple values and nested dictionaries."""

--- a/api/tests/src/services/xml_generation/test_configurable_namespaces.py
+++ b/api/tests/src/services/xml_generation/test_configurable_namespaces.py
@@ -1,7 +1,5 @@
 """Tests for configurable XML namespaces feature."""
 
-import pytest
-
 from src.services.xml_generation.models import XMLGenerationRequest
 from src.services.xml_generation.service import XMLGenerationService
 

--- a/api/tests/src/services/xml_generation/test_configurable_namespaces.py
+++ b/api/tests/src/services/xml_generation/test_configurable_namespaces.py
@@ -1,0 +1,95 @@
+"""Tests for configurable XML namespaces feature."""
+
+import pytest
+
+from src.services.xml_generation.models import XMLGenerationRequest
+from src.services.xml_generation.service import XMLGenerationService
+
+
+class TestConfigurableNamespaces:
+    """Test configurable XML namespace functionality."""
+
+    def test_generate_xml_with_namespace_prefixes(self):
+        """Test that XML generation uses correct namespace prefixes for configured fields."""
+        service = XMLGenerationService()
+
+        application_data = {
+            "submission_type": "Application",
+            "organization_name": "Test Organization",
+            "applicant_address": {
+                "street1": "123 Main St",
+                "city": "Washington",
+                "state": "DC",
+                "zip_postal_code": "20001",
+                "country": "UNITED STATES",
+            },
+            "authorized_representative": {"first_name": "John", "last_name": "Doe"},
+        }
+
+        request = XMLGenerationRequest(application_data=application_data, form_name="SF424_4_0")
+
+        response = service.generate_xml(request)
+
+        assert response.success
+        assert response.xml_data is not None
+
+        # Verify that address fields use globLib namespace
+        xml_content = response.xml_data
+        assert "globLib:Street1" in xml_content
+        assert "globLib:City" in xml_content
+        assert "globLib:State" in xml_content
+        assert "globLib:ZipPostalCode" in xml_content
+        assert "globLib:Country" in xml_content
+
+        # Verify that authorized representative name fields use globLib namespace
+        assert "globLib:FirstName" in xml_content
+        assert "globLib:LastName" in xml_content
+
+        # Verify that root-level fields still use SF424_4_0 namespace
+        assert "SF424_4_0:OrganizationName" in xml_content
+        assert "SF424_4_0:SubmissionType" in xml_content
+
+    def test_backward_compatibility_without_namespace_config(self):
+        """Test that fields without namespace config use default behavior."""
+        service = XMLGenerationService()
+
+        application_data = {
+            "organization_name": "Test Organization",
+            "submission_type": "Application",
+        }
+
+        request = XMLGenerationRequest(application_data=application_data, form_name="SF424_4_0")
+
+        response = service.generate_xml(request)
+
+        assert response.success
+        assert response.xml_data is not None
+
+        # Fields without namespace config should use SF424_4_0 namespace
+        xml_content = response.xml_data
+        assert "SF424_4_0:OrganizationName" in xml_content
+        assert "SF424_4_0:SubmissionType" in xml_content
+
+    def test_namespace_configuration_in_xml_output(self):
+        """Test that namespace declarations are properly included in XML output."""
+        service = XMLGenerationService()
+
+        application_data = {
+            "submission_type": "Application",
+            "applicant_address": {
+                "street1": "123 Main St",
+                "city": "Washington",
+            },
+        }
+
+        request = XMLGenerationRequest(application_data=application_data, form_name="SF424_4_0")
+
+        response = service.generate_xml(request)
+
+        assert response.success
+        assert response.xml_data is not None
+
+        xml_content = response.xml_data
+        # Verify namespace declarations are present
+        assert 'xmlns:SF424_4_0="http://apply.grants.gov/forms/SF424_4_0-V4.0"' in xml_content
+        assert 'xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0"' in xml_content

--- a/api/tests/src/services/xml_generation/test_none_handling.py
+++ b/api/tests/src/services/xml_generation/test_none_handling.py
@@ -30,8 +30,8 @@ class TestNoneHandling:
         # Verify None field is excluded
         assert "OrganizationName" not in xml_data
         # Verify non-None fields are included
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<ProjectTitle>Test Project</ProjectTitle>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert "<SF424_4_0:ProjectTitle>Test Project</SF424_4_0:ProjectTitle>" in xml_data
 
     def test_none_handling_include_null(self):
         """Test include_null behavior - include empty XML elements."""
@@ -56,8 +56,8 @@ class TestNoneHandling:
             or "<DateReceived />" in xml_data
         )
         # Verify non-None fields are included normally
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<ProjectTitle>Test Project</ProjectTitle>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert "<SF424_4_0:ProjectTitle>Test Project</SF424_4_0:ProjectTitle>" in xml_data
 
     def test_none_handling_default_value(self):
         """Test default_value behavior - use configured default when None."""
@@ -78,8 +78,8 @@ class TestNoneHandling:
         # Verify None field gets default value
         assert f"<StateReview>{NO_VALUE}</StateReview>" in xml_data
         # Verify non-None fields are included normally
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<ProjectTitle>Test Project</ProjectTitle>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert "<SF424_4_0:ProjectTitle>Test Project</SF424_4_0:ProjectTitle>" in xml_data
 
     def test_none_handling_mixed_behaviors(self):
         """Test multiple None handling behaviors in same request."""
@@ -108,8 +108,8 @@ class TestNoneHandling:
         )  # empty element
         assert f"<StateReview>{NO_VALUE}</StateReview>" in xml_data  # default value
         # Verify non-None fields are included normally
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<ProjectTitle>Test Project</ProjectTitle>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert "<SF424_4_0:ProjectTitle>Test Project</SF424_4_0:ProjectTitle>" in xml_data
 
     def test_none_handling_with_value_transforms(self):
         """Test None handling works with value transformations."""
@@ -132,8 +132,8 @@ class TestNoneHandling:
         assert "FederalEstimatedFunding" not in xml_data
         assert "DelinquentFederalDebt" not in xml_data
         # Verify non-None fields are included
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<ProjectTitle>Test Project</ProjectTitle>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert "<SF424_4_0:ProjectTitle>Test Project</SF424_4_0:ProjectTitle>" in xml_data
 
     def test_none_handling_invalid_configuration(self):
         """Test that invalid null_handling values fall back to exclude."""

--- a/api/tests/src/services/xml_generation/test_xml_generation_service.py
+++ b/api/tests/src/services/xml_generation/test_xml_generation_service.py
@@ -35,11 +35,18 @@ class TestXMLGenerationService:
         # Verify XML contains expected elements
         xml_data = response.xml_data
         assert "<SF424_4_0" in xml_data
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<OrganizationName>Test University</OrganizationName>" in xml_data
-        assert "<ProjectTitle>Research Project</ProjectTitle>" in xml_data
-        assert "<FederalEstimatedFunding>50000.00</FederalEstimatedFunding>" in xml_data
-        assert f"<CertificationAgree>{YES_VALUE}</CertificationAgree>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert (
+            "<SF424_4_0:OrganizationName>Test University</SF424_4_0:OrganizationName>" in xml_data
+        )
+        assert "<SF424_4_0:ProjectTitle>Research Project</SF424_4_0:ProjectTitle>" in xml_data
+        assert (
+            "<SF424_4_0:FederalEstimatedFunding>50000.00</SF424_4_0:FederalEstimatedFunding>"
+            in xml_data
+        )
+        assert (
+            f"<SF424_4_0:CertificationAgree>{YES_VALUE}</SF424_4_0:CertificationAgree>" in xml_data
+        )
 
     def test_generate_xml_no_application_data(self):
         """Test XML generation when no application data is provided."""
@@ -81,7 +88,7 @@ class TestXMLGenerationService:
         # Verify response and namespace
         assert response.success is True
         xml_data = response.xml_data
-        assert 'xmlns="http://apply.grants.gov/forms/SF424_4_0-V4.0"' in xml_data
+        assert 'xmlns:SF424_4_0="http://apply.grants.gov/forms/SF424_4_0-V4.0"' in xml_data
 
     def test_generate_xml_handles_none_values(self):
         """Test XML generation properly handles None values."""
@@ -102,9 +109,12 @@ class TestXMLGenerationService:
         xml_data = response.xml_data
 
         # Should include non-None values
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<ProjectTitle>Test Project</ProjectTitle>" in xml_data
-        assert "<FederalEstimatedFunding>0.00</FederalEstimatedFunding>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert "<SF424_4_0:ProjectTitle>Test Project</SF424_4_0:ProjectTitle>" in xml_data
+        assert (
+            "<SF424_4_0:FederalEstimatedFunding>0.00</SF424_4_0:FederalEstimatedFunding>"
+            in xml_data
+        )
 
         # Should not include None values
         assert "OrganizationName" not in xml_data
@@ -128,9 +138,9 @@ class TestXMLGenerationService:
         xml_data = response.xml_data
 
         # Verify mapped fields are included
-        assert "<SubmissionType>Application</SubmissionType>" in xml_data
-        assert "<OrganizationName>Test Org</OrganizationName>" in xml_data
-        assert "<ProjectTitle>Test Project</ProjectTitle>" in xml_data
+        assert "<SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>" in xml_data
+        assert "<SF424_4_0:OrganizationName>Test Org</SF424_4_0:OrganizationName>" in xml_data
+        assert "<SF424_4_0:ProjectTitle>Test Project</SF424_4_0:ProjectTitle>" in xml_data
 
         # Verify unmapped field is excluded
         assert "unmapped_field" not in xml_data
@@ -142,13 +152,13 @@ class TestXMLGenerationService:
             "submission_type": "Application",
             "organization_name": "Test University",
             "applicant_address": {
-                "address_line_1": "123 Main Street",
-                "address_line_2": "Suite 100",
+                "street1": "123 Main Street",
+                "street2": "Suite 100",
                 "city": "Washington",
                 "county": "District of Columbia",
-                "state_code": "DC",
-                "country_code": "US",
-                "zip_code": "20001-1234",
+                "state": "DC",
+                "country": "US",
+                "zip_postal_code": "20001-1234",
             },
             "project_title": "Research Project",
         }
@@ -164,15 +174,15 @@ class TestXMLGenerationService:
         xml_data = response.xml_data
 
         # Verify nested address structure is created correctly
-        assert "<Applicant>" in xml_data
-        assert "<Street1>123 Main Street</Street1>" in xml_data
-        assert "<Street2>Suite 100</Street2>" in xml_data
-        assert "<City>Washington</City>" in xml_data
-        assert "<County>District of Columbia</County>" in xml_data
-        assert "<State>DC</State>" in xml_data
-        assert "<Country>US</Country>" in xml_data
-        assert "<ZipPostalCode>20001-1234</ZipPostalCode>" in xml_data
-        assert "</Applicant>" in xml_data
+        assert "<SF424_4_0:Applicant>" in xml_data
+        assert "<globLib:Street1>123 Main Street</globLib:Street1>" in xml_data
+        assert "<globLib:Street2>Suite 100</globLib:Street2>" in xml_data
+        assert "<globLib:City>Washington</globLib:City>" in xml_data
+        assert "<globLib:County>District of Columbia</globLib:County>" in xml_data
+        assert "<globLib:State>DC</globLib:State>" in xml_data
+        assert "<globLib:Country>US</globLib:Country>" in xml_data
+        assert "<globLib:ZipPostalCode>20001-1234</globLib:ZipPostalCode>" in xml_data
+        assert "</SF424_4_0:Applicant>" in xml_data
 
     def test_generate_xml_pretty_print_vs_condensed(self):
         """Test XML generation with pretty-print vs condensed formatting."""


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #6313 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added `lxml` for proper namespace handling
Added `globLib` namespace definition to _xml_config.namespaces
Update / add tests.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We want to be able to configure how the XML namespaces get defined in our JSON->XML mapping logic. While most fields within a given form will have a namespace defined at the form level (eg. for the SF424 fields will be like <SF424_4_0:SubmissionType>Application</SF424_4_0:SubmissionType>), some fields that are defined in a different XSD file require a different namespace.

Configurable XSD-driven testing and validating is coming in a subsequent PR for #6314 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See updated unit tests.