### PR TITLE
[Unticketed] Add back old auth key

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -21,6 +21,7 @@ ENVIRONMENT=dev
 
 # Hardcode public auth key for local to local calls
 # This is also hardcoded and checked-in on the API
+API_AUTH_TOKEN=LOCAL_AUTH_12345678
 API_GW_AUTH=local-dev-api-key
 
 AUTH_LOGIN_URL=http://localhost:8080/v1/users/login


### PR DESCRIPTION
## Summary

## Changes proposed

Put back the original auth key for local and CI/CD since not all endpoints use the new key yet

