### PR TITLE
[Issue #6317] Add an endpoint for listing application audit events

### DIFF
--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -5,9 +5,16 @@ from src.api.schemas.extension import Schema, fields
 from src.api.schemas.response_schema import (
     AbstractResponseSchema,
     FileResponseSchema,
+    PaginationMixinSchema,
     WarningMixinSchema,
 )
-from src.constants.lookup_constants import ApplicationFormStatus, ApplicationStatus
+from src.api.schemas.shared_schema import SimpleUserSchema
+from src.constants.lookup_constants import (
+    ApplicationAuditEvent,
+    ApplicationFormStatus,
+    ApplicationStatus,
+)
+from src.pagination.pagination_schema import generate_pagination_schema
 
 
 class ApplicationStartRequestSchema(Schema):
@@ -371,3 +378,72 @@ class ApplicationFormInclusionUpdateResponseSchema(AbstractResponseSchema):
 
 class ApplicationAddOrganizationResponseSchema(AbstractResponseSchema):
     data = fields.Nested(ApplicationUpdateResponseDataSchema())
+
+
+class ApplicationAuditRequestSchema(Schema):
+
+    pagination = fields.Nested(
+        generate_pagination_schema(
+            "ApplicationAuditRequestPaginationSchema",
+            ["created_at"],
+            default_sort_order=[{"order_by": "created_at", "sort_direction": "descending"}],
+        ),
+        required=True,
+    )
+
+
+class ApplicationAuditAppFormSchema(Schema):
+
+    application_form_id = fields.UUID(metadata={"description": "The ID of the application form"})
+    competition_form_id = fields.UUID(metadata={"description": "The ID of the competition form"})
+    form_id = fields.UUID(metadata={"description": "The ID of the form"})
+    form_name = fields.String(metadata={"description": "The name of the form"})
+
+
+class ApplicationAuditAttachmentSchema(Schema):
+
+    application_attachment_id = fields.UUID(
+        metadata={"description": "The ID of the application attachment"}
+    )
+    file_name = fields.String(
+        metadata={
+            "description": "The file name of the application attachment",
+            "example": "my_example.pdf",
+        }
+    )
+
+    is_deleted = fields.Boolean(metadata={"description": "Whether the attachment has been deleted"})
+
+
+class ApplicationAuditDataSchema(Schema):
+    application_audit_id = fields.UUID(
+        metadata={"description": "The ID of the application audit event"}
+    )
+    application_audit_event = fields.Enum(
+        ApplicationAuditEvent,
+        metadata={"description": "The type of application audit event recorded"},
+    )
+
+    user = fields.Nested(
+        SimpleUserSchema(), metadata={"description": "The user who did the event that was audited"}
+    )
+    target_user = fields.Nested(
+        SimpleUserSchema(),
+        metadata={"description": "The user the audit event affected (if applicable)"},
+    )
+
+    target_application_form = fields.Nested(
+        ApplicationAuditAppFormSchema(),
+        metadata={"description": "The application form modified (if applicable)"},
+    )
+
+    target_attachment = fields.Nested(
+        ApplicationAuditAttachmentSchema(),
+        metadata={"description": "The application attachment modified (if applicable)"},
+    )
+
+    created_at = fields.DateTime(metadata={"description": "When the audit event was created"})
+
+
+class ApplicationAuditResponseSchema(AbstractResponseSchema, PaginationMixinSchema):
+    data = fields.List(fields.Nested(ApplicationAuditDataSchema()))

--- a/api/src/api/schemas/shared_schema.py
+++ b/api/src/api/schemas/shared_schema.py
@@ -1,4 +1,4 @@
-from src.api.schemas.extension import Schema, fields
+from src.api.schemas.extension import Schema, fields, validators
 from src.constants.lookup_constants import Privilege
 
 
@@ -37,4 +37,24 @@ class OpportunityAssistanceListingV1Schema(Schema):
             "description": "The assistance listing number, see https://sam.gov/content/assistance-listings for more detail",
             "example": "43.012",
         },
