### PR TITLE
[Issue #6685] Better reporting on and conservation of disk space during CI/CD runner

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -77,9 +77,11 @@ jobs:
           key: ${{ inputs.app_name }}-docker-img-${{ needs.get-commit-hash.outputs.commit_hash }}
 
       - name: Set up Docker Buildx
+        if: steps.check-docker-image-cached.outputs.cache-hit != 'true'
         uses: docker/setup-buildx-action@master
 
       - name: Restore Docker layers
+        if: steps.check-docker-image-cached.outputs.cache-hit != 'true'
         id: restore-buildx
         uses: actions/cache/restore@v4
         with:
@@ -89,6 +91,7 @@ jobs:
             ${{ inputs.app_name }}-buildx-
 
       - name: Ensure Buildx cache exists
+        if: steps.check-docker-image-cached.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/.buildx-cache
           echo Pre-docker build file sizes
@@ -121,6 +124,7 @@ jobs:
 
       #- name: Delete installed packages
       - name: Cache Docker layers
+        if: steps.check-docker-image-cached.outputs.cache-hit != 'true'
         id: cache-buildx
         uses: actions/cache/save@v4
         with:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6685 

## Changes proposed

- Better checking and skipping of unnecessary steps if we don't actually need to build anything
- If we do need to build, additional logging of free space on disk throughout the process so we can know if we're running low on space
- Adopt Docker Build Cache approach from recent Platform Template changes to ensure we are trimming the cache run to run

## Context for reviewers

We were running out of disk space on the runner that does the vulnerability scans. This was partially due to:
- the amount of tools pre-installed on the runner
- the images we downloaded/ran as part of this step
- the build artifacts we kept around on disk after we didn't need them any more. 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
