### PR TITLE
[Unticketed] Revert SOAP get_pem method fix

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -52,7 +52,7 @@ class SOAPClientCertificate(BaseModel):
             ) from None
         try:
             value = key_map[str(self.legacy_certificate.legacy_certificate_id)]
-            return f"{value}"
+            return f"{value}\n\n{self.cert}"
         except KeyError:
             raise SOAPClientCertificateNotConfigured("cert is not configured") from None
         except Exception:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
@@ -97,7 +97,7 @@ def test_client_auth(db_session, enable_factory_create):
     MOCK_SOAP_PRIVATE_KEYS = {f"{legacy_certificate.legacy_certificate_id}": MOCK_CERT}
     auth = SOAPAuth(certificate=mock_client_cert)
     cert = auth.certificate.get_pem(MOCK_SOAP_PRIVATE_KEYS)
-    assert cert == f"{MOCK_CERT}"
+    assert cert == f"{MOCK_CERT}\n\n{MOCK_CERT_STR}"
 
 
 def test_client_auth_exceptions(db_session, enable_factory_create):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8219  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Reverting the update to the get_pem method. 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
After revisiting the [tech spec docs](https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/2125398123/Tech+Spec+Soap+Cert+Mapping+to+Simpler+Auth) it turns out that the fix is in the formatting of the dict in the Parameter store and not how the code creates the PEM. I took out the certificate part in the dictionary and just left in the private key. Now it works as intended.

In the parameter store it should be `{"<uuid>": "<private key>"}` as opposed to how it was which was `{"<uuid>": "<private key>\n\n<certificate>"}`

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
If you run this curl you should get a single ApplicationSubmission back, assuming you have the grants_s2s_soap_certs. This is assuming it's been deployed to staging which I have been doing as part of testing.
```
curl -v 'https://soap.staging.simpler.grants.gov/grantsws-agency/services/v2/AgencyWebServicesSoapPort' \
--header 'Content-Type: application/xml' \
--cert "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/bps_keys/bps_grantors.crt" \
--key "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/bps_keys/bps_grantors.key" \
--data '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElemen
ts-V1.0">
   <soapenv:Header/>
   <soapenv:Body>
      <agen:GetSubmissionListExpandedRequest>
            <gran:ExpandedApplicationFilter>
                <gran:FilterType>GrantsGovTrackingNumber</gran:FilterType>
                <gran:FilterValue>GRANT00627429</gran:FilterValue>
         </gran:ExpandedApplicationFilter>
      </agen:GetSubmissionListExpandedRequest>
   </soapenv:Body>
</soapenv:Envelope>'
```
