### PR TITLE
[Issue #6522] wire up account page

### DIFF
--- a/frontend/src/app/[locale]/(base)/search/page.tsx
+++ b/frontend/src/app/[locale]/(base)/search/page.tsx
@@ -152,7 +152,6 @@ function Search({ searchParams, params }: SearchPageProps) {
   );
 }
 
-// Exports page behind both feature flags
 export default withFeatureFlag<SearchPageProps, never>(
   Search,
   "searchOff",

--- a/frontend/src/app/[locale]/(base)/user/account/actions.ts
+++ b/frontend/src/app/[locale]/(base)/user/account/actions.ts
@@ -31,7 +31,7 @@ export const userProfileAction = async (
 ): Promise<UserProfileResponse> => {
   const session = await getSession();
 
-  if (!session || !session.token) {
+  if (!session || !session.token || !session.user_id) {
     return {
       errorMessage: "Not logged in",
     };
@@ -52,7 +52,11 @@ export const userProfileAction = async (
 
   let userDetailsResponse;
   try {
-    userDetailsResponse = await updateUserDetails(session.token, rawFormData);
+    userDetailsResponse = await updateUserDetails(
+      session.token,
+      session.user_id,
+      rawFormData,
+    );
     return { data: userDetailsResponse };
   } catch (e) {
     // General try failure catch error

--- a/frontend/src/app/[locale]/(base)/user/account/actions.ts
+++ b/frontend/src/app/[locale]/(base)/user/account/actions.ts
@@ -57,7 +57,7 @@ export const userProfileAction = async (
       session.user_id,
       rawFormData,
     );
-    return { data: userDetailsResponse };
+    return { data: userDetailsResponse, success: true };
   } catch (e) {
     // General try failure catch error
     const error = e as Error;

--- a/frontend/src/app/[locale]/(base)/user/account/actions.ts
+++ b/frontend/src/app/[locale]/(base)/user/account/actions.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { getSession } from "src/services/auth/session";
+import { updateUserDetails } from "src/services/fetch/fetchers/userFetcher";
+import { UserProfileResponse } from "src/types/userTypes";
+import { z } from "zod";
+
+import { getTranslations } from "next-intl/server";
+
+const validateUserProfileAction = async (formData: FormData) => {
+  const t = await getTranslations("UserAccount.validationErrors");
+  const schema = z.object({
+    firstName: z.string().min(1, { message: t("firstName") }),
+    lastName: z.string().min(1, { message: t("lastName") }),
+  });
+
+  const validatedFields = schema.safeParse({
+    firstName: formData.get("firstName"),
+    lastName: formData.get("lastName"),
+  });
+
+  // Return early if the form data is invalid (server side validation!)
+  if (!validatedFields.success) {
+    return validatedFields.error.flatten().fieldErrors;
+  }
+};
+
+export const userProfileAction = async (
+  _prevState: unknown,
+  formData: FormData,
+): Promise<UserProfileResponse> => {
+  const session = await getSession();
+
+  if (!session || !session.token) {
+    return {
+      errorMessage: "Not logged in",
+    };
+  }
+
+  const validationErrors = await validateUserProfileAction(formData);
+  if (validationErrors) {
+    return {
+      validationErrors,
+    };
+  }
+
+  const rawFormData = {
+    first_name: formData.get("firstName") as string,
+    middle_name: formData.get("middleName") as string,
+    last_name: formData.get("lastName") as string,
+  };
+
+  let userDetailsResponse;
+  try {
+    userDetailsResponse = await updateUserDetails(session.token, rawFormData);
+    return { data: userDetailsResponse };
+  } catch (e) {
+    // General try failure catch error
+    const error = e as Error;
+    console.error(
+      `Error updating user details - ${error.message} ${error.cause?.toString() || ""}`,
+    );
+    return {
+      errorMessage: error.message,
+    };
+  }
+};

--- a/frontend/src/app/[locale]/(base)/user/account/page.tsx
+++ b/frontend/src/app/[locale]/(base)/user/account/page.tsx
@@ -1,0 +1,41 @@
+import { getSession } from "src/services/auth/session";
+import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
+import { getUserDetails } from "src/services/fetch/fetchers/userFetcher";
+
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { ErrorMessage, GridContainer } from "@trussworks/react-uswds";
+
+import { UserProfileForm } from "src/components/user/UserProfileForm";
+
+async function UserAccount() {
+  const t = await getTranslations("UserAccount");
+
+  const session = await getSession();
+  if (!session?.email) {
+    // this won't happen, as email is required on sessions, and we're wrapping this in an auth gate in the layout
+    console.error("no user session, or user has no email address");
+    return;
+  }
+  let userDetails;
+  try {
+    userDetails = await getUserDetails(session.token, session.user_id);
+  } catch (e) {
+    console.error("Unable to fetch user details", e);
+  }
+
+  return (
+    <GridContainer className="padding-top-2 tablet:padding-y-6">
+      <h1>{t("title")}</h1>
+      {userDetails ? (
+        <UserProfileForm userDetails={userDetails} />
+      ) : (
+        <ErrorMessage>{t("fetchError")}</ErrorMessage>
+      )}
+    </GridContainer>
+  );
+}
+
+export default withFeatureFlag<object, never>(UserAccount, "userAdminOff", () =>
+  redirect("/maintenance"),
+);

--- a/frontend/src/app/[locale]/(base)/user/layout.tsx
+++ b/frontend/src/app/[locale]/(base)/user/layout.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+import { LayoutProps } from "src/types/generalTypes";
+import { LocalizedPageProps } from "src/types/intl";
+
+import { getTranslations } from "next-intl/server";
+
+import { AuthenticationGate } from "src/components/user/AuthenticationGate";
+
+export async function generateMetadata({
+  params,
+}: LocalizedPageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale });
+  const meta: Metadata = {
+    title: t("UserAccount.pageTitle"),
+    description: t("Index.metaDescription"),
+  };
+  return meta;
+}
+export default function UserLayout({ children }: LayoutProps) {
+  return <AuthenticationGate>{children}</AuthenticationGate>;
+}

--- a/frontend/src/components/ConditionalFormActionError.tsx
+++ b/frontend/src/components/ConditionalFormActionError.tsx
@@ -1,0 +1,13 @@
+import { ErrorMessage } from "@trussworks/react-uswds";
+
+export function ConditionalFormActionError<
+  T extends { [key: string]: string[] },
+>({ errors, fieldName }: { errors?: T; fieldName: keyof T }) {
+  if (!errors) {
+    return;
+  }
+  const error = errors[fieldName];
+  if (error) {
+    return <ErrorMessage className="maxw-mobile-lg">{error[0]}</ErrorMessage>;
+  }
+}

--- a/frontend/src/components/RequiredFieldIndicator.tsx
+++ b/frontend/src/components/RequiredFieldIndicator.tsx
@@ -1,0 +1,10 @@
+import { PropsWithChildren } from "react";
+
+export const RequiredFieldIndicator = ({ children }: PropsWithChildren) => (
+  <span
+    className="usa-hint usa-hint--required"
+    data-testid="required-field-indicator"
+  >
+    {children}
+  </span>
+);

--- a/frontend/src/components/user/UserProfileForm.tsx
+++ b/frontend/src/components/user/UserProfileForm.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { userProfileAction } from "src/app/[locale]/(base)/user/account/actions";
+import { UserDetail, UserProfileValidationErrors } from "src/types/userTypes";
+
+import { useTranslations } from "next-intl";
+import { useActionState } from "react";
+import {
+  Button,
+  ErrorMessage,
+  Label,
+  TextInput,
+} from "@trussworks/react-uswds";
+
+import { ConditionalFormActionError } from "src/components/ConditionalFormActionError";
+import { RequiredFieldIndicator } from "src/components/RequiredFieldIndicator";
+
+const UserProfileValidationError =
+  ConditionalFormActionError<UserProfileValidationErrors>;
+
+export function UserProfileForm({ userDetails }: { userDetails: UserDetail }) {
+  const t = useTranslations("UserAccount");
+
+  const [state, formAction, isPending] = useActionState(userProfileAction, {
+    validationErrors: {},
+  });
+
+  return (
+    <form action={formAction}>
+      {state.errorMessage && <ErrorMessage>{state.errorMessage}</ErrorMessage>}
+      <Label htmlFor="firstName">
+        <span>{t("inputs.firstName")}</span>
+        <RequiredFieldIndicator> *</RequiredFieldIndicator>
+      </Label>
+      <UserProfileValidationError
+        fieldName="firstName"
+        errors={state.validationErrors}
+      />
+      <TextInput
+        id="edit-user-first-name"
+        name="firstName"
+        type="text"
+        defaultValue={state.data?.first_name || userDetails.first_name}
+      />
+      <Label htmlFor="middle-name">{t("inputs.middleName")}</Label>
+      <TextInput
+        id="edit-user-middle-name"
+        name="middleName"
+        type="text"
+        defaultValue={state.data?.middle_name || userDetails.middle_name}
+      />
+      <Label htmlFor="lastName">
+        <span>{t("inputs.lastName")}</span>
+        <RequiredFieldIndicator> *</RequiredFieldIndicator>
+      </Label>
+      <UserProfileValidationError
+        fieldName="lastName"
+        errors={state.validationErrors}
+      />
+      <TextInput
+        id="edit-user-last-name"
+        name="lastName"
+        type="text"
+        defaultValue={state.data?.last_name || userDetails.last_name}
+      />
+      <Label htmlFor="email">{t("inputs.email")}</Label>
+      <TextInput
+        id="edit-user-email"
+        name="email"
+        type="text"
+        defaultValue={userDetails.email}
+        disabled
+      />
+      <Button type="submit" disabled={isPending} className="margin-top-4">
+        {t(isPending ? "pending" : "save")}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/components/user/UserProfileForm.tsx
+++ b/frontend/src/components/user/UserProfileForm.tsx
@@ -40,14 +40,18 @@ export function UserProfileForm({ userDetails }: { userDetails: UserDetail }) {
         id="edit-user-first-name"
         name="firstName"
         type="text"
-        defaultValue={state.data?.first_name || userDetails.first_name}
+        defaultValue={
+          state.data?.profile?.first_name || userDetails.profile?.first_name
+        }
       />
       <Label htmlFor="middle-name">{t("inputs.middleName")}</Label>
       <TextInput
         id="edit-user-middle-name"
         name="middleName"
         type="text"
-        defaultValue={state.data?.middle_name || userDetails.middle_name}
+        defaultValue={
+          state.data?.profile?.middle_name || userDetails.profile?.middle_name
+        }
       />
       <Label htmlFor="lastName">
         <span>{t("inputs.lastName")}</span>
@@ -61,7 +65,9 @@ export function UserProfileForm({ userDetails }: { userDetails: UserDetail }) {
         id="edit-user-last-name"
         name="lastName"
         type="text"
-        defaultValue={state.data?.last_name || userDetails.last_name}
+        defaultValue={
+          state.data?.profile?.last_name || userDetails.profile?.last_name
+        }
       />
       <Label htmlFor="email">{t("inputs.email")}</Label>
       <TextInput

--- a/frontend/src/components/user/UserProfileForm.tsx
+++ b/frontend/src/components/user/UserProfileForm.tsx
@@ -5,12 +5,7 @@ import { UserDetail, UserProfileValidationErrors } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { useActionState } from "react";
-import {
-  Button,
-  ErrorMessage,
-  Label,
-  TextInput,
-} from "@trussworks/react-uswds";
+import { Alert, Button, Label, TextInput } from "@trussworks/react-uswds";
 
 import { ConditionalFormActionError } from "src/components/ConditionalFormActionError";
 import { RequiredFieldIndicator } from "src/components/RequiredFieldIndicator";
@@ -26,60 +21,74 @@ export function UserProfileForm({ userDetails }: { userDetails: UserDetail }) {
   });
 
   return (
-    <form action={formAction}>
-      {state.errorMessage && <ErrorMessage>{state.errorMessage}</ErrorMessage>}
-      <Label htmlFor="firstName">
-        <span>{t("inputs.firstName")}</span>
-        <RequiredFieldIndicator> *</RequiredFieldIndicator>
-      </Label>
-      <UserProfileValidationError
-        fieldName="firstName"
-        errors={state.validationErrors}
-      />
-      <TextInput
-        id="edit-user-first-name"
-        name="firstName"
-        type="text"
-        defaultValue={
-          state.data?.profile?.first_name || userDetails.profile?.first_name
-        }
-      />
-      <Label htmlFor="middle-name">{t("inputs.middleName")}</Label>
-      <TextInput
-        id="edit-user-middle-name"
-        name="middleName"
-        type="text"
-        defaultValue={
-          state.data?.profile?.middle_name || userDetails.profile?.middle_name
-        }
-      />
-      <Label htmlFor="lastName">
-        <span>{t("inputs.lastName")}</span>
-        <RequiredFieldIndicator> *</RequiredFieldIndicator>
-      </Label>
-      <UserProfileValidationError
-        fieldName="lastName"
-        errors={state.validationErrors}
-      />
-      <TextInput
-        id="edit-user-last-name"
-        name="lastName"
-        type="text"
-        defaultValue={
-          state.data?.profile?.last_name || userDetails.profile?.last_name
-        }
-      />
-      <Label htmlFor="email">{t("inputs.email")}</Label>
-      <TextInput
-        id="edit-user-email"
-        name="email"
-        type="text"
-        defaultValue={userDetails.email}
-        disabled
-      />
-      <Button type="submit" disabled={isPending} className="margin-top-4">
-        {t(isPending ? "pending" : "save")}
-      </Button>
-    </form>
+    <>
+      {state?.errorMessage && (
+        <Alert
+          heading={t("errorHeading")}
+          headingLevel="h2"
+          type="warning"
+          validation
+        >
+          {state?.errorMessage}
+        </Alert>
+      )}
+      {state?.success && (
+        <Alert heading={t("successHeading")} headingLevel="h2" type="success" />
+      )}
+      <form action={formAction}>
+        <Label htmlFor="firstName">
+          <span>{t("inputs.firstName")}</span>
+          <RequiredFieldIndicator> *</RequiredFieldIndicator>
+        </Label>
+        <UserProfileValidationError
+          fieldName="firstName"
+          errors={state.validationErrors}
+        />
+        <TextInput
+          id="edit-user-first-name"
+          name="firstName"
+          type="text"
+          defaultValue={
+            state.data?.profile?.first_name || userDetails.profile?.first_name
+          }
+        />
+        <Label htmlFor="middle-name">{t("inputs.middleName")}</Label>
+        <TextInput
+          id="edit-user-middle-name"
+          name="middleName"
+          type="text"
+          defaultValue={
+            state.data?.profile?.middle_name || userDetails.profile?.middle_name
+          }
+        />
+        <Label htmlFor="lastName">
+          <span>{t("inputs.lastName")}</span>
+          <RequiredFieldIndicator> *</RequiredFieldIndicator>
+        </Label>
+        <UserProfileValidationError
+          fieldName="lastName"
+          errors={state.validationErrors}
+        />
+        <TextInput
+          id="edit-user-last-name"
+          name="lastName"
+          type="text"
+          defaultValue={
+            state.data?.profile?.last_name || userDetails.profile?.last_name
+          }
+        />
+        <Label htmlFor="email">{t("inputs.email")}</Label>
+        <TextInput
+          id="edit-user-email"
+          name="email"
+          type="text"
+          defaultValue={userDetails.email}
+          disabled
+        />
+        <Button type="submit" disabled={isPending} className="margin-top-4">
+          {t(isPending ? "pending" : "save")}
+        </Button>
+      </form>
+    </>
   );
 }

--- a/frontend/src/components/workspace/StartApplicationModal/IneligibleStartApplicationModal.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/IneligibleStartApplicationModal.tsx
@@ -1,5 +1,5 @@
 import { ApplicantTypes } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/UserTypes";
+import { Organization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { RefObject } from "react";

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationDescription.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationDescription.tsx
@@ -1,6 +1,6 @@
 import { ExternalRoutes } from "src/constants/routes";
 import { ApplicantTypes } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/UserTypes";
+import { Organization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationInputs.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationInputs.tsx
@@ -1,4 +1,4 @@
-import { Organization } from "src/types/UserTypes";
+import { Organization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import {

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationModal.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationModal.tsx
@@ -1,6 +1,6 @@
 import { useClientFetch } from "src/hooks/useClientFetch";
 import { ApplicantTypes } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/UserTypes";
+import { Organization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationModalControl.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationModalControl.tsx
@@ -6,7 +6,7 @@ import {
   ApplicantTypes,
   Competition,
 } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/UserTypes";
+import { Organization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1431,4 +1431,21 @@ export const messages = {
     technicalSupportMessage:
       "For technical support or to give feedback, email <mailToGrants>simpler@grants.gov</mailToGrants>.",
   },
+  UserAccount: {
+    pageTitle: "User Account | Simpler.Grants.gov",
+    title: "User Account",
+    inputs: {
+      firstName: "First name",
+      middleName: "Middle name",
+      lastName: "Last name",
+      email: "Email",
+    },
+    save: "Save",
+    validationErrors: {
+      firstName: "First name is required",
+      lastName: "Last name is required",
+    },
+    fetchError: "Error fetching user data. Please try refreshing the page.",
+    pending: "Saving...",
+  },
 };

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1447,5 +1447,7 @@ export const messages = {
     },
     fetchError: "Error fetching user data. Please try refreshing the page.",
     pending: "Saving...",
+    errorHeading: "Error",
+    successHeading: "Account updated",
   },
 };

--- a/frontend/src/services/fetch/fetchers/userFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/userFetcher.ts
@@ -1,11 +1,11 @@
 "server only";
 
+import { JSONRequestBody } from "src/services/fetch/fetcherHelpers";
 import {
-  // fetchUserWithMethod,
+  fetchUserWithMethod,
   postUserLogout,
 } from "src/services/fetch/fetchers/fetchers";
-import { DynamicUserDetails, UserDetail } from "src/types/userTypes";
-import { fakeUser } from "src/utils/testing/fixtures";
+import { UserDetail } from "src/types/userTypes";
 
 export const postLogout = async (token: string) => {
   const jwtAuthHeader = { "X-SGG-Token": token };
@@ -13,38 +13,34 @@ export const postLogout = async (token: string) => {
 };
 
 export const getUserDetails = async (
-  _token: string,
-  _userId: string,
+  token: string,
+  userId: string,
 ): Promise<UserDetail> => {
-  return Promise.resolve(fakeUser);
-
-  // uncomment this once the API changes to add support for names are implemented
-
-  // const ssgToken = {
-  //   "X-SGG-Token": token,
-  // };
-  // const resp = await fetchUserWithMethod("GET")({
-  //   subPath: userId,
-  //   additionalHeaders: ssgToken,
-  // });
-  // const json = (await resp.json()) as { data: UserDetail };
-  // return json.data;
+  const ssgToken = {
+    "X-SGG-Token": token,
+  };
+  const resp = await fetchUserWithMethod("GET")({
+    subPath: userId,
+    additionalHeaders: ssgToken,
+  });
+  const json = (await resp.json()) as { data: UserDetail };
+  return json.data;
 };
 
 export const updateUserDetails = async (
-  _token: string,
-  updates: DynamicUserDetails,
+  token: string,
+  userId: string,
+  updates: JSONRequestBody,
 ): Promise<UserDetail> => {
-  return Promise.resolve({ ...fakeUser, ...updates } as UserDetail);
-  // uncomment this once the API changes to add support for names are implemented
+  const ssgToken = {
+    "X-SGG-Token": token,
+  };
 
-  // const ssgToken = {
-  //   "X-SGG-Token": token,
-  // };
-
-  // return fetchUserWithMethod("PUT")({
-  //   subPath: userId,
-  //   additionalHeaders: ssgToken,
-  //   body: payload,
-  // });
+  const response = await fetchUserWithMethod("PUT")({
+    subPath: `${userId}/profile`,
+    additionalHeaders: ssgToken,
+    body: updates,
+  });
+  const json = (await response.json()) as { data: UserDetail };
+  return json.data;
 };

--- a/frontend/src/services/fetch/fetchers/userFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/userFetcher.ts
@@ -1,6 +1,50 @@
-import { postUserLogout } from "src/services/fetch/fetchers/fetchers";
+"server only";
+
+import {
+  // fetchUserWithMethod,
+  postUserLogout,
+} from "src/services/fetch/fetchers/fetchers";
+import { DynamicUserDetails, UserDetail } from "src/types/userTypes";
+import { fakeUser } from "src/utils/testing/fixtures";
 
 export const postLogout = async (token: string) => {
   const jwtAuthHeader = { "X-SGG-Token": token };
   return postUserLogout({ additionalHeaders: jwtAuthHeader });
+};
+
+export const getUserDetails = async (
+  _token: string,
+  _userId: string,
+): Promise<UserDetail> => {
+  return Promise.resolve(fakeUser);
+
+  // uncomment this once the API changes to add support for names are implemented
+
+  // const ssgToken = {
+  //   "X-SGG-Token": token,
+  // };
+  // const resp = await fetchUserWithMethod("GET")({
+  //   subPath: userId,
+  //   additionalHeaders: ssgToken,
+  // });
+  // const json = (await resp.json()) as { data: UserDetail };
+  // return json.data;
+};
+
+export const updateUserDetails = async (
+  _token: string,
+  updates: DynamicUserDetails,
+): Promise<UserDetail> => {
+  return Promise.resolve({ ...fakeUser, ...updates } as UserDetail);
+  // uncomment this once the API changes to add support for names are implemented
+
+  // const ssgToken = {
+  //   "X-SGG-Token": token,
+  // };
+
+  // return fetchUserWithMethod("PUT")({
+  //   subPath: userId,
+  //   additionalHeaders: ssgToken,
+  //   body: payload,
+  // });
 };

--- a/frontend/src/types/UserTypes.ts
+++ b/frontend/src/types/UserTypes.ts
@@ -1,9 +1,0 @@
-export type Organization = {
-  is_organization_owner: boolean;
-  organization_id: string;
-  sam_gov_entity: {
-    expiration_date: string;
-    legal_business_name: string;
-    uei: string;
-  };
-};

--- a/frontend/src/types/userTypes.ts
+++ b/frontend/src/types/userTypes.ts
@@ -13,15 +13,16 @@ export type UserProfileValidationErrors = {
   lastName?: string[];
 };
 
-export interface DynamicUserDetails {
+export interface UserProfile {
   first_name: string;
   middle_name?: string;
   last_name: string;
 }
 
-export interface UserDetail extends DynamicUserDetails {
-  id: string;
+export interface UserDetail {
+  user_id: string;
   email: string;
+  profile: UserProfile | null;
 }
 
 export interface UserProfileResponse {

--- a/frontend/src/types/userTypes.ts
+++ b/frontend/src/types/userTypes.ts
@@ -1,0 +1,31 @@
+export type Organization = {
+  is_organization_owner: boolean;
+  organization_id: string;
+  sam_gov_entity: {
+    expiration_date: string;
+    legal_business_name: string;
+    uei: string;
+  };
+};
+
+export type UserProfileValidationErrors = {
+  firstName?: string[];
+  lastName?: string[];
+};
+
+export interface DynamicUserDetails {
+  first_name: string;
+  middle_name?: string;
+  last_name: string;
+}
+
+export interface UserDetail extends DynamicUserDetails {
+  id: string;
+  email: string;
+}
+
+export interface UserProfileResponse {
+  validationErrors?: UserProfileValidationErrors;
+  errorMessage?: string;
+  data?: UserDetail;
+}

--- a/frontend/src/types/userTypes.ts
+++ b/frontend/src/types/userTypes.ts
@@ -13,7 +13,7 @@ export type UserProfileValidationErrors = {
   lastName?: string[];
 };
 
-export interface UserProfile {
+export interface UserDetailProfile {
   first_name: string;
   middle_name?: string;
   last_name: string;
@@ -22,7 +22,7 @@ export interface UserProfile {
 export interface UserDetail {
   user_id: string;
   email: string;
-  profile: UserProfile | null;
+  profile: UserDetailProfile | null;
 }
 
 export interface UserProfileResponse {

--- a/frontend/src/types/userTypes.ts
+++ b/frontend/src/types/userTypes.ts
@@ -29,4 +29,5 @@ export interface UserProfileResponse {
   validationErrors?: UserProfileValidationErrors;
   errorMessage?: string;
   data?: UserDetail;
+  success?: boolean;
 }

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -16,7 +16,7 @@ import {
   SearchAPIResponse,
   SearchFetcherActionType,
 } from "src/types/search/searchRequestTypes";
-import { UserDetail } from "src/types/userTypes";
+import { UserDetail, UserDetailProfile } from "src/types/userTypes";
 
 export const mockOpportunity: BaseOpportunity = {
   opportunity_id: "63588df8-f2d1-44ed-a201-5804abba696a",
@@ -545,8 +545,10 @@ export const fakeWidgetProps = {
 };
 
 export const fakeUser: UserDetail = {
-  id: "1",
+  user_id: "1",
   email: "not-the-real-email@fake.com",
-  first_name: "joe",
-  last_name: "quisling",
+  profile: {
+    first_name: "joe",
+    last_name: "quisling",
+  } as UserDetailProfile,
 };

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -16,6 +16,7 @@ import {
   SearchAPIResponse,
   SearchFetcherActionType,
 } from "src/types/search/searchRequestTypes";
+import { UserDetail } from "src/types/userTypes";
 
 export const mockOpportunity: BaseOpportunity = {
   opportunity_id: "63588df8-f2d1-44ed-a201-5804abba696a",
@@ -541,4 +542,11 @@ export const fakeWidgetProps = {
   rawErrors: [],
   value: "hi",
   options: {},
+};
+
+export const fakeUser: UserDetail = {
+  id: "1",
+  email: "not-the-real-email@fake.com",
+  first_name: "joe",
+  last_name: "quisling",
 };

--- a/frontend/tests/api/user/organizations/route.test.ts
+++ b/frontend/tests/api/user/organizations/route.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { getUserOrganizations } from "src/app/api/user/organizations/handler";
-import { Organization } from "src/types/UserTypes";
+import { Organization } from "src/types/userTypes";
 import { fakeOrganization } from "src/utils/testing/fixtures";
 
 const mockFetchOrganizations = jest.fn();

--- a/frontend/tests/components/ConditionalFormActionError.test.tsx
+++ b/frontend/tests/components/ConditionalFormActionError.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+
+import { ConditionalFormActionError } from "src/components/ConditionalFormActionError";
+
+const TypedConditionalFormActionError = ConditionalFormActionError<{
+  someFieldName?: string[];
+  anotherFieldName?: string[];
+}>;
+
+describe("ConditionalFormActionError", () => {
+  it("matches snapshot", () => {
+    const { container } = render(
+      <TypedConditionalFormActionError
+        fieldName="someFieldName"
+        errors={{ someFieldName: ["special error"] }}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it("does not render error if no errors", () => {
+    render(<TypedConditionalFormActionError fieldName="someFieldName" />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+  it("does not render error if no error matches field name", () => {
+    render(
+      <TypedConditionalFormActionError
+        fieldName="someFieldName"
+        errors={{ anotherFieldName: ["error"] }}
+      />,
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+  it("renders error for field name", () => {
+    render(
+      <TypedConditionalFormActionError
+        fieldName="someFieldName"
+        errors={{ someFieldName: ["special error"] }}
+      />,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("special error")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/RequiredFieldIndicator.test.tsx
+++ b/frontend/tests/components/RequiredFieldIndicator.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+
+import { RequiredFieldIndicator } from "src/components/RequiredFieldIndicator";
+
+describe("RequiredFieldIndicator", () => {
+  it("matches snapshot", () => {
+    const { container } = render(
+      <RequiredFieldIndicator>hi</RequiredFieldIndicator>,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it("returns children wrapped in USWDS required classes", () => {
+    render(<RequiredFieldIndicator>hi</RequiredFieldIndicator>);
+    expect(screen.getByText("hi")).toBeInTheDocument();
+    expect(screen.getByTestId("required-field-indicator")).toHaveClass(
+      "usa-hint usa-hint--required",
+    );
+  });
+});

--- a/frontend/tests/components/__snapshots__/ConditionalFormActionError.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/ConditionalFormActionError.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConditionalFormActionError matches snapshot 1`] = `
+<div>
+  <span
+    class="usa-error-message maxw-mobile-lg"
+    data-testid="errorMessage"
+    role="alert"
+  >
+    special error
+  </span>
+</div>
+`;

--- a/frontend/tests/components/__snapshots__/RequiredFieldIndicator.test.tsx.snap
+++ b/frontend/tests/components/__snapshots__/RequiredFieldIndicator.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RequiredFieldIndicator matches snapshot 1`] = `
+<div>
+  <span
+    class="usa-hint usa-hint--required"
+    data-testid="required-field-indicator"
+  >
+    hi
+  </span>
+</div>
+`;

--- a/frontend/tests/components/user/UserProfileForm.test.tsx
+++ b/frontend/tests/components/user/UserProfileForm.test.tsx
@@ -90,8 +90,8 @@ describe("userProfileForm", () => {
 
     render(<UserProfileForm userDetails={fakeUser} />);
 
-    const alert = screen.getByRole("alert");
+    const alert = screen.getByRole("heading");
     expect(alert).toBeInTheDocument();
-    expect(alert).toHaveTextContent("big error");
+    expect(alert).toHaveTextContent("errorHeading");
   });
 });

--- a/frontend/tests/components/user/UserProfileForm.test.tsx
+++ b/frontend/tests/components/user/UserProfileForm.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { noop } from "lodash";
+import { fakeUser } from "src/utils/testing/fixtures";
+import { useTranslationsMock } from "src/utils/testing/intlMocks";
+
+import { UserProfileForm } from "src/components/user/UserProfileForm";
+
+const mockUseActionState = jest.fn();
+
+jest.mock("react", () => ({
+  ...jest.requireActual<typeof import("react")>("react"),
+  useActionState: () => mockUseActionState() as unknown,
+}));
+
+jest.mock("src/app/[locale]/(base)/user/account/actions", () => ({
+  userProfileAction: noop,
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => useTranslationsMock(),
+}));
+
+describe("userProfileForm", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("matches snapshot", () => {
+    mockUseActionState.mockReturnValue([{}, noop, false]);
+    const { container } = render(<UserProfileForm userDetails={fakeUser} />);
+    expect(container).toMatchSnapshot();
+  });
+  it("renders validation errors", () => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: { firstName: ["some error"] } },
+      noop,
+      false,
+    ]);
+
+    render(<UserProfileForm userDetails={fakeUser} />);
+
+    const alert = screen.getByRole("alert");
+
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent("some error");
+  });
+  it("displays values from userDetail props if form is not submitted", () => {
+    mockUseActionState.mockReturnValue([{}, noop, false]);
+
+    render(<UserProfileForm userDetails={fakeUser} />);
+
+    expect(screen.getByDisplayValue(fakeUser.first_name)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(fakeUser.last_name)).toBeInTheDocument();
+  });
+  it("displays values from form action when available", () => {
+    mockUseActionState.mockReturnValue([
+      {
+        data: {
+          first_name: "something",
+          middle_name: "else",
+          last_name: "entirely",
+        },
+      },
+      noop,
+      false,
+    ]);
+
+    render(<UserProfileForm userDetails={fakeUser} />);
+
+    expect(screen.getByDisplayValue("something")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("else")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("entirely")).toBeInTheDocument();
+  });
+  it("displays error message on error", () => {
+    mockUseActionState.mockReturnValue([
+      {
+        errorMessage: "big error",
+      },
+      noop,
+      false,
+    ]);
+
+    render(<UserProfileForm userDetails={fakeUser} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(alert).toHaveTextContent("big error");
+  });
+});

--- a/frontend/tests/components/user/UserProfileForm.test.tsx
+++ b/frontend/tests/components/user/UserProfileForm.test.tsx
@@ -44,20 +44,29 @@ describe("userProfileForm", () => {
     expect(alert).toHaveTextContent("some error");
   });
   it("displays values from userDetail props if form is not submitted", () => {
+    if (!fakeUser.profile) {
+      throw new Error("this will not happen, just here to get TS to behave");
+    }
     mockUseActionState.mockReturnValue([{}, noop, false]);
 
     render(<UserProfileForm userDetails={fakeUser} />);
 
-    expect(screen.getByDisplayValue(fakeUser.first_name)).toBeInTheDocument();
-    expect(screen.getByDisplayValue(fakeUser.last_name)).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue(fakeUser.profile.first_name),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue(fakeUser.profile.last_name),
+    ).toBeInTheDocument();
   });
   it("displays values from form action when available", () => {
     mockUseActionState.mockReturnValue([
       {
         data: {
-          first_name: "something",
-          middle_name: "else",
-          last_name: "entirely",
+          profile: {
+            first_name: "something",
+            middle_name: "else",
+            last_name: "entirely",
+          },
         },
       },
       noop,

--- a/frontend/tests/components/user/__snapshots__/UserProfileForm.test.tsx.snap
+++ b/frontend/tests/components/user/__snapshots__/UserProfileForm.test.tsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`userProfileForm matches snapshot 1`] = `
+<div>
+  <form
+    action="javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')"
+  >
+    <label
+      class="usa-label"
+      data-testid="label"
+      for="firstName"
+    >
+      <span>
+        inputs.firstName
+      </span>
+      <span
+        class="usa-hint usa-hint--required"
+        data-testid="required-field-indicator"
+      >
+         *
+      </span>
+    </label>
+    <input
+      class="usa-input"
+      data-testid="textInput"
+      id="edit-user-first-name"
+      name="firstName"
+      type="text"
+      value="joe"
+    />
+    <label
+      class="usa-label"
+      data-testid="label"
+      for="middle-name"
+    >
+      inputs.middleName
+    </label>
+    <input
+      class="usa-input"
+      data-testid="textInput"
+      id="edit-user-middle-name"
+      name="middleName"
+      type="text"
+    />
+    <label
+      class="usa-label"
+      data-testid="label"
+      for="lastName"
+    >
+      <span>
+        inputs.lastName
+      </span>
+      <span
+        class="usa-hint usa-hint--required"
+        data-testid="required-field-indicator"
+      >
+         *
+      </span>
+    </label>
+    <input
+      class="usa-input"
+      data-testid="textInput"
+      id="edit-user-last-name"
+      name="lastName"
+      type="text"
+      value="quisling"
+    />
+    <label
+      class="usa-label"
+      data-testid="label"
+      for="email"
+    >
+      inputs.email
+    </label>
+    <input
+      class="usa-input"
+      data-testid="textInput"
+      disabled=""
+      id="edit-user-email"
+      name="email"
+      type="text"
+      value="not-the-real-email@fake.com"
+    />
+    <button
+      class="usa-button margin-top-4"
+      data-testid="button"
+      type="submit"
+    >
+      save
+    </button>
+  </form>
+</div>
+`;

--- a/frontend/tests/pages/user/account/actions.test.ts
+++ b/frontend/tests/pages/user/account/actions.test.ts
@@ -13,8 +13,8 @@ jest.mock("next-intl/server", () => ({
 }));
 
 jest.mock("src/services/fetch/fetchers/userFetcher", () => ({
-  updateUserDetails: (token: unknown, data: unknown) =>
-    mockUpdateUserDetails(token, data) as unknown,
+  updateUserDetails: (token: unknown, id: unknown, data: unknown) =>
+    mockUpdateUserDetails(token, id, data) as unknown,
 }));
 
 describe("user profile form action", () => {
@@ -22,7 +22,7 @@ describe("user profile form action", () => {
     jest.resetAllMocks();
   });
   it("returns validation warning if first name is missing", async () => {
-    getSessionMock.mockResolvedValue({ token: "logged in" });
+    getSessionMock.mockResolvedValue({ token: "logged in", user_id: "1" });
     const profileFormData = new FormData();
     profileFormData.append("firstName", "populated");
     const result = await userProfileAction(null, profileFormData);
@@ -31,7 +31,7 @@ describe("user profile form action", () => {
     });
   });
   it("returns validation warning if last name is missing", async () => {
-    getSessionMock.mockResolvedValue({ token: "logged in" });
+    getSessionMock.mockResolvedValue({ token: "logged in", user_id: "1" });
     const profileFormData = new FormData();
     profileFormData.append("lastName", "populated");
     const result = await userProfileAction(null, profileFormData);
@@ -46,8 +46,10 @@ describe("user profile form action", () => {
     expect(result.errorMessage).toEqual("Not logged in");
   });
   it("returns result of update on success", async () => {
-    getSessionMock.mockResolvedValue({ token: "logged in" });
-    mockUpdateUserDetails.mockImplementation((_token, data) => data as unknown);
+    getSessionMock.mockResolvedValue({ token: "logged in", user_id: "1" });
+    mockUpdateUserDetails.mockImplementation((_token, _id, data) => {
+      return data as unknown;
+    });
 
     const profileFormData = new FormData();
     profileFormData.append("firstName", "jones");
@@ -62,7 +64,7 @@ describe("user profile form action", () => {
     });
   });
   it("returns API error when applicable", async () => {
-    getSessionMock.mockResolvedValue({ token: "logged in" });
+    getSessionMock.mockResolvedValue({ token: "logged in", user_id: "1" });
     mockUpdateUserDetails.mockRejectedValue(new Error("fake error"));
 
     const profileFormData = new FormData();

--- a/frontend/tests/pages/user/account/actions.test.ts
+++ b/frontend/tests/pages/user/account/actions.test.ts
@@ -1,0 +1,76 @@
+import { identity } from "lodash";
+import { userProfileAction } from "src/app/[locale]/(base)/user/account/actions";
+
+const getSessionMock = jest.fn();
+const mockUpdateUserDetails = jest.fn();
+
+jest.mock("src/services/auth/session", () => ({
+  getSession: (): unknown => getSessionMock(),
+}));
+
+jest.mock("next-intl/server", () => ({
+  getTranslations: () => identity,
+}));
+
+jest.mock("src/services/fetch/fetchers/userFetcher", () => ({
+  updateUserDetails: (token: unknown, data: unknown) =>
+    mockUpdateUserDetails(token, data) as unknown,
+}));
+
+describe("user profile form action", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("returns validation warning if first name is missing", async () => {
+    getSessionMock.mockResolvedValue({ token: "logged in" });
+    const profileFormData = new FormData();
+    profileFormData.append("firstName", "populated");
+    const result = await userProfileAction(null, profileFormData);
+    expect(result.validationErrors).toEqual({
+      lastName: ["Expected string, received null"],
+    });
+  });
+  it("returns validation warning if last name is missing", async () => {
+    getSessionMock.mockResolvedValue({ token: "logged in" });
+    const profileFormData = new FormData();
+    profileFormData.append("lastName", "populated");
+    const result = await userProfileAction(null, profileFormData);
+    expect(result.validationErrors).toEqual({
+      firstName: ["Expected string, received null"],
+    });
+  });
+  it("returns error if not logged in", async () => {
+    getSessionMock.mockResolvedValue({ token: null });
+    const profileFormData = new FormData();
+    const result = await userProfileAction(null, profileFormData);
+    expect(result.errorMessage).toEqual("Not logged in");
+  });
+  it("returns result of update on success", async () => {
+    getSessionMock.mockResolvedValue({ token: "logged in" });
+    mockUpdateUserDetails.mockImplementation((_token, data) => data as unknown);
+
+    const profileFormData = new FormData();
+    profileFormData.append("firstName", "jones");
+    profileFormData.append("middleName", "williams");
+    profileFormData.append("lastName", "smith");
+
+    const result = await userProfileAction(null, profileFormData);
+    expect(result.data).toEqual({
+      first_name: "jones",
+      last_name: "smith",
+      middle_name: "williams",
+    });
+  });
+  it("returns API error when applicable", async () => {
+    getSessionMock.mockResolvedValue({ token: "logged in" });
+    mockUpdateUserDetails.mockRejectedValue(new Error("fake error"));
+
+    const profileFormData = new FormData();
+    profileFormData.append("firstName", "jones");
+    profileFormData.append("middleName", "williams");
+    profileFormData.append("lastName", "smith");
+
+    const result = await userProfileAction(null, profileFormData);
+    expect(result.errorMessage).toEqual("fake error");
+  });
+});

--- a/frontend/tests/utils/getRoutes.test.ts
+++ b/frontend/tests/utils/getRoutes.test.ts
@@ -26,6 +26,7 @@ describe("getNextRoutes", () => {
       "/(base)/saved-search-queries",
       "/(base)/search",
       "/(base)/unauthenticated",
+      "/(base)/user/account",
       "/(base)/vision",
       "/(base)/workspace/applications/application/[applicationId]/form/[appFormId]",
       "/(base)/workspace/applications/application/[applicationId]/form/[appFormId]/success",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6522

Depends on https://github.com/HHS/simpler-grants-gov/pull/6521 

## Changes proposed

connects user profile form to API to fetch and save data

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

also adds success and API error messaging

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/user/account
3. log in
4. _VERIFY_: form is blank
5. fill in the form
6. save
7. _VERIFY_: success message is showed
8. _VERIFY_: your updates persist in the form
9. refresh page
10. _VERIFY_: your updates persist in the form