### PR TITLE
[Unticketed] Fix EPA 4700-4 to post-populate to correct fields

### DIFF
--- a/api/src/form_schema/forms/epa_form_4700_4.py
+++ b/api/src/form_schema/forms/epa_form_4700_4.py
@@ -321,7 +321,7 @@ FORM_RULE_SCHEMA = {
     #### PRE-POPULATION RULES
     "sam_uei": {"gg_pre_population": {"rule": "uei"}},
     #### POST-POPULATION RULES
-    "application_signature": {
+    "applicant_signature": {
         "aor_signature": {"gg_post_population": {"rule": "signature"}},
         "submitted_date": {"gg_post_population": {"rule": "current_date"}},
     },

--- a/api/tests/src/form_schema/forms/test_epa_form_4700_4.py
+++ b/api/tests/src/form_schema/forms/test_epa_form_4700_4.py
@@ -281,10 +281,10 @@ def test_epa_form_v5_0_post_population(
     validation_issues = validate_application_form(application_form, ApplicationAction.SUBMIT)
     assert len(validation_issues) == 0
     assert (
-        application_form.application_response["application_signature"]["aor_signature"]
+        application_form.application_response["applicant_signature"]["aor_signature"]
         == "my-fake-email@mail.com"
     )
     assert (
-        application_form.application_response["application_signature"]["submitted_date"]
+        application_form.application_response["applicant_signature"]["submitted_date"]
         == "2024-04-03"
     )


### PR DESCRIPTION
## Summary

## Changes proposed
Fix the name of the path that the post-population fields are populated to in the EPA-4700-4

## Context for reviewers
In the JSON schema, we nest the values in the `applicant_signature` object, but there was a typo in the post-population rules as well as the tests. This fixes the path.

## Validation steps
Submitted the form locally, the fields now get populated:
<img width="714" height="497" alt="Screenshot 2026-01-05 at 12 55 58 PM" src="https://github.com/user-attachments/assets/8a963ea8-623b-4e13-bdd2-cb7c13503470" />

