### PR TITLE
[Issue #7410] add Hao to code owners and maintainers.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,13 +3,13 @@
 
 * @mdragon # project lead
 
-/documentation/  @andycochran @btabaska @chouinar @doug-s-nava @joshtonava @mdragon @myduong-navapbc @widal001 @prasnava @jakobpederson @ErinPattisonNava @glenblosser-nava @nathan-stricker # everyone
+/documentation/  @andycochran @btabaska @chouinar @doug-s-nava @joshtonava @mdragon @myduong-navapbc @widal001 @prasnava @jakobpederson @ErinPattisonNava @glenblosser-nava @nathan-stricker @hao10282025-sudo # everyone
 
 /analytics/               @widal001
 /documentation/analytics/ @widal001
 
-/api/               @chouinar @mdragon @joshtonava @jakobpederson @chay-REIsys
-/documentation/api/ @chouinar @mdragon @joshtonava @jakobpederson @chay-REIsys
+/api/               @chouinar @mdragon @joshtonava @jakobpederson @chay-REIsys @hao10282025-sudo
+/documentation/api/ @chouinar @mdragon @joshtonava @jakobpederson @chay-REIsys @hao10282025-sudo
 
 /frontend/               @andycochran @btabaska @doug-s-nava @myduong-navapbc @ErinPattisonNava @chay-REIsys @glenblosser-nava @nathan-stricker
 /documentation/frontend/ @andycochran @btabaska @doug-s-nava @myduong-navapbc @ErinPattisonNava @chay-REIsys @glenblosser-nava @nathan-stricker

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,7 @@ This is a list of maintainers for this project. See [CODEOWNERS](/.github/CODEOW
 * Glen Blosser
 * Dao Nguyen
 * Nathan Stricker
+* Hao Wang
 
 ## Content and Design
 


### PR DESCRIPTION
## Summary

Fixes #7410  

## Changes proposed

Summary
Update the code owners and maintainers file for @hao10282025-sudo

## Context for reviewers

onboarding action

## Validation steps

Ensure @hao10282025-sudo is in the code owners and maintainers file
