### PR TITLE
[Unticketed] Fix pagination logic to return the item not raise

### DIFF
--- a/api/src/pagination/pagination_schema.py
+++ b/api/src/pagination/pagination_schema.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from marshmallow import pre_load
 
 from src.api.schemas.extension import Schema, fields, validators
@@ -7,7 +9,7 @@ from src.pagination.pagination_models import SortDirection
 class BasePaginationSchema(Schema):
 
     @pre_load
-    def before_load(self, item: dict, many: bool, **kwargs: dict) -> dict:
+    def before_load(self, item: Any, many: bool, **kwargs: dict) -> Any:
         # If input is not a dict, just return it; Marshmallow will raise a ValidationError
         if not isinstance(item, dict):
             return item

--- a/api/tests/src/pagination/test_paginator.py
+++ b/api/tests/src/pagination/test_paginator.py
@@ -199,6 +199,7 @@ def test_sort_order_string_returns_422(client):
         ],
     )
 
+
 def test_pagination_invalid_422(client):
     # Sending an invalid pagination object
     payload = {"pagination": 5}
@@ -211,6 +212,7 @@ def test_pagination_invalid_422(client):
             ("pagination", "invalid"),
         ],
     )
+
 
 def test_sort_order_invalid_json_returns_422(client):
     # Sending broken JSON


### PR DESCRIPTION
## Summary

## Changes proposed
* Fixes an issue with a recent change which should return the invalid value rather than raise it

## Context for reviewers
This function is called for pre-processing pagination parameters in a request. If a user passes in `{"pagination": 5}` instead of the proper pagination object, this first if-statement prevents us from parsing the value and returns it. Other type validation will then kick in and say "that's not an object" and error appropriately. We mistakenly were raising the object as an error, and `raise 5` has no meaning in python and gives a separate error entirely.

## Validation steps
Tests updated, but found by manually adjusting params locally when calling endpoint as well.