### PR TITLE
[Issue #7159]: Update workflows to reduce slack notifications

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -55,7 +55,7 @@ jobs:
       version: ${{ inputs.version || github.ref }}
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: [analytics-checks, vulnerability-scans, deploy]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -54,7 +54,7 @@ jobs:
       version: ${{ inputs.version || github.ref }}
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: [api-checks, vulnerability-scans, deploy]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -54,7 +54,7 @@ jobs:
       version: ${{ inputs.version || github.ref }}
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: [frontend-checks, vulnerability-scans, deploy]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/cd-metabase.yml
+++ b/.github/workflows/cd-metabase.yml
@@ -34,7 +34,7 @@ jobs:
       environment: ${{ matrix.envs }}
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: [deploy]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -55,7 +55,7 @@ jobs:
       version: ${{ inputs.version || github.ref || 'main' }}
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: [checks, deploy, vulnerability-scans]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/ci-cron-vulnerability-scans.yml
+++ b/.github/workflows/ci-cron-vulnerability-scans.yml
@@ -21,7 +21,7 @@ jobs:
       app_name: ${{ matrix.app_name }}
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: vulnerability-scans
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/ci-weekly-vulnerability-report.yml
+++ b/.github/workflows/ci-weekly-vulnerability-report.yml
@@ -23,7 +23,7 @@ jobs:
       fail_on_vulns: false
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: vulnerability-scans
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/scheduled-dev-deploy.yml
+++ b/.github/workflows/scheduled-dev-deploy.yml
@@ -85,7 +85,7 @@ jobs:
       version: "main"
 
   send-slack-notification:
-    if: failure()
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: [api-deploy, frontend-deploy, analytics-deploy, nofos-deploy]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit


### PR DESCRIPTION
## Summary

Updated GitHub workflows to reduce slack notifications. 

## Validation steps

All workflows should continue to work as is except slack notifications should only be triggered when merged into main or when a release is created. 