### PR TITLE
Add new secrets to terraform for Grabzit API keys

### DIFF
--- a/infra/nofos/app-config/env-config/environment_variables.tf
+++ b/infra/nofos/app-config/env-config/environment_variables.tf
@@ -22,6 +22,16 @@ locals {
       secret_store_name = "/nofos/${var.environment}/docraptor-api-key"
     }
 
+    GRABZIT_APPLICATION_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/nofos/${var.environment}/grabzit-application-key"
+    }
+
+    GRABZIT_SECRET_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/nofos/${var.environment}/grabzit-secret-key"
+    }
+
     SECRET_KEY = {
       manage_method     = "manual"
       secret_store_name = "/nofos/${var.environment}/secret-key"


### PR DESCRIPTION
## Summary
To integrate Grabzit, the HTML -> DOCX solution we are leveraging, we need to make API secrets available for deployed environments. 

## Changes proposed
Adds a new secret for GRABZIT_APPLICATION_KEY and GRABZIT_SECRET_KEY to terraform configuration for NOFO environment variables. These correspond to the recently created AWS parameters. 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
