### PR TITLE
[Unticketed] Schedule the build-automatic-opportunities job

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -161,8 +161,10 @@ locals {
       environment_vars    = try(local.scheduled_jobs_config[var.environment].environment_vars, null)
     }
     build-automatic-opportunities = {
-      # Every day at 8am Eastern Time during DST. 9am during non-DST.
-      schedule_expression = "cron(0 13 * * ? *)"
+      task_command = ["poetry", "run", "flask", "task", "build-automatic-opportunities"]
+      # Every day at 7:15am Eastern Time during DST. 8:15am during non-DST.
+      # Runs just before the search load job that runs 30 minutes after the hour.
+      schedule_expression = "cron(15 12 * * ? *)"
       # Only enable in dev/staging/training, do not run in prod
       state            = local.build-automatic-opportunities-state[var.environment]
       cpu              = try(local.scheduled_jobs_config[var.environment].cpu, null)


### PR DESCRIPTION
## Summary

## Changes proposed
Add a schedule to run a new command I've built for generating automatic opportunities based on forms.

## Context for reviewers
This is a task that grabs every form in the environment, and generates an opportunity if one doesn't yet exist for that form. Every time it runs it always creates an opportunity that has all forms (that way as we add forms, we don't need to adjust that, just find the latest).

I've manually run the task in each of dev/staging/training already. You can see the opportunities this creates by searching `SGG` like so:  https://staging.simpler.grants.gov/search?query=SGG

