### PR TITLE
[Issue 8427]: add grype ignore for api and analytics vuln's

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -76,3 +76,46 @@ ignore:
   # Dependencies: @next/third-parties
   # Last checked: 01/29/26
   - vulnerability: GHSA-5f7q-jpqc-wp7h
+
+  # ============================================================================
+  # Amazon Linux 2023 packages - fixes not yet available in public repos
+  # The security advisories have been published but the patched packages
+  # have not been released to the Amazon Linux 2023 repositories yet.
+  # Monitor: https://alas.aws.amazon.com/alas2023.html
+  # Last checked: 02/06/26
+  # ============================================================================
+
+  # openssl: Stack buffer overflow in CMS message parsing (ALAS2023-2026-1406)
+  # https://alas.aws.amazon.com/AL2023/ALAS-2026-1406.html
+  # Fixed version 1:3.2.2-1.amzn2023.0.4 not available in repos (latest is 0.3)
+  - vulnerability: ALAS2023-2026-1406
+
+  # libtasn1: Stack-based buffer overflow (ALAS2023-2026-1395)
+  # https://alas.aws.amazon.com/AL2023/ALAS-2026-1395.html
+  # Fixed version 4.19.0-1.amzn2023.0.6 not available in repos (latest is 0.5)
+  - vulnerability: ALAS2023-2026-1395
+
+  # libcap: Multiple vulnerabilities (ALAS2023-2026-1389)
+  # https://alas.aws.amazon.com/AL2023/ALAS-2026-1389.html
+  # Fixed version 2.73-1.amzn2023.0.6 not available in repos (latest is 0.5)
+  - vulnerability: ALAS2023-2026-1389
+
+  # libxml2: Uncontrolled recursion in xmlCatalogXMLResolveURI (ALAS2023-2026-1396)
+  # https://alas.aws.amazon.com/AL2023/ALAS-2026-1396.html
+  # Fixed version 2.10.4-1.amzn2023.0.16 not available in repos (latest is 0.15)
+  - vulnerability: ALAS2023-2026-1396
+
+  # libxml2: Uncontrolled recursion in RelaxNG parser (ALAS2023-2026-1397)
+  # https://alas.aws.amazon.com/AL2023/ALAS-2026-1397.html
+  # Fixed version 2.10.4-1.amzn2023.0.17 not available in repos (latest is 0.15)
+  - vulnerability: ALAS2023-2026-1397
+
+  # unzip: Denial of service via overlapping files in ZIP (ALAS2023-2026-1422)
+  # https://alas.aws.amazon.com/AL2023/ALAS-2026-1422.html
+  # Fixed version 6.0-68.amzn2023.0.1 not available in repos (latest is 6.0-57.amzn2023.0.2)
+  - vulnerability: ALAS2023-2026-1422
+
+  # python3-pip-wheel: urllib3 decompression bomb vulnerability (ALAS2023-2026-1416)
+  # https://alas.aws.amazon.com/AL2023/ALAS-2026-1416.html
+  # Fixed version 21.3.1-2.amzn2023.0.16 not available in repos (latest is 0.15)
+  - vulnerability: ALAS2023-2026-1416


### PR DESCRIPTION
## Summary

Resolve analytics and api base image anchore cve vulnerabilities. 

## Validation steps

Deployed the api w/ this branch: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/21762537075)

## Notes: 

We can add the following command to update the packages but it requires us to run the docker build on an ec2 instance: 

```
RUN dnf update --advisory ALAS2023-2026-1406 --releasever 2023.10.20260202
RUN dnf update --advisory ALAS2023-2026-1397 --releasever 2023.10.20260202
RUN dnf update --advisory ALAS2023-2026-1422 --releasever 2023.10.20260202
RUN dnf update --advisory ALAS2023-2026-1395 --releasever 2023.10.20260202
RUN dnf update --advisory ALAS2023-2026-1416 --releasever 2023.10.20260202
```

The aws cdn authenticates the request with the ec2 instance id. When we run from local or from the github actions pipeline we get the error below: 
```

2026-02-06T18:09:20.8387223Z #27 5.009 Amazon Linux 2023 repository                     55  B/s | 263  B     00:04    
2026-02-06T18:09:21.0764499Z #27 5.009 Errors during downloading metadata for repository 'amazonlinux':
2026-02-06T18:09:21.0765764Z #27 5.009   - Status code: 403 for https://cdn.amazonlinux.com/al2023/core/mirrors/2023.10.20260202/x86_64/mirror.list?instance_id=none (IP: 13.32.164.11)
2026-02-06T18:09:21.0766910Z #27 5.009   - Status code: 403 for https://cdn.amazonlinux.com/al2023/core/mirrors/2023.10.20260202/x86_64/mirror.list?instance_id=none (IP: 13.32.164.70)
2026-02-06T18:09:21.0768046Z #27 5.009   - Status code: 403 for https://cdn.amazonlinux.com/al2023/core/mirrors/2023.10.20260202/x86_64/mirror.list?instance_id=none (IP: 13.32.164.19)
2026-02-06T18:09:21.0769767Z #27 5.009 Error: Failed to download metadata for repo 'amazonlinux': Cannot prepare internal mirrorlist: Status code: 403 for https://cdn.amazonlinux.com/al2023/core/mirrors/2023.10.20260202/x86_64/mirror.list?instance_id=none (IP: 13.32.164.19)
```

We have to wait for amazon to release these fixes in their next official image release. The live page for amazon cve's is here: https://alas.aws.amazon.com/