### PR TITLE
[Issue #8556]: fix type on metabase service module

### DIFF
--- a/infra/analytics/metabase/main.tf
+++ b/infra/analytics/metabase/main.tf
@@ -106,8 +106,8 @@ module "service" {
   vpc_id                   = data.aws_vpc.network.id
   public_subnet_ids        = data.aws_subnets.public.ids
   private_subnet_ids       = data.aws_subnets.private.ids
-  cpu                      = 1024
-  memory                   = 2048
+  fargate_cpu              = 2048
+  fargate_memory           = 4096
   container_port           = 3000
   readonly_root_filesystem = false
   drop_linux_capabilities  = false


### PR DESCRIPTION
## Summary

Fixed the typo in the metabase service module for the fargate cpu and mem.

This change was caught during the metabase upgrade to version v1.55.20 to resolve a critical cve update.

## Validation steps

The metabase service infra should be able to successfully deploy.