### PR TITLE
Fix nofos deploy workflow to use nofos-specific pipeline

### DIFF
--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -1,17 +1,14 @@
-name: Deploy nofos
-# Need to set a default value for when the workflow is triggered from a git push
-# which bypasses the default configuration for inputs
-run-name: Deploy ${{ inputs.version || 'main' }} to nofos ${{ inputs.environment || 'dev' }}
+name: Deploy NOFOs
+run-name: Deploy ${{ inputs.version || 'main' }} to NOFOs ${{ inputs.environment }}
 
 on:
-  # !! Uncomment the following lines once you've set up the dev environment and ready to turn on continuous deployment
-  # push:
-  #   branches:
-  #     - "main"
-  #   paths:
-  #     - "nofos/**"
-  #     - "bin/**"
-  #     - "infra/**"
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/*-nofos.yml"
+      - "infra/nofos/**"
+      - "infra/modules/**"
   workflow_dispatch:
     inputs:
       environment:
@@ -21,18 +18,31 @@ on:
         type: choice
         options:
           - dev
-          - staging
+          - training
+          - grantee1
           - prod
       version:
+        description: "git reference to deploy (e.g., a branch, tag, or commit SHA)"
         required: true
         default: "main"
-        description: Tag or branch or SHA to deploy
+        type: string
 
 jobs:
+  checks:
+    name: Checks
+    uses: ./.github/workflows/ci-nofos.yml
+    with:
+      version: ${{ inputs.version || 'main' }}
+
+  vulnerability-scans:
+    name: Vulnerability Scans
+    needs: [checks]
+    uses: ./.github/workflows/vulnerability-scans-nofos.yml
+
   deploy:
     name: Deploy
-    uses: ./.github/workflows/deploy.yml
+    needs: [checks, vulnerability-scans]
+    uses: ./.github/workflows/deploy-nofos.yml
     with:
-      app_name: nofos
       environment: ${{ inputs.environment || 'dev' }}
-      version: ${{ inputs.version || 'main' }}
+      version: ${{ inputs.version || github.ref || 'main' }}


### PR DESCRIPTION
## Summary
- Restores `cd-nofos.yml` to use `deploy-nofos.yml` instead of the generic `deploy.yml`
- PR #8548 replaced the nofos CD workflow with the generic template-infra deploy pipeline, but nofos is an external app without a source directory in this repo
- The generic `build-and-publish.yml` fails with `fatal: ambiguous argument 'nofos': unknown revision or path not in the working tree` because it expects a `nofos/` directory for `git log ... main nofos`
- Restores CI checks (`ci-nofos.yml`) and vulnerability scans (`vulnerability-scans-nofos.yml`) that were also removed
- Restores the original environment options (dev, training, grantee1, prod) and push trigger paths

## Test plan
- [ ] Trigger a manual nofos deploy to dev via workflow_dispatch
- [ ] Verify the deploy completes successfully using `deploy-nofos.yml`

Fixes deploy failure: https://github.com/HHS/simpler-grants-gov/actions/runs/22681433564