### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # [Simpler.Grants.gov](https://simpler.grants.gov/)
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/HHS/simpler-grants-gov)
 
 A modernization effort for [Grants.gov](https://grants.gov/)
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/HHS/simpler-grants-gov) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.