### PR TITLE
[Issue #8585] Update build_automatic_opportunities.py to add data per requirements

### DIFF
--- a/api/src/task/opportunities/build_automatic_opportunities.py
+++ b/api/src/task/opportunities/build_automatic_opportunities.py
@@ -422,7 +422,7 @@ class BuildAutomaticOpportunitiesTask(Task):
             competitions=[
                 CompetitionContainer(
                     competition_title="TEST-APPLY-ORG-IND-CT01",
-                    required_form_ids=[SF424_v4_0.form_id],
+                    required_form_ids=[SF424b_v1_1.form_id],
                     optional_form_ids=[SFLLL_v2_0.form_id],
                     open_to_applicants=[
                         CompetitionOpenToApplicant.ORGANIZATION,
@@ -442,7 +442,7 @@ class BuildAutomaticOpportunitiesTask(Task):
             competitions=[
                 CompetitionContainer(
                     competition_title="TEST-APPLY-ORG-CT01",
-                    required_form_ids=[SF424_v4_0.form_id],
+                    required_form_ids=[SF424b_v1_1.form_id],
                     optional_form_ids=[SFLLL_v2_0.form_id],
                     open_to_applicants=[CompetitionOpenToApplicant.ORGANIZATION],
                 )
@@ -459,7 +459,7 @@ class BuildAutomaticOpportunitiesTask(Task):
             competitions=[
                 CompetitionContainer(
                     competition_title="TEST-APPLY-IND-CT01",
-                    required_form_ids=[SF424_v4_0.form_id],
+                    required_form_ids=[SF424b_v1_1.form_id],
                     optional_form_ids=[SFLLL_v2_0.form_id],
                     open_to_applicants=[CompetitionOpenToApplicant.INDIVIDUAL],
                 )


### PR DESCRIPTION
## Summary

Work for : Task #[8585 ](https://github.com/HHS/simpler-grants-gov/issues/8585)

## Changes proposed

- Update build_automatic_opportunities.py to add data per requirements in https://github.com/HHS/simpler-grants-gov/issues/8037 , required for scripting work in https://github.com/HHS/simpler-grants-gov/issues/7953 .
- The data includes:
  - TEST-APPLY-ORG-IND-ON01 -> open to both organizations and individuals
  - TEST-APPLY-ORG-ON01 -> organizations only
  - TEST-APPLY-IND-ON01 -> individuals only
- Forms attached to each competition:
  - SF424B -> required
  - SFLLL_2_0 -> conditional

## Context for reviewers
- This change is for https://github.com/HHS/simpler-grants-gov/issues/8037 deployed environment set up
- Enables testing and validation for https://github.com/HHS/simpler-grants-gov/issues/7953 scripting work.

## Validation steps
- Verify the below three opportunities exist in deployed environments (Staging, Dev, Training)
  - TEST-APPLY-ORG-IND-ON01 -> open to both organizations and individuals
  - TEST-APPLY-ORG-ON01 -> organizations only
  - TEST-APPLY-IND-ON01 -> individuals only
- Check that SF424B is required and SFLLL_2_0 is conditional in each competition.
