### PR TITLE
Fix API Gateway pdf uploads for alpha/applications

### DIFF
--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -138,7 +138,7 @@ locals {
         "method" : "PUT",
         "api_key_required" : true,
         "method_parameters" : {
-          "method.request.path.application_id" = true,
+          "method.request.path.application_id"            = true,
           "method.request.path.application_attachment_id" = true,
         },
         "request_parameters" : {


### PR DESCRIPTION
## Summary

This PR fixes the issue for the alpha application attachments not being useable downstream

Fixes / Work for #7647 

## Changes proposed

- Defined endpoint for `/alpha/applications/{app_id}/attachments`
- Defined endpoint for `/alpha/applications/{application_id}/attachments/{application_attachment_id}`
- Defined endpoint for `/alpha/forms/{form_id}/form_instructions/{form_instruction_id}`
- Model for PDF uploads
- Allow uploads for specific file types on the gateway

## Context for reviewers

API Gateway encodes all request bodies by default, which was causing the attachments file to "work", but we couldn't open the uploads. This PR introduces and implements an infra side change to allow attachments, and not encode them, so downstream systems can use them as intended

## Validation steps

This PR's changes have been deployed so we can allow the reviewers to test

- Login to the dev site
- Start a new application
- Upload a file
- Go into S3, find your upload, and then download and open it
    - If the file is either blank, or the file fails to open, then ping me. The fix isn't working for your upload
