### PR TITLE
[Issue #6585] Stream soap proxy response data instead of chunking

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -85,7 +85,7 @@ class BaseSOAPClient:
 
         try:
             proxy_response_payload = SOAPPayload(
-                proxy_response.data.decode(errors="replace"),
+                proxy_response.to_bytes().decode(errors="replace"),
                 operation_name=self.operation_config.response_operation_name,
                 force_list_attributes=self.operation_config.force_list_attributes,
             )
@@ -150,7 +150,9 @@ class BaseSOAPClient:
                 },
             )
 
-    def get_simpler_soap_response(self, proxy_response: SOAPResponse) -> tuple:
+    def get_simpler_soap_response(
+        self, proxy_response: SOAPResponse, compare: bool = False
+    ) -> tuple:
         """
         This method is responsible getting the simpler soap xml payload.
 
@@ -158,13 +160,6 @@ class BaseSOAPClient:
         proxy responses. We then utilize the SOAPPayload class to get the
         XML soap response from the validated XML dicts.
         """
-        proxy_response_soap_dict = self.get_proxy_soap_response_dict(proxy_response)
-        log_local(
-            msg="proxy response validated dict",
-            data=proxy_response_soap_dict,
-            formatter=json_formatter,
-        )
-
         simpler_response_soap_dict = self.get_soap_response_dict()
         log_local(
             msg="simpler response dict", data=simpler_response_soap_dict, formatter=json_formatter
@@ -180,11 +175,18 @@ class BaseSOAPClient:
         )
         log_local(msg="simpler response XML", data=simpler_response_xml, formatter=xml_formatter)
 
-        # We will only run diffs for responses that do not match.
-        if proxy_response_soap_dict == simpler_response_soap_dict:
-            logger.info("soap_api_diff responses match", extra={"soap_responses_match": True})
-        else:
-            self.log_diffs(proxy_response_soap_dict, simpler_response_soap_dict)
+        if compare:
+            proxy_response_soap_dict = self.get_proxy_soap_response_dict(proxy_response)
+            log_local(
+                msg="proxy response validated dict",
+                data=proxy_response_soap_dict,
+                formatter=json_formatter,
+            )
+            # We will only run diffs for responses that do not match.
+            if proxy_response_soap_dict == simpler_response_soap_dict:
+                logger.info("soap_api_diff responses match", extra={"soap_responses_match": True})
+            else:
+                self.log_diffs(proxy_response_soap_dict, simpler_response_soap_dict)
 
         use_simpler_response = False
         return (

--- a/api/src/legacy_soap_api/legacy_soap_api_schemas.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_schemas.py
@@ -1,3 +1,5 @@
+from typing import Iterator, List
+
 from pydantic import BaseModel, ConfigDict
 
 from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth
@@ -76,12 +78,38 @@ class SOAPRequest(BaseModel):
 
 
 class SOAPResponse(BaseModel):
-    data: bytes
+    data: bytes | Iterator[bytes] | List[bytes]
     status_code: int
     headers: dict
+    _cached_bytes: bytes | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def to_flask_response(self) -> tuple:
-        return self.data, self.status_code, self.headers
+        response_data = self.data if isinstance(self.data, bytes) else self.stream()
+        return response_data, self.status_code, self.headers
+
+    def to_bytes(self) -> bytes:
+        if isinstance(self.data, bytes):
+            return self.data
+        if self._cached_bytes is not None:
+            return self._cached_bytes
+        else:
+            self._cached_bytes = b"".join(iter(self.data))
+            return self._cached_bytes
+
+    def stream(self) -> Iterator[bytes] | List[bytes]:
+
+        def _data_generator(data: bytes) -> Iterator[bytes]:
+            data_length = len(data)
+            for i in range(0, data_length, 4000):
+                yield data[i : i + 4000]
+
+        if self._cached_bytes:
+            return _data_generator(self._cached_bytes)
+        if isinstance(self.data, bytes):
+            return _data_generator(self.data)
+        return self.data
 
 
 class BaseSOAPSchema(BaseModel):

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,7 +10,7 @@ from src.legacy_soap_api.applicants.schemas import (
     GetOpportunityListResponse,
     OpportunityDetails,
 )
-from src.legacy_soap_api.legacy_soap_api_client import SimplerApplicantsS2SClient
+from src.legacy_soap_api.legacy_soap_api_client import BaseSOAPClient, SimplerApplicantsS2SClient
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPRequest, SOAPResponse
 from src.util.datetime_util import parse_grants_gov_date
@@ -245,3 +246,85 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
                 simpler_soap_client.operation_config.response_operation_name
             )
         )
