### PR TITLE
[Issue #6935]: adding the organizations page

### DIFF
--- a/frontend/src/app/[locale]/(base)/dashboard/page.tsx
+++ b/frontend/src/app/[locale]/(base)/dashboard/page.tsx
@@ -77,10 +77,13 @@ async function ActivityDashboard() {
       )}
       <ActivityDashboardLinksSection />
       {userRoles && userOrganizations ? (
-        <UserOrganizationsList
-          userOrganizations={userOrganizations}
-          userRoles={userRoles}
-        />
+        <div className="margin-top-4">
+          <h2>{t("organizations")}</h2>
+          <UserOrganizationsList
+            userOrganizations={userOrganizations}
+            userRoles={userRoles}
+          />
+        </div>
       ) : (
         <ErrorMessage>{t("fetchError")}</ErrorMessage>
       )}

--- a/frontend/src/app/[locale]/(base)/organizations/layout.tsx
+++ b/frontend/src/app/[locale]/(base)/organizations/layout.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next";
+import { LayoutProps } from "src/types/generalTypes";
+import { LocalizedPageProps } from "src/types/intl";
+
+import { getTranslations } from "next-intl/server";
+
+import { AuthenticationGate } from "src/components/user/AuthenticationGate";
+
+export async function generateMetadata({ params }: LocalizedPageProps) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale });
+  const meta: Metadata = {
+    title: t("Organizations.pageTitle"),
+    description: t("Organizations.metaDescription"),
+  };
+  return meta;
+}
+
+export default function OrganizationsLayout({ children }: LayoutProps) {
+  return (
+    <>
+      <AuthenticationGate>{children}</AuthenticationGate>
+    </>
+  );
+}

--- a/frontend/src/app/[locale]/(base)/organizations/page.tsx
+++ b/frontend/src/app/[locale]/(base)/organizations/page.tsx
@@ -1,0 +1,86 @@
+import { UnauthorizedError } from "src/errors";
+import { getSession } from "src/services/auth/session";
+import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
+import { getUserOrganizations } from "src/services/fetch/fetchers/organizationsFetcher";
+import { getUserPrivileges } from "src/services/fetch/fetchers/userFetcher";
+import { Organization } from "src/types/applicationResponseTypes";
+import { LocalizedPageProps } from "src/types/intl";
+import { UserPrivilegesResponse } from "src/types/userTypes";
+
+import { useTranslations } from "next-intl";
+import { setRequestLocale } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { PropsWithChildren } from "react";
+import { Alert, GridContainer } from "@trussworks/react-uswds";
+
+import { UserOrganizationsList } from "src/components/workspace/UserOrganizationsList";
+
+const OrganizationsPageWrapper = ({ children }: PropsWithChildren) => {
+  const t = useTranslations("Organizations");
+  return (
+    <GridContainer>
+      <h1 className="margin-top-9 margin-bottom-5">{t("pageTitle")}</h1>
+      {children}
+    </GridContainer>
+  );
+};
+
+const OrganizationsErrorPage = () => {
+  const t = useTranslations("Organizations");
+
+  return (
+    <OrganizationsPageWrapper>
+      <div className="margin-bottom-15">
+        <Alert slim={true} headingLevel="h6" noIcon={true} type="error">
+          {t("errorMessage")}
+        </Alert>
+      </div>
+    </OrganizationsPageWrapper>
+  );
+};
+
+async function OrganizationsPage({ params }: LocalizedPageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  let userOrganizations: Organization[];
+  let userRoles: UserPrivilegesResponse;
+  try {
+    const session = await getSession();
+    if (!session || !session.token) {
+      throw new UnauthorizedError(
+        "No active session for viewing Organizations.",
+      );
+    }
+    const userRolesPromise = getUserPrivileges(session.token, session.user_id);
+    const userOrganizationsPromise = getUserOrganizations(
+      session.token,
+      session.user_id,
+    );
+
+    [userRoles, userOrganizations] = await Promise.all([
+      userRolesPromise,
+      userOrganizationsPromise,
+    ]);
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      throw error;
+    }
+    return <OrganizationsErrorPage />;
+  }
+
+  return (
+    <OrganizationsPageWrapper>
+      <UserOrganizationsList
+        userOrganizations={userOrganizations}
+        userRoles={userRoles}
+      />
+    </OrganizationsPageWrapper>
+  );
+}
+
+export default withFeatureFlag<LocalizedPageProps, never>(
+  OrganizationsPage,
+  "manageUsersOff",
+  () => redirect("/maintenance"),
+);

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -134,6 +134,12 @@ const NavLinks = ({
       text: t("applications"),
       href: "/applications",
     });
