### PR TITLE
[Issue #8026] Don't need to clean up CI/CD runner docker images anymore

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -48,11 +48,6 @@ jobs:
           npm ci
           npx playwright install --with-deps
 
-      - name: Cleanup Docker disk space
-        run: |
-          docker rmi node:22 node:20 node:18 || true
-          docker image ls
-
       - name: Start API Server for e2e tests
         run: |
           cd ../api


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8026 
GitHub changed this in early January 2026 https://github.com/actions/runner-images/issues/13472

## Changes proposed

Remove call to delete pre-installed docker images as GitHub no longer pre-installs images.

## Context for reviewers

We originally added this because we were running low on space in the runner. Now that the images aren't present on the runner by default we don't need to free up the space.

## Validation steps

Checks pass
