### PR TITLE
[Issue #8014] Schedule E2E tests to run daily

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -1,8 +1,8 @@
 name: E2E Tests (Deployed Target)
 on:
-  push:
-    branches:
-      - "dschrashun/7973-e2e-ci-staging-refactor"
+  schedule:
+    # Run every day at (6/7am Eastern) before the start of the workday
+    - cron: "0 11 * * *"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #8014 

## Changes proposed

Schedules the E2E Staging job to run daily

## Validation steps
- Lints pass
- After merge, E2E jobs are running every morning.