### PR TITLE
[ISSUE #6339] Organization endpoints - List organization members

### DIFF
--- a/api/src/api/organizations_v1/organization_routes.py
+++ b/api/src/api/organizations_v1/organization_routes.py
@@ -5,11 +5,17 @@ from src.adapters import db
 from src.adapters.db import flask_db
 from src.api import response
 from src.api.organizations_v1.organization_blueprint import organization_blueprint
-from src.api.organizations_v1.organization_schemas import OrganizationGetResponseSchema
+from src.api.organizations_v1.organization_schemas import (
+    OrganizationGetResponseSchema,
+    OrganizationUsersResponseSchema,
+)
 from src.auth.api_jwt_auth import api_jwt_auth
 from src.db.models.user_models import UserTokenSession
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 from src.services.organizations_v1.get_organization import get_organization_and_verify_access
+from src.services.organizations_v1.organization_users_list import (
+    get_organization_users_and_verify_access,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,3 +44,28 @@ def organization_get(db_session: db.Session, organization_id: UUID) -> response.
         )
 
     return response.ApiResponse(message="Success", data=organization)
+
+
+@organization_blueprint.post("/<uuid:organization_id>/users")
+@organization_blueprint.output(OrganizationUsersResponseSchema)
+@organization_blueprint.doc(responses=[200, 401, 403, 404])
+@organization_blueprint.auth_required(api_jwt_auth)
+@flask_db.with_db_session()
+def organization_users_list(db_session: db.Session, organization_id: UUID) -> response.ApiResponse:
+    """Get all users in an organization"""
+    add_extra_data_to_current_request_logs({"organization_id": organization_id})
+    logger.info("POST /v1/organizations/:organization_id/users")
+
+    # Get authenticated user
+    user_token_session: UserTokenSession = api_jwt_auth.get_user_token_session()
+
+    with db_session.begin():
+        # Add the user from the token session to our current session
+        db_session.add(user_token_session)
+
+        # Get organization users using service layer
+        users = get_organization_users_and_verify_access(
+            db_session, user_token_session.user, organization_id
+        )
+
+    return response.ApiResponse(message="Success", data=users)

--- a/api/src/api/organizations_v1/organization_schemas.py
+++ b/api/src/api/organizations_v1/organization_schemas.py
@@ -32,9 +32,58 @@ class OrganizationDataSchema(Schema):
     )
 
 
+class OrganizationUserRoleSchema(Schema):
+    """Schema for user role information with privileges"""
+
+    role_id = fields.UUID(
+        metadata={
+            "description": "Role unique identifier",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+        }
+    )
+    role_name = fields.String(
+        metadata={"description": "Role name", "example": "Organization Admin"}
+    )
+    privileges = fields.List(
+        fields.String(),
+        metadata={
+            "description": "List of privileges for this role",
+            "example": ["manage_org_membership"],
+        },
+    )
+
+
+class OrganizationMemberSchema(Schema):
+    """Schema for organization member information"""
+
+    user_id = fields.UUID(
+        metadata={
+            "description": "User unique identifier",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+        }
+    )
+    email = fields.String(
+        allow_none=True,
+        metadata={"description": "User email from login.gov", "example": "user@example.com"},
+    )
+    roles = fields.List(
+        fields.Nested(OrganizationUserRoleSchema),
+        metadata={"description": "User roles in this organization"},
+    )
+
+
 class OrganizationGetResponseSchema(AbstractResponseSchema):
     """Schema for GET /organizations/:organization_id response"""
 
     data = fields.Nested(
         OrganizationDataSchema, metadata={"description": "Organization information"}
+    )
+
+
+class OrganizationUsersResponseSchema(AbstractResponseSchema):
+    """Schema for POST /organizations/:organization_id/users response"""
+
+    data = fields.List(
+        fields.Nested(OrganizationMemberSchema),
+        metadata={"description": "List of organization members"},
     )

