### PR TITLE
[Issue #7658] Add missing XML elements

### DIFF
--- a/api/src/form_schema/forms/sf424.py
+++ b/api/src/form_schema/forms/sf424.py
@@ -876,7 +876,8 @@ FORM_XML_TRANSFORM_RULES = {
     },
     "sam_uei": {"xml_transform": {"target": "SAMUEI"}},
     # Address information - nested structure with GlobalLibrary namespace
-    "applicant_address": {
+    # Order must match XSD: Street1, Street2, City, County, State/Province, ZipPostalCode, Country
+    "applicant": {
         "xml_transform": {"target": "Applicant", "type": "nested_object"},
         "street1": {"xml_transform": {"target": "Street1", "namespace": "globLib"}},
         "street2": {"xml_transform": {"target": "Street2", "namespace": "globLib"}},
@@ -884,8 +885,24 @@ FORM_XML_TRANSFORM_RULES = {
         "county": {"xml_transform": {"target": "County", "namespace": "globLib"}},
         "state": {"xml_transform": {"target": "State", "namespace": "globLib"}},
         "province": {"xml_transform": {"target": "Province", "namespace": "globLib"}},
-        "country": {"xml_transform": {"target": "Country", "namespace": "globLib"}},
         "zip_code": {"xml_transform": {"target": "ZipPostalCode", "namespace": "globLib"}},
+        "country": {"xml_transform": {"target": "Country", "namespace": "globLib"}},
+    },
+    # Contact person - nested structure with GlobalLibrary namespace for names
+    "contact_person": {
+        "xml_transform": {"target": "ContactPerson", "type": "nested_object"},
+        "first_name": {
+            "xml_transform": {
+                "target": "FirstName",
+                "namespace": "globLib",
+            }
+        },
+        "last_name": {
+            "xml_transform": {
+                "target": "LastName",
+                "namespace": "globLib",
+            }
+        },
     },
     # Contact information - direct field mappings
     "phone_number": {"xml_transform": {"target": "PhoneNumber"}},
@@ -911,6 +928,12 @@ FORM_XML_TRANSFORM_RULES = {
     "assistance_listing_program_title": {"xml_transform": {"target": "CFDAProgramTitle"}},
     "funding_opportunity_number": {"xml_transform": {"target": "FundingOpportunityNumber"}},
     "funding_opportunity_title": {"xml_transform": {"target": "FundingOpportunityTitle"}},
+    "competition_identification_number": {
+        "xml_transform": {"target": "CompetitionIdentificationNumber"}
+    },
+    "competition_identification_title": {
+        "xml_transform": {"target": "CompetitionIdentificationTitle"}
+    },
     # Project information - direct field mappings
     "project_title": {"xml_transform": {"target": "ProjectTitle"}},
     "congressional_district_applicant": {

--- a/api/src/services/xml_generation/service.py
+++ b/api/src/services/xml_generation/service.py
@@ -597,7 +597,7 @@ class XMLGenerationService:
         """
         # Get element order from config
         address_order = self._get_element_order_from_config(
-            transform_config, nested_path="applicant_address"
+            transform_config, nested_path="applicant"
         )
 
         # Add elements in the correct order

--- a/api/tests/src/services/xml_generation/test_configurable_namespaces.py
+++ b/api/tests/src/services/xml_generation/test_configurable_namespaces.py
@@ -15,7 +15,7 @@ class TestConfigurableNamespaces:
         application_data = {
             "submission_type": "Application",
             "organization_name": "Test Organization",
-            "applicant_address": {
+            "applicant": {
                 "street1": "123 Main St",
                 "city": "Washington",
                 "state": "DC",
@@ -81,7 +81,7 @@ class TestConfigurableNamespaces:
 
         application_data = {
             "submission_type": "Application",
-            "applicant_address": {
+            "applicant": {
                 "street1": "123 Main St",
                 "city": "Washington",
             },

--- a/api/tests/src/services/xml_generation/test_none_handling.py
+++ b/api/tests/src/services/xml_generation/test_none_handling.py
@@ -159,7 +159,7 @@ class TestNoneHandling:
         """Test None handling with nested object structures."""
         application_data = {
             "submission_type": "Application",
-            "applicant_address": {
+            "applicant": {
                 "street1": "123 Main St",
                 "street2": None,  # Should be excluded from nested structure
                 "city": "Washington",

--- a/api/tests/src/services/xml_generation/test_submission_xsd_validation.py
+++ b/api/tests/src/services/xml_generation/test_submission_xsd_validation.py
@@ -98,12 +98,16 @@ class TestSubmissionXSDValidation:
                 "organization_name": "Test Research University",
                 "employer_taxpayer_identification_number": "123456789",  # Required per XSD
                 "sam_uei": "TEST12345678",  # Required per XSD (exactly 12 chars)
-                "applicant_address": {  # Required per XSD
+                "applicant": {  # Required per XSD
                     "street1": "123 Main St",
                     "city": "Washington",
                     "state": "DC: District of Columbia",
-                    "zip_postal_code": "20001",
+                    "zip_code": "20001",
                     "country": "USA: UNITED STATES",
+                },
+                "contact_person": {  # Required per XSD
+                    "first_name": "John",
+                    "last_name": "Doe",
                 },
                 "phone_number": "555-123-4567",  # Required per XSD
                 "email": "test@example.org",  # Required per XSD
@@ -367,12 +371,16 @@ class TestSubmissionXSDValidation:
                 "organization_name": "Multi-Form Test Org",
                 "employer_taxpayer_identification_number": "987654321",  # Required per XSD
                 "sam_uei": "MULTI8765432",  # Required per XSD (exactly 12 chars)
-                "applicant_address": {  # Required per XSD
+                "applicant": {  # Required per XSD
                     "street1": "456 Oak Ave",
                     "city": "Washington",
                     "state": "DC: District of Columbia",
-                    "zip_postal_code": "20002",
+                    "zip_code": "20002",
                     "country": "USA: UNITED STATES",
+                },
+                "contact_person": {  # Required per XSD
+                    "first_name": "Jane",
+                    "last_name": "Smith",
                 },
                 "phone_number": "555-987-6543",  # Required per XSD
                 "email": "multi@example.org",  # Required per XSD


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #7658

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add configuration / update SF424 form to accommodate `ContactPerson`, `Applicant`,  `CompetitionIdentificationNumber`, `CompetitionIdentificationTitle` 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Recently discovered comparing SF-424 responses between grants.gov and Simpler responses. There will be additional PRs for less severe XML matching issues, decsribed in https://github.com/HHS/simpler-grants-gov/issues/7387#issuecomment-3687671745.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See updated unit tests. New form data confirmed existing in local XML tests.