### PR TITLE
[Issue #7645] cleanup incremental load

### DIFF
--- a/api/src/search/backend/load_search_data.py
+++ b/api/src/search/backend/load_search_data.py
@@ -1,5 +1,3 @@
-import click
-
 import src.adapters.db as db
 import src.adapters.search as search
 from src.adapters.db import flask_db


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #7645  

## Changes proposed

Removed the --full-refresh/--incremental Click option from the load-opportunity-data CLI command
## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The full_refresh parameter was recently removed from the underlying index loader, but the Click CLI option was still defined on the load-opportunity-data command.
Click automatically injects option values as keyword arguments, which caused ECS tasks and E2E tests to fail when full_refresh was passed to code paths that no longer accept it.
## Validation steps
Ran the load-opportunity-data command locally and confirmed it executes successfully without passing full_refresh
Verified ECS task execution no longer receives a full_refresh kwarg