### PR TITLE
[Unticketed] Change application list to sort by created_at by default

### DIFF
--- a/api/src/api/users/user_schemas.py
+++ b/api/src/api/users/user_schemas.py
@@ -276,10 +276,8 @@ class UserApplicationListRequestSchema(Schema):
     pagination = fields.Nested(
         generate_pagination_schema(
             "UserApplicationPaginationSchema",
-            [
-                "updated_at",
-            ],
-            default_sort_order=[{"order_by": "updated_at", "sort_direction": "descending"}],
+            ["created_at"],
+            default_sort_order=[{"order_by": "created_at", "sort_direction": "descending"}],
         ),
         required=True,
     )

--- a/api/src/task/apply/create_application_submission_task.py
+++ b/api/src/task/apply/create_application_submission_task.py
@@ -238,7 +238,11 @@ class CreateApplicationSubmissionTask(Task):
         # Create the submission object (file size will be updated after zip creation)
         application_submission = ApplicationSubmission(
             application_submission_id=submission_id,
-            application=application,
+            # We specify application_id instead of application directly
+            # as SQLAlchemy will complain about this not being added to the DB session yet.
+            # We don't want it in the DB session until we've finished processing
+            # in case we hit an issue below.
+            application_id=application.application_id,
             file_location=s3_path,
             file_size_bytes=0,
             legacy_tracking_number=tracking_number,

--- a/api/tests/src/task/apply/test_create_application_submission_task.py
+++ b/api/tests/src/task/apply/test_create_application_submission_task.py
@@ -36,7 +36,6 @@ from tests.src.db.models.factories import (
 def validate_manifest_contents(contents_of_manifest: str, expected_files: list[str]):
     # We don't validate the structure, just that
     # the files we expected are present.
-    print(contents_of_manifest)
     assert contents_of_manifest.startswith("Manifest for Grant Application")
 
     for expected_file in expected_files:


### PR DESCRIPTION
## Summary

## Changes proposed
* Make the application list page sort by created_at instead of updated_at
* Fix a SQLAlchemy warning in a recent change from the create submission work

## Context for reviewers
After a recent chat with frontend/product, we agreed that sorting by `created_at` makes more sense. `updated_at` is a bit clunky as it only changes when a user updates the application name (form updates would not change this). Created at is consistent as it gets set once.

The  other fix is unrelated entirely, but fixes a SQLAlchemy warning that was happening from an unrelated change.

