### PR TITLE
[Issue #8629] Adjust AuthZ enforcement for workflow service

### DIFF
--- a/api/src/workflow/base_state_machine.py
+++ b/api/src/workflow/base_state_machine.py
@@ -40,6 +40,15 @@ class BaseStateMachine(StateMachine):
         # iterable for some reason.
         return {e.id for e in cls.events}  # type: ignore[attr-defined]
 
+    @classmethod
+    def get_valid_events_for_state(cls, state: str) -> list[str]:
+
+        s = cls.states_map.get(state, None)
+        if s is None:
+            return []
+
+        return [event.id for event in s.transitions.unique_events]
+
     #############################
     # Event Handlers
     #############################

--- a/api/src/workflow/service/approval_service.py
+++ b/api/src/workflow/service/approval_service.py
@@ -3,12 +3,18 @@ import logging
 from sqlalchemy import select
 
 from src.adapters import db
+from src.auth.endpoint_access_util import can_access
 from src.constants.lookup_constants import ApprovalResponseType, ApprovalType
+from src.db.models.agency_models import Agency
 from src.db.models.user_models import User
 from src.db.models.workflow_models import Workflow, WorkflowApproval
 from src.workflow.event.state_machine_event import StateMachineEvent
+from src.workflow.workflow_config import WorkflowConfig
 from src.workflow.workflow_constants import WorkflowConstants
-from src.workflow.workflow_errors import InvalidWorkflowResponseTypeError
+from src.workflow.workflow_errors import (
+    InvalidWorkflowResponseTypeError,
+    OpportunityWithoutAgencyError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,3 +66,58 @@ def get_approval_response_type(state_machine_event: StateMachineEvent) -> Approv
             "Approval response type is not a valid value", extra=state_machine_event.get_log_extra()
         )
         raise InvalidWorkflowResponseTypeError("Approval response type is not a valid value") from e
+
+
+def _get_agencies_for_workflow(workflow: Workflow) -> list[Agency]:
+    agencies_map = {}
+
+    for opportunity in workflow.opportunities:
+        if opportunity.agency_record is None:
+            raise OpportunityWithoutAgencyError("Opportunity does not have an agency record")
+
+        agencies_map[opportunity.agency_record.agency_id] = opportunity.agency_record
+
+    for application in workflow.applications:
+        opportunity = application.competition.opportunity
+        if opportunity.agency_record is None:
+            raise OpportunityWithoutAgencyError("Opportunity does not have an agency record")
+
+        agencies_map[opportunity.agency_record.agency_id] = opportunity.agency_record
+
+    return list(agencies_map.values())
+
+
+def can_user_do_agency_approval(
+    user: User, workflow: Workflow, config: WorkflowConfig, event_to_send: str
+) -> bool:
+    """Check if a user can do an approval for a given workflow."""
+    log_extra = workflow.get_log_extra() | {"user_id": user.user_id, "event_to_send": event_to_send}
+
+    approval_config = config.approval_mapping.get(event_to_send)
+
+    if approval_config is None:
+        logger.info("No approval mapping found for event", extra=log_extra)
+        return False
+
+    # Technically, an opportunity can have a null agency record
+    # As a safety precaution, if we ever see this, disallow access
+    # regardless of the other agencies that might be present.
+    try:
+        agencies = _get_agencies_for_workflow(workflow)
+    except OpportunityWithoutAgencyError:
+        logger.warning("Opportunity associated with workflow has no agency", extra=log_extra)
+        return False
+
+    required_privileges = set(approval_config.required_privileges)
+    for agency in agencies:
+        agency_log_extra = log_extra | {
+            "agency_id": agency.agency_id,
+            "agency_code": agency.agency_code,
+        }
+        logger.info("Checking if user can access agency for approvals", extra=agency_log_extra)
+        if not can_access(user, required_privileges, agency):
+            logger.info("User cannot access agency for approvals", extra=agency_log_extra)
+            return False
+
+    logger.info("User can access agencies for approvals", extra=log_extra)
+    return True

--- a/api/src/workflow/state_machine/initial_prototype_state_machine.py
+++ b/api/src/workflow/state_machine/initial_prototype_state_machine.py
@@ -29,12 +29,12 @@ initial_prototype_state_machine_config = WorkflowConfig(
     entity_types=[WorkflowEntityType.OPPORTUNITY],
     approval_mapping={
         # Program Officer Approvals
-        InitialPrototypeState.PENDING_PROGRAM_OFFICER_APPROVAL: ApprovalConfig(
+        "receive_program_officer_approval": ApprovalConfig(
             approval_type=ApprovalType.PROGRAM_OFFICER_APPROVAL,
             required_privileges=[Privilege.PROGRAM_OFFICER_APPROVAL],
         ),
         # Budget Officer Approvals
-        InitialPrototypeState.PENDING_BUDGET_OFFICER_APPROVAL: ApprovalConfig(
+        "receive_budget_officer_approval": ApprovalConfig(
             approval_type=ApprovalType.BUDGET_OFFICER_APPROVAL,
             required_privileges=[Privilege.BUDGET_OFFICER_APPROVAL],
         ),

--- a/api/src/workflow/workflow_config.py
+++ b/api/src/workflow/workflow_config.py
@@ -23,4 +23,5 @@ class WorkflowConfig:
     # For now, this assumes exactly 1 of the entity type
     entity_types: list[WorkflowEntityType] = dataclasses.field(default_factory=list)
 
+    # A mapping of events to approval configs
     approval_mapping: dict[str, ApprovalConfig] = dataclasses.field(default_factory=dict)

--- a/api/src/workflow/workflow_errors.py
+++ b/api/src/workflow/workflow_errors.py
@@ -81,3 +81,7 @@ class UserAccessError(NonRetryableWorkflowError):
 
 class DuplicateApprovalError(NonRetryableWorkflowError):
     pass
+
+
+class OpportunityWithoutAgencyError(NonRetryableWorkflowError):
+    pass

--- a/api/tests/lib/agency_test_utils.py
+++ b/api/tests/lib/agency_test_utils.py
@@ -53,6 +53,12 @@ def create_user_in_agency(
     return user, agency
 
 
+def give_user_privilege_in_agency(user: User, agency: Agency, privileges: list[Privilege]) -> None:
+    agency_user = AgencyUserFactory.create(user=user, agency=agency)
+    role = RoleFactory.create(privileges=privileges)
+    AgencyUserRoleFactory.create(agency_user=agency_user, role=role)
+
+
 def create_user_in_agency_with_jwt(
     db_session: db.Session,
     agency: Agency | None = None,

--- a/api/tests/workflow/processor/test_approval_processor.py
+++ b/api/tests/workflow/processor/test_approval_processor.py
@@ -6,11 +6,7 @@ from src.constants.lookup_constants import (
     Privilege,
     WorkflowType,
 )
-from src.workflow.workflow_errors import (
-    DuplicateApprovalError,
-    InvalidWorkflowResponseTypeError,
-    UserAccessError,
-)
+from src.workflow.workflow_errors import DuplicateApprovalError, InvalidWorkflowResponseTypeError
 from tests.lib.agency_test_utils import create_user_in_agency
 from tests.src.db.models.factories import (
     OpportunityFactory,
@@ -365,30 +361,6 @@ def test_agency_approval_approve_then_decline(db_session, agency, program_office
             },
         ],
     )
-
-
-def test_agency_approval_missing_required_privilege(
-    db_session, agency, budget_officer, opportunity
-):
-    workflow = WorkflowFactory.create(
-        workflow_type=WorkflowType.BASIC_TEST_WORKFLOW,
-        current_workflow_state=BasicState.PENDING_PROGRAM_OFFICER_APPROVAL,
-        opportunities=[opportunity],
-    )
-
-    with pytest.raises(
-        UserAccessError, match="User does not have access to approve workflow for given state"
-    ):
-        send_process_event(
-            db_session=db_session,
-            event_to_send="receive_program_officer_approval",
-            workflow_id=workflow.workflow_id,
-            user=budget_officer,
-            expected_state=BasicState.PENDING_PROGRAM_OFFICER_APPROVAL,
-            approval_response_type=ApprovalResponseType.APPROVED,
-        )
-
-    assert len(workflow.workflow_approvals) == 0
 
 
 def test_agency_approval_invalid_response_type(db_session, agency, budget_officer, opportunity):

--- a/api/tests/workflow/service/test_approval_service.py
+++ b/api/tests/workflow/service/test_approval_service.py
@@ -1,0 +1,282 @@
+from src.constants.lookup_constants import Privilege, WorkflowType
+from src.workflow.service.approval_service import can_user_do_agency_approval
+from tests.lib.agency_test_utils import create_user_in_agency, give_user_privilege_in_agency
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    ApplicationFactory,
+    CompetitionFactory,
+    OpportunityFactory,
+    UserFactory,
+    WorkflowFactory,
+)
+from tests.workflow.state_machine.test_state_machines import (
+    BasicTestStateMachine,
+    basic_test_workflow_config,
+)
+
+
+def test_can_user_do_agency_approval(db_session, enable_factory_create):
+    config = basic_test_workflow_config
+
+    # create a few different agencies
+    agency_a = AgencyFactory.create()
+    agency_b = AgencyFactory.create()
+
+    # Create a few users
+    agency_a_budget_officer, _ = create_user_in_agency(
+        agency=agency_a, privileges=[Privilege.BUDGET_OFFICER_APPROVAL]
+    )
+    agency_b_budget_officer, _ = create_user_in_agency(
+        agency=agency_b, privileges=[Privilege.BUDGET_OFFICER_APPROVAL]
+    )
+
+    agency_a_program_officer, _ = create_user_in_agency(
+        agency=agency_a, privileges=[Privilege.PROGRAM_OFFICER_APPROVAL]
+    )
+    agency_b_program_officer, _ = create_user_in_agency(
+        agency=agency_b, privileges=[Privilege.PROGRAM_OFFICER_APPROVAL]
+    )
+
+    # These users are in both agency A & B
+    agency_ab_program_officer, _ = create_user_in_agency(
+        agency=agency_a, privileges=[Privilege.PROGRAM_OFFICER_APPROVAL]
+    )
+    give_user_privilege_in_agency(
+        agency_ab_program_officer, agency_b, privileges=[Privilege.PROGRAM_OFFICER_APPROVAL]
+    )
+
+    agency_ab_budget_officer, _ = create_user_in_agency(
+        agency=agency_a, privileges=[Privilege.BUDGET_OFFICER_APPROVAL]
+    )
+    give_user_privilege_in_agency(
+        agency_ab_budget_officer, agency_b, privileges=[Privilege.BUDGET_OFFICER_APPROVAL]
+    )
+
+    # Create a few opportunities for various agencies
+    opportunity_a1 = OpportunityFactory.create(agency_code=agency_a.agency_code)
+    opportunity_a2 = OpportunityFactory.create(agency_code=agency_a.agency_code)
+
+    opportunity_b = OpportunityFactory.create(agency_code=agency_b.agency_code)
+
+    competition_a1 = CompetitionFactory.create(opportunity=opportunity_a1)
+    competition_b = CompetitionFactory.create(opportunity=opportunity_b)
+
+    application_a1 = ApplicationFactory.create(competition=competition_a1)
+
+    application_b = ApplicationFactory.create(competition=competition_b)
+
+    ##################
+    # Simple Opportunity/Application Workflow
+    ##################
+    # The access ends up the same between opp/application for this
+    simple_opportunity_workflow = WorkflowFactory.create(
+        workflow_type=WorkflowType.BASIC_TEST_WORKFLOW, opportunities=[opportunity_a1]
+    )
+    simple_application_workflow = WorkflowFactory.create(
+        workflow_type=WorkflowType.BASIC_TEST_WORKFLOW, applications=[application_a1]
+    )
+
+    # Budget officer can do budget officer approval
+    assert (
+        can_user_do_agency_approval(
+            agency_a_budget_officer,
+            simple_opportunity_workflow,
+            config,
+            "receive_budget_officer_approval",
+        )
+        is True
+    )
+    assert (
+        can_user_do_agency_approval(
+            agency_a_program_officer,
+            simple_opportunity_workflow,
+            config,
+            "receive_budget_officer_approval",
+        )
+        is False
+    )
+
+    assert (
+        can_user_do_agency_approval(
+            agency_a_budget_officer,
+            simple_application_workflow,
+            config,
+            "receive_budget_officer_approval",
+        )
+        is True
+    )
+    assert (
+        can_user_do_agency_approval(
+            agency_a_program_officer,
+            simple_application_workflow,
+            config,
+            "receive_budget_officer_approval",
+        )
+        is False
+    )
+
+    # Program officer can do program officer approval
+    assert (
+        can_user_do_agency_approval(
+            agency_a_program_officer,
+            simple_opportunity_workflow,
+            config,
+            "receive_program_officer_approval",
+        )
+        is True
+    )
+    assert (
+        can_user_do_agency_approval(
+            agency_a_budget_officer,
+            simple_opportunity_workflow,
+            config,
+            "receive_program_officer_approval",
+        )
+        is False
+    )
+
+    assert (
+        can_user_do_agency_approval(
+            agency_a_program_officer,
+            simple_application_workflow,
+            config,
+            "receive_program_officer_approval",
+        )
+        is True
+    )
+    assert (
+        can_user_do_agency_approval(
+            agency_a_budget_officer,
+            simple_application_workflow,
+            config,
+            "receive_program_officer_approval",
+        )
+        is False
+    )
+
+    # Other random users can't do anything
+    for event in BasicTestStateMachine.get_valid_events():
+        assert (
+            can_user_do_agency_approval(
+                agency_b_program_officer, simple_opportunity_workflow, config, event
+            )
+            is False
+        )
+        assert (
+            can_user_do_agency_approval(
+                agency_b_budget_officer, simple_opportunity_workflow, config, event
+            )
+            is False
+        )
+
+        assert (
+            can_user_do_agency_approval(
+                agency_b_program_officer, simple_application_workflow, config, event
+            )
+            is False
+        )
+        assert (
+            can_user_do_agency_approval(
+                agency_b_budget_officer, simple_application_workflow, config, event
+            )
+            is False
+        )
+
+    ##################
+    # Multiple Opportunity/Application Workflow
+    ##################
+    # To do anything here, you'd need to have the privilege
+    # against both agency A & B
+
+    multiple_entity_workflow = WorkflowFactory.create(
+        workflow_type=WorkflowType.BASIC_TEST_WORKFLOW,
+        opportunities=[opportunity_a1, opportunity_a2],
+        applications=[application_b],
+    )
+
+    # Program officer can do program officer approval
+    assert (
+        can_user_do_agency_approval(
+            agency_ab_program_officer,
+            multiple_entity_workflow,
+            config,
+            "receive_program_officer_approval",
+        )
+        is True
+    )
+    assert (
+        can_user_do_agency_approval(
+            agency_ab_program_officer,
+            multiple_entity_workflow,
+            config,
+            "receive_budget_officer_approval",
+        )
+        is False
+    )
+
+    # Budget officer can do budget officer approval
+    assert (
+        can_user_do_agency_approval(
+            agency_ab_budget_officer,
+            multiple_entity_workflow,
+            config,
+            "receive_program_officer_approval",
+        )
+        is False
+    )
+    assert (
+        can_user_do_agency_approval(
+            agency_ab_budget_officer,
+            multiple_entity_workflow,
+            config,
+            "receive_budget_officer_approval",
+        )
+        is True
+    )
+
+    # The users in only one of the agencies cannot do anything
+    for event in BasicTestStateMachine.get_valid_events():
+        assert (
+            can_user_do_agency_approval(
+                agency_a_program_officer, multiple_entity_workflow, config, event
+            )
+            is False
+        )
+        assert (
+            can_user_do_agency_approval(
+                agency_a_budget_officer, multiple_entity_workflow, config, event
+            )
+            is False
+        )
+
+        assert (
+            can_user_do_agency_approval(
+                agency_b_program_officer, multiple_entity_workflow, config, event
+            )
+            is False
+        )
+        assert (
+            can_user_do_agency_approval(
+                agency_b_budget_officer, multiple_entity_workflow, config, event
+            )
+            is False
+        )
+
+
+def test_can_user_do_agency_approval_with_null_opp_agency(db_session, enable_factory_create):
+    # Privileges won't matter, we don't check them in this case
+    user = UserFactory.create()
+
+    opportunity = OpportunityFactory.create(
+        agency_id=None, agency_code="a-code-that-won't-connect-to-anything"
+    )
+    workflow = WorkflowFactory.create(
+        workflow_type=WorkflowType.BASIC_TEST_WORKFLOW, opportunities=[opportunity]
+    )
+
+    assert (
+        can_user_do_agency_approval(
+            user, workflow, basic_test_workflow_config, "receive_program_officer_approval"
+        )
+        is False
+    )

--- a/api/tests/workflow/state_machine/test_initial_prototype_state_machine.py
+++ b/api/tests/workflow/state_machine/test_initial_prototype_state_machine.py
@@ -2,7 +2,12 @@ import pytest
 
 from src.constants.lookup_constants import ApprovalResponseType, ApprovalType, WorkflowType
 from src.workflow.handler.event_handler import EventHandler
-from src.workflow.state_machine.initial_prototype_state_machine import InitialPrototypeState
+from src.workflow.service.approval_service import can_user_do_agency_approval
+from src.workflow.state_machine.initial_prototype_state_machine import (
+    InitialPrototypeState,
+    InitialPrototypeStateMachine,
+    initial_prototype_state_machine_config,
+)
 from src.workflow.workflow_errors import InvalidEventError
 from tests.src.db.models.factories import UserFactory, WorkflowFactory
 from tests.workflow.workflow_test_util import (
@@ -226,3 +231,48 @@ def test_initial_prototype_state_machine_invalid_events(
 
     # No approvals added due to error
     assert len(workflow.workflow_approvals) == 0
+
+
+def test_initial_prototype_state_privileges(
+    db_session, agency, opportunity, budget_officer, program_officer
+):
+    """Test that we've configured the privileges as expected."""
+    workflow = WorkflowFactory.create(
+        workflow_type=WorkflowType.INITIAL_PROTOTYPE,
+        opportunities=[opportunity],
+    )
+    config = initial_prototype_state_machine_config
+
+    assert (
+        can_user_do_agency_approval(
+            program_officer, workflow, config, "receive_budget_officer_approval"
+        )
+        is False
+    )
+    assert (
+        can_user_do_agency_approval(
+            budget_officer, workflow, config, "receive_budget_officer_approval"
+        )
+        is True
+    )
+
+    assert (
+        can_user_do_agency_approval(
+            program_officer, workflow, config, "receive_program_officer_approval"
+        )
+        is True
+    )
+    assert (
+        can_user_do_agency_approval(
+            budget_officer, workflow, config, "receive_program_officer_approval"
+        )
+        is False
+    )
+
+    for event in InitialPrototypeStateMachine.get_valid_events():
+        # checked these above
+        if event in ["receive_program_officer_approval", "receive_budget_officer_approval"]:
+            continue
+
+        assert can_user_do_agency_approval(program_officer, workflow, config, event) is False
+        assert can_user_do_agency_approval(budget_officer, workflow, config, event) is False

--- a/api/tests/workflow/state_machine/test_state_machines.py
+++ b/api/tests/workflow/state_machine/test_state_machines.py
@@ -42,13 +42,13 @@ basic_test_workflow_config = WorkflowConfig(
     entity_types=[WorkflowEntityType.OPPORTUNITY],
     approval_mapping={
         # Program Officer Approvals
-        BasicState.PENDING_PROGRAM_OFFICER_APPROVAL: ApprovalConfig(
+        "receive_program_officer_approval": ApprovalConfig(
             approval_type=ApprovalType.PROGRAM_OFFICER_APPROVAL,
             required_privileges=[Privilege.PROGRAM_OFFICER_APPROVAL],
             minimum_approvals_required=3,  # require 3 approvals
         ),
         # Budget Officer Approvals
-        BasicState.PENDING_BUDGET_OFFICER_APPROVAL: ApprovalConfig(
+        "receive_budget_officer_approval": ApprovalConfig(
             approval_type=ApprovalType.BUDGET_OFFICER_APPROVAL,
             required_privileges=[Privilege.BUDGET_OFFICER_APPROVAL],
         ),


### PR DESCRIPTION
## Summary
Fixes #8629 

## Changes proposed
* Made it so the approval configuration is now event->ApprovalConfig instead of state->ApprovalConfig (Will make AuthZ in endpoint easier)
* Removed AuthZ enforcement from approval in workflow service
* Made a utility for checking AuthZ for a given user + workflow (to be used in the event API)

## Context for reviewers
This is a follow-up to a few discussions and is a first step in simplifying a bit of the AuthZ. The general purpose is to make it so all AuthZ is enforced in our API, and none is done in the workflow service. The utility created and tested in this is what we'll use in the API to do that enforcement.

## Validation steps
Still just tests at the moment
