### PR TITLE
[Unticketed] Switch FE to new Env Var with new static value

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -21,7 +21,7 @@ ENVIRONMENT=dev
 
 # Hardcode public auth key for local to local calls
 # This is also hardcoded and checked-in on the API
-API_AUTH_TOKEN=LOCAL_AUTH_12345678
+API_GW_AUTH=local-dev-api-key
 
 AUTH_LOGIN_URL=http://localhost:8080/v1/users/login
 


### PR DESCRIPTION
## Summary

## Context for reviewers

We removed support for our original API keys in a recent ticket but the FE E2E tests were still using the obsolete key structure.

## Validation steps

PR checks should pass