### PR TITLE
[Issue #7344]: Add guard duty image ecr permissions to the task executor role

### DIFF
--- a/infra/modules/service/access_control.tf
+++ b/infra/modules/service/access_control.tf
@@ -79,6 +79,17 @@ data "aws_iam_policy_document" "task_executor" {
     resources = [local.fluent_bit_repo_arn]
   }
 
+  # Allow ECS to download images for GuardDuty agent
+  statement {
+    sid = "ECRPullAccessGuardDuty"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = ["arn:aws:ecr:us-east-1:593207742271:repository/aws-guardduty-agent-fargate"]
+  }
+
   statement {
     sid = "PullSharedNewRelicKey"
     actions = [


### PR DESCRIPTION
## Summary

Added the IAM ECR permissions to the ecs task executor role. 

## Context for reviewers

The step functions are failing because the task executor role is missing ecr permissions for the guard duty image. 

## Validation steps

The step functions should continue to run successfully. 