### PR TITLE
[Issue #8379] Add environmental variables for Soap Partner Gateway

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -29,6 +29,9 @@ class LegacySoapAPIConfig(PydanticBaseEnvConfig):
     enable_verbose_logging: bool = Field(default=False, alias="SOAP_ENABLE_VERBOSE_LOGGING")
     use_simpler: bool = Field(default=False, alias="USE_SIMPLER")
 
+    soap_partner_gateway_uri: str = Field("", alias="SOAP_PARTNER_GATEWAY_URI")
+    soap_partner_gateway_auth_key: str = Field("", alias="SOAP_PARTNER_GATEWAY_AUTH_KEY")
+
     @property
     def gg_url(self) -> str:
         # Full url including port for grants.gov S2S SOAP API.

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -96,6 +96,16 @@ locals {
       secret_store_name = "/api/${var.environment}/soap-private-keys"
     }
 
+    SOAP_PARTNER_GATEWAY_URI = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/soap-partner-gateway-uri"
+    }
+
+    SOAP_PARTNER_GATEWAY_AUTH_KEY = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/soap-partner-gateway-auth-key"
+    }
+
     SAM_GOV_API_KEY = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/sam-gov-api-key"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8379  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added two variables to the LegacySoapApiConfig: `soap_partner_gateway_uri` and `soap_partner_gateway_auth_key`. Updated the environmental variables to pull those values from AWS Parameter Store. Added those entries to the Parameter Store.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
As we move to use the JWT auth for MH in the SOAP/Proxy we need to store the key and uri we will need to use those values.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
