### PR TITLE
[Issue #6538] organization roster table

### DIFF
--- a/frontend/src/app/[locale]/(base)/organization/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/organization/[id]/page.tsx
@@ -9,6 +9,7 @@ import { notFound, redirect } from "next/navigation";
 import { ErrorMessage, GridContainer } from "@trussworks/react-uswds";
 
 import { OrganizationInfo } from "src/components/organization/OrganizationInfo";
+import { OrganizationRoster } from "src/components/organization/OrganizationRoster";
 
 type OrganizationDetailPageProps = {
   params: Promise<{ id: string }>;
@@ -27,11 +28,7 @@ export async function generateMetadata({
     if (!session?.token) {
       throw new Error("not logged in");
     }
-    const organizationDetails = await getOrganizationDetails(
-      session.token,
-      session.user_id,
-      id,
-    );
+    const organizationDetails = await getOrganizationDetails(session.token, id);
     title = `${t("OrganizationDetail.pageTitle")} - ${organizationDetails.sam_gov_entity.legal_business_name || ""}`;
   } catch (error) {
     console.error("Failed to render page title due to API error", error);
@@ -59,11 +56,7 @@ async function OrganizationDetail({ params }: OrganizationDetailPageProps) {
   }
   let organizationDetails;
   try {
-    organizationDetails = await getOrganizationDetails(
-      session.token,
-      session.user_id,
-      id,
-    );
+    organizationDetails = await getOrganizationDetails(session.token, id);
   } catch (e) {
     console.error("Unable to fetch user details", e);
   }
@@ -82,6 +75,7 @@ async function OrganizationDetail({ params }: OrganizationDetailPageProps) {
       <OrganizationInfo
         organizationDetails={organizationDetails.sam_gov_entity}
       />
+      <OrganizationRoster organizationId={id} />
     </GridContainer>
   );
 }

--- a/frontend/src/app/[locale]/(base)/organization/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/organization/[id]/page.tsx
@@ -1,0 +1,93 @@
+import { Metadata } from "next";
+import { ApiRequestError, parseErrorStatus } from "src/errors";
+import { getSession } from "src/services/auth/session";
+import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
+import { getOrganizationDetails } from "src/services/fetch/fetchers/organizationsFetcher";
+
+import { getTranslations } from "next-intl/server";
+import { notFound, redirect } from "next/navigation";
+import { ErrorMessage, GridContainer } from "@trussworks/react-uswds";
+
+import { OrganizationInfo } from "src/components/organization/OrganizationInfo";
+
+type OrganizationDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; id: string }>;
+}): Promise<Metadata> {
+  const { locale, id } = await params;
+  const t = await getTranslations({ locale });
+  let title = `${t("OrganizationDetail.pageTitle")}`;
+  try {
+    const session = await getSession();
+    if (!session?.token) {
+      throw new Error("not logged in");
+    }
+    const organizationDetails = await getOrganizationDetails(
+      session.token,
+      session.user_id,
+      id,
+    );
+    title = `${t("OrganizationDetail.pageTitle")} - ${organizationDetails.sam_gov_entity.legal_business_name || ""}`;
+  } catch (error) {
+    console.error("Failed to render page title due to API error", error);
+    if (parseErrorStatus(error as ApiRequestError) === 404) {
+      return notFound();
+    }
+  }
+  return {
+    title,
+    description: t("Index.metaDescription"),
+  };
+}
+
+async function OrganizationDetail({ params }: OrganizationDetailPageProps) {
+  const t = await getTranslations("OrganizationDetail");
+  const { id } = await params;
+
+  const session = await getSession();
+  if (!session?.token) {
+    return (
+      <GridContainer className="padding-top-2 tablet:padding-y-6">
+        <div>not logged in</div>
+      </GridContainer>
+    );
+  }
+  let organizationDetails;
+  try {
+    organizationDetails = await getOrganizationDetails(
+      session.token,
+      session.user_id,
+      id,
+    );
+  } catch (e) {
+    console.error("Unable to fetch user details", e);
+  }
+
+  if (!organizationDetails) {
+    return (
+      <GridContainer className="padding-top-2 tablet:padding-y-6">
+        <ErrorMessage>{t("fetchError")}</ErrorMessage>
+      </GridContainer>
+    );
+  }
+
+  return (
+    <GridContainer className="padding-top-2 tablet:padding-y-6">
+      <h1>{organizationDetails.sam_gov_entity.legal_business_name}</h1>
+      <OrganizationInfo
+        organizationDetails={organizationDetails.sam_gov_entity}
+      />
+    </GridContainer>
+  );
+}
+
+export default withFeatureFlag<OrganizationDetailPageProps, never>(
+  OrganizationDetail,
+  "userAdminOff",
+  () => redirect("/maintenance"),
+);

--- a/frontend/src/components/application/InformationCard.tsx
+++ b/frontend/src/components/application/InformationCard.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { ApplicationDetail, Status } from "src/types/applicationResponseTypes";
+import {
+  ApplicationDetail,
+  SamGovEntity,
+  Status,
+} from "src/types/applicationResponseTypes";
 import { Competition } from "src/types/competitionsResponseTypes";
 
 import { useTranslations } from "next-intl";
