### PR TITLE
[Issue #6731] Remove Dereference Usage

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^14.2.1",
         "@newrelic/next": "^0.10.0",
         "@next/third-parties": "15.5.10",
         "@opentelemetry/api": "^1.8.0",
@@ -112,24 +111,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.2.1.tgz",
-      "integrity": "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
-      },
-      "peerDependencies": {
-        "@types/json-schema": "^7.0.15"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -7516,8 +7497,8 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema-merge-allof": {
       "version": "0.6.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,6 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": "^14.2.1",
     "@newrelic/next": "^0.10.0",
     "@next/third-parties": "15.5.10",
     "@opentelemetry/api": "^1.8.0",

--- a/frontend/src/components/applyForm/FormFields.test.tsx
+++ b/frontend/src/components/applyForm/FormFields.test.tsx
@@ -26,7 +26,6 @@ type FormActionResult = Promise<{
 const mockHandleFormAction = jest.fn<FormActionResult, FormActionArgs>();
 const mockRevalidateTag = jest.fn<void, [string]>();
 const getSessionMock = jest.fn();
-const mockDereference = jest.fn();
 const mockMergeAllOf = jest.fn();
 
 jest.mock("src/components/applyForm/actions", () => ({
@@ -45,10 +44,6 @@ jest.mock("react", () => ({
 
 jest.mock("src/services/auth/session", () => ({
   getSession: (): unknown => getSessionMock(),
-}));
-
-jest.mock("@apidevtools/json-schema-ref-parser", () => ({
-  dereference: () => mockDereference() as unknown,
 }));
 
 jest.mock("json-schema-merge-allof", () => ({

--- a/frontend/src/components/applyForm/actions.ts
+++ b/frontend/src/components/applyForm/actions.ts
@@ -117,7 +117,7 @@ async function getFormSchema(formId: string): Promise<RJSFSchema | undefined> {
     console.error(`Error retrieving form details for formID (${formId})`, e);
   }
   try {
-    const { formSchema } = await processFormSchema(formDetail.form_json_schema);
+    const { formSchema } = processFormSchema(formDetail.form_json_schema);
     return formSchema;
   } catch (e) {
     console.error(`Error parsing JSON schema for ${formId}`, e);

--- a/frontend/src/utils/formDataToJson.test.ts
+++ b/frontend/src/utils/formDataToJson.test.ts
@@ -5,7 +5,6 @@ import { formDataToObject } from "src/components/applyForm/formDataToJson";
 const mockHandleFormAction = jest.fn();
 const mockRevalidateTag = jest.fn();
 const getSessionMock = jest.fn();
-const mockDereference = jest.fn();
 const mockMergeAllOf = jest.fn();
 
 // all of these mocks should not be necessary but are currently because of cascading imports
@@ -27,10 +26,6 @@ jest.mock("react", () => ({
 
 jest.mock("src/services/auth/session", () => ({
   getSession: (): unknown => getSessionMock(),
-}));
-
-jest.mock("@apidevtools/json-schema-ref-parser", () => ({
-  dereference: () => mockDereference() as unknown,
 }));
 
 jest.mock("json-schema-merge-allof", () => ({

--- a/frontend/src/utils/getFormData.test.ts
+++ b/frontend/src/utils/getFormData.test.ts
@@ -20,7 +20,10 @@ jest.mock("src/components/applyForm/validate", () => ({
 
 describe("getFormData", () => {
   beforeEach(() => {
-    mockProcessFormSchema.mockReturnValue({});
+    mockProcessFormSchema.mockReturnValue({
+      formSchema: {},
+      conditionalValidationRules: {},
+    });
     mockValidateUISchema.mockReturnValue(null);
   });
   afterEach(() => {
@@ -85,7 +88,10 @@ describe("getFormData", () => {
 
   it("returns data on success", async () => {
     mockGetSession.mockResolvedValue({ token: "session-token" });
-    mockProcessFormSchema.mockResolvedValue({ formSchema: {} });
+    mockProcessFormSchema.mockReturnValue({
+      formSchema: {},
+      conditionalValidationRules: {},
+    });
     mockGetApplicationFormDetails.mockResolvedValue({
       status_code: 200,
       data: {

--- a/frontend/src/utils/getFormData.ts
+++ b/frontend/src/utils/getFormData.ts
@@ -130,7 +130,7 @@ export default async function getFormData({
   }
 
   try {
-    const result = await processFormSchema(form_json_schema);
+    const result = processFormSchema(form_json_schema);
     return {
       data: {
         applicationAttachments: applicationFormData.application_attachments,


### PR DESCRIPTION
## Summary

With a new backend approach to be implemented in https://github.com/HHS/simpler-grants-gov/issues/6498 the frontend will no longer need to perform this dereferencing.

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6731 

## Changes proposed

- remove the (@apidevtools/json-schema-ref-parser) package from the application
- update tests
- fix any linting issues

## Context for reviewers

These are all the current forms that would be affected by the dereferencing 

```
project_narrative_attachment.py
"items": {"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}]},

sf424.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("sam_uei")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("address")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_email")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"items": {"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}]},
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],

epa_form_4700_4.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("city")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("state")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("zip_code")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("sam_uei")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_email")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": "#/$defs/civil_rights_lawsuit_question"}],
"allOf": [{"$ref": "#/$defs/civil_rights_lawsuit_question"}],
"allOf": [{"$ref": "#/$defs/civil_rights_lawsuit_question"}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],

sf424b.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],

sf424a.py
"allOf": [{"$ref": "#/$defs/budget_summary"}],
"allOf": [{"$ref": "#/$defs/budget_categories"}],
"allOf": [{"$ref": "#/$defs/non_federal_resources"}],
"allOf": [{"$ref": "#/$defs/federal_fund_estimates"}],
"allOf": [{"$ref": "#/$defs/budget_summary"}],
"allOf": [{"$ref": "#/$defs/budget_categories"}],
"allOf": [{"$ref": "#/$defs/non_federal_resources"}],
"allOf": [{"$ref": "#/$defs/forecasted_cash_needs"}],
"allOf": [{"$ref": "#/$defs/forecasted_cash_needs"}],
"allOf": [{"$ref": "#/$defs/forecasted_cash_needs"}],
"allOf": [{"$ref": "#/$defs/federal_fund_estimates"}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],

project_abstract_summary.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],

sf424d.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],

supplementary_neh_cover_sheet.py
"allOf": [{"$ref": "#/$defs/field_of_study"}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": "#/$defs/project_discipline"}],
"allOf": [{"$ref": "#/$defs/project_discipline"}],
"allOf": [{"$ref": "#/$defs/project_discipline"}],

gg_lobbying_form.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}]
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],

epa_key_contacts.py
"authorized_representative": {"$ref": "#/$defs/key_contact_person"},
"payee": {"$ref": "#/$defs/key_contact_person"},
"administrative_contact": {"$ref": "#/$defs/key_contact_person"},
"project_manager": {"$ref": "#/$defs/key_contact_person"},
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("simple_address_with_country")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_email")}],

cd511.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],

project_abstract.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],

attachment_form.py
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}],

other_narrative_attachment.py
"items": {"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}]},

sflll.py
"$ref": "#/$defs/reporting_entity_awardee",
"$ref": "#/$defs/reporting_entity_awardee",
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("simple_address")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("simple_address")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],
"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
"allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("simple_address")}],

budget_narrative_attachment.py
"items": {"allOf": [{"$ref": COMMON_SHARED_V1.field_ref("attachment")}]},
```

## Validation steps

Above is a list of fields and forms a that are affected by this PR (removal of dereference). To validate: 

`reminder that you can get directly to an open application containing all forms by running npm run local, logging in as many_app_user and clicking test application in the user dropdown`

- run `npm run local`
- log in as `many_app_user`
- in user dropdown, test any application
- VALIDATE that any field changed will save 
- VALIDATE that when you navigate to `/print/application/[ID]/form/[ID]` that the value is reflected here
