### PR TITLE
[Hotfix] Update 2025 Big Demo link

### DIFF
--- a/frontend/src/app/[locale]/(base)/events/EventsDemo.tsx
+++ b/frontend/src/app/[locale]/(base)/events/EventsDemo.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { Grid, GridContainer } from "@trussworks/react-uswds";
 
-const demoLink = "https://vimeo.com/1050177794/278fa78e0b?share=copy";
+const demoLink = "https://youtu.be/uASJmvcy0aM?si=OniP7Z7KU8ie3FhS";
 
 export default function EventsDemo() {
   const t = useTranslations("Events.demo");


### PR DESCRIPTION
## Summary

Un-ticketed work

## Changes proposed

- Change the 2025 Big Demo video URL to https://youtu.be/uASJmvcy0aM?si=OniP7Z7KU8ie3FhS

## Context for reviewers

The 2025 COFFA demo link on the events page is broken, because COFFA switched from Vimeo to YouTube.

## Validation steps

- go to the Events page
- follow the big demo link
- it should load a YouTube video (not a dead Vimeo page) 