### PR TITLE
[Issue #6667]: Add ConfirmApplicationDeliverySchema

### DIFF
--- a/api/src/legacy_soap_api/applicants/fault_messages.py
+++ b/api/src/legacy_soap_api/applicants/fault_messages.py
@@ -10,3 +10,9 @@ OpportunityListRequestInvalidParams = FaultMessage(
     faultstring="Unable to Get Opportunity List: At least one filter is required. Filtering by Competition ID requires Opportunity Number and/or CFDA.",
     faultcode="soap:Server",
 )
+
+
+ConfirmApplicationDeliveryInvalidTrackingNumber = FaultMessage(
+    faultstring="Failed to validate request. cvc-pattern-valid: Value is not facet-valid with respect to pattern 'GRANT[0-9]{8}' for type 'GrantsGovTrackingNumberType'.",
+    faultcode="soap:Server",
+)

--- a/api/src/legacy_soap_api/grantors/schemas/__init__.py
+++ b/api/src/legacy_soap_api/grantors/schemas/__init__.py
@@ -1,6 +1,5 @@
 from src.legacy_soap_api.grantors.schemas.confirm_application_delivery_schemas import (
     ConfirmApplicationDeliveryRequest,
-    ConfirmApplicationDeliveryResponseSOAPBody,
     ConfirmApplicationDeliveryResponseSOAPEnvelope,
 )
 from src.legacy_soap_api.grantors.schemas.get_application_zip_schemas import (
@@ -31,5 +30,4 @@ __all__ = [
     "SubmissionInfo",
     "ConfirmApplicationDeliveryResponseSOAPEnvelope",
     "ConfirmApplicationDeliveryRequest",
-    "ConfirmApplicationDeliveryResponseSOAPBody",
 ]

--- a/api/src/legacy_soap_api/grantors/schemas/confirm_application_delivery_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/confirm_application_delivery_schemas.py
@@ -1,39 +1,24 @@
 import re
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import Field, field_validator
 
-from src.legacy_soap_api.applicants.fault_messages import OpportunityListRequestInvalidParams
+from src.legacy_soap_api.applicants.fault_messages import (
+    ConfirmApplicationDeliveryInvalidTrackingNumber,
+)
 from src.legacy_soap_api.legacy_soap_api_schemas import BaseSOAPSchema
 from src.legacy_soap_api.legacy_soap_api_utils import SOAPFaultException
 
-CONFIRM_APPLICATION_DELIVERY_NO_TRACKING_NUMBER_ERR = "No grants_gov_tracking_number provided."
 CONFIRM_APPLICATION_DELIVERY_INVALID_TRACKING_NUMBER_ERR = (
     "Invalid grants_gov_tracking_number provided."
 )
 
 
-class ConfirmApplicationDeliveryResponse(BaseSOAPSchema):
+class ConfirmApplicationDeliveryResponseSOAPEnvelope(BaseSOAPSchema):
     grants_gov_tracking_number: str | None = Field(default=None, alias="GrantsGovTrackingNumber")
     response_message: str | None = Field(default=None, alias="ResponseMessage")
 
-
-class ConfirmApplicationDeliveryResponseSOAPBody(BaseSOAPSchema):
-    confirm_application_delivery_response: ConfirmApplicationDeliveryResponse = Field(
-        alias="ns2:ConfirmApplicationDeliveryResponse",
-        # From testing it looks like the response comes in with the namespace ns2 but when we convert
-        # it to a dict via the SOAPPayload the namespace can be lost so using validation_alias in order
-        # to handle both cases
-        validation_alias=AliasChoices(
-            "ns2:ConfirmApplicationDeliveryResponse", "ConfirmApplicationDeliveryResponse"
-        ),
-    )
-
-
-class ConfirmApplicationDeliveryResponseSOAPEnvelope(BaseSOAPSchema):
-    body: ConfirmApplicationDeliveryResponseSOAPBody = Field(alias="Body")
-
     def to_soap_envelope_dict(self, operation_name: str) -> dict:
-        return {"Envelope": self.model_dump(by_alias=True)}
+        return super().to_soap_envelope_dict(f"ns2:{operation_name}")
 
 
 class ConfirmApplicationDeliveryRequest(BaseSOAPSchema):
@@ -42,14 +27,9 @@ class ConfirmApplicationDeliveryRequest(BaseSOAPSchema):
     @field_validator("grants_gov_tracking_number", mode="after")
     @classmethod
     def validate_required_properties(cls, value: str) -> str:
-        if not value:
-            raise SOAPFaultException(
-                CONFIRM_APPLICATION_DELIVERY_NO_TRACKING_NUMBER_ERR,
-                fault=OpportunityListRequestInvalidParams,
-            )
-        if not re.fullmatch(r"GRANT[0-9]{8}", value):
+        if not value or not re.fullmatch(r"GRANT[0-9]{8}", value):
             raise SOAPFaultException(
                 CONFIRM_APPLICATION_DELIVERY_INVALID_TRACKING_NUMBER_ERR,
-                fault=OpportunityListRequestInvalidParams,
+                fault=ConfirmApplicationDeliveryInvalidTrackingNumber,
             )
         return value

--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -270,8 +270,6 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         yield b"\n" + boundary.encode("utf-8") + b"--"
 
     def get_simpler_soap_response(self, proxy_response: SOAPResponse) -> SOAPResponse:
-        if self.operation_config.is_mtom is False:
-            return proxy_response
         # MTOM message is assembled here
         # 1. --uuid: {boundary_uuid}\n
         # 2. headers:

--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -77,7 +77,6 @@ class SOAPOperationConfig:
     request_operation_name: str
     response_operation_name: str
     compare_endpoints: bool = False
-    is_mtom: bool = False
     always_call_simpler: bool = False
 
     # These are the privileges needed for these endpoints:
@@ -142,19 +141,16 @@ SIMPLER_SOAP_OPERATION_CONFIGS: dict[SimplerSoapAPI, dict[str, SOAPOperationConf
         "GetApplicationZipRequest": SOAPOperationConfig(
             request_operation_name="GetApplicationZipRequest",
             response_operation_name="GetApplicationZipResponse",
-            is_mtom=True,
             privileges={Privilege.LEGACY_AGENCY_GRANT_RETRIEVER},
         ),
         "GetSubmissionListExpandedRequest": SOAPOperationConfig(
             request_operation_name="GetSubmissionListExpandedRequest",
             response_operation_name="GetSubmissionListExpandedResponse",
-            is_mtom=True,
             privileges={Privilege.LEGACY_AGENCY_GRANT_RETRIEVER},
         ),
         "ConfirmApplicationDeliveryRequest": SOAPOperationConfig(
             request_operation_name="ConfirmApplicationDeliveryRequest",
             response_operation_name="ConfirmApplicationDeliveryResponse",
-            is_mtom=True,
             privileges={Privilege.LEGACY_AGENCY_GRANT_RETRIEVER},
         ),
     },

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_confirm_application_delivery_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_confirm_application_delivery_schema.py
@@ -14,7 +14,7 @@ RESPONSE_MESSAGE = "Success"
 
 
 class TestLegacySoapGrantorConfirmApplicationRequestSchema:
-    def test_can_convert_confirm_application_delivery_request_soap_payload_dict(self, db_session):
+    def test_can_convert_confirm_application_delivery_request_soap_payload_dict(self):
         request_xml = (
             "<soapenv:Envelope "
             'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
@@ -44,7 +44,7 @@ class TestLegacySoapGrantorConfirmApplicationRequestSchema:
         }
         assert soap_payload_dict == expected
 
-    def test_can_convert_confirm_application_delivery_request_xml_bytes_to_dict(self, db_session):
+    def test_can_convert_confirm_application_delivery_request_xml_bytes_to_dict(self):
         request_xml = (
             "<soapenv:Envelope "
             'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
@@ -68,7 +68,7 @@ class TestLegacySoapGrantorConfirmApplicationRequestSchema:
         }
 
     def test_confirm_application_delivery_request_validates_there_is_a_grants_gov_tracking_number_exists(
-        self, db_session
+        self,
     ):
         request_xml = (
             "<soapenv:Envelope "
@@ -88,10 +88,10 @@ class TestLegacySoapGrantorConfirmApplicationRequestSchema:
         )
         with pytest.raises(SOAPFaultException) as e:
             grantors_schemas.ConfirmApplicationDeliveryRequest(**soap_operation_dict)
-        assert e.value.message == "No grants_gov_tracking_number provided."
+        assert e.value.message == "Invalid grants_gov_tracking_number provided."
 
     def test_confirm_application_delivery_request_validates_there_is_a_grants_gov_tracking_number_is_in_correct_format(
-        self, db_session
+        self,
     ):
         BAD_NUMBER = "123456"
         request_xml = (
@@ -116,7 +116,7 @@ class TestLegacySoapGrantorConfirmApplicationRequestSchema:
 
 
 class TestLegacySoapGrantorConfirmApplicationResponseSchema:
-    def test_can_convert_confirm_application_delivery_response_xml_bytes_to_dict(self, db_session):
+    def test_can_convert_confirm_application_delivery_response_xml_bytes_to_dict(self):
         response_xml_bytes = (
             f"--uuid:{BOUNDARY_UUID}"
             'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
@@ -143,17 +143,16 @@ class TestLegacySoapGrantorConfirmApplicationResponseSchema:
             "</soap:Body>"
             "</soap:Envelope>"
         ).encode("utf-8")
-        soap_payload_dict = SOAPPayload(soap_payload=response_xml_bytes.decode()).to_dict()
-        schema = grantors_schemas.ConfirmApplicationDeliveryResponseSOAPEnvelope(
-            body=soap_payload_dict.get("Envelope", {}).get("Body")
-        )
-        assert (
-            schema.body.confirm_application_delivery_response.grants_gov_tracking_number
-            == GRANTS_GOV_TRACKING_NUMBER
-        )
-        assert (
-            schema.body.confirm_application_delivery_response.response_message == RESPONSE_MESSAGE
-        )
+        soap_payload_dict = SOAPPayload(soap_payload=response_xml_bytes.decode()).to_dict()[
+            "Envelope"
+        ]["Body"]["ConfirmApplicationDeliveryResponse"]
+        schema_data = {
+            "grants_gov_tracking_number": soap_payload_dict["GrantsGovTrackingNumber"],
+            "response_message": soap_payload_dict["ResponseMessage"],
+        }
+        schema = grantors_schemas.ConfirmApplicationDeliveryResponseSOAPEnvelope(**schema_data)
+        assert schema.grants_gov_tracking_number == GRANTS_GOV_TRACKING_NUMBER
+        assert schema.response_message == RESPONSE_MESSAGE
         result = schema.to_soap_envelope_dict(operation_name="ConfirmApplicationDeliveryResponse")
         expected = {
             "Envelope": {
@@ -167,7 +166,7 @@ class TestLegacySoapGrantorConfirmApplicationResponseSchema:
         }
         assert result == expected
 
-    def test_can_convert_confirm_application_delivery_response_to_dict(self, db_session):
+    def test_can_convert_confirm_application_delivery_response_to_dict(self):
         response_xml_bytes = (
             f"--uuid:{BOUNDARY_UUID}"
             'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
@@ -220,9 +219,7 @@ class TestLegacySoapGrantorConfirmApplicationResponseSchema:
         }
         assert soap_xml_dict == expected
 
-    def test_can_convert_confirm_application_delivery_response_dict_to_mtom_message(
-        self, db_session
-    ):
+    def test_can_convert_confirm_application_delivery_response_dict_to_mtom_message(self):
         response_xml_bytes = (
             f"--uuid:{BOUNDARY_UUID}"
             'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
@@ -249,9 +246,15 @@ class TestLegacySoapGrantorConfirmApplicationResponseSchema:
             "</soap:Body>"
             "</soap:Envelope>"
         ).encode("utf-8")
-        soap_payload_dict = SOAPPayload(soap_payload=response_xml_bytes.decode()).to_dict()
+        soap_payload_dict = SOAPPayload(soap_payload=response_xml_bytes.decode()).to_dict()[
+            "Envelope"
+        ]["Body"]["ConfirmApplicationDeliveryResponse"]
+        schema_data = {
+            "grants_gov_tracking_number": soap_payload_dict["GrantsGovTrackingNumber"],
+            "response_message": soap_payload_dict["ResponseMessage"],
+        }
         result = grantors_schemas.ConfirmApplicationDeliveryResponseSOAPEnvelope(
-            Body=soap_payload_dict.get("Envelope", {}).get("Body")
+            **schema_data
         ).to_soap_envelope_dict(operation_name="ConfirmApplicationDeliveryResponse")
         ns = {
             "ns12": "http://schemas.xmlsoap.org/wsdl/soap/",

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -590,39 +590,6 @@ class TestSimplerSOAPGetApplicationZip:
         assert response.data == mock_proxy_response.data
         assert response.status_code == mock_proxy_response.status_code
 
-    def test_get_simpler_soap_response_returns_proxy_response_if_is_mtom_is_false_on_operation_config(
-        self, db_session
-    ):
-        request_xml_bytes = (
-            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
-            "<soapenv:Header/>"
-            "<soapenv:Body>"
-            "<agen:GetApplicationZipRequest>"
-            f"<gran:GrantsGovTrackingNumber>{GRANTS_GOV_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>"
-            "</agen:GetApplicationZipRequest>"
-            "</soapenv:Body>"
-            "</soapenv:Envelope>"
-        ).encode("utf-8")
-        soap_request = SOAPRequest(
-            data=SoapRequestStreamer(stream=io.BytesIO(request_xml_bytes)),
-            full_path="x",
-            headers={},
-            method="POST",
-            api_name=SimplerSoapAPI.GRANTORS,
-            operation_name="GetApplicationZipRequest",
-        )
-        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
-        with patch.object(uuid, "uuid4") as mock_uuid4:
-            mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
-            client = SimplerGrantorsS2SClient(soap_request, db_session)
-            # Directly changing the config value here will change it for other tests
-            # so for safety I use a MagicMock as the operation_config
-            client.operation_config = MagicMock(**client.operation_config.__dict__)
-            client.operation_config.is_mtom = False
-            result = client.get_simpler_soap_response(mock_proxy_response)
-            assert result.data == mock_proxy_response.data
-            assert result.status_code == mock_proxy_response.status_code
-
 
 class TestSimplerSOAPGetSubmissionListExpanded:
     def setup_application_submission(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_schemas.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_schemas.py
@@ -90,7 +90,6 @@ def test_legacy_soap_api_request_raises_error_if_soap_config_privileges_are_none
                 "GetApplicationZipResponse": "ns2",
             },
             privileges=None,
-            is_mtom=True,
         )
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #6667 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add schema for SOAP/Proxy `ConfirmApplicationDelivery`.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
As part of the step of building out the endpoint we need the schemas for the `Request` and `Response` aspect of `ConfirmApplicationDelivery`. The structures can be found [here](https://www.grants.gov/system-to-system/grantor-system-to-system/web-services/confirm-application-delivery).

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] unit tests passing
