### PR TITLE
[unticketed] fix search styling bug by reordering rules

### DIFF
--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -422,14 +422,6 @@ button.usa-pagination__button.usa-button {
 // these styles are taken from the desktop imlementation of the dropdown and applied at all breakpoints
 .usa-nav__primary {
   .mobile-nav-dropdown-uncollapsed-override {
-    @include at-media("desktop") {
-      button:hover {
-        background-color: white;
-      }
-      .usa-nav__submenu {
-        right: 0;
-      }
-    }
     button[aria-expanded="true"]:hover {
       background-color: color("mint-40");
     }
@@ -472,6 +464,14 @@ button.usa-pagination__button.usa-button {
         color: white;
         line-height: 1.4;
         display: block;
+      }
+    }
+    @include at-media("desktop") {
+      button:hover {
+        background-color: white;
+      }
+      .usa-nav__submenu {
+        right: 0;
       }
     }
   }
@@ -599,17 +599,17 @@ dl {
 .simpler-responsive-table {
   min-width: 100%;
   thead {
+    display: none;
     @include at-media("tablet-lg") {
       display: table-header-group;
     }
-    display: none;
   }
   tr {
+    display: flex;
+    flex-direction: column;
     @include at-media("tablet-lg") {
       display: table-row;
     }
-    display: flex;
-    flex-direction: column;
   }
   tbody {
     td {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed, related to bug introduced in https://github.com/HHS/simpler-grants-gov/pull/8407

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The sass upgrade required for upgrading storybook changed how css insertion order is managed, resulting in some mis-applied styles

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. on main run npm ci
2. start a local server on main
3. visit http://localhost:3000/search
4. _VERIFY_: search table is in "mobile mode" at desktop width (see screenshot)
5. start a local server on this branch
3. visit http://localhost:3000/search
4. _VERIFY_: search table is in "desktop mode" at desktop width (see screenshot)

Bonus:
1. _VERIFY_: search table switches correctly to "mobile mode" at mobile widths

## Screenshots

### Before

<img width="1228" height="683" alt="Screenshot 2026-02-12 at 12 12 20 PM" src="https://github.com/user-attachments/assets/511c0099-27dc-4bf3-b9fd-bbc1f06dffca" />


### After
<img width="1252" height="509" alt="Screenshot 2026-02-12 at 12 12 34 PM" src="https://github.com/user-attachments/assets/37b2de07-0f97-43d5-b161-761043e4d9e6" />