--- a/api/src/services/organizations_v1/organization_users_list.py
+++ b/api/src/services/organizations_v1/organization_users_list.py
@@ -1,0 +1,84 @@
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
+import src.adapters.db as db
+from src.db.models.user_models import OrganizationUser, OrganizationUserRole, User
+from src.services.organizations_v1.get_organization import get_organization_and_verify_access
+
+
+def _fetch_organization_users(db_session: db.Session, organization_id: UUID) -> list[User]:
+    """Fetch all users in an organization with their roles and privileges eagerly loaded."""
+    stmt = (
+        select(User)
+        .join(OrganizationUser)
+        .options(
+            # Only load the organization membership for the specific organization we're querying
+            joinedload(User.organizations.and_(OrganizationUser.organization_id == organization_id))
+            .joinedload(OrganizationUser.organization_user_roles)
+            .joinedload(OrganizationUserRole.role),
+            joinedload(User.linked_login_gov_external_user),
+        )
+        .where(OrganizationUser.organization_id == organization_id)
+    )
+    users = db_session.execute(stmt).scalars().unique().all()
+    return list(users)
+
+
+def get_organization_users_and_verify_access(
+    db_session: db.Session, user: User, organization_id: UUID
+) -> list[dict[str, Any]]:
+    """Get organization users and verify user has access.
+
+    Args:
+        db_session: Database session
+        user: User requesting access
+        organization_id: UUID of the organization
+
+    Returns:
+        list[dict]: List of user data with roles and privileges
+
+    Raises:
+        FlaskError: 404 if organization not found, 403 if access denied
+    """
+
+    # Check if user has VIEW_ORG_MEMBERSHIP privilege for this organization
+    get_organization_and_verify_access(db_session, user, organization_id)
+
+    return get_organization_users(db_session, organization_id)
+
+
+def get_organization_users(db_session: db.Session, organization_id: UUID) -> list[dict[str, Any]]:
+    """Get all users in an organization with their roles and privileges.
+
+    Args:
+        db_session: Database session
+        organization_id: UUID of the organization
+
+    Returns:
+        list[dict]: List of user data with roles and privileges
+    """
+    users = _fetch_organization_users(db_session, organization_id)
+
+    return [
+        {
+            "user_id": user.user_id,
+            "email": (
+                user.linked_login_gov_external_user.email
+                if user.linked_login_gov_external_user
+                else None
+            ),
+            "roles": [
+                {
+                    "role_id": org_user_role.role.role_id,
+                    "role_name": org_user_role.role.role_name,
+                    "privileges": [priv.value for priv in org_user_role.role.privileges],
+                }
+                for org_user in user.organizations
+                for org_user_role in org_user.organization_user_roles
+            ],
+        }
+        for user in users
+    ]

