### PR TITLE
[Issue #8813] Test flaky, skip for now

### DIFF
--- a/frontend/tests/e2e/search/search.spec.ts
+++ b/frontend/tests/e2e/search/search.spec.ts
@@ -39,18 +39,15 @@ const categoryCheckboxes = {
   "category-agriculture": "agriculture",
 };
 
-test.describe("Search page tests", () => {
+test.skip("Search page tests", () => {
   // Set all inputs, then refresh the page. Those same inputs should be
   // set from query params.
-  test("should refresh and retain filters in a new tab", async ({
-    page,
-    browserName,
-  }, { project }) => {
+  test("should refresh and retain filters in a new tab", async ({ page }, {
+    project,
+  }) => {
     const isMobile = !!project.name.match(/[Mm]obile/);
     const agencyCheckboxes: { [key: string]: string } = {};
     await page.goto("/search");
-
-    test.skip(browserName === "firefox", "This test is flaky in Firefox");
 
     await waitForSearchResultsInitialLoad(page);
     await fillSearchInputAndSubmit(searchTerm, page, project.name);


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #8813 

## Changes proposed

Skips the test that is randomly failing

## Validation steps

Test "should refresh and retain filters in a new tab" is skipped.
