### PR TITLE
[Issue #6656] Set submitted_at and submitted_by during the Submit logic

### DIFF
--- a/api/src/services/applications/submit_application.py
+++ b/api/src/services/applications/submit_application.py
@@ -13,6 +13,7 @@ from src.services.applications.application_validation import (
     validate_forms,
 )
 from src.services.applications.get_application import get_application
+from src.util.datetime_util import utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +32,10 @@ def submit_application(db_session: db.Session, application_id: UUID, user: User)
     validate_competition_open(application.competition, ApplicationAction.SUBMIT)
     validate_forms(application, ApplicationAction.SUBMIT)
 
-    # Update application status
+    # Update application status and submission metadata
     application.application_status = ApplicationStatus.SUBMITTED
+    application.submitted_at = utcnow()
+    application.submitted_by = user.user_id
     logger.info("Application successfully submitted")
 
     # Add application metadata to logs

--- a/api/tests/src/services/applications/test_submit_application.py
+++ b/api/tests/src/services/applications/test_submit_application.py
@@ -59,9 +59,15 @@ def test_submit_application_success(enable_factory_create, db_session):
     # Verify the application status was updated
     assert updated_application.application_status == ApplicationStatus.SUBMITTED
 
+    # Verify submitted_at and submitted_by are set
+    assert updated_application.submitted_at is not None
+    assert updated_application.submitted_by == user.user_id
+
     # Fetch the application from the database to verify the status has been updated
     db_session.refresh(application)
     assert application.application_status == ApplicationStatus.SUBMITTED
+    assert application.submitted_at is not None
+    assert application.submitted_by == user.user_id
 
 
 def test_submit_application_with_missing_required_form(enable_factory_create, db_session):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6656 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Set `submitted_at` and `submitted_by` in `submit_application` endpoint
Update tests

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
This follows #6655 and unblocks #6478

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See updated unit test