### PR TITLE
HOTFIX: 20251001 banner

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -37,6 +37,28 @@ export default function Layout({ children, locale }: Props) {
         <LoginModalProvider>
           <Header locale={locale} />
           <main id="main-content" className="border-top-0">
+            {/* temp Oct 1, 2025 banner */}
+            <div className="bg-warning-lighter padding-y-3">
+              <div className="grid-container">
+                <p className="measure-none">
+                  There has been a lapse in appropriated federal funds as of
+                  October 1, 2025. <a href="https://grants.gov/">Grants.gov</a>{" "}
+                  and{" "}
+                  <a href="https://simpler.grants.gov/">Simpler.Grants.gov</a>{" "}
+                  will still be available, but service may be delayed with
+                  reduced Federal support staff presence.
+                </p>
+                <p className="measure-none">
+                  For those programs affected by the funding lapse, the{" "}
+                  <a href="https://grants.gov/">Grants.gov</a> and{" "}
+                  <a href="https://simpler.grants.gov/">Simpler.Grants.gov</a>{" "}
+                  systems will accept and store applications until such time as
+                  the responsible awarding agency has the authority and funding
+                  to return to normal business operations.
+                </p>
+              </div>
+            </div>
+            {/* end temp banner */}
             {children}
           </main>
         </LoginModalProvider>


### PR DESCRIPTION
## Summary

This is a hotfix to add a temporary banner for Oct 01, 2025.

## Changes proposed

* Hardcode a message in the `Layout` that displays below the site header

## Context for reviewers

As this is temporary, the content is hardcoded and does not make use of i18n. This change is sandwiched in a comment so the code can easily be removed. 

## Validation steps

Load the app and you should see the following message on a yellow background.

<img width="1408" height="1282" alt="image" src="https://github.com/user-attachments/assets/5336720f-7fd5-48c0-9f7c-d9b060e11891" />

