### PR TITLE
[Issue #6563] Update co-planning sync script

### DIFF
--- a/.github/linters/coplanning/README.md
+++ b/.github/linters/coplanning/README.md
@@ -20,7 +20,11 @@ python run.py \
     --org "HHS" \
     --repo "simpler-grants-gov" \
     --label "Coplanning Proposal" \
-    --issue-section "Summary" \
+    --issue-sections "Summary" \
+    --issue-sections "Problem Statement" \
+    --issue-sections "Proposed Solution" \
+    --issue-sections "Success Criteria" \
+    --issue-sections "Additional Context" \
     --platform "fider" \
     --sync-direction "github-to-platform" \
     --update-existing
@@ -37,7 +41,11 @@ python run.py \
     --org "HHS" \
     --repo "simpler-grants-gov" \
     --label "Coplanning Proposal" \
-    --issue-section "Summary" \
+    --issue-sections "Summary" \
+    --issue-sections "Problem Statement" \
+    --issue-sections "Proposed Solution" \
+    --issue-sections "Success Criteria" \
+    --issue-sections "Additional Context" \
     --platform "fider" \
     --sync-direction "platform-to-github"
 ```
@@ -51,7 +59,10 @@ The CLI supports the following options:
 - `--label`: The GitHub issue label to sync data from
 - `--state`: The GitHub issue state to sync data from (e.g. `open`, `closed`, `all`), defaults to `open`
 - `--batch`: The number of issues to sync at a time, defaults to `100` which is the max batch size for the GitHub API
-- `--issue-section`: The section of the GitHub issue body to use for the Fider post description
+- `--issue-sections`: The sections of the GitHub issue body to use for the Fider post description. Can be specified multiple times, or can receive multiple string arguments. When passing multiple arguments, each needs to be enclosed in quotes. For example:
+  ```bash
+  --issue-sections "Summary" "Problem Statement" "Proposed Solution" "Success Criteria" "Additional Context"
+  ```
 - `--platform`: The platform to sync to (currently only `fider` is supported) but it could be extended to other platforms in the future
 - `--sync-direction`: The direction of the sync `github-to-platform` or `platform-to-github`
 - `--update-existing`: Whether to update existing posts on the platform with the latest GitHub issue data

--- a/.github/linters/coplanning/fider.py
+++ b/.github/linters/coplanning/fider.py
@@ -130,7 +130,7 @@ def update_post(
 def upsert_posts(
     github_issues: dict[str, GithubIssueData],
     fider_posts: dict[str, PostData],
-    issue_section: str = "Summary",
+    issue_sections: list[str],
     *,
     update_existing: bool = False,
     dry_run: bool = False,
@@ -151,7 +151,7 @@ def upsert_posts(
         formatted_description = format_post_description(
             issue_url,
             issue_data.body,
-            issue_section,
+            issue_sections,
         )
 
         if existing_post:

--- a/.github/linters/coplanning/fider.py
+++ b/.github/linters/coplanning/fider.py
@@ -39,7 +39,11 @@ def fetch_posts() -> dict[str, PostData]:
 def parse_posts(posts: list[dict], fider_url: str) -> dict[str, PostData]:
     """Parse Fider posts and return PostData keyed by GitHub issue URLs."""
     posts_dict: dict[str, PostData] = {}
-    pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/issues/[0-9]+")
+    pattern = re.compile(
+        # Matches: [GitHub issue](https://github.com/org/repo/issues/123)
+        # which is inserted at the end of the fider post by utils.format_post_description()
+        r"\[GitHub issue\]\((https://github\.com/[^/]+/[^/]+/issues/[0-9]+)\)"
+    )
 
     for post in posts:
         description = post.get("description", "")
@@ -48,7 +52,10 @@ def parse_posts(posts: list[dict], fider_url: str) -> dict[str, PostData]:
         matches = pattern.findall(description)
         if not matches:
             continue
-        github_url = matches[0]  # Take the first match
+        # Take the last match if there are multiple GitHub issue URLs in the post
+        # This is because the source GitHub issue URL is always inserted
+        # at the end of the fider post by utils.format_post_description()
+        github_url = matches[-1]
         fider_url = f"{FIDER_URL}/posts/{post.get('number')}"
         posts_dict[github_url] = PostData(
             url=fider_url,

--- a/.github/linters/coplanning/run.py
+++ b/.github/linters/coplanning/run.py
@@ -6,9 +6,14 @@ Usage: From the root of the coplanning/ directory:
     --org HHS \
     --repo simpler-grants-gov \
     --label "Coplanning Proposal" \
-    --issue-section "Summary" \
+    --issue-sections "Summary" \
+    --issue-sections "Problem Statement" \
+    --issue-sections "Proposed Solution" \
+    --issue-sections "Success Criteria" \
+    --issue-sections "Additional Context" \
     --platform fider \
     --sync-direction github-to-platform \
+    --update-existing \
     --dry-run
 """
 
@@ -31,7 +36,7 @@ class CliArgs:
     org: str
     repo: str
     label: str
-    issue_section: str
+    issue_sections: list[str]
     platform: str
     sync_direction: str = "github-to-platform"
     state: str = "open"
@@ -49,9 +54,10 @@ def parse_args() -> CliArgs:
     parser.add_argument("--repo", required=True, help="GitHub repository")
     parser.add_argument("--label", required=True, help="GitHub issue label")
     parser.add_argument(
-        "--issue-section",
+        "--issue-sections",
         required=True,
-        help="GitHub issue section to use for post description",
+        action="append",
+        help="GitHub issue sections to use for post description (can be specified multiple times)",
     )
     parser.add_argument(
         "--sync-direction",
@@ -79,7 +85,7 @@ def parse_args() -> CliArgs:
         org=args.org,
         repo=args.repo,
         label=args.label,
-        issue_section=args.issue_section,
+        issue_sections=args.issue_sections,
         platform=args.platform,
         sync_direction=args.sync_direction,
         state=args.state,
@@ -114,7 +120,7 @@ def sync_github_to_fider(args: CliArgs) -> None:
     fider.upsert_posts(
         github_issues=github_issues,
         fider_posts=fider_posts,
-        issue_section=args.issue_section,
+        issue_sections=args.issue_sections,
         update_existing=args.update_existing,
         dry_run=args.dry_run,
     )

--- a/.github/linters/coplanning/utils.py
+++ b/.github/linters/coplanning/utils.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sys
+from typing import Never
 import urllib.request
 
 # #######################################################
@@ -27,11 +28,15 @@ def log(message: str) -> None:
     logger.info(message)
 
 
-def err(message: str, *, exit: bool = True) -> None:
+def err(message: str) -> None:
     """Log an error message and exit."""
     logger.error(message)
-    if exit:
-        sys.exit(1)
+
+
+def err_and_exit(message: str) -> Never:
+    """Log an error message and exit."""
+    err(message)
+    sys.exit(1)
 
 
 # #######################################################
@@ -43,8 +48,7 @@ def get_env(name: str) -> str:
     """Get an environment variable and exit if it's not set."""
     value = os.environ.get(name)
     if not value:
-        err(f"{name} environment variable must be set", exit=True)
-        return ""  # For type checking, never reached due to sys.exit() in err()
+        err_and_exit(f"{name} environment variable must be set")
     return value
 
 
@@ -72,14 +76,11 @@ def make_request(
         with urllib.request.urlopen(req) as response:
             return json.loads(response.read().decode())
     except urllib.request.HTTPError as e:
-        err(f"HTTP request failed: {e.code} - {e.reason}", exit=True)
-        return {}  # For type checking, never reached due to sys.exit() in err()
+        err_and_exit(f"HTTP request failed: {e.code} - {e.reason}")
     except json.JSONDecodeError:
-        err("Failed to parse JSON response", exit=True)
-        return {}  # For type checking, never reached due to sys.exit() in err()
+        err_and_exit("Failed to parse JSON response")
     except Exception as e:
-        err(f"Request failed: {e}", exit=True)
-        return {}  # For type checking, never reached due to sys.exit() in err()
+        err_and_exit(f"Request failed: {e}")
 
 
 # #######################################################

--- a/.github/linters/coplanning/utils.py
+++ b/.github/linters/coplanning/utils.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import sys
-import urllib.parse
 import urllib.request
 
 # #######################################################
@@ -44,7 +43,8 @@ def get_env(name: str) -> str:
     """Get an environment variable and exit if it's not set."""
     value = os.environ.get(name)
     if not value:
-        err(f"{name} environment variable must be set")
+        err(f"{name} environment variable must be set", exit=True)
+        return ""  # For type checking, never reached due to sys.exit() in err()
     return value
 
 
@@ -72,11 +72,14 @@ def make_request(
         with urllib.request.urlopen(req) as response:
             return json.loads(response.read().decode())
     except urllib.request.HTTPError as e:
-        err(f"HTTP request failed: {e.code} - {e.reason}")
+        err(f"HTTP request failed: {e.code} - {e.reason}", exit=True)
+        return {}  # For type checking, never reached due to sys.exit() in err()
     except json.JSONDecodeError:
-        err("Failed to parse JSON response")
+        err("Failed to parse JSON response", exit=True)
+        return {}  # For type checking, never reached due to sys.exit() in err()
     except Exception as e:
-        err(f"Request failed: {e}")
+        err(f"Request failed: {e}", exit=True)
+        return {}  # For type checking, never reached due to sys.exit() in err()
 
 
 # #######################################################

--- a/.github/workflows/coplanning-sync-fider-to-gh.yml
+++ b/.github/workflows/coplanning-sync-fider-to-gh.yml
@@ -3,7 +3,7 @@ name: "Co-planning: Sync Fider to GitHub"
 on:
   pull_request:
     paths:
-      - "linters/coplanning/**"
+      - ".github/linters/coplanning/**"
       - ".github/workflows/coplanning-sync-fider-to-gh.yml"
   workflow_dispatch: # for manual runs
   schedule:
@@ -41,7 +41,11 @@ jobs:
             --org "${{ github.repository_owner }}" \
             --repo "${{ github.event.repository.name }}" \
             --label "Coplanning Proposal" \
-            --issue-section Summary \
+            --issue-sections "Summary" \
+            --issue-sections "Problem Statement" \
+            --issue-sections "Proposed Solution" \
+            --issue-sections "Success Criteria" \
+            --issue-sections "Additional Context" \
             --platform fider \
             --sync-direction platform-to-github \
             --dry-run
@@ -53,6 +57,10 @@ jobs:
             --org "${{ github.repository_owner }}" \
             --repo "${{ github.event.repository.name }}" \
             --label "Coplanning Proposal" \
-            --issue-section Summary \
+            --issue-sections "Summary" \
+            --issue-sections "Problem Statement" \
+            --issue-sections "Proposed Solution" \
+            --issue-sections "Success Criteria" \
+            --issue-sections "Additional Context" \
             --platform fider \
             --sync-direction platform-to-github

--- a/.github/workflows/coplanning-sync-gh-to-fider.yml
+++ b/.github/workflows/coplanning-sync-gh-to-fider.yml
@@ -3,7 +3,7 @@ name: "Co-planning: Sync GitHub to Fider"
 on:
   pull_request:
     paths:
-      - "linters/coplanning/**"
+      - ".github/linters/coplanning/**"
       - ".github/workflows/coplanning-sync-gh-to-fider.yml"
   workflow_dispatch: # for manual runs
 
@@ -39,7 +39,11 @@ jobs:
             --org "${{ github.repository_owner }}" \
             --repo "${{ github.event.repository.name }}" \
             --label "Coplanning Proposal" \
-            --issue-section Summary \
+            --issue-sections "Summary" \
+            --issue-sections "Problem Statement" \
+            --issue-sections "Proposed Solution" \
+            --issue-sections "Success Criteria" \
+            --issue-sections "Additional Context" \
             --platform fider \
             --sync-direction github-to-platform \
             --update-existing \
@@ -52,7 +56,11 @@ jobs:
             --org "${{ github.repository_owner }}" \
             --repo "${{ github.event.repository.name }}" \
             --label "Coplanning Proposal" \
-            --issue-section Summary \
+            --issue-sections "Summary" \
+            --issue-sections "Problem Statement" \
+            --issue-sections "Proposed Solution" \
+            --issue-sections "Success Criteria" \
+            --issue-sections "Additional Context" \
             --platform fider \
             --sync-direction github-to-platform \
-            --update-existing \
+            --update-existing


### PR DESCRIPTION
## Summary

Updates the GitHub to Fider Co-planning sync script to allow us to populate Fider posts with multiple sections from the GitHub issue body.

Fixes #6563 

## Changes proposed

- Fixes a few small type checking warnings
- Adds support for passing multiple sections to the `--issue-sections` flag
- Updates the CI script to use all of the sections in the GitHub issue template for co-planning proposals

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

In the "Internal - Co-planning Proposal" issue template, we replaced the "Summary" section with a new set of sections that we want to be copied over. The previous syncing pattern only allowed us to copy over a single section (or would default to the entire ticket if that section wasn't found).

This new pattern allows us to copy over multiple sections and includes any matching sections in the Fider post. If no matching sections are found, it still defaults to use the entire issue body.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Here's an example of what would be copied over to Fider based on the PR run:

<img width="1054" height="696" alt="Screenshot 2025-10-01 at 1 03 22 PM" src="https://github.com/user-attachments/assets/b08d8c91-893b-4477-9da7-6d9a57942f7f" />
