### PR TITLE
[unticketed] hardcode storybook to english to work around vite asset path bug

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -7,7 +7,7 @@ import { Loader, Preview } from "@storybook/react";
 import "src/styles/styles.scss";
 
 import { defaultLocale, locales } from "src/i18n/config";
-import { getMessagesWithFallbacks } from "src/i18n/getMessagesWithFallbacks";
+import { messages } from "src/i18n/messages/en";
 
 import I18nStoryWrapper from "./I18nStoryWrapper";
 
@@ -43,10 +43,9 @@ const parameters = {
   },
 };
 
-const i18nMessagesLoader: Loader = async (context) => {
-  const messages = await getMessagesWithFallbacks(
-    context.globals.locale as string,
-  );
+// not using `getMessagesWithFallbacks` as the import asset paths in there
+// cause problems during vite compilation. Hardcoding to english for now
+const i18nMessagesLoader: Loader = () => {
   return { messages };
 };
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

fixes bug that was causing all storybook stories to throw an error (see screenshot) based on inability to find messages files

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The function we're using to grab messages for next-intl relies on a hardcoded path that vite was not able to properly resolve in storybook builds. Hardcoding to English works around this

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


1. `npm ci && npm run storybook-build && npx http-server ./storybook-static` on this branch
2. _VERIFY_: all storybook stories load as expected

## Screenshots

### Error state

<img width="1342" height="652" alt="Screenshot 2026-02-18 at 12 13 17 PM" src="https://github.com/user-attachments/assets/0df49fda-91ad-4296-a9a0-d4017b26b2ee" />
