### PR TITLE
[Issue #6445] Warn to save after an attachment is deleted

### DIFF
--- a/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
@@ -39,11 +39,16 @@ export async function generateMetadata({
 }
 
 interface FormPageProps {
-  params: Promise<{ appFormId: string; applicationId: string; locale: string }>;
+  params: Promise<{
+    appFormId: string;
+    applicationId: string;
+    locale: string;
+    setAttachmentsChanged: (value: boolean) => void;
+  }>;
 }
 
 export default async function FormPage({ params }: FormPageProps) {
-  const { applicationId, appFormId } = await params;
+  const { applicationId, appFormId, setAttachmentsChanged } = await params;
   const headersList = await headers();
   const internalToken = headersList.get("X-SGG-Internal-Token") ?? undefined;
 
@@ -79,6 +84,7 @@ export default async function FormPage({ params }: FormPageProps) {
         formSchema={formSchema}
         uiSchema={formUiSchema}
         attachments={applicationAttachments}
+        setAttachmentsChanged={setAttachmentsChanged}
       />
     </>
   );

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -8,7 +8,13 @@ import { Attachment } from "src/types/attachmentTypes";
 
 import { useTranslations } from "next-intl";
 import { useNavigationGuard } from "next-navigation-guard";
-import React, { ReactNode, useActionState, useMemo, useState } from "react";
+import React, {
+  ReactNode,
+  useActionState,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { Alert, Button, FormGroup } from "@trussworks/react-uswds";
 
 import { handleFormAction } from "./actions";
@@ -89,9 +95,10 @@ const ApplyForm = ({
   });
 
   const [formChanged, setFormChanged] = useState<boolean>(false);
+  const [attachmentsChanged, setAttachmentsChanged] = useState<boolean>(false);
 
   useNavigationGuard({
-    enabled: formChanged,
+    enabled: formChanged || attachmentsChanged,
     confirm: () =>
       // eslint-disable-next-line no-alert
       window.confirm(translate("unsavedChangesWarning")),
@@ -136,7 +143,10 @@ const ApplyForm = ({
           name="apply-form-button"
           className="margin-top-0"
           value="save"
-          onClick={() => setFormChanged(false)}
+          onClick={() => {
+            setFormChanged(false);
+            setAttachmentsChanged(false);
+          }}
         >
           {pending ? "Saving..." : "Save"}
         </Button>
@@ -149,7 +159,9 @@ const ApplyForm = ({
             validationWarnings={validationWarnings}
             isBudgetForm={isBudgetForm}
           />
-          <AttachmentsProvider value={attachments ?? []}>
+          <AttachmentsProvider
+            value={{ attachments: attachments ?? [], setAttachmentsChanged }}
+          >
             <FormFields
               key={saved ? "after-save" : "before-save"}
               errors={saved ? validationWarnings : null}

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -8,13 +8,7 @@ import { Attachment } from "src/types/attachmentTypes";
 
 import { useTranslations } from "next-intl";
 import { useNavigationGuard } from "next-navigation-guard";
-import React, {
-  ReactNode,
-  useActionState,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { ReactNode, useActionState, useMemo, useState } from "react";
 import { Alert, Button, FormGroup } from "@trussworks/react-uswds";
 
 import { handleFormAction } from "./actions";

--- a/frontend/src/components/applyForm/PrintForm.tsx
+++ b/frontend/src/components/applyForm/PrintForm.tsx
@@ -12,14 +12,18 @@ export default function PrintForm({
   formSchema,
   savedFormData,
   uiSchema,
+  setAttachmentsChanged,
 }: {
   attachments: Attachment[];
   formSchema: RJSFSchema;
   savedFormData: object;
   uiSchema: UiSchema;
+  setAttachmentsChanged: (value: boolean) => void;
 }) {
   return (
-    <AttachmentsProvider value={attachments ?? []}>
+    <AttachmentsProvider
+      value={{ attachments: attachments ?? [], setAttachmentsChanged }}
+    >
       <FormFields
         errors={null}
         formData={savedFormData}

--- a/frontend/src/components/applyForm/widgets/AttachmentUploadWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/AttachmentUploadWidget.tsx
@@ -35,7 +35,7 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
 
   const labelType = getLabelTypeFromOptions(options?.["widget-label"]);
 
-  const attachments = useApplicationAttachments();
+  const { attachments, setAttachmentsChanged } = useApplicationAttachments();
   const fileInputRef = useRef<FileInputRef | null>(null);
   const deleteModalRef = useRef<ModalRef | null>(null);
   const applicationId = useApplicationId();
@@ -95,7 +95,11 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
     );
 
     setShowFile(!!newAttachmentId);
-  }, [value, attachments]);
+
+    if (newAttachmentId) {
+      setAttachmentsChanged(true);
+    }
+  }, [value, attachments, setAttachmentsChanged]);
 
   const handleChange = async (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -109,6 +113,7 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
       setFileName(file.name);
       setShowFile(true);
       onChange?.(uploadedId);
+      setAttachmentsChanged(true);
     }
 
     fileInputRef.current?.clearFiles();

--- a/frontend/src/components/applyForm/widgets/MultiAttachmentUploadList.tsx
+++ b/frontend/src/components/applyForm/widgets/MultiAttachmentUploadList.tsx
@@ -13,7 +13,7 @@ export const MultipleAttachmentUploadList = ({
   handleRemove,
   uploadedFiles,
 }: Props) => {
-  const attachments = useApplicationAttachments();
+  const { attachments, setAttachmentsChanged } = useApplicationAttachments();
   return (
     <ul className="usa-list usa-list--unstyled margin-top-2">
       {uploadedFiles.map((file, index) => {

--- a/frontend/src/components/applyForm/widgets/MultiAttachmentUploadList.tsx
+++ b/frontend/src/components/applyForm/widgets/MultiAttachmentUploadList.tsx
@@ -13,7 +13,7 @@ export const MultipleAttachmentUploadList = ({
   handleRemove,
   uploadedFiles,
 }: Props) => {
-  const { attachments, setAttachmentsChanged } = useApplicationAttachments();
+  const { attachments } = useApplicationAttachments();
   return (
     <ul className="usa-list usa-list--unstyled margin-top-2">
       {uploadedFiles.map((file, index) => {

--- a/frontend/src/components/applyForm/widgets/MultipleAttachmentUploadWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/MultipleAttachmentUploadWidget.tsx
@@ -34,7 +34,7 @@ const MultipleAttachmentUploadWidget = ({
 }: UswdsWidgetProps) => {
   const { description, options, title } = schema as SchemaWithLabelOption;
 
-  const attachments = useApplicationAttachments();
+  const { attachments, setAttachmentsChanged } = useApplicationAttachments();
 
   const error = rawErrors.length ? true : undefined;
 
@@ -111,8 +111,15 @@ const MultipleAttachmentUploadWidget = ({
       setFileToDeleteIndex(null);
       setDeletePendingName(null);
       deleteModalRef.current?.toggleModal();
+      setAttachmentsChanged(true);
     }
-  }, [deleteState, fileToDeleteIndex, uploadedFiles, onChange]);
+  }, [
+    deleteState,
+    fileToDeleteIndex,
+    uploadedFiles,
+    onChange,
+    setAttachmentsChanged,
+  ]);
 
   const handleFileChange = async (files: FileList | null): Promise<void> => {
     if (!files || !applicationId) return;

--- a/frontend/src/hooks/ApplicationAttachments.tsx
+++ b/frontend/src/hooks/ApplicationAttachments.tsx
@@ -4,7 +4,14 @@ import type { Attachment } from "src/types/attachmentTypes";
 
 import { createContext, PropsWithChildren, useContext } from "react";
 
-const AttachmentsContext = createContext<Attachment[] | null>(null);
+export interface AttachmentsContext {
+  attachments: Attachment[] | null;
+  setAttachmentsChanged: (value: boolean) => void;
+}
+
+const AttachmentsContext = createContext<AttachmentsContext>(
+  {} as AttachmentsContext,
+);
 
 export const useApplicationAttachments = () => {
   const ctx = useContext(AttachmentsContext);
@@ -19,10 +26,9 @@ export const useApplicationAttachments = () => {
 export function AttachmentsProvider({
   value,
   children,
-}: PropsWithChildren<{ value?: Attachment[] }>) {
-  const safe = Array.isArray(value) ? value : [];
+}: PropsWithChildren<{ value: AttachmentsContext }>) {
   return (
-    <AttachmentsContext.Provider value={safe}>
+    <AttachmentsContext.Provider value={value}>
       {children}
     </AttachmentsContext.Provider>
   );

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -370,7 +370,8 @@ export const messages = {
         "Correct the following errors before submitting your application.",
       required: "A red asterisk <abr>*</abr> indicates a required field.",
       navTitle: "Sections in this form",
-      unsavedChangesWarning: "You have unsaved changes that will be lost.",
+      unsavedChangesWarning:
+        "You have unsaved changes or attachments that will be lost if you click OK",
     },
   },
   Index: {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -371,7 +371,7 @@ export const messages = {
       required: "A red asterisk <abr>*</abr> indicates a required field.",
       navTitle: "Sections in this form",
       unsavedChangesWarning:
-        "You have unsaved changes or attachments that will be lost if you click OK",
+        "You have unsaved changes or attachments that will be lost if you select OK.",
     },
   },
   Index: {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6445 

## Changes proposed

Add attachment changed state tracking to parallel the form change that already pops the warning of navigating away with pending changes.

## Validation steps
1. Checkout the branch
2. Disable strict mode in Next config
3. Run `npm run dev`
4. Sign in with one_org_user
5. Go to the Budget Narrative Attachment Form for an Application 
6. Ensure there is nothing uploaded, delete and Save if there is.  And refresh the page.
7. Upload a file but don't save
8. Try to navigate away and confirm you get the warning "You have unsaved changes or attachments that will be lost if you click OK"
9. Click cancel
10. Save
11. Try to navigate away (you should get no warning)
12. Go back to the form
13. Remove the attachment but don't save
14. Try to navigate away and confirm you get the warning "You have unsaved changes or attachments that will be lost if you click OK"
15. Click cancel
16. Click save
17. Try to navigate away (you should get no warning)