### PR TITLE
[Issue #7285] invite organization users bugfixes

### DIFF
--- a/frontend/src/app/[locale]/(base)/organization/[id]/manage-users/actions.ts
+++ b/frontend/src/app/[locale]/(base)/organization/[id]/manage-users/actions.ts
@@ -41,6 +41,7 @@ export const inviteUserAction = async (
   _prevState: unknown,
   formData: FormData,
   organizationId: string,
+  genericErrorMessage: string,
 ): Promise<OrganizationInviteResponse> => {
   const session = await getSession();
 
@@ -80,7 +81,7 @@ export const inviteUserAction = async (
       `Error inviting user to org - ${error.message} ${error.cause?.toString() || ""}`,
     );
     return {
-      errorMessage: error.message,
+      errorMessage: `${genericErrorMessage}: ${error.message}`,
     };
   }
 };

--- a/frontend/src/components/manageUsers/UserInviteForm.tsx
+++ b/frontend/src/components/manageUsers/UserInviteForm.tsx
@@ -34,8 +34,9 @@ const OrganizationInviteValidationError =
 
 // in order to pass the organizationId into the form action call
 export const inviteUserActionForOrganization =
-  (organizationId: string) => (_prevState: unknown, formData: FormData) =>
-    inviteUserAction(_prevState, formData, organizationId);
+  (organizationId: string, errorMessage: string) =>
+  (_prevState: unknown, formData: FormData) =>
+    inviteUserAction(_prevState, formData, organizationId, errorMessage);
 
 export const RoleOptions = ({ roles }: { roles: UserRole[] }) => {
   const t = useTranslations("ManageUsers.inviteUser.inputs.role");
@@ -95,13 +96,11 @@ export function UserInviteForm({
   const [selectedRole, setSelectedRole] = useState<string | undefined>();
 
   const inviteUser = useMemo(
-    () => inviteUserActionForOrganization(organizationId),
-    [organizationId],
+    () => inviteUserActionForOrganization(organizationId, t("errorMessage")),
+    [organizationId, t],
   );
 
-  const [formState, formAction, isPending] = useActionState(inviteUser, {
-    invitationCreated: "",
-  });
+  const [formState, formAction, isPending] = useActionState(inviteUser, {});
 
   const onRoleChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1590,6 +1590,7 @@ export const messages = {
     inviteUser: {
       heading: "Add users to collaborate on opportunities.",
       errorHeading: "Error",
+      errorMessage: "Error inviting user, please try again",
       description:
         "Users are automatically added to your organization when they sign up. Until then, their status will be pending.",
       inputs: {
@@ -1604,7 +1605,7 @@ export const messages = {
       },
       button: {
         label: "Add to organization",
-        success: "User added to pending",
+        success: "User invited to organization",
       },
       validationErrors: {
         email: "Email is required",

--- a/frontend/tests/pages/organization/manage-users/actions.test.ts
+++ b/frontend/tests/pages/organization/manage-users/actions.test.ts
@@ -25,7 +25,12 @@ describe("user profile form action", () => {
     getSessionMock.mockResolvedValue({ token: "logged in", user_id: "1" });
     const inviteFormData = new FormData();
     inviteFormData.append("role", "populated");
-    const result = await inviteUserAction(null, inviteFormData, "1");
+    const result = await inviteUserAction(
+      null,
+      inviteFormData,
+      "1",
+      "generic error message",
+    );
     expect(result.validationErrors).toEqual({
       email: ["Expected string, received null"],
     });
@@ -34,7 +39,12 @@ describe("user profile form action", () => {
     getSessionMock.mockResolvedValue({ token: "logged in", user_id: "1" });
     const inviteFormData = new FormData();
     inviteFormData.append("email", "populated");
-    const result = await inviteUserAction(null, inviteFormData, "1");
+    const result = await inviteUserAction(
+      null,
+      inviteFormData,
+      "1",
+      "generic error message",
+    );
     expect(result.validationErrors).toEqual({
       role: ["Expected string, received null"],
     });
@@ -42,7 +52,12 @@ describe("user profile form action", () => {
   it("returns error if not logged in", async () => {
     getSessionMock.mockResolvedValue({ token: null });
     const inviteFormData = new FormData();
-    const result = await inviteUserAction(null, inviteFormData, "1");
+    const result = await inviteUserAction(
+      null,
+      inviteFormData,
+      "1",
+      "generic error message",
+    );
     expect(result.errorMessage).toEqual("Not logged in");
   });
   it("returns result of update on success", async () => {
@@ -55,7 +70,12 @@ describe("user profile form action", () => {
     inviteFormData.append("email", "an email");
     inviteFormData.append("role", "smith");
 
-    const result = await inviteUserAction(null, inviteFormData, "1");
+    const result = await inviteUserAction(
+      null,
+      inviteFormData,
+      "1",
+      "generic error message",
+    );
     expect(result.data).toEqual({
       email: "an email",
       roleId: ["smith"],
@@ -72,7 +92,12 @@ describe("user profile form action", () => {
     inviteFormData.append("email", "an email");
     inviteFormData.append("role", "smith");
 
-    const result = await inviteUserAction(null, inviteFormData, "1");
-    expect(result.errorMessage).toEqual("fake error");
+    const result = await inviteUserAction(
+      null,
+      inviteFormData,
+      "1",
+      "generic error message",
+    );
+    expect(result.errorMessage).toEqual("generic error message: fake error");
   });
 });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #7285 and maybe #7286

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes bugs on organization invitation form where:

* on second submission using the same form, error was received about "role" parameter not being supplied
* on successful submission, input values were not reset to default
* on second submission, success message was not displayed

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->


Underlying bugs were:

* state of selected role in organization invitation form was not being properly tracked
* form state was not being properly reset on success
* success state was not reset when making a second request with the form

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with npm run dev
2. visit http://localhost:3000/?_ff=userAdminOff:false;manageUsersOff:false
3. log in as two_org_user
4. vist the user management page for any organization
5. invite a user
6. _VERIFY_: after sending invite, form fields are returned to their default state
7. invite another user
8. _VERIFY_: invitiation goes through without error
9. _VERIFY_: success message is displayed