+
+
+class TestSimplerBaseSOAPClient:
+
+    def xml_streamer(self):
+        yield b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        yield (b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>")
+        yield b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+
+    def test_get_proxy_soap_response_dict_handles_data_that_is_generator(self, db_session):
+        soap_request = SOAPRequest(
+            data=b"<soap:Envelope><Body><GetOpportunityListRequest></GetOpportunityListRequest></Body></soap:Envelope>",
+            full_path="x",
+            headers={},
+            method="POST",
+            api_name=SimplerSoapAPI.APPLICANTS,
+            operation_name="GetOpportunityListRequest",
+        )
+        client = BaseSOAPClient(soap_request, db_session)
+        proxy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
+        proxy_soap_response_dict = client.get_proxy_soap_response_dict(proxy_response)
+        expected = {
+            "Envelope": {
+                "Body": {
+                    "GetOpportunityListResponse": {
+                        "OpportunityDetails": [{"OpeningDate": "2025-07-20"}]
+                    }
+                }
+            }
+        }
+        assert proxy_soap_response_dict == expected
+
+    def test_get_simpler_soap_response_when_compare_is_compares_outputs_and_true_logs_diffs(
+        self, db_session, caplog
+    ):
+        soap_request = SOAPRequest(
+            data=b"<soap:Envelope><Body><GetOpportunityListRequest></GetOpportunityListRequest></Body></soap:Envelope>",
+            full_path="x",
+            headers={},
+            method="POST",
+            api_name=SimplerSoapAPI.APPLICANTS,
+            operation_name="GetOpportunityListRequest",
+        )
+        client = BaseSOAPClient(soap_request, db_session)
+        proxy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
+        with patch(
+            "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_soap_response_dict"
+        ) as mock_soap_response_dict:
+            caplog.set_level(logging.DEBUG)
+            mock_soap_response_dict.return_value = {}
+            with patch(
+                "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_proxy_soap_response_dict"
+            ) as mock_get_proxy_soap_response_dict:
+                client.get_simpler_soap_response(proxy_response, compare=True)
+                assert len(caplog.records) == 1
+                assert caplog.records[0].message == "soap_api_diff complete"
+                mock_get_proxy_soap_response_dict.assert_called_once_with(proxy_response)
+
+    def test_get_simpler_soap_response_when_compare_is_false_does_not_compare_outputs_and_does_not_not_log_diffs(
+        self, db_session, caplog
+    ):
+        soap_request = SOAPRequest(
+            data=b"<soap:Envelope><Body><GetOpportunityListRequest></GetOpportunityListRequest></Body></soap:Envelope>",
+            full_path="x",
+            headers={},
+            method="POST",
+            api_name=SimplerSoapAPI.APPLICANTS,
+            operation_name="GetOpportunityListRequest",
+        )
+        client = BaseSOAPClient(soap_request, db_session)
+        proxy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
+        with patch(
+            "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_soap_response_dict"
+        ) as mock_soap_response_dict:
+            caplog.set_level(logging.DEBUG)
+            mock_soap_response_dict.return_value = {}
+            with patch(
+                "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_proxy_soap_response_dict"
+            ) as mock_get_proxy_soap_response_dict:
+                mock_get_proxy_soap_response_dict.assert_not_called()
+            client.get_simpler_soap_response(proxy_response, compare=False)
+            assert len(caplog.records) == 0

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_schemas.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_schemas.py
@@ -1,7 +1,23 @@
+from typing import Iterator
+
 import pytest
 from pydantic import ValidationError
 
 from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage, SOAPResponse
+
+
+def xml_bytes() -> bytes:
+    return (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+
+
+def xml_streamer() -> Iterator:
+    yield b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+    yield (b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>")
+    yield b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
 
 
 def test_legacy_soap_api_response_schema_missing_required_fields() -> None:
@@ -29,3 +45,100 @@ def test_fault_message() -> None:
 </soap:Envelope>
 """.encode()
     assert fault.to_xml() == expected_xml_message.strip()
+
+
+def test_soap_response_to_bytes_converts_iterator_to_bytes() -> None:
+    soap_response = SOAPResponse(data=xml_streamer(), status_code=200, headers={})
+    data = soap_response.to_bytes()
+    assert data == (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+
+
+def test_soap_response_to_bytes_returns_bytes_if_data_is_already_bytes() -> None:
+    soap_response = SOAPResponse(data=xml_bytes(), status_code=200, headers={})
+    data = soap_response.to_bytes()
+    assert data == (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+
+
+def test_soap_response_to_bytes_caches_bytes_data() -> None:
+    soap_response = SOAPResponse(data=xml_streamer(), status_code=200, headers={})
+    expected = (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+    data_1 = soap_response.to_bytes()
+    assert data_1 == expected
+    # Since soap_response.data was a generator it is now exhausted
+    assert list(soap_response.data) == []
+    data_2 = soap_response.to_bytes()
+    assert data_2 == expected
+
+
+def test_soap_response_to_flask_response_returns_stream_obj_when_passed_iterator_as_data() -> None:
+    soap_response = SOAPResponse(data=xml_streamer(), status_code=200, headers={})
+    flask_response = soap_response.to_flask_response()[0]
+    assert isinstance(flask_response, Iterator) is True
+    expected = (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+    assert b"".join(flask_response) == expected
+
+
+def test_soap_response_to_flask_response_returns_bytes_when_passed_bytes_as_data() -> None:
+    soap_response = SOAPResponse(data=xml_bytes(), status_code=200, headers={})
+    flask_response = soap_response.to_flask_response()[0]
+    assert isinstance(flask_response, bytes) is True
+    expected = (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+    assert flask_response == expected
+
+
+def test_soap_response_stream_returns_iterator_when_data_is_an_iterator() -> None:
+    soap_response = SOAPResponse(data=xml_streamer(), status_code=200, headers={})
+    stream_response = soap_response.stream()
+    assert isinstance(stream_response, Iterator) is True
+    expected = (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+    assert b"".join(stream_response) == expected
+
+
+def test_soap_response_stream_returns_iterator_when_data_is_bytes() -> None:
+    soap_response = SOAPResponse(data=xml_bytes(), status_code=200, headers={})
+    stream_response = soap_response.stream()
+    assert isinstance(stream_response, Iterator) is True
+    expected = (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+    assert b"".join(stream_response) == expected
+
+
+def test_soap_response_stream_returns_iterator_when_data_is_a_data_stream_from_cache() -> None:
+    soap_response = SOAPResponse(data=xml_streamer(), status_code=200, headers={})
+    soap_response.to_bytes()
+    assert list(soap_response.data) == []
+    stream_response = soap_response.stream()
+    assert isinstance(stream_response, Iterator) is True
+    expected = (
+        b"<soap:Envelope><Body><GetOpportunityListResponse><OpportunityDetails>"
+        b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>"
+        b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
+    )
+    assert b"".join(stream_response) == expected

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_utils.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_utils.py
@@ -67,7 +67,7 @@ def test_get_streamed_soap_response_success():
     expected_headers = {"Content-Type": "application/xml"}
 
     assert isinstance(result, SOAPResponse)
-    assert result.data == expected_data
+    assert b"".join(result.data) == expected_data
     assert result.status_code, 200
     assert result.headers == expected_headers
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #ISSUE6585 

## Changes proposed

Modify SoapResponse to take in bytes or an iterator for data. This is so we can stream data from the soap proxy instead of chunking it into a string.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Currently modifying SoapResponse to perform identically if you pass it an iterator or bytes. Adding the iterator did add some challenges because that iterator could be exhausted, so I modified SoapResponse to cache that data. I also put in a boolean check for the part of the client that compares the two responses (and logs the difference) since you have to stop streaming in order to do that. In the future if we want to, we can flip the boolean based on the operation_name.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
