### PR TITLE
Frontend API Gateway key and secret

### DIFF
--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -172,7 +172,11 @@ module "service" {
     module.app_config.enable_identity_provider ? [{
       # name      = "COGNITO_CLIENT_SECRET"
       # valueFrom = module.identity_provider_client[0].client_secret_arn
-    }] : []
+    }] : [],
+    [{
+      name      = "X-API-KEY",
+      valueFrom = aws_ssm_parameter.frontend_api_access_token.arn
+    }]
   )
 
   extra_policies = merge(

--- a/infra/frontend/service/secrets.tf
+++ b/infra/frontend/service/secrets.tf
@@ -14,3 +14,20 @@ module "secrets" {
   )
   manage_method = each.value.manage_method
 }
+
+resource "aws_ssm_parameter" "frontend_api_access_token" {
+  #checkov:skip=CKV_AWS_337:Use AWS-managed KMS for terraform-managed SSM parameters
+  name  = "/${module.app_config.app_name}/${var.environment_name}/X-API-KEY"
+  type  = "SecureString"
+  value = "Manually update from internal-${module.app_config.app_name}-${var.environment_name}-key"
+
+  description = "Token that the frontend uses to authenticate when making Grants API fetch requests via API Gateway."
+
+  # Won't overwrite value once changed from the placeholder, this value is set manually from the
+  # created key in the API playbook. Terraform cannot dynamically pull the token's value
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -280,3 +280,13 @@ resource "aws_api_gateway_rest_api_policy" "api_access_restriction" {
   rest_api_id = aws_api_gateway_rest_api.api[0].id
   policy      = data.aws_iam_policy_document.api_access_restriction[0].json
 }
+
+resource "aws_api_gateway_api_key" "frontend_api_access" {
+  count = var.enable_api_gateway ? 1 : 0
+
+  name = "internal-frontend-${var.environment_name}-key"
+
+  # Because we can't automatically save the value of the token via terraform, we have to manually
+  # save it to SSM. That parameter is created below
+  description = "Frontend key for access the ${var.service_name} ECS service via the API Gateway"
+}


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #ISSUE 

## Changes proposed

- API Gateway key for frontend
- SSM param for frontend to store key in
- Update frontend ECS task def

## Context for reviewers

This PR will create an API key for the frontend to use, and a SSM param that will require someone to copy the key value into (terraform will not do this automatically). I setup the param in the frontend playbook because it would cause a race condition if it was made in the API gateway file, since frontend and API would be deployed at the same time

## Validation steps

Dependent on code and steps from @btabaska to be tested via frontend. The gateway has been set to full proxy mode, so I would need to set an endpoint to have auth required and then test via that path
