### PR TITLE
[Issue #6331] Add auto summation to sf424 and sf424a

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -949,7 +949,7 @@ FORM_UI_SCHEMA = [
                 "definition": "/properties/program_income_estimated_funding",
             },
             {
-                "type": "field",
+                "type": "null",
                 "definition": "/properties/total_estimated_funding",
             },
         ],
@@ -1047,6 +1047,19 @@ FORM_RULE_SCHEMA = {
     "funding_opportunity_title": {"gg_pre_population": {"rule": "opportunity_title"}},
     "competition_identification_number": {"gg_pre_population": {"rule": "public_competition_id"}},
     "competition_identification_title": {"gg_pre_population": {"rule": "competition_title"}},
+    "total_estimated_funding": {
+        "gg_pre_population": {
+            "rule": "sum_monetary",
+            "fields": [
+                "federal_estimated_funding",
+                "applicant_estimated_funding",
+                "state_estimated_funding",
+                "local_estimated_funding",
+                "other_estimated_funding",
+                "program_income_estimated_funding",
+            ],
+        }
+    },
     ##### POST-POPULATION RULES
     "date_received": {"gg_post_population": {"rule": "current_date"}},
     "date_signed": {"gg_post_population": {"rule": "current_date"}},

--- a/api/src/form_schema/forms/sf424a.py
+++ b/api/src/form_schema/forms/sf424a.py
@@ -395,6 +395,394 @@ FORM_UI_SCHEMA = [
     },
 ]
 