+    )
+
+
+class SimpleUserSchema(Schema):
+    """Schema for a simple user schema with user ID, name and email"""
+
+    user_id = fields.UUID(
+        metadata={
+            "description": "ID of the user",
+        }
+    )
+    email = fields.String(
+        metadata={"description": "Email address of the user", "example": "example@example.com"},
+        validate=[validators.Email()],
+    )
+    first_name = fields.String(
+        allow_none=True, metadata={"description": "Users first name", "example": "John"}
+    )
+    last_name = fields.String(
+        allow_none=True, metadata={"description": "Users last name", "example": "Smith"}
     )

--- a/api/src/db/models/competition_models.py
+++ b/api/src/db/models/competition_models.py
@@ -321,6 +321,13 @@ class Application(ApiSchemaTable, TimestampMixin):
         cascade="all, delete-orphan",
     )
 
+    application_audits: Mapped[list["ApplicationAudit"]] = relationship(
+        "ApplicationAudit",
+        uselist=True,
+        back_populates="application",
+        cascade="all, delete-orphan",
+    )
+
     @property
     def users(self) -> list["User"]:
         """Return the list of User objects associated with this application"""

--- a/api/src/services/applications/list_application_audit.py
+++ b/api/src/services/applications/list_application_audit.py
@@ -1,0 +1,96 @@
+import uuid
+from collections.abc import Sequence
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+import src.adapters.db as db
+from src.auth.endpoint_access_util import verify_access
+from src.constants.lookup_constants import Privilege
+from src.db.models.competition_models import ApplicationAudit, ApplicationForm, CompetitionForm
+from src.db.models.user_models import User
+from src.pagination.pagination_models import PaginationInfo, PaginationParams
+from src.pagination.paginator import Paginator
+from src.services.applications.get_application import get_application
+from src.services.service_utils import apply_sorting
+
+
+class ApplicationAuditRequest(BaseModel):
+    pagination: PaginationParams
+
+
+def list_application_audit(
+    db_session: db.Session, application_id: uuid.UUID, user: User, request: dict
+) -> tuple[list[dict], PaginationInfo]:
+    # Turn the request params into something easier to work with
+    params = ApplicationAuditRequest.model_validate(request)
+
+    # Fetch the application, verifying it exists
+    application = get_application(db_session, application_id, user)
+
+    # Verify the user can access the application
+    verify_access(user, {Privilege.VIEW_APPLICATION}, application)
+
+    # Setup request, needs audit records for the app + loading relationships
+    stmt = (
+        select(ApplicationAudit)
+        .where(ApplicationAudit.application_id == application_id)
+        .options(
+            # Preload the user + their profile & login.gov email
+            selectinload(ApplicationAudit.user).options(
+                selectinload(User.profile), selectinload(User.linked_login_gov_external_user)
+            ),
+            # Preload the target user + their profile & login.gov email
+            selectinload(ApplicationAudit.target_user).options(
+                selectinload(User.profile), selectinload(User.linked_login_gov_external_user)
+            ),
+            # Preload the application form + competition form + form
+            selectinload(ApplicationAudit.target_application_form)
+            .selectinload(ApplicationForm.competition_form)
+            .selectinload(CompetitionForm.form),
+            # Preload the attachment
+            selectinload(ApplicationAudit.target_attachment),
+        )
+    )
+    stmt = apply_sorting(stmt, ApplicationAudit, params.pagination.sort_order)
+
+    # Paginate the results
+    paginator: Paginator[ApplicationAudit] = Paginator(
+        ApplicationAudit, stmt, db_session, page_size=params.pagination.page_size
+    )
+    paginated_results = paginator.page_at(page_offset=params.pagination.page_offset)
+    pagination_info = PaginationInfo.from_pagination_params(params.pagination, paginator)
+
+    # Transform the results into the expected shape for the response
+    return _transform_app_audits(paginated_results), pagination_info
+
+
+def _transform_app_audits(audit_events: Sequence[ApplicationAudit]) -> list[dict]:
+    results = []
+    for audit_event in audit_events:
+        # Convert any app form into the response schema shape
+        if app_form := audit_event.target_application_form:
+            target_app_form = {
+                "application_form_id": app_form.application_form_id,
+                "competition_form_id": app_form.competition_form_id,
+                "form_id": app_form.form.form_id,
+                "form_name": app_form.form.form_name,
+            }
+        else:
+            target_app_form = None
+
+        # Most of these don't need to be modified, so we just add the DB objects
+        results.append(
+            {
+                "application_audit_id": audit_event.application_audit_id,
+                "application_audit_event": audit_event.application_audit_event,
+                "user": audit_event.user,
+                "target_user": audit_event.target_user,
+                "target_application_form": target_app_form,
+                "target_attachment": audit_event.target_attachment,
+                "created_at": audit_event.created_at,
+            }
+        )
+
+    return results

