### PR TITLE
[Issue #6536] Create a task that automatically makes sam.gov extracts from users in lower envs

### DIFF
--- a/api/src/task/sam_extracts/sam_extract_cli.py
+++ b/api/src/task/sam_extracts/sam_extract_cli.py
@@ -10,6 +10,7 @@ from src.task.sam_extracts.cleanup_old_sam_extracts import CleanupOldSamExtracts
 from src.task.sam_extracts.create_orgs_from_sam_entity import CreateOrgsFromSamEntityTask
 from src.task.sam_extracts.fetch_sam_extracts import FetchSamExtractsTask
 from src.task.sam_extracts.process_sam_extracts import ProcessSamExtractsTask
+from src.task.sam_extracts.setup_lower_env_sam_extracts import SetupLowerEnvSamExtractsTask
 from src.task.task_blueprint import task_blueprint
 
 logger = logging.getLogger(__name__)
@@ -19,6 +20,9 @@ logger = logging.getLogger(__name__)
     "sam-extracts", help="Fetch SAM.gov daily and monthly extracts, and process them in our system"
 )
 @click.option("--fetch-extracts/--no-fetch-extracts", default=True, help="run FetchSamExtractsTask")
+@click.option(
+    "--setup-lower-env/--no-setup-lower-env", default=False, help="run SetupLowerEnvSamExtract"
+)
 @click.option(
     "--process-extracts/--no-process-extracts", default=True, help="run ProcessSamExtractsTask"
 )