--- a/api/tests/src/api/organizations_v1/test_organization_users_list_routes.py
+++ b/api/tests/src/api/organizations_v1/test_organization_users_list_routes.py
@@ -1,0 +1,257 @@
+import uuid
+
+from src.constants.lookup_constants import Privilege
+from tests.lib.organization_test_utils import create_user_in_org, create_user_not_in_org
+from tests.src.db.models.factories import OrganizationFactory
+
+
+class TestOrganizationUsers:
+    """Test POST /v1/organizations/:organization_id/users endpoint"""
+
+    def test_get_organization_users_200_with_multiple_members(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test getting organization users with multiple members"""
+        # Create organization owner with required privileges
+        owner, organization, owner_token = create_user_in_org(
+            privileges=[Privilege.VIEW_ORG_MEMBERSHIP],
+            db_session=db_session,
+            is_organization_owner=True,
+        )
+
+        # Create additional member with different role
+        member, _, _ = create_user_in_org(
+            privileges=[Privilege.VIEW_APPLICATION],
+            db_session=db_session,
+            organization=organization,
+            is_organization_owner=False,
+        )
+
+        # Make request
+        resp = client.post(
+            f"/v1/organizations/{organization.organization_id}/users",
+            headers={"X-SGG-Token": owner_token},
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data["message"] == "Success"
+        assert len(data["data"]) == 2
+
+        # Verify user data structure
+        for user_data in data["data"]:
+            assert "user_id" in user_data
+            assert "email" in user_data
+            assert "roles" in user_data
+            assert isinstance(user_data["roles"], list)
+
+            # Verify role structure
+            for role in user_data["roles"]:
+                assert "role_id" in role
+                assert "role_name" in role
+                assert "privileges" in role
+                assert isinstance(role["privileges"], list)
+
+    def test_get_organization_users_200_single_member(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test getting organization users with single member"""
+        # Create user in organization with required privileges
+        user, organization, token = create_user_in_org(
+            privileges=[Privilege.VIEW_ORG_MEMBERSHIP],
+            db_session=db_session,
+            is_organization_owner=True,
+        )
+
+        # Make request
+        resp = client.post(
+            f"/v1/organizations/{organization.organization_id}/users",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data["message"] == "Success"
+        assert len(data["data"]) == 1
+        assert data["data"][0]["user_id"] == str(user.user_id)
+
+    def test_get_organization_users_200_empty_organization(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test getting organization users when organization has no members"""
+        # Create user with privileges but in different organization
+        user, user_org, token = create_user_in_org(
+            privileges=[Privilege.VIEW_ORG_MEMBERSHIP],
+            db_session=db_session,
+            is_organization_owner=True,
+        )
+
+        # Create empty organization
+        empty_organization = OrganizationFactory.create()
+
+        # Add user to empty organization with proper privileges
+        _, _, _ = create_user_in_org(
+            privileges=[Privilege.VIEW_ORG_MEMBERSHIP],
+            db_session=db_session,
+            organization=empty_organization,
+            is_organization_owner=True,
+        )
+
+        # Make request to empty organization
+        resp = client.post(
+            f"/v1/organizations/{empty_organization.organization_id}/users",
+            headers={"X-SGG-Token": token},
+        )
+
+        # This should return 403 because user is not a member of empty_organization
+        assert resp.status_code == 403
+
+    def test_get_organization_users_403_no_privilege(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test that user without VIEW_ORG_MEMBERSHIP privilege gets 403"""
+        # Create user in organization with wrong privilege (not VIEW_ORG_MEMBERSHIP)
+        user, organization, token = create_user_in_org(
+            privileges=[Privilege.VIEW_APPLICATION],
+            db_session=db_session,
+        )
+
+        # Make request
+        resp = client.post(
+            f"/v1/organizations/{organization.organization_id}/users",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 403
+
+    def test_get_organization_users_403_different_organization(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test that user from different organization gets 403"""
+        # Create user in one organization with proper privileges
+        user, user_organization, token = create_user_in_org(
+            privileges=[Privilege.VIEW_ORG_MEMBERSHIP],
+            db_session=db_session,
+        )
+
+        # Create a different organization that user is NOT a member of
+        other_organization = OrganizationFactory.create()
+
+        # Try to access other_organization
+        resp = client.post(
+            f"/v1/organizations/{other_organization.organization_id}/users",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 403
+
+    def test_get_organization_users_403_not_organization_member(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test that non-member trying to access gets 403"""
+        # Create user that is NOT a member of any organization
+        user, token = create_user_not_in_org(db_session)
+
+        # Create organization (user is NOT a member)
+        organization = OrganizationFactory.create()
+
+        # Make request
+        resp = client.post(
+            f"/v1/organizations/{organization.organization_id}/users",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 403
+
+    def test_get_organization_users_404_organization_not_found(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test that non-existent organization returns 404"""
+        # Create user (doesn't need to be in any organization for this test)
+        user, token = create_user_not_in_org(db_session)
+
+        # Try to access non-existent organization
+        non_existent_id = str(uuid.uuid4())
+        resp = client.post(
+            f"/v1/organizations/{non_existent_id}/users",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 404
+
+    def test_get_organization_users_401_no_token(self, client):
+        """Test that accessing organization users without auth token returns 401"""
+        random_org_id = str(uuid.uuid4())
+
+        resp = client.post(f"/v1/organizations/{random_org_id}/users")
+
+        assert resp.status_code == 401
+
+    def test_get_organization_users_401_invalid_token(self, client):
+        """Test that accessing organization users with invalid token returns 401"""
+        random_org_id = str(uuid.uuid4())
+
+        resp = client.post(
+            f"/v1/organizations/{random_org_id}/users",
+            headers={"X-SGG-Token": "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_get_organization_users_with_multiple_roles(
+        self, enable_factory_create, client, db_session
+    ):
+        """Test users with multiple roles in same organization"""
+        # Create organization owner with required privileges
+        owner, organization, owner_token = create_user_in_org(
+            privileges=[Privilege.VIEW_ORG_MEMBERSHIP, Privilege.MANAGE_ORG_MEMBERS],
+            db_session=db_session,
+            is_organization_owner=True,
+        )
+
+        # Make request
+        resp = client.post(
+            f"/v1/organizations/{organization.organization_id}/users",
+            headers={"X-SGG-Token": owner_token},
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data["message"] == "Success"
+        assert len(data["data"]) == 1
+
+        user_data = data["data"][0]
+        assert len(user_data["roles"]) == 1  # User has one role with multiple privileges
+
+        role = user_data["roles"][0]
+        privileges = role["privileges"]
+        assert "view_org_membership" in privileges
+        assert "manage_org_members" in privileges
+
+    def test_get_organization_users_with_email(self, enable_factory_create, client, db_session):
+        """Test that user email is properly returned"""
+        # Create user in organization with required privileges
+        user, organization, token = create_user_in_org(
+            privileges=[Privilege.VIEW_ORG_MEMBERSHIP],
+            db_session=db_session,
+            is_organization_owner=True,
+        )
+
+        # Make request
+        resp = client.post(
+            f"/v1/organizations/{organization.organization_id}/users",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        assert data["message"] == "Success"
+        assert len(data["data"]) == 1
+
+        user_data = data["data"][0]
+        assert user_data["email"] is not None
+        assert "@" in user_data["email"]  # Basic email format check


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6339 

## Changes proposed

- Added `POST /organizations/:organization_id/users` endpoint to retrieve organization information by ID, including associated SAM.gov entity data.
- Privilege-based authorization using VIEW_ORG_MEMBERSHIP

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This endpoint will enable organization management features in the frontend, specifically:
- Display section showing all organization users
- Show each member's email, roles, and permissions
- Enable organizations members to see who has access to what functionality

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

To run the tests 

```bash
make test args="-vv tests/src/api/organizations_v1/test_organization_users_list_routes.py"
```
