### PR TITLE
[Issue #7125] Add filtering to the audit event endpoint

### DIFF
--- a/api/src/api/application_alpha/application_schemas.py
+++ b/api/src/api/application_alpha/application_schemas.py
@@ -8,6 +8,7 @@ from src.api.schemas.response_schema import (
     PaginationMixinSchema,
     WarningMixinSchema,
 )
+from src.api.schemas.search_schema import StrSearchSchemaBuilder
 from src.api.schemas.shared_schema import SimpleUserSchema
 from src.constants.lookup_constants import (
     ApplicationAuditEvent,
@@ -380,7 +381,20 @@ class ApplicationAddOrganizationResponseSchema(AbstractResponseSchema):
     data = fields.Nested(ApplicationUpdateResponseDataSchema())
 
 
+class ApplicationAuditFilterSchema(Schema):
+
+    application_audit_event = fields.Nested(
+        StrSearchSchemaBuilder("ApplicationAuditEventFieldFilterSchema")
+        .with_one_of(
+            allowed_values=ApplicationAuditEvent, example=ApplicationAuditEvent.APPLICATION_CREATED
+        )
+        .build()
+    )
+
+
 class ApplicationAuditRequestSchema(Schema):
+
+    filters = fields.Nested(ApplicationAuditFilterSchema(), required=False, allow_none=True)
 
     pagination = fields.Nested(
         generate_pagination_schema(

--- a/api/src/search/search_models.py
+++ b/api/src/search/search_models.py
@@ -1,11 +1,16 @@
 from datetime import date
+from enum import StrEnum
 from uuid import UUID
 
 from pydantic import BaseModel
 
 
 class StrSearchFilter(BaseModel):
-    one_of: list[str] | None = None
+    # str | StrEnum keeps Pydantic from converting
+    # something that is a StrEnum to just a string
+    # helping preserve the type where relevant like
+    # when we do a SQLAlchemy where clause
+    one_of: list[str | StrEnum] | None = None
 
 
 class BoolSearchFilter(BaseModel):

--- a/api/tests/lib/application_test_utils.py
+++ b/api/tests/lib/application_test_utils.py
@@ -1,5 +1,7 @@
 from src.auth.api_jwt_auth import create_jwt_for_user
 from src.constants.lookup_constants import Privilege
+from src.db.models.competition_models import Application
+from src.db.models.user_models import User
 from tests.src.db.models.factories import (
     ApplicationFactory,
     ApplicationUserFactory,
@@ -19,7 +21,7 @@ def create_user_in_app(
     role=None,
     privileges: list[Privilege] = None,
     **kwargs
-) -> tuple:
+) -> tuple[User, Application, str]:
     """
     Create a user and associates them with an application, optionally creating related roles and privileges.
 


### PR DESCRIPTION
## Summary
Fixes #7125

## Changes proposed
Adds the ability to filter by application audit events to the list application audit event endpoint

## Context for reviewers
Follows our usual conventions for setting up filters in a request and passing them through to a DB query.

## Validation steps
Unit tests show various filter conditions - also added tests for pagination as I realized I hadn't done that when setting up the endpoint.