### PR TITLE
Fix Frontend env naming for API Gateway

### DIFF
--- a/infra/frontend/app-config/env-config/environment_variables.tf
+++ b/infra/frontend/app-config/env-config/environment_variables.tf
@@ -119,7 +119,7 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/api-jwt-public-key"
     },
-    API_GATEWAY_API_TOKEN = {
+    API_AUTH_X_API_KEY = {
       manage_method     = "manual"
       secret_store_name = "/${var.app_name}/${var.environment}/X-API-KEY"
     },

--- a/infra/frontend/app-config/env-config/environment_variables.tf
+++ b/infra/frontend/app-config/env-config/environment_variables.tf
@@ -119,7 +119,7 @@ locals {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/api-jwt-public-key"
     },
-    API_JWT_PUBLIC_KEY = {
+    API_GATEWAY_API_TOKEN = {
       manage_method     = "manual"
       secret_store_name = "/${var.app_name}/${var.environment}/X-API-KEY"
     },


### PR DESCRIPTION
## Summary

Fixes bug introduced from previous PR

## Changes proposed

- Fixes the naming for env var for API gateway token in frontend

## Context for reviewers

In my previous PR, I copied pasted the object to add my env var, and I forgot to change the name. This caused my param to overwrite the API JWT token, causing the frontend to fail

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
