### PR TITLE
feat(frontend): sf424a adds row number to rows 1-4

### DIFF
--- a/frontend/src/components/applyForm/widgets/budget/Budget424aSectionA.tsx
+++ b/frontend/src/components/applyForm/widgets/budget/Budget424aSectionA.tsx
@@ -242,6 +242,7 @@ function Budget424aSectionA<
               {/* Column A: activity title */}
               <DataCell>
                 <div className="display-flex flex-align-end">
+                  <span className="text-bold text-no-wrap margin-right-2">{row + 1}.</span>
                   <div className="margin-top-05 padding-top-0">
                     <TextWidget
                       schema={activityTitleSchema}


### PR DESCRIPTION
## Summary

Work for #6145 Part 3 of 3

## Context for reviewers

This PR covers the SF-424A (budget) form, it adds the numberings to rows 1-4.

SF-424a ([PDF Form](https://apply07.grants.gov/apply/forms/readonly/SF424A-V1.0.pdf), [PDF Instructions](https://apply07.grants.gov/apply/forms/instructions/SF424A-V1.0-Instructions.pdf))

## Validation steps

1. to run locally, you would need to `run npm run build && npm start`
2. `make remake-backend && docker compose up`
3. navigate to `search`
4. search for `pilot`
5. you should see an opportunity called `Local Pilot-equivalent Opportunity`
6. sign in
7. start new application
8. navigate to form table of the application
9. click Budget Information for Non-Construction Programs (SF-424A)

