### PR TITLE
[Issue #8376] Don't fail on vuln scan findings if we're going to staging

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -40,6 +40,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: analytics
+      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment), 'staging') }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -39,6 +39,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: api
+      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment), 'staging') }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -39,6 +39,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: frontend
+      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment), 'staging') }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8376  

## Changes proposed

Check the target environment and if it includes staging don't fail the deploy since that shouldn't block other ongoing development work.

## Context for reviewers

Was noted that blocking all engineers for vulnerability scans in Staging doesn't really make sense, especially with our larger team size now.

## Validation steps

Will test Dev vs Staging deploys, but we won't really know until the next vulnerability pops.
