### PR TITLE
Fix /tmp directory permissions for ECS tasks with read-only root filesystem

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -95,6 +95,10 @@ COPY --from=base /api/.venv /api/.venv
 COPY --from=base /api/newrelic.ini /api/newrelic.ini
 COPY --from=base /tmp/py_version.txt /tmp/py_version.txt
 
+# Fix /tmp permissions - COPY --from creates parent directories as root with
+# default permissions (755), overriding the 1777 set in the base stage
+RUN chmod 1777 /tmp
+
 # Clean up to reduce image size:
 # - Remove Python bytecode cache files
 # - Remove pip cache


### PR DESCRIPTION
## Summary

Fixes `FileNotFoundError: No usable temporary directory found` errors in production by adding a writable `/tmp` volume mount to ECS task definitions.

**Note:** The Dockerfile fix was already merged to main. This PR adds the ECS task definition changes.

## Problem

The ECS task definitions have `readonlyRootFilesystem = true` (security best practice), but no volume mount for `/tmp`. This makes the entire filesystem read-only, including `/tmp`.

When Python's `tempfile.NamedTemporaryFile` tries to create a temp file, it fails:

```
FileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/tmp', '/var/tmp', '/usr/tmp', '/api']
```

## Fix

Add an ephemeral volume mounted at `/tmp` for both app and migrator task definitions. This provides a writable temp directory while maintaining the security benefits of a read-only root filesystem.

## Changes

- `infra/modules/service/main.tf`: Add `volume { name = "tmp" }` and `mountPoints` for `/tmp` to both task definitions

## Testing

- [x] Verified the issue in New Relic logs
- [ ] Deploy to dev and confirm SOAP proxy requests succeed