### PR TITLE
[Issue #6186] keep form save in view

### DIFF
--- a/frontend/src/app/[locale]/(base)/workspace/applications/application/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/applications/application/[applicationId]/form/[appFormId]/page.tsx
@@ -74,7 +74,7 @@ async function FormPage({ params }: formPageProps) {
 
   return (
     <>
-      <GridContainer>
+      <GridContainer className="overflow-auto maxh-viewport">
         <Breadcrumbs
           breadcrumbList={[
             { title: "home", path: "/" },

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -129,7 +129,7 @@ const ApplyForm = ({
       // turns off html5 validation so all error displays are consistent
       noValidate
     >
-      <div className="display-flex flex-justify">
+      <div className="display-flex flex-justify position-sticky top-0 bg-white z-100">
         <div>{required}</div>
         <Button
           data-testid="apply-form-save"

--- a/frontend/src/components/applyForm/ApplyForm.tsx
+++ b/frontend/src/components/applyForm/ApplyForm.tsx
@@ -129,21 +129,23 @@ const ApplyForm = ({
       // turns off html5 validation so all error displays are consistent
       noValidate
     >
-      <div className="display-flex flex-justify position-sticky top-0 bg-white z-100">
-        <div>{required}</div>
-        <Button
-          data-testid="apply-form-save"
-          type="submit"
-          name="apply-form-button"
-          className="margin-top-0"
-          value="save"
-          onClick={() => {
-            setFormChanged(false);
-            setAttachmentsChanged(false);
-          }}
-        >
-          {pending ? "Saving..." : "Save"}
-        </Button>
+      <div className="position-sticky top-0 bg-white z-100">
+        <div className="display-flex flex-justify padding-top-2">
+          <div>{required}</div>
+          <Button
+            data-testid="apply-form-save"
+            type="submit"
+            name="apply-form-button"
+            className="margin-top-0"
+            value="save"
+            onClick={() => {
+              setFormChanged(false);
+              setAttachmentsChanged(false);
+            }}
+          >
+            {pending ? "Saving..." : "Save"}
+          </Button>
+        </div>
       </div>
       <div className="usa-in-page-nav-container">
         <FormGroup className="order-2 width-full">


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6186

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds css to make the div containing the form save button sticky at the top of the form

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Without design guidance I'm not sure if this is the best implementation, but it gets the job done for now

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch using `npm run dev`
2. start an application using this [readme](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/app/%5Blocale%5D/workspace/applications/application/%5BapplicationId%5D/README.md)
3. open the sf424 form
4. scroll the form down
5. _VERIFY_: save button stays at top of form during scroll

### Screenshot
<img width="1256" height="670" alt="Screenshot 2025-10-06 at 11 36 33 AM" src="https://github.com/user-attachments/assets/60d3c2a8-e872-407b-8b29-634ee30613fd" />

