### PR TITLE
[Issue #7207] Distinguish 'Other' pills across filter categories

### DIFF
--- a/frontend/src/utils/search/filterUtils.test.ts
+++ b/frontend/src/utils/search/filterUtils.test.ts
@@ -521,6 +521,55 @@ describe("formatPillLabel", () => {
   });
 });
 
+describe("formatPillLabel - Other filter disambiguation", () => {
+  const mockOptions = [
+    { value: "other", label: "Other", id: "other" },
+    { value: "grant", label: "Grant", id: "grant" },
+  ];
+
+  it('returns "Other - Funding instrument" for fundingInstrument other value', () => {
+    expect(formatPillLabel("fundingInstrument", "other", mockOptions)).toEqual(
+      "Other - Funding instrument",
+    );
+  });
+
+  it('returns "Other - Eligibility" for eligibility other value', () => {
+    expect(formatPillLabel("eligibility", "other", mockOptions)).toEqual(
+      "Other - Eligibility",
+    );
+  });
+
+  it('returns "Other - Category" for category other value', () => {
+    expect(formatPillLabel("category", "other", mockOptions)).toEqual(
+      "Other - Category",
+    );
+  });
+
+  it("returns standard label for fundingInstrument non-other value", () => {
+    expect(formatPillLabel("fundingInstrument", "grant", mockOptions)).toEqual(
+      "Grant",
+    );
+  });
+
+  it("returns standard label for eligibility non-other value", () => {
+    expect(
+      formatPillLabel("eligibility", "individuals", [
+        ...mockOptions,
+        { value: "individuals", label: "Individuals", id: "individuals" },
+      ]),
+    ).toEqual("Individuals");
+  });
+
+  it("returns standard label for category non-other value", () => {
+    expect(
+      formatPillLabel("category", "agriculture", [
+        ...mockOptions,
+        { value: "agriculture", label: "Agriculture", id: "agriculture" },
+      ]),
+    ).toEqual("Agriculture");
+  });
+});
+
 describe("formatPillLabels", () => {
   it("returns correctly formatted labels for all types of pills", () => {
     const result = formatPillLabels(
@@ -584,6 +633,48 @@ describe("formatPillLabels", () => {
           label: "ALN 15.808",
           queryParamKey: "assistanceListingNumber",
           queryParamValue: "15.808",
+        },
+      ]),
+    );
+  });
+
+  it("returns correctly formatted labels with distinct 'Other' pills", () => {
+    const result = formatPillLabels(
+      {
+        ...searchFetcherParams,
+        fundingInstrument: new Set(["grant", "other"]),
+        eligibility: new Set(["other"]),
+        category: new Set(["other", "agriculture"]),
+      },
+      [],
+    );
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          label: "Grant",
+          queryParamKey: "fundingInstrument",
+          queryParamValue: "grant",
+        },
+        {
+          label: "Other - Funding instrument",
+          queryParamKey: "fundingInstrument",
+          queryParamValue: "other",
+        },
+        {
+          label: "Other - Eligibility",
+          queryParamKey: "eligibility",
+          queryParamValue: "other",
+        },
+        {
+          label: "Other - Category",
+          queryParamKey: "category",
+          queryParamValue: "other",
+        },
+        {
+          label: "Agriculture",
+          queryParamKey: "category",
+          queryParamValue: "agriculture",
         },
       ]),
     );

--- a/frontend/src/utils/search/filterUtils.ts
+++ b/frontend/src/utils/search/filterUtils.ts
@@ -175,6 +175,21 @@ export const formatPillLabel = (
       return `Closing within ${value} days`;
     case "assistanceListingNumber":
       return `ALN ${value}`;
+    case "fundingInstrument":
+      if (value === "other") {
+        return "Other - Funding instrument";
+      }
+      return getFilterOptionLabel(value, options);
+    case "eligibility":
+      if (value === "other") {
+        return "Other - Eligibility";
+      }
+      return getFilterOptionLabel(value, options);
+    case "category":
+      if (value === "other") {
+        return "Other - Category";
+      }
+      return getFilterOptionLabel(value, options);
     default:
       return getFilterOptionLabel(value, options);
   }


### PR DESCRIPTION
## Summary
Fixes #7207

Resolves bug where 'Other' pills from different filter categories (Funding Instrument, Eligibility, Category) were indistinguishable, causing Clear All Filters to fail and creating an infinite loop.

## Changes
- Modified formatPillLabel() in filterUtils.ts to add category identifiers for 'other' values:
  - 'Other - Funding instrument'
  - 'Other - Eligibility'
  - 'Other - Category'
- Added 6 unit tests for Other pill disambiguation
- Added 1 integration test for multiple Other pills

## Testing
- [x] All 24 unit tests passing (including 7 new tests)
- [x] Manual testing verified fix works (Tests 1-6 passed)
- [x] Frontend build succeeds
- [x] Format check passes

## Manual Test Results
- Test 1: Filter counts correct (FI Other=104, Eligibility Other=14, Category Other=16)
- Test 2: Pills display with distinct labels
- Test 3: Individual pill removal works
- Test 4: Clear All Filters works correctly
- Test 5: Mixed filters work properly
- Test 6: Single Other filter works correctly