### PR TITLE
[Issue #6511] Don't always set the form to be included in the submission 

### DIFF
--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -136,7 +136,7 @@ export const handleUpdateApplicationForm = async (
   };
   const response = await fetchApplicationWithMethod("PUT")({
     subPath: `${applicationId}/forms/${applicationFormId}`,
-    body: { application_response: values, is_included_in_submission: true },
+    body: { application_response: values },
     additionalHeaders: ssgToken,
   });
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6511  

## Changes proposed

At some point we had a hard coded default to include any form that the user touched at some point. Removing that for now as that's not the desired behavior.

