### PR TITLE
[Issue #7234]: Hotfix for public files endpoint

### DIFF
--- a/infra/modules/service/cdn.tf
+++ b/infra/modules/service/cdn.tf
@@ -160,7 +160,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     cached_methods           = ["GET", "HEAD"]
     target_origin_id         = local.default_origin_id
     cache_policy_id          = aws_cloudfront_cache_policy.api_no_cache[0].id
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.forward_all_cookies[0].id
+    origin_request_policy_id = var.enable_alb_cdn ? aws_cloudfront_origin_request_policy.forward_all_cookies[0].id : null
     compress                 = true
     viewer_protocol_policy   = "redirect-to-https"
   }
@@ -170,7 +170,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     cached_methods           = ["GET", "HEAD", "OPTIONS"]
     target_origin_id         = local.default_origin_id
     cache_policy_id          = aws_cloudfront_cache_policy.default[0].id
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.forward_all_cookies[0].id
+    origin_request_policy_id = var.enable_alb_cdn ? aws_cloudfront_origin_request_policy.forward_all_cookies[0].id : null
     compress                 = true
     viewer_protocol_policy   = "redirect-to-https"
   }


### PR DESCRIPTION
## Summary

The public files endpoint in all lower environments are not working. The issue was we were applying to the same origin policy as the frontend and the files endpoint. This was resulting in the aws authorization headers not being passed correctly to the s3 origin. 

## Validation steps

The public files download functionality should continue to work as is. 