### PR TITLE
[Issue #6892] Upgrade PostgreSQL version for Compose

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   grants-db:
-    image: postgres:15-alpine
+    image: postgres:17.5-alpine
     container_name: grants-db
     command: postgres -c "log_lock_waits=on" -N 1000 -c "fsync=off"
     env_file: ./local.env


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6892 
Anyone running the API locally will need to run the following steps in the `api/` directory:
- `docker compose down` or `make stop`
- `make remake-backend` 
- `docker compose up` or `make run-logs`

## Changes proposed

Bumps the container version to match the PostgresSQL version we're running in AWS

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

1. Check out this branch
2. Run the steps above in the `api/` folder
3. Validate that FE/API still work locally