+    if (showUserAdminNavItems) {
+      workspaceSubNavs.push({
+        text: t("organizations"),
+        href: "/organizations",
+      });
+    }
     if (showSavedOpportunities) {
       workspaceSubNavs.push({
         text: t("savedOpportunities"),

--- a/frontend/src/components/workspace/UserOrganizationsList.tsx
+++ b/frontend/src/components/workspace/UserOrganizationsList.tsx
@@ -6,27 +6,75 @@ import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { Button, Grid } from "@trussworks/react-uswds";
 
-const OrganizationItem = ({
+import { USWDSIcon } from "src/components/USWDSIcon";
+
+const ManageUsersButton = ({
   organization,
-  role,
 }: {
   organization: Organization;
-  role: string;
 }) => {
   const t = useTranslations("ActivityDashboard");
   return (
+    <Link href={`/organization/${organization.organization_id}/manage-users`}>
+      <Button type="button">
+        <USWDSIcon name="people" /> {t("organizationButtons.manage")}
+      </Button>
+    </Link>
+  );
+};
+
+const ViewDetailsButton = ({
+  organization,
+}: {
+  organization: Organization;
+}) => {
+  const t = useTranslations("ActivityDashboard");
+  return (
+    <Link href={`/organization/${organization.organization_id}`}>
+      <Button type="button">
+        <USWDSIcon name="visibility" />
+        {t("organizationButtons.view")}
+      </Button>
+    </Link>
+  );
+};
+
+const OrganizationItem = ({
+  organization,
+  userRoles,
+}: {
+  organization: Organization;
+  userRoles: UserPrivilegesResponse;
+}) => {
+  const role = userRoleForOrganization(organization, userRoles);
+
+  const orgPermissions = userRoles.organization_users.find(
+    (role) =>
+      role.organization.organization_id === organization.organization_id,
+  );
+  const canManageUsers = orgPermissions?.organization_user_roles.find((role) =>
+    role.privileges.includes("manage_org_members"),
+  );
+
+  return (
     <li className="border-base-lighter border-1px padding-2 margin-top-2">
       <Grid row>
-        <Grid tablet={{ col: 6 }}>
+        <Grid tablet={{ col: "fill" }}>
           <div className="font-sans-2xs text-base-dark">{role}</div>
           <h3 className="margin-top-0">
             {organization.sam_gov_entity.legal_business_name}
           </h3>
         </Grid>
-        <Grid tablet={{ col: 6 }} className="flex-align-self-end text-right">
-          <Link href={`/organization/${organization.organization_id}`}>
-            <Button type="button">{t("organizationButtons.view")}</Button>
-          </Link>
+        <Grid
+          tablet={{ col: "auto" }}
+          className="flex-align-self-end text-right"
+        >
+          <ViewDetailsButton organization={organization} />
+          {canManageUsers ? (
+            <ManageUsersButton organization={organization} />
+          ) : (
+            ""
+          )}
         </Grid>
       </Grid>
     </li>
@@ -50,25 +98,21 @@ export const UserOrganizationsList = ({
   userOrganizations: Organization[];
   userRoles: UserPrivilegesResponse;
 }) => {
-  const t = useTranslations("ActivityDashboard");
   return (
-    <div className="margin-top-4">
-      <h2>{t("organizations")}</h2>
-      <ul className="usa-list--unstyled">
-        {!userOrganizations.length ? (
-          <NoOrganizations />
-        ) : (
-          <>
-            {userOrganizations.map((userOrganization) => (
-              <OrganizationItem
-                organization={userOrganization}
-                role={userRoleForOrganization(userOrganization, userRoles)}
-                key={userOrganization.organization_id}
-              />
-            ))}
-          </>
-        )}
-      </ul>
-    </div>
+    <ul className="usa-list--unstyled">
+      {!userOrganizations.length ? (
+        <NoOrganizations />
+      ) : (
+        <>
+          {userOrganizations.map((userOrganization) => (
+            <OrganizationItem
+              organization={userOrganization}
+              userRoles={userRoles}
+              key={userOrganization.organization_id}
+            />
+          ))}
+        </>
+      )}
+    </ul>
   );
 };

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -627,6 +627,7 @@ export const messages = {
       login: "Sign in",
       logout: "Sign out",
       menuToggle: "Menu",
+      organizations: "Organizations",
       research: "Research",
       roadmap: "Product roadmap",
       savedOpportunities: "Saved opportunities",
@@ -1463,7 +1464,7 @@ export const messages = {
         "You'll be notified when an organization adds you, and you can accept the invitation to access their details.",
     },
     organizationButtons: {
-      view: "View organization details",
+      view: "View details",
       manage: "Manage users",
     },
     linksSection: {
@@ -1619,5 +1620,13 @@ export const messages = {
       type: "Type",
       opportunity: "Opportunity",
     },
+  },
+  Organizations: {
+    errorMessage:
+      "We have encountered an error loading your organizations, please try again later.",
+    manageUsers: "Manage Users",
+    metaDescription: "View your organizations",
+    pageHeading: "Organizations",
+    pageTitle: "Organizations",
   },
 };

--- a/frontend/tests/components/workspace/UserOrganizationsList.test.tsx
+++ b/frontend/tests/components/workspace/UserOrganizationsList.test.tsx
@@ -67,35 +67,69 @@ describe("UserOrganizationsList", () => {
     expect(listItems[0].textContent).toBeTruthy();
   });
 
-  it("renders an organization item for each provided organization with role, name and link", () => {
-    render(
-      <UserOrganizationsList
-        userOrganizations={[
-          fakeOrganizationDetailsResponse,
-          makeOrg("another", "another fake org"),
-        ]}
-        userRoles={fakeUserPrivilegesResponse}
-      />,
-    );
+  describe("renders an organization item for each provided organization with role, name and link", () => {
+    it("should have two items", () => {
+      render(
+        <UserOrganizationsList
+          userOrganizations={[
+            makeOrg("1", "fake org where I am an admin"),
+            makeOrg("4", "fake org where I am a member"),
+          ]}
+          userRoles={fakeUserPrivilegesResponse}
+        />,
+      );
+      const listItems = screen.getAllByRole("listitem");
+      expect(listItems).toHaveLength(2);
+    });
 
-    const listItems = screen.getAllByRole("listitem");
-    expect(listItems).toHaveLength(2);
+    it("first org is admin, has appropriate title and two buttons", () => {
+      render(
+        <UserOrganizationsList
+          userOrganizations={[
+            makeOrg("1", "fake org where I am an admin"),
+            makeOrg("4", "fake org where I am a member"),
+          ]}
+          userRoles={fakeUserPrivilegesResponse}
+        />,
+      );
+      const listItems = screen.getAllByRole("listitem");
+      const firstItem = listItems[0];
 
-    // Check name and role for first item
-    expect(
-      within(listItems[0]).getByText(
-        fakeOrganizationDetailsResponse.sam_gov_entity.legal_business_name,
-      ),
-    ).toBeInTheDocument();
-    expect(within(listItems[0]).getByText("Admin")).toBeInTheDocument();
+      // Check name and role for first item
+      expect(
+        within(firstItem).getByText("fake org where I am an admin"),
+      ).toBeInTheDocument();
+      expect(within(firstItem).getByText("Admin")).toBeInTheDocument();
 
-    // Link should point to organization page
-    const links = screen.getAllByRole("link");
-    expect(links).toHaveLength(2);
-    expect(links[0]).toHaveAttribute(
-      "href",
-      `/organization/${fakeOrganizationDetailsResponse.organization_id}`,
-    );
-    expect(links[1]).toHaveAttribute("href", "/organization/another");
+      // check it has both buttons
+      const links = within(firstItem).getAllByRole("link");
+      expect(links).toHaveLength(2);
+      expect(links[0]).toHaveAttribute("href", "/organization/1");
+      expect(links[1]).toHaveAttribute("href", "/organization/1/manage-users");
+    });
+
+    it("second org is member, should only have view details button", () => {
+      render(
+        <UserOrganizationsList
+          userOrganizations={[
+            makeOrg("1", "fake org where I am an admin"),
+            makeOrg("4", "fake org where I am a member"),
+          ]}
+          userRoles={fakeUserPrivilegesResponse}
+        />,
+      );
+      const listItems = screen.getAllByRole("listitem");
+      const secondItem = listItems[1];
+
+      // Check name for second item (role is mocked above so it will come back incorrect)
+      expect(
+        within(secondItem).getByText("fake org where I am a member"),
+      ).toBeInTheDocument();
+
+      // check it has only the view details buttons
+      const links = within(secondItem).getAllByRole("link");
+      expect(links).toHaveLength(1);
+      expect(links[0]).toHaveAttribute("href", "/organization/4");
+    });
   });
 });

--- a/frontend/tests/components/workspace/__snapshots__/UserOrganizationsList.test.tsx.snap
+++ b/frontend/tests/components/workspace/__snapshots__/UserOrganizationsList.test.tsx.snap
@@ -2,96 +2,107 @@
 
 exports[`UserOrganizationsList matches snapshot with multiple organizations 1`] = `
 <div>
-  <div
-    class="margin-top-4"
+  <ul
+    class="usa-list--unstyled"
   >
-    <h2>
-      organizations
-    </h2>
-    <ul
-      class="usa-list--unstyled"
+    <li
+      class="border-base-lighter border-1px padding-2 margin-top-2"
     >
-      <li
-        class="border-base-lighter border-1px padding-2 margin-top-2"
+      <div
+        class="grid-row"
+        data-testid="grid"
       >
         <div
-          class="grid-row"
+          class="tablet:grid-col-fill"
           data-testid="grid"
         >
           <div
-            class="tablet:grid-col-6"
-            data-testid="grid"
+            class="font-sans-2xs text-base-dark"
           >
-            <div
-              class="font-sans-2xs text-base-dark"
-            >
-              Admin
-            </div>
-            <h3
-              class="margin-top-0"
-            >
-              Completely Legal Organization
-            </h3>
+            Admin
           </div>
-          <div
-            class="tablet:grid-col-6 flex-align-self-end text-right"
-            data-testid="grid"
+          <h3
+            class="margin-top-0"
           >
-            <a
-              href="/organization/great id"
-            >
-              <button
-                class="usa-button"
-                data-testid="button"
-                type="button"
-              >
-                organizationButtons.view
-              </button>
-            </a>
-          </div>
+            Completely Legal Organization
+          </h3>
         </div>
-      </li>
-      <li
-        class="border-base-lighter border-1px padding-2 margin-top-2"
+        <div
+          class="tablet:grid-col-auto flex-align-self-end text-right"
+          data-testid="grid"
+        >
+          <a
+            href="/organization/great id"
+          >
+            <button
+              class="usa-button"
+              data-testid="button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="usa-icon"
+                role="img"
+              >
+                <use
+                  href="/img.jpg#visibility"
+                />
+              </svg>
+              organizationButtons.view
+            </button>
+          </a>
+        </div>
+      </div>
+    </li>
+    <li
+      class="border-base-lighter border-1px padding-2 margin-top-2"
+    >
+      <div
+        class="grid-row"
+        data-testid="grid"
       >
         <div
-          class="grid-row"
+          class="tablet:grid-col-fill"
           data-testid="grid"
         >
           <div
-            class="tablet:grid-col-6"
-            data-testid="grid"
+            class="font-sans-2xs text-base-dark"
           >
-            <div
-              class="font-sans-2xs text-base-dark"
-            >
-              Admin
-            </div>
-            <h3
-              class="margin-top-0"
-            >
-              another fake org
-            </h3>
+            Admin
           </div>
-          <div
-            class="tablet:grid-col-6 flex-align-self-end text-right"
-            data-testid="grid"
+          <h3
+            class="margin-top-0"
           >
-            <a
-              href="/organization/another"
-            >
-              <button
-                class="usa-button"
-                data-testid="button"
-                type="button"
-              >
-                organizationButtons.view
-              </button>
-            </a>
-          </div>
+            another fake org
+          </h3>
         </div>
-      </li>
-    </ul>
-  </div>
+        <div
+          class="tablet:grid-col-auto flex-align-self-end text-right"
+          data-testid="grid"
+        >
+          <a
+            href="/organization/another"
+          >
+            <button
+              class="usa-button"
+              data-testid="button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="usa-icon"
+                role="img"
+              >
+                <use
+                  href="/img.jpg#visibility"
+                />
+              </svg>
+              organizationButtons.view
+            </button>
+          </a>
+        </div>
+      </div>
+    </li>
+  </ul>
 </div>
 `;

--- a/frontend/tests/utils/getRoutes.test.ts
+++ b/frontend/tests/utils/getRoutes.test.ts
@@ -24,6 +24,7 @@ describe("getNextRoutes", () => {
       "/(base)/opportunity/1",
       "/(base)/organization/1/manage-users",
       "/(base)/organization/1",
+      "/(base)/organizations",
       "/(base)",
       "/(base)/roadmap",
       "/(base)/saved-opportunities",


### PR DESCRIPTION
## Summary

Work for #6935 

## Changes proposed

We're creating a new Organizations page behind the `manageUsersOff` feature flag so users can see the organizations where they are members, and have easy access to link to the organization details and (if applicable) manage the users in that organization. 

## Context for reviewers

We'll be reusing a component already created on the Activity Dashboard and updating it as well to have the Manage Users functionality.  

I don't have unittests right now for any of the work gated by feature flags due to the lack of examples in our code base for how to create them.  I've created a follow up ticket [here](https://github.com/HHS/simpler-grants-gov/issues/7231).  

## Validation steps

For setup, first set the feature flags (http://localhost:3000/dev/feature-flags) page 

- [ ] If manageUsersOff is set to enabled, then link should not appear in header and when going to [/organizations](http://localhost:3000/organizations) it should redirect you to the maintenance page

For all other instructions, manageUsersOff is set to disabled

- [ ] If user is logged out when going to   [/organizations](http://localhost:3000/organizations) then user is prompted to log in
- [ ] Organizations always appears in the header under workspace alphabetically
- [ ] A user with no organizations (sign in with random new user name) should see appropriate message on  [/organizations](http://localhost:3000/organizations) and  [/dashboard](http://localhost:3000/dashboard)
- [ ] A user with mixed organizations (sign in with `mixed_roles_user`) sees two organizations
   - [ ] The org where they are an admin they see the view details and the manage users links
   - [ ] The org where they are member they only see the view details links
- [ ] Links to view organization details are correct
- [ ] Links to the manage users page are correct 
- [ ] The Activity Dashboard Organizations section appears correct for users as well
- [ ] In the case of error an appropriate error message is shown -- You can do this by adding ` raise_flask_error(500, f"BREAKING API”)` to this [line](https://github.com/HHS/simpler-grants-gov/blob/main/api/src/api/users/user_routes.py#L208)
