### PR TITLE
[Unticketed] Add a log message at the end of application submission processing

### DIFF
--- a/api/src/task/apply/create_application_submission_task.py
+++ b/api/src/task/apply/create_application_submission_task.py
@@ -282,6 +282,7 @@ class CreateApplicationSubmissionTask(Task):
             "Finished processing application submission",
             extra={
                 "application_id": application.application_id,
+                "opportunity_id": application.competition.opportunity_id,
                 "competition_id": application.competition_id,
                 "application_submission_id": submission_id,
                 "submission_location": s3_path,


### PR DESCRIPTION
## Summary

## Changes proposed
Adds a log message at the end of the application submission creation process with info about what was created

## Context for reviewers
Will make it easier to find these, our logs are thorough already, but were missing a metadata pieces to properly identify/find the submission without looking at several messages together.

## Validation steps
It's a log message, the tests didn't break.