### PR TITLE
[Issue #6903] Add CD511 and form building docs

### DIFF
--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -150,6 +150,8 @@ class FormType(StrEnum):
     BUDGET_NARRATIVE_ATTACHMENT = "BudgetNarrativeAttachment"
     PROJECT_ABSTRACT_SUMMARY = "ProjectAbstractSummary"
 
+    CD511 = "CD511"
+
 
 class CompetitionOpenToApplicant(StrEnum):
     INDIVIDUAL = "individual"

--- a/api/src/db/models/lookup_models.py
+++ b/api/src/db/models/lookup_models.py
@@ -159,6 +159,7 @@ FORM_TYPE_CONFIG: LookupConfig[FormType] = LookupConfig(
         LookupStr(FormType.PROJECT_NARRATIVE_ATTACHMENT, 5),
         LookupStr(FormType.BUDGET_NARRATIVE_ATTACHMENT, 6),
         LookupStr(FormType.PROJECT_ABSTRACT_SUMMARY, 7),
+        LookupStr(FormType.CD511, 8),
     ]
 )
 

--- a/api/src/form_schema/forms/README.md
+++ b/api/src/form_schema/forms/README.md
@@ -4,43 +4,355 @@ we currently support. This is a very simple approach
 to organization of the forms, and likely won't be
 the approach we take long-term past the pilot.
 
+# How to rebuild a form from grants.gov
 
-# How to Build
-To build the JSON schema, you need a few things from the existing system for a given form:
-* The .dat file
-* The XML/.xsd schema
-* The fillable PDF
+## Required files
+We need to collect several files in order to build a form.
+Several of these can be found by finding the form on
+https://grants.gov/forms/forms-repository/ and going to the
+FID page for the form.
 
-All of these can be found under https://grants.gov/forms/forms-repository/ - for example
-for building out the SF424, you can find all of the relevant links on the "Form Item Descriptions"
-page: https://grants.gov/forms/form-items-description/fid/713
+### .dat
+The .dat file can be downloaded on the FID page. The FID
+page also contains the .dat information.
 
+This contains a description of each field in the form
+including validation rules and conditionally required rules
+like whether a field is only required when a different field
+is answered a certain way.
 
-Actually building out the JSON schema is mostly manual, but we have a utility
-that can at least help with getting most of the fields pulled into something.
-Running the `make dat-to-jsonschema` command and passing it the .dat file
-will at least give you a very, very rough schema.
-`make dat-to-jsonschema args="~/Downloads/SF424_4_0-V4.0_F713.xls" > out.txt`
+### PDF
+The PDF file can be downloaded on the FID page.
 
-It does not however get a valid JSON schema, and you will need to go field-by-field
-and fix the schema. A few callouts:
-* The dat often contains fields that are actually labels OR actually represent a complex type, look at how the XSD and PDF represent the data
-* The types don't line up exactly, check all of them, especially fields like monetary amounts and attachments which work different in our system
-* Look thoroughly at the XML/.xsd file, it provides more validation details than the .dat
-* Conditionally required fields (if X == Y, then Z is required), are defined on the form-item-description page and need to be built manually
-* The title/description fields are used by our UI, they almost certainly need to be rewritten completely from what the .dat file put
-* Common or nested fields should be defined in the `$defs` section
+This can be very helpful in confirming your understanding
+of how fields work as you can see the behavior of validation,
+conditionally required fields, and is a great visual aid
+that should be used as a good way of resolving any inconsistencies
+you see between other files.
 
-Be aware that some schemas are quite complex and may not be represented in a way
-that our tool can transform properly (eg. the SF424A budget form), in these cases
-I'd recommend using the XSD + PDF as a starting point.
+### .xsd Schema
+The .xsd schema can be downloaded on the FID page.
 
-### Reading the .xsd file
-A few tips:
-* Many fields reference/import types. The files they import from are at the top of the XSD, but mostly those types are defined in https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd
-* If a field has `minOccurs="0"` and no maxOccurs, it means the field is not required (at least by default, conditional validation may change that)
-* Many string fields have a min and max length defined, copy those to our schema
+This defines the schema of the underlying data of
+a form in grants.gov. We need to make sure that every
+answerable field in this gets translated into our JSON schema
+in some form. We should generally try to keep the same
+general structure as the XSD schema, although this
+is not 100% required as we can fix the shape when
+we have to transform it back.
 
