### PR TITLE
[Unticketed] Upgrade package for vulnerability scan

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2534,14 +2534,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pypdf"
-version = "6.1.1"
+version = "6.1.3"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pypdf-6.1.1-py3-none-any.whl", hash = "sha256:7781f99493208a37a7d4275601d883e19af24e62a525c25844d22157c2e4cde7"},
-    {file = "pypdf-6.1.1.tar.gz", hash = "sha256:10f44d49bf2a82e54c3c5ba3cdcbb118f2a44fc57df8ce51d6fb9b1ed9bfbe8b"},
+    {file = "pypdf-6.1.3-py3-none-any.whl", hash = "sha256:eb049195e46f014fc155f566fa20e09d70d4646a9891164ac25fa0cbcfcdbcb5"},
+    {file = "pypdf-6.1.3.tar.gz", hash = "sha256:8d420d1e79dc1743f31a57707cabb6dcd5b17e8b9a302af64b30202c5700ab9d"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary

## Changes proposed
Upgrade pypdf which has a vulnerability in 6.1.1

## Context for reviewers
```
NAME   INSTALLED  FIXED IN  TYPE    VULNERABILITY        SEVERITY  EPSS  RISK  
pypdf  6.1.1      6.1.3     python  GHSA-jfx9-29x2-rv3j  Medium    N/A   N/A   
pypdf  6.1.1      6.1.3     python  GHSA-vr63-x8vc-m265  Medium    N/A   N/A   
```
