### PR TITLE
[Unticketed] Add a unit test that validates all factories work

### DIFF
--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -63,8 +63,6 @@ from src.constants.static_role_values import (
     ORG_MEMBER,
 )
 from src.db.models import agency_models
-from src.db.models.lookup.lookup_registry import LookupRegistry
-from src.db.models.lookup_models import LkCompetitionOpenToApplicant
 from src.util import file_util
 
 # Needed for generating Opportunity Json Blob for OpportunityVersion
@@ -1039,7 +1037,7 @@ class UserSavedSearchFactory(BaseFactory):
 
     name = factory.Faker("sentence")
 
-    search_query = factory.LazyAttribute(lambda s: s.search_query)
+    search_query = {"query": "example"}
 
     last_notified_at = factory.Faker("date_time_between", start_date="-5y", end_date="-3y")
 
@@ -1299,22 +1297,6 @@ class FormInstructionFactory(BaseFactory):
             ) from e
 
         return obj
-
-
-class LinkCompetitionOpenToApplicantFactory(BaseFactory):
-    class Meta:
-        model = competition_models.LinkCompetitionOpenToApplicant
-
-    competition = factory.SubFactory(CompetitionFactory)
-    competition_id = factory.LazyAttribute(lambda o: o.competition.competition_id)
-
-    # We need to get both the ID and the relationship object
-    competition_open_to_applicant_id = factory.LazyFunction(
-        lambda: LookupRegistry.get_lookup_int_for_enum(
-            LkCompetitionOpenToApplicant,
-            random.choice(list(lookup_models.CompetitionOpenToApplicant)),
-        )
-    )
 
 
 class FormFactory(BaseFactory):
@@ -1840,6 +1822,7 @@ class JobLogFactory(BaseFactory):
         model = task_models.JobLog
 
     job_id = Generators.UuidObj
+    job_type = "ExampleTask"
     job_status = factory.lazy_attribute(lambda _: JobStatus.COMPLETED)
     metrics = None
 
@@ -2580,11 +2563,11 @@ class ForeignTfundinstrForecastHistFactory(ForeignTfundinstrForecastFactory):
 
 class ForeignTfundinstrSynopsisFactory(TfundinstrFactory):
     class Meta:
-        model = staging.synopsis.TfundinstrSynopsis
+        model = foreign.synopsis.TfundinstrSynopsis
 
     fi_syn_id = factory.Sequence(lambda n: n)
 
-    synopsis = factory.SubFactory(StagingTsynopsisFactory)
+    synopsis = factory.SubFactory(ForeignTsynopsisFactory)
     opportunity_id = factory.LazyAttribute(lambda s: s.synopsis.opportunity_id)
 
 

--- a/api/tests/src/db/models/test_factories.py
+++ b/api/tests/src/db/models/test_factories.py
@@ -102,7 +102,7 @@ factories_to_skip = [
 ]
 
 
-def test_factory_create(enable_factory_create):
+def test_factory_create(db_session, enable_factory_create):
     """Iterate over all factories and verify that they are setup
     to work correctly by default. This doesn't guarantee that every
     use case for a given factory works, but is a nice sanity test
@@ -126,7 +126,11 @@ def test_factory_create(enable_factory_create):
                 continue
 
             try:
-                obj.create()
+                instance = obj.create()
+                # Some tests rely on specific data when pulling from a whole table
+                # Avoid breaking those by cleaning up what we just made. Also
+                # tests that deletes work properly for all our models/foreign keys.
+                db_session.delete(instance)
             except Exception:
                 # catch the error to add the factory name to the stack trace
                 # so it's a bit clearer which factory failed.

--- a/api/tests/src/db/models/test_factories.py
+++ b/api/tests/src/db/models/test_factories.py
@@ -1,8 +1,10 @@
+import inspect
 from datetime import datetime
 
 import pytest
 
 import src.adapters.db as db
+import tests.src.db.models.factories as factories
 from src.constants.lookup_constants import OpportunityCategory
 from src.db.models.opportunity_models import Opportunity
 from tests.src.db.models.factories import OpportunityFactory
@@ -82,3 +84,50 @@ def test_opportunity_factory_create(enable_factory_create, db_session: db.Sessio
     null_params = {"agency_code": None}
     opportunity = OpportunityFactory.create(**null_params)
     validate_opportunity_record(opportunity, null_params)
+
+
+factories_to_skip = [
+    # Using this factory directly hits some circular
+    # issues that don't happen when using the opportunity
+    # or opportunity summary factories that in turn call this.
+    factories.CurrentOpportunitySummaryFactory,
+    # These end up a bit flaky because if you use them
+    # it creates an opportunity summary, which also adds
+    # rows of their kind and can lead to uniqueness problems
+    # We'll just rely on the OpportunitySummary factory to validate
+    # that these are working.
+    factories.LinkOpportunitySummaryFundingCategoryFactory,
+    factories.LinkOpportunitySummaryApplicantTypeFactory,
+    factories.LinkOpportunitySummaryFundingInstrumentFactory,
+]
+
+
+def test_factory_create(enable_factory_create):
+    """Iterate over all factories and verify that they are setup
+    to work correctly by default. This doesn't guarantee that every
+    use case for a given factory works, but is a nice sanity test
+    for when we build factories prior to using them.
+    """
+    # Iterates over everything defined in the factories module
+    # and filters to:
+    # * Classes
+    # * Derived from the BaseFactory
+    # * That aren't defined as Abstract
+    for obj in factories.__dict__.values():
+        if (
+            inspect.isclass(obj)
+            and issubclass(obj, factories.BaseFactory)
+            # Note that the "class Meta" added to factories
+            # gets renamed to _meta by the internals of the factories
+            and getattr(getattr(obj, "_meta", {}), "abstract", False) is False
+        ):
+
+            if obj in factories_to_skip:
+                continue
+
+            try:
+                obj.create()
+            except Exception:
+                # catch the error to add the factory name to the stack trace
+                # so it's a bit clearer which factory failed.
+                pytest.fail(f"Failed to run create for factory {obj.__name__}")


### PR DESCRIPTION
## Summary

## Changes proposed
Add a unit test to our factories that validates every factory works and `create()` can be called.

## Context for reviewers
Something that can be tricky for folks is adding/modifying our DB tables, and setting up factories not knowing if their factories are right. Factories are ultimately just for test data, so writing unit tests for them isn't something we generally do (testing tests leads to testing test tests, and other confusing ideas). But it's useful to have at least the most basic of validation that what you setup works. So, this test I added does that. For each factory it calls `.create()` on it, verifying that at least the defaults defined work, and can in fact be inserted into the DB.

I removed a factory that wasn't used anywhere that otherwise needed fixing, and fixed another one that didn't work. A handful can't be run directly, which is explained in the test why.

## Validation steps
The test itself