-# Future Ideas/Work
-* Common Schemas - Having a central/common schema instead of our current approach of putting everything a schema needs into that single schema.
-* An approach to developing and managing the deployment of schemas
+Sometimes we may exclude fields from the xsd in our JSON
+schema if the value is static, or a duplicate of another field.
+
+### Instructions
+The instructions can be downloaded on the FID page.
+
+Some forms do not have instructions. The instructions
+will need to be re-uploaded in our system, and can help
+you better understand the behavior of fields.
+
+### Form information
+We have to fetch extra form information from grants.gov's database
+in order to properly populate information below.
+
+Ask other engineers for the latest copy of our form information.
+
+### Pre/post-population rules
+Pre/post population rules are partially defined in a database table
+in grants.gov called `TWORKSPACE_POP_REF`. We'll need to collect
+rules from that for a given form.
+
+Ask other engineers for the latest copy of this information.
+
+## Information to collect
+Our forms require the following information to create:
+* `form_id` - a static UUID, generate a new one for the form
+* `legacy_form_id` - Integer, pulled from legacy system, can get from the end of the URL of the FID page.
+* `form_name` - String, the `formname` from the form information.
+* `short_form_name` - String, the `shortformname` from the form information
+* `form_version` - String, the `version` from the form information, can also see it in the FID page.
+* `agency_code` - `SGG` - At the moment, we say all forms are owned by our own `Simpler Grants.gov` agency
+* `omb_number` - String, the `ombnumber` from the form information.
+* `form_json_schema` - JSON - this is the largest component to build and is described further below.
+* `form_ui_schema` - JSON - this is configured by our frontend engineers.
+* `form_rule_schema` - JSON - this contains an optional set of pre/post/other validation rules, further described below.
+* `json_to_xml_schema` - JSON - this contains rules on how to transform the JSON into XML to be compatible with grants.gov's form data format, further described below.
+* `form_instruction_id` - UUID - this is necessary if a form has instructions, null otherwise. When updating a form in an environment, you'll first need to upload the attachments, further described below.
+* `form_type` - FormType enum - This should be used to group forms of different versions together. Generally just name this similar to the short form name without any version info.
+* `sgg_version` - `1.0` - represents a version of a form in our system, all our forms will start at `1.0`
+* `is_deprecated` - `False` - this represents whether a form is deprecated, if it's a new form, it won't be deprecated
+
+## Building the JSON Schema
+The JSON schema is by far the most complex part of setting up a form
+as it needs to contain most of the information about a form, specifically
+all of the fields within the form, their validations, as well as conditional
+validations.
+
+We do have a utility for turning a .dat file into a very rough
+JSON schema, although it's still going to require quite a bit of work to setup
+and in many cases you'll need to do the JSON schema setup manually.
+If you want to use the utility, make sure you have the .dat file for the JSON schema
+and run: `make dat-to-jsonschema args="~/Downloads/SF424_4_0-V4.0_F713.xls" > out.txt`
+specifying whatever dat file you downloaded.
+
+When building JSON schemas, a few important things to keep in mind:
+* If a field is a commonly used field (like an address or name), use the shared schema.
+This will save you time as you don't need to redefine entire parts of the data model.
+* If a part of the schema repeats, but isn't something that would be used outside of
+the form you are working on, put it in the "$defs" section to be reusable.
+* Keep naming consistent, don't worry about how the fields are named in the XML if they
+go against our conventions. Use `snake_case` for field names.
+* Unit tests are vital to making sure the schema is defined correctly.
+It can help to first start by defining what the JSON data will look like
+in a test and then make the schema that validates it as correct.
+
+### Shared Schema
+We define many fields in a shared schema. These are field types that
+get reused in many different places in our schemas as they represent
+common types like addresses or names.
+
+You can use the shared schema when defining a form schema by doing the
+following:
+
+```python
+from src.form_schema.shared import ADDRESS_SHARED_V1
+
+MY_EXAMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "my_simple_address": {
+            # Whatever field passed into the field_ref function
+            # will properly reference that field in the schema
+            # A shared schema can contain several different fields
+            # that can be imported, this is how you pick which one you want
+            "allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("simple_address")}],
+            # Note that you can exclude the title/description, whatever is
+            # defined in the referenced schema will be used.
+            "title": "My Simple Address",
+            "description": "The simple address you need to enter"
+        }
+    }
+}
+```
+Note that when referencing another field, we put it in an `allOf`. This
+is because otherwise the title/description we specify would get overriden
+by the reference. `allOf` behaves sorta like inheritance so doing it this way
+we'll first grab the address, and then add our own title/description.
+
+If a field looks like it appears in several forms, consider adding it
+to a shared schema. This will save more time as we build out future forms
+as we will need to
+
+### Some helpful JSON schema tips
+The [JSON schema reference](https://json-schema.org/understanding-json-schema/reference) is a great starting place
+for furthering your understanding of JSON schema and contains many examples.
+
+#### Attachments
+The way we handle attachments is much different than the way they're
+specified in the XML. For an attachment field, we define them as
+a simple UUID field (an array is also acceptible for a multi-attachment field)
+like so:
+
+```python
+from src.form_schema.shared import COMMON_SHARED_V1
+
+MY_EXAMPLE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "single_attachment": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
+            "title": "My Single Attachment",
+            "description": "Please add an attachment to explain your situation"
+        },
+        "array_attachment": {
+            "type": "array",
+            "title": "My array attachment",
+            "description": "Add several attachments to explain",
+            "maxItems": 100, # Good to add a limit to the number of files
+            "items": {"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}]},
+        }
+    }
+}
+```
+
+Additionally, when defining the rule schema YOU MUST add
+a rule to validate the attachment. This is required to account
+for certain scenarios where a user could have deleted an attachment,
+but it still exist in the answers they gave on a form.
+
+```python
+FORM_RULE_SCHEMA = {
+    "single_attachment": {"gg_validation": {"rule": "attachment"}},
+    "array_attachment": {"gg_validation": {"rule": "attachment"}},
+}
+```
+
+#### Figuring out validations required
+Determining what validations we need to add to a field can be tricky.
+Most validations fall into one of a few categories:
+* Field length (min and/or max)
+* Pattern/regex matching
+* Formats (date, email, uuid)
+* Whether the field is required (or conditionally required)
+* Allowed values (enumerations)
+
+Most of this information can be parsed from:
+* The .xsd / XML schema
+* The .dat / FID page
+* Testing out the behavior in the PDF form
+
+##### Parsing the .xsd
+The XML schema is good for determining many of the field restrictions.
+Here are a few examples, and how to interpret them.
+
+Many fields refer to types that are defined in other schemas. For example
+it's not uncommon for a field like an address to have fields defined like
+```xml
+<xs:element name="Street1" type="globLib:StreetDataType"/>
+```
+This is saying that the type of the object can be pulled from the globLib
+namespace (namespaces are defined at the top of the schema generally and including a link)
+and to check that file.
+
+If we go to the GlobalLibrary schema, we find that field defined as:
+```xml
+<xs:simpleType name="StreetDataType">
+    <xs:restriction base="xs:string">
+        <xs:minLength value="1"/>
+        <xs:maxLength value="55"/>
+    </xs:restriction>
+</xs:simpleType>
+```
+This defines a min and max length of the field and gives its basic type. We
+can easily translate these values into a JSON schema.
+
+---
+
+If a field represents an enumeration, it defines the values like so:
+```xml
+<xs:simpleType name="RevisionCodeDataType">
+    <xs:restriction base="xs:string">
+        <xs:enumeration value="A: Increase Award"/>
+        <xs:enumeration value="B: Decrease Award"/>
+        <xs:enumeration value="C: Increase Duration"/>
+        <xs:enumeration value="D: Decrease Duration"/>
+    </xs:restriction>
+</xs:simpleType>
+```
+Where the 4 possible values can be pulled from the enumeration array.
+
+---
+
+A field with a pattern/regex might look like:
+```xml
+<xs:simpleType name="SocialSecurityNumberDataType">
+    <xs:restriction base="xs:string">
+        <xs:pattern value="[0-9]{3}\-[0-9]{2}\-[0-9]{4}"/>
+    </xs:restriction>
+</xs:simpleType>
+```
+
+---
+
+Whether a field is required is based on the `minOccurs` attribute.
+If this value is set as `minOccurs="0"` then the field is NOT required.
+If the value is greater than 0 or not present at all then the field IS required.
+
+For example, this would be a required field because `minOccurs` is missing.
+```xml
+<xs:element name="Street1" type="globLib:StreetDataType"/>
+```
+
+##### Parsing the .dat
+The .dat / FID file explains field validations, and is
+generally pretty understandable, providing min/max lengths,
+allowed values, and any business rules.
+
+The most important one to keep an eye out for are conditionally
+required field rules. This is the main place we can find that information
+as the only other place it's really defined is in the PDFs.
+
+However, be careful as there are some rules that grants.gov
+might have that we don't yet have any corresponding behavior yet.
+The .dat often describes how fields populate from another form
+(most often pulling values from the SF424 or similar). We don't
+have that support, so those fields will require a user to populate
+even if the .dat says a user can't touch them.
+
+#### Conditionally required fields
+Let's assume we have a form with two questions, one that asks
+a multi-select question, and another that if you answered "other"
+it would become required. To specify that the second question is conditionally
+required you could have a JSON schema like so:
+
+```python
+MY_EXAMPLE_JSON_SCHEMA = {
+    "type": "object",
+    "required": [
+        # Only the select field is required by default
+        "my_select_field"
+    ],
+    "properties": {
+        "my_select_field": {
+            "type": "string",
+            "title": "My Select Field",
+            "description": "A field that can be selected!",
+            "enum": ["Yes", "No", "Other"]
+        },
+        "my_select_field_other": {
+            "type": "string",
+            "title": "My Select Field Other",
+            "description": "Answer this if you said 'Other' to the above question"
+        }
+    },
+    # Define conditionally required fields in an "allOf"
+    # otherwise we can only have a single one on the whole schema.
+    # This just makes it a list of if/then/else
+    "allOf": [
+        # If my_select_field is Other, my_select_field_other becomes required
+        {
+            "if": {
+                # This basically says 'if my_select_field == "Other"'
+                "properties": {"my_select_field": {"const": "Other"}},
+                # Required here makes it so the rule only runs if my_select_field is set
+                # which avoids some odd behavior otherwise. Should generally always include the field you're checking
+                "required": ["my_select_field"]
+            },
+            # This says to add anything in the list to the required on the object
+            # Multiple fields can be specified
+            # If we instead wanted to change other behavior (adding a regex) that is also doable
+            "then": {"required": ["my_select_field_other"]}
+        }
+    ]
+}
+```
+
+## Building the rule schema
+We currently have 3 groups of rules:
+* Pre-population - fields we populate when a user starts OR updates an application form
+* Post-population - fields we populate only when a user submits an application form
+* Validation - fields we validate with custom rules that can't be expressed in JSON schema
+
+For details on how these rules work, and how to configure them,
+see the [Rule Processing README](../rule_processing/README.md)
+
+To know which rules we need to add, we need to consult the
+pre/post-population documentation. In this we need to find
+which fields that grants.gov populated for a given form. We
+should generally support most of the rules already, note that
+they called pre-population `CORE` and post-population `POST`.
+This document contains many cross-form population rules as well
+that we don't yet support.
+
+However, this doesn't contain all population rules, as any
+auto-summation isn't defined in this. That type of rule can really
+only be found by figuring out the behavior from the PDF. Consult
+with product and confirm the behavior we want for any auto-summed fields.
+
+## Building the XML Conversion Schema
+TODO - we'll want to document this when we build out
+more of the schemas.
+
+## Deploying a form
+We deploy forms to a given environment using a set of scripts.
+This is documented in [task/forms/README.md](/api/src/task/forms/README.md)

--- a/api/src/form_schema/forms/__init__.py
+++ b/api/src/form_schema/forms/__init__.py
@@ -1,6 +1,7 @@
 from src.db.models.competition_models import Form
 
 from .budget_narrative_attachment import BudgetNarrativeAttachment_v1_2
+from .cd511 import CD511_v1_1
 from .project_abstract_summary import ProjectAbstractSummary_v2_0
 from .project_narrative_attachment import ProjectNarrativeAttachment_v1_2
 from .sf424 import SF424_v4_0
@@ -19,4 +20,5 @@ def get_active_forms() -> list[Form]:
         ProjectAbstractSummary_v2_0,
         BudgetNarrativeAttachment_v1_2,
         ProjectNarrativeAttachment_v1_2,
+        CD511_v1_1,
     ]

