### PR TITLE
[unticketed] do not remove double slashes from protocol definitions

### DIFF
--- a/frontend/src/services/fetch/fetcherHelpers.ts
+++ b/frontend/src/services/fetch/fetcherHelpers.ts
@@ -49,7 +49,6 @@ export function createRequestUrl(
   subPath = "",
   body?: JSONRequestBody,
 ) {
-  // Remove leading slash
   const cleanedPaths = compact([basePath, version, namespace, subPath]);
   let url = [...cleanedPaths].map(removeRedundantSlashes).join("/");
   if (method === "GET" && body && !(body instanceof FormData)) {
@@ -68,10 +67,10 @@ export function createRequestUrl(
 }
 
 /**
- * Remove leading slash and double slashes (in case a segment such a version is not provided)
+ * Remove leading slash and (non protocol related) double slashes (in case a segment such a version is not provided)
  */
-function removeRedundantSlashes(path: string) {
-  return path.replace(/^\//, "").replace(/\/\//g, "/");
+export function removeRedundantSlashes(path: string) {
+  return path.replace(/^\//, "").replace(/(?<!:)\/\//g, "/");
 }
 
 /**

--- a/frontend/tests/services/fetch/FetcherHelpers.test.ts
+++ b/frontend/tests/services/fetch/FetcherHelpers.test.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { UnauthorizedError } from "src/errors";
 import {
   createRequestUrl,
+  removeRedundantSlashes,
   throwError,
 } from "src/services/fetch/fetcherHelpers";
 import { wrapForExpectedError } from "src/utils/testing/commonTestUtils";
@@ -159,5 +160,23 @@ describe("getDefaultHeaders", () => {
     expect(headers["X-AUTH"]).toBeUndefined();
     expect(headers["X-API-KEY"]).toBeUndefined();
     expect(headers["Content-Type"]).toEqual("application/json");
+  });
+});
+
+describe("removeRedundantSlashes", () => {
+  it("removes leading slashes", () => {
+    expect(removeRedundantSlashes("/something/something/something")).toEqual(
+      "something/something/something",
+    );
+  });
+  it("retains protocol slashes", () => {
+    expect(removeRedundantSlashes("http://anyhost.com/path")).toEqual(
+      "http://anyhost.com/path",
+    );
+  });
+  it("removes double path slashes", () => {
+    expect(
+      removeRedundantSlashes("http://toomany.slashes//path/subpath"),
+    ).toEqual("http://toomany.slashes/path/subpath");
   });
 });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

https://github.com/HHS/simpler-grants-gov/pull/7073 introduced a bug in the url generation logic for frontend fetcher functions, where double slashes in protocol definitions were replaced with single slashes. This fixes that bug

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Note that somehow this change was not causing problems in all situations. Without the double slash in the url we'd assume that all fetches would fail, but they didn't. Unsolved mystery

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run local`
2. visit http://localhost:3000/
3. _VERIFY_: all content loads correctly, including the list of local users in the drop down at top of the page, no errors received in console