### PR TITLE
[Issue #7394] setup simpler multiauth for JWT and new API key

### DIFF
--- a/api/src/auth/multi_auth.py
+++ b/api/src/auth/multi_auth.py
@@ -93,7 +93,7 @@ api_key_multi_auth = MultiHttpTokenAuth(api_user_key_auth, api_key_auth)
 # We define the JWT auth first as the frontend will pass us a users JWT
 # and the frontend's API key for all user-based requests in order to validate
 # with our API gateway that handles rate limiting.
-jwt_or_api_user_key_multi_auth_simpler = MultiHttpTokenAuthSimpler(api_jwt_auth, api_user_key_auth)
+jwt_or_api_user_key_multi_auth = MultiHttpTokenAuthSimpler(api_jwt_auth, api_user_key_auth)
 
 
 # Helper function to format security schemes for OpenAPI
@@ -127,7 +127,7 @@ api_key_multi_auth_security_schemes = _get_security_requirement(
 )
 
 # List of security scheme names for JWT or API User Key multi-auth
-jwt_or_api_user_key_simpler_security_schemes = _get_security_requirement(
+jwt_or_api_user_key_security_schemes = _get_security_requirement(
     [
         api_jwt_auth.security_scheme_name,
         api_user_key_auth.security_scheme_name,

--- a/api/tests/src/auth/test_multi_auth.py
+++ b/api/tests/src/auth/test_multi_auth.py
@@ -9,7 +9,7 @@ from src.auth.internal_jwt_auth import create_jwt_for_internal_token
 from src.auth.multi_auth import (
     AuthType,
     jwt_key_or_internal_multi_auth,
-    jwt_or_api_user_key_multi_auth_simpler,
+    jwt_or_api_user_key_multi_auth,
     jwt_or_key_multi_auth,
 )
 from src.util import datetime_util
@@ -55,9 +55,9 @@ def mini_app(monkeypatch_module):
         }
 
     @mini_app.get("/dummy_auth_endpoint_simpler")
-    @mini_app.auth_required(jwt_or_api_user_key_multi_auth_simpler)
+    @mini_app.auth_required(jwt_or_api_user_key_multi_auth)
     def dummy_endpoint_simpler():
-        user = jwt_or_api_user_key_multi_auth_simpler.get_user()
+        user = jwt_or_api_user_key_multi_auth.get_user()
 
         return {
             "message": "ok",
@@ -194,7 +194,7 @@ def test_internal_multi_auth_precedence(
 
 
 def test_multi_auth_simpler_with_jwt(mini_app, enable_factory_create, db_session):
-    """Test that the jwt_or_api_user_key_multi_auth_simpler works with JWT tokens and returns the actual user"""
+    """Test that the jwt_or_api_user_key_multi_auth works with JWT tokens and returns the actual user"""
     user = UserFactory.create()
     token, _ = create_jwt_for_user(user, db_session)
     db_session.commit()
@@ -208,7 +208,7 @@ def test_multi_auth_simpler_with_jwt(mini_app, enable_factory_create, db_session
 
 
 def test_multi_auth_simpler_with_api_user_key(mini_app, enable_factory_create, db_session):
-    """Test that the jwt_or_api_user_key_multi_auth_simpler works with api user keys and returns the actual user"""
+    """Test that the jwt_or_api_user_key_multi_auth works with api user keys and returns the actual user"""
     user = UserFactory.create()
     api_key = UserApiKeyFactory.create(user=user, is_active=True)
     db_session.commit()
@@ -222,7 +222,7 @@ def test_multi_auth_simpler_with_api_user_key(mini_app, enable_factory_create, d
 
 
 def test_multi_auth_simpler_precedence(mini_app, enable_factory_create, db_session):
-    """Test that JWT auth takes precedence over api user key auth when both are provided for jwt_or_api_user_key_multi_auth_simpler"""
+    """Test that JWT auth takes precedence over api user key auth when both are provided for jwt_or_api_user_key_multi_auth"""
     # Create two different users
     jwt_user = UserFactory.create()
     api_user_key_user = UserFactory.create()
@@ -245,13 +245,13 @@ def test_multi_auth_simpler_precedence(mini_app, enable_factory_create, db_sessi
 
 
 def test_multi_auth_simpler_no_auth(mini_app):
-    """Test that authentication fails when no auth is provided for jwt_or_api_user_key_multi_auth_simpler"""
+    """Test that authentication fails when no auth is provided for jwt_or_api_user_key_multi_auth"""
     resp = mini_app.test_client().get("/dummy_auth_endpoint_simpler", headers={})
     assert resp.status_code == 401
 
 
 def test_multi_auth_simpler_invalid_auth(mini_app):
-    """Test that authentication fails with invalid credentials for jwt_or_api_user_key_multi_auth_simpler"""
+    """Test that authentication fails with invalid credentials for jwt_or_api_user_key_multi_auth"""
     resp = mini_app.test_client().get(
         "/dummy_auth_endpoint_simpler", headers={"X-SGG-Token": "invalid-token"}
     )


### PR DESCRIPTION
## Summary

Fixes #7394  

## Changes proposed

- Create a [multiauth](https://github.com/HHS/simpler-grants-gov/blob/main/api/src/auth/multi_auth.py) class alternative to MultiHttpTokenAuth - it should have a get_user function that returns an actual user - not one of the auth types like the existing one (we don't need the key, we want the user itself). The only possible auth types it should support are UserApiKey and UserTokenSession
- Define an auth object in the file that allows for either of the two auths
- Add tests that verify this auth can be used on a generic route (don't add it to a real route yet)
- Add docs on how to use it - calling out that you can't use the APIFlask decorator due to it not supporting multiauth yet

## Context for reviewers

For our endpoints, we can configure multiple auth types to be allowed, we want to add JWT and API User Key auth to many of our endpoints, but first need to setup the multiauth to support this.

## Validation steps

- New multiauth container class created which has a get_user method that always returns a user record regardless of which of the two auths it is.
- Tests added that verify the auth works
