### PR TITLE
[ISSUE #7240] Fix current-region script for running scripts locally 

### DIFF
--- a/bin/current-region
+++ b/bin/current-region
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 region=$(aws configure list | grep region | awk '{print $2}')
-region=":"
 if [ "$region" = ":" ]; then
     echo "Newer AWS CLI adds : in the region output" >&2
     # Newer AWS CLI has added : to the output of this command so if we see that in position 2, adjust


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #7240 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Stop overwriting region in current-region script

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

After pulling in the region into our bash script, we were overwriting it with `:` everytime. 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

runing the following command locally should give you correct region us-east-1  

```bash
bin/current-region
```