### PR TITLE
[Unticketed] Resolve conflict with DB migration

### DIFF
--- a/api/src/db/migrations/versions/2025_09_22_merge_multiple_heads.py
+++ b/api/src/db/migrations/versions/2025_09_22_merge_multiple_heads.py
@@ -1,0 +1,24 @@
+"""Merge multiple heads
+
+Revision ID: e4ac8da61902
+Revises: 430b57cd6d23, 5de110bf1389
+Create Date: 2025-09-22 12:39:56.691320
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e4ac8da61902"
+down_revision = ("430b57cd6d23", "5de110bf1389")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## Summary

## Changes proposed
Resolve conflict between multiple DB migrations

## Context for reviewers
Alembic has to handle migrations in a specified order, if we merge two DB migrations that both have the same head/predecessor, it can't run them. This tells it to run them in a specified order. This is just generated by running `make db-migrate-merge-heads`.

See: https://alembic.sqlalchemy.org/en/latest/branches.html

## Validation steps
`make db-migrate` now works.
