### PR TITLE
[Unticketed] Don't log an error if someone calls callback directly

### DIFF
--- a/api/src/services/users/login_gov_callback_handler.py
+++ b/api/src/services/users/login_gov_callback_handler.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 class CallbackParams(BaseModel):
     code: str | None = None
-    state: str
+    state: str | None = None
     error: str | None = None
     error_description: str | None = None
 
@@ -70,9 +70,13 @@ def handle_login_gov_callback_request(
         error_message = f"{callback_params.error} {callback_params.error_description}"
         raise_flask_error(500, error_message)
 
-    # This shouldn't be possible, if there is no error, this should always be set
+    # This should only ever happen if someone directly calls the API
+    # We can't validate the request like normal due to the redirect nature
+    # of these endpoints.
     if callback_params.code is None:
-        raise_flask_error(500, "Missing code in request")
+        raise_flask_error(422, "Missing code in request")
+    if callback_params.state is None:
+        raise_flask_error(422, "Missing state in request")
 
     # If the state value we received isn't a valid UUID
     # then it's likely someone randomly calling the endpoint

--- a/api/tests/src/api/users/test_user_route_login.py
+++ b/api/tests/src/api/users/test_user_route_login.py
@@ -507,6 +507,28 @@ def test_user_callback_token_fails_validation_no_valid_key_302(
     assert db_state is None
 
 
+def test_user_callback_null_code_302(client):
+    resp = client.get(f"/v1/users/login/callback?state={uuid.uuid4()}", follow_redirects=True)
+
+    # The final endpoint returns a 200 even when erroring as it is just a GET endpoint
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+
+    assert resp_json["message"] == "error"
+    assert resp_json["error_description"] == "Missing code in request"
+
+
+def test_user_callback_null_state_302(client):
+    resp = client.get("/v1/users/login/callback?code=abc123", follow_redirects=True)
+
+    # The final endpoint returns a 200 even when erroring as it is just a GET endpoint
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+
+    assert resp_json["message"] == "error"
+    assert resp_json["error_description"] == "Missing state in request"
+
+
 ##########################################
 # PIV/CAC validation tests
 ##########################################


### PR DESCRIPTION
## Summary

## Changes proposed
* Don't raise a 500 / error when someone calls our login callback without required parameters

## Context for reviewers
We received an error earlier today for someone calling our callback endpoint for the login flow without any parameters. This shouldn't happen for any normal operation, and any normal operation should handle this with a proper redirect. This makes it so the error won't get logged as an error by adjusting the validation to be more explicit.

Note that unlike our normal endpoints, we can't do this as part of request validation because that wouldn't allow us to redirect the response.

## Validation steps
You can see this issue right now by going to `http://localhost:8080/v1/users/login/callback` - without this change it'll cause the API to fail and log an error, you won't be redirected. With the fix, you'll redirect through to the frontend and end up at `http://localhost:3000/unauthenticated`.