### PR TITLE
[Issue #7359] add pagination and sorting to organization users call

### DIFF
--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
@@ -60,20 +60,23 @@ export const getOrganizationUsers = async (
   const resp = await fetchOrganizationWithMethod("POST")({
     subPath: `${organizationId}/users`,
     additionalHeaders: ssgToken,
+    body: {
+      pagination: {
+        page_offset: 1,
+        page_size: 5000,
+        sort_order: [
+          {
+            order_by: "email",
+            sort_direction: "ascending",
+          },
+        ],
+      },
+    },
   });
 
   const json = (await resp.json()) as { data: UserDetail[] };
 
-  // Sort by email, this will be temp until we get the results from the backend with sorting applied
-  const sorted = [...json.data].sort((first, second) => {
-    const a = (first.email ?? "").toLowerCase();
-    const b = (second.email ?? "").toLowerCase();
-    if (a < b) return -1;
-    if (a > b) return 1;
-    return 0;
-  });
-
-  return sorted;
+  return json.data;
 };
 
 export const getOrganizationRoles = async (

--- a/frontend/tests/services/fetch/fetchers/organizationsFetcher.test.ts
+++ b/frontend/tests/services/fetch/fetchers/organizationsFetcher.test.ts
@@ -134,31 +134,19 @@ describe("getOrganizationUsers", () => {
       additionalHeaders: {
         "X-SGG-Token": "faketoken",
       },
+      body: {
+        pagination: {
+          page_offset: 1,
+          page_size: 5000,
+          sort_order: [
+            {
+              order_by: "email",
+              sort_direction: "ascending",
+            },
+          ],
+        },
+      },
     });
-  });
-
-  it("sorts returned users by email ascending and case-insensitive", async () => {
-    mockGetSession.mockResolvedValue({ token: "faketoken" });
-    fetchOrganizationMock.mockReturnValue({
-      ok: true,
-      status: 200,
-      json: () => ({
-        data: [
-          { email: "zeta@example.com" },
-          { email: "Alpha@example.com" },
-          { email: "beta@example.com" },
-        ],
-      }),
-    });
-    fetchOrganizationWithMethodMock.mockReturnValue(fetchOrganizationMock);
-
-    const result = await getOrganizationUsers("org-123");
-
-    expect(result).toEqual([
-      { email: "Alpha@example.com" },
-      { email: "beta@example.com" },
-      { email: "zeta@example.com" },
-    ]);
   });
 
   it("throws UnauthorizedError when session is missing or has no token", async () => {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #7359 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Adds pagination to organization users API call in order to conform to schema shape introduced in https://github.com/HHS/simpler-grants-gov/issues/6938

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Until this is merged, organization pages will be broken due to requests not conforming to the API schema

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. log in as 'one_org_user'
3. visit http://localhost:3000/organizations?_ff=userAdminOff:false;manageUsersOff:false
4. click on button to view an organization
5. _VERIFY_: page loads with no errors
6. _VERIFY_: members are sorted alphabetically (ascending) by email address
