### PR TITLE
[Issue #8791] Fix SF-424a PDF output to include entries from Section B

### DIFF
--- a/frontend/src/components/applyForm/FormFields.test.tsx
+++ b/frontend/src/components/applyForm/FormFields.test.tsx
@@ -219,4 +219,45 @@ describe("buildFormTreeRecursive", () => {
     expect(screen.getByTestId("section--field1")).toBeInTheDocument();
     expect(screen.getByTestId("section--field2")).toBeInTheDocument();
   });
+
+  describe("FormFields formContext forwarding", () => {
+    it("forwards formContext to rendered widgets", () => {
+      const schema: RJSFSchema = {
+        type: "object",
+        properties: {
+          example: { type: "string", title: "Example" },
+        },
+      };
+
+      const uiSchema: UiSchema = [
+        {
+          type: "field",
+          definition: "/properties/example",
+        },
+      ];
+
+      const formContext = {
+        rootFormData: { activity_line_items: [{ activity_title: "Test" }] },
+        rootSchema: schema,
+      };
+
+      render(
+        <FormFields
+          errors={null}
+          formData={{ example: "hello" }}
+          schema={schema}
+          uiSchema={uiSchema}
+          formContext={formContext}
+        />,
+      );
+
+      // grab the rendered input
+      const input = screen.getByTestId("example");
+
+      expect(input).toBeInTheDocument();
+
+      // verify that rendering still works with formContext
+      expect(input).toHaveValue("hello");
+    });
+  });
 });

--- a/frontend/src/components/applyForm/PrintForm.tsx
+++ b/frontend/src/components/applyForm/PrintForm.tsx
@@ -29,6 +29,7 @@ export default function PrintForm({
         formData={savedFormData}
         schema={formSchema}
         uiSchema={uiSchema}
+        formContext={{ rootFormData: savedFormData, rootSchema: formSchema }}
       />
     </AttachmentsProvider>
   );


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #8791  

### What was broken

`Budget424aSectionB` expects to read the entire SF-424A root object so it can build the **Section B table** from:

- `activity_line_items[] `(activity columns 1–4)
- `total_budget_categories` (column 5 totals)

Inside the widget we derive the data using:

```
const rootFormDataFromContext =
  (formContext as { rootFormData?: unknown } | undefined)?.rootFormData;
const rawValue: unknown = rootFormDataFromContext ?? value ?? {};
const activityItemsUnknown = get(rawValue as object, "activity_line_items");
```

And they were all returning `undefined` from the Print Page
On the print page (PrintForm → FormFields) was not passing any `formContext` into the widget tree:

```
formContext was undefined
rootFormDataFromContext was undefined
rawValue fell back to value
```

In RJSF widgets, value is only the value at the widget’s field path, not the full form data. In this case, value did not include `activity_line_items` at the top level, so:

```
activityItemsUnknown was undefined
activityItems normalized to []
```

This is why the logs showed nothing and why the table inputs for Section B couldn’t resolve the expected rows/columns.

### Fix

`Pass the root data into formContext from the print page` so the widget can access the root form shape consistently:

```
<FormFields
  errors={null}
  formData={savedFormData}
  schema={formSchema}
  uiSchema={uiSchema}
  formContext={{ rootFormData: savedFormData, rootSchema: formSchema }}
/>
```

I've added some unit tests around context forwarding.

<img width="1723" height="43" alt="Screenshot 2026-03-04 at 1 36 49 PM" src="https://github.com/user-attachments/assets/5c618277-7981-4041-bab1-65524f424f32" />

### Test Steps

- Sign in
- Do a search for `test` and look for `Test Opportunity for SF424A 1.0`
- Fill out the form and save it
- [verify] when you navigate to the print page (http://localhost:3000/print/application/[app_id]/form/[form_id]), that section B is not blank.

### Other Context

The longer more involved fixed will be covered in this this [enhancement ticket](https://github.com/HHS/simpler-grants-gov/issues/8818).