### PR TITLE
[Issue #7113] Add NEH Supplementary cover sheet XML

### DIFF
--- a/api/src/form_schema/forms/supplementary_neh_cover_sheet.py
+++ b/api/src/form_schema/forms/supplementary_neh_cover_sheet.py
@@ -177,52 +177,8 @@ FIELD_OF_STUDY_CODE_MAP = {
     "Other: Statistics": "2881",
 }
 
-# Mapping from display values to XSD numeric codes for organization types
-# The display value is in format "CODE: Description", XSD expects just the code
-ORGANIZATION_TYPE_CODE_MAP = {
-    "1326: Center For Advanced Study/Research Institute": "1326",
-    "1327: Publishing": "1327",
-    "1328: Two-Year College": "1328",
-    "1329: Four-Year College": "1329",
-    "1330: University": "1330",
-    "1331: Professional School": "1331",
-    "1332: Elementary/Middle School": "1332",
-    "1333: Secondary School": "1333",
-    "1334: School District": "1334",
-    "1335: State Department of Education": "1335",
-    "1336: Non-Profit Educational Center": "1336",
-    "1337: Educational Consortium": "1337",
-    "1338: Philanthropic Foundation": "1338",
-    "1339: State/Local/Federal Government": "1339",
-    "1340: Historical Society": "1340",
-    "1341: Archives": "1341",
-    "1342: Historical Site/House": "1342",
-    "1343: Historic Preservation Organization": "1343",
-    "1344: Public Library": "1344",
-    "1345: Academic Library": "1345",
-    "1346: Independent Research Library": "1346",
-    "1347: History Museum": "1347",
-    "1348: Natural History Museum": "1348",
-    "1349: Art Museum": "1349",
-    "1350: University Museum": "1350",
-    "1351: Anthropology/Archaeology Museum": "1351",
-    "1352: Science and Technology Museum": "1352",
-    "1353: General Museum": "1353",
-    "1354: Nature Center/Botanical Garden/Arboretum": "1354",
-    "1355: National Organization": "1355",
-    "1356: State Humanities Council": "1356",
-    "1357: Community-Level Organization": "1357",
-    "1358: Indian Tribal Organization": "1358",
-    "1359: Professional Association": "1359",
-    "1360: Arts Related Organizations": "1360",
-    "1361: Television/Station": "1361",
-    "1362: Radio Station": "1362",
-    "1363: Independent Production Company": "1363",
-    "1364: Press": "1364",
-    "2786: Museums": "2786",
-    "2787: Libraries": "2787",
-    "2819: Unknown": "2819",
-}
+# Note: Organization type values are passed through as-is (full "CODE: Description" format)
+# The XSD expects the full value, not just the code number
 
 PROJECT_DISCIPLINE_VALUES = [
     "Arts: General",  # 117
@@ -688,13 +644,10 @@ FORM_XML_TRANSFORM_RULES = {
         }
     },
     # 2. InstType - Institution/Organization Type
+    # Note: Organization type is passed through as-is (full "CODE: Description" format)
     "organization_type": {
         "xml_transform": {
             "target": "InstType",
-            "value_transform": {
-                "type": "map_values",
-                "params": {"mappings": ORGANIZATION_TYPE_CODE_MAP},
-            },
         }
     },
     # 3. ProjectFunding - Nested structure for funding amounts

--- a/api/src/services/xml_generation/README.md
+++ b/api/src/services/xml_generation/README.md
@@ -447,14 +447,10 @@ FORM_XML_TRANSFORM_RULES = {
             },
         }
     },
-    # Institution/Organization Type - maps "1330: University" to "1330"
+    # Institution/Organization Type - passed through as-is (full "CODE: Description" format)
     "organization_type": {
         "xml_transform": {
             "target": "InstType",
-            "value_transform": {
-                "type": "map_values",
-                "params": {"mappings": ORGANIZATION_TYPE_CODE_MAP},
-            },
         }
     },
     # Nested structure for project funding amounts