@@ -33,6 +37,7 @@ logger = logging.getLogger(__name__)
 def run_sam_extracts(
     db_session: db.Session,
     fetch_extracts: bool,
+    setup_lower_env: bool,
     process_extracts: bool,
     create_orgs: bool,
     cleanup_old_files: bool,
@@ -45,6 +50,9 @@ def run_sam_extracts(
         sam_gov_client = create_sam_gov_client()
         # Initialize and run the task
         FetchSamExtractsTask(db_session, sam_gov_client).run()
+
+    if setup_lower_env:
+        SetupLowerEnvSamExtractsTask(db_session).run()
 
     if process_extracts:
         ProcessSamExtractsTask(db_session).run()

--- a/api/src/task/sam_extracts/setup_lower_env_sam_extracts.py
+++ b/api/src/task/sam_extracts/setup_lower_env_sam_extracts.py
@@ -1,0 +1,218 @@
+import logging
+import os
+import secrets
+import string
+import uuid
+import zipfile
+from datetime import date
+from enum import StrEnum
+from typing import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+import src.adapters.db as db
+from src.adapters.aws import S3Config
+from src.constants.lookup_constants import SamGovExtractType, SamGovProcessingStatus
+from src.db.models.entity_models import Organization, SamGovEntity
+from src.db.models.sam_extract_models import SamExtractFile
+from src.db.models.user_models import LinkExternalUser, OrganizationUser, User
+from src.task.sam_extracts.process_sam_extracts import ExtractIndex
+from src.task.task import Task
+from src.util import datetime_util, file_util
+
+logger = logging.getLogger(__name__)
+
+
+class SetupLowerEnvSamExtractsTask(Task):
+    """Task that creates a fake sam.gov extract
+    file that automatically sets up each user
+    in their own organization in our lower environment.
+    """
+
+    class Metrics(StrEnum):
+        USER_COUNT = "user_count"
+        HAS_EXISTING_ORG_COUNT = "has_existing_org_count"
+        NEW_ORG_COUNT = "new_org_count"
+
+    def __init__(self, db_session: db.Session, current_date: date | None = None) -> None:
+        super().__init__(db_session)
+
+        if current_date is None:
+            current_date = datetime_util.get_now_us_eastern_date()
+
+        self.current_date = current_date
+
+        self.s3_config = S3Config()
+
+        self.environment: str | None = os.getenv("ENVIRONMENT", None)
+
+    def run_task(self) -> None:
+        # We do not want to let this task run outside of our development
+        # environments. While it shouldn't be configured to do so, this
+        # is making extra certain that that is the case.
+        if self.environment not in ("local", "dev", "staging"):
+            raise Exception("ENVIRONMENT must be local, dev or staging")
+
+        with self.db_session.begin():
+            # Multiple extract files in one day runs into logic issues with
+            # processing them out-of-order as well as needing to change file names.
+            existing_extract_file = self.db_session.execute(
+                select(SamExtractFile).where(SamExtractFile.extract_date == self.current_date)
+            ).scalar_one_or_none()
+            if existing_extract_file is not None:
+                logger.info("Already created an extract file for today, not creating another one.")
+                return
+
+            users = self.get_users()
+
+            # For each user, create a row in the fake sam extract
+            # file for them so they'll all get an organization
+            # If a user already has one of these organizations, it
+            # should be reused.
+            rows = []
+            for user in users:
+                self.increment(self.Metrics.USER_COUNT)
+                uei = self.determine_uei(user)
+                rows.append(self.build_sam_extract_row(user, uei))
+
+            self.create_extract_file(rows)
+
+    def get_users(self) -> Sequence[User]:
+        """Get all users"""
+        users = (
+            self.db_session.execute(
+                select(User)
+                .join(LinkExternalUser)
+                .options(
+                    selectinload(User.organizations)
+                    .selectinload(OrganizationUser.organization)
+                    .selectinload(Organization.sam_gov_entity)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        return users
+
+    def determine_uei(self, user: User) -> str:
+        """Determine the UEI for a user
+
+        All UEIs we generate are formatted as "AUTO________"
+
+        If a user has previously had an automatically added
+        sam.gov entity record, find it. We'll assume that
+        a user only has one organization where their email
+        is the EBIZ POC + the UEI is of the AUTO format.
+        Even if this ends up wrong, the purpose of this logic is
+        to give each user an org, this type of user would already have
+        multiple orgs so it wouldn't matter much
+        """
+
+        for org_user in user.organizations:
+            entity = org_user.organization.sam_gov_entity
+            if (
+                entity is not None
+                and entity.uei.startswith("AUTO")
+                and entity.ebiz_poc_email == user.email
+            ):
+                self.increment(self.Metrics.HAS_EXISTING_ORG_COUNT)
+                logger.info(
+                    "User has an existing organization",
+                    extra={"uei": entity.uei, "user_id": user.user_id},
+                )
+                return entity.uei
+
+        # Assume this is a new user, generate a new UEI for them
+
+        for _ in range(5):
+            uei = generate_uei()
+
+            existing_record = self.db_session.execute(
+                select(SamGovEntity).where(SamGovEntity.uei == uei)
+            ).scalar_one_or_none()
+            if existing_record is None:
+                self.increment(self.Metrics.NEW_ORG_COUNT)
+                logger.info(
+                    "User has no existing organization", extra={"uei": uei, "user_id": user.user_id}
+                )
+                return uei
+
+        raise Exception("Could not generate a unique UEI after 5 attempts")
+
+    def create_extract_file(self, rows: list[str]) -> None:
+        # The header and footer are formatted as
+        # BOF/EOF FOUO V2 STARTDATE ENDDATE RECORD_COUNT SEQUENCE_NUMBER
+        # In the monthly extract we're pretending to be, start date is all 0s
+        # We don't look at the sequence, so just make it static
+        date_str = self.current_date.strftime("%Y%m%d")
+        row_count = len(rows)
+        header = f"BOF FOUO V2 00000000 {date_str} {row_count} 0000000"
+        footer = f"EOF FOUO V2 00000000 {date_str} {row_count} 0000000"
+
+        file_contents = [header] + rows + [footer]
+        file_text = "\n".join(file_contents)
+
+        filename = f"SAM_FOUO_FAKE_MONTHLY_V2_{date_str}.ZIP"
+        s3_path = f"{self.s3_config.draft_files_bucket_path}/sam-extracts/fake-monthly/{filename}"
+        with file_util.open_stream(s3_path, "wb") as outfile:
+            with zipfile.ZipFile(outfile, "w") as extract_zip:
+                extract_zip.writestr(f"SAM_FOUO_V2_{date_str}.dat", file_text)
+
+        # Create an extract record, we mark these
+        # as monthly because it's always a full extract
+        extract = SamExtractFile(
+            extract_type=SamGovExtractType.MONTHLY,
+            extract_date=self.current_date,
+            filename=filename,
+            s3_path=s3_path,
+            processing_status=SamGovProcessingStatus.PENDING,
+            sam_extract_file_id=uuid.uuid4(),
+        )
+        self.db_session.add(extract)
+        logger.info(
+            "Created a fake monthly extract file",
+            extra={"extract_date": self.current_date, "s3_path": s3_path},
+        )
+
+    def build_sam_extract_row(self, user: User, uei: str) -> str:
+        """For each user, create a record in the extract"""
+        # This shouldn't happen if we fetched the data right
+        # but just as a safety net
+        if user.email is None:
+            raise Exception("User has no email, can't make an org")
+
+        # Initialize an array with 300 empty strings
+        # we'll populate just the values we care about
+        data = [""] * 300
+
+        # The configuration we have sets the numbers to match what
+        # the documentation says which starts counting at 1, so subtract
+        # to setup the indexes properly.
+        data[ExtractIndex.UEI - 1] = uei
+        data[ExtractIndex.SAM_EXTRACT_CODE - 1] = "A"
+        data[ExtractIndex.LEGAL_BUSINESS_NAME - 1] = (
+            f"Automatic {self.environment} Organization for UEI {uei}"
+        )
+        data[ExtractIndex.REGISTRATION_EXPIRATION_DATE - 1] = "20600101"
+        data[ExtractIndex.EBIZ_POC_EMAIL - 1] = user.email
+        data[ExtractIndex.EBIZ_POC_FIRST_NAME - 1] = (
+            user.profile.first_name if user.profile else "Unknown"
+        )
+        data[ExtractIndex.EBIZ_POC_LAST_NAME - 1] = (
+            user.profile.first_name if user.profile else "Person"
+        )
+        data[ExtractIndex.DEBT_SUBJECT_TO_OFFSET - 1] = ""
+        data[ExtractIndex.EXCLUSION_STATUS_FLAG - 1] = "N"
+        data[ExtractIndex.ENTITY_EFT_INDICATOR - 1] = ""
+        data[ExtractIndex.INITIAL_REGISTRATION_DATE - 1] = "20250101"
+        data[ExtractIndex.LAST_UPDATE_DATE - 1] = self.current_date.strftime("%Y%m%d")
+
+        return "|".join(data) + "!end"
+
+
+def generate_uei() -> str:
+    """Generate an UEI for each user"""
+    # Note that UEI MUST be 12-characters long.
+    return "AUTO" + "".join(secrets.choice(string.ascii_uppercase) for _ in range(8))

--- a/api/tests/src/task/sam_extracts/test_setup_lower_env_sam_extracts.py
+++ b/api/tests/src/task/sam_extracts/test_setup_lower_env_sam_extracts.py
@@ -1,0 +1,113 @@
+import logging
+import zipfile
+from datetime import date
+
+import pytest
+
+from src.db.models.sam_extract_models import SamExtractFile
+from src.db.models.user_models import LinkExternalUser
+from src.task.sam_extracts.process_sam_extracts import ExtractIndex
+from src.task.sam_extracts.setup_lower_env_sam_extracts import SetupLowerEnvSamExtractsTask
+from src.util import file_util
+from tests.conftest import BaseTestClass
+from tests.lib.db_testing import cascade_delete_from_db_table
+from tests.src.db.models.factories import (
+    LinkExternalUserFactory,
+    OrganizationUserFactory,
+    SamExtractFileFactory,
+    SamGovEntityFactory,
+    UserFactory,
+)
+
+
+def verify_record_in_extract(
+    extract_rows: list[str], user_email: str, expected_uei: str | None = None
+) -> None:
+    found_record = False
+    for row in extract_rows:
+        tokens = row.split("|")
+        if tokens[ExtractIndex.EBIZ_POC_EMAIL - 1] == user_email:
+            if expected_uei is not None:
+                assert tokens[ExtractIndex.UEI - 1] == expected_uei
+            found_record = True
+
+            break
+
+    assert found_record, f"Could not find expected record, user with email {user_email}"
+
+
+class TestSetupLowerEnvSamExtractsTask(BaseTestClass):
+
+    @pytest.fixture(autouse=True)
+    def cleanup_data(self, db_session):
+        cascade_delete_from_db_table(db_session, SamExtractFile)
+        cascade_delete_from_db_table(db_session, LinkExternalUser)
+
+    @pytest.fixture
+    def setup_lower_env_sam_extracts_task(
+        self, db_session, enable_factory_create, monkeypatch, mock_s3_bucket
+    ):
+        monkeypatch.setenv("DRAFT_FILES_BUCKET", "s3://" + mock_s3_bucket)
+        return SetupLowerEnvSamExtractsTask(db_session, date(2025, 9, 1))
+
+    def test_run_task(self, setup_lower_env_sam_extracts_task, mock_s3_bucket):
+        # These users will need new orgs
+        new_org_users = LinkExternalUserFactory.create_batch(size=3)
+
+        # Existing org users
+        existing_org_users = LinkExternalUserFactory.create_batch(size=4)
+        for i, existing_org_user in enumerate(existing_org_users):
+            sam_gov_entity = SamGovEntityFactory.create(
+                uei=f"AUTO000000{i}", ebiz_poc_email=existing_org_user.email, has_organization=True
+            )
+            OrganizationUserFactory.create(
+                organization=sam_gov_entity.organization, user=existing_org_user.user
+            )
+
+        # These users don't have a link external record, and will be skipped
+        UserFactory.create_batch(size=2)
+
+        setup_lower_env_sam_extracts_task.run()
+
+        contents = ""
+        with file_util.open_stream(
+            f"s3://{mock_s3_bucket}/sam-extracts/fake-monthly/SAM_FOUO_FAKE_MONTHLY_V2_20250901.ZIP",
+            "rb",
+        ) as f:
+            with zipfile.ZipFile(f) as extract_zip:
+                with extract_zip.open("SAM_FOUO_V2_20250901.dat") as file_in_zip:
+                    contents = file_in_zip.read().decode()
+
+        all_lines = contents.split("\n")
+        data_rows = all_lines[1:-1]
+
+        for new_org_user in new_org_users:
+            verify_record_in_extract(data_rows, new_org_user.email)
+
+        for existing_org_user in existing_org_users:
+            verify_record_in_extract(
+                data_rows,
+                existing_org_user.email,
+                existing_org_user.user.organizations[0].organization.sam_gov_entity.uei,
+            )
+
+        assert len(data_rows) == len(new_org_users) + len(existing_org_users)
+
+        # Verify the header and footer
+        assert all_lines[0] == "BOF FOUO V2 00000000 20250901 7 0000000"
+        assert all_lines[-1] == "EOF FOUO V2 00000000 20250901 7 0000000"
+
+    def test_run_task_already_processed_for_day(self, setup_lower_env_sam_extracts_task, caplog):
+        caplog.set_level(logging.INFO)
+        SamExtractFileFactory.create(extract_date=date(2025, 9, 1))
+
+        setup_lower_env_sam_extracts_task.run()
+
+        assert (
+            setup_lower_env_sam_extracts_task.metrics[
+                setup_lower_env_sam_extracts_task.Metrics.USER_COUNT
+            ]
+            == 0
+        )
+
+        assert "Already created an extract file for today" in caplog.text

--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -57,6 +57,13 @@ locals {
       "--sync-status"
     ],
   }
+  sam-extract-args = {
+    # In dev/staging we don't fetch extracts, but generate our own
+    dev      = ["poetry", "run", "flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
+    staging  = ["poetry", "run", "flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
+    training = ["poetry", "run", "flask", "task", "sam-extracts"]
+    prod     = ["poetry", "run", "flask", "task", "sam-extracts"]
+  }
   scheduled_jobs = {
     load-transform = {
       task_command = local.load-transform-args[var.environment]
@@ -95,7 +102,7 @@ locals {
       state               = "ENABLED"
     }
     sam-extracts = {
-      task_command = ["poetry", "run", "flask", "task", "sam-extracts"]
+      task_command = local.sam-extract-args[var.environment]
       # Every day at 8am Eastern Time during DST. 9am during non-DST.
       schedule_expression = "cron(0 13 * * ? *)"
       state               = "ENABLED"


### PR DESCRIPTION
## Summary
Fixes #6536

## Changes proposed
Create a new task that will automatically generate a sam.gov extract file in our lower environments giving everyone their own personal organization.

## Context for reviewers
This solves two problems in one:
* Sam.gov doesn't generate extracts in the lower environment that we can process
* In dev/staging, it's really tedious to manually setup orgs for folks. This'll give every user an automatic organization. It does not prevent us from making other orgs, or even from folks inviting to each others orgs.

This task is only meant to run in our lower environments, by default it is off, I modified the job to only enable it in dev/staging AND the task will outright fail if you try to run in prod/training.

## Validation steps
If you run `make db-seed-local`, a few users will be created. You can then run this by doing something like: `make cmd args="task sam-extracts --no-fetch-extracts --setup-lower-env --process-extracts --create-orgs --no-cleanup-old-files"`.

The users should have an additional org now. For example, logging in as the `one_org_user`, it now has another org:
<img width="557" height="284" alt="Screenshot 2025-09-29 at 4 33 05 PM" src="https://github.com/user-attachments/assets/cc2328b7-2d84-47fb-abad-5fc29dbba01a" />