--- a/api/tests/src/api/applications/test_application_audit_routes.py
+++ b/api/tests/src/api/applications/test_application_audit_routes.py
@@ -1,0 +1,352 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.constants.lookup_constants import Privilege
+from tests.lib.application_test_utils import create_user_in_app
+from tests.lib.organization_test_utils import create_user_in_org
+from tests.src.db.models.factories import (
+    ApplicationAuditFactory,
+    ApplicationFactory,
+    LinkExternalUserFactory,
+    UserFactory,
+)
+
+
+def _make_datetime(hour: int) -> datetime:
+    """Utility function to setup datetime, just to be slightly less verbose"""
+    return datetime(2025, 12, 1, hour, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize("has_organization", [True, False])
+def test_list_application_audit_200(client, enable_factory_create, db_session, has_organization):
+    user_no_email_profile = UserFactory.create()
+    user_with_email = LinkExternalUserFactory.create().user
+    user_with_profile = UserFactory.create(with_profile=True)
+
+    user_with_email_and_profile = UserFactory.create(with_profile=True)
+    LinkExternalUserFactory.create(user=user_with_email_and_profile)
+
+    app_params = {}
+    if has_organization:
+        user, org, token = create_user_in_org(
+            db_session=db_session, privileges=[Privilege.VIEW_APPLICATION]
+        )
+        app_params["organization"] = org
+
+    application = ApplicationFactory.create(with_forms=True, with_attachments=True, **app_params)
+
+    app_form = application.application_forms[0]
+    attachment = application.application_attachments[0]
+
+    if not has_organization:
+        user, _, token = create_user_in_app(
+            db_session=db_session, application=application, privileges=[Privilege.VIEW_APPLICATION]
+        )
+
+    ### Add audit events of each type
+    ### Give them an ascending set of timestamps so they get returned in this order
+
+    # Create
+    create_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_email_and_profile,
+        is_create=True,
+        created_at=_make_datetime(hour=1),
+    )
+
+    # App name changed
+    name_change_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_profile,
+        is_name_changed=True,
+        created_at=_make_datetime(hour=2),
+    )
+
+    # Attachment add/update/delete
+    attachment_add_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_email,
+        is_attachment_added=True,
+        target_attachment=attachment,
+        created_at=_make_datetime(hour=3),
+    )
+    attachment_update_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_email,
+        is_attachment_added=True,
+        target_attachment=attachment,
+        created_at=_make_datetime(hour=4),
+    )
+    attachment_delete_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_email_and_profile,
+        is_attachment_deleted=True,
+        created_at=_make_datetime(hour=5),
+    )
+
+    # User added/updated/removed
+    user_add_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_no_email_profile,
+        target_user=user_with_email,
+        is_user_added=True,
+        created_at=_make_datetime(hour=6),
+    )
+    user_update_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_profile,
+        target_user=user_with_email,
+        is_user_updated=True,
+        created_at=_make_datetime(hour=7),
+    )
+    user_delete_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_no_email_profile,
+        target_user=user_with_email,
+        is_user_removed=True,
+        created_at=_make_datetime(hour=8),
+    )
+
+    # Update form
+    form_update_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_no_email_profile,
+        target_application_form=app_form,
+        is_form_updated=True,
+        created_at=_make_datetime(hour=9),
+    )
+
+    # Submit rejected
+    submit_rejected_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_profile,
+        is_submit_rejected=True,
+        created_at=_make_datetime(hour=10),
+    )
+
+    # Submit
+    submit_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_profile,
+        is_submit=True,
+        created_at=_make_datetime(hour=11),
+    )
+
+    # Submission created
+    submission_event = ApplicationAuditFactory.create(
+        application=application,
+        user=user_with_profile,
+        is_submission_created=True,
+        created_at=_make_datetime(hour=12),
+    )
+
+    events = [
+        create_event,
+        name_change_event,
+        attachment_add_event,
+        attachment_update_event,
+        attachment_delete_event,
+        user_add_event,
+        user_update_event,
+        user_delete_event,
+        form_update_event,
+        submit_rejected_event,
+        submit_event,
+        submission_event,
+    ]
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/audit_history",
+        json={"pagination": {"page_offset": 1, "page_size": 25}},
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 200
+    results = response.json["data"]
+    assert len(results) == len(events)
+
+    # We reverse the events as we get latest events first
+    for resp, event in zip(results, events[::-1], strict=True):
+        assert resp["application_audit_id"] == str(event.application_audit_id)
+        assert resp["application_audit_event"] == event.application_audit_event
+        assert resp["created_at"] == event.created_at.isoformat()
+        assert resp["user"] == {
+            "user_id": str(event.user_id),
+            "email": event.user.email,
+            "first_name": event.user.first_name,
+            "last_name": event.user.last_name,
+        }
+
+        if event.target_user:
+            assert resp["target_user"] == {
+                "user_id": str(event.target_user.user_id),
+                "email": event.target_user.email,
+                "first_name": event.target_user.first_name,
+                "last_name": event.target_user.last_name,
+            }
+        else:
+            assert resp["target_user"] is None
+
+        if event.target_application_form:
+            assert resp["target_application_form"] == {
+                "application_form_id": str(event.target_application_form.application_form_id),
+                "competition_form_id": str(event.target_application_form.competition_form_id),
+                "form_id": str(event.target_application_form.form.form_id),
+                "form_name": event.target_application_form.form.form_name,
+            }
+        else:
+            assert resp["target_application_form"] is None
+
+        if event.target_attachment:
+            assert resp["target_attachment"] == {
+                "application_attachment_id": str(event.target_attachment_id),
+                "file_name": event.target_attachment.file_name,
+                "is_deleted": event.target_attachment.is_deleted,
+            }
+        else:
+            assert resp["target_attachment"] is None
+
+    pagination = response.json["pagination_info"]
+    assert pagination == {
+        "page_offset": 1,
+        "page_size": 25,
+        "total_pages": 1,
+        "total_records": len(events),
+        "sort_order": [
+            {"order_by": "created_at", "sort_direction": "descending"},
+        ],
+    }
+
+
+@pytest.mark.parametrize("has_organization", [True, False])
+def test_list_application_empty_result_200(
+    client, enable_factory_create, db_session, has_organization
+):
+    app_params = {}
+    if has_organization:
+        user, org, token = create_user_in_org(
+            db_session=db_session, privileges=[Privilege.VIEW_APPLICATION]
+        )
+        app_params["organization"] = org
+
+    application = ApplicationFactory.create(with_forms=True, with_attachments=True, **app_params)
+
+    if not has_organization:
+        user, _, token = create_user_in_app(
+            db_session=db_session, application=application, privileges=[Privilege.VIEW_APPLICATION]
+        )
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/audit_history",
+        json={"pagination": {"page_offset": 1, "page_size": 25}},
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 200
+    assert response.json["data"] == []
+
+
+def test_list_application_audit_not_in_app_403(client, enable_factory_create, db_session):
+    application = ApplicationFactory.create()
+
+    user, _different_app, token = create_user_in_app(
+        db_session=db_session, privileges=[Privilege.VIEW_APPLICATION]
+    )
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/audit_history",
+        json={"pagination": {"page_offset": 1, "page_size": 25}},
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 403
+    assert response.json["message"] == "Forbidden"
+
+
+def test_list_application_audit_in_app_missing_right_privilege_403(
+    client, enable_factory_create, db_session
+):
+    application = ApplicationFactory.create()
+    user, _different_app, token = create_user_in_app(
+        db_session=db_session, application=application, privileges=[Privilege.START_APPLICATION]
+    )
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/audit_history",
+        json={"pagination": {"page_offset": 1, "page_size": 25}},
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 403
+    assert response.json["message"] == "Forbidden"
+
+
+def test_list_application_audit_not_in_org_403(client, enable_factory_create, db_session):
+    application = ApplicationFactory.create(with_organization=True)
+
+    user, _different_org, token = create_user_in_org(
+        db_session=db_session, privileges=[Privilege.VIEW_APPLICATION]
+    )
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/audit_history",
+        json={"pagination": {"page_offset": 1, "page_size": 25}},
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 403
+    assert response.json["message"] == "Forbidden"
+
+
+def test_list_application_audit_in_org_missing_right_privilege_403(
+    client, enable_factory_create, db_session
+):
+    application = ApplicationFactory.create(with_organization=True)
+
+    user, _different_org, token = create_user_in_org(
+        db_session=db_session,
+        organization=application.organization,
+        privileges=[Privilege.START_APPLICATION],
+    )
+
+    response = client.post(
+        f"/alpha/applications/{application.application_id}/audit_history",
+        json={"pagination": {"page_offset": 1, "page_size": 25}},
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 403
+    assert response.json["message"] == "Forbidden"
+
+
+def test_list_application_audit_no_auth_401(client):
+    response = client.post(
+        f"/alpha/applications/{uuid.uuid4()}/audit_history",
+        json={"pagination": {"page_offset": 1, "page_size": 25}},
+    )
+    assert response.status_code == 401
+    assert response.json["message"] == "Unable to process token"
+
+
+def test_list_application_audit_missing_required_422(client, db_session, enable_factory_create):
+    user, _, token = create_user_in_app(
+        db_session=db_session, privileges=[Privilege.VIEW_APPLICATION]
+    )
+
+    response = client.post(
+        f"/alpha/applications/{uuid.uuid4()}/audit_history",
+        json={},
+        headers={"X-SGG-Token": token},
+    )
+    assert response.status_code == 422
+    assert response.json["message"] == "Validation error"
+    assert response.json["errors"] == [
+        {
+            "field": "pagination",
+            "message": "Missing data for required field.",
+            "type": "required",
+            "value": None,
+        }
+    ]

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -36,6 +36,7 @@ from src.constants.lookup_constants import (
     AgencyDownloadFileType,
     AgencySubmissionNotificationSetting,
     ApplicantType,
+    ApplicationAuditEvent,
     ApplicationStatus,
     CompetitionOpenToApplicant,
     ExternalUserType,
@@ -1484,6 +1485,11 @@ class ApplicationAttachmentFactory(BaseFactory):
         lambda a: f"s3://local-mock-public-bucket/applications/{a.application_id}/attachments/{fake.uuid4()}/{a.file_name}"
     )
 
+    class Params:
+        setup_deleted = factory.Trait(
+            is_deleted=True, file_contents="SKIP", file_location="DELETED"
+        )
+
     @classmethod
     def _build(cls, model_class, *args, **kwargs):
         kwargs.pop("file_contents")  # Don't file for build strategy
@@ -1493,6 +1499,9 @@ class ApplicationAttachmentFactory(BaseFactory):
     def _create(cls, model_class, *args, **kwargs):
         file_contents = kwargs.pop("file_contents")
         attachment = super()._create(model_class, *args, **kwargs)
+
+        if file_contents == "SKIP":
+            return attachment
 
         try:
             with file_util.open_stream(attachment.file_location, "w") as my_file:
@@ -1603,6 +1612,78 @@ class ApplicationUserRoleFactory(BaseFactory):
 
     role = factory.SubFactory(RoleFactory, is_application_role=True)
     role_id = factory.LazyAttribute(lambda o: o.role.role_id)
+
+
+class ApplicationAuditFactory(BaseFactory):
+    class Meta:
+        model = competition_models.ApplicationAudit
+
+    application_audit_id = Generators.UuidObj
+
+    user = factory.SubFactory(UserFactory, with_profile=True)
+    user_id = factory.LazyAttribute(lambda a: a.user.user_id)
+
+    application = factory.SubFactory(ApplicationFactory)
+    application_id = factory.LazyAttribute(lambda a: a.application.application_id)
+
+    application_audit_event = ApplicationAuditEvent.APPLICATION_CREATED
+
+    class Params:
+        is_create = factory.Trait(application_audit_event=ApplicationAuditEvent.APPLICATION_CREATED)
+        is_name_changed = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.APPLICATION_NAME_CHANGED
+        )
+        is_submit = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.APPLICATION_SUBMITTED
+        )
+        is_submit_rejected = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.APPLICATION_SUBMIT_REJECTED
+        )
+        is_attachment_added = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.ATTACHMENT_ADDED,
+            target_attachment=factory.SubFactory(
+                ApplicationAttachmentFactory, application=factory.SelfAttribute("..application")
+            ),
+        )
+        is_attachment_deleted = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.ATTACHMENT_DELETED,
+            target_attachment=factory.SubFactory(
+                ApplicationAttachmentFactory,
+                application=factory.SelfAttribute("..application"),
+                setup_deleted=True,
+            ),
+        )
+        is_attachment_updated = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.ATTACHMENT_UPDATED,
+            target_attachment=factory.SubFactory(
+                ApplicationAttachmentFactory, application=factory.SelfAttribute("..application")
+            ),
+        )
+        is_submission_created = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.SUBMISSION_CREATED,
+            application=factory.SubFactory(ApplicationFactory),
+        )
+        is_user_added = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.USER_ADDED,
+            target_user=factory.SubFactory(UserFactory, with_profile=True),
+            target_user_id=factory.LazyAttribute(lambda a: a.target_user.user_id),
+        )
+        is_user_updated = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.USER_UPDATED,
+            target_user=factory.SubFactory(UserFactory, with_profile=True),
+            target_user_id=factory.LazyAttribute(lambda a: a.target_user.user_id),
+        )
+        is_user_removed = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.USER_REMOVED,
+            target_user=factory.SubFactory(UserFactory, with_profile=True),
+            target_user_id=factory.LazyAttribute(lambda a: a.target_user.user_id),
+        )
+        is_form_updated = factory.Trait(
+            application_audit_event=ApplicationAuditEvent.FORM_UPDATED,
+            target_application_form=factory.SubFactory(
+                ApplicationFormFactory, application=factory.SelfAttribute("..application")
+            ),
+        )
 
 
 ###################


### PR DESCRIPTION
## Summary
Fixes #6317 

## Changes proposed
* Adds an endpoint for fetching audit events for an application
* Adds a lot to the application audit factory to setup events in reasonable states

## Context for reviewers
Another ticket will handle adding audit events in our application endpoints, but this one is for fetching those from the already created table.

In the future, we may want to add filters and/or more sorting options, but keeping it very basic for now.

## Validation steps
Tests verify that each of the event type scenarios should flow through uneventfully with expected fields populated.