### PR TITLE
[Issue #6445] Fix unsaved attachment warnings

### DIFF
--- a/frontend/src/components/applyForm/widgets/AttachmentUploadWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/AttachmentUploadWidget.tsx
@@ -78,6 +78,7 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
       setAttachmentId(null);
       onChange?.(undefined);
       deleteModalRef.current?.toggleModal();
+      setAttachmentsChanged(true);
     }
   }, [deleteState, onChange]);
 
@@ -95,10 +96,6 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
     );
 
     setShowFile(!!newAttachmentId);
-
-    if (newAttachmentId) {
-      setAttachmentsChanged(true);
-    }
   }, [value, attachments, setAttachmentsChanged]);
 
   const handleChange = async (
@@ -113,7 +110,6 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
       setFileName(file.name);
       setShowFile(true);
       onChange?.(uploadedId);
-      setAttachmentsChanged(true);
     }
 
     fileInputRef.current?.clearFiles();


### PR DESCRIPTION
## Summary

Work for #6445 and #6480 

## Changes proposed

Better placement of when we mark attachments as dirty for single attachment form widget

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

1. Go into the 424
2. Go to the Areas Affected section
3. Ensure there's no attachment and save
4. Upload a file but don't save the form
5. Try to leave the form and you should get a warning about unsaved attachment, click cancel.
6. Save
7. Try to leave the form and you should be able to
8. Return to the 424
9. Remove the attachment, but don't save
10. Known bug: The file name will be removed but will still show as "(Previously uploaded file)"
11. Try to leave the form and you should get a warning about unsaved attachment, click cancel.
12. Save
13. Try to leave the form and you should be able to.