### PR TITLE
[Unticketed] Add soap-private-keys to terraform

### DIFF
--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -93,9 +93,9 @@ locals {
       secret_store_name = "/api/${var.environment}/domain-verification-content"
     }
 
-    SOAP_AUTH_CONTENT = {
+    SOAP_PRIVATE_KEYS = {
       manage_method     = "manual"
-      secret_store_name = "/api/${var.environment}/soap-auth-content"
+      secret_store_name = "/api/${var.environment}/soap-private-keys"
     }
 
     SAM_GOV_API_KEY = {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #6816 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added env vars to the terraform file.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We're going to change over from SOAP_AUTH_CONTENT to SOAP_PRIVATE_KEYS and part of this is updating the terraform file as well as on AWS parameter store.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