@@ -13,6 +17,54 @@ type CompetitionDetails = { competition: Competition };
 
 export type ApplicationDetailsCardProps = ApplicationDetail &
   CompetitionDetails;
+
+const OrganizationDetailsDisplay = ({
+  samGovEntity,
+}: {
+  samGovEntity: SamGovEntity;
+}) => {
+  const t = useTranslations("Application.information");
+  const { legal_business_name, uei, expiration_date } = samGovEntity;
+
+  return (
+    <>
+      <div className="margin-bottom-1">
+        <dt className="margin-right-1 text-bold">{t("applicant")}: </dt>
+        <dd>{legal_business_name ?? "-"}</dd>
+      </div>
+      <Grid row className="margin-bottom-1">
+        <div>
+          <dt className="margin-right-1 text-bold">{t("uei")}: </dt>
+          <dd>{uei ?? "-"}</dd>
+        </div>
+        <div className="margin-left-4">
+          <dt className="margin-right-1 text-bold">{t("renewal")}: </dt>
+          <dd>{expiration_date ?? "-"}</dd>
+        </div>
+      </Grid>
+    </>
+  );
+};
+
+const ApplicantDetails = ({
+  hasOrganization,
+  samGovEntity,
+}: {
+  hasOrganization: boolean;
+  samGovEntity: SamGovEntity;
+}) => {
+  const t = useTranslations("Application.information");
+  if (hasOrganization) {
+    return <OrganizationDetailsDisplay samGovEntity={samGovEntity} />;
+  }
+
+  return (
+    <div className="margin-bottom-1">
+      <dt className="margin-right-1 text-bold">{t("applicant")}: </dt>
+      <dd>{t("applicantTypeIndividual")}</dd>
+    </div>
+  );
+};
 
 export const InformationCard = ({
   applicationDetails,
@@ -31,39 +83,6 @@ export const InformationCard = ({
 }) => {
   const t = useTranslations("Application.information");
   const hasOrganization = Boolean(applicationDetails.organization);
-
-  const ApplicantDetails = () => {
-    if (hasOrganization) {
-      const { legal_business_name, uei, expiration_date } =
-        applicationDetails.organization.sam_gov_entity;
-
-      return (
-        <>
-          <div className="margin-bottom-1">
-            <dt className="margin-right-1 text-bold">{t("applicant")}: </dt>
-            <dd>{legal_business_name ?? "-"}</dd>
-          </div>
-          <Grid row className="margin-bottom-1">
-            <div>
-              <dt className="margin-right-1 text-bold">{t("uei")}: </dt>
-              <dd>{uei ?? "-"}</dd>
-            </div>
-            <div className="margin-left-4">
-              <dt className="margin-right-1 text-bold">{t("renewal")}: </dt>
-              <dd>{expiration_date ?? "-"}</dd>
-            </div>
-          </Grid>
-        </>
-      );
-    }
-
-    return (
-      <div className="margin-bottom-1">
-        <dt className="margin-right-1 text-bold">{t("applicant")}: </dt>
-        <dd>{t("applicantTypeIndividual")}</dd>
-      </div>
-    );
-  };
 
   const ApplicationInstructionsDownload = () => {
     return (
@@ -150,7 +169,10 @@ export const InformationCard = ({
         </Grid>
         <Grid tablet={{ col: 6 }} mobile={{ col: 12 }}>
           <dl>
-            <ApplicantDetails />
+            <ApplicantDetails
+              hasOrganization={hasOrganization}
+              samGovEntity={applicationDetails.organization.sam_gov_entity}
+            />
             {applicationDetails.competition.competition_instructions.length ? (
               <ApplicationInstructionsDownload />
             ) : (

--- a/frontend/src/components/organization/OrganizationInfo.tsx
+++ b/frontend/src/components/organization/OrganizationInfo.tsx
@@ -1,0 +1,52 @@
+import { SamGovEntity } from "src/types/applicationResponseTypes";
+
+import { useTranslations } from "next-intl";
+import { Grid } from "@trussworks/react-uswds";
+
+export const OrganizationInfo = ({
+  organizationDetails,
+}: {
+  organizationDetails: SamGovEntity;
+}) => {
+  const t = useTranslations("OrganizationDetail");
+  const {
+    ebiz_poc_email,
+    ebiz_poc_first_name,
+    ebiz_poc_last_name,
+    expiration_date,
+    uei,
+  } = organizationDetails;
+  return (
+    <>
+      <Grid row>
+        <Grid tablet={{ col: 3 }}>
+          <span className="text-bold padding-right-2">{t("ebizPoc")}:</span>
+          <span>
+            {ebiz_poc_first_name} {ebiz_poc_last_name}
+          </span>
+        </Grid>
+        <Grid tablet={{ col: 3 }}>
+          <span className="text-bold padding-right-2">{t("contact")}:</span>
+          <span>{ebiz_poc_email}</span>
+        </Grid>
+        <Grid tablet={{ col: 3 }}>
+          <span className="text-bold padding-right-2">{t("uei")}:</span>
+          <span>{uei}</span>
+        </Grid>
+        <Grid tablet={{ col: 3 }}>
+          <span className="text-bold padding-right-2">{t("expiration")}:</span>
+          <span>{expiration_date}</span>
+        </Grid>
+      </Grid>
+      <div className="margin-top-2">
+        {t.rich("visitSam", {
+          link: (chunk) => (
+            <a href="https://sam.gov" target="_blank">
+              {chunk}
+            </a>
+          ),
+        })}
+      </div>
+    </>
+  );
+};

--- a/frontend/src/components/organization/OrganizationRoster.tsx
+++ b/frontend/src/components/organization/OrganizationRoster.tsx
@@ -11,7 +11,8 @@ const OrganizationUserRow = ({ email, profile, roles }: UserDetail) => {
   const { first_name, last_name } = profile || {};
   const fullName = first_name && last_name ? `${first_name} ${last_name}` : "";
   const roleNames = roles?.reduce(
-    (joined, { role_name }) => joined + `, ${role_name}`,
+    (joined, { role_name }, index) =>
+      joined + `${index > 0 ? ", " : ""}${role_name}`,
     "",
   );
   return (
@@ -51,17 +52,25 @@ export const OrganizationRoster = async ({
 
   if (organizationUsers?.length) {
     return (
-      <Table>
+      <Table className="width-full overflow-wrap simpler-application-forms-table">
         <thead>
           <tr>
-            <th scope="col">{t("headings.email")}</th>
-            <th scope="col">{t("headings.name")}</th>
-            <th scope="col">{t("headings.roles")}</th>
+            <th scope="col" className="bg-base-lightest padding-y-205">
+              {t("headings.email")}
+            </th>
+            <th scope="col" className="bg-base-lightest padding-y-205">
+              {t("headings.name")}
+            </th>
+            <th scope="col" className="bg-base-lightest padding-y-205">
+              {t("headings.roles")}
+            </th>
           </tr>
         </thead>
-        {organizationUsers.map((props: UserDetail) => (
-          <OrganizationUserRow {...props} key={props.email} />
-        ))}
+        <tbody>
+          {organizationUsers.map((props: UserDetail) => (
+            <OrganizationUserRow {...props} key={props.email} />
+          ))}
+        </tbody>
       </Table>
     );
   }

--- a/frontend/src/components/organization/OrganizationRoster.tsx
+++ b/frontend/src/components/organization/OrganizationRoster.tsx
@@ -24,6 +24,16 @@ const OrganizationUserRow = ({ email, profile, roles }: UserDetail) => {
   );
 };
 
+const OrganizationRosterInfo = () => {
+  const t = useTranslations("OrganizationDetail.rosterTable");
+  return (
+    <>
+      <h3>{t("title")}</h3>
+      <div>{t("explanation")}</div>
+    </>
+  );
+};
+
 export const OrganizationRoster = async ({
   organizationId,
 }: {
@@ -52,26 +62,29 @@ export const OrganizationRoster = async ({
 
   if (organizationUsers?.length) {
     return (
-      <Table className="width-full overflow-wrap simpler-application-forms-table">
-        <thead>
-          <tr>
-            <th scope="col" className="bg-base-lightest padding-y-205">
-              {t("headings.email")}
-            </th>
-            <th scope="col" className="bg-base-lightest padding-y-205">
-              {t("headings.name")}
-            </th>
-            <th scope="col" className="bg-base-lightest padding-y-205">
-              {t("headings.roles")}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {organizationUsers.map((props: UserDetail) => (
-            <OrganizationUserRow {...props} key={props.email} />
-          ))}
-        </tbody>
-      </Table>
+      <>
+        <OrganizationRosterInfo />
+        <Table className="width-full overflow-wrap simpler-application-forms-table">
+          <thead>
+            <tr>
+              <th scope="col" className="bg-base-lightest padding-y-205">
+                {t("headings.email")}
+              </th>
+              <th scope="col" className="bg-base-lightest padding-y-205">
+                {t("headings.name")}
+              </th>
+              <th scope="col" className="bg-base-lightest padding-y-205">
+                {t("headings.roles")}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {organizationUsers.map((props: UserDetail) => (
+              <OrganizationUserRow {...props} key={props.email} />
+            ))}
+          </tbody>
+        </Table>
+      </>
     );
   }
 };

--- a/frontend/src/components/organization/OrganizationRoster.tsx
+++ b/frontend/src/components/organization/OrganizationRoster.tsx
@@ -1,13 +1,16 @@
 import { getSession } from "src/services/auth/session";
+import { getOrganizationUsers } from "src/services/fetch/fetchers/organizationsFetcher";
+import { UserDetail } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { Alert, Table } from "@trussworks/react-uswds";
 
 import ServerErrorAlert from "src/components/ServerErrorAlert";
 
-const OrganizationUserRow = ({ email, first_name, last_name, roles }) => {
+const OrganizationUserRow = ({ email, profile, roles }: UserDetail) => {
+  const { first_name, last_name } = profile || {};
   const fullName = first_name && last_name ? `${first_name} ${last_name}` : "";
-  const roleNames = roles.reduce(
+  const roleNames = roles?.reduce(
     (joined, { role_name }) => joined + `, ${role_name}`,
     "",
   );
@@ -37,7 +40,10 @@ export const OrganizationRoster = async ({
 
   let organizationUsers;
   try {
-    organizationUsers = await getOrganizationUsers(organizationId);
+    organizationUsers = await getOrganizationUsers(
+      session.token,
+      organizationId,
+    );
   } catch (e) {
     console.error(e);
     return <ServerErrorAlert />;
@@ -53,8 +59,8 @@ export const OrganizationRoster = async ({
             <th scope="col">{t("headings.roles")}</th>
           </tr>
         </thead>
-        {organizationUsers.map((props) => (
-          <OrganizationUserRow {...props} />
+        {organizationUsers.map((props: UserDetail) => (
+          <OrganizationUserRow {...props} key={props.email} />
         ))}
       </Table>
     );

--- a/frontend/src/components/organization/OrganizationRoster.tsx
+++ b/frontend/src/components/organization/OrganizationRoster.tsx
@@ -1,0 +1,62 @@
+import { getSession } from "src/services/auth/session";
+
+import { useTranslations } from "next-intl";
+import { Alert, Table } from "@trussworks/react-uswds";
+
+import ServerErrorAlert from "src/components/ServerErrorAlert";
+
+const OrganizationUserRow = ({ email, first_name, last_name, roles }) => {
+  const fullName = first_name && last_name ? `${first_name} ${last_name}` : "";
+  const roleNames = roles.reduce(
+    (joined, { role_name }) => joined + `, ${role_name}`,
+    "",
+  );
+  return (
+    <tr>
+      <td>{email}</td>
+      <td>{fullName}</td>
+      <td>{roleNames}</td>
+    </tr>
+  );
+};
+
+export const OrganizationRoster = async ({
+  organizationId,
+}: {
+  organizationId: string;
+}) => {
+  const t = useTranslations("OrganizationDetail.rosterTable");
+  const session = await getSession();
+  if (!session?.token) {
+    return (
+      <Alert headingLevel="h3" type="error">
+        not logged in
+      </Alert>
+    );
+  }
+
+  let organizationUsers;
+  try {
+    organizationUsers = await getOrganizationUsers(organizationId);
+  } catch (e) {
+    console.error(e);
+    return <ServerErrorAlert />;
+  }
+
+  if (organizationUsers?.length) {
+    return (
+      <Table>
+        <thead>
+          <tr>
+            <th scope="col">{t("headings.email")}</th>
+            <th scope="col">{t("headings.name")}</th>
+            <th scope="col">{t("headings.roles")}</th>
+          </tr>
+        </thead>
+        {organizationUsers.map((props) => (
+          <OrganizationUserRow {...props} />
+        ))}
+      </Table>
+    );
+  }
+};

--- a/frontend/src/components/workspace/StartApplicationModal/IneligibleStartApplicationModal.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/IneligibleStartApplicationModal.tsx
@@ -1,5 +1,5 @@
 import { ApplicantTypes } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/userTypes";
+import { UserOrganization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { RefObject } from "react";
@@ -19,7 +19,7 @@ export const IneligibleApplicationStart = ({
   onClose,
   cancelText,
 }: {
-  organizations: Organization[];
+  organizations: UserOrganization[];
   applicantTypes: ApplicantTypes[];
   modalRef: RefObject<ModalRef | null>;
   onClose: () => void;

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationDescription.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationDescription.tsx
@@ -1,6 +1,6 @@
 import { ExternalRoutes } from "src/constants/routes";
 import { ApplicantTypes } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/userTypes";
+import { UserOrganization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 
@@ -8,7 +8,7 @@ export const StartApplicationDescription = ({
   organizations,
   applicantTypes,
 }: {
-  organizations: Organization[];
+  organizations: UserOrganization[];
   applicantTypes: ApplicantTypes[];
 }) => {
   const t = useTranslations(

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationInputs.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationInputs.tsx
@@ -1,4 +1,4 @@
-import { Organization } from "src/types/userTypes";
+import { UserOrganization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import {
@@ -15,7 +15,7 @@ export const StartApplicationOrganizationInput = ({
   selectedOrganization,
 }: {
   onOrganizationChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
-  organizations: Organization[];
+  organizations: UserOrganization[];
   selectedOrganization?: string; // organization_id
   validationError?: string;
 }) => {

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationModal.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationModal.tsx
@@ -1,6 +1,6 @@
 import { useClientFetch } from "src/hooks/useClientFetch";
 import { ApplicantTypes } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/userTypes";
+import { UserOrganization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
@@ -34,7 +34,7 @@ export const StartApplicationModal = ({
   opportunityTitle: string;
   modalRef: RefObject<ModalRef | null>;
   applicantTypes: ApplicantTypes[];
-  organizations: Organization[];
+  organizations: UserOrganization[];
   token: string | null;
   loading: boolean;
   competitionId: string;

--- a/frontend/src/components/workspace/StartApplicationModal/StartApplicationModalControl.tsx
+++ b/frontend/src/components/workspace/StartApplicationModal/StartApplicationModalControl.tsx
@@ -6,7 +6,7 @@ import {
   ApplicantTypes,
   Competition,
 } from "src/types/competitionsResponseTypes";
-import { Organization } from "src/types/userTypes";
+import { UserOrganization } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
@@ -30,7 +30,7 @@ export const StartApplicationModalControl = ({
   const { user } = useUser();
 
   const { clientFetch: fetchUserOrganizations } = useClientFetch<
-    Organization[]
+    UserOrganization[]
   >("Error fetching user organizations");
   const { clientFetch: fetchCompetition } = useClientFetch<Competition>(
     "Error fetching competition",
@@ -42,9 +42,9 @@ export const StartApplicationModalControl = ({
   const [competitionApplicantTypes, setCompetitionApplicantTypes] = useState<
     ApplicantTypes[]
   >([]);
-  const [userOrganizations, setUserOrganizations] = useState<Organization[]>(
-    [],
-  );
+  const [userOrganizations, setUserOrganizations] = useState<
+    UserOrganization[]
+  >([]);
 
   const token = user?.token || null;
 

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1467,5 +1467,15 @@ export const messages = {
     expiration: "Exp",
     visitSam:
       "Visit <link>sam.gov</link> to make changes to your organization’s details.",
+    rosterTable: {
+      title: "Organization roster",
+      explanation:
+        "Your organization's active members are listed below. Manage Users to add or update roles and permissions.",
+      headings: {
+        email: "Email",
+        name: "Name",
+        roles: "Roles",
+      },
+    },
   },
 };

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1455,5 +1455,17 @@ export const messages = {
     pageTitle: "User Workspace | Simpler.Grants.gov",
     title: "User Workspace",
     fetchError: "Error fetching user data. Please try refreshing the page.",
+    organizations: "Organizations",
+  },
+  OrganizationDetail: {
+    pageTitle: "Organization",
+    fetchError: "Unable to fetch organization details",
+    organizationDetailsHeader: "Organization details",
+    ebizPoc: "eBiz POC",
+    contact: "Contact",
+    uei: "UEI",
+    expiration: "Exp",
+    visitSam:
+      "Visit <link>sam.gov</link> to make changes to your organization’s details.",
   },
 };

--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -81,3 +81,10 @@ export const searchAgenciesEndpoint = {
   namespace: "agencies/search",
   method: "POST" as ApiMethod,
 };
+
+export const getOrganizationEndpoint = {
+  basePath: environment.API_URL,
+  version: "v1",
+  namespace: "organizations",
+  method: "GET" as ApiMethod,
+};

--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -56,7 +56,6 @@ export const userLogoutEndpoint = {
   method: "POST" as ApiMethod,
 };
 
-// can expand to support GET when the time comes
 export const toDynamicUsersEndpoint = (
   type: "POST" | "DELETE" | "PUT" | "GET",
 ) => {
@@ -82,9 +81,13 @@ export const searchAgenciesEndpoint = {
   method: "POST" as ApiMethod,
 };
 
-export const getOrganizationEndpoint = {
-  basePath: environment.API_URL,
-  version: "v1",
-  namespace: "organizations",
-  method: "GET" as ApiMethod,
+export const toDynamicOrganizationsEndpoint = (
+  type: "POST" | "DELETE" | "PUT" | "GET",
+) => {
+  return {
+    basePath: environment.API_URL,
+    version: "v1",
+    namespace: "organizations",
+    method: type as ApiMethod,
+  };
 };

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -6,6 +6,7 @@ import {
   fetchCompetitionEndpoint,
   fetchFormEndpoint,
   fetchOpportunityEndpoint,
+  getOrganizationEndpoint,
   opportunitySearchEndpoint,
   searchAgenciesEndpoint,
   toDynamicApplicationsEndpoint,
@@ -127,3 +128,5 @@ export const fetchUserWithMethod = (type: "POST" | "DELETE" | "PUT" | "GET") =>
 export const postTokenRefresh = requesterForEndpoint(userRefreshEndpoint);
 
 export const searchAgencies = requesterForEndpoint(searchAgenciesEndpoint);
+
+export const getOrganization = requesterForEndpoint(getOrganizationEndpoint);

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -6,10 +6,10 @@ import {
   fetchCompetitionEndpoint,
   fetchFormEndpoint,
   fetchOpportunityEndpoint,
-  getOrganizationEndpoint,
   opportunitySearchEndpoint,
   searchAgenciesEndpoint,
   toDynamicApplicationsEndpoint,
+  toDynamicOrganizationsEndpoint,
   toDynamicUsersEndpoint,
   userLogoutEndpoint,
   userRefreshEndpoint,
@@ -129,4 +129,6 @@ export const postTokenRefresh = requesterForEndpoint(userRefreshEndpoint);
 
 export const searchAgencies = requesterForEndpoint(searchAgenciesEndpoint);
 
-export const getOrganization = requesterForEndpoint(getOrganizationEndpoint);
+export const fetchOrganizationWithMethod = (
+  type: "POST" | "DELETE" | "PUT" | "GET",
+) => requesterForEndpoint(toDynamicOrganizationsEndpoint(type));

--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
@@ -1,11 +1,7 @@
 import { Organization } from "src/types/applicationResponseTypes";
 import { UserDetail } from "src/types/userTypes";
 
-import {
-  fetchOrganizationWithMethod,
-  fetchUserWithMethod,
-  getOrganization,
-} from "./fetchers";
+import { fetchOrganizationWithMethod, fetchUserWithMethod } from "./fetchers";
 
 export const getOrganizationDetails = async (
   token: string,

--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
@@ -1,0 +1,34 @@
+import { Organization } from "src/types/applicationResponseTypes";
+
+import { fetchUserWithMethod, getOrganization } from "./fetchers";
+
+export const getOrganizationDetails = async (
+  token: string,
+  userId: string,
+  organizationId: string,
+): Promise<Organization> => {
+  const ssgToken = {
+    "X-SGG-Token": token,
+  };
+  const resp = await getOrganization({
+    subPath: organizationId,
+    additionalHeaders: ssgToken,
+  });
+  const json = (await resp.json()) as { data: Organization };
+  return json.data;
+};
+
+export const getUserOrganizations = async (
+  token: string,
+  userId: string,
+): Promise<Organization[]> => {
+  const ssgToken = {
+    "X-SGG-Token": token,
+  };
+  const resp = await fetchUserWithMethod("GET")({
+    subPath: `${userId}/organizations`,
+    additionalHeaders: ssgToken,
+  });
+  const json = (await resp.json()) as { data: Organization[] };
+  return json.data;
+};

--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
@@ -1,16 +1,20 @@
 import { Organization } from "src/types/applicationResponseTypes";
+import { UserDetail } from "src/types/userTypes";
 
-import { fetchUserWithMethod, getOrganization } from "./fetchers";
+import {
+  fetchOrganizationWithMethod,
+  fetchUserWithMethod,
+  getOrganization,
+} from "./fetchers";
 
 export const getOrganizationDetails = async (
   token: string,
-  userId: string,
   organizationId: string,
 ): Promise<Organization> => {
   const ssgToken = {
     "X-SGG-Token": token,
   };
-  const resp = await getOrganization({
+  const resp = await fetchOrganizationWithMethod("GET")({
     subPath: organizationId,
     additionalHeaders: ssgToken,
   });
@@ -33,17 +37,17 @@ export const getUserOrganizations = async (
   return json.data;
 };
 
-export const getOrganizationUsers = (
+export const getOrganizationUsers = async (
   token: string,
   organizationId: string,
-): Promise<Organization> => {
+): Promise<UserDetail[]> => {
   const ssgToken = {
     "X-SGG-Token": token,
   };
-  const resp = await getOrganization({
-    subPath: organizationId,
+  const resp = await fetchOrganizationWithMethod("POST")({
+    subPath: `${organizationId}/users`,
     additionalHeaders: ssgToken,
   });
-  const json = (await resp.json()) as { data: Organization };
+  const json = (await resp.json()) as { data: UserDetail[] };
   return json.data;
 };

--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
@@ -32,3 +32,18 @@ export const getUserOrganizations = async (
   const json = (await resp.json()) as { data: Organization[] };
   return json.data;
 };
+
+export const getOrganizationUsers = (
+  token: string,
+  organizationId: string,
+): Promise<Organization> => {
+  const ssgToken = {
+    "X-SGG-Token": token,
+  };
+  const resp = await getOrganization({
+    subPath: organizationId,
+    additionalHeaders: ssgToken,
+  });
+  const json = (await resp.json()) as { data: Organization };
+  return json.data;
+};

--- a/frontend/src/types/applicationResponseTypes.ts
+++ b/frontend/src/types/applicationResponseTypes.ts
@@ -15,13 +15,16 @@ export enum Status {
   ACCEPTED = "accepted",
 }
 
-interface SamGovEntity {
+export interface SamGovEntity {
   expiration_date: string;
   legal_business_name: string;
   uei: string;
+  ebiz_poc_email: string;
+  ebiz_poc_first_name: string;
+  ebiz_poc_last_name: string;
 }
 
-export interface Oranization {
+export interface Organization {
   organization_id: string;
   sam_gov_entity: SamGovEntity;
 }
@@ -55,7 +58,7 @@ export interface ApplicationDetail {
   application_status: string;
   competition: Competition;
   form_validation_warnings?: FormValidationWarnings;
-  organization: Oranization;
+  organization: Organization;
   users: {
     email: string;
     user_id: string;

--- a/frontend/src/types/userTypes.ts
+++ b/frontend/src/types/userTypes.ts
@@ -4,6 +4,12 @@ export interface UserOrganization extends Organization {
   is_organization_owner: boolean;
 }
 
+export interface RoleDefinition {
+  privileges: string[];
+  role_id: string;
+  role_name: string;
+}
+
 export type UserProfileValidationErrors = {
   firstName?: string[];
   lastName?: string[];
@@ -19,6 +25,7 @@ export interface UserDetail {
   user_id: string;
   email: string;
   profile: UserDetailProfile | null;
+  roles?: RoleDefinition[];
 }
 
 export interface UserProfileResponse {

--- a/frontend/src/types/userTypes.ts
+++ b/frontend/src/types/userTypes.ts
@@ -1,12 +1,8 @@
-export type Organization = {
+import { Organization } from "./applicationResponseTypes";
+
+export interface UserOrganization extends Organization {
   is_organization_owner: boolean;
-  organization_id: string;
-  sam_gov_entity: {
-    expiration_date: string;
-    legal_business_name: string;
-    uei: string;
-  };
-};
+}
 
 export type UserProfileValidationErrors = {
   firstName?: string[];

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -1,6 +1,7 @@
 import { JSONSchema7 } from "json-schema";
 import { ApiKey } from "src/types/apiKeyTypes";
 import { PaginationInfo } from "src/types/apiResponseTypes";
+import { Organization } from "src/types/applicationResponseTypes";
 import { BaseOpportunity } from "src/types/opportunity/opportunityResponseTypes";
 import {
   FilterOption,
@@ -16,7 +17,11 @@ import {
   SearchAPIResponse,
   SearchFetcherActionType,
 } from "src/types/search/searchRequestTypes";
-import { UserDetail, UserDetailProfile } from "src/types/userTypes";
+import {
+  UserDetail,
+  UserDetailProfile,
+  UserOrganization,
+} from "src/types/userTypes";
 
 export const mockOpportunity: BaseOpportunity = {
   opportunity_id: "63588df8-f2d1-44ed-a201-5804abba696a",
@@ -380,10 +385,25 @@ export const fakeFilterPillLabelData: FilterPillLabelData[] = [
   },
 ];
 
-export const fakeOrganization = {
+export const fakeUserOrganization: UserOrganization = {
   is_organization_owner: true,
   organization_id: "great id",
   sam_gov_entity: {
+    ebiz_poc_email: "email@email.email",
+    ebiz_poc_first_name: "first",
+    ebiz_poc_last_name: "last",
+    expiration_date: "1-1-25",
+    legal_business_name: "Completely Legal Organization",
+    uei: "unique entity identifier",
+  },
+};
+
+export const fakeOrganizationDetailsResponse: Organization = {
+  organization_id: "great id",
+  sam_gov_entity: {
+    ebiz_poc_email: "email@email.email",
+    ebiz_poc_first_name: "first",
+    ebiz_poc_last_name: "last",
     expiration_date: "1-1-25",
     legal_business_name: "Completely Legal Organization",
     uei: "unique entity identifier",

--- a/frontend/tests/api/user/organizations/route.test.ts
+++ b/frontend/tests/api/user/organizations/route.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { getUserOrganizations } from "src/app/api/user/organizations/handler";
-import { Organization } from "src/types/userTypes";
-import { fakeOrganization } from "src/utils/testing/fixtures";
+import { UserOrganization } from "src/types/userTypes";
+import { fakeUserOrganization } from "src/utils/testing/fixtures";
 
 const mockFetchOrganizations = jest.fn();
 const getSessionMock = jest.fn();
@@ -21,7 +21,7 @@ jest.mock("src/services/auth/session", () => ({
 describe("user/organizations GET requests", () => {
   beforeEach(() => {
     mockFetchOrganizations.mockResolvedValue({
-      json: () => Promise.resolve({ data: [fakeOrganization] }),
+      json: () => Promise.resolve({ data: [fakeUserOrganization] }),
     });
     getSessionMock.mockReturnValue({ token: "a token", user_id: "1" });
   });
@@ -39,8 +39,8 @@ describe("user/organizations GET requests", () => {
   it("returns a new response with competition data", async () => {
     const response = await getUserOrganizations();
     expect(response.status).toEqual(200);
-    const body = (await response.json()) as Organization[];
-    expect(body).toEqual([fakeOrganization]);
+    const body = (await response.json()) as UserOrganization[];
+    expect(body).toEqual([fakeUserOrganization]);
   });
 
   it("returns a new response with with error if error on data fetch", async () => {

--- a/frontend/tests/components/organization/OrganizationInfo.test.tsx
+++ b/frontend/tests/components/organization/OrganizationInfo.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { fakeOrganizationDetailsResponse } from "src/utils/testing/fixtures";
+import { useTranslationsMock } from "src/utils/testing/intlMocks";
+
+import { OrganizationInfo } from "src/components/organization/OrganizationInfo";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => useTranslationsMock(),
+}));
+
+describe("OragnizationInfo", () => {
+  it("matches snapshot", () => {
+    const { container } = render(
+      <OrganizationInfo
+        organizationDetails={fakeOrganizationDetailsResponse.sam_gov_entity}
+      />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+  it("displays all necessary organization data", () => {
+    render(
+      <OrganizationInfo
+        organizationDetails={fakeOrganizationDetailsResponse.sam_gov_entity}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        `${fakeOrganizationDetailsResponse.sam_gov_entity.ebiz_poc_first_name} ${fakeOrganizationDetailsResponse.sam_gov_entity.ebiz_poc_last_name}`,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        fakeOrganizationDetailsResponse.sam_gov_entity.ebiz_poc_email,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(fakeOrganizationDetailsResponse.sam_gov_entity.uei),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        fakeOrganizationDetailsResponse.sam_gov_entity.expiration_date,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/organization/__snapshots__/OrganizationInfo.test.tsx.snap
+++ b/frontend/tests/components/organization/__snapshots__/OrganizationInfo.test.tsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OragnizationInfo matches snapshot 1`] = `
+<div>
+  <div
+    class="grid-row"
+    data-testid="grid"
+  >
+    <div
+      class="tablet:grid-col-3"
+      data-testid="grid"
+    >
+      <span
+        class="text-bold padding-right-2"
+      >
+        ebizPoc
+        :
+      </span>
+      <span>
+        first
+         
+        last
+      </span>
+    </div>
+    <div
+      class="tablet:grid-col-3"
+      data-testid="grid"
+    >
+      <span
+        class="text-bold padding-right-2"
+      >
+        contact
+        :
+      </span>
+      <span>
+        email@email.email
+      </span>
+    </div>
+    <div
+      class="tablet:grid-col-3"
+      data-testid="grid"
+    >
+      <span
+        class="text-bold padding-right-2"
+      >
+        uei
+        :
+      </span>
+      <span>
+        unique entity identifier
+      </span>
+    </div>
+    <div
+      class="tablet:grid-col-3"
+      data-testid="grid"
+    >
+      <span
+        class="text-bold padding-right-2"
+      >
+        expiration
+        :
+      </span>
+      <span>
+        1-1-25
+      </span>
+    </div>
+  </div>
+  <div
+    class="margin-top-2"
+  >
+    visitSam
+  </div>
+</div>
+`;

--- a/frontend/tests/components/workspace/StartApplicationModal/StartApplicationModal.test.tsx
+++ b/frontend/tests/components/workspace/StartApplicationModal/StartApplicationModal.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { fakeOrganization } from "src/utils/testing/fixtures";
+import { fakeUserOrganization } from "src/utils/testing/fixtures";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import { createRef } from "react";
@@ -41,7 +41,7 @@ describe("StartApplicationModal", () => {
         opportunityTitle="blessed opportunity"
         modalRef={createRef()}
         applicantTypes={["organization"]}
-        organizations={[fakeOrganization]}
+        organizations={[fakeUserOrganization]}
         token={"a token"}
         loading={false}
       />,
@@ -82,7 +82,7 @@ describe("StartApplicationModal", () => {
         opportunityTitle="blessed opportunity"
         modalRef={createRef()}
         applicantTypes={["organization"]}
-        organizations={[fakeOrganization]}
+        organizations={[fakeUserOrganization]}
         token={"a token"}
         loading={false}
       />,
@@ -179,7 +179,7 @@ describe("StartApplicationModal", () => {
         opportunityTitle="blessed opportunity"
         modalRef={createRef()}
         applicantTypes={["organization"]}
-        organizations={[fakeOrganization]}
+        organizations={[fakeUserOrganization]}
         token={"a token"}
         loading={false}
       />,
@@ -189,7 +189,7 @@ describe("StartApplicationModal", () => {
     const input = await screen.findByTestId("textInput");
     const select = await screen.findByTestId("Select");
     await userEvent.type(input, "new application");
-    await userEvent.selectOptions(select, fakeOrganization.organization_id);
+    await userEvent.selectOptions(select, fakeUserOrganization.organization_id);
 
     act(() => saveButton.click());
     expect(clientFetchMock).toHaveBeenCalledWith("/api/applications/start", {
@@ -197,7 +197,7 @@ describe("StartApplicationModal", () => {
       body: JSON.stringify({
         applicationName: "new application",
         competitionId: "1",
-        organization: fakeOrganization.organization_id,
+        organization: fakeUserOrganization.organization_id,
       }),
     });
 

--- a/frontend/tests/components/workspace/StartApplicationModal/StartApplicationModalControl.test.tsx
+++ b/frontend/tests/components/workspace/StartApplicationModal/StartApplicationModalControl.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { fakeCompetition, fakeOrganization } from "src/utils/testing/fixtures";
+import {
+  fakeCompetition,
+  fakeUserOrganization,
+} from "src/utils/testing/fixtures";
 import { useTranslationsMock } from "src/utils/testing/intlMocks";
 
 import { StartApplicationModalControl } from "src/components/workspace/StartApplicationModal/StartApplicationModalControl";
@@ -17,7 +20,7 @@ const mocks = {
     if (url.match("competitions")) {
       return Promise.resolve(fakeCompetition);
     }
-    return Promise.resolve([fakeOrganization]);
+    return Promise.resolve([fakeUserOrganization]);
   },
 };
 

--- a/frontend/tests/utils/getRoutes.test.ts
+++ b/frontend/tests/utils/getRoutes.test.ts
@@ -20,6 +20,7 @@ describe("getNextRoutes", () => {
       "/(base)/newsletter",
       "/(base)/newsletter/unsubscribe",
       "/(base)/opportunity/1",
+      "/(base)/organization/1",
       "/(base)",
       "/(base)/roadmap",
       "/(base)/saved-opportunities",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6538 

Based off of https://github.com/HHS/simpler-grants-gov/pull/6590, that should be merged first

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds a user roster table to the organization page

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->



## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

depends on seed being updated in TICKET TBA. if that hasn't merged yet, prepare your local db by

1. find the role id in your local `role` table for `Organization Member`
2. find the organization_user id for the one_org_user in the `organization_user` table
3. enter these ids into a new entry in the `organization_user_role` table (you can copy paste timestamps from any other record)

otherwise

1. start a local server on this branch with `npm run dev`
4. visit http://localhost:3000?_ff=userAdminOff:false
5. log in with one_org_user
6. select the workspace nav item from the user drop down
7. _VERIFY_: you see a link to an organization in the page
8. click the link
10. _VERIFY_: you see your user and one other in organization roster table
