### PR TITLE
[Issue #8376] Need to handle when it's run from push and inputs.environment isn't set

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -40,7 +40,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: analytics
-      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment), 'staging') }}
+      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment != null && format('["{0}"]', inputs.environment) || github.ref_name == 'main' && '["staging"]' || '["dev"]'), 'staging') }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: api
-      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment), 'staging') }}
+      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment != null && format('["{0}"]', inputs.environment) || github.ref_name == 'main' && '["staging"]' || '["dev"]'), 'staging') }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -39,7 +39,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: frontend
-      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment), 'staging') }}
+      fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment != null && format('["{0}"]', inputs.environment) || github.ref_name == 'main' && '["staging"]' || '["dev"]'), 'staging') }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8376  

## Changes proposed

Needed to handle when it's running off a push and the inputs.environment is not set (like it's set when you force it to run directly)

