### PR TITLE
[Issue #7656] Change auth on agency search endpoint to JWT + User Key Auth

### DIFF
--- a/api/src/api/agencies_v1/agency_routes.py
+++ b/api/src/api/agencies_v1/agency_routes.py
@@ -5,7 +5,7 @@ import src.api.response as response
 from src.adapters import search
 from src.adapters.search import flask_opensearch
 from src.api.agencies_v1.agency_blueprint import agency_blueprint
-from src.auth.multi_auth import api_key_multi_auth, api_key_multi_auth_security_schemes
+from src.auth.multi_auth import jwt_or_user_api_key_multi_auth, jwt_or_user_api_key_security_schemes
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 from src.services.agencies_v1.search_agencies import search_agencies
 from src.util.dict_util import flatten_dict
@@ -59,8 +59,8 @@ examples = {
     examples=examples,
 )
 @agency_blueprint.output(agency_schema.AgencySearchResponseV1Schema)
-@agency_blueprint.doc(security=api_key_multi_auth_security_schemes)
-@api_key_multi_auth.login_required
+@agency_blueprint.doc(security=jwt_or_user_api_key_security_schemes)
+@jwt_or_user_api_key_multi_auth.login_required
 @flask_opensearch.with_search_client()
 def agency_search(
     search_client: search.SearchClient, raw_search_params: dict

--- a/api/tests/src/api/agencies_v1/test_agency_auth.py
+++ b/api/tests/src/api/agencies_v1/test_agency_auth.py
@@ -50,16 +50,14 @@ def get_agency_search_request(
         ("POST", "/v1/agencies/search", get_agency_search_request()),
     ],
 )
-def test_agency_search_unauthorized_401_env_key(client, api_auth_token, method, url, body):
-    """Test agency search endpoint with invalid environment API key (X-Auth header)"""
-    # open is just the generic method that post/get/etc. call under the hood
-    response = client.open(url, method=method, json=body, headers={"X-Auth": "incorrect token"})
+def test_agency_search_unauthorized_401_jwt(client, method, url, body):
+    """Test agency search endpoint with invalid JWT token (X-SGG-Token header)"""
+    response = client.open(
+        url, method=method, json=body, headers={"X-SGG-Token": "invalid-jwt-token"}
+    )
 
     assert response.status_code == 401
-    assert (
-        response.get_json()["message"]
-        == "The server could not verify that you are authorized to access the URL requested"
-    )
+    assert response.get_json()["message"] == "Unable to process token"
 
 
 @pytest.mark.parametrize(

--- a/api/tests/src/api/agencies_v1/test_agency_routes_search.py
+++ b/api/tests/src/api/agencies_v1/test_agency_routes_search.py
@@ -178,9 +178,9 @@ class TestAgencyRoutesSearch(BaseTestClass):
             ),
         ],
     )
-    def test_search_agencies(self, client, api_auth_token, search_request, expected_result):
+    def test_search_agencies(self, client, user_api_key_id, search_request, expected_result):
         resp = client.post(
-            "/v1/agencies/search", json=search_request, headers={"X-Auth": api_auth_token}
+            "/v1/agencies/search", json=search_request, headers={"X-API-Key": user_api_key_id}
         )
         data = resp.json["data"]
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #7656  

## Changes proposed

- Updated agency_routes.py to use `jwt_or_user_api_key_multi_auth`
- Updated test_agency_auth.py to account for auth changes
- Updated test_agency_routes_search.py to account for auth changes

## Context for reviewers

We want to modify our `POST /v1/agencies/search` endpoint to remove the legacy API key auth, we should instead make it support JWT auth + our new api key auth.

## Validation steps

Confirm tests pass and the correct auth method is used in the Swagger docs.