### PR TITLE
[Issue #7985] Update opportunity ALN format documentation

### DIFF
--- a/documentation/wiki/product/api/search-opportunities.md
+++ b/documentation/wiki/product/api/search-opportunities.md
@@ -78,6 +78,8 @@ The opportunity search endpoint accepts the following parameters:
 **Other Filters**
 
 * **`assistance_listing_number`**: Specific CFDA number
+  * Format: `##.##` (e.g., "45.C9")
+  * Example: `{"one_of": ["45.C9"]}`
   * Format: `##.###` (e.g., "45.1C9")
   * Example: `{"one_of": ["45.1C9"]}`
 * **`is_cost_sharing`**: Whether cost sharing is required


### PR DESCRIPTION
## Summary

Fixes #7985.

## Changes proposed

Replace existing example with two new examples to reflect updated regex tolerances.

## Context for reviewers

The old regex only allowed ALN values of `^\d{2}\.{d}{3}$`. The new regex allows `^\d{2}\.[a-zA-Z0-9]{2,3}$`.

## Validation steps

I checked the document for the regex `\b\w{2}\.\w{2,3}\b` to make sure I didn't miss any examples that needed to be updated. (That more permissive regex can catch additional possibilities.)
