### PR TITLE
API Gateway temp full proxy fix

### DIFF
--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -30,6 +30,19 @@ resource "aws_api_gateway_rest_api" "api" {
               "schema" : {
                 "type" : "string"
               }
+            },
+            # Temp, for full proxy mode
+            {
+              "name" : "accept",
+              "in" : "header",
+              "required" : false,
+              "type" : "string"
+            },
+            {
+              "name" : "X-Auth",
+              "in" : "header",
+              "required" : false,
+              "type" : "string"
             }
           ],
           "security" : [
@@ -44,6 +57,9 @@ resource "aws_api_gateway_rest_api" "api" {
             "uri" : "https://${var.optional_extra_alb_domains[0]}/{proxy}",
             "requestParameters" : {
               "integration.request.path.proxy" : "method.request.path.proxy",
+              # Temp, for full proxy mode
+              "integration.request.header.X-Auth" : "method.request.header.X-Auth",
+              "integration.request.header.accept" : "method.request.header.accept",
               # Might not be needed, but adding for testing
               "integration.request.header.Host" : "'${var.domain_name}'"
             },

--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -58,7 +58,11 @@ resource "aws_api_gateway_rest_api" "api" {
             "requestParameters" : {
               "integration.request.path.proxy" : "method.request.path.proxy",
               # Temp, for full proxy mode
-              "integration.request.header.X-Auth" : "method.request.header.X-Auth",
+              # Gateway converts all header values into lowercase for mapping, so we should default 
+              # to using lowercase for this to make sure we catch any x-auth headers. If we camel case
+              # this, it will forward both the lower case and upper at the same time, and the API will
+              # return an auth failure error
+              "integration.request.header.X-Auth" : "method.request.header.x-auth",
               "integration.request.header.accept" : "method.request.header.accept",
               # Might not be needed, but adding for testing
               "integration.request.header.Host" : "'${var.domain_name}'"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #ISSUE 

## Changes proposed

- Force passing `accept` and `X-Auth` headers downstream

## Context for reviewers

For API Gateway, full proxying isn't always a "full proxy", and we ran into that with the current temp full proxy setup. We saw the auth and accept headers weren't being passed down to the underlying API, and it looks to be because the gateway is dropping the header at itself. We need to map them to pass them down, which is important to see because we'll most likely need to map the Gateway token to pass it down too

## Validation steps

- Get the the API Gateway URL (go into AWS to get it), add `/v1/v1/YOUR_ENDPOINT_HERE`
    - The final version will not need the extra `v1` in the path because the domain will be mapped to the Gateway's `v1`
- Run your commands either via postman or terminal, and make sure they are passed down as expected
- Example
```bash
curl -vvv -X 'GET' -H 'X-Auth: YOUR_TOKEN_HERE' -H 'accept: application/json' https://GATEWAY_ID.execute-api.us-east-1.amazonaws.com/v1/v1/opportunities/SOME_UUID
```