### PR TITLE
Create local data requirements in 8037 for testing 7953

### DIFF
--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -1,9 +1,3 @@
-def fetch_competition(db_session, competition_id):
-    return db_session.scalar(
-        select(Competition).where(Competition.competition_id == competition_id)
-    )
-
-
 import dataclasses
 import logging
 import uuid
@@ -27,6 +21,13 @@ from tests.lib.seed_agencies import _build_agencies
 from tests.lib.seed_data_utils import CompetitionContainer
 from tests.lib.seed_e2e import _build_users_and_tokens
 from tests.lib.seed_orgs_and_users import _build_organizations_and_users, seed_internal_admin
+
+
+def fetch_competition(db_session, competition_id):
+    return db_session.scalar(
+        select(Competition).where(Competition.competition_id == competition_id)
+    )
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Work for : Task #[8284](https://github.com/HHS/simpler-grants-gov/issues/8284) 

## Changes proposed
- Added _build_8037_custom_competitions() to create local test competitions for #8037, required for scripting work in #7953.
- The competitions include:
    - TEST-BR-8037-IOU-OT01 -> open to both organizations and individuals
    - TEST-BR-8037-OU-OT01 -> organizations only
    - TEST-BR-8037-IT-OT01 -> individuals only
- Forms attached to each competition:
    - SF424B -> required
    - SFLLL_2_0 -> conditional
- Log statements include local URLs for quick verification in the browser.

## Context for reviewers
- This change is for #8037 local test data setup only and does not affect deployed environments
- Enables testing and validation for #7953 scripting work.
- Ensures each competition scenario matches the applicant types and forms required.

## Validation steps
- Verify the three new competitions exist in local DB:
    - TEST-BR-8037-IOU-OT01 -> both applicant types
    - TEST-BR-8037-OU-OT01 -> organizations only
    - TEST-BR-8037-IT-OT01 -> individuals only
- Check that SF424B is required and SFLLL_2_0 is conditional in each competition.
- Confirm log output contains URLs for each competition that can be opened in local environment.