--- a/api/src/form_schema/forms/cd511.py
+++ b/api/src/form_schema/forms/cd511.py
@@ -1,0 +1,161 @@
+import uuid
+
+from src.constants.lookup_constants import FormType
+from src.db.models.competition_models import Form
+from src.form_schema.shared import COMMON_SHARED_V1
+
+DIRECTIONS = """Applicants should also review the instructions for certification included in the regulations before completing this form. Signature on this form provides for
+compliance with certification requirements under 15 CFR Part 28, 'New Restrictions on Lobbying.' The certifications shall be treated as a material representation
+of fact upon which reliance will be placed when the Department of Commerce determines to award the covered transaction, grant, or cooperative agreement.
+
+LOBBYING
+
+As required by Section 1352, Title 31 of the U.S. Code, and implemented at 15 CFR Part 28, for persons entering into a grant, cooperative agreement or contract over $100,000 or a loan or loan guarantee over $150,000 as defined at 15 CFR Part 28, Sections 28.105 and 28.110, the applicant certifies that to the best of his or her knowledge and belief, that:
+
+(1) No Federal appropriated funds have been paid or will be paid, by or on behalf of the undersigned, to any person for influencing or attempting to influence an officer or employee of any agency, a Member of Congress in connection with the awarding of any Federal contract, the making of any Federal grant, the making of any Federal loan, the entering into of any cooperative agreement, and the extension, continuation, renewal, amendment, or modification of any Federal contract, grant, loan, or cooperative agreement.
+
+(2) If any funds other than Federal appropriated funds have been paid or will be paid to any person for influencing or attempting to influence an officer or employee of any agency, a Member of Congress, an officer or employee of Congress, or an employee of a member of Congress in connection with this Federal contract, grant, loan, or cooperative agreement, the undersigned shall complete and submit Standard Form-LLL, 'Disclosure Form to Report Lobbying.' in accordance with its instructions.
+
+(3) The undersigned shall require that the language of this certification be included in the award documents for all subawards at all tiers (including subcontracts, subgrants, and contracts under grants, loans, and cooperative agreements) and that all subrecipients shall certify and disclose accordingly.
+
+This certification is a material representation of fact upon which reliance was placed when this transaction was made or entered into. Submission of this certification is a prerequisite for making or entering into this transaction imposed by section 1352, title 31, U.S. Code. Any person who fails to file the required certification shall be subject to a civil penalty of not less than $10,000 and not more than $100,000 for each such failure occurring on or before October 23, 1996, and of not less than $11,000 and not more than $110,000 for each such failure occurring after October 23, 1996.
+
+Statement for Loan Guarantees and Loan Insurance
+
+The undersigned states, to the best of his or her knowledge and belief, that:
+
+In any funds have been paid or will be paid to any person for influencing or attempting to influence an officer or employee of any agency, a Member of Congress, an officer or employee of Congress, or an employee of a Member of Congress in connection with this commitment providing for the United States to insure or guarantee a loan, the undersigned shall complete and submit Standard Form-LLL, 'Disclosure Form to Report Lobbying,' in accordance with its instructions.
+
+Submission of this statement is a prerequisite for making or entering into this transaction imposed by section 1352, title 31, U.S. Code. Any person who fails to file the required statement shall be subject to a civil penalty of not less than $10,000 and not more than $100,000 for each such failure occurring on or before October 23, 1996, and of not less than $11,000 and not more than $110,000 for each such failure occurring after October 23, 1996.
+
+As the duly authorized representative of the applicant, I hereby certify that the applicant will comply with the above applicable certification.
+"""
+
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    "required": [
+        "applicant_name",
+        "contact_person",
+        "contact_person_title",
+    ],
+    "allOf": [
+        ### These two rules go together and make sure that one of
+        ### award_number and project_name is provided.
+        #
+        # If award_number is not present, then project_name is required
+        {
+            "if": {"not": {"required": ["award_number"]}},
+            "then": {"required": ["project_name"]},
+        },
+        # If project_name is not present, then award_number is required
+        {
+            "if": {"not": {"required": ["project_name"]}},
+            "then": {"required": ["award_number"]},
+        },
+    ],
+    "properties": {
+        # Note this was called OrganizationName in the legacy system
+        # but the display text was "Name of Applicant".
+        "applicant_name": {
+            "type": "string",
+            "title": "Name of Applicant",
+            "minLength": 1,
+            "maxLength": 60,
+        },
+        "award_number": {
+            "type": "string",
+            "title": "Award Number",
+            "description": "Required if Project Name is blank",
+            "minLength": 1,
+            "maxLength": 25,
+        },
+        "project_name": {
+            "type": "string",
+            "title": "Project Name",
+            "description": "Required if Award Number is blank",
+            "minLength": 1,
+            "maxLength": 60,
+        },
+        "contact_person": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
+            "title": "Contact Name",
+        },
+        "contact_person_title": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
+        },
+        "signature": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
+        },
+        "submitted_date": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],
+        },
+    },
+}
+
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "1. Directions",
+        "name": "directions",
+        "description": DIRECTIONS,
+        "children": [],
+    },
+    {
+        "type": "section",
+        "name": "award",
+        "label": "2. Award",
+        "children": [
+            {"type": "field", "definition": "/properties/applicant_name"},
+            {"type": "field", "definition": "/properties/award_number"},
+            {"type": "field", "definition": "/properties/project_name"},
+        ],
+    },
+    {
+        "type": "section",
+        "name": "contact_person",
+        "label": "3. Contact Person",
+        "children": [
+            {"type": "field", "definition": "/properties/contact_person/properties/prefix"},
+            {"type": "field", "definition": "/properties/contact_person/properties/first_name"},
+            {"type": "field", "definition": "/properties/contact_person/properties/middle_name"},
+            {"type": "field", "definition": "/properties/contact_person/properties/last_name"},
+            {"type": "field", "definition": "/properties/contact_person/properties/suffix"},
+            {"type": "field", "definition": "/properties/contact_person_title"},
+        ],
+    },
+    {
+        "type": "section",
+        "name": "signature",
+        "label": "4. Signature",
+        "children": [
+            {"type": "null", "definition": "/properties/signature"},
+            {"type": "null", "definition": "/properties/submitted_date"},
+        ],
+    },
+]
+
+
+FORM_RULE_SCHEMA = {
+    ##### POST-POPULATION RULES
+    "submitted_date": {"gg_post_population": {"rule": "current_date"}},
+    "signature": {"gg_post_population": {"rule": "signature"}},
+}
+
+CD511_v1_1 = Form(
+    # https://www.grants.gov/forms/form-items-description/fid/276
+    form_id=uuid.UUID("7057eaee-f043-4029-b7f2-c932f11ce900"),
+    legacy_form_id=276,
+    form_name="CD511",
+    short_form_name="CD511",
+    form_version="1.1",
+    agency_code="SGG",
+    omb_number=None,
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    form_rule_schema=FORM_RULE_SCHEMA,
+    json_to_xml_schema=None,
+    # CD511 does not have any instructions
+    form_type=FormType.CD511,
+    sgg_version="1.0",
+    is_deprecated=False,
+)

