### PR TITLE
[Issue #7109] Supplementary Cover Sheet for NEH Grant Programs Form

### DIFF
--- a/api/src/form_schema/forms/supplementary_neh_cover_sheet.py
+++ b/api/src/form_schema/forms/supplementary_neh_cover_sheet.py
@@ -565,7 +565,6 @@ FORM_UI_SCHEMA = [
         "type": "section",
         "label": "4. Application Information",
         "name": "Application Information",
-        "description": "A non-zero amount is required for either Outright Funds or Federal Match.",
         "children": [
             {
                 "type": "field",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #7109  

## Changes proposed

- [ ] Include additional description/instructions below Project funding that states: "A non-zero amount is required for either Outright Funds or Federal Match."

- [ ] "Additional Funding" question should be able to select yes or no, not a single checkbox.

screenshot of html page for docraptor
<img width="610" height="1308" alt="Screenshot 2025-12-24 at 4 36 23 PM" src="https://github.com/user-attachments/assets/6369032f-e940-40f0-b877-98208b7f0afb" />

## Changes proposed

A bit of a unique situation. A non-zero amount is required for either Outright Funds or Federal Match. They are required but not really. 

My vote is to mark them both as required

## Validation steps

1. to run locally, you would need to `run npm run build && npm start`
2. `make remake-backend && docker compose up`
3. navigate to `search`
4. search for `test`
5. you should see an opportunity called `Test Opportunity for SupplementaryCoverSheetforNEHGrantPrograms 3.0`
6. sign in
7. start new application
8. navigate to form table of the application
9. click Supplementary Cover Sheet for NEH Grant Programs Form
10. VERIFY the form loads
11. fill out the form, save
12. run `make generate-internal-token` from `api` directory
13. grab the token and place in request header "X-SGG-Internal-Token" and the token (I use a plugin called Modheader)
14. navigate to http://localhost:3000/print/application/APP_ID/form/FORM_ID
15. VERIFY the form data saves correctly
