### PR TITLE
[Issue 7612] Remove legacy API key auth from form management scripts

### DIFF
--- a/api/src/task/forms/README.md
+++ b/api/src/task/forms/README.md
@@ -12,11 +12,9 @@ the src.form_schemas.forms.__init__.get_active_forms function.
 
 # Auth
 Both of these scripts talk with our API endpoints in the specified environment
-and need an auth token to work. There are currently two different auth token approaches
-you can use:
+and need an API key to work.
 
 * `FORM_X_API_KEY_ID` - An API key attached to your user in the specified environment. The update-form task requires this user have the `update_form` privilege.
-* `NON_LOCAL_API_AUTH_TOKEN` (deprecated - will be removed soon) - the auth token for calling the environment - at the moment MUST be the same auth token the frontend uses (the first one configured in our API_AUTH_TOKEN env var)
 
 To setup your `FORM_X_API_KEY_ID`, do the following:
 * Go to the specified environment and generate an API key after logging in (eg. in staging, go to the [API Dashboard](https://staging.simpler.grants.gov/api-dashboard))

--- a/api/src/task/forms/form_task_shared.py
+++ b/api/src/task/forms/form_task_shared.py
@@ -29,49 +29,30 @@ ENV_FORM_INSTRUCTION_URL_MAP = {
 
 
 class FormTaskConfig(PydanticBaseEnvConfig):
-    # This is the legacy API key approach
-    non_local_api_auth_token: str | None = None
-    # This is the new API key approach
-    form_x_api_key_id: str | None = None
+    form_x_api_key_id: str
 
 
 class BaseFormTask(abc.ABC):
     def __init__(self) -> None:
         self.config = FormTaskConfig()
-        if self.config.non_local_api_auth_token is None and self.config.form_x_api_key_id is None:
-            raise Exception(
-                "Please set either the NON_LOCAL_API_AUTH_TOKEN or FORM_X_API_KEY_ID environment variable for the environment you wish to call"
-            )
 
     def build_headers(self) -> dict:
-
-        headers = {
+        return {
             "Content-Type": "application/json",
             "Accept": "application/json",
+            "X-API-Key": self.config.form_x_api_key_id,
         }
-        if self.config.form_x_api_key_id is not None:
-            headers["X-API-Key"] = self.config.form_x_api_key_id
-        if self.config.non_local_api_auth_token is not None:
-            headers["X-Auth"] = self.config.non_local_api_auth_token
-
-        return headers
 
     def build_file_upload_headers(self) -> dict:
         """Build headers for file upload requests (multipart/form-data).
 
         Note: Content-Type is not set here because requests will automatically
         set the correct Content-Type with boundary for multipart/form-data.
-
-        Note: X-Auth is not included here because the form instruction endpoint
-        only supports X-API-Key authentication.
         """
-        headers = {
+        return {
             "Accept": "application/json",
+            "X-API-Key": self.config.form_x_api_key_id,
         }
-        if self.config.form_x_api_key_id is not None:
-            headers["X-API-Key"] = self.config.form_x_api_key_id
-
-        return headers
 
     def get_forms(self) -> list[Form]:
         """Utility function to get active forms in derived classes"""

--- a/api/tests/src/task/forms/conftest.py
+++ b/api/tests/src/task/forms/conftest.py
@@ -2,10 +2,5 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def non_local_api_auth_token(monkeypatch_module):
-    monkeypatch_module.setenv("NON_LOCAL_API_AUTH_TOKEN", "fake-auth-token")
-
-
-@pytest.fixture(autouse=True)
 def form_x_api_key(monkeypatch_module):
     monkeypatch_module.setenv("FORM_X_API_KEY_ID", "fake-x-api-key")

--- a/api/tests/src/task/forms/test_form_task_shared.py
+++ b/api/tests/src/task/forms/test_form_task_shared.py
@@ -98,7 +98,6 @@ def test_build_headers():
         "Content-Type": "application/json",
         "Accept": "application/json",
         "X-API-Key": "fake-x-api-key",
-        "X-Auth": "fake-auth-token",
     }
 
 


### PR DESCRIPTION
## Summary

Fixes #7612

## Changes proposed

- Removed `non_local_api_auth_token` field from `FormTaskConfig` and all references to it
- Made `form_x_api_key_id` non-nullable (now a required field, enforced by Pydantic)
- Simplified `build_headers()` method to directly return headers with X-API-Key
- Simplified `build_file_upload_headers()` method similarly
- Updated README to remove references to legacy `NON_LOCAL_API_AUTH_TOKEN` auth approach
- Updated test fixtures in `conftest.py` to remove the legacy auth environment variable
- Updated `test_build_headers` to no longer expect X-Auth header

## Context for reviewers

The form management scripts previously supported two authentication methods: the legacy `NON_LOCAL_API_AUTH_TOKEN` (X-Auth header) and the newer `FORM_X_API_KEY_ID` (X-API-Key header). Per the issue, we are standardizing on X-API-Key only.

With `form_x_api_key_id` now being a required field in `FormTaskConfig`, Pydantic will automatically raise a validation error if the `FORM_X_API_KEY_ID` environment variable is not set, eliminating the need for manual null checks.

## Validation steps

1. Run the form task tests:
   ```bash
   make test args="tests/src/task/forms/ -v"
   ```
2. Verify scripts require `FORM_X_API_KEY_ID` to be set (should fail without it)
3. Test `list-forms` and `update-form` commands work with valid API key