### PR TITLE
Windows Front End Documentation Update

### DIFF
--- a/documentation/frontend/development.md
+++ b/documentation/frontend/development.md
@@ -11,7 +11,7 @@ This [Next.js](https://nextjs.org) application can be run natively (or locally)
 For version 0.1.0, please install and use node <= v22.13.0.
 
 * **For Mac** - Run `npm install && npm run local` to install and start the application.
-* **For Windows** - First follow [this guide](https://www.freecodecamp.org/news/node-version-manager-nvm-install-guide/) for installing Node Version Manager (How to Install NVM on Windows). Then in Windows PowerShell in the \simpler-grants-gov\frontend directory, run `npm install` to install the application. Run `npx run dev` afterwards to start the application.
+* **For Windows** - First follow [this guide](https://www.freecodecamp.org/news/node-version-manager-nvm-install-guide/) for installing Node Version Manager (How to Install NVM on Windows). Then in Windows PowerShell in the \simpler-grants-gov\frontend directory, run `npm install` to install the application. Run `npx next dev` afterwards to start the application.
 
 Optionally, disable [telemetry data collection](https://nextjs.org/telemetry)
 


### PR DESCRIPTION
Realized that I originally put `npx run dev` instead of `npx next dev` when I created the Windows documentation. Running `npx run dev` in the front end directory will actually throw an error that the node module cannot be found, `npx next dev` will automatically grab the node package and run it.