### PR TITLE
[unticketed] fix errors loading organization detail page

### DIFF
--- a/frontend/src/app/[locale]/(base)/organization/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/organization/[id]/page.tsx
@@ -6,10 +6,14 @@ import { getOrganizationDetails } from "src/services/fetch/fetchers/organization
 
 import { getTranslations } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
+import { Suspense } from "react";
 import { ErrorMessage, GridContainer } from "@trussworks/react-uswds";
 
 import { OrganizationInfo } from "src/components/organization/OrganizationInfo";
-import { OrganizationRoster } from "src/components/organization/OrganizationRoster";
+import {
+  OrganizationRoster,
+  OrganizationRosterSkeleton,
+} from "src/components/organization/OrganizationRoster";
 
 type OrganizationDetailPageProps = {
   params: Promise<{ id: string }>;
@@ -75,7 +79,9 @@ async function OrganizationDetail({ params }: OrganizationDetailPageProps) {
       <OrganizationInfo
         organizationDetails={organizationDetails.sam_gov_entity}
       />
-      <OrganizationRoster organizationId={id} />
+      <Suspense fallback={<OrganizationRosterSkeleton />}>
+        <OrganizationRoster organizationId={id} />
+      </Suspense>
     </GridContainer>
   );
 }

--- a/frontend/src/components/organization/OrganizationRoster.tsx
+++ b/frontend/src/components/organization/OrganizationRoster.tsx
@@ -3,9 +3,43 @@ import { getOrganizationUsers } from "src/services/fetch/fetchers/organizationsF
 import { UserDetail } from "src/types/userTypes";
 
 import { useTranslations } from "next-intl";
+import { getTranslations } from "next-intl/server";
 import { Alert, Table } from "@trussworks/react-uswds";
 
 import ServerErrorAlert from "src/components/ServerErrorAlert";
+
+export const OrganizationRosterSkeleton = () => {
+  const t = useTranslations("OrganizationDetail.rosterTable");
+  return (
+    <>
+      <OrganizationRosterInfo />
+      <Table className="width-full overflow-wrap simpler-application-forms-table">
+        <thead>
+          <tr>
+            <th scope="col" className="bg-base-lightest padding-y-205">
+              {t("headings.email")}
+            </th>
+            <th scope="col" className="bg-base-lightest padding-y-205">
+              {t("headings.name")}
+            </th>
+            <th scope="col" className="bg-base-lightest padding-y-205">
+              {t("headings.roles")}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <OrganizationUserRow
+            email="Loading"
+            user_id="0"
+            first_name="Loading"
+            last_name="Loading"
+            key="suspended"
+          />
+        </tbody>
+      </Table>
+    </>
+  );
+};
 
 const OrganizationUserRow = ({
   email,
@@ -33,7 +67,9 @@ const OrganizationRosterInfo = () => {
   return (
     <>
       <h3>{t("title")}</h3>
-      <div>{t("explanation")}</div>
+      <div>
+        {t("explanation")} {t("manageUsersExplanation")}
+      </div>
     </>
   );
 };
@@ -43,7 +79,7 @@ export const OrganizationRoster = async ({
 }: {
   organizationId: string;
 }) => {
-  const t = useTranslations("OrganizationDetail.rosterTable");
+  const t = await getTranslations("OrganizationDetail.rosterTable");
   const session = await getSession();
   if (!session?.token) {
     return (

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1469,8 +1469,9 @@ export const messages = {
       "Visit <link>sam.gov</link> to make changes to your organization’s details.",
     rosterTable: {
       title: "Organization roster",
-      explanation:
-        "Your organization's active members are listed below. Manage Users to add or update roles and permissions.",
+      explanation: "Your organization's active members are listed below.",
+      manageUsersExplanation:
+        "Manage Users to add or update roles and permissions.",
       headings: {
         email: "Email",
         name: "Name",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
 unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Fixes a couple of problems with loading the organization page successfully

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

* use `getTranslations` in the <OrganizationRoster> rather than `useTranslations`, since it's an async component
* add suspense and a skeleton for the organization roster

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
4. visit http://localhost:3000?_ff=userAdminOff:false
5. log in with one_org_user
6. select the workspace nav item from the user drop down
7. _VERIFY_: you see a link to an organization in the page
8. click the link
10. _VERIFY_: you see your user and at least one other in organization roster table