### PR TITLE
[Issue #8072] (2/2) Add workflow service user to terraform in dev/staging

### DIFF
--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -55,6 +55,9 @@ module "dev_config" {
     FRONTEND_URL             = "https://dev.simpler.grants.gov"
     DOCRAPTOR_TEST_MODE      = "true"
     PDF_GENERATION_USE_MOCKS = "false"
+
+    # Workflow
+    WORKFLOW_SERVICE_INTERNAL_USER_ID = "5711f79c-2445-47c7-bbcb-c8caa293ffad"
   }
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -55,6 +55,9 @@ module "staging_config" {
     FRONTEND_URL             = "https://staging.simpler.grants.gov"
     DOCRAPTOR_TEST_MODE      = "true"
     PDF_GENERATION_USE_MOCKS = "false"
+
+    # Workflow
+    WORKFLOW_SERVICE_INTERNAL_USER_ID = "903bf2e6-b213-4744-9f95-66ccfd98a819"
   }
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html


### PR DESCRIPTION
## Summary
Fixes #8072 

## Changes proposed
Adds the workflow service user ID to the dev/staging terraform

## Context for reviewers
Prior work setup logic around configuring a user including creating a role for them, I created the user in the dev/staging DB, just adding the env var for them.

## Validation steps
n/a