### PR TITLE
Rename Grabzit "secret-key" to "application-secret"

### DIFF
--- a/infra/nofos/app-config/env-config/environment_variables.tf
+++ b/infra/nofos/app-config/env-config/environment_variables.tf
@@ -27,9 +27,9 @@ locals {
       secret_store_name = "/nofos/${var.environment}/grabzit-application-key"
     }
 
-    GRABZIT_SECRET_KEY = {
+    GRABZIT_APPLICATION_SECRET = {
       manage_method     = "manual"
-      secret_store_name = "/nofos/${var.environment}/grabzit-secret-key"
+      secret_store_name = "/nofos/${var.environment}/grabzit-application-secret"
     }
 
     SECRET_KEY = {


### PR DESCRIPTION

## Summary

The "secret-key" does not match what I added into the AWS console, which was "application-secret". This mirrors the names used by Grabzit themselves.

<img width="333" height="196" alt="Screenshot 2026-01-23 at 15 26 51" src="https://github.com/user-attachments/assets/40fe4201-c77a-45a6-a618-2fdc36f68b06" />

