### PR TITLE
[Issue #8020] Run Local E2E Tests On All Merges to Main

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -1,5 +1,15 @@
 name: E2E Tests (Local Github Target)
 on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "api/**"
+      - "frontend/**"
+      - "infra/api/**"
+      - "infra/frontend/**"
+      - "infra/modules/**"
+      - ".github/workflows/ci-frontend-e2e.yml"
   workflow_dispatch:
     inputs:
       api_logs:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #8020  

## Changes proposed

- Updated ci-frontend-e2e.yml to add push trigger for merges to main

## Context for reviewers

Whenever any API, frontend or infrastructure code is merged (pushed, in the parlance of Github Actions) to main, a run of the full E2E test suite against a locally spun up environment in Github Actions should be started in parallel with other CI tasks.
Since deployment jobs are defined on a API vs frontend basis, and we want to run this on all merges that touch either piece of code, but not run duplicate runs when both services are being deployed, it is easiest for now to define this run as a new trigger on the e2e job.

## Validation steps

Confirm that the ci-frontend-e2e job is invoked once whenever any API, frontend or infrastructure code is merged to main.