### PR TITLE
[Unticketed] Fix bug in jsonref resolver which incorrectly resolves schemas

### DIFF
--- a/api/src/form_schema/jsonschema_resolver.py
+++ b/api/src/form_schema/jsonschema_resolver.py
@@ -1,8 +1,53 @@
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 import jsonref
 
 from src.form_schema.shared import SharedSchema, get_shared_schemas
+
+"""
+HACKY FIX
+
+The jsonref library has a bug when resolving references that
+can cause it to resolve them incorrectly. This was fixed in
+https://github.com/gazpachoking/jsonref/commit/e827f232cdbef2f7f49d3ccc6e93bc43868ae96b
+but the library hasn't made a new release available in PyPi
+more than a year after the fix was made. As an alternative
+to changing our poetry to install directly from GitHub, we
+have copied the change here and swap out the function in the jsonref library.
+"""
+
+
+def _walk_refs(
+    obj: Any, func: Callable[[Any], Any], replace: bool = False, _processed: dict | None = None
+) -> Any:
+    # Keep track of already processed items to prevent recursion
+    _processed = _processed or {}
+    if type(obj) is jsonref.JsonRef:
+        oid = id(obj)
+        if oid in _processed:
+            return _processed[oid]
+        r = func(obj)
+        obj = r if replace else obj
+        _processed[oid] = obj
+    if isinstance(obj, Mapping):
+        for k, v in obj.items():
+            r = _walk_refs(v, func, replace=replace, _processed=_processed)
+            if replace:
+                obj[k] = r  # type: ignore[index]
+    elif isinstance(obj, Sequence) and not isinstance(obj, str):
+        for i, v in enumerate(obj):
+            r = _walk_refs(v, func, replace=replace, _processed=_processed)
+            if replace:
+                obj[i] = r  # type: ignore[index]
+    return obj
+
+
+# Replace the _walk_refs function with the updated one
+jsonref._walk_refs = _walk_refs
+"""
+END hacky fix
+"""
 
 
 def _get_shared_schemas_map() -> dict[str, SharedSchema]:


### PR DESCRIPTION
## Summary

## Changes proposed
* Ports a bugfix from the jsonref library in to fix an issue with resolving schemas incorrectly.

## Context for reviewers
Added context in the ticket - but the issue this was causing was that depending on the order we resolved schemas, it would sometimes incorrectly resolve a schema to have the wrong fields. The linked fix changes some internal method for how it tracks references to fix it, but it hasn't been made into a release yet, so manually patched/overrode the function to the newer fixed one.

## Validation steps
Before, running the tests in the forms folder could fail ( `make test args="-x -s -vv tests/src/form_schema/forms"`).
