### PR TITLE
[ISSUE #6654] Remove political review code

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -17,8 +17,7 @@ locals {
       "--load",
       "--transform",
       "--set-current",
-      "--store-version",
-      "--sync-status"
+      "--store-version"
     ],
     staging = [
       "poetry",
@@ -29,8 +28,7 @@ locals {
       "--load",
       "--transform",
       "--set-current",
-      "--store-version",
-      "--sync-status"
+      "--store-version"
     ],
     training = [
       "poetry",
@@ -41,8 +39,7 @@ locals {
       "--load",
       "--transform",
       "--set-current",
-      "--store-version",
-      "--sync-status"
+      "--store-version"
     ],
     prod = [
       "poetry",
@@ -53,8 +50,7 @@ locals {
       "--load",
       "--transform",
       "--set-current",
-      "--store-version",
-      "--sync-status"
+      "--store-version"
     ],
   }
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6654 

## Changes proposed

- Removed `--sync-status` flag from `load-transform` command in all environments

## Context for reviewers

- The `SyncOpportunityReviewStatus` task will no longer run as part of the scheduled hourly job
