### PR TITLE
[Issue #6272] Update deliverable linter to post comments to GitHub 

### DIFF
--- a/.github/ISSUE_TEMPLATE/4_internal_deliverable.yml
+++ b/.github/ISSUE_TEMPLATE/4_internal_deliverable.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        **Required Fields:** Please see [Deliverable Expectations](https://github.com/HHS/simpler-grants-gov/blob/main/.github/linters/documentation/ISSUE_BODY_LINTER.md) for information on required fields.
+        **Note:** Please see [Deliverable Expectations](https://github.com/HHS/simpler-grants-gov/blob/main/.github/linters/documentation/ISSUE_BODY_LINTER.md) for information on required fields.
 
   - type: textarea
     id: press_release

--- a/.github/ISSUE_TEMPLATE/4_internal_deliverable.yml
+++ b/.github/ISSUE_TEMPLATE/4_internal_deliverable.yml
@@ -2,6 +2,11 @@ name: Internal - Deliverable
 description: Describe an agile deliverable
 type: Deliverable
 body:
+  - type: markdown
+    attributes:
+      value: |
+        **Required Fields:** Please see [Deliverable Expectations](https://github.com/HHS/simpler-grants-gov/blob/main/.github/linters/documentation/ISSUE_BODY_LINTER.md) for information on required fields.
+
   - type: textarea
     id: press_release
     attributes:

--- a/.github/linters/documentation/ISSUE_BODY_LINTER.md
+++ b/.github/linters/documentation/ISSUE_BODY_LINTER.md
@@ -1,0 +1,58 @@
+# Issue Body Linter Expectations
+
+This automated linter checks GitHub project issues to ensure they contain required sections with proper formatting.
+
+## Issue Types
+
+The linter supports two types of issues:
+
+### Deliverable Issues
+Deliverable issues must contain two required sections:
+
+1. **Acceptance Criteria** (`### Acceptance criteria`)
+   - Must contain at least one checkbox item
+   - Checkboxes can be checked `[x]` or unchecked `[ ]`
+   - Example:
+     ```
+     ### Acceptance criteria
+     - [ ] User can log in with valid credentials
+     - [x] Error message displays for invalid credentials
+     ```
+
+2. **Metrics** (`### Metrics`)
+   - Must contain at least one checkbox item
+   - Checkboxes can be checked `[x]` or unchecked `[ ]`
+   - Example:
+     ```
+     ### Metrics
+     - [ ] Page load time under 2 seconds
+     - [ ] 95% uptime achieved
+     ```
+
+### Proposal Issues
+Proposal issues must contain one required section:
+
+1. **Summary** (`### Summary`)
+   - Must contain non-empty content
+   - No specific formatting requirements beyond having content
+   - Example:
+     ```
+     ### Summary
+     This proposal outlines a new authentication system that will improve security and user experience.
+     ```
+
+## How the Linter Works
+
+- The linter searches for section headers using case-insensitive matching
+- For checkbox sections (Acceptance Criteria and Metrics), it looks for the pattern `[x]` or `[ ]`
+- For the Summary section, it simply checks that content exists after the header
+- Issues that fail validation will receive an automated comment with a link to this documentation
+
+## Fixing Failed Issues
+
+If your issue fails the linter check:
+
+1. Add the missing required section(s) for your issue type
+2. Ensure checkbox sections contain at least one checkbox item
+3. Ensure the Summary section contains descriptive text
+4. The linter will re-check your issue on the next run

--- a/.github/linters/documentation/ISSUE_BODY_LINTER.md
+++ b/.github/linters/documentation/ISSUE_BODY_LINTER.md
@@ -48,7 +48,7 @@ Proposal issues must contain one required section:
 - For the Summary section, it simply checks that content exists after the header
 - Issues that fail validation will receive an automated comment with a link to this documentation
 
-## Fixing Failed Issues
+## How to Fix Linter Errors
 
 If your issue fails the linter check:
 

--- a/.github/linters/scripts/lint-issue-body.sh
+++ b/.github/linters/scripts/lint-issue-body.sh
@@ -369,3 +369,6 @@ summary_invalid_count=$((issue_count - summary_valid_count))
 
 # Display results
 display_results "$issue_type" "$issue_count" "$ac_valid_count" "$ac_invalid_count" "$metrics_valid_count" "$metrics_invalid_count" "$summary_valid_count" "$summary_invalid_count"
+
+# Exit with nonzero status if any validation failed
+exit $(( ac_invalid_count || metrics_invalid_count || summary_invalid_count ))

--- a/.github/linters/scripts/lint-issue-body.sh
+++ b/.github/linters/scripts/lint-issue-body.sh
@@ -362,13 +362,13 @@ if [[ "$issue_count" -gt 0 ]]; then
    lint_issue_body "$issue_type" "$filtered_data" "$issue_count"
 fi
 
-# Calculate issues without valid content
-ac_invalid_count=$((issue_count - ac_valid_count))
-metrics_invalid_count=$((issue_count - metrics_valid_count))
-summary_invalid_count=$((issue_count - summary_valid_count))
+# Calculate number of failures
+ac_invalid_count=${#ac_failed_issues[@]}
+metrics_invalid_count=${#metrics_failed_issues[@]}
+summary_invalid_count=${#summary_failed_issues[@]}
 
 # Display results
 display_results "$issue_type" "$issue_count" "$ac_valid_count" "$ac_invalid_count" "$metrics_valid_count" "$metrics_invalid_count" "$summary_valid_count" "$summary_invalid_count"
 
-# Exit with nonzero status if any validation failed
+# Exit with nonzero status if there were any failures
 exit $(( ac_invalid_count || metrics_invalid_count || summary_invalid_count ))

--- a/.github/linters/scripts/lint-issue-body.sh
+++ b/.github/linters/scripts/lint-issue-body.sh
@@ -293,50 +293,29 @@ display_results() {
     Deliverable)
       echo "✅ Total issues with valid acceptance criteria: $ac_valid_count"
       echo "✅ Total issues with valid metrics: $metrics_valid_count"
-      echo ""
       ;;
     Proposal)
       echo "✅ Total issues with valid summary: $summary_valid_count"
-      echo ""
       ;;
   esac 
 
   case "$issue_type" in 
     Deliverable)
       if [[ "$ac_invalid_count" -gt 0 ]]; then
-        echo "===== ISSUES WITH INVALID ACCEPTANCE CRITERIA ====="
         echo "❌ Total issues with invalid acceptance criteria: $ac_invalid_count"
-        if [[ ${#ac_failed_issues[@]} -gt 0 ]]; then
-          printf '%s\n' "${ac_failed_issues[@]}" | sort | while IFS='|' read -r title url; do
-            echo "- $title ($url)"
-          done
-        fi
       fi
-      echo ""
       if [[ "$metrics_invalid_count" -gt 0 ]]; then
-        echo "===== ISSUES WITH INVALID METRICS ====="
         echo "❌ Total issues with invalid metrics: $metrics_invalid_count"
-        if [[ ${#metrics_failed_issues[@]} -gt 0 ]]; then
-          printf '%s\n' "${metrics_failed_issues[@]}" | sort | while IFS='|' read -r title url; do
-            echo "- $title ($url)"
-          done
-        fi
       fi
-      echo ""
       ;;
     Proposal)
       if [[ "$summary_invalid_count" -gt 0 ]]; then
-        echo "===== ISSUES WITH INVALID SUMMARY ====="
         echo "❌ Total issues with invalid summary: $summary_invalid_count"
-        if [[ ${#summary_failed_issues[@]} -gt 0 ]]; then
-          printf '%s\n' "${summary_failed_issues[@]}" | sort | while IFS='|' read -r title url; do
-            echo "- $title ($url)"
-          done
-        fi
       fi
-      echo ""
       ;;
   esac
+
+  echo ""
 }
 
 # #######################################################

--- a/.github/linters/scripts/lint-issue-body.sh
+++ b/.github/linters/scripts/lint-issue-body.sh
@@ -141,6 +141,7 @@ fetch_data() {
       .content.issueType.name == $issue_type and
       .content.body != null and
       .content.body != "" and
+      .status.name != null and
       .status.name != "Done"
     )) |
     map({
@@ -217,9 +218,13 @@ validate_acceptance_criteria() {
   local title="$2"
   local url="$3"
 
+  # Convert body and header to lowercase for case-insensitive matching
+  local body_lc=$(echo "$body" | tr '[:upper:]' '[:lower:]')
+  local header=$(echo "$HEADER_ACCEPTANCE_CRITERIA" | tr '[:upper:]' '[:lower:]')
+
   # Extract the acceptance criteria section and ensure it contains checkboxes
-  local ac_section=$(echo "$body" | sed -n "/$HEADER_ACCEPTANCE_CRITERIA/,/^###/{ /^###/d; p; }")
-  if [[ -z "$ac_section" ]] || ! echo "$ac_section" | grep -q "\[[ x]\]"; then
+  local section=$(echo "$body_lc" | sed -n "/$header/,/^###/{ /^###/d; p; }")
+  if [[ -z "$section" ]] || ! echo "$section" | grep -q "\[[ x]\]"; then
     warn "  ❌ Acceptance criteria missing!"
     ac_failed_issues+=("$title|$url")
   else
@@ -232,9 +237,13 @@ validate_metrics() {
   local title="$2"
   local url="$3"
 
+  # Convert body and header to lowercase for case-insensitive matching
+  local body_lc=$(echo "$body" | tr '[:upper:]' '[:lower:]')
+  local header=$(echo "$HEADER_METRICS" | tr '[:upper:]' '[:lower:]')
+
   # Extract the metrics section and ensure it contains checkboxes
-  local metrics_section=$(echo "$body" | sed -n "/$HEADER_METRICS/,/^###/{ /^###/d; p; }")
-  if [[ -z "$metrics_section" ]] || ! echo "$metrics_section" | grep -q "\[[ x]\]"; then
+  local section=$(echo "$body_lc" | sed -n "/$header/,/^###/{ /^###/d; p; }")
+  if [[ -z "$section" ]] || ! echo "$section" | grep -q "\[[ x]\]"; then
     warn "  ❌ Metrics missing!"
     metrics_failed_issues+=("$title|$url")
   else
@@ -247,9 +256,13 @@ validate_summary() {
   local title="$2"
   local url="$3"
 
+  # Convert body and header to lowercase for case-insensitive matching
+  local body_lc=$(echo "$body" | tr '[:upper:]' '[:lower:]')
+  local header=$(echo "$HEADER_SUMMARY" | tr '[:upper:]' '[:lower:]')
+
   # Extract the summary section and ensure it contains something
-  local summary_section=$(echo "$body" | sed -n "/$HEADER_SUMMARY/,/^###/{ /^###/d; p; }")
-  if [[ -z "$summary_section" ]]; then
+  local section=$(echo "$body_lc" | sed -n "/$header/,/^###/{ /^###/d; p; }")
+  if [[ -z "$section" ]]; then
     warn "  ❌ Summary missing!"
     summary_failed_issues+=("$title|$url")
   else

--- a/.github/linters/scripts/lint-issue-body.sh
+++ b/.github/linters/scripts/lint-issue-body.sh
@@ -21,7 +21,7 @@ DEFAULT_ISSUE_TYPE="Deliverable"
 ALLOWED_ISSUE_TYPES=("Deliverable" "Proposal")
 
 # #######################################################
-# Initialize variables for tracking results
+# Initialize variables 
 # #######################################################
 
 ac_valid_count=0
@@ -159,7 +159,7 @@ fetch_data() {
     err "Failed to count filtered items: $issue_count"
   fi
 
-  log "Found $issue_count items of type '$issue_type'"
+  log "Found $issue_count item(s) of type '$issue_type'"
 
   # Return the filtered data
   echo "$filtered_data"
@@ -226,7 +226,7 @@ validate_acceptance_criteria() {
   local section=$(echo "$body_lc" | sed -n "/$header/,/^###/{ /^###/d; p; }")
   if [[ -z "$section" ]] || ! echo "$section" | grep -q "\[[ x]\]"; then
     warn "  ❌ Acceptance criteria missing!"
-    ac_failed_issues+=("$title|$url")
+    ac_failed_issues+=("$url")
   else
     ac_valid_count=$((ac_valid_count + 1))
   fi
@@ -245,7 +245,7 @@ validate_metrics() {
   local section=$(echo "$body_lc" | sed -n "/$header/,/^###/{ /^###/d; p; }")
   if [[ -z "$section" ]] || ! echo "$section" | grep -q "\[[ x]\]"; then
     warn "  ❌ Metrics missing!"
-    metrics_failed_issues+=("$title|$url")
+    metrics_failed_issues+=("$url")
   else
     metrics_valid_count=$((metrics_valid_count + 1))
   fi
@@ -264,10 +264,83 @@ validate_summary() {
   local section=$(echo "$body_lc" | sed -n "/$header/,/^###/{ /^###/d; p; }")
   if [[ -z "$section" ]]; then
     warn "  ❌ Summary missing!"
-    summary_failed_issues+=("$title|$url")
+    summary_failed_issues+=("$url")
   else
     summary_valid_count=$((summary_valid_count + 1))
   fi
+}
+
+# #######################################################
+# Post comments to failed issues
+# #######################################################
+
+get_comment_body() {
+  local comment_template="## ⚠️ Automated Lint Check Failed
+
+This issue failed an automated lint process that checks the content of required sections.
+
+**Next steps:**
+Please review the [linter expectations documentation](https://github.com/HHS/simpler-grants-gov/blob/main/.github/linters/README.md) and update this issue accordingly.
+
+---
+*This comment was automatically generated.*"
+
+    echo "$comment_template"
+}
+
+extract_issue_id_from_url() {
+  local issue_url="$1"
+  
+  # Extract issue number from URL (format: https://github.com/org/repo/issues/123)
+  local issue_id=$(echo "$issue_url" | sed -n 's/.*\/issues\/\([0-9]*\).*/\1/p')
+
+  echo "$issue_id"
+}  
+  
+comment_on_failed_issues() {
+  local dry_run="$1"
+  local issue_type="$2"
+
+  log "Preparing to post comments to items that failed linting"
+
+  # Aggregate failed issues
+  local failed_issues=()
+  case "$issue_type" in 
+    Deliverable)
+      failed_issues+=(${ac_failed_issues[@]+"${ac_failed_issues[@]}"})
+      failed_issues+=(${metrics_failed_issues[@]+"${metrics_failed_issues[@]}"})
+      failed_issues=($(printf '%s\n' ${failed_issues[@]+"${failed_issues[@]}"} | sort -u))
+      ;;
+    Proposal)
+      failed_issues=(${summary_failed_issues[@]+"${summary_failed_issues[@]}"})
+      ;;
+  esac 
+
+  # No-op if there are zero lint failures
+  local failed_count=${#failed_issues[@]}
+  log "Found $failed_count unique item(s) that require comments"
+  if [[ "$failed_count" == 0 ]]; then
+    return 0
+  fi
+
+  # No-op if dry-run mode enabled
+  if [[ "$dry_run" == "true" ]]; then
+    warn "Dry-run mode enabled, comments will NOT be posted"
+    return 0
+  fi
+
+  # Define body of comment
+  local comment_body="$(get_comment_body)"
+
+  # Post comment to each issue
+  for url in "${failed_issues[@]}"; do
+    local issue_id=$(extract_issue_id_from_url "$url")
+    if ! gh issue comment "$issue_id" --body "$comment_body" > /dev/null 2>&1; then
+      warn "  ❌ Failed to post comment to issue #$issue_id"
+    fi
+  done
+
+  log "Done posting comments"
 }
 
 # #######################################################
@@ -345,6 +418,9 @@ fi
 ac_invalid_count=${#ac_failed_issues[@]}
 metrics_invalid_count=${#metrics_failed_issues[@]}
 summary_invalid_count=${#summary_failed_issues[@]}
+
+# Comment on failed issues
+comment_on_failed_issues "$dry_run" "$issue_type"
 
 # Display results
 display_results "$issue_type" "$issue_count" "$ac_valid_count" "$ac_invalid_count" "$metrics_valid_count" "$metrics_invalid_count" "$summary_valid_count" "$summary_invalid_count"

--- a/.github/linters/scripts/lint-issue-body.sh
+++ b/.github/linters/scripts/lint-issue-body.sh
@@ -280,7 +280,7 @@ get_comment_body() {
 This issue failed an automated lint process that checks the content of required sections.
 
 **Next steps:**
-Please review the [linter expectations documentation](https://github.com/HHS/simpler-grants-gov/blob/main/.github/linters/README.md) and update this issue accordingly.
+Please review the [linter expectations documentation](https://github.com/HHS/simpler-grants-gov/blob/main/.github/linters/documentation/ISSUE_BODY_LINTER.md) and update this issue accordingly.
 
 ---
 *This comment was automatically generated.*"

--- a/.github/workflows/lint-deliverable-metrics.yml
+++ b/.github/workflows/lint-deliverable-metrics.yml
@@ -26,13 +26,11 @@ jobs:
           ./scripts/lint-issue-body.sh \
             --org "HHS" \
             --project "13" \
-            --issue-type "Deliverable" \
-            --dry-run 
+            --issue-type "Deliverable" 
 
       - name: Lint Project 17
         run: |
           ./scripts/lint-issue-body.sh \
             --org "HHS" \
             --project "17" \
-            --issue-type "Deliverable" \
-            --dry-run 
+            --issue-type "Deliverable" 


### PR DESCRIPTION
## Summary

Fixes #6271 and #6272 

## Changes proposed

This PR: 
* Extends the deliverable linter to post comments to GitHub issues
* Fixes logic for certain edge cases (e.g. status=null)
* Adds documentation to explain the deliverable linter and deliverable formatting expectations
* Updates deliverable issue template (used to create new deliverables) to link to the linter documentation 

## Context for reviewers

This is a follow-up to https://github.com/HHS/simpler-grants-gov/pull/6417 

## Validation steps

Trigger workflow manually from GitHub Actions page

<img width="919" height="890" alt="Screenshot 2025-09-18 at 6 37 04 PM" src="https://github.com/user-attachments/assets/f8fc1117-07dd-49a5-85f1-f71f40d40fbd" />

