### PR TITLE
[Unticketed] Document how we should be removing columns from DB tables

### DIFF
--- a/documentation/api/database/database-management.md
+++ b/documentation/api/database/database-management.md
@@ -133,3 +133,39 @@ a new migration. If there would be anything created, it errors.
 
 This check also runs as part of our CI/CD, so even if you forget to run it yourself during development,
 it will be caught when you send a pull request.
+
+# Operations
+## Removing a column
+
+**First Deploy**
+
+In order to remove a column, we'll first need to remove all usage of the column in the API code base.
+
+However, since the column will still be in the database model, SQLAlchemy will still include it in `SELECT`s and `INSERT`s for the table. We'll need to set this column to `deferred`, in order to exclude it from queries, and to `evaluates_none`, to stop inserting null for it. This does require that the column be nullable to work, if it isn't you'll first need to make it nullable in an earlier migration.
+
+```python
+class Example(ApiSchemaTable, TimestampMixin):
+    __tablename__ = "example"
+
+    example_id: Mapped[uuid.UUID] = mapped_column(
+        UUID, primary_key=True, default=uuid.uuid4
+    )
+
+    # The column we want to deprecate, needs both
+    # the call to evaluates_none() and deferred=True
+    my_column: Mapped[str | None] = mapped_column(Text.evaluates_none(), deferred=True)
+```
+
+**Second Deploy**
+
+Once the column usage removal has been deployed (including deprecating the column in the database model), we can safely remove the column from the database model and the actual database. To do so, simply delete the deprecated column from the database model and create a corresponding database migration.
+
+## Removing a table
+
+**First Deploy**
+
+Removing a table is similar to, but simpler than, removing a column. You'll still start by removing all usage of the table in the API code base. No further steps are required at this point, since SQLAlchemy won't be interacting with the table at this point.
+
+**Second Deploy**
+
+Once the table usage removal has been deployed, we can safely remove the table from the database model and the actual database. Again, simply delete the table from the database model and create a corresponding migration.


### PR DESCRIPTION
## Summary

## Changes proposed
* Add docs about how to delete a column from a DB table

## Context for reviewers
We had an issue with the prod deploy today. Because our migrations run before code is deployed, what happened is:
* Migration ran, deleting a DB column
* Code querying that table failed because the DB said "I have no idea what that column is"
* API code was updated
* Code stopped failing

For about 5 minutes any calls to our opportunity endpoints were 500ing. 

Unfortunately, the proper solution requires handling it a bit different, and a bit more annoyingly. We need to tell SQLAlchemy to ignore a column first, do the prod deploy THEN delete the column. Meaning any column deletes take two weeks to do. These docs (and the way of resolving the issue) are pulled from a prior project where we hit this issue.

## Validation steps
Admittedly, haven't verified this, but can't really test it without doing it. At the very least, this is based on hitting this issue several times on a prior project, and at worst, I'm slightly off on what we need to configure.
