### PR TITLE
[Issue #8191] Enable competition instruction transformation

### DIFF
--- a/api/src/data_migration/transformation/transform_oracle_data_task.py
+++ b/api/src/data_migration/transformation/transform_oracle_data_task.py
@@ -55,7 +55,7 @@ class TransformOracleDataTaskConfig(PydanticBaseEnvConfig):
     )
     enable_competition: bool = True  # TRANSFORM_ORACLE_DATA_ENABLE_COMPETITION
     enable_competition_instruction: bool = (
-        False  # TRANSFORM_ORACLE_DATA_ENABLE_COMPETITION_INSTRUCTION
+        True  # TRANSFORM_ORACLE_DATA_ENABLE_COMPETITION_INSTRUCTION
     )
 
 


### PR DESCRIPTION
## Summary
Fixes #8191 

## Changes proposed
Make the competition instruction transformation run by default as part of the hourly job

## Context for reviewers
Already run this manually in all environments, this is just flipping the switch to have it be a part of the hourly job.

## Validation steps
I've manually run this job already in each environment for the backfill

Had to work around a few bits of bad data and mark that as processed including:
* Null file
* Competition didn't exist - there isn't a foreign key from the instructions table to the competition table in grants.gov
* We didn't transform the competition because there isn't a foreign key from a competition back to an opportunity in grants.gov (oversimplification, the connection is a bit more complex).

Details on how I did that are on https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/2706964549/Initial+Transform+Competition+Instructions+Run+-+Jan+2026
