### PR TITLE
[Issue #8219] Fix get SOAP/proxy certificate pem method

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -52,7 +52,7 @@ class SOAPClientCertificate(BaseModel):
             ) from None
         try:
             value = key_map[str(self.legacy_certificate.legacy_certificate_id)]
-            return f"{value}\n\n{self.cert}"
+            return f"{value}"
         except KeyError:
             raise SOAPClientCertificateNotConfigured("cert is not configured") from None
         except Exception:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
@@ -97,7 +97,7 @@ def test_client_auth(db_session, enable_factory_create):
     MOCK_SOAP_PRIVATE_KEYS = {f"{legacy_certificate.legacy_certificate_id}": MOCK_CERT}
     auth = SOAPAuth(certificate=mock_client_cert)
     cert = auth.certificate.get_pem(MOCK_SOAP_PRIVATE_KEYS)
-    assert cert == f"{MOCK_CERT}\n\n{MOCK_CERT_STR}"
+    assert cert == f"{MOCK_CERT}"
 
 
 def test_client_auth_exceptions(db_session, enable_factory_create):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8219 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Removed the text added to the end of the value extracted from the Parameter Store. The entire pem is in the parameter store so adding it on was breaking things.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We had the correct certificate data in the Parameter Store but were adding the incoming cert to it which was causing it to become invalid.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
