### PR TITLE
HOTFIX: remove 20251001 banner

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -37,30 +37,6 @@ export default function Layout({ children, locale }: Props) {
         <LoginModalProvider>
           <Header locale={locale} />
           <main id="main-content" className="border-top-0">
-            {/* temp Oct 1, 2025 banner */}
-            <div className="bg-warning-lighter padding-y-3">
-              <div className="grid-container">
-                <div className="grid-row grid-gap-4 font-sans-2xs">
-                  <div className="tablet-lg:grid-col-5">
-                    There has been a lapse in appropriated federal funds as of
-                    October 1, 2025.{" "}
-                    <a href="https://grants.gov/">Grants.gov</a> and{" "}
-                    <a href="https://simpler.grants.gov/">Simpler.Grants.gov</a>{" "}
-                    will still be available, but service may be delayed with
-                    reduced Federal support staff presence.
-                  </div>
-                  <div className="tablet-lg:grid-col-7 margin-top-2 tablet-lg:margin-top-0">
-                    For those programs affected by the funding lapse, the{" "}
-                    <a href="https://grants.gov/">Grants.gov</a> and{" "}
-                    <a href="https://simpler.grants.gov/">Simpler.Grants.gov</a>{" "}
-                    systems will accept and store applications until such time
-                    as the responsible awarding agency has the authority and
-                    funding to return to normal business operations.
-                  </div>
-                </div>
-              </div>
-            </div>
-            {/* end temp banner */}
             {children}
           </main>
         </LoginModalProvider>


### PR DESCRIPTION
## Summary

This is a hotfix to remove the temporary banner for Oct 01, 2025.

## Changes proposed

* Remove the hardcoded message in the `Layout` that displays below the site header

## Context for reviewers

This undoes https://github.com/HHS/simpler-grants-gov/pull/6562 

## Validation steps

Load the app and you should **NOT** see the "October 1, 2025" message at the top of every page. 
