### PR TITLE
[No ticket] Fix inherit parent metadata linter

### DIFF
--- a/.github/linters/scripts/inherit-parent-deliverable.sh
+++ b/.github/linters/scripts/inherit-parent-deliverable.sh
@@ -138,7 +138,7 @@ fi
 
 # Update the deliverable field
 # Note: We need to pass the value as a raw field to prevent the gh CLI from parsing
-#       the option ID as a number if there are no alphanumeric characters e.g. 360523
+#       the option ID as a number if there are no alphabetic characters e.g. 360523
 log "Updating deliverable field to match parent: '$parent_deliverable_option_name'"
 gh api graphql \
   --field projectId="$child_project_id" \

--- a/.github/linters/scripts/inherit-parent-deliverable.sh
+++ b/.github/linters/scripts/inherit-parent-deliverable.sh
@@ -73,8 +73,8 @@ mutation_query=$(cat $query_dir/updateProjectFieldValue.graphql)
 log "Fetching issue and parent milestone details using gh CLI..."
 data=$(
   gh api graphql \
-    -F url="$issue_url" \
-    -f query="$fetch_query" \
+    --field url="$issue_url" \
+    --raw-field query="$fetch_query" \
     --jq '.data.resource'
 )
 
@@ -137,11 +137,13 @@ fi
 # #######################################################
 
 # Update the deliverable field
+# Note: We need to pass the value as a raw field to prevent the gh CLI from parsing
+#       the option ID as a number if there are no alphanumeric characters e.g. 360523
 log "Updating deliverable field to match parent: '$parent_deliverable_option_name'"
 gh api graphql \
-  -F projectId="$child_project_id" \
-  -F itemId="$child_item_id" \
-  -F fieldId="$parent_deliverable_field_id" \
-  -F value="$parent_deliverable_option_id" \
-  -f query="$mutation_query"
+  --field projectId="$child_project_id" \
+  --field itemId="$child_item_id" \
+  --field fieldId="$parent_deliverable_field_id" \
+  --raw-field value="$parent_deliverable_option_id" \
+  --raw-field query="$mutation_query"
 log "Deliverable field updated successfully to '$parent_deliverable_option_name'"


### PR DESCRIPTION
## Summary

Fixes a bug in how the deliverable option ID was passed to one of our linter scripts which caused it to fail when the option ID looked like a number (i.e. no alpha characters)

## Changes proposed

- Switches flag passing option ID value to `--raw-field` to preserve the escaping which makes it a string
- Switches to the more verbose (and clear) `--field` and `--raw-field` instead of (`-F` and `-f` respectively)

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This error was flagged by @chris-kuryak after he noticed this GitHub action failed when he was creating some issues. It only failed on issues created for the "Scale apply user workflow *" deliverable because that option ID doesn't contain any alpha characters (`35970549`) and the gh CLI was parsing it as a number instead of a string even when escaping it with quotes.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


https://github.com/user-attachments/assets/cf4d5dc5-b7c3-4ff6-a03e-2981d13069ff


