### PR TITLE
[Issue #6492] Create a script to list the status of forms in an env

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2072,7 +2072,7 @@ version = "3.16.0"
 description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "prettytable-3.16.0-py3-none-any.whl", hash = "sha256:b5eccfabb82222f5aa46b798ff02a8452cf530a352c31bddfa29be41242863aa"},
     {file = "prettytable-3.16.0.tar.gz", hash = "sha256:3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57"},
@@ -3322,7 +3322,7 @@ version = "0.2.14"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.6"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1"},
     {file = "wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"},
@@ -3513,4 +3513,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13"
-content-hash = "9dfc6881802a982dc031b2db9baa9dfe54740d62b0d1a59a0c04825918dbfee5"
+content-hash = "142c85f2628f16b66bbbe5c5876a086669e288a9969299df71dc20be6b04bb23"

--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -1926,8 +1926,6 @@ groups = ["main"]
 files = [
     {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
     {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
-    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0"},
-    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b"},
     {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50"},
     {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae"},
     {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9"},
@@ -1937,8 +1935,6 @@ files = [
     {file = "pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f"},
     {file = "pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722"},
     {file = "pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288"},
-    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d"},
-    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494"},
     {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58"},
     {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f"},
     {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e"},
@@ -1948,8 +1944,6 @@ files = [
     {file = "pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd"},
     {file = "pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4"},
     {file = "pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69"},
-    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d"},
-    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6"},
     {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7"},
     {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024"},
     {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809"},
@@ -1962,8 +1956,6 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f"},
     {file = "pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c"},
     {file = "pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd"},
-    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e"},
-    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1"},
     {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805"},
     {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8"},
     {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2"},
@@ -1973,8 +1965,6 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580"},
     {file = "pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e"},
     {file = "pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d"},
-    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced"},
-    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c"},
     {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8"},
     {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59"},
     {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe"},
@@ -1984,8 +1974,6 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e"},
     {file = "pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12"},
     {file = "pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a"},
-    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632"},
-    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673"},
     {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027"},
     {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77"},
     {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874"},
@@ -1995,8 +1983,6 @@ files = [
     {file = "pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6"},
     {file = "pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae"},
     {file = "pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653"},
-    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6"},
-    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36"},
     {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b"},
     {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477"},
     {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50"},
@@ -2006,8 +1992,6 @@ files = [
     {file = "pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa"},
     {file = "pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f"},
     {file = "pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081"},
-    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4"},
-    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc"},
     {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06"},
     {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a"},
     {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978"},
@@ -2017,15 +2001,11 @@ files = [
     {file = "pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe"},
-    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c"},
-    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438"},
-    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"},
-    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
@@ -2085,6 +2065,24 @@ files = [
     {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
 ]
+
+[[package]]
+name = "prettytable"
+version = "3.16.0"
+description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "prettytable-3.16.0-py3-none-any.whl", hash = "sha256:b5eccfabb82222f5aa46b798ff02a8452cf530a352c31bddfa29be41242863aa"},
+    {file = "prettytable-3.16.0.tar.gz", hash = "sha256:3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "pytest-lazy-fixtures"]
 
 [[package]]
 name = "psycopg"
@@ -3319,6 +3317,18 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "wcwidth"
+version = "0.2.14"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = ">=3.6"
+groups = ["dev"]
+files = [
+    {file = "wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1"},
+    {file = "wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605"},
+]
+
+[[package]]
 name = "webargs"
 version = "8.7.0"
 description = "Declarative parsing and validation of HTTP request objects, with built-in support for popular web frameworks, including Flask, Django, Bottle, Tornado, Pyramid, Falcon, and aiohttp."
@@ -3503,4 +3513,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.13"
-content-hash = "dcca930f1a810e0691ff79fc616e67b309921a70425c4e7c99558127861d4080"
+content-hash = "9dfc6881802a982dc031b2db9baa9dfe54740d62b0d1a59a0c04825918dbfee5"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -44,6 +44,7 @@ defusedxml = "^0.7.1"
 xmltodict = "^0.15.0"
 docraptor = "^3.0.0"
 jsonpath-ng = "^1.7.0"
+prettytable = "^3.16.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.0.0"
@@ -67,7 +68,6 @@ freezegun = "^1.5.0"
 types-requests = "^2.31"
 graphviz = "^0.20.3"
 eralchemy = "^1.5.0"
-prettytable = "^3.16.0"
 
 
 [build-system]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -67,6 +67,7 @@ freezegun = "^1.5.0"
 types-requests = "^2.31"
 graphviz = "^0.20.3"
 eralchemy = "^1.5.0"
+prettytable = "^3.16.0"
 
 
 [build-system]

--- a/api/src/task/__init__.py
+++ b/api/src/task/__init__.py
@@ -9,6 +9,7 @@ import src.task.sam_extracts.sam_extract_cli  # noqa: F401 E402 isort:skip
 import src.task.apply.create_application_submission_task  # noqa: F401 E402 isort:skip
 import src.task.generate_internal_token  # noqa: F401 E402 isort:skip
 import src.task.forms.update_form_task  # noqa: F401 E402 isort:skip
+import src.task.forms.list_forms_task  # noqa: F401 E402 isort:skip
 import src.task.opportunities.generate_opportunity_sql  # noqa: F401 E402 isort:skip
 
 __all__ = ["task_blueprint"]

--- a/api/src/task/forms/README.md
+++ b/api/src/task/forms/README.md
@@ -1,13 +1,45 @@
 # Overview
+The `list_forms_task.py` script in this folder can be used
+to check all forms in a specified environment and output
+whether they're up-to-date.
+
 The `update_form_task.py` script in this folder can be used
 to update a form in any environment copying the form from your
 local database to the specified environment.
 
-__IMPORTANT__ - Because this script pulls data from your local database,
+__IMPORTANT__ - Because these scripts pull data from your local database,
 it is recommended that you completely remake and reload forms into your database
-locally before running it.
+locally before running it by doing:
+```shell
+make volume-recreate db-seed-local
+```
 
-# Running
+# List Form Task
+## Running
+The script takes in the following parameters:
+* `--environment` - The environment you want to run in
+* `--verbose` - Whether to output how every field will change, can be very noisy if large fields like the JSON schema will change
+* (Environment Variable) `NON_LOCAL_API_AUTH_TOKEN` - the auth token for calling the environment - at the moment MUST be the same auth token the frontend uses (the first one configured in our API_AUTH_TOKEN env var).
+
+```sh
+make cmd args="task list-forms --environment=dev --verbose"
+```
+
+This will produce a table view of all the forms in your local database
+and whether they are different than the form in a given environment.
+
+It will also produce the commands for the update-form script for any forms
+that require updates, or isn't yet in that environment.
+
+### Form Instructions
+This logic does not diff the form instruction record in any way. It will
+always match as we don't have form instructions setup locally at this time.
+
+The command it outputs for using the update-form script will always have the
+form instructions ID of the form we fetched from the given environment.
+
+# Update Form Task
+## Running
 __IMPORTANT__ - As currently written, this script has a few caveats:
 * If you want to test against your local database, you must be running outside of Docker due to Docker/network weirdness that I didn't try to solve.
 * The form instruction record must be manually uploaded to s3 and inserted into the database - see the below section for details.
@@ -16,14 +48,13 @@ The script takes in the following parameters:
 * `--environment` - The environment you want to run in
 * `--form-id` - The ID of the form you want to update - Grab the ID from our static definition of a form in our code, do not create a new ID
 * `--form-instruction-id` - The ID of the form instruction of a form, if not included will be set as null, see section below for details
-* `--dry-run/--no-dry-run` - Whether to actually make the call to the API endpoint - in dry-run mode a call will be made to the GET /forms endpoint and you will be presented with what fields would change.
 * (Environment Variable) `NON_LOCAL_API_AUTH_TOKEN` - the auth token for calling the environment - at the moment MUST be the same auth token the frontend uses (the first one configured in our API_AUTH_TOKEN env var).
 
 ```sh
-make cmd args="task update-form --environment=local --form-id=c3c5c7e9-0b24-41f8-8da3-98241fb341fe --dry-run"
+make cmd args="task update-form --environment=local --form-id=c3c5c7e9-0b24-41f8-8da3-98241fb341fe"
 ```
 
-## Setting up a form instruction record
+### Setting up a form instruction record
 For now, we have to manually setup the form instruction record. This requires the following steps:
 1. Copy the file to the s3 public s3 bucket: `aws s3 cp EXAMPLE-V1.0-Instructions.pdf s3://api-dev-public-files-20241217184925208000000003/forms/c3c5c7e9-0b24-41f8-8da3-98241fb341fe/instructions/EXAMPLE-V1.0-Instructions.pdf`
 2. Login to the DB and insert the record, generate a new UUID for this. The file_location should match the same s3 path, and the file_name should be just the name of the file:

--- a/api/src/task/forms/form_task_shared.py
+++ b/api/src/task/forms/form_task_shared.py
@@ -1,0 +1,59 @@
+import logging
+from abc import ABC
+
+import src.adapters.db as db
+from src.db.models.competition_models import Form
+from src.task.task import Task
+from src.util.env_config import PydanticBaseEnvConfig
+
+logger = logging.getLogger(__name__)
+
+# URLs for each environment
+ENV_URL_MAP = {
+    "local": "http://localhost:8080/alpha/forms/{}",
+    "dev": "https://api.dev.simpler.grants.gov/alpha/forms/{}",
+    "staging": "https://api.staging.simpler.grants.gov/alpha/forms/{}",
+    "prod": "https://api.simpler.grants.gov/alpha/forms/{}",
+}
+
+
+class FormTaskConfig(PydanticBaseEnvConfig):
+    non_local_api_auth_token: str | None = None
+
+
+class BaseFormTask(Task, ABC):
+    def __init__(self, db_session: db.Session):
+        super().__init__(db_session)
+
+        self.config = FormTaskConfig()
+        if self.config.non_local_api_auth_token is None:
+            raise Exception(
+                "Please set the NON_LOCAL_API_AUTH_TOKEN environment variable for the environment you wish to call"
+            )
+
+    def build_headers(self) -> dict:
+        return {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Auth": self.config.non_local_api_auth_token,
+        }
+
+
+def build_form_json(form: Form, form_instruction_id: str | None) -> dict:
+    return {
+        "agency_code": form.agency_code,
+        "form_instruction_id": form_instruction_id,
+        "form_json_schema": form.form_json_schema,
+        "form_name": form.form_name,
+        "form_rule_schema": form.form_rule_schema,
+        "form_ui_schema": form.form_ui_schema,
+        "form_version": form.form_version,
+        "legacy_form_id": form.legacy_form_id,
+        "omb_number": form.omb_number,
+        "short_form_name": form.short_form_name,
+    }
+
+
+def get_form_url(environment: str, form_id: str) -> str:
+    base_url = ENV_URL_MAP[environment]
+    return base_url.format(form_id)

--- a/api/src/task/forms/list_forms_task.py
+++ b/api/src/task/forms/list_forms_task.py
@@ -1,0 +1,217 @@
+import datetime
+import logging
+
+import click
+import requests
+from prettytable import PrettyTable
+from sqlalchemy import select
+
+import src.adapters.db as db
+from src.adapters.db import flask_db
+from src.db.models.competition_models import Form
+from src.task.ecs_background_task import ecs_background_task
+from src.task.forms.form_task_shared import BaseFormTask, build_form_json, get_form_url
+from src.task.task_blueprint import task_blueprint
+from src.util.local import error_if_not_local
+
+logger = logging.getLogger(__name__)
+
+
+@task_blueprint.cli.command(
+    "list-forms",
+    help="List forms in an environment and whether they're up-to-date",
+)
+@click.option(
+    "--environment", required=True, type=click.Choice(["local", "dev", "staging", "prod"])
+)
+@click.option("--verbose", default=False, is_flag=True, help="Show the full diff of forms")
+@flask_db.with_db_session()
+@ecs_background_task(task_name="list-forms")
+def list_forms(db_session: db.Session, environment: str, verbose: bool) -> None:
+    # This script is only meant for running locally at this time
+    error_if_not_local()
+
+    ListFormsTask(db_session, environment, verbose).run()
+
+
+class ListFormsTask(BaseFormTask):
+
+    def __init__(
+        self, db_session: db.Session, environment: str, verbose: bool, print_output: bool = True
+    ) -> None:
+        super().__init__(db_session)
+        self.environment = environment
+        self.verbose = verbose
+        self.print_output = print_output
+
+        self.out_of_date_forms: list[str] = []
+
+        # Setup a pretty table for making a helpful output.
+        self.output_table = PrettyTable()
+        self.output_table.align = "l"
+        self.output_table.field_names = ["Form Name", "Version", "Last Updated", "Changed Fields"]
+
+    def run_task(self) -> None:
+        with self.db_session.begin():
+            forms = (
+                self.db_session.execute(select(Form).order_by(Form.form_name.asc())).scalars().all()
+            )
+            if len(forms) == 0:
+                raise Exception(
+                    "No forms found, have you run 'make db-seed-local' to initialize the forms?"
+                )
+
+            for form in forms:
+                self.process_form(form)
+
+            if self.print_output:
+                self.print_outputs()
+
+    def process_form(self, form: Form) -> None:
+        """Process a form, collecting information about whether it is up-to-date"""
+        form_id = str(form.form_id)
+        form_txt = f"{form.form_name} {form.form_version}"  # for output
+
+        # Fetch the form from the given environment
+        url = get_form_url(self.environment, form_id)
+        env_form = get_form_from_env(url, self.build_headers(), form_id, self.environment)
+
+        if env_form is None:
+            logger.warning(f"{form_txt} has not yet been created in environment {self.environment}")
+            self.output_table.add_row(
+                [form.form_name, form.form_version, "n/a", "ALL"], divider=True
+            )
+
+            update_cmd = get_update_cmd(self.environment, form_id, None)
+
+            # Add a message to the out-of-date forms list so we can make it easier
+            # to update those forms by generating the command with some messages for organization
+            self.out_of_date_forms.extend(
+                [
+                    f"# {form_txt}",
+                    "# WARNING: If this form has a form_instruction record you'll need to create that"
+                    "# and add it to the command below manually.\n",
+                    update_cmd,
+                ]
+            )
+            return
+
+        # Make the local form a dict for easier comparison
+        # Note we don't have the form instruction ID configured locally
+        # so just reuse whatever was in the environment
+        form_instruction_id = get_form_instruction_id(env_form)
+        local_form = build_form_json(form, form_instruction_id)
+
+        # Diff the local and non-local forms
+        results = diff_form(local_form, env_form)
+        changed_fields = ", ".join(results.keys())
+
+        # Add information about the form to a table.
+        updated_at = format_timestamp(env_form.get("updated_at"))
+        self.output_table.add_row(
+            [form.form_name, form.form_version, updated_at, changed_fields], divider=True
+        )
+
+        if len(results) > 0:
+            logger.warning(f"{form_txt} has the following changed fields: {changed_fields}")
+            # If we turn on verbose mode, we will print out all the changes
+            # which if the schema fields have changed, will be quite a lot.
+            if self.verbose:
+                for changed_field, changes in results.items():
+                    existing_value = changes.get("existing_value", None)
+                    planned_value = changes.get("planned_value", None)
+
+                    logger.warning(
+                        f"Field {changed_field} will change from {existing_value} to {planned_value}"
+                    )
+
+            update_cmd = get_update_cmd(self.environment, form_id, form_instruction_id)
+            self.out_of_date_forms.extend([f"# {form_txt}\n", update_cmd, "\n---"])
+
+    def print_outputs(self) -> None:
+        """Print output values giving helpful info collected during processing.
+
+        NOTE: We print rather than log here because we want to display
+              the data formatted in a specific way for readability.
+        """
+        print(self.output_table.get_string(sortby="Last Updated"))
+
+        if len(self.out_of_date_forms) > 0:
+            print("-" * 40)
+            print("OUT OF DATE FORMS")
+            print("-" * 40)
+            for out_of_date in self.out_of_date_forms:
+                print(out_of_date)
+            print()
+
+
+def get_form_from_env(url: str, headers: dict, form_id: str, environment: str) -> dict | None:
+    """Query the GET form endpoint"""
+    resp = requests.get(url, headers=headers, timeout=5)
+
+    if resp.status_code == 404:
+        logger.info(f"Form {form_id} does not yet exist in {environment}")
+        return None
+
+    if resp.status_code != 200:
+        raise Exception(f"Failed to fetch existing form from {environment}: {resp.text}")
+
+    existing_form_data = resp.json().get("data", None)
+    return existing_form_data
+
+
+def get_form_instruction_id(form_data: dict) -> str | None:
+    # The instruction ID isn't returned in the top-level object, but can be found
+    # in the form instructions object, so pull it out differently.
+    form_instruction_obj = form_data.get("form_instruction", {})
+    if form_instruction_obj is None:
+        return None
+
+    return form_instruction_obj.get("form_instruction_id", None)
+
+
+def diff_form(planned_put_request: dict, existing_form_data: dict) -> dict[str, dict]:
+    """Diff what we plan to send to the Form endpoint with what it already has"""
+    changed_fields = {}
+    for field, planned_value in planned_put_request.items():
+        # The instruction ID isn't returned in the top-level object, but can be found
+        # in the form instructions object, so pull it out differently.
+        if field == "form_instruction_id":
+            existing_value = get_form_instruction_id(existing_form_data)
+        else:
+            existing_value = existing_form_data.get(field)
+        if planned_value != existing_value:
+            changed_fields[field] = {
+                "existing_value": existing_value,
+                "planned_value": planned_value,
+            }
+
+    return changed_fields
+
+
+def format_timestamp(value: str | None) -> str | None:
+    """Convert the timestamp format from isoformat to one that is
+    slightly more human-readable, removing fractions of a second
+    and making the timezone aware.
+
+    For example:
+     2025-09-19T19:53:02.220955+00:00
+     becomes
+     2025-09-19 19:53:02 UTC
+    """
+    if value is None:
+        return None
+
+    timestamp = datetime.datetime.fromisoformat(value)
+
+    return timestamp.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def get_update_cmd(environment: str, form_id: str, form_instruction_id: str | None) -> str:
+    """Build a command for running the update-form script paired with this one"""
+    args = f"task update-form --environment={environment} --form-id={form_id}"
+
+    if form_instruction_id is not None:
+        args += f" --form-instruction-id={form_instruction_id}"
+
+    return f'make cmd args="{args}"'

--- a/api/src/task/forms/update_form_task.py
+++ b/api/src/task/forms/update_form_task.py
@@ -9,20 +9,11 @@ import src.adapters.db as db
 from src.adapters.db import flask_db
 from src.db.models.competition_models import Form
 from src.task.ecs_background_task import ecs_background_task
-from src.task.task import Task
+from src.task.forms.form_task_shared import BaseFormTask, build_form_json, get_form_url
 from src.task.task_blueprint import task_blueprint
-from src.util.env_config import PydanticBaseEnvConfig
 from src.util.local import error_if_not_local
 
 logger = logging.getLogger(__name__)
-
-# URLs for each environment
-ENV_URL_MAP = {
-    "local": "http://localhost:8080/alpha/forms/{}",
-    "dev": "https://api.dev.simpler.grants.gov/alpha/forms/{}",
-    "staging": "https://api.staging.simpler.grants.gov/alpha/forms/{}",
-    "prod": "https://api.simpler.grants.gov/alpha/forms/{}",
-}
 
 
 @dataclass
@@ -30,11 +21,6 @@ class UpdateFormContainer:
     environment: str
     form_id: str
     form_instruction_id: str | None
-    is_dry_run: bool
-
-
-class UpdateFormTaskConfig(PydanticBaseEnvConfig):
-    non_local_api_auth_token: str | None = None
 
 
 @task_blueprint.cli.command(
@@ -46,7 +32,6 @@ class UpdateFormTaskConfig(PydanticBaseEnvConfig):
 )
 @click.option("--form-id", required=True, type=str)
 @click.option("--form-instruction-id", type=str, default=None)
-@click.option("--dry-run/--no-dry-run", default=True)
 @flask_db.with_db_session()
 @ecs_background_task(task_name="update-form")
 def update_form(
@@ -54,7 +39,6 @@ def update_form(
     environment: str,
     form_id: str,
     form_instruction_id: str | None,
-    dry_run: bool,
 ) -> None:
     # This script is only meant for running locally at this time
     error_if_not_local()
@@ -63,22 +47,15 @@ def update_form(
         environment=environment,
         form_id=form_id,
         form_instruction_id=form_instruction_id,
-        is_dry_run=dry_run,
     )
     UpdateFormTask(db_session, update_form_container).run()
 
 
-class UpdateFormTask(Task):
+class UpdateFormTask(BaseFormTask):
 
     def __init__(self, db_session: db.Session, update_form_container: UpdateFormContainer):
         super().__init__(db_session)
         self.update_form_container = update_form_container
-
-        self.config = UpdateFormTaskConfig()
-        if self.config.non_local_api_auth_token is None:
-            raise Exception(
-                "Please set the NON_LOCAL_API_AUTH_TOKEN environment variable for the environment you wish to call"
-            )
 
     def run_task(self) -> None:
         logger.info("Fetching form from local database")
@@ -91,17 +68,11 @@ class UpdateFormTask(Task):
                 f"No form found with ID {self.update_form_container.form_id} - have you seeded your local DB?"
             )
 
-        request = self.build_request(form)
+        request = build_form_json(form, self.update_form_container.form_instruction_id)
         headers = self.build_headers()
-        url = self.get_url()
-
-        if self.update_form_container.is_dry_run:
-            self.call_get_and_diff(url, headers, request)
-            logger.info(f"DRY RUN - NOT SENDING REQUEST TO {url}")
-            logger.info(
-                f"DRY RUN - WOULD HAVE UPDATED FORM {form.form_id} | {form.short_form_name}"
-            )
-            return
+        url = get_form_url(
+            self.update_form_container.environment, self.update_form_container.form_id
+        )
 
         logger.info(f"Calling {url}")
         resp = requests.put(url, headers=headers, json=request, timeout=5)
@@ -114,79 +85,3 @@ class UpdateFormTask(Task):
         logger.info(
             f"Successfully updated form {form.form_id} | {form.short_form_name} in {self.update_form_container.environment} environment"
         )
-
-    def build_request(self, form: Form) -> dict:
-        return {
-            "agency_code": form.agency_code,
-            "form_instruction_id": self.update_form_container.form_instruction_id,
-            "form_json_schema": form.form_json_schema,
-            "form_name": form.form_name,
-            "form_rule_schema": form.form_rule_schema,
-            "form_ui_schema": form.form_ui_schema,
-            "form_version": form.form_version,
-            "legacy_form_id": form.legacy_form_id,
-            "omb_number": form.omb_number,
-            "short_form_name": form.short_form_name,
-        }
-
-    def build_headers(self) -> dict:
-        return {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "X-Auth": self.config.non_local_api_auth_token,
-        }
-
-    def get_url(self) -> str:
-        base_url = ENV_URL_MAP[self.update_form_container.environment]
-        return base_url.format(self.update_form_container.form_id)
-
-    def call_get_and_diff(self, url: str, headers: dict, planned_put_request: dict) -> None:
-        """Call the GET /forms endpoint in the given environment and
-        note down what would change.
-        """
-        resp = requests.get(url, headers=headers, timeout=5)
-
-        if resp.status_code == 404:
-            logger.info(
-                f"Form {self.update_form_container.form_id} does not yet exist in {self.update_form_container.environment}"
-            )
-            return
-
-        if resp.status_code != 200:
-            raise Exception(
-                f"Failed to fetch existing form from {self.update_form_container.environment}: {resp.text}"
-            )
-
-        existing_form_data = resp.json().get("data", None)
-        self.do_diff(planned_put_request, existing_form_data)
-
-    def do_diff(self, planned_put_request: dict, existing_form_data: dict) -> list[str]:
-        """Diff what we plan to send to the Form endpoint with what it already has"""
-        changed_fields = []
-        for field, planned_value in planned_put_request.items():
-            # The instruction ID isn't returned in the top-level object, but can be found
-            # in the form instructions object, so pull it out differently.
-            if field == "form_instruction_id":
-                form_instruction_obj = existing_form_data.get("form_instruction", {})
-                if form_instruction_obj is None:
-                    existing_value = None
-                else:
-                    existing_value = form_instruction_obj.get("form_instruction_id", None)
-            else:
-                existing_value = existing_form_data.get(field)
-            if planned_value != existing_value:
-                logger.warning(
-                    f"Value of {field} will change from {existing_value} to {planned_value}"
-                )
-                changed_fields.append(field)
-            else:
-                logger.info(f"Value of {field} will not change")
-
-        if changed_fields:
-            logger.warning(
-                f"Running this will update the following fields on the form: {changed_fields}"
-            )
-        else:
-            logger.info(f"No fields would be changed in {self.update_form_container.environment}")
-
-        return changed_fields

--- a/api/tests/src/task/forms/conftest.py
+++ b/api/tests/src/task/forms/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def non_local_api_auth_token(monkeypatch_module):
+    monkeypatch_module.setenv("NON_LOCAL_API_AUTH_TOKEN", "fake-auth-token")

--- a/api/tests/src/task/forms/test_form_task_shared.py
+++ b/api/tests/src/task/forms/test_form_task_shared.py
@@ -1,0 +1,44 @@
+import pytest
+
+from src.task.forms.form_task_shared import BaseFormTask, build_form_json, get_form_url
+from tests.src.db.models.factories import FormFactory
+
+
+class DummyFormTask(BaseFormTask):
+    def run_task(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize(
+    "environment,expected_url",
+    [
+        ("local", "http://localhost:8080/alpha/forms/my-example-form-id"),
+        ("dev", "https://api.dev.simpler.grants.gov/alpha/forms/my-example-form-id"),
+        ("staging", "https://api.staging.simpler.grants.gov/alpha/forms/my-example-form-id"),
+        ("prod", "https://api.simpler.grants.gov/alpha/forms/my-example-form-id"),
+    ],
+)
+def test_get_url(db_session, environment, expected_url):
+    assert get_form_url(environment, "my-example-form-id") == expected_url
+
+
+def test_build_form_json(db_session, enable_factory_create):
+    form = FormFactory.create()
+    form_request = build_form_json(form, "my-form-instruction-id")
+
+    # Check a few of the parameters are right
+    assert form_request["agency_code"] == form.agency_code
+    assert form_request["form_instruction_id"] == "my-form-instruction-id"
+    assert form_request["form_rule_schema"] == form.form_rule_schema
+    assert form_request["form_ui_schema"] == form.form_ui_schema
+    assert form_request["form_json_schema"] == form.form_json_schema
+
+
+def test_build_headers(db_session):
+    dummy_form_task = DummyFormTask(db_session)
+
+    assert dummy_form_task.build_headers() == {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-Auth": "fake-auth-token",
+    }

--- a/api/tests/src/task/forms/test_list_forms_task.py
+++ b/api/tests/src/task/forms/test_list_forms_task.py
@@ -1,0 +1,131 @@
+import uuid
+
+import pytest
+import requests_mock
+
+from src.api.form_alpha.form_schema import FormAlphaSchema
+from src.task.forms.form_task_shared import build_form_json
+from src.task.forms.list_forms_task import ListFormsTask, diff_form, get_update_cmd
+from tests.src.db.models.factories import FormFactory
+
+
+@pytest.fixture
+def list_forms_task(db_session):
+    return ListFormsTask(db_session, "local", False, print_output=False)
+
+
+def test_list_forms_task(list_forms_task, enable_factory_create):
+    unchanged_form = FormFactory.create(form_name="Unchanged Form", with_instruction=True)
+    new_form = FormFactory.create(form_name="New Form")
+    modified_form = FormFactory.create(form_name="Modified Form")
+
+    unchanged_form_response = build_form_json(
+        unchanged_form, str(unchanged_form.form_instruction_id)
+    )
+    unchanged_form_response["updated_at"] = "2025-09-19T19:53:02.220955+00:00"
+
+    modified_form_response = build_form_json(modified_form, str(modified_form.form_instruction_id))
+    modified_form_response["updated_at"] = "2025-07-25T23:15:45.123456+00:00"
+    modified_form_response["form_version"] = "1000.12345"
+    modified_form_response["omb_number"] = "1234-5678"
+    modified_form_response["agency_code"] = "XYZ-ABC-123-456-789"
+
+    with requests_mock.Mocker() as mock:
+        # By default return a 404
+        mock.get(requests_mock.ANY, status_code=404)
+        mock.get(
+            f"http://localhost:8080/alpha/forms/{unchanged_form.form_id}",
+            status_code=200,
+            json={"data": unchanged_form_response},
+        )
+        mock.get(
+            f"http://localhost:8080/alpha/forms/{modified_form.form_id}",
+            status_code=200,
+            json={"data": modified_form_response},
+        )
+
+        list_forms_task.run()
+
+    # Verify the table we processed has all of the forms
+    # Note that we might have more forms because we don't cleanup the DB
+    assert list_forms_task.output_table.rowcount >= 3
+    output_table_str = list_forms_task.output_table.get_string()
+    assert modified_form.form_name in output_table_str
+    assert new_form.form_name in output_table_str
+    assert unchanged_form.form_name in output_table_str
+
+    out_of_date_form_output = list_forms_task.out_of_date_forms
+    # We expect the modified form to be in the output generated
+    assert any(str(modified_form.form_id) in r for r in out_of_date_form_output)
+    # We expect the new form to be in the output
+    assert any(str(new_form.form_id) in r for r in out_of_date_form_output)
+    # The unmodified form should not be mentioned
+    assert not any(str(unchanged_form.form_id) in r for r in out_of_date_form_output)
+
+
+@pytest.mark.parametrize(
+    "environment, form_id, form_instruction_id, expected_result",
+    [
+        (
+            "staging",
+            "my-form-id",
+            None,
+            'make cmd args="task update-form --environment=staging --form-id=my-form-id"',
+        ),
+        (
+            "dev",
+            "my-other-form-id",
+            "my-form-instruction-id",
+            'make cmd args="task update-form --environment=dev --form-id=my-other-form-id --form-instruction-id=my-form-instruction-id"',
+        ),
+    ],
+)
+def test_get_update_cmd(environment, form_id, form_instruction_id, expected_result):
+    assert get_update_cmd(environment, form_id, form_instruction_id) == expected_result
+
+
+def test_do_diff_no_changes(enable_factory_create):
+    form = FormFactory.create()
+    planned_request = build_form_json(form, None)
+
+    schema = FormAlphaSchema()
+    endpoint_response = schema.dump(form)
+
+    assert len(diff_form(planned_request, endpoint_response)) == 0
+
+
+def test_do_diff_no_changes_with_instruction(enable_factory_create):
+    form = FormFactory.create(with_instruction=True)
+    planned_request = build_form_json(form, str(form.form_instruction_id))
+
+    schema = FormAlphaSchema()
+    endpoint_response = schema.dump(form)
+
+    assert len(diff_form(planned_request, endpoint_response)) == 0
+
+
+def test_do_diff_with_diff(enable_factory_create):
+    form = FormFactory.create(with_instruction=True)
+
+    new_uuid = str(uuid.uuid4())
+    planned_request = build_form_json(form, new_uuid)
+    planned_request["agency_code"] = "XYZ-123j142"
+    planned_request["form_json_schema"] = {}
+    planned_request["form_rule_schema"] = {}
+    planned_request["omb_number"] = "1234-567823"
+
+    schema = FormAlphaSchema()
+    endpoint_response = schema.dump(form)
+
+    diff = diff_form(planned_request, endpoint_response)
+
+    assert diff == {
+        "form_instruction_id": {
+            "existing_value": str(form.form_instruction_id),
+            "planned_value": new_uuid,
+        },
+        "agency_code": {"existing_value": form.agency_code, "planned_value": "XYZ-123j142"},
+        "form_json_schema": {"existing_value": form.form_json_schema, "planned_value": {}},
+        "form_rule_schema": {"existing_value": form.form_rule_schema, "planned_value": {}},
+        "omb_number": {"existing_value": form.omb_number, "planned_value": "1234-567823"},
+    }

--- a/api/tests/src/task/forms/test_update_form_task.py
+++ b/api/tests/src/task/forms/test_update_form_task.py
@@ -2,20 +2,14 @@ from unittest import mock
 
 import pytest
 
-from src.api.form_alpha.form_schema import FormAlphaSchema
 from src.task.forms.update_form_task import UpdateFormContainer, UpdateFormTask
 from tests.src.db.models.factories import FormFactory
-
-
-@pytest.fixture(autouse=True)
-def non_local_api_auth_token(monkeypatch_module):
-    monkeypatch_module.setenv("NON_LOCAL_API_AUTH_TOKEN", "fake-auth-token")
 
 
 def test_update_form_task(db_session, enable_factory_create):
     form = FormFactory.create()
     update_form_container = UpdateFormContainer(
-        environment="local", form_id=form.form_id, form_instruction_id="", is_dry_run=False
+        environment="local", form_id=form.form_id, form_instruction_id=""
     )
     task = UpdateFormTask(db_session, update_form_container)
 
@@ -29,7 +23,7 @@ def test_update_form_task(db_session, enable_factory_create):
 def test_update_form_task_non_200(db_session, enable_factory_create):
     form = FormFactory.create()
     update_form_container = UpdateFormContainer(
-        environment="local", form_id=form.form_id, form_instruction_id="", is_dry_run=False
+        environment="local", form_id=form.form_id, form_instruction_id=""
     )
     task = UpdateFormTask(db_session, update_form_container)
 
@@ -41,110 +35,3 @@ def test_update_form_task_non_200(db_session, enable_factory_create):
             task.run_task()
 
         mock_request.assert_called_once()
-
-
-@pytest.mark.parametrize(
-    "environment,expected_url",
-    [
-        ("local", "http://localhost:8080/alpha/forms/my-example-form-id"),
-        ("dev", "https://api.dev.simpler.grants.gov/alpha/forms/my-example-form-id"),
-        ("staging", "https://api.staging.simpler.grants.gov/alpha/forms/my-example-form-id"),
-        ("prod", "https://api.simpler.grants.gov/alpha/forms/my-example-form-id"),
-    ],
-)
-def test_get_url(db_session, environment, expected_url):
-    form_id = "my-example-form-id"
-    update_form_container = UpdateFormContainer(
-        environment=environment, form_id=form_id, form_instruction_id="", is_dry_run=True
-    )
-
-    task = UpdateFormTask(db_session, update_form_container)
-    assert task.get_url() == expected_url
-
-
-def test_build_request(db_session, enable_factory_create):
-    form = FormFactory.create()
-    update_form_container = UpdateFormContainer(
-        environment="local",
-        form_id=str(form.form_id),
-        form_instruction_id="my-form-instruction-id",
-        is_dry_run=True,
-    )
-
-    task = UpdateFormTask(db_session, update_form_container)
-    form_request = task.build_request(form)
-
-    # Check a few of the parameters are right
-    assert form_request["agency_code"] == form.agency_code
-    assert form_request["form_instruction_id"] == "my-form-instruction-id"
-    assert form_request["form_rule_schema"] == form.form_rule_schema
-    assert form_request["form_ui_schema"] == form.form_ui_schema
-    assert form_request["form_json_schema"] == form.form_json_schema
-
-
-def test_build_headers(db_session):
-    update_form_container = UpdateFormContainer(
-        environment="local", form_id="", form_instruction_id="", is_dry_run=True
-    )
-    task = UpdateFormTask(db_session, update_form_container)
-
-    assert task.build_headers() == {
-        "Content-Type": "application/json",
-        "Accept": "application/json",
-        "X-Auth": "fake-auth-token",
-    }
-
-
-def test_do_diff_no_changes(db_session, enable_factory_create):
-    form = FormFactory.create()
-    update_form_container = UpdateFormContainer(
-        environment="local", form_id="", form_instruction_id=None, is_dry_run=True
-    )
-    task = UpdateFormTask(db_session, update_form_container)
-    planned_request = task.build_request(form)
-
-    schema = FormAlphaSchema()
-    endpoint_response = schema.dump(form)
-
-    assert task.do_diff(planned_request, endpoint_response) == []
-
-
-def test_do_diff_no_changes_with_instruction(db_session, enable_factory_create):
-    form = FormFactory.create(with_instruction=True)
-    update_form_container = UpdateFormContainer(
-        environment="local",
-        form_id="",
-        form_instruction_id=str(form.form_instruction_id),
-        is_dry_run=True,
-    )
-    task = UpdateFormTask(db_session, update_form_container)
-    planned_request = task.build_request(form)
-
-    schema = FormAlphaSchema()
-    endpoint_response = schema.dump(form)
-
-    assert task.do_diff(planned_request, endpoint_response) == []
-
-
-def test_do_diff_with_diff(db_session, enable_factory_create):
-    form = FormFactory.create(with_instruction=True)
-    update_form_container = UpdateFormContainer(
-        environment="local", form_id="", form_instruction_id=None, is_dry_run=True
-    )
-    task = UpdateFormTask(db_session, update_form_container)
-    planned_request = task.build_request(form)
-    planned_request["agency_code"] = "XYZ-123"
-    planned_request["form_json_schema"] = {}
-    planned_request["form_rule_schema"] = {}
-    planned_request["omb_number"] = "1234-5678"
-
-    schema = FormAlphaSchema()
-    endpoint_response = schema.dump(form)
-
-    assert set(task.do_diff(planned_request, endpoint_response)) == {
-        "form_instruction_id",
-        "agency_code",
-        "form_json_schema",
-        "form_rule_schema",
-        "omb_number",
-    }


### PR DESCRIPTION
## Summary
Fixes  #6492  

## Changes proposed
* Creates a script to list forms in a given environment and tell you whether they are up-to-date
* Remove the dry-run/diff logic from the update-form script (made redundant by this script)
* A bunch of refactoring to move code shared by both scripts to a central location

## Context for reviewers
The update-form script has been very helpful in checking forms and updating them, but is a bit clunky to check multiple forms. So, I made a new script that just checks everything and makes it even less effort to update forms by giving you an output.

The goal of this script is to generally run this before the update-form script, then copy the output to make it so you don't even need to find commands to run.

## Validation steps
First make sure to run `make db-seed-local` so all of your forms locally are up-to-date.

If you make sure to set the env var as described in the README, then you can use the tool.

For example, if I run `make cmd args="task list-forms --environment=dev --verbose"` I get the following output (note I manually adjusted a form for testing + added a new dummy form, you won't see these):
<img width="1437" height="788" alt="Screenshot 2025-09-25 at 3 52 40 PM" src="https://github.com/user-attachments/assets/d576909d-4176-4f2b-a091-048d5cd107e0" />
