### PR TITLE
[Issue #7382] put manage users button on dashboard page behind feature flag

### DIFF
--- a/frontend/src/components/workspace/UserOrganizationItem.tsx
+++ b/frontend/src/components/workspace/UserOrganizationItem.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useFeatureFlags } from "src/hooks/useFeatureFlags";
+import { Organization } from "src/types/applicationResponseTypes";
+import { UserPrivilegesResponse } from "src/types/userTypes";
+import { userRoleForOrganization } from "src/utils/userUtils";
+
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { Button, Grid } from "@trussworks/react-uswds";
+
+import { USWDSIcon } from "src/components/USWDSIcon";
+
+const ManageUsersButton = ({
+  organization,
+}: {
+  organization: Organization;
+}) => {
+  const t = useTranslations("ActivityDashboard");
+  return (
+    <Link href={`/organization/${organization.organization_id}/manage-users`}>
+      <Button type="button">
+        <USWDSIcon name="people" /> {t("organizationButtons.manage")}
+      </Button>
+    </Link>
+  );
+};
+
+const ViewDetailsButton = ({
+  organization,
+}: {
+  organization: Organization;
+}) => {
+  const t = useTranslations("ActivityDashboard");
+  return (
+    <Link href={`/organization/${organization.organization_id}`}>
+      <Button type="button">
+        <USWDSIcon name="visibility" />
+        {t("organizationButtons.view")}
+      </Button>
+    </Link>
+  );
+};
+
+export const OrganizationItem = ({
+  organization,
+  userRoles,
+}: {
+  organization: Organization;
+  userRoles: UserPrivilegesResponse;
+}) => {
+  const role = userRoleForOrganization(organization, userRoles);
+
+  const orgPermissions = userRoles.organization_users.find(
+    (role) =>
+      role.organization.organization_id === organization.organization_id,
+  );
+  const canManageUsers = orgPermissions?.organization_user_roles.find((role) =>
+    role.privileges.includes("manage_org_members"),
+  );
+
+  const { checkFeatureFlag } = useFeatureFlags();
+  const manageUsersTurnedOn = !checkFeatureFlag("manageUsersOff");
+
+  return (
+    <li className="border-base-lighter border-1px padding-2 margin-top-2">
+      <Grid row>
+        <Grid tablet={{ col: "fill" }}>
+          <div className="font-sans-2xs text-base-dark">{role}</div>
+          <h3 className="margin-top-0">
+            {organization.sam_gov_entity.legal_business_name}
+          </h3>
+        </Grid>
+        <Grid
+          tablet={{ col: "auto" }}
+          className="flex-align-self-end text-right"
+        >
+          {canManageUsers && manageUsersTurnedOn ? (
+            <ManageUsersButton organization={organization} />
+          ) : (
+            ""
+          )}
+          <ViewDetailsButton organization={organization} />
+        </Grid>
+      </Grid>
+    </li>
+  );
+};

--- a/frontend/src/components/workspace/UserOrganizationsList.tsx
+++ b/frontend/src/components/workspace/UserOrganizationsList.tsx
@@ -1,85 +1,9 @@
 import { Organization } from "src/types/applicationResponseTypes";
 import { UserPrivilegesResponse } from "src/types/userTypes";
-import { userRoleForOrganization } from "src/utils/userUtils";
 
 import { useTranslations } from "next-intl";
-import Link from "next/link";
-import { Button, Grid } from "@trussworks/react-uswds";
 
-import { USWDSIcon } from "src/components/USWDSIcon";
-
-const ManageUsersButton = ({
-  organization,
-}: {
-  organization: Organization;
-}) => {
-  const t = useTranslations("ActivityDashboard");
-  return (
-    <Link href={`/organization/${organization.organization_id}/manage-users`}>
-      <Button type="button">
-        <USWDSIcon name="people" /> {t("organizationButtons.manage")}
-      </Button>
-    </Link>
-  );
-};
-
-const ViewDetailsButton = ({
-  organization,
-}: {
-  organization: Organization;
-}) => {
-  const t = useTranslations("ActivityDashboard");
-  return (
-    <Link href={`/organization/${organization.organization_id}`}>
-      <Button type="button">
-        <USWDSIcon name="visibility" />
-        {t("organizationButtons.view")}
-      </Button>
-    </Link>
-  );
-};
-
-const OrganizationItem = ({
-  organization,
-  userRoles,
-}: {
-  organization: Organization;
-  userRoles: UserPrivilegesResponse;
-}) => {
-  const role = userRoleForOrganization(organization, userRoles);
-
-  const orgPermissions = userRoles.organization_users.find(
-    (role) =>
-      role.organization.organization_id === organization.organization_id,
-  );
-  const canManageUsers = orgPermissions?.organization_user_roles.find((role) =>
-    role.privileges.includes("manage_org_members"),
-  );
-
-  return (
-    <li className="border-base-lighter border-1px padding-2 margin-top-2">
-      <Grid row>
-        <Grid tablet={{ col: "fill" }}>
-          <div className="font-sans-2xs text-base-dark">{role}</div>
-          <h3 className="margin-top-0">
-            {organization.sam_gov_entity.legal_business_name}
-          </h3>
-        </Grid>
-        <Grid
-          tablet={{ col: "auto" }}
-          className="flex-align-self-end text-right"
-        >
-          {canManageUsers ? (
-            <ManageUsersButton organization={organization} />
-          ) : (
-            ""
-          )}
-          <ViewDetailsButton organization={organization} />
-        </Grid>
-      </Grid>
-    </li>
-  );
-};
+import { OrganizationItem } from "./UserOrganizationItem";
 
 const NoOrganizations = () => {
   const t = useTranslations("ActivityDashboard.noOrganizations");

--- a/frontend/tests/components/workspace/UserOrganizationsList.test.tsx
+++ b/frontend/tests/components/workspace/UserOrganizationsList.test.tsx
@@ -19,6 +19,12 @@ jest.mock("src/utils/userUtils", () => ({
   userRoleForOrganization: jest.fn(() => "Admin"),
 }));
 
+jest.mock("src/hooks/useFeatureFlags", () => ({
+  useFeatureFlags: () => ({
+    checkFeatureFlag: () => false,
+  }),
+}));
+
 const makeOrg = (id: string, name: string) => ({
   organization_id: id,
   sam_gov_entity: {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
 Work for #7382

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Puts manage users button on user dashboard page behind "manageUsersOff" feature flag

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run dev`
2. visit http://localhost:3000/dashboard?_ff=manageUsersOff:true
3. log in as "two_org_user"
4. _VERIFY_: organization list does not contain links to manage users page
