### PR TITLE
[Issue-#7183]-Add background color to current pagination button

### DIFF
--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -414,6 +414,10 @@ button.usa-pagination__button.usa-button {
   }
 }
 
+.usa-pagination .usa-current {
+  background-color: color("mint-60") !important;
+}
+
 // we are implementing the uswds nav drop down at mobile widths, which is not ordinarily supported
 // these styles are taken from the desktop imlementation of the dropdown and applied at all breakpoints
 .usa-nav__primary {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes  for #7386 

## Changes proposed

adding a custom style for current page button to have our desired colored as new usdws update is adding transparent by default for selected page

## Context for reviewers

adding a custom style for current page button to have our desired colored as new usdws update is adding transparent by default for selected page

## Validation steps

any grid with pagination shouldn't have transparent color for selected pagination button

<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/0ce72864-6ef1-4e30-8658-a1d7a1980dc0" />

