### PR TITLE
Exclude Inspector findings from Security Hub alerts

### DIFF
--- a/infra/accounts/security_hub_alerts.tf
+++ b/infra/accounts/security_hub_alerts.tf
@@ -231,9 +231,10 @@ resource "aws_sns_topic_subscription" "security_hub_findings_slack" {
 }
 
 # EventBridge rule for CRITICAL severity findings
+# Excludes Inspector findings (CVE vulnerabilities) which are too noisy for real-time alerts
 resource "aws_cloudwatch_event_rule" "security_hub_critical_findings" {
   name        = "security-hub-critical-findings"
-  description = "Capture CRITICAL severity findings from Security Hub"
+  description = "Capture CRITICAL severity findings from Security Hub (excluding Inspector)"
 
   event_pattern = jsonencode({
     source      = ["aws.securityhub"]
@@ -247,6 +248,11 @@ resource "aws_cloudwatch_event_rule" "security_hub_critical_findings" {
           Status = ["NEW"]
         }
         RecordState = ["ACTIVE"]
+        ProductArn = [{
+          "anything-but" = {
+            "prefix" = "arn:aws:securityhub:us-east-1::product/aws/inspector"
+          }
+        }]
       }
     }
   })
@@ -259,9 +265,10 @@ resource "aws_cloudwatch_event_target" "security_hub_critical_findings_sns" {
 }
 
 # EventBridge rule for HIGH severity findings
+# Excludes Inspector findings (CVE vulnerabilities) which are too noisy for real-time alerts
 resource "aws_cloudwatch_event_rule" "security_hub_high_findings" {
   name        = "security-hub-high-findings"
-  description = "Capture HIGH severity findings from Security Hub"
+  description = "Capture HIGH severity findings from Security Hub (excluding Inspector)"
 
   event_pattern = jsonencode({
     source      = ["aws.securityhub"]
@@ -275,6 +282,11 @@ resource "aws_cloudwatch_event_rule" "security_hub_high_findings" {
           Status = ["NEW"]
         }
         RecordState = ["ACTIVE"]
+        ProductArn = [{
+          "anything-but" = {
+            "prefix" = "arn:aws:securityhub:us-east-1::product/aws/inspector"
+          }
+        }]
       }
     }
   })


### PR DESCRIPTION
## Summary
- Excludes AWS Inspector findings from Security Hub Slack and email alerts
- Inspector CVE vulnerability findings are too noisy (~400+ alerts at once during container scans)
- Keeps alerts for GuardDuty, Security Hub config checks, Access Analyzer, and other services

## Why
Inspector generates a high volume of CVE findings whenever container images are scanned. These are better reviewed in the Security Hub console rather than flooding Slack/email channels.

## What still triggers alerts
- GuardDuty (threat detection)
- Security Hub compliance checks
- Access Analyzer (IAM issues)
- Firewall Manager
- Systems Manager
- Macie
- Health events

## Test plan
- [ ] Deploy to AWS
- [ ] Verify Inspector findings no longer trigger Slack alerts
- [ ] Verify other finding types (e.g., Security Hub config checks) still trigger alerts