### PR TITLE
[Issue #6207] Remove ability to change application name after successful submission

### DIFF
--- a/frontend/src/components/application/InformationCard.tsx
+++ b/frontend/src/components/application/InformationCard.tsx
@@ -138,11 +138,14 @@ export const InformationCard = ({
         <Grid tablet={{ col: 12 }} mobile={{ col: 12 }}>
           <h3 className="margin-top-2">
             {applicationDetails.application_name}
-            <EditAppFilingName
-              applicationId={applicationDetails.application_id}
-              applicationName={applicationDetails.application_name}
-              opportunityName={opportunityName}
-            />
+            {applicationDetails.application_status !== Status.SUBMITTED &&
+              applicationDetails.application_status !== Status.ACCEPTED && (
+                <EditAppFilingName
+                  applicationId={applicationDetails.application_id}
+                  applicationName={applicationDetails.application_name}
+                  opportunityName={opportunityName}
+                />
+              )}
           </h3>
         </Grid>
         <Grid tablet={{ col: 6 }} mobile={{ col: 12 }}>

--- a/frontend/tests/components/application/InformationCard.test.tsx
+++ b/frontend/tests/components/application/InformationCard.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import {
+  ApplicationDetail,
+  Status,
+} from "src/types/applicationResponseTypes";
+import { useTranslationsMock } from "src/utils/testing/intlMocks";
+import applicationMock from "stories/components/application/application.mock.json";
+
+import { InformationCard } from "src/components/application/InformationCard";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => useTranslationsMock(),
+}));
+
+jest.mock("src/components/application/editAppFilingName/EditAppFilingName", () => ({
+  EditAppFilingName: () => <button>buttonText</button>,
+}));
+
+const mockApplicationDetails =
+  applicationMock as unknown as ApplicationDetail;
+
+describe("InformationCard - Edit filing name button visibility", () => {
+  const defaultProps = {
+    applicationDetails: mockApplicationDetails,
+    applicationSubmitHandler: jest.fn(),
+    applicationSubmitted: false,
+    opportunityName: "Test Opportunity",
+    submissionLoading: false,
+    instructionsDownloadPath: "http://path-to-instructions.com",
+  };
+
+  it("shows Edit filing name button when application status is in_progress", () => {
+    const inProgressApplication = {
+      ...mockApplicationDetails,
+      application_status: Status.IN_PROGRESS,
+    };
+
+    render(
+      <InformationCard
+        {...defaultProps}
+        applicationDetails={inProgressApplication}
+      />,
+    );
+
+    const editButton = screen.getByText("buttonText");
+    expect(editButton).toBeInTheDocument();
+  });
+
+  it("hides Edit filing name button when application status is submitted", () => {
+    const submittedApplication = {
+      ...mockApplicationDetails,
+      application_status: Status.SUBMITTED,
+    };
+
+    render(
+      <InformationCard
+        {...defaultProps}
+        applicationDetails={submittedApplication}
+      />,
+    );
+
+    const editButton = screen.queryByText("buttonText");
+    expect(editButton).not.toBeInTheDocument();
+  });
+
+  it("hides Edit filing name button when application status is accepted", () => {
+    const acceptedApplication = {
+      ...mockApplicationDetails,
+      application_status: Status.ACCEPTED,
+    };
+
+    render(
+      <InformationCard
+        {...defaultProps}
+        applicationDetails={acceptedApplication}
+      />,
+    );
+
+    const editButton = screen.queryByText("buttonText");
+    expect(editButton).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/application/InformationCard.test.tsx
+++ b/frontend/tests/components/application/InformationCard.test.tsx
@@ -1,8 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import {
-  ApplicationDetail,
-  Status,
-} from "src/types/applicationResponseTypes";
+import { ApplicationDetail, Status } from "src/types/applicationResponseTypes";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 import applicationMock from "stories/components/application/application.mock.json";
 
@@ -12,12 +9,14 @@ jest.mock("next-intl", () => ({
   useTranslations: () => useTranslationsMock(),
 }));
 
-jest.mock("src/components/application/editAppFilingName/EditAppFilingName", () => ({
-  EditAppFilingName: () => <button>buttonText</button>,
-}));
+jest.mock(
+  "src/components/application/editAppFilingName/EditAppFilingName",
+  () => ({
+    EditAppFilingName: () => <button>buttonText</button>,
+  }),
+);
 
-const mockApplicationDetails =
-  applicationMock as unknown as ApplicationDetail;
+const mockApplicationDetails = applicationMock as unknown as ApplicationDetail;
 
 describe("InformationCard - Edit filing name button visibility", () => {
   const defaultProps = {


### PR DESCRIPTION
## Summary

Fixes #6207 

## Changes proposed
Prevent user from editing application filinging name after submitting the application

## Context for reviewers
We don't have acceptance implemented yet 