@@ -482,9 +478,9 @@ FORM_XML_TRANSFORM_RULES = {
 ```
 
 **Supplementary Cover Sheet for NEH Grant Programs Field Mapping Notes:**
-- Uses `map_values` transformation to convert human-readable enum values to XSD-required numeric codes
+- Uses `map_values` transformation to convert human-readable enum values to XSD-required numeric codes for discipline fields
 - `major_field` (Project Director's Major Field): Maps ~150 discipline display values (e.g., "History: U.S. History") to numeric codes (e.g., "4")
-- `organization_type`: Maps institution type display values (e.g., "1330: University") to just the code (e.g., "1330")
+- `organization_type`: Passed through as-is (full "CODE: Description" format, e.g., "1330: University")
 - `primary_project_discipline`, `secondary_project_discipline`, `tertiary_project_discipline`: Same mapping as `major_field` but uses a subset of values (project disciplines only, not the additional "Other" field of study values)
 - `funding_group` → `ProjectFunding`: Nested structure with currency-formatted amounts
 - `application_info` → `ApplicationInfo`: Nested structure with boolean-to-yes/no conversion for `additional_funding`

--- a/api/tests/src/services/xml_generation/test_supplementary_neh_cover_sheet_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_supplementary_neh_cover_sheet_xml_generation.py
@@ -66,8 +66,8 @@ class TestSupplementaryNEHCoverSheetXMLGeneration:
         # Verify discipline codes are transformed correctly
         assert "PDMajorField>4<" in xml_data  # "History: U.S. History" -> "4"
         assert "PrimaryPDNEH>4<" in xml_data  # Same mapping
-        # Verify organization type code
-        assert "InstType>1330<" in xml_data  # "1330: University" -> "1330"
+        # Verify organization type (passed through as full value)
+        assert "InstType>1330: University<" in xml_data  # Full value preserved
 
     def test_generate_neh_cover_sheet_xml_discipline_code_mapping(self):
         """Test that discipline display values are correctly mapped to XSD numeric codes."""
@@ -108,17 +108,18 @@ class TestSupplementaryNEHCoverSheetXMLGeneration:
             assert f"PDMajorField>{expected_code}<" in response.xml_data
             assert f"PrimaryPDNEH>{expected_code}<" in response.xml_data
 
-    def test_generate_neh_cover_sheet_xml_organization_type_mapping(self):
-        """Test that organization type display values are correctly mapped to codes."""
+    def test_generate_neh_cover_sheet_xml_organization_type_passthrough(self):
+        """Test that organization type values are passed through as-is (full value)."""
         test_cases = [
-            ("1326: Center For Advanced Study/Research Institute", "1326"),
-            ("1330: University", "1330"),
-            ("1344: Public Library", "1344"),
-            ("1349: Art Museum", "1349"),
-            ("2819: Unknown", "2819"),
+            "1326: Center For Advanced Study/Research Institute",
+            "1330: University",
+            "1344: Public Library",
+            "1349: Art Museum",
+            "1329: Four-Year College",
+            "2819: Unknown",
         ]
 
-        for display_value, expected_code in test_cases:
+        for display_value in test_cases:
             application_data = {
                 "major_field": "History: U.S. History",
                 "organization_type": display_value,
@@ -143,7 +144,8 @@ class TestSupplementaryNEHCoverSheetXMLGeneration:
             response = service.generate_xml(request)
 
             assert response.success is True, f"Failed for {display_value}"
-            assert f"InstType>{expected_code}<" in response.xml_data
+            # Organization type should be passed through as full value
+            assert f"InstType>{display_value}<" in response.xml_data
 
     def test_generate_neh_cover_sheet_xml_with_federal_match(self):
         """Test NEH Cover Sheet XML generation with federal match funding."""


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #7113 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add `FORM_XML_TRANSFORM_RULES` and static lookups to `supplementary_neh_cover_sheet.py`
Add tests
Update README

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The [XSD](https://apply07.grants.gov/apply/forms/schemas/SupplementaryCoverSheetforNEHGrantPrograms_3_0-V3.0.xsd) contains several enums in the XSD which have been built out here.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See unit tests and sample input JSON / output XML

JSON
```
{
  "major_field": "History: U.S. History",
  "organization_type": "1330: University",
  "funding_group": {
    "outright_funds": "50000.00",
    "total_from_neh": "50000.00",
    "total_project_costs": "50000.00"
  },
  "application_info": {
    "additional_funding": false,
    "application_type": "New"
  },
  "primary_project_discipline": "History: U.S. History"
}
```

XML
```
<?xml version='1.0' encoding='UTF-8'?>
<SupplementaryCoverSheetforNEHGrantPrograms_3_0:SupplementaryCoverSheetforNEHGrantPrograms_3_0 
    xmlns:SupplementaryCoverSheetforNEHGrantPrograms_3_0="http://apply.grants.gov/forms/SupplementaryCoverSheetforNEHGrantPrograms_3_0-V3.0" 
    xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0" 
    FormVersion="3.0">
  <SupplementaryCoverSheetforNEHGrantPrograms_3_0:PDMajorField>4</SupplementaryCoverSheetforNEHGrantPrograms_3_0:PDMajorField>
  <SupplementaryCoverSheetforNEHGrantPrograms_3_0:InstType>1330</SupplementaryCoverSheetforNEHGrantPrograms_3_0:InstType>
  <SupplementaryCoverSheetforNEHGrantPrograms_3_0:ProjectFunding>
    <SupplementaryCoverSheetforNEHGrantPrograms_3_0:OutrightFunds>50000.00</SupplementaryCoverSheetforNEHGrantPrograms_3_0:OutrightFunds>
    <SupplementaryCoverSheetforNEHGrantPrograms_3_0:TotalFromNEH>50000.00</SupplementaryCoverSheetforNEHGrantPrograms_3_0:TotalFromNEH>
    <SupplementaryCoverSheetforNEHGrantPrograms_3_0:TotalProjectCosts>50000.00</SupplementaryCoverSheetforNEHGrantPrograms_3_0:TotalProjectCosts>
  </SupplementaryCoverSheetforNEHGrantPrograms_3_0:ProjectFunding>
  <SupplementaryCoverSheetforNEHGrantPrograms_3_0:ApplicationInfo>
    <SupplementaryCoverSheetforNEHGrantPrograms_3_0:AdditionalFunding>N: No</SupplementaryCoverSheetforNEHGrantPrograms_3_0:AdditionalFunding>
    <SupplementaryCoverSheetforNEHGrantPrograms_3_0:ApplicationType>New</SupplementaryCoverSheetforNEHGrantPrograms_3_0:ApplicationType>
  </SupplementaryCoverSheetforNEHGrantPrograms_3_0:ApplicationInfo>
  <SupplementaryCoverSheetforNEHGrantPrograms_3_0:PrimaryPDNEH>4</SupplementaryCoverSheetforNEHGrantPrograms_3_0:PrimaryPDNEH>
</SupplementaryCoverSheetforNEHGrantPrograms_3_0:SupplementaryCoverSheetforNEHGrantPrograms_3_0>
```