### PR TITLE
[Issue #7647] Fix binary media uploads via API Gateway

### DIFF
--- a/api/src/task/forms/update_form_instruction_task.py
+++ b/api/src/task/forms/update_form_instruction_task.py
@@ -88,4 +88,3 @@ class UpdateFormInstructionTask(BaseFormTask):
             f"Successfully uploaded form instruction {self.form_instruction_id} "
             f"for form {self.form_id} in {self.environment} environment"
         )
-

--- a/api/tests/src/task/forms/test_update_form_instruction_task.py
+++ b/api/tests/src/task/forms/test_update_form_instruction_task.py
@@ -106,4 +106,3 @@ def test_update_form_instruction_task_dev_environment(temp_instruction_file):
             "https://api.dev.simpler.grants.gov/alpha/forms/test-form-id/form_instructions/test-instruction-id"
             == call_args[0][0]
         )
-


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #7647 

## Changes proposed
Add `binary_media_types` to Terraform config for API Gateway

<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Without `binary_media_types`, binary file uploads are corrupted when they pass through API Gateway.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Deploy changes to TF. For that environment, confirm a file upload in S3 can be downloaded out and opened. Try this for ZIP, PDF, PNG, JPG, TXT, and any other possible files we'd expect as uploads.