### PR TITLE
[Issue #6440] correctly mark failed validation for missing activity title when no activity line items are saved

### DIFF
--- a/frontend/tests/components/applyForm/utils.test.ts
+++ b/frontend/tests/components/applyForm/utils.test.ts
@@ -397,6 +397,60 @@ describe("pruneEmptyNestedFields", () => {
       },
     });
   });
+  it("removes empty nested objects from within arrays", () => {
+    expect(
+      pruneEmptyNestedFields({
+        thing: [
+          {
+            stuff: {
+              more: undefined,
+            },
+            here: "it is",
+          },
+        ],
+      }),
+    ).toEqual({
+      thing: [{ here: "it is" }],
+    });
+  });
+  it("removes empty array values from arrays", () => {
+    expect(
+      pruneEmptyNestedFields({
+        thing: [
+          {
+            stuff: {
+              more: undefined,
+            },
+            here: undefined,
+          },
+        ],
+      }),
+    ).toEqual({
+      thing: [],
+    });
+  });
+  it("removes empty array values from nested arrays", () => {
+    expect(
+      pruneEmptyNestedFields({
+        thing: [
+          {
+            stuff: [
+              {
+                more: undefined,
+              },
+            ],
+            here: undefined,
+          },
+        ],
+      }),
+    ).toEqual({
+      thing: [
+        {
+          stuff: [],
+        },
+      ],
+    });
+  });
 });
 
 describe("getFieldNameForHtml", () => {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #6440

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Only a single activity line item with the activity title filled in is required in section A of the budget form

Currently if activity titles are not filled in, failed validation comes back for all activity titles. With this change, the activity title should be marked as invalid only if:

* there is other data in the line item, but the title is missing
* there is no data for any line items, and the activity title is in the first line item

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. open the budget form
4. save
5. _VERIFY_: the activity title box for the first line item in section A is marked as invalid, all other activity titles are fine

### Screenshots
<img width="1266" height="869" alt="Screenshot 2025-09-18 at 4 00 39 PM" src="https://github.com/user-attachments/assets/6ebaeca7-8d03-47cb-8537-432dccbd6860" />

