### PR TITLE
Patch api/Dockerfile to fix step functions failure.

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -38,6 +38,7 @@ COPY newrelic.ini /api/newrelic.ini
 RUN PY_MM=$(cat /tmp/py_version.txt) && \
     /usr/local/bin/python"${PY_MM}" -m poetry build --format wheel && \
     /api/.venv/bin/python -m pip install --no-cache-dir dist/simpler_grants_gov_api-0.1.0-py3-none-any.whl && \
+    /api/.venv/bin/python -m pip install --no-cache-dir "virtualenv>=20.35.3" && \
     SITE_BASE="/api/.venv/lib/python${PY_MM}/site-packages" && \
     mkdir -p "${SITE_BASE}/src" && \
     cp "/api/newrelic.ini" "${SITE_BASE}/src/newrelic.ini" && \
@@ -113,11 +114,7 @@ RUN PY_MM=$(cat /tmp/py_version.txt) && \
       /api/.venv/bin/pip* \
       /api/.venv/bin/easy_install* \
       /root/.local/share/virtualenv \
-      "/home/${RUN_USER}/.local/share/virtualenv" \
-      /usr/local/lib/python"${PY_MM}"/site-packages/virtualenv/seed/wheels/embed/pip-*.whl \
-      /usr/local/lib/python"${PY_MM}"/site-packages/virtualenv/seed/wheels/embed/setuptools-*.whl \
-      /usr/local/lib/python"${PY_MM}"/site-packages/virtualenv/seed/wheels/embed/wheel-*.whl \
-      /usr/local/lib/python"${PY_MM}"/site-packages/virtualenv || true
+      "/home/${RUN_USER}/.local/share/virtualenv" || true
 
 ENV PATH="/api/.venv/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin" \
     HOST=0.0.0.0 \


### PR DESCRIPTION
## Summary

Steps functions are failing in dev w/ the error message: 

`No module named 'virtualenv'`

Added the virtualenv module back. 

Ensured we have no regressions: 

1. FrontEnd tests still passing [here](https://github.com/HHS/simpler-grants-gov/actions/runs/18884076672)
2. API CI Anchore scans passing [here](https://github.com/HHS/simpler-grants-gov/actions/runs/18884049361): 
3. Deployed in dev to test step functions [here](https://github.com/HHS/simpler-grants-gov/actions/runs/18884168966)
4. Latest successful step functions "load-search-oppurtunity-data" -> [3469010b-a88b-469d-8a40-ed5b725fc986](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:315341936575:execution:api-dev-load-search-opportunity-data:3469010b-a88b-469d-8a40-ed5b725fc986)

## Validation steps

Api and step functions should function as normal.