### PR TITLE
[Issue #7298] Limit number of attachments on an application to 150

### DIFF
--- a/api/src/app_config.py
+++ b/api/src/app_config.py
@@ -16,3 +16,6 @@ class AppConfig(PydanticBaseEnvConfig):
 
     # Maximum file upload size in bytes (2 GB)
     max_file_upload_size_bytes: int = 2 * 1024 * 1024 * 1024
+
+    # Maximum number of attachments allowed per application
+    max_attachments_per_application: int = 150

--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -192,6 +192,7 @@ class SubmissionIssue(StrEnum):
     APPLICATION_FORM_NOT_FOUND_NO_RESPONSE = "application_form_not_found_no_response"
     INVALID_FILE_NAME = "invalid_file_name"
     ATTACHMENT_NOT_FOUND = "attachment_not_found"
+    ATTACHMENT_LIMIT_EXCEEDED = "attachment_limit_exceeded"
 
 
 class SamGovExtractType(StrEnum):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #7298

Adds a configurable limit (default: 150) on the number of attachments per application to prevent abuse and performance issues. Creation is blocked with a 422 error when the limit is reached; update operations are unaffected.

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added attachment count validation in create_application_attachment()
Added ATTACHMENT_LIMIT_EXCEEDED to SubmissionIssue enum
Added max_attachments_per_application to AppConfig (env var: MAX_ATTACHMENTS_PER_APPLICATION, default: 150)
Soft-deleted attachments (is_deleted=True) are excluded from the count
UPDATE operations bypass the limit check (replacing files doesn't increase count)

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The validation is in `create_application_attachment` only, not in the shared upsert_application_attachment() function. This means updates naturally bypass the limit.

Post-deployment: A New Relic alert should be configured on the ATTACHMENT_LIMIT_EXCEEDED submission_issue to notify the alerts Slack channel.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See updated unit tests
New tests cover: limit enforcement (422 at limit), soft-delete exclusion (deleted don't count), and update bypass (PUT succeeds at limit)