### PR TITLE
[Issue #6880] "(Previously uploaded file)" showing on empty attachment fields in PDF

### DIFF
--- a/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
+++ b/frontend/src/components/applyForm/widgets/PrintAttachmentWidget.tsx
@@ -1,21 +1,21 @@
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 import { useApplicationAttachments } from "src/hooks/ApplicationAttachments";
+import { Attachment } from "src/types/attachmentTypes";
 
 import { FormGroup } from "@trussworks/react-uswds";
 
 import { UswdsWidgetProps } from "src/components/applyForm/types";
 
-function PrintAttachmentWidget<
-  T = unknown,
-  S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = never,
->({ id, required, schema, value, formClassName }: UswdsWidgetProps<T, S, F>) {
-  const { title } = schema as S;
-  const { attachments } = useApplicationAttachments();
-
-  const values = Array.isArray(value)
-    ? (value as string[])
-    : ([value] as string[]);
+const hydrateAttachmentReferences = (
+  attachmentIds: unknown,
+  attachments: Attachment[] | null,
+): { id: string; name: string }[] => {
+  if (!attachmentIds) {
+    return [];
+  }
+  const values = Array.isArray(attachmentIds)
+    ? (attachmentIds as string[])
+    : ([attachmentIds] as string[]);
   let hydrated: { id: string; name: string }[] = [];
 
   if (values.length > 0) {
@@ -29,6 +29,18 @@ function PrintAttachmentWidget<
       };
     });
   }
+  return hydrated;
+};
+
+function PrintAttachmentWidget<
+  T = unknown,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = never,
+>({ id, required, schema, value, formClassName }: UswdsWidgetProps<T, S, F>) {
+  const { title } = schema as S;
+  const { attachments } = useApplicationAttachments();
+
+  const hydrated = hydrateAttachmentReferences(value, attachments);
 
   return (
     <FormGroup className={formClassName} key={`form-group__text-input--${id}`}>


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #6880 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes bug where attachment fields with no items are appearing with `Previously uploaded file` in print / pdf view

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. start a local server on this branch with `npm run local`
2. visit http://localhost:3000
3. log in as `many_app_user`
4. select `test application` under the user dropdown
5. open sf424 form
6. click save
7. run  `make generate-internal-token` in /api
8. copy generated key and paste into `X-SGG-Internal-Token` header using ModHeader
9. copy sf424 form url, and change /applications path to /print/application and visit
10. _VERIFY_: no fields show `Previously uploaded file`