### PR TITLE
[Issue #7398] Scale OpenSearch out

### DIFF
--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -52,7 +52,7 @@ module "prod_config" {
   # Use the AWS Console to determine the number of availability zones in your region.
   search_data_instance_type      = "or1.medium.search"
   search_data_volume_size        = 20
-  search_data_instance_count     = 3
+  search_data_instance_count     = 6
   search_availability_zone_count = 3
   # Versions: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version
   search_engine_version = "OpenSearch_2.15"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #7398  

## Changes proposed
This is one of two scaling approaches we're preparing for scaling Search traffic.

This approach will scale our search nodes out by increasing the nodes from 3 to 6. This is the smallest increment we can make as we must adjust in multiples of our availability zone count which is 3.

We are reviewing the change, so we are ready, but not planning to apply/deploy the change yet.