--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -230,11 +230,9 @@ FORM_JSON_SCHEMA = {
             "description": "Enter information about the contact person.",
         },
         "contact_person_title": {
-            "type": "string",
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
             "title": "Title",
             "description": "Enter the position title.",
-            "minLength": 1,
-            "maxLength": 45,
         },
         "organization_affiliation": {
             "type": "string",
@@ -498,17 +496,12 @@ FORM_JSON_SCHEMA = {
             "description": "Enter a valid email Address.",
         },
         "aor_signature": {
-            "type": "string",
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
             "title": "AOR Signature",
-            "description": "Completed by Grants.gov upon submission.",
-            "minLength": 1,
-            "maxLength": 144,
         },
         "date_signed": {
-            "type": "string",
-            "format": "date",
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],
             "title": "Date Signed",
-            "description": "Completed by Grants.gov upon submission.",
         },
     },
 }

--- a/api/src/form_schema/forms/sf424b.py
+++ b/api/src/form_schema/forms/sf424b.py
@@ -2,6 +2,7 @@ import uuid
 
 from src.constants.lookup_constants import FormType
 from src.db.models.competition_models import Form
+from src.form_schema.shared import COMMON_SHARED_V1
 
 DIRECTIONS = """Public reporting burden for this collection of information is estimated to average 15 minutes per response, including time for reviewing instructions, searching existing data sources, gathering and maintaining the data needed, and completing and reviewing the collection of information. Send comments regarding the burden estimate or any other aspect of this collection of information, including suggestions for reducing this burden, to the Office of Management and Budget, Paperwork Reduction Project (0348-0040), Washington, DC 20503.
 
@@ -53,19 +54,14 @@ FORM_JSON_SCHEMA = {
     "required": ["title", "applicant_organization"],
     "properties": {
         "signature": {
-            "type": "string",
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
             "title": "Signature of the Authorized Certifying Official",
             "description": "Completed by Grants.gov upon submission.",
-            "minLength": 1,
-            "maxLength": 144,
         },
         "title": {
             # FUTURE WORK: This gets copied from the SF-424's AuthorizedRepresentativeTitle field
-            "type": "string",
-            "title": "Title",
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
             "description": "This should match the 'Authorized Representative Title' field from the SF-424 form",
-            "minLength": 1,
-            "maxLength": 45,
         },
         "applicant_organization": {
             # FUTURE WORK: This gets copied from the SF-424's OrganizationName field (called Legal Name in the UI)
@@ -76,10 +72,8 @@ FORM_JSON_SCHEMA = {
             "maxLength": 60,
         },
         "date_signed": {
-            "type": "string",
-            "format": "date",
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],
             "title": "Date Signed",
-            "description": "Completed by Grants.gov upon submission.",
         },
     },
 }

--- a/api/src/form_schema/forms/sflll.py
+++ b/api/src/form_schema/forms/sflll.py
@@ -178,34 +178,23 @@ FORM_JSON_SCHEMA = {
             "required": ["name"],
             "properties": {
                 "signature": {
-                    "type": "string",
-                    "title": "Signature",
-                    "description": "Completed by Grants.gov upon submission.",
-                    "minLength": 1,
-                    "maxLength": 144,
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
                 },
                 "name": {
                     "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
                 },
                 "title": {
-                    "type": "string",
-                    "title": "Title",
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
                     "description": "Enter the title of the Certifying Official.",
-                    "minLength": 1,
-                    "maxLength": 45,
                 },
                 "telephone": {
-                    "type": "string",
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
                     "title": "Telephone No.",
                     "description": "Enter the telephone number of the certifying official.",
-                    "minLength": 1,
-                    "maxLength": 25,
                 },
                 "signed_date": {
-                    "type": "string",
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],
                     "title": "Signature Date",
-                    "description": "Completed by Grants.gov upon submission.",
-                    "format": "date",
                 },
             },
         },

--- a/api/src/form_schema/shared/common_shared.py
+++ b/api/src/form_schema/shared/common_shared.py
@@ -67,6 +67,26 @@ COMMON_SHARED_JSON_SCHEMA_V1 = {
         "minLength": 1,
         "maxLength": 25,
     },
+    "contact_person_title": {
+        "type": "string",
+        "title": "Title",
+        "description": "Enter the position title.",
+        "minLength": 1,
+        "maxLength": 45,
+    },
+    "signature": {
+        "type": "string",
+        "title": "Signature",
+        "description": "Completed by Grants.gov upon submission.",
+        "minLength": 1,
+        "maxLength": 144,
+    },
+    "submitted_date": {
+        "type": "string",
+        "format": "date",
+        "title": "Submitted Date",
+        "description": "Completed by Grants.gov upon submission.",
+    },
 }
 
 

--- a/api/tests/src/form_schema/forms/conftest.py
+++ b/api/tests/src/form_schema/forms/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from src.db.models.competition_models import Form
 from src.form_schema.forms import (
     BudgetNarrativeAttachment_v1_2,
+    CD511_v1_1,
     ProjectAbstractSummary_v2_0,
     ProjectNarrativeAttachment_v1_2,
     SF424_v4_0,
@@ -32,6 +33,24 @@ def validate_required(data: dict, expected_required_fields: list[str], form: For
     for validation_issue in validation_issues:
         assert validation_issue.type == "required"
         assert validation_issue.field in expected_required_fields
+
+
+def validate_min_length(data, expected_fields_to_error: list[str], form: Form):
+    validation_issues = validate_json_schema_for_form(data, form)
+
+    assert len(validation_issues) == len(expected_fields_to_error)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "minLength"
+        assert validation_issue.field in expected_fields_to_error
+
+
+def validate_max_length(data, expected_fields_to_error: list[str], form: Form):
+    validation_issues = validate_json_schema_for_form(data, form)
+
+    assert len(validation_issues) == len(expected_fields_to_error)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "maxLength"
+        assert validation_issue.field in expected_fields_to_error
 
 
 @pytest.fixture(scope="session")
@@ -67,3 +86,8 @@ def project_narrative_attachment_v1_2():
 @pytest.fixture(scope="session")
 def budget_narrative_attachment_v1_2():
     return setup_resolved_form(BudgetNarrativeAttachment_v1_2)
+
+
+@pytest.fixture(scope="session")
+def cd511_v1_1():
+    return setup_resolved_form(CD511_v1_1)

--- a/api/tests/src/form_schema/forms/test_cd511.py
+++ b/api/tests/src/form_schema/forms/test_cd511.py
@@ -1,0 +1,194 @@
+import freezegun
+import pytest
+
+from src.services.applications.application_validation import (
+    ApplicationAction,
+    validate_application_form,
+)
+from tests.lib.data_factories import setup_application_for_form_validation
+from tests.src.form_schema.forms.conftest import (
+    validate_max_length,
+    validate_min_length,
+    validate_required,
+)
+
+
+@pytest.fixture
+def minimal_cd511_v1_1():
+    return {
+        "applicant_name": "Example Inc.",
+        "project_name": "My example project",
+        "contact_person": {
+            "first_name": "Bob",
+            "last_name": "Smith",
+        },
+        "contact_person_title": "Director",
+    }
+
+
+@pytest.fixture
+def full_cd511_v1_1():
+    return {
+        "applicant_name": "Example Inc.",
+        "award_number": "ABC-XYZ",
+        "project_name": "My example project",
+        "contact_person": {
+            "prefix": "Ms",
+            "first_name": "Sally",
+            "middle_name": "Sue",
+            "last_name": "Sanders",
+            "suffix": "III",
+        },
+        "contact_person_title": "Director",
+        "signature": "Bob Smith",
+        "submitted_date": "2025-01-01",
+    }
+
+
+def test_cd511_v1_1_minimal(minimal_cd511_v1_1, cd511_v1_1):
+    validate_required(minimal_cd511_v1_1, [], cd511_v1_1)
+
+
+def test_cd511_v1_1_full(full_cd511_v1_1, cd511_v1_1):
+    validate_required(full_cd511_v1_1, [], cd511_v1_1)
+
+
+def test_cd511_v1_1_empty_json(cd511_v1_1):
+    validate_required(
+        {},
+        [
+            "$.applicant_name",
+            "$.contact_person",
+            "$.contact_person_title",
+            "$.project_name",
+            "$.award_number",
+        ],
+        cd511_v1_1,
+    )
+
+
+def test_cd511_v1_1_empty_contact_person(minimal_cd511_v1_1, cd511_v1_1):
+    data = minimal_cd511_v1_1
+    data["contact_person"] = {}
+    validate_required(
+        data, ["$.contact_person.first_name", "$.contact_person.last_name"], cd511_v1_1
+    )
+
+
+def test_cd511_v1_1_mutually_required_fields(cd511_v1_1):
+    """Test that one of project_name or award_number is required
+    and will make their collective error messages go away."""
+    base_data = {
+        "applicant_name": "Example Inc.",
+        "contact_person": {
+            "first_name": "Bob",
+            "last_name": "Smith",
+        },
+        "contact_person_title": "Director",
+    }
+    validate_required(base_data, ["$.project_name", "$.award_number"], cd511_v1_1)
+
+    # Adding project_name or award_number removes all the errors.
+    validate_required(base_data | {"project_name": "my example project"}, [], cd511_v1_1)
+    validate_required(base_data | {"award_number": "abc123"}, [], cd511_v1_1)
+    # Both can be included as well
+    validate_required(
+        base_data | {"award_number": "abc123", "project_name": "my example project"}, [], cd511_v1_1
+    )
+
+
+def test_cd511_v1_1_min_length(cd511_v1_1):
+    data = {
+        "applicant_name": "",
+        "award_number": "",
+        "project_name": "",
+        "contact_person": {
+            "prefix": "",
+            "first_name": "",
+            "middle_name": "",
+            "last_name": "",
+            "suffix": "",
+        },
+        "contact_person_title": "",
+        "signature": "",
+    }
+
+    EXPECTED_ERROR_FIELDS = [
+        "$.applicant_name",
+        "$.award_number",
+        "$.project_name",
+        "$.contact_person.prefix",
+        "$.contact_person.first_name",
+        "$.contact_person.middle_name",
+        "$.contact_person.last_name",
+        "$.contact_person.suffix",
+        "$.contact_person_title",
+        "$.signature",
+    ]
+    validate_min_length(data, EXPECTED_ERROR_FIELDS, cd511_v1_1)
+
+
+def test_cd511_v1_1_max_length(cd511_v1_1):
+    data = {
+        "applicant_name": "A" * 61,
+        "award_number": "B" * 26,
+        "project_name": "C" * 61,
+        "contact_person": {
+            "prefix": "D" * 11,
+            "first_name": "E" * 36,
+            "middle_name": "F" * 26,
+            "last_name": "G" * 61,
+            "suffix": "H" * 11,
+        },
+        "contact_person_title": "I" * 46,
+        "signature": "J" * 145,
+    }
+
+    EXPECTED_ERROR_FIELDS = [
+        "$.applicant_name",
+        "$.award_number",
+        "$.project_name",
+        "$.contact_person.prefix",
+        "$.contact_person.first_name",
+        "$.contact_person.middle_name",
+        "$.contact_person.last_name",
+        "$.contact_person.suffix",
+        "$.contact_person_title",
+        "$.signature",
+    ]
+    validate_max_length(data, EXPECTED_ERROR_FIELDS, cd511_v1_1)
+
+
+def test_cd511_v1_1_pre_population(enable_factory_create, full_cd511_v1_1, cd511_v1_1):
+    # Note that this form has no pre-population, this is mostly a sanity check
+    # that nothing gets changed by it.
+    application_form = setup_application_for_form_validation(
+        full_cd511_v1_1,
+        json_schema=cd511_v1_1.form_json_schema,
+        rule_schema=cd511_v1_1.form_rule_schema,
+    )
+
+    issues = validate_application_form(application_form, ApplicationAction.MODIFY)
+    assert len(issues) == 0
+
+    # No changes
+    assert full_cd511_v1_1 == application_form.application_response
+
+
+@freezegun.freeze_time("2024-06-15 12:00:00", tz_offset=0)
+def test_cd511_v1_1_post_population(enable_factory_create, full_cd511_v1_1, cd511_v1_1):
+    application_form = setup_application_for_form_validation(
+        full_cd511_v1_1,
+        json_schema=cd511_v1_1.form_json_schema,
+        rule_schema=cd511_v1_1.form_rule_schema,
+        user_email="myexamplemail@example.com",
+    )
+
+    issues = validate_application_form(application_form, ApplicationAction.SUBMIT)
+    assert len(issues) == 0
+    app_json = application_form.application_response
+    # Verify just the two post-population fields were added
+    assert app_json == full_cd511_v1_1 | {
+        "signature": "myexamplemail@example.com",
+        "submitted_date": "2024-06-15",
+    }

--- a/api/tests/src/form_schema/shared/test_common_shared.py
+++ b/api/tests/src/form_schema/shared/test_common_shared.py
@@ -189,3 +189,81 @@ def test_shared_common_v1_phone_number_max_length():
     assert len(validation_issues) == 1
     assert validation_issues[0].type == "maxLength"
     assert validation_issues[0].field == "$.my_field"
+
+
+###################################
+# Contact Person Title
+###################################
+@pytest.mark.parametrize(
+    "value", ["Doctor", "Director", "3rd Best Employee", "Her Royal Highness, First of Her Name"]
+)
+def test_shared_common_v1_contact_person_title(value):
+    schema = build_schema(COMMON_SHARED_V1, "contact_person_title")
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 0
+
+
+def test_shared_common_v1_contact_person_title_min_length():
+    schema = build_schema(COMMON_SHARED_V1, "contact_person_title")
+
+    validation_issues = validate_json_schema({"my_field": ""}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
+def test_shared_common_v1_contact_person_title_max_length():
+    schema = build_schema(COMMON_SHARED_V1, "phone_number")
+
+    validation_issues = validate_json_schema({"my_field": "A" * 46}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
+###################################
+# Signature
+###################################
+@pytest.mark.parametrize("value", ["Fred Jones", "Norville 'Shaggy' Rogers", "Scooby"])
+def test_shared_common_v1_signature(value):
+    schema = build_schema(COMMON_SHARED_V1, "signature")
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 0
+
+
+def test_shared_common_v1_signature_min_length():
+    schema = build_schema(COMMON_SHARED_V1, "signature")
+
+    validation_issues = validate_json_schema({"my_field": ""}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
+def test_shared_common_v1_signature_max_length():
+    schema = build_schema(COMMON_SHARED_V1, "phone_number")
+
+    validation_issues = validate_json_schema({"my_field": "A" * 145}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
+###################################
+# Submitted Date
+###################################
+@pytest.mark.parametrize("value", ["2025-01-01", "1970-05-13", "2167-12-31"])
+def test_shared_common_v1_submitted_date(value):
+    schema = build_schema(COMMON_SHARED_V1, "submitted_date")
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 0
+
+
+@pytest.mark.parametrize("value", ["not-a-date", "-1234-56-78", "2025-01-01T12:00:00", "123-45-67"])
+def test_shared_common_v1_submitted_date_invalid_format(value):
+    schema = build_schema(COMMON_SHARED_V1, "submitted_date")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "format"
+    assert validation_issues[0].field == "$.my_field"


### PR DESCRIPTION
## Summary
Fixes #6903 

## Changes proposed
* Adds the CD511 form
* Rewrote and expanded docs about how to build a form
* Moved a few common data fields (signature, date submitted, contact person title) to the shared schema
* Added a quick UI schema - frontend folks will need to clean it up a bit, but all the fields are there and functional. Not sure if they'll want to adjust the big set of instructions at the top to be formatted differently, I just kept them as rough paragraphs for each part.

## Context for reviewers
This form is pretty simple, you can see what it looks like for yourself on https://www.grants.gov/forms/form-items-description/fid/276 - The only complexity is that the `award_number` and `project_name` are both required, but only as long as you haven't filled out the other one, or in other words, at least one is required. The "right" way to implement that in JSON schema would be to do a `oneOf` rule with two rules in it, but the error that generates is vague and unhelpful (roughly "none of the schemas in the oneOf validated" with no helpful details). Instead I made two rules that both do a `if x is not included, y is required` and vice-versa. This means that if neither is included, but are flagged, but at least the error message is relatively intuitive.

I'm really curious what folks think of the docs I wrote, I need to figure out where we'll put some of the form information that isn't public that is easy for engineers to reach. Probably will look to put it on our confluence?

## Validation steps
Easiest way to get to see the form:
* Run `make db-seed-local` - in the output you'll see a line early on that says `Created a competition for form 'CD511 1.1'` with a link to an opportunity with only this form. Go to that link
* Login as any user and start an app.

Here are some screenshots of what it looks like:
<img width="920" height="700" alt="Screenshot 2025-11-03 at 1 30 47 PM" src="https://github.com/user-attachments/assets/73730826-e7e6-48a9-92de-121815ecb99a" />
<img width="515" height="729" alt="Screenshot 2025-11-03 at 1 30 52 PM" src="https://github.com/user-attachments/assets/291673d8-5fa3-4dad-aa9d-211b91b2d5d4" />
<img width="489" height="716" alt="Screenshot 2025-11-03 at 1 30 58 PM" src="https://github.com/user-attachments/assets/0ec7ee79-f3b8-441c-ba2f-0c20322b309d" />
