### PR TITLE
[Issue #6949] Setup foreign staging tables legacy users[2/2]

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -39,6 +39,8 @@ TABLES_TO_LOAD = [
     "tcompetition",
     "tinstructions",
     "tcertificates",
+    "vuser_account",
+    "tuser_profile",
 ]
 
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #6949  

## Changes proposed

Add `tuser_profile` and `vuser_account` tables to the load job for hourly sync.

## Context for reviewers
Foreign and legacy tables have been successfully added in the staging environment.
The load job was tested locally against the staging environment, and data was confirmed to sync successfully.