### PR TITLE
[unticketed] allow playwright to point to deployed env

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -41,3 +41,5 @@ NEW_RELIC_LICENSE_KEY=
 SESSION_SECRET=extraSecretSessionSecretValueSssh
 
 E2E_USER_AUTH_TOKEN=  # used for spoofing logins in e2e need to sync with API via seed
+
+PLAYWRIGHT_BASE_URL= # used to point playwright testing to a deployed environment

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://127.0.0.1:3000",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -72,9 +72,11 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: "npm run start",
-    url: "http://127.0.0.1:3000",
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: "npm run start",
+        url: "http://127.0.0.1:3000",
+        reuseExistingServer: !process.env.CI,
+      },
 });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Sets up env var to control where playwright tests will run

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

For the moment this is only for local testing, but will support running against deployed env in CI in the future

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


1. set `PLAYWRIGHT_BASE_URL="https://staging.simpler.grants.gov"` in your .env.local
2. run the playwright test suite
3. _VERIFY_: tests run against staging and pass as expected