### PR TITLE
[Issue #7350] Change job to generate Zip of successfully submitted application to run hourly

### DIFF
--- a/api/src/task/forms/update_form_instruction_task.py
+++ b/api/src/task/forms/update_form_instruction_task.py
@@ -88,4 +88,3 @@ class UpdateFormInstructionTask(BaseFormTask):
             f"Successfully uploaded form instruction {self.form_instruction_id} "
             f"for form {self.form_id} in {self.environment} environment"
         )
-

--- a/api/tests/src/task/forms/test_update_form_instruction_task.py
+++ b/api/tests/src/task/forms/test_update_form_instruction_task.py
@@ -106,4 +106,3 @@ def test_update_form_instruction_task_dev_environment(temp_instruction_file):
             "https://api.dev.simpler.grants.gov/alpha/forms/test-form-id/form_instructions/test-instruction-id"
             == call_args[0][0]
         )
-


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #7350

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Update Terraform to run `create-application-submission` task hourly.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
This was updated to offset by 15 minutes to avoid collision with other hourly jobs, but this can be changed back to on-the-hour.

**Do not merge until https://github.com/HHS/simpler-grants-gov/issues/7350 is closed.**

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Once merged, confirm TF applies these to environments.