+
+FORM_RULE_SCHEMA = {
+    ##### PRE-POPULATION RULES
+    "activity_line_items": {
+        # Marking this as an array means each line item that exists
+        # will have rules run on them iteratively.
+        # For each of these we use "@THIS." to tell it to do a relative
+        # path within the same array that we're summing to.
+        "gg_type": "array",
+        "budget_summary": {
+            # Section A - Budget Summary: Total amount (Column G, Rows 1-4)
+            # is the sum of Columns C-G within the same row.
+            "total_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "@THIS.federal_estimated_unobligated_amount",
+                        "@THIS.non_federal_estimated_unobligated_amount",
+                        "@THIS.federal_new_or_revised_amount",
+                        "@THIS.non_federal_new_or_revised_amount",
+                    ],
+                }
+            }
+        },
+        "budget_categories": {
+            # Section B - Budget Categories: Total direct charge amount (Row 6I, Columns 1-4)
+            # is the sum of Rows 6A-6H within the same column.
+            "total_direct_charge_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "@THIS.personnel_amount",
+                        "@THIS.fringe_benefits_amount",
+                        "@THIS.travel_amount",
+                        "@THIS.equipment_amount",
+                        "@THIS.supplies_amount",
+                        "@THIS.contractual_amount",
+                        "@THIS.construction_amount",
+                        "@THIS.other_amount",
+                    ],
+                }
+            },
+            # Section B - Budget Categories: Total amount (Row 6K, Columns 1-4)
+            # is the sum of Rows 6I+6J within the same column.
+            "total_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "@THIS.total_direct_charge_amount",
+                        "@THIS.total_indirect_charge_amount",
+                    ],
+                    # This rule needs to run after we calculate the total_direct_charge_amount above
+                    "order": 2,
+                }
+            },
+        },
+        "non_federal_resources": {
+            # Section C - Non-federal resources: Total Amount (Column E, Rows 8-11)
+            # is the sum of Columns B-D within the same row.
+            "total_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "@THIS.applicant_amount",
+                        "@THIS.state_amount",
+                        "@THIS.other_amount",
+                    ],
+                }
+            }
+        },
+    },
+    "total_budget_summary": {
+        # Section A - Budget Summary: Total Federal Estimated Unobligated Funds (Column C, Row 5)
+        # is the sum of (Column C, Rows 1-4)
+        "federal_estimated_unobligated_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": [
+                    "activity_line_items[*].budget_summary.federal_estimated_unobligated_amount"
+                ],
+            }
+        },
+        # Section A - Budget Summary: Total Non-Federal Estimated Unobligated Funds (Column D, Row 5)
+        # is the sum of (Column D, Rows 1-4)
+        "non_federal_estimated_unobligated_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": [
+                    "activity_line_items[*].budget_summary.non_federal_estimated_unobligated_amount"
+                ],
+            }
+        },
+        # Section A - Budget Summary: Total Federal New or Revised Budget (Column E, Row 5)
+        # is the sum of (Column E, Rows 1-4)
+        "federal_new_or_revised_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_summary.federal_new_or_revised_amount"],
+            }
+        },
+        # Section A - Budget Summary: Total Federal New or Revised Budget (Column F, Row 5)
+        # is the sum of (Column F, Rows 1-4)
+        "non_federal_new_or_revised_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": [
+                    "activity_line_items[*].budget_summary.non_federal_new_or_revised_amount"
+                ],
+            }
+        },
+        # Section A - Total Amount (Column E, Row 5)
+        # is the sum of (Column E, Rows 1-4)
+        "total_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_summary.total_amount"],
+                # Run this in the 2nd iteration after the total_amount of the activity line items is calculated
+                "order": 2,
+            }
+        },
+    },
+    "total_budget_categories": {
+        # Section B - Budget Categories: Total Personnel Amount (Row A, Column 5)
+        # is the sum of (Row A, Columns 1-4)
+        "personnel_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.personnel_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Fringe Benefits Amount (Row B, Column 5)
+        # is the sum of (Row B, Columns 1-4)
+        "fringe_benefits_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.fringe_benefits_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Travel Amount (Row C, Column 5)
+        # is the sum of (Row C, Columns 1-4)
+        "travel_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.travel_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Equipment Amount (Row D, Column 5)
+        # is the sum of (Row D, Columns 1-4)
+        "equipment_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.equipment_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Supplies Amount (Row E, Column 5)
+        # is the sum of (Row E, Columns 1-4)
+        "supplies_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.supplies_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Contractual Amount (Row F, Column 5)
+        # is the sum of (Row F, Columns 1-4)
+        "contractual_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.contractual_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Construction Amount (Row G, Column 5)
+        # is the sum of (Row G, Columns 1-4)
+        "construction_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.construction_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Other Amount (Row H, Column 5)
+        # is the sum of (Row H, Columns 1-4)
+        "other_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.other_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Direct Charges Amount (Row I, Column 5)
+        # is the sum of (Row I, Columns 1-4)
+        "total_direct_charge_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.total_direct_charge_amount"],
+                # Needs to run after we calculate this in the activity line items
+                "order": 2,
+            }
+        },
+        # Section B - Budget Categories: Total Indirect Charges Amount (Row J, Column 5)
+        # is the sum of (Row j, Columns 1-4)
+        "total_indirect_charge_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.total_indirect_charge_amount"],
+            }
+        },
+        # Section B - Budget Categories: Total Amount (Row K, Column 5)
+        # is the sum of (Row K, Columns 1-4)
+        "total_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.total_amount"],
+                # This needs to run after we calculate the total amount in the activity line items
+                # which happens in the 2nd iteration.
+                "order": 3,
+            }
+        },
+        # Section B - Budget Categories: Program Income (Row 7, Column 5)
+        # is the sum of (Row 7, Columns 1-4)
+        "program_income_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].budget_categories.program_income_amount"],
+            }
+        },
+    },
+    "total_non_federal_resources": {
+        # Section C - Non-federal Resources: Total Applicant Amount (Row 12, Column B)
+        # is the sum of (Column B, Rows 8-11)
+        "applicant_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].non_federal_resources.applicant_amount"],
+            }
+        },
+        # Section C - Non-federal Resources: Total State Amount (Row 12, Column C)
+        # is the sum of (Column C, Rows 8-11)
+        "state_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].non_federal_resources.state_amount"],
+            }
+        },
+        # Section C - Non-federal Resources: Total Other Amount (Row 12, Column D)
+        # is the sum of (Column D, Rows 8-11)
+        "other_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].non_federal_resources.other_amount"],
+            }
+        },
+        # Section C - Non-federal Resources: Total Amount (Row 12, Column E)
+        # is the sum of (Column E, Rows 8-11)
+        "total_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].non_federal_resources.total_amount"],
+                # Needs to be calculated after the value from activity line items
+                "order": 2,
+            }
+        },
+    },
+    "forecasted_cash_needs": {
+        "federal_forecasted_cash_needs": {
+            # Section D - Forecasted Cash Needs: Federal Total (Column E, Row 13)
+            # is the sum of (Row 13, Columns A-D)
+            "total_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "@THIS.first_quarter_amount",
+                        "@THIS.second_quarter_amount",
+                        "@THIS.third_quarter_amount",
+                        "@THIS.fourth_quarter_amount",
+                    ],
+                }
+            }
+        },
+        "non_federal_forecasted_cash_needs": {
+            # Section D - Forecasted Cash Needs: Non-Federal Total (Column E, Row 14)
+            # is the sum of (Row 14, Columns A-D)
+            "total_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "@THIS.first_quarter_amount",
+                        "@THIS.second_quarter_amount",
+                        "@THIS.third_quarter_amount",
+                        "@THIS.fourth_quarter_amount",
+                    ],
+                }
+            }
+        },
+        "total_forecasted_cash_needs": {
+            # Section D - Forecasted Cash Needs: 1st Quarter Total (Row 15, Column A)
+            # is the sum of (Column A, Rows 13-14)
+            "first_quarter_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "forecasted_cash_needs.federal_forecasted_cash_needs.first_quarter_amount",
+                        "forecasted_cash_needs.non_federal_forecasted_cash_needs.first_quarter_amount",
+                    ],
+                }
+            },
+            # Section D - Forecasted Cash Needs: 2nd Quarter Total (Row 15, Column B)
+            # is the sum of (Column B, Rows 13-14)
+            "second_quarter_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "forecasted_cash_needs.federal_forecasted_cash_needs.second_quarter_amount",
+                        "forecasted_cash_needs.non_federal_forecasted_cash_needs.second_quarter_amount",
+                    ],
+                }
+            },
+            # Section D - Forecasted Cash Needs: 3rd Quarter Total (Row 15, Column C)
+            # is the sum of (Column C, Rows 13-14)
+            "third_quarter_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "forecasted_cash_needs.federal_forecasted_cash_needs.third_quarter_amount",
+                        "forecasted_cash_needs.non_federal_forecasted_cash_needs.third_quarter_amount",
+                    ],
+                }
+            },
+            # Section D - Forecasted Cash Needs: 4th Quarter Total (Row 15, Column D)
+            # is the sum of (Column D, Rows 13-14)
+            "fourth_quarter_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "forecasted_cash_needs.federal_forecasted_cash_needs.fourth_quarter_amount",
+                        "forecasted_cash_needs.non_federal_forecasted_cash_needs.fourth_quarter_amount",
+                    ],
+                }
+            },
+            # Section D - Forecasted Cash Needs: Total Amount (Row 15, Column E)
+            # is the sum of (Column E, Rows 13-14)
+            "total_amount": {
+                "gg_pre_population": {
+                    "rule": "sum_monetary",
+                    "fields": [
+                        "forecasted_cash_needs.federal_forecasted_cash_needs.total_amount",
+                        "forecasted_cash_needs.non_federal_forecasted_cash_needs.total_amount",
+                    ],
+                    # Needs to run after we calculate the total for each of federal and non-federal
+                    # forecasted cash needs that runs in the first iteration
+                    "order": 2,
+                }
+            },
+        },
+    },
+    "total_federal_fund_estimates": {
+        # Section E - Federal Fund Estimates: First Year Amount (Row 20, Column B)
+        # is the sum of (Column B, Rows 16-19)
+        "first_year_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].federal_fund_estimates.first_year_amount"],
+            }
+        },
+        # Section E - Federal Fund Estimates: Second Year Amount (Row 20, Column C)
+        # is the sum of (Column C, Rows 16-19)
+        "second_year_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].federal_fund_estimates.second_year_amount"],
+            }
+        },
+        # Section E - Federal Fund Estimates: Third Year Amount (Row 20, Column D)
+        # is the sum of (Column D, Rows 16-19)
+        "third_year_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].federal_fund_estimates.third_year_amount"],
+            }
+        },
+        # Section E - Federal Fund Estimates: Fourth Year Amount (Row 20, Column E)
+        # is the sum of (Column E, Rows 16-19)
+        "fourth_year_amount": {
+            "gg_pre_population": {
+                "rule": "sum_monetary",
+                "fields": ["activity_line_items[*].federal_fund_estimates.fourth_year_amount"],
+            }
+        },
+    },
+}
+
 SF424a_v1_0 = Form(
     # https://grants.gov/forms/form-items-description/fid/241
     form_id=uuid.UUID("08e6603f-d197-4a60-98cd-d49acb1fc1fd"),
@@ -406,7 +794,6 @@ SF424a_v1_0 = Form(
     omb_number="4040-0006",
     form_json_schema=FORM_JSON_SCHEMA,
     form_ui_schema=FORM_UI_SCHEMA,
-    # No rule schema yet, we'll likely but automated sums in this
-    form_rule_schema=None,
+    form_rule_schema=FORM_RULE_SCHEMA,
     # No form instructions at the moment.
 )

--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -187,7 +187,11 @@ def sum_monetary_values(context: JsonRuleContext, json_rule: JsonRule) -> str:
             continue
         result += monetary_value
 
-    return str(result.quantize(result))
+    # Quantize will make the value always contain 2 values after the decimal.
+    # Because our validation of monetary fields limits them to 2 decimals
+    # this only matters when a user enters something that would be flagged
+    # for a validation issue anyways, but at least this maintains consistency.
+    return str(result.quantize(ZERO_DECIMAL))
 
 
 population_func = Callable[[JsonRuleContext, JsonRule], Any]

--- a/api/src/form_schema/rule_processing/json_rule_util.py
+++ b/api/src/form_schema/rule_processing/json_rule_util.py
@@ -62,11 +62,11 @@ def get_field_values(data: dict, fields: list[str], path: list[str]) -> list:
 
     fields should be a list of paths that can either be:
     * absolute: "x.y[*].z[0]"
-    * relative: "$THIS.x.y[*]"
+    * relative: "@THIS.x.y[*]"
 
     Relative paths get appended to the path we're currently processing at
     after removing the current node
-    For example: a path of ["a[*]", "b"] and a relative path of $THIS.x.y will be treated as ["a[*]", "x", "y"]
+    For example: a path of ["a[*]", "b"] and a relative path of @THIS.x.y will be treated as ["a[*]", "x", "y"]
 
     Arrays are supported, we will fetch all values under that path if [*] is specified
     """

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -102,6 +102,33 @@ def set_env_var_defaults(monkeypatch_session):
     monkeypatch_session.setenv("SOAP_ENABLE_VERBOSE_LOGGING", "0")
 
 
+@pytest.fixture
+def verify_no_warning_error_logs(caplog):
+    """Fixture that if included will verify no warning/error log occurred during the test
+
+    Note that if this fails it will report that the teardown of the test failed, not
+    the test itself which will be marked as passed.
+
+    Should roughly be the equivalent of doing the following in a test:
+
+        def test_something(caplog):
+            caplog.set_level(logging.WARNING)
+            # test stuff
+            assert len(caplog.messages) == 0
+
+     Modified from example at https://docs.pytest.org/en/stable/how-to/logging.html#caplog-fixture
+    """
+    yield  # Run the test - we only want to do stuff after
+    for when in ("setup", "call"):
+        messages = [
+            r.message
+            for r in caplog.get_records(when)
+            if r.levelno in (logging.WARNING, logging.ERROR)
+        ]
+        if messages:
+            pytest.fail(f"Warning/error messages encountered during test: {messages}")
+
+
 ####################
 # Test DB session
 ####################

--- a/api/tests/src/form_schema/forms/test_sf424.py
+++ b/api/tests/src/form_schema/forms/test_sf424.py
@@ -375,7 +375,9 @@ def test_sf424_v4_0_conditionally_required_fields(
         assert validation_issue.field in required_fields
 
 
-def test_sf424_v4_0_pre_population_with_all_non_null_values(enable_factory_create, valid_json_v4_0):
+def test_sf424_v4_0_pre_population_with_all_non_null_values(
+    enable_factory_create, valid_json_v4_0, verify_no_warning_error_logs
+):
     application_form = setup_application_for_form_validation(
         valid_json_v4_0,
         json_schema=SF424_v4_0.form_json_schema,
@@ -447,8 +449,52 @@ def test_sf424_v4_0_pre_population_with_all_null_values(enable_factory_create, v
     assert "aor_signature" not in app_json
 
 
+@pytest.mark.parametrize(
+    "data,expected_sum",
+    [
+        (
+            {
+                "federal_estimated_funding": "1.00",
+                "applicant_estimated_funding": "2.00",
+                "state_estimated_funding": "3.00",
+                "local_estimated_funding": "4.00",
+                "other_estimated_funding": "5.00",
+                "program_income_estimated_funding": "6.00",
+            },
+            "21.00",
+        ),
+        (
+            {
+                "federal_estimated_funding": "invalid value",
+                "applicant_estimated_funding": "xyz",
+                "state_estimated_funding": "srerser",
+                "local_estimated_funding": "=123",
+                "other_estimated_funding": "4343434.sefse",
+                "program_income_estimated_funding": "a",
+            },
+            "0.00",
+        ),
+        ({}, "0.00"),
+    ],
+)
+def test_sf424_pre_population_auto_sum(
+    enable_factory_create, valid_json_v4_0, data, expected_sum, verify_no_warning_error_logs
+):
+
+    application_form = setup_application_for_form_validation(
+        data,
+        json_schema=SF424_v4_0.form_json_schema,
+        rule_schema=SF424_v4_0.form_rule_schema,
+    )
+
+    validate_application_form(application_form, ApplicationAction.MODIFY)
+    assert application_form.application_response["total_estimated_funding"] == expected_sum
+
+
 @freezegun.freeze_time("2023-02-20 12:00:00", tz_offset=0)
-def test_sf424_post_population(enable_factory_create, valid_json_v4_0):
+def test_sf424_post_population(
+    enable_factory_create, valid_json_v4_0, verify_no_warning_error_logs
+):
     application_form = setup_application_for_form_validation(
         valid_json_v4_0,
         json_schema=SF424_v4_0.form_json_schema,

--- a/api/tests/src/form_schema/forms/test_sf424a.py
+++ b/api/tests/src/form_schema/forms/test_sf424a.py
@@ -2,6 +2,147 @@ import pytest
 
 from src.form_schema.forms.sf424a import SF424a_v1_0
 from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+from src.services.applications.application_validation import (
+    ApplicationAction,
+    validate_application_form,
+)
+from tests.lib.data_factories import setup_application_for_form_validation
+
+
+@pytest.fixture
+def activity_line_item1():
+    return {
+        "activity_title": "Line1",
+        "assistance_listing_number": "12.345",
+        "budget_summary": {
+            "federal_estimated_unobligated_amount": "1.00",
+            "non_federal_estimated_unobligated_amount": "2.00",
+            "federal_new_or_revised_amount": "3.00",
+            "non_federal_new_or_revised_amount": "4.00",
+        },
+        "budget_categories": {
+            "personnel_amount": "1.00",
+            "fringe_benefits_amount": "2.00",
+            "travel_amount": "3.00",
+            "equipment_amount": "4.00",
+            "supplies_amount": "5.00",
+            "contractual_amount": "6.00",
+            "construction_amount": "7.00",
+            "other_amount": "8.00",
+            "total_indirect_charge_amount": "9.00",
+            "program_income_amount": "10.00",
+        },
+        "non_federal_resources": {
+            "applicant_amount": "1.00",
+            "state_amount": "2.00",
+            "other_amount": "3.00",
+        },
+        "federal_fund_estimates": {
+            "first_year_amount": "1.00",
+            "second_year_amount": "2.00",
+            "third_year_amount": "3.00",
+            "fourth_year_amount": "4.00",
+        },
+    }
+
+
+@pytest.fixture
+def activity_line_item2():
+    return {
+        "activity_title": "Line2",
+        "assistance_listing_number": "12.345",
+        "budget_summary": {
+            "federal_estimated_unobligated_amount": "10.00",
+            "non_federal_estimated_unobligated_amount": "-12.00",
+            "federal_new_or_revised_amount": "35.00",
+            "non_federal_new_or_revised_amount": "43.00",
+        },
+        "budget_categories": {
+            "personnel_amount": "100.00",
+            "fringe_benefits_amount": "22.00",
+            "travel_amount": "35.00",
+            "equipment_amount": "74.00",
+            "supplies_amount": "85.00",
+            "contractual_amount": "1006.00",
+            "construction_amount": "-7.00",
+            "other_amount": "10008.00",
+            "total_indirect_charge_amount": "29.00",
+            "program_income_amount": "-10000.00",
+        },
+        "non_federal_resources": {
+            "applicant_amount": "331.00",
+            "state_amount": "52.00",
+            "other_amount": "773.00",
+        },
+        "federal_fund_estimates": {
+            "first_year_amount": "61.00",
+            "second_year_amount": "72.00",
+            "third_year_amount": "63.00",
+            "fourth_year_amount": "447.00",
+        },
+    }
+
+
+@pytest.fixture
+def activity_line_item3():
+    return {
+        "activity_title": "Line3",
+        "budget_summary": {
+            "federal_estimated_unobligated_amount": "0.01",
+            "non_federal_estimated_unobligated_amount": "0.02",
+            "federal_new_or_revised_amount": "0.03",
+            "non_federal_new_or_revised_amount": "0.04",
+        },
+        "budget_categories": {
+            "personnel_amount": "0.01",
+            "fringe_benefits_amount": "0.02",
+            "travel_amount": "0.03",
+            "equipment_amount": "0.04",
+            "supplies_amount": "0.05",
+            "contractual_amount": "0.06",
+            "construction_amount": "0.07",
+            "other_amount": "0.08",
+            "total_indirect_charge_amount": "0.09",
+            "program_income_amount": "0.10",
+        },
+        "non_federal_resources": {
+            "applicant_amount": "0.01",
+            "state_amount": "0.02",
+            "other_amount": "0.03",
+        },
+        "federal_fund_estimates": {
+            "first_year_amount": "0.01",
+            "second_year_amount": "0.02",
+            "third_year_amount": "0.03",
+            "fourth_year_amount": "0.04",
+        },
+    }
+
+
+@pytest.fixture
+def activity_line_item4():
+    # This one only has a handful of values populated
+    # Missing values will be treated as 0
+    return {
+        "activity_title": "Line4",
+        "budget_summary": {
+            "federal_estimated_unobligated_amount": "14.01",
+            "federal_new_or_revised_amount": "13.02",
+        },
+        "budget_categories": {
+            "personnel_amount": "12.03",
+            "travel_amount": "11.04",
+            "equipment_amount": "10.05",
+        },
+        "non_federal_resources": {
+            "applicant_amount": "9.06",
+        },
+        "federal_fund_estimates": {
+            "first_year_amount": "8.07",
+            "second_year_amount": "7.08",
+            "fourth_year_amount": "6.09",
+        },
+    }
 
 
 @pytest.fixture
@@ -183,7 +324,7 @@ def test_sf424a_v1_0_too_many_line_items(full_valid_json_v1_0, full_valid_activi
     assert validation_issues[0].field == "$.activity_line_items"
 
 
-def test_sf424_confirmation_must_be_true(full_valid_json_v1_0):
+def test_sf424a_confirmation_must_be_true(full_valid_json_v1_0):
     data = full_valid_json_v1_0
     data["confirmation"] = False
     validation_issues = validate_json_schema_for_form(data, SF424a_v1_0)
@@ -194,7 +335,7 @@ def test_sf424_confirmation_must_be_true(full_valid_json_v1_0):
     assert validation_issues[0].message == "False is not one of [True]"
 
 
-def test_sf424_allowed_monetary_formats(full_valid_json_v1_0):
+def test_sf424a_allowed_monetary_formats(full_valid_json_v1_0):
     """Test the regex for the monetary formats"""
     data = full_valid_json_v1_0
     # All of these are valid formats
@@ -217,7 +358,7 @@ def test_sf424_allowed_monetary_formats(full_valid_json_v1_0):
     assert len(validation_issues) == 0
 
 
-def test_sf424_disallowed_monetary_formats(full_valid_json_v1_0):
+def test_sf424a_disallowed_monetary_formats(full_valid_json_v1_0):
     """Test the regex for the monetary formats"""
     data = full_valid_json_v1_0
     # All of these are valid formats
@@ -240,3 +381,202 @@ def test_sf424_disallowed_monetary_formats(full_valid_json_v1_0):
     assert len(validation_issues) == 12
     for validation_issue in validation_issues:
         assert validation_issue.type == "pattern"
+
+
+def test_sf424a_v_1_0_auto_summation_empty_state(
+    enable_factory_create, verify_no_warning_error_logs
+):
+    data = {}
+    application_form = setup_application_for_form_validation(
+        data,
+        json_schema=SF424a_v1_0.form_json_schema,
+        rule_schema=SF424a_v1_0.form_rule_schema,
+    )
+
+    validate_application_form(application_form, ApplicationAction.MODIFY)
+    app_json = application_form.application_response
+
+    # Nearly every monetary field outside of the activity line items
+    # gets pre-populated as 0.00
+    assert app_json == {
+        "total_budget_summary": {
+            "federal_estimated_unobligated_amount": "0.00",
+            "non_federal_estimated_unobligated_amount": "0.00",
+            "federal_new_or_revised_amount": "0.00",
+            "non_federal_new_or_revised_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "total_budget_categories": {
+            "personnel_amount": "0.00",
+            "fringe_benefits_amount": "0.00",
+            "travel_amount": "0.00",
+            "equipment_amount": "0.00",
+            "supplies_amount": "0.00",
+            "contractual_amount": "0.00",
+            "construction_amount": "0.00",
+            "other_amount": "0.00",
+            "total_direct_charge_amount": "0.00",
+            "total_indirect_charge_amount": "0.00",
+            "total_amount": "0.00",
+            "program_income_amount": "0.00",
+        },
+        "total_non_federal_resources": {
+            "applicant_amount": "0.00",
+            "state_amount": "0.00",
+            "other_amount": "0.00",
+            "total_amount": "0.00",
+        },
+        "forecasted_cash_needs": {
+            "federal_forecasted_cash_needs": {
+                "total_amount": "0.00",
+            },
+            "non_federal_forecasted_cash_needs": {
+                "total_amount": "0.00",
+            },
+            "total_forecasted_cash_needs": {
+                "first_quarter_amount": "0.00",
+                "second_quarter_amount": "0.00",
+                "third_quarter_amount": "0.00",
+                "fourth_quarter_amount": "0.00",
+                "total_amount": "0.00",
+            },
+        },
+        "total_federal_fund_estimates": {
+            "first_year_amount": "0.00",
+            "second_year_amount": "0.00",
+            "third_year_amount": "0.00",
+            "fourth_year_amount": "0.00",
+        },
+    }
+
+
+def test_sf424a_v_1_0_auto_summation_full_data(
+    enable_factory_create,
+    activity_line_item1,
+    activity_line_item2,
+    activity_line_item3,
+    activity_line_item4,
+    verify_no_warning_error_logs,
+):
+    data = {
+        "activity_line_items": [
+            activity_line_item1,
+            activity_line_item2,
+            activity_line_item3,
+            activity_line_item4,
+        ],
+        "forecasted_cash_needs": {
+            "federal_forecasted_cash_needs": {
+                "first_quarter_amount": "12.25",
+                "second_quarter_amount": "78.15",
+                "third_quarter_amount": "45.35",
+                "fourth_quarter_amount": "3.50",
+            },
+            "non_federal_forecasted_cash_needs": {
+                "first_quarter_amount": "67.34",
+                "second_quarter_amount": "33.33",
+                "third_quarter_amount": "29.33",
+                "fourth_quarter_amount": "71.33",
+            },
+        },
+        "confirmation": True,
+    }
+    application_form = setup_application_for_form_validation(
+        data,
+        json_schema=SF424a_v1_0.form_json_schema,
+        rule_schema=SF424a_v1_0.form_rule_schema,
+    )
+
+    validate_application_form(application_form, ApplicationAction.MODIFY)
+    app_json = application_form.application_response
+
+    # Add the expected calculated values to the activity line items
+    expected_activity_line_item1 = activity_line_item1
+    expected_activity_line_item1["budget_summary"]["total_amount"] = "10.00"
+    expected_activity_line_item1["budget_categories"]["total_direct_charge_amount"] = "36.00"
+    expected_activity_line_item1["budget_categories"]["total_amount"] = "45.00"
+    expected_activity_line_item1["non_federal_resources"]["total_amount"] = "6.00"
+
+    expected_activity_line_item2 = activity_line_item2
+    expected_activity_line_item2["budget_summary"]["total_amount"] = "76.00"
+    expected_activity_line_item2["budget_categories"]["total_direct_charge_amount"] = "11323.00"
+    expected_activity_line_item2["budget_categories"]["total_amount"] = "11352.00"
+    expected_activity_line_item2["non_federal_resources"]["total_amount"] = "1156.00"
+
+    expected_activity_line_item3 = activity_line_item3
+    expected_activity_line_item3["budget_summary"]["total_amount"] = "0.10"
+    expected_activity_line_item3["budget_categories"]["total_direct_charge_amount"] = "0.36"
+    expected_activity_line_item3["budget_categories"]["total_amount"] = "0.45"
+    expected_activity_line_item3["non_federal_resources"]["total_amount"] = "0.06"
+
+    expected_activity_line_item4 = activity_line_item4
+    expected_activity_line_item4["budget_summary"]["total_amount"] = "27.03"
+    expected_activity_line_item4["budget_categories"]["total_direct_charge_amount"] = "33.12"
+    expected_activity_line_item4["budget_categories"]["total_amount"] = "33.12"
+    expected_activity_line_item4["non_federal_resources"]["total_amount"] = "9.06"
+
+    assert app_json == {
+        "activity_line_items": [
+            expected_activity_line_item1,
+            expected_activity_line_item2,
+            expected_activity_line_item3,
+            expected_activity_line_item4,
+        ],
+        "total_budget_summary": {
+            "federal_estimated_unobligated_amount": "25.02",
+            "non_federal_estimated_unobligated_amount": "-9.98",
+            "federal_new_or_revised_amount": "51.05",
+            "non_federal_new_or_revised_amount": "47.04",
+            "total_amount": "113.13",
+        },
+        "total_budget_categories": {
+            "personnel_amount": "113.04",
+            "fringe_benefits_amount": "24.02",
+            "travel_amount": "49.07",
+            "equipment_amount": "88.09",
+            "supplies_amount": "90.05",
+            "contractual_amount": "1012.06",
+            "construction_amount": "0.07",
+            "other_amount": "10016.08",
+            "total_direct_charge_amount": "11392.48",
+            "total_indirect_charge_amount": "38.09",
+            "total_amount": "11430.57",
+            "program_income_amount": "-9989.90",
+        },
+        "total_non_federal_resources": {
+            "applicant_amount": "341.07",
+            "state_amount": "54.02",
+            "other_amount": "776.03",
+            "total_amount": "1171.12",
+        },
+        "forecasted_cash_needs": {
+            "federal_forecasted_cash_needs": {
+                "first_quarter_amount": "12.25",
+                "second_quarter_amount": "78.15",
+                "third_quarter_amount": "45.35",
+                "fourth_quarter_amount": "3.50",
+                "total_amount": "139.25",
+            },
+            "non_federal_forecasted_cash_needs": {
+                "first_quarter_amount": "67.34",
+                "second_quarter_amount": "33.33",
+                "third_quarter_amount": "29.33",
+                "fourth_quarter_amount": "71.33",
+                "total_amount": "201.33",
+            },
+            "total_forecasted_cash_needs": {
+                "first_quarter_amount": "79.59",
+                "second_quarter_amount": "111.48",
+                "third_quarter_amount": "74.68",
+                "fourth_quarter_amount": "74.83",
+                "total_amount": "340.58",
+            },
+        },
+        "total_federal_fund_estimates": {
+            "first_year_amount": "70.08",
+            "second_year_amount": "81.10",
+            "third_year_amount": "66.03",
+            "fourth_year_amount": "457.13",
+        },
+        "confirmation": True,
+    }

--- a/api/tests/src/form_schema/rule_processing/test_json_rule_field_population.py
+++ b/api/tests/src/form_schema/rule_processing/test_json_rule_field_population.py
@@ -126,6 +126,12 @@ def test_handle_field_population_pre_population_with_null_value(
             {"x": "10.01", "y": "-21.50"},
             "-11.49",
         ),
+        # Values will be quantized
+        (
+            {"rule": "sum_monetary", "fields": ["x", "y"]},
+            {"x": "123.010000", "y": "456.560000"},
+            "579.57",
+        ),
     ],
 )
 def test_handle_field_population_pre_population_sum_monetary(


### PR DESCRIPTION
**NOTE: we will hold merging this for a few days, we don't need this for launch, and don't want to interfere with testing**
## Summary
Work for #6331

## Changes proposed
Add auto-summation to the SF424 and SF424A forms

## Context for reviewers
The actual implementation of auto-summation was already implemented, I did fix one minor issue with rounding, but otherwise it just required a whole bunch of configuration as there are 36 fields in the SF424A that have to be summed.

## Validation steps
Need both the frontend and API running locally.

Run `make db-seed-local` to get form changes in your DB. Navigate to the pilot-like opportunity with an application (via search or look at the link the seed script gives you).

If you go to the 424 or 424a and populate any of the monetary fields, the summations should work. The SF424A doesn't have the summed fields as non-fillable yet (needs frontend changes due to how that form works), but I was able to adjust the SF424:
<img width="674" height="825" alt="Screenshot 2025-09-19 at 1 30 28 PM" src="https://github.com/user-attachments/assets/734eb926-7299-4565-9f4f-b9379fb8ae76" />


<img width="1197" height="685" alt="Screenshot 2025-09-19 at 1 32 51 PM" src="https://github.com/user-attachments/assets/8f7350cc-fd80-4886-b3ec-87163541a092" />
