### PR TITLE
[Issue #6544] Update print page with print widgets

### DIFF
--- a/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
@@ -6,6 +6,7 @@ import getFormData from "src/utils/getFormData";
 import { headers } from "next/headers";
 
 import PrintForm from "src/components/applyForm/PrintForm";
+import { addPrintWidgetToFields } from "src/components/applyForm/utils";
 
 export const dynamic = "force-dynamic";
 
@@ -76,13 +77,15 @@ export default async function FormPage({ params }: FormPageProps) {
     applicationAttachments,
   } = data;
 
+  const modifiedUiSchema = addPrintWidgetToFields(formUiSchema);
+
   return (
     <>
       <h1>{formName}</h1>
       <PrintForm
         savedFormData={applicationResponse}
         formSchema={formSchema}
-        uiSchema={formUiSchema}
+        uiSchema={modifiedUiSchema}
         attachments={applicationAttachments}
         setAttachmentsChanged={setAttachmentsChanged}
       />

--- a/frontend/src/components/applyForm/types.ts
+++ b/frontend/src/components/applyForm/types.ts
@@ -56,6 +56,8 @@ export type WidgetTypes =
   | "Radio"
   | "Select"
   | "MultiSelect"
+  | "Print"
+  | "PrintAttachment"
   | "Budget424aSectionA"
   | "Budget424aSectionB"
   | "Budget424aSectionC"

--- a/frontend/src/components/applyForm/utils.ts
+++ b/frontend/src/components/applyForm/utils.ts
@@ -827,3 +827,26 @@ export const condenseFormSchemaProperties = (schema: object): object => {
 export const pointerToFieldName = (pointer: string): string => {
   return pointer.replace("$.", "").replace(/\./g, "--");
 };
+
+export function addPrintWidgetToFields(uiSchema: UiSchema): UiSchema {
+  return uiSchema.map((item) => {
+    if (item.type === "field") {
+      if (item.widget && item.widget === "AttachmentArray") {
+        return {
+          ...item,
+          widget: "PrintAttachment",
+        };
+      }
+      return {
+        ...item,
+        widget: "Print",
+      };
+    } else if (item.type === "section") {
+      return {
+        ...item,
+        children: addPrintWidgetToFields(item.children),
+      };
+    }
+    return item;
+  });
+}

--- a/frontend/src/components/applyForm/utils.ts
+++ b/frontend/src/components/applyForm/utils.ts
@@ -831,7 +831,10 @@ export const pointerToFieldName = (pointer: string): string => {
 export function addPrintWidgetToFields(uiSchema: UiSchema): UiSchema {
   return uiSchema.map((item) => {
     if (item.type === "field") {
-      if (item.widget && item.widget === "AttachmentArray") {
+      if (
+        item.widget &&
+        (item.widget === "AttachmentArray" || item.widget === "Attachment")
+      ) {
         return {
           ...item,
           widget: "PrintAttachment",

--- a/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
@@ -1,0 +1,120 @@
+// file adapted from https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/templates/BaseInputTemplate.tsx
+// changes made to include USWDS and allow to functional as non-reactive form field
+import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
+import { useApplicationAttachments } from "src/hooks/ApplicationAttachments";
+
+import { useEffect, useState } from "react";
+import { FormGroup } from "@trussworks/react-uswds";
+
+import { FieldErrors } from "src/components/applyForm/FieldErrors";
+import { UploadedFile, UswdsWidgetProps } from "src/components/applyForm/types";
+import { DynamicFieldLabel } from "./DynamicFieldLabel";
+
+/** The `TextWidget` component uses the `BaseInputTemplate`.
+ *
+ * @param props - The `WidgetProps` for this component
+ */
+function PrintAttachmentWidget<
+  T = unknown,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = never,
+>({
+  id,
+  required,
+  schema,
+  value,
+  rawErrors = [],
+  formClassName,
+}: UswdsWidgetProps<T, S, F>) {
+  const { title, description } = schema as S;
+  const { attachments } = useApplicationAttachments();
+  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+
+  useEffect(() => {
+    let parsedValue: string[] = [];
+
+    if (Array.isArray(value)) {
+      parsedValue = value as string[];
+    } else if (typeof value === "string") {
+      try {
+        // casting doesn’t fully satisfy the linter because it treats schema as possibly any underneath
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const parsed = JSON.parse(value);
+        if (
+          Array.isArray(parsed) &&
+          parsed.every((item) => typeof item === "string")
+        ) {
+          parsedValue = parsed;
+        }
+      } catch {
+        console.warn("Invalid JSON string for attachment:", value);
+      }
+    }
+
+    if (parsedValue.length > 0) {
+      const hydrated = parsedValue.map((uuid) => {
+        const match = attachments?.find(
+          (a) => a.application_attachment_id === uuid,
+        );
+        return {
+          id: uuid,
+          name: match?.file_name || "(Previously uploaded file)",
+        };
+      });
+
+      setUploadedFiles(hydrated);
+    }
+  }, [value, attachments]);
+
+  const error = rawErrors.length ? true : undefined;
+
+  return (
+    <FormGroup
+      className={formClassName}
+      key={`form-group__text-input--${id}`}
+      error={error}
+    >
+      <DynamicFieldLabel
+        idFor={id}
+        title={title}
+        required={required}
+        description={description as string}
+        labelType={"hide-helper-text"}
+      />
+      {error && (
+        <FieldErrors fieldName={id} rawErrors={rawErrors as string[]} />
+      )}
+      {uploadedFiles.length > 0 && (
+        <ul className="usa-list usa-list--unstyled margin-top-2">
+          {uploadedFiles.map((file, index) => {
+            const attachment = attachments?.find(
+              (a) => a.application_attachment_id === file.id,
+            );
+
+            return (
+              <li
+                key={`${file.id}-${index}`}
+                className="margin-bottom-1 display-flex flex-align-center"
+              >
+                {attachment?.download_path ? (
+                  <a
+                    href={attachment.download_path}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary display-inline-flex align-items-center"
+                  >
+                    {file.name}
+                  </a>
+                ) : (
+                  <span>{file.name}</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </FormGroup>
+  );
+}
+
+export default PrintAttachmentWidget;

--- a/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
@@ -1,77 +1,37 @@
-// file adapted from https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/templates/BaseInputTemplate.tsx
-// changes made to include USWDS and allow to functional as non-reactive form field
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 import { useApplicationAttachments } from "src/hooks/ApplicationAttachments";
 
-import { useEffect, useState } from "react";
 import { FormGroup } from "@trussworks/react-uswds";
 
-import { UploadedFile, UswdsWidgetProps } from "src/components/applyForm/types";
+import { UswdsWidgetProps } from "src/components/applyForm/types";
 
-/** The `TextWidget` component uses the `BaseInputTemplate`.
- *
- * @param props - The `WidgetProps` for this component
- */
 function PrintAttachmentWidget<
   T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
   F extends FormContextType = never,
->({
-  id,
-  required,
-  schema,
-  value,
-  rawErrors = [],
-  formClassName,
-}: UswdsWidgetProps<T, S, F>) {
+>({ id, required, schema, value, formClassName }: UswdsWidgetProps<T, S, F>) {
   const { title } = schema as S;
   const { attachments } = useApplicationAttachments();
-  const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
 
-  useEffect(() => {
-    let parsedValue: string[] = [];
+  const values = Array.isArray(value)
+    ? (value as string[])
+    : ([value] as string[]);
+  let hydrated: { id: string; name: string }[] = [];
 
-    if (Array.isArray(value)) {
-      parsedValue = value as string[];
-    } else if (typeof value === "string") {
-      try {
-        // casting doesn’t fully satisfy the linter because it treats schema as possibly any underneath
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const parsed = JSON.parse(value);
-        if (
-          Array.isArray(parsed) &&
-          parsed.every((item) => typeof item === "string")
-        ) {
-          parsedValue = parsed;
-        }
-      } catch {
-        console.warn("Invalid JSON string for attachment:", value);
-      }
-    }
-
-    if (parsedValue.length > 0) {
-      const hydrated = parsedValue.map((uuid) => {
-        const match = attachments?.find(
-          (a) => a.application_attachment_id === uuid,
-        );
-        return {
-          id: uuid,
-          name: match?.file_name || "(Previously uploaded file)",
-        };
-      });
-
-      setUploadedFiles(hydrated);
-    }
-  }, [value, attachments]);
-
-  const error = rawErrors.length ? true : undefined;
+  if (values.length > 0) {
+    hydrated = values.map((uuid) => {
+      const match = attachments?.find(
+        (a) => a.application_attachment_id === uuid,
+      );
+      return {
+        id: uuid,
+        name: match?.file_name || "(Previously uploaded file)",
+      };
+    });
+  }
 
   return (
-    <FormGroup
-      className={formClassName}
-      key={`form-group__text-input--${id}`}
-      error={error}
-    >
+    <FormGroup className={formClassName} key={`form-group__text-input--${id}`}>
       <div className="text-bold">
         {title}
         {required && (
@@ -80,9 +40,9 @@ function PrintAttachmentWidget<
           </span>
         )}
       </div>
-      {uploadedFiles.length > 0 && (
+      {hydrated.length > 0 && (
         <ul className="usa-list usa-list--unstyled margin-top-2">
-          {uploadedFiles.map((file, index) => {
+          {hydrated.map((file, index) => {
             return (
               <li
                 key={`${file.id}-${index}`}

--- a/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
@@ -6,9 +6,7 @@ import { useApplicationAttachments } from "src/hooks/ApplicationAttachments";
 import { useEffect, useState } from "react";
 import { FormGroup } from "@trussworks/react-uswds";
 
-import { FieldErrors } from "src/components/applyForm/FieldErrors";
 import { UploadedFile, UswdsWidgetProps } from "src/components/applyForm/types";
-import { DynamicFieldLabel } from "./DynamicFieldLabel";
 
 /** The `TextWidget` component uses the `BaseInputTemplate`.
  *
@@ -26,7 +24,7 @@ function PrintAttachmentWidget<
   rawErrors = [],
   formClassName,
 }: UswdsWidgetProps<T, S, F>) {
-  const { title, description } = schema as S;
+  const { title } = schema as S;
   const { attachments } = useApplicationAttachments();
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
 
@@ -74,40 +72,23 @@ function PrintAttachmentWidget<
       key={`form-group__text-input--${id}`}
       error={error}
     >
-      <DynamicFieldLabel
-        idFor={id}
-        title={title}
-        required={required}
-        description={description as string}
-        labelType={"hide-helper-text"}
-      />
-      {error && (
-        <FieldErrors fieldName={id} rawErrors={rawErrors as string[]} />
-      )}
+      <div className="text-bold">
+        {title}
+        {required && (
+          <span className="usa-hint usa-hint--required text-no-underline">
+            *
+          </span>
+        )}
+      </div>
       {uploadedFiles.length > 0 && (
         <ul className="usa-list usa-list--unstyled margin-top-2">
           {uploadedFiles.map((file, index) => {
-            const attachment = attachments?.find(
-              (a) => a.application_attachment_id === file.id,
-            );
-
             return (
               <li
                 key={`${file.id}-${index}`}
-                className="margin-bottom-1 display-flex flex-align-center"
+                className="margin-bottom-1 display-flex flex-align-center border-1px bg-base-lightest font-family-mono padding-05 maxw-tablet border-base-lighter"
               >
-                {attachment?.download_path ? (
-                  <a
-                    href={attachment.download_path}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-primary display-inline-flex align-items-center"
-                  >
-                    {file.name}
-                  </a>
-                ) : (
-                  <span>{file.name}</span>
-                )}
+                <span className="">{file.name}</span>
               </li>
             );
           })}

--- a/frontend/src/components/applyForm/widgets/PrintWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/PrintWidget.tsx
@@ -6,7 +6,6 @@ import { FormGroup } from "@trussworks/react-uswds";
 
 import { FieldErrors } from "src/components/applyForm/FieldErrors";
 import { UswdsWidgetProps } from "src/components/applyForm/types";
-import { DynamicFieldLabel } from "./DynamicFieldLabel";
 
 /** The `TextWidget` component uses the `BaseInputTemplate`.
  *
@@ -25,7 +24,7 @@ function PrintWidget<
   formClassName,
   inputClassName,
 }: UswdsWidgetProps<T, S, F>) {
-  const { title, description } = schema as S;
+  const { title } = schema as S;
 
   const error = rawErrors.length ? true : undefined;
 
@@ -35,13 +34,14 @@ function PrintWidget<
       key={`form-group__text-input--${id}`}
       error={error}
     >
-      <DynamicFieldLabel
-        idFor={id}
-        title={title}
-        required={required}
-        description={description as string}
-        labelType={"hide-helper-text"}
-      />
+      <div className="text-bold">
+        {title}
+        {required && (
+          <span className="usa-hint usa-hint--required text-no-underline">
+            *
+          </span>
+        )}
+      </div>
       {error && (
         <FieldErrors fieldName={id} rawErrors={rawErrors as string[]} />
       )}

--- a/frontend/src/components/applyForm/widgets/PrintWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/PrintWidget.tsx
@@ -1,16 +1,9 @@
-// file adapted from https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/templates/BaseInputTemplate.tsx
-// changes made to include USWDS and allow to functional as non-reactive form field
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 
 import { FormGroup } from "@trussworks/react-uswds";
 
-import { FieldErrors } from "src/components/applyForm/FieldErrors";
 import { UswdsWidgetProps } from "src/components/applyForm/types";
 
-/** The `TextWidget` component uses the `BaseInputTemplate`.
- *
- * @param props - The `WidgetProps` for this component
- */
 function PrintWidget<
   T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
@@ -20,20 +13,13 @@ function PrintWidget<
   required,
   schema,
   value,
-  rawErrors = [],
   formClassName,
   inputClassName,
 }: UswdsWidgetProps<T, S, F>) {
   const { title } = schema as S;
 
-  const error = rawErrors.length ? true : undefined;
-
   return (
-    <FormGroup
-      className={formClassName}
-      key={`form-group__text-input--${id}`}
-      error={error}
-    >
+    <FormGroup className={formClassName} key={`form-group__text-input--${id}`}>
       <div className="text-bold">
         {title}
         {required && (
@@ -42,9 +28,6 @@ function PrintWidget<
           </span>
         )}
       </div>
-      {error && (
-        <FieldErrors fieldName={id} rawErrors={rawErrors as string[]} />
-      )}
       <div data-testid={id} className={inputClassName} id={id} key={id}>
         {(value as string) ?? ""}
       </div>

--- a/frontend/src/components/applyForm/widgets/PrintWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/PrintWidget.tsx
@@ -1,0 +1,55 @@
+// file adapted from https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/templates/BaseInputTemplate.tsx
+// changes made to include USWDS and allow to functional as non-reactive form field
+import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
+
+import { FormGroup } from "@trussworks/react-uswds";
+
+import { FieldErrors } from "src/components/applyForm/FieldErrors";
+import { UswdsWidgetProps } from "src/components/applyForm/types";
+import { DynamicFieldLabel } from "./DynamicFieldLabel";
+
+/** The `TextWidget` component uses the `BaseInputTemplate`.
+ *
+ * @param props - The `WidgetProps` for this component
+ */
+function PrintWidget<
+  T = unknown,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = never,
+>({
+  id,
+  required,
+  schema,
+  value,
+  rawErrors = [],
+  formClassName,
+  inputClassName,
+}: UswdsWidgetProps<T, S, F>) {
+  const { title, description } = schema as S;
+
+  const error = rawErrors.length ? true : undefined;
+
+  return (
+    <FormGroup
+      className={formClassName}
+      key={`form-group__text-input--${id}`}
+      error={error}
+    >
+      <DynamicFieldLabel
+        idFor={id}
+        title={title}
+        required={required}
+        description={description as string}
+        labelType={"hide-helper-text"}
+      />
+      {error && (
+        <FieldErrors fieldName={id} rawErrors={rawErrors as string[]} />
+      )}
+      <div data-testid={id} className={inputClassName} id={id} key={id}>
+        {(value as string) ?? ""}
+      </div>
+    </FormGroup>
+  );
+}
+
+export default PrintWidget;

--- a/frontend/src/components/applyForm/widgets/Widgets.tsx
+++ b/frontend/src/components/applyForm/widgets/Widgets.tsx
@@ -11,6 +11,8 @@ import Budget424aSectionF from "./budget/Budget424aSectionF";
 import CheckboxWidget from "./CheckboxWidget";
 import AttachmentArrayWidget from "./MultipleAttachmentUploadWidget";
 import MultiSelect from "./MultiSelectWidget";
+import PrintAttachmentWidget from "./PrintAttachmentWidget";
+import PrintWidget from "./PrintWidget";
 import RadioWidget from "./RadioWidget";
 import SelectWidget from "./SelectWidget";
 import TextAreaWidget from "./TextAreaWidget";
@@ -25,6 +27,9 @@ export const widgetComponents: Record<
   Radio: (widgetProps: UswdsWidgetProps) => RadioWidget(widgetProps),
   Select: (widgetProps: UswdsWidgetProps) => SelectWidget(widgetProps),
   Checkbox: (widgetProps: UswdsWidgetProps) => CheckboxWidget(widgetProps),
+  Print: (widgetProps: UswdsWidgetProps) => PrintWidget(widgetProps),
+  PrintAttachment: (widgetProps: UswdsWidgetProps) =>
+    PrintAttachmentWidget(widgetProps),
   Attachment: (widgetProps: UswdsWidgetProps) => AttachmentWidget(widgetProps),
   AttachmentArray: (widgetProps: UswdsWidgetProps) =>
     AttachmentArrayWidget(widgetProps),

--- a/frontend/tests/components/applyForm/PrintForm.test.tsx
+++ b/frontend/tests/components/applyForm/PrintForm.test.tsx
@@ -1,0 +1,258 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { RJSFSchema } from "@rjsf/utils";
+import { render, screen } from "@testing-library/react";
+import { Attachment } from "src/types/attachmentTypes";
+
+import PrintForm from "src/components/applyForm/PrintForm";
+import { UiSchema } from "src/components/applyForm/types";
+
+// Mock FormFields component
+jest.mock("src/components/applyForm/FormFields", () => ({
+  FormFields: ({ formData, schema, uiSchema, errors }: any) => (
+    <div data-testid="form-fields">
+      <div data-testid="form-data">{JSON.stringify(formData)}</div>
+      <div data-testid="schema">{JSON.stringify(schema)}</div>
+      <div data-testid="ui-schema">{JSON.stringify(uiSchema)}</div>
+      <div data-testid="errors">{JSON.stringify(errors)}</div>
+    </div>
+  ),
+}));
+
+// Mock AttachmentsProvider
+jest.mock("src/hooks/ApplicationAttachments", () => ({
+  AttachmentsProvider: ({ children, value }: any) => (
+    <div data-testid="attachments-provider" data-value={JSON.stringify(value)}>
+      {children}
+    </div>
+  ),
+}));
+
+describe("PrintForm", () => {
+  const mockSetAttachmentsChanged = jest.fn();
+
+  const defaultProps = {
+    attachments: [] as Attachment[],
+    formSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", title: "Name" },
+        email: { type: "string", title: "Email" },
+      },
+    } as RJSFSchema,
+    savedFormData: {
+      name: "John Doe",
+      email: "john@example.com",
+    },
+    uiSchema: [
+      {
+        type: "field" as const,
+        definition: "/properties/name" as const,
+        schema: { title: "Name" },
+      },
+      {
+        type: "field" as const,
+        definition: "/properties/email" as const,
+        schema: { title: "Email" },
+      },
+    ] as UiSchema,
+    setAttachmentsChanged: mockSetAttachmentsChanged,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders with basic props", () => {
+    render(<PrintForm {...defaultProps} />);
+
+    expect(screen.getByTestId("attachments-provider")).toBeInTheDocument();
+    expect(screen.getByTestId("form-fields")).toBeInTheDocument();
+  });
+
+  it("passes form data to FormFields", () => {
+    render(<PrintForm {...defaultProps} />);
+
+    const formDataElement = screen.getByTestId("form-data");
+    expect(formDataElement).toHaveTextContent(
+      JSON.stringify(defaultProps.savedFormData),
+    );
+  });
+
+  it("passes form schema to FormFields", () => {
+    render(<PrintForm {...defaultProps} />);
+
+    const schemaElement = screen.getByTestId("schema");
+    expect(schemaElement).toHaveTextContent(
+      JSON.stringify(defaultProps.formSchema),
+    );
+  });
+
+  it("passes ui schema to FormFields", () => {
+    render(<PrintForm {...defaultProps} />);
+
+    const uiSchemaElement = screen.getByTestId("ui-schema");
+    expect(uiSchemaElement).toHaveTextContent(
+      JSON.stringify(defaultProps.uiSchema),
+    );
+  });
+
+  it("passes null errors to FormFields", () => {
+    render(<PrintForm {...defaultProps} />);
+
+    const errorsElement = screen.getByTestId("errors");
+    expect(errorsElement).toHaveTextContent("null");
+  });
+
+  it("provides empty array when attachments is undefined", () => {
+    const props = {
+      ...defaultProps,
+      attachments: undefined as any,
+    };
+
+    render(<PrintForm {...props} />);
+
+    const providerElement = screen.getByTestId("attachments-provider");
+    const providerValue: { attachments: Attachment[] } = JSON.parse(
+      providerElement.getAttribute("data-value") || "{}",
+    );
+
+    expect(providerValue.attachments).toEqual([]);
+  });
+
+  it("provides empty array when attachments is null", () => {
+    const props = {
+      ...defaultProps,
+      attachments: null as any,
+    };
+
+    render(<PrintForm {...props} />);
+
+    const providerElement = screen.getByTestId("attachments-provider");
+    const providerValue: { attachments: Attachment[] } = JSON.parse(
+      providerElement.getAttribute("data-value") || "{}",
+    );
+
+    expect(providerValue.attachments).toEqual([]);
+  });
+
+  it("handles complex form data", () => {
+    const complexFormData = {
+      personalInfo: {
+        firstName: "Jane",
+        lastName: "Smith",
+        address: {
+          street: "123 Main St",
+          city: "Anytown",
+          zipCode: "12345",
+        },
+      },
+      preferences: ["email", "phone"],
+      isActive: true,
+    };
+
+    const props = {
+      ...defaultProps,
+      savedFormData: complexFormData,
+    };
+
+    render(<PrintForm {...props} />);
+
+    const formDataElement = screen.getByTestId("form-data");
+    expect(formDataElement).toHaveTextContent(JSON.stringify(complexFormData));
+  });
+
+  it("handles complex form schema", () => {
+    const complexSchema: RJSFSchema = {
+      type: "object",
+      properties: {
+        personalInfo: {
+          type: "object",
+          properties: {
+            firstName: { type: "string", title: "First Name" },
+            lastName: { type: "string", title: "Last Name" },
+          },
+          required: ["firstName", "lastName"],
+        },
+        preferences: {
+          type: "array",
+          items: { type: "string" },
+          title: "Preferences",
+        },
+      },
+      required: ["personalInfo"],
+    };
+
+    const props = {
+      ...defaultProps,
+      formSchema: complexSchema,
+    };
+
+    render(<PrintForm {...props} />);
+
+    const schemaElement = screen.getByTestId("schema");
+    expect(schemaElement).toHaveTextContent(JSON.stringify(complexSchema));
+  });
+
+  it("handles complex ui schema", () => {
+    const complexUiSchema: UiSchema = [
+      {
+        type: "section" as const,
+        name: "personal-section",
+        label: "Personal Information",
+        children: [
+          {
+            type: "field" as const,
+            definition:
+              "/properties/personalInfo/properties/firstName" as const,
+            schema: { title: "First Name" },
+          },
+          {
+            type: "field" as const,
+            definition: "/properties/personalInfo/properties/lastName" as const,
+            schema: { title: "Last Name" },
+          },
+        ],
+      },
+      {
+        type: "field" as const,
+        definition: "/properties/preferences" as const,
+        schema: { title: "Preferences" },
+      },
+    ];
+
+    const props = {
+      ...defaultProps,
+      uiSchema: complexUiSchema,
+    };
+
+    render(<PrintForm {...props} />);
+
+    const uiSchemaElement = screen.getByTestId("ui-schema");
+    expect(uiSchemaElement).toHaveTextContent(JSON.stringify(complexUiSchema));
+  });
+
+  it("handles empty form data", () => {
+    const props = {
+      ...defaultProps,
+      savedFormData: {},
+    };
+
+    render(<PrintForm {...props} />);
+
+    const formDataElement = screen.getByTestId("form-data");
+    expect(formDataElement).toHaveTextContent("{}");
+  });
+
+  it("handles empty ui schema", () => {
+    const props = {
+      ...defaultProps,
+      uiSchema: [] as UiSchema,
+    };
+
+    render(<PrintForm {...props} />);
+
+    const uiSchemaElement = screen.getByTestId("ui-schema");
+    expect(uiSchemaElement).toHaveTextContent("[]");
+  });
+});

--- a/frontend/tests/components/applyForm/widgets/PrintAttachmentWidget.test.tsx
+++ b/frontend/tests/components/applyForm/widgets/PrintAttachmentWidget.test.tsx
@@ -1,0 +1,173 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { RJSFSchema } from "@rjsf/utils";
+import { render, screen } from "@testing-library/react";
+import { Attachment } from "src/types/attachmentTypes";
+
+import { UswdsWidgetProps } from "src/components/applyForm/types";
+import PrintAttachmentWidget from "src/components/applyForm/widgets/PrintAttachmentWidget";
+
+type UseApplicationAttachmentsResult = {
+  attachments: Attachment[] | null;
+};
+
+const mockUseApplicationAttachments = jest.fn<
+  UseApplicationAttachmentsResult,
+  []
+>();
+jest.mock("src/hooks/ApplicationAttachments", () => ({
+  useApplicationAttachments: (): UseApplicationAttachmentsResult =>
+    mockUseApplicationAttachments(),
+}));
+
+describe("PrintAttachmentWidget", () => {
+  const defaultProps: UswdsWidgetProps = {
+    id: "test-attachment-field",
+    required: false,
+    schema: {
+      title: "Upload Documents",
+      type: "array",
+    } as RJSFSchema,
+    value: [],
+    rawErrors: [],
+    formClassName: "test-form-class",
+    inputClassName: "test-input-class",
+    label: "Test Label",
+  };
+
+  const mockAttachments: Attachment[] = [
+    {
+      application_attachment_id: "uuid-1",
+      file_name: "document1.pdf",
+      download_path: "/download/uuid-1",
+      file_size_bytes: 12345,
+      mime_type: "application/pdf",
+      created_at: "2024-01-01T00:00:00.000Z",
+      updated_at: "2024-01-01T00:00:00.000Z",
+    },
+    {
+      application_attachment_id: "uuid-2",
+      file_name: "document2.docx",
+      download_path: "/download/uuid-2",
+      file_size_bytes: 23456,
+      mime_type:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      created_at: "2024-01-02T00:00:00.000Z",
+      updated_at: "2024-01-02T00:00:00.000Z",
+    },
+    {
+      application_attachment_id: "uuid-3",
+      file_name: "document3.txt",
+      download_path: "/download/uuid-2",
+      file_size_bytes: 345,
+      mime_type: "text/plain",
+      created_at: "2024-01-03T00:00:00.000Z",
+      updated_at: "2024-01-03T00:00:00.000Z",
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApplicationAttachments.mockReturnValue({
+      attachments: mockAttachments,
+    });
+  });
+
+  it("renders with basic props and no attachments", () => {
+    render(<PrintAttachmentWidget {...defaultProps} />);
+
+    expect(screen.getByText("Upload Documents")).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("displays the field title from schema", () => {
+    const props = {
+      ...defaultProps,
+      schema: {
+        ...defaultProps.schema,
+        title: "Custom Attachment Field",
+      },
+    };
+
+    render(<PrintAttachmentWidget {...props} />);
+
+    expect(screen.getByText("Custom Attachment Field")).toBeInTheDocument();
+  });
+
+  it("shows required indicator when field is required", () => {
+    const props = {
+      ...defaultProps,
+      required: true,
+    };
+
+    render(<PrintAttachmentWidget {...props} />);
+
+    expect(screen.getByText("*")).toBeInTheDocument();
+    expect(screen.getByText("*")).toHaveClass(
+      "usa-hint",
+      "usa-hint--required",
+      "text-no-underline",
+    );
+  });
+
+  it("does not show required indicator when field is not required", () => {
+    const props = {
+      ...defaultProps,
+      required: false,
+    };
+
+    render(<PrintAttachmentWidget {...props} />);
+
+    expect(screen.queryByText("*")).not.toBeInTheDocument();
+  });
+
+  it("displays uploaded files from array value", () => {
+    const props = {
+      ...defaultProps,
+      value: ["uuid-1", "uuid-2"],
+    };
+
+    render(<PrintAttachmentWidget {...props} />);
+
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getByText("document1.pdf")).toBeInTheDocument();
+    expect(screen.getByText("document2.docx")).toBeInTheDocument();
+  });
+
+  it("displays file name as text", () => {
+    const props = {
+      ...defaultProps,
+      value: ["uuid-3"],
+    };
+
+    render(<PrintAttachmentWidget {...props} />);
+
+    expect(screen.getByText("document3.txt")).toBeInTheDocument();
+  });
+
+  it("displays fallback text for files not found in attachments", () => {
+    const props = {
+      ...defaultProps,
+      value: ["uuid-unknown"],
+    };
+
+    render(<PrintAttachmentWidget {...props} />);
+
+    expect(screen.getByText("(Previously uploaded file)")).toBeInTheDocument();
+  });
+
+  it("handles empty attachments array", () => {
+    mockUseApplicationAttachments.mockReturnValue({
+      attachments: [],
+    });
+
+    const props = {
+      ...defaultProps,
+      value: ["uuid-1"],
+    };
+
+    render(<PrintAttachmentWidget {...props} />);
+
+    expect(screen.getByText("(Previously uploaded file)")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/applyForm/widgets/PrintWidget.test.tsx
+++ b/frontend/tests/components/applyForm/widgets/PrintWidget.test.tsx
@@ -103,19 +103,6 @@ describe("PrintWidget", () => {
     expect(screen.queryByText("*")).not.toBeInTheDocument();
   });
 
-  it("displays errors when rawErrors are provided", () => {
-    const props = {
-      ...defaultProps,
-      rawErrors: ["Error message 1", "Error message 2"],
-    };
-
-    render(<PrintWidget {...props} />);
-
-    expect(screen.getByTestId("errorMessage")).toBeInTheDocument();
-    expect(screen.getByText("Error message 1")).toBeInTheDocument();
-    expect(screen.getByText("Error message 2")).toBeInTheDocument();
-  });
-
   it("does not display errors when rawErrors is empty", () => {
     const props = {
       ...defaultProps,
@@ -127,16 +114,6 @@ describe("PrintWidget", () => {
     expect(
       screen.queryByTestId("field-errors-test-field"),
     ).not.toBeInTheDocument();
-  });
-
-  it("applies error state to FormGroup when errors exist", () => {
-    const props = {
-      ...defaultProps,
-      rawErrors: ["Some error"],
-    };
-
-    render(<PrintWidget {...props} />);
-    expect(screen.getByTestId("errorMessage")).toBeInTheDocument();
   });
 
   it("applies custom CSS classes", () => {

--- a/frontend/tests/components/applyForm/widgets/PrintWidget.test.tsx
+++ b/frontend/tests/components/applyForm/widgets/PrintWidget.test.tsx
@@ -1,0 +1,186 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable testing-library/no-node-access */
+import { RJSFSchema } from "@rjsf/utils";
+import { render, screen } from "@testing-library/react";
+
+import PrintWidget from "src/components/applyForm/widgets/PrintWidget";
+
+describe("PrintWidget", () => {
+  const defaultProps = {
+    id: "test-field",
+    required: false,
+    schema: {
+      title: "Test Field",
+      type: "string" as const,
+    },
+    value: "Test Value",
+    rawErrors: [],
+    formClassName: "test-form-class",
+    inputClassName: "test-input-class",
+    placeholder: "",
+    readonly: false,
+    disabled: false,
+    autofocus: false,
+    label: "Test Label",
+    hideLabel: false,
+    hideError: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders with basic props", () => {
+    render(<PrintWidget {...defaultProps} />);
+
+    expect(screen.getByText("Test Field")).toBeInTheDocument();
+    expect(screen.getByText("Test Value")).toBeInTheDocument();
+    expect(screen.getByTestId("test-field")).toBeInTheDocument();
+  });
+
+  it("displays the field title from schema", () => {
+    const props = {
+      ...defaultProps,
+      schema: {
+        ...defaultProps.schema,
+        title: "Custom Field Title",
+      },
+    };
+
+    render(<PrintWidget {...props} />);
+
+    expect(screen.getByText("Custom Field Title")).toBeInTheDocument();
+  });
+
+  it("displays the field value", () => {
+    const props = {
+      ...defaultProps,
+      value: "Custom Test Value",
+    };
+
+    render(<PrintWidget {...props} />);
+
+    expect(screen.getByText("Custom Test Value")).toBeInTheDocument();
+  });
+
+  it("displays empty string when value is null or undefined", () => {
+    const propsWithNull = {
+      ...defaultProps,
+      value: null,
+    };
+
+    render(<PrintWidget {...propsWithNull} />);
+
+    const fieldElement = screen.getByTestId("test-field");
+    expect(fieldElement).toHaveTextContent("");
+  });
+
+  it("shows required indicator when field is required", () => {
+    const props = {
+      ...defaultProps,
+      required: true,
+    };
+
+    render(<PrintWidget {...props} />);
+
+    expect(screen.getByText("*")).toBeInTheDocument();
+    expect(screen.getByText("*")).toHaveClass(
+      "usa-hint",
+      "usa-hint--required",
+      "text-no-underline",
+    );
+  });
+
+  it("does not show required indicator when field is not required", () => {
+    const props = {
+      ...defaultProps,
+      required: false,
+    };
+
+    render(<PrintWidget {...props} />);
+
+    expect(screen.queryByText("*")).not.toBeInTheDocument();
+  });
+
+  it("displays errors when rawErrors are provided", () => {
+    const props = {
+      ...defaultProps,
+      rawErrors: ["Error message 1", "Error message 2"],
+    };
+
+    render(<PrintWidget {...props} />);
+
+    expect(screen.getByTestId("errorMessage")).toBeInTheDocument();
+    expect(screen.getByText("Error message 1")).toBeInTheDocument();
+    expect(screen.getByText("Error message 2")).toBeInTheDocument();
+  });
+
+  it("does not display errors when rawErrors is empty", () => {
+    const props = {
+      ...defaultProps,
+      rawErrors: [],
+    };
+
+    render(<PrintWidget {...props} />);
+
+    expect(
+      screen.queryByTestId("field-errors-test-field"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies error state to FormGroup when errors exist", () => {
+    const props = {
+      ...defaultProps,
+      rawErrors: ["Some error"],
+    };
+
+    render(<PrintWidget {...props} />);
+    expect(screen.getByTestId("errorMessage")).toBeInTheDocument();
+  });
+
+  it("applies custom CSS classes", () => {
+    const props = {
+      ...defaultProps,
+      formClassName: "custom-form-class",
+      inputClassName: "custom-input-class",
+    };
+
+    render(<PrintWidget {...props} />);
+
+    const inputElement = screen.getByTestId("test-field");
+    expect(inputElement).toHaveClass("custom-input-class");
+  });
+
+  it("sets correct HTML attributes", () => {
+    render(<PrintWidget {...defaultProps} />);
+
+    const fieldElement = screen.getByTestId("test-field");
+    expect(fieldElement).toHaveAttribute("id", "test-field");
+    expect(fieldElement).toHaveAttribute("data-testid", "test-field");
+  });
+
+  it("handles numeric values by converting to string", () => {
+    const props = {
+      ...defaultProps,
+      value: 12345,
+    };
+
+    render(<PrintWidget {...props} />);
+
+    expect(screen.getByText("12345")).toBeInTheDocument();
+  });
+
+  it("renders with minimal props", () => {
+    const minimalProps = {
+      id: "minimal",
+      schema: { title: "Minimal" } as RJSFSchema,
+      value: "Value",
+    };
+
+    render(<PrintWidget {...minimalProps} />);
+
+    expect(screen.getByText("Minimal")).toBeInTheDocument();
+    expect(screen.getByText("Value")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #6544 #6138 #6141 #6142

## Changes proposed

Creates new print widgets and print component to make the print view look better. Updates uiSchema for print to display printed versions. Ignores `multiField`, so no update to budget forms.

### Figma

<img width="556" height="459" alt="image" src="https://github.com/user-attachments/assets/4de9f55c-33cd-4f95-9e49-653caa55deca" />

https://www.figma.com/design/zPlDWcYM396szw2yL3UXvk/Simpler-Grants-2025?node-id=5219-57461&m=dev

### Screenshots

<img width="817" height="438" alt="image" src="https://github.com/user-attachments/assets/05eeb907-eae8-4ee2-83ba-6b695c9c2e30" />

<img width="779" height="722" alt="image" src="https://github.com/user-attachments/assets/32914c99-de1e-408c-8189-962f2bce5c08" />


## Validation steps

1. Create a new application, fill out the forms.
2. Create a token in the API folder `make generate-internal-token`
3. Replace `workspace/applications` with `print` in form URL
4. View the form (I use https://modheader.com/) to add the internal token so I can see it in the web browser


