### PR TITLE
[Issue #8023] Add support for hard-coded opportunity IDs when building automatic opportunities for lower environments

### DIFF
--- a/api/src/task/opportunities/build_automatic_opportunities.py
+++ b/api/src/task/opportunities/build_automatic_opportunities.py
@@ -213,7 +213,6 @@ class BuildAutomaticOpportunitiesTask(Task):
             OpportunityContainer(
                 opportunity_title=f"Opportunity with ALL forms - {datetime_util.get_now_us_eastern_date().isoformat()}",
                 opportunity_number=f"SGG-ALL-Forms-{datetime_util.get_now_us_eastern_date().isoformat()}",
-                opportunity_id=uuid.uuid5(uuid.NAMESPACE_DNS, "simpler-grants-gov.all-forms"),
             ),
             competitions=[CompetitionContainer(optional_form_ids=[form.form_id for form in forms])],
         )


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8023 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Adds a configurable field opportunity_id: uuid.UUID = field(default_factory=uuid.uuid4)  to OpportunityContainer class
- Update opportunity creation logic to use the provided ID instead of uuid.uuid4()
- Add explicit UUIDs to all opportunity scenarios in _create_opportunity_scenarios() and the dynamic form-based opportunities
- Add a --force-recreate flag that deletes existing opportunities by number and recreates with new IDs
- Update the task to detect ID mismatches and update/replace records

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The only remaining part of the AC is `Manually go into AWS log into the DB for each environment and clean up the records`, which I'm not sure should happen after this is merged, or the timing of this action.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See updated unit tests for task to confirm consistent IDs across runs and mismatches replace records.
