### PR TITLE
[unticketed] Increase timeout gunicorn

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -24,3 +24,6 @@ bind = app_config.host + ':' + str(app_config.port)
 
 workers = (len(os.sched_getaffinity(0)) * 2) + 1
 threads = 4
+
+# timeout to 80 seconds
+timeout = 80


### PR DESCRIPTION
## Summary

Fixes / Work for [unticketed]

## Changes proposed

This PR increases timeout on gunicorn from 30 (default) to 80 seconds.

## Context for reviewers

This change is to further investigate large incoming soap requests.

## Validation steps

- Ensure unit tests pass
- Follow up to determine if this resolved the issue