### PR TITLE
[Issue #7119] remove js-yaml from explicit deps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,6 @@
         "isomorphic-dompurify": "^2.15.0",
         "jose": "^5.9.6",
         "js-cookie": "^3.0.5",
-        "js-yaml": "4.1.1",
         "json-pointer": "^0.6.2",
         "json-schema-merge-allof": "^0.8.1",
         "lodash": "^4.17.23",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,6 @@
     "isomorphic-dompurify": "^2.15.0",
     "jose": "^5.9.6",
     "js-cookie": "^3.0.5",
-    "js-yaml": "4.1.1",
     "json-pointer": "^0.6.2",
     "json-schema-merge-allof": "^0.8.1",
     "lodash": "^4.17.23",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #7119 

## Changes proposed

Removes redundant inclusion of js-yaml in explicit npm dependencies

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Including js-yaml 4.1.1 explicitly was done to work around a vulnerability in 4.1.0 while subdependencies worked on updating to the patched version. It seems like all those subdependencies are now patched, and there are no longer vulnerabilities appearing in the scan when the explicit inclusion of 4.1.1 is removed from our package.json

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. _VERIFY_: vulnerability scans pass
