### PR TITLE
[Issue: 6385] Fix newsletter hero image (standardize heroes) 

### DIFF
--- a/frontend/src/app/[locale]/(base)/events/EventsHero.tsx
+++ b/frontend/src/app/[locale]/(base)/events/EventsHero.tsx
@@ -8,10 +8,7 @@ export default function EventsHero() {
   const t = useTranslations("Events");
 
   return (
-    <div
-      data-testid="events-hero"
-      className="text-white bg-primary-darkest padding-top-4 tablet:padding-y-6"
-    >
+    <div className="text-white bg-primary-darkest padding-top-2 tablet:padding-y-6">
       <GridContainer>
         <Grid row gap>
           <Grid tablet={{ col: "fill" }}>

--- a/frontend/src/app/[locale]/(base)/newsletter/page.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/page.tsx
@@ -30,17 +30,16 @@ export default function Subscribe({ params }: LocalizedPageProps) {
       <div className="text-white bg-primary-darkest padding-top-2 tablet:padding-y-6">
         <GridContainer>
           <Grid row gap>
-            <Grid
-              tablet={{ col: "fill" }}
-              className="tablet:margin-bottom-0 margin-bottom-4"
-            >
+            <Grid tablet={{ col: "fill" }}>
               <h1>{t("title")}</h1>
-              <div className="font-sans-md">
-                <p>{t("paragraph1")}</p>
-                <p>{t("paragraph2")}</p>
-              </div>
+              <p className="text-balance font-sans-md tablet:font-sans-lg margin-bottom-4 tablet:margin-bottom-0">
+                {t("paragraph1")}
+              </p>
+              <p className="text-balance font-sans-md tablet:font-sans-lg margin-bottom-4 tablet:margin-bottom-0">
+                {t("paragraph2")}
+              </p>
             </Grid>
-            <Grid tablet={{ col: "auto" }}>
+            <Grid tablet={{ col: 6 }} tabletLg={{ col: "auto" }}>
               <Grid className="display-flex flex-justify-center flex-align-center margin-x-neg-2 tablet:margin-x-0">
                 <Image
                   src="/img/statue-of-liberty-blue.png"

--- a/frontend/src/components/vision/sections/VisionHeader.tsx
+++ b/frontend/src/components/vision/sections/VisionHeader.tsx
@@ -15,7 +15,7 @@ export default function VisionHeader() {
               {t("pageHeaderParagraph")}
             </p>
           </Grid>
-          <Grid tablet={{ col: "auto" }}>
+          <Grid tablet={{ col: 6 }} tabletLg={{ col: "auto" }}>
             <Grid className="display-flex flex-justify-center flex-align-center margin-x-neg-2 tablet:margin-x-0">
               <Image
                 src="/img/statue-of-liberty.jpg"

--- a/frontend/tests/pages/events/__snapshots__/page.test.tsx.snap
+++ b/frontend/tests/pages/events/__snapshots__/page.test.tsx.snap
@@ -3,8 +3,7 @@
 exports[`Events renders Events page unchanged 1`] = `
 <div>
   <div
-    class="text-white bg-primary-darkest padding-top-4 tablet:padding-y-6"
-    data-testid="events-hero"
+    class="text-white bg-primary-darkest padding-top-2 tablet:padding-y-6"
   >
     <div
       class="grid-container"


### PR DESCRIPTION
## Summary

This PR standardizes the markup for the page hero. This change ensures that the `/newsletter` page's hero behaves responsively just like the other heroes. 

## Changes proposed

- nix unused `data-testid`
- nix unnecessary classes on newsletter hero's 1st `Grid`
- apply classes to newsletter hero's `p` elements (not their wrapping `div`), as done on other heroes — fixes margin/padding 
- ensure every hero's 2nd `Grid` is sized consistently (full on mobile, `6` on tablet, `auto` on large tablets)

## Context for reviewers

The hero image on the `/newsletter` page overlapped the text when the viewport was at the smallest size in the tablet breakpoint range. 

_Note: Since all this layout code is repeated, we might consider creating a `Hero` component and passing props (image, size, etc) and children for the text._ 

## Validation steps

- Load each of the 4 pages that have a hero image
- All images should have the same responsive behavior at various screen sizes