### PR TITLE
Add API root proxying for Gateway

### DIFF
--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -20,6 +20,20 @@ resource "aws_api_gateway_rest_api" "api" {
       #     }
       #   }
       # },
+      # Will need to have endpoints with no auth for the following
+      # GET /robots.txt
+      # GET /.well-known/pki-validation/{proxy}
+      # POST /<service_name>/services/v2/<service_port_name>
+      "/" : {
+        "get" : {
+          "x-amazon-apigateway-integration" : {
+            "type" : "http_proxy",
+            "httpMethod" : "GET",
+            "uri" : "https://${var.optional_extra_alb_domains[0]}/",
+            "passthroughBehavior" : "when_no_match"
+          }
+        }
+      },
       "/{proxy+}" : {
         "x-amazon-apigateway-any-method" : {
           "parameters" : [


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #ISSUE 

## Changes proposed

- Add routing logic for the root path
- Add comments for future PR

## Context for reviewers

This PR fixes a finding Michael had from the gateway not having any routing logic for the root path. This PR adds that, and some comments for future work on what needs to have non-API token required logic

## Validation steps

This was done manually for a few minutes in dev, and both Michael and I confirmed the page was loading as expected. Before merging this, I'll make sure to deploy and test to make sure. AWS console and terraform have different restrictions
