### PR TITLE
Add /tmp volume mount for ECS tasks with read-only root filesystem

### DIFF
--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -184,7 +184,13 @@ resource "aws_ecs_task_definition" "app" {
       logConfiguration = {
         logDriver = "awsfirelens",
       }
-      mountPoints    = []
+      mountPoints = [
+        {
+          sourceVolume  = "tmp"
+          containerPath = "/tmp"
+          readOnly      = false
+        }
+      ]
       systemControls = []
       volumesFrom    = []
     },
@@ -250,6 +256,11 @@ resource "aws_ecs_task_definition" "app" {
   # Reference https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
   network_mode = "awsvpc"
 
+  # Ephemeral volume for /tmp - required when readonlyRootFilesystem is true
+  volume {
+    name = "tmp"
+  }
+
   depends_on = [
     aws_cloudwatch_log_group.service_logs,
     aws_cloudwatch_log_group.fluentbit,
@@ -289,7 +300,13 @@ resource "aws_ecs_task_definition" "migrator" {
       logConfiguration = {
         logDriver = "awsfirelens",
       }
-      mountPoints    = []
+      mountPoints = [
+        {
+          sourceVolume  = "tmp"
+          containerPath = "/tmp"
+          readOnly      = false
+        }
+      ]
       systemControls = []
       volumesFrom    = []
     },
@@ -342,6 +359,11 @@ resource "aws_ecs_task_definition" "migrator" {
 
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
+
+  # Ephemeral volume for /tmp - required when readonlyRootFilesystem is true
+  volume {
+    name = "tmp"
+  }
 
   depends_on = [
     aws_cloudwatch_log_group.service_logs,


### PR DESCRIPTION
## Summary

Adds a writable `/tmp` volume mount to ECS task definitions to fix `FileNotFoundError: No usable temporary directory found` errors.

## Problem

The ECS task definitions have `readonlyRootFilesystem = true` (security best practice), but no volume mount for `/tmp`. This makes the entire filesystem read-only, including `/tmp`.

When Python's `tempfile.NamedTemporaryFile` tries to create a temp file, it fails:

```
FileNotFoundError: [Errno 2] No usable temporary directory found in ['/tmp', '/tmp', '/var/tmp', '/usr/tmp', '/api']
```

## Fix

Add an ephemeral volume mounted at `/tmp` for both app and migrator task definitions. This provides a writable temp directory while maintaining the security benefits of a read-only root filesystem.

## Changes

- `infra/modules/service/main.tf`: Add `volume { name = "tmp" }` and `mountPoints` for `/tmp` to both task definitions

## Testing

- [x] Verified the issue in New Relic logs
- [x] Applied to dev environment and confirmed deployment successful