### PR TITLE
HOTFIX: 20260131 banner

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -54,6 +54,30 @@ export default async function Layout({ children, locale }: Props) {
             testUsers={testUsers}
           />
           <main id="main-content" className="border-top-0">
+            {/* temp Jan 31, 2026 banner */}
+            <div className="bg-warning-lighter padding-y-3">
+              <div className="grid-container">
+                <div className="grid-row grid-gap-4 font-sans-2xs">
+                  <div className="tablet-lg:grid-col-5">
+                    There has been a lapse in appropriated federal funds as of
+                    February 1, 2026.{" "}
+                    <a href="https://grants.gov/">Grants.gov</a> and{" "}
+                    <a href="https://simpler.grants.gov/">Simpler.Grants.gov</a>{" "}
+                    will still be available, but service may be delayed with
+                    reduced Federal support staff presence.
+                  </div>
+                  <div className="tablet-lg:grid-col-7 margin-top-2 tablet-lg:margin-top-0">
+                    For those programs affected by the funding lapse, the{" "}
+                    <a href="https://grants.gov/">Grants.gov</a> and{" "}
+                    <a href="https://simpler.grants.gov/">Simpler.Grants.gov</a>{" "}
+                    systems will accept and store applications until such time
+                    as the responsible awarding agency has the authority and
+                    funding to return to normal business operations.
+                  </div>
+                </div>
+              </div>
+            </div>
+            {/* end temp banner */}
             {children}
           </main>
         </LoginModalProvider>


### PR DESCRIPTION
## Summary

This is a hotfix to add a temporary banner for Jan 31, 2026.

## Changes proposed

* Hardcode a message in the `Layout` that displays below the site header

## Context for reviewers

As this is temporary, the content is hardcoded and does not make use of i18n. This change is sandwiched in a comment so the code can easily be removed.

## Validation steps

Load the app and you should see the following message on a yellow background.

<img width="612" height="690" alt="image" src="https://github.com/user-attachments/assets/80096a9e-3eb9-49c8-882e-0abd7b0fab49" />
