### PR TITLE
Add Nathan Stricker and Kevin Lyu to github maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 * @mdragon # project lead
 
-/documentation/  @andycochran @btabaska @chouinar @doug-s-nava @joshtonava @mdragon @myduong-navapbc @widal001 @prasnava @jakobpederson @ErinPattisonNava @glenblosser-nava # everyone
+/documentation/  @andycochran @btabaska @chouinar @doug-s-nava @joshtonava @mdragon @myduong-navapbc @widal001 @prasnava @jakobpederson @ErinPattisonNava @glenblosser-nava @nathan-stricker # everyone
 
 /analytics/               @widal001
 /documentation/analytics/ @widal001
@@ -11,8 +11,8 @@
 /api/               @chouinar @mdragon @joshtonava @jakobpederson @chay-REIsys
 /documentation/api/ @chouinar @mdragon @joshtonava @jakobpederson @chay-REIsys
 
-/frontend/               @andycochran @btabaska @doug-s-nava @myduong-navapbc @ErinPattisonNava @chay-REIsys @glenblosser-nava
-/documentation/frontend/ @andycochran @btabaska @doug-s-nava @myduong-navapbc @ErinPattisonNava @chay-REIsys @glenblosser-nava
+/frontend/               @andycochran @btabaska @doug-s-nava @myduong-navapbc @ErinPattisonNava @chay-REIsys @glenblosser-nava @nathan-stricker
+/documentation/frontend/ @andycochran @btabaska @doug-s-nava @myduong-navapbc @ErinPattisonNava @chay-REIsys @glenblosser-nava @nathan-stricker
 
 /infra/                    @mdragon @joshtonava @chouinar @prasnava @sean-navapbc
 /infra/nofos/              @mdragon @pcraig3 @joshtonava @chouinar @prasnava 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,6 +21,7 @@ This is a list of maintainers for this project. See [CODEOWNERS](/.github/CODEOW
 * Erin Pattison
 * Glen Blosser
 * Dao Nguyen
+* Nathan Stricker
 
 ## Content and Design
 
@@ -50,5 +51,6 @@ This is a list of maintainers for this project. See [CODEOWNERS](/.github/CODEOW
 * Eric Serrato
 * Glenn Grieves
 * Brian Lee
+* Kevin Lyu
 
 


### PR DESCRIPTION
## Summary

Adding myself and Kevin Lyu to docs.

## Changes proposed

- Added myself to CODEOWNERS and MAINTAINERS files
- Added Kevin Lyu to MAINTAINERS file (under Product and Program Management)

## Context for reviewers

N/A

## Validation steps

- [ ] Read documentation in preview.
