### PR TITLE
[Issue #8339] Fix Project Abstract XML structure to match legacy Grants.gov format

### DIFF
--- a/api/src/form_schema/forms/project_abstract.py
+++ b/api/src/form_schema/forms/project_abstract.py
@@ -76,7 +76,8 @@ FORM_XML_TRANSFORM_RULES = {
         "attachment_fields": {
             "attachment": {
                 "xml_element": "ProjectAbstractAddAttachment",
-                "type": "single",
+                "type": "single_with_wrapper",
+                "file_element": "AttachedFile",
             },
         },
     },

--- a/api/src/services/xml_generation/transformers/attachment_transformer.py
+++ b/api/src/services/xml_generation/transformers/attachment_transformer.py
@@ -147,6 +147,14 @@ class AttachmentTransformer:
             </AttachmentForm_1_2:ATT1File>
         </AttachmentForm_1_2:ATT1>
 
+        When 'file_element' is set in field_config, that name is used instead of '{element_name}File':
+        <Project_Abstract_1_2:ProjectAbstractAddAttachment>
+            <Project_Abstract_1_2:AttachedFile>
+                <att:FileName>...</att:FileName>
+                ...
+            </Project_Abstract_1_2:AttachedFile>
+        </Project_Abstract_1_2:ProjectAbstractAddAttachment>
+
         Example structure without wrapper (type='single'):
         <att:FileName>...</att:FileName>
         <att:MimeType>...</att:MimeType>
@@ -157,28 +165,30 @@ class AttachmentTransformer:
             element_name: Name of the attachment element (e.g., "ATT1")
             attachment_data: Attachment data dictionary
             nsmap: Namespace map
-            field_config: Field configuration containing type information
+            field_config: Field configuration containing type and optional file_element
         """
         # Check if this field requires wrapper elements based on configuration
         uses_wrapper = field_config and field_config.get("type") == "single_with_wrapper"
 
         if uses_wrapper:
-            # Get the default namespace from nsmap
-            default_ns = None
-            for _, uri in nsmap.items():
-                # Look for any namespace in the nsmap (first one is typically the default)
-                if not default_ns:
-                    default_ns = uri
+            # Determine inner element name: config override or default to '{element_name}File'
+            file_element_name = (
+                field_config.get("file_element", f"{element_name}File")
+                if field_config
+                else f"{element_name}File"
+            )
+
+            default_ns = next(iter(nsmap.values()), None) if nsmap else None
 
             # Create the wrapper element (e.g., <ATT1>) in the default namespace
             if default_ns:
                 attachment_elem = lxml_etree.SubElement(parent, f"{{{default_ns}}}{element_name}")
                 file_elem = lxml_etree.SubElement(
-                    attachment_elem, f"{{{default_ns}}}{element_name}File"
+                    attachment_elem, f"{{{default_ns}}}{file_element_name}"
                 )
             else:
                 attachment_elem = lxml_etree.SubElement(parent, element_name)
-                file_elem = lxml_etree.SubElement(attachment_elem, f"{element_name}File")
+                file_elem = lxml_etree.SubElement(attachment_elem, file_element_name)
 
             # Populate the File element with attachment content
             self._populate_attachment_content(file_elem, attachment_data, nsmap)

--- a/api/src/services/xml_generation/validation/test_cases.py
+++ b/api/src/services/xml_generation/validation/test_cases.py
@@ -1772,6 +1772,29 @@ EPA_KEY_CONTACTS_TEST_CASES = [
 ]
 
 
+# Sample test cases for Project Abstract v1.2 validation
+PROJECT_ABSTRACT_TEST_CASES = [
+    {
+        "name": "project_abstract_with_attachment",
+        "json_input": {
+            "attachment": "11111111-1111-1111-1111-111111111111",
+        },
+        "form_name": "Project_Abstract",
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/Project_Abstract_1_2-V1.2.xsd",
+        "pretty_print": True,
+        "attachment_mapping": {
+            "11111111-1111-1111-1111-111111111111": {
+                "FileName": "project_abstract.pdf",
+                "MimeType": "application/pdf",
+                "FileLocation": "project_abstract.pdf",
+                "HashValue": "aeB1+6gdFwih51ijIRn3b8QYn24=",
+                "HashAlgorithm": "SHA-1",
+            }
+        },
+    },
+]
+
+
 def get_all_test_cases() -> list[dict[str, Any]]:
     """Get all available test cases.
 
@@ -1786,6 +1809,7 @@ def get_all_test_cases() -> list[dict[str, Any]]:
         + CD511_TEST_CASES
         + GG_LOBBYING_FORM_TEST_CASES
         + PROJECT_ABSTRACT_SUMMARY_TEST_CASES
+        + PROJECT_ABSTRACT_TEST_CASES
         + EPA4700_4_TEST_CASES
         + EPA_KEY_CONTACTS_TEST_CASES
         + ATTACHMENTFORM_TEST_CASES

--- a/api/tests/src/services/xml_generation/test_attachment_transformer.py
+++ b/api/tests/src/services/xml_generation/test_attachment_transformer.py
@@ -78,7 +78,11 @@ class TestAttachmentTransformer:
         assert custom_transformer.attachment_namespace == "http://custom.namespace"
 
     def test_add_single_attachment_element(self):
-        """Test adding a single attachment element."""
+        """Test adding a single attachment element.
+
+        type='single' adds content directly to the parent — no wrapper element is created.
+        All attachment fields use the att: and glob: namespace prefixes.
+        """
         root = lxml_etree.Element("TestRoot", nsmap=self.nsmap)
 
         attachment_data = {
@@ -95,15 +99,19 @@ class TestAttachmentTransformer:
             root, "AreasAffected", attachment_data, self.nsmap
         )
 
-        # Verify XML structure
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
+        glob_ns = "http://apply.grants.gov/system/Global-V1.0"
 
-        assert "<AreasAffected>" in xml_string
-        assert "<FileName>test_document.pdf</FileName>" in xml_string
-        assert "<MimeType>application/pdf</MimeType>" in xml_string
-        assert 'href="./attachments/test_document.pdf"' in xml_string
-        assert 'hashAlgorithm="SHA-1"' in xml_string
-        assert "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Q=" in xml_string
+        # type='single' adds content directly to root — no <AreasAffected> wrapper
+        assert root.find(f"{{{att_ns}}}FileName").text == "test_document.pdf"
+        assert root.find(f"{{{att_ns}}}MimeType").text == "application/pdf"
+        assert (
+            root.find(f"{{{att_ns}}}FileLocation").get(f"{{{att_ns}}}href")
+            == "./attachments/test_document.pdf"
+        )
+        hash_val = root.find(f"{{{glob_ns}}}HashValue")
+        assert hash_val.get(f"{{{glob_ns}}}hashAlgorithm") == "SHA-1"
+        assert hash_val.text == "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Q="
 
     def test_add_multiple_attachment_element(self):
         """Test adding a multiple attachment element."""
@@ -130,14 +138,15 @@ class TestAttachmentTransformer:
             root, "AdditionalProjectTitle", attachment_data, self.nsmap
         )
 
-        # Verify XML structure
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
 
-        assert "<AdditionalProjectTitle>" in xml_string
-        assert xml_string.count("<AttachedFile>") == 2
-        assert "<FileName>document1.pdf</FileName>" in xml_string
-        assert "<FileName>document2.xlsx</FileName>" in xml_string
-        assert "spreadsheetml.sheet" in xml_string
+        group = root.find("AdditionalProjectTitle")
+        assert group is not None
+        attached_files = group.findall("AttachedFile")
+        assert len(attached_files) == 2
+        assert attached_files[0].find(f"{{{att_ns}}}FileName").text == "document1.pdf"
+        assert attached_files[1].find(f"{{{att_ns}}}FileName").text == "document2.xlsx"
+        assert "spreadsheetml.sheet" in attached_files[1].find(f"{{{att_ns}}}MimeType").text
 
     def test_add_multiple_attachment_element_single_file(self):
         """Test adding multiple attachment element with single file."""
@@ -156,11 +165,13 @@ class TestAttachmentTransformer:
             root, "AdditionalProjectTitle", attachment_data, self.nsmap
         )
 
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
 
-        assert "<AdditionalProjectTitle>" in xml_string
-        assert xml_string.count("<AttachedFile>") == 1
-        assert "<FileName>single_document.pdf</FileName>" in xml_string
+        group = root.find("AdditionalProjectTitle")
+        assert group is not None
+        attached_files = group.findall("AttachedFile")
+        assert len(attached_files) == 1
+        assert attached_files[0].find(f"{{{att_ns}}}FileName").text == "single_document.pdf"
 
     def test_add_multiple_attachment_element_direct_list(self):
         """Test adding multiple attachment element with direct list."""
@@ -185,11 +196,13 @@ class TestAttachmentTransformer:
             root, "AdditionalProjectTitle", attachment_data, self.nsmap
         )
 
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
 
-        assert xml_string.count("<AttachedFile>") == 2
-        assert "<FileName>list_document1.pdf</FileName>" in xml_string
-        assert "<FileName>list_document2.docx</FileName>" in xml_string
+        group = root.find("AdditionalProjectTitle")
+        attached_files = group.findall("AttachedFile")
+        assert len(attached_files) == 2
+        assert attached_files[0].find(f"{{{att_ns}}}FileName").text == "list_document1.pdf"
+        assert attached_files[1].find(f"{{{att_ns}}}FileName").text == "list_document2.docx"
 
     def test_populate_attachment_content_complete(self):
         """Test populating complete attachment content."""
@@ -204,16 +217,18 @@ class TestAttachmentTransformer:
 
         self.transformer._populate_attachment_content(root, attachment_data, self.nsmap)
 
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
+        glob_ns = "http://apply.grants.gov/system/Global-V1.0"
 
-        # Verify all elements are present
-        assert "<FileName>complete_test.pdf</FileName>" in xml_string
-        assert "<MimeType>application/pdf</MimeType>" in xml_string
+        assert root.find(f"{{{att_ns}}}FileName").text == "complete_test.pdf"
+        assert root.find(f"{{{att_ns}}}MimeType").text == "application/pdf"
         assert (
-            "<FileLocation" in xml_string and 'href="./attachments/complete_test.pdf"' in xml_string
+            root.find(f"{{{att_ns}}}FileLocation").get(f"{{{att_ns}}}href")
+            == "./attachments/complete_test.pdf"
         )
-        assert "<HashValue" in xml_string and 'hashAlgorithm="SHA-1"' in xml_string
-        assert "Y29tcGxldGV0ZXN0aGFzaA==" in xml_string
+        hash_val = root.find(f"{{{glob_ns}}}HashValue")
+        assert hash_val.get(f"{{{glob_ns}}}hashAlgorithm") == "SHA-1"
+        assert hash_val.text == "Y29tcGxldGV0ZXN0aGFzaA=="
 
     def test_populate_attachment_content_string_file_location(self):
         """Test populating attachment content with string file location."""
@@ -247,13 +262,16 @@ class TestAttachmentTransformer:
 
         self.transformer._populate_attachment_content(root, attachment_data, self.nsmap)
 
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
+        glob_ns = "http://apply.grants.gov/system/Global-V1.0"
 
-        # Should only contain provided fields
-        assert "<FileName>partial_test.pdf</FileName>" in xml_string
-        assert "<MimeType>" not in xml_string
-        assert 'href="./attachments/partial_test.pdf"' in xml_string
-        assert "<HashValue>" not in xml_string
+        assert root.find(f"{{{att_ns}}}FileName").text == "partial_test.pdf"
+        assert root.find(f"{{{att_ns}}}MimeType") is None
+        assert (
+            root.find(f"{{{att_ns}}}FileLocation").get(f"{{{att_ns}}}href")
+            == "./attachments/partial_test.pdf"
+        )
+        assert root.find(f"{{{glob_ns}}}HashValue") is None
 
     def test_populate_attachment_content_invalid_data(self):
         """Test populating attachment content with invalid data."""
@@ -280,14 +298,19 @@ class TestAttachmentTransformer:
 
         self.transformer.add_attachment_elements(root, data, self.nsmap)
 
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
+        glob_ns = "http://apply.grants.gov/system/Global-V1.0"
 
-        assert "<AreasAffected>" in xml_string
-        assert "<FileName>test_document.pdf</FileName>" in xml_string
-        assert "<MimeType>application/pdf</MimeType>" in xml_string
-        assert 'href="./attachments/test_document.pdf"' in xml_string
-        assert 'hashAlgorithm="SHA-1"' in xml_string
-        assert "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Q=" in xml_string
+        # type='single' adds content directly to root — no <AreasAffected> wrapper
+        assert root.find(f"{{{att_ns}}}FileName").text == "test_document.pdf"
+        assert root.find(f"{{{att_ns}}}MimeType").text == "application/pdf"
+        assert (
+            root.find(f"{{{att_ns}}}FileLocation").get(f"{{{att_ns}}}href")
+            == "./attachments/test_document.pdf"
+        )
+        hash_val = root.find(f"{{{glob_ns}}}HashValue")
+        assert hash_val.get(f"{{{glob_ns}}}hashAlgorithm") == "SHA-1"
+        assert hash_val.text == "aGVsbG8gd29ybGQgdGhpcyBpcyBhIHRlc3Q="
 
     def test_uuid_based_multiple_attachments(self):
         """Test adding multiple attachments using UUIDs."""
@@ -298,13 +321,15 @@ class TestAttachmentTransformer:
 
         self.transformer.add_attachment_elements(root, data, self.nsmap)
 
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
 
-        assert "<AdditionalProjectTitle>" in xml_string
-        assert xml_string.count("<AttachedFile>") == 2
-        assert "<FileName>document1.pdf</FileName>" in xml_string
-        assert "<FileName>document2.xlsx</FileName>" in xml_string
-        assert "spreadsheetml.sheet" in xml_string
+        group = root.find("AdditionalProjectTitle")
+        assert group is not None
+        attached_files = group.findall("AttachedFile")
+        assert len(attached_files) == 2
+        assert attached_files[0].find(f"{{{att_ns}}}FileName").text == "document1.pdf"
+        assert attached_files[1].find(f"{{{att_ns}}}FileName").text == "document2.xlsx"
+        assert "spreadsheetml.sheet" in attached_files[1].find(f"{{{att_ns}}}MimeType").text
 
     def test_uuid_not_found_error(self):
         """Test error when UUID not found in mapping."""
@@ -345,17 +370,19 @@ class TestAttachmentTransformer:
 
         self.transformer.add_attachment_elements(root, data, self.nsmap)
 
-        xml_string = lxml_etree.tostring(root, encoding="unicode", pretty_print=True)
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
 
-        # Check single attachment
-        assert "<DebtExplanation>" in xml_string
-        assert "<FileName>test_document.pdf</FileName>" in xml_string
+        # type='single': content added directly to root, no <DebtExplanation> wrapper
+        filenames = root.findall(f"{{{att_ns}}}FileName")
+        assert any(f.text == "test_document.pdf" for f in filenames)
 
-        # Check multiple attachments
-        assert "<AdditionalProjectTitle>" in xml_string
-        assert xml_string.count("<AttachedFile>") == 2
-        assert "<FileName>document1.pdf</FileName>" in xml_string
-        assert "<FileName>document2.xlsx</FileName>" in xml_string
+        # type='multiple': wrapped in <AdditionalProjectTitle>
+        group = root.find("AdditionalProjectTitle")
+        assert group is not None
+        attached_files = group.findall("AttachedFile")
+        assert len(attached_files) == 2
+        assert attached_files[0].find(f"{{{att_ns}}}FileName").text == "document1.pdf"
+        assert attached_files[1].find(f"{{{att_ns}}}FileName").text == "document2.xlsx"
 
     def test_no_attachments_in_data(self):
         """Test handling when no attachments are in the data."""
@@ -371,3 +398,69 @@ class TestAttachmentTransformer:
         assert "AreasAffected" not in xml_string
         assert "DebtExplanation" not in xml_string
         assert "AdditionalProjectTitle" not in xml_string
+
+    def test_single_with_wrapper_custom_file_element(self):
+        """single_with_wrapper with file_element override uses the given inner element name."""
+        form_ns = "http://apply.grants.gov/forms/Project_Abstract_1_2-V1.2"
+        nsmap = {
+            "Project_Abstract_1_2": form_ns,
+            "att": "http://apply.grants.gov/system/Attachments-V1.0",
+            "glob": "http://apply.grants.gov/system/Global-V1.0",
+        }
+        root = lxml_etree.Element(f"{{{form_ns}}}Project_Abstract_1_2", nsmap=nsmap)
+
+        attachment_data = {
+            "FileName": "abstract.pdf",
+            "MimeType": "application/pdf",
+            "FileLocation": {"@href": "abstract.pdf"},
+            "HashValue": {"@hashAlgorithm": "SHA-1", "#text": "aeB1+6gdFwih51ijIRn3b8QYn24="},
+        }
+        field_config = {"type": "single_with_wrapper", "file_element": "AttachedFile"}
+
+        transformer = AttachmentTransformer()
+        transformer._add_single_attachment_element(
+            root, "ProjectAbstractAddAttachment", attachment_data, nsmap, field_config
+        )
+
+        # Both wrapper elements must be in the form's namespace
+        outer = root.find(f"{{{form_ns}}}ProjectAbstractAddAttachment")
+        assert outer is not None, "ProjectAbstractAddAttachment missing"
+
+        inner = outer.find(f"{{{form_ns}}}AttachedFile")
+        assert inner is not None, "AttachedFile missing"
+
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
+        assert inner.find(f"{{{att_ns}}}FileName").text == "abstract.pdf"
+        assert inner.find(f"{{{att_ns}}}MimeType").text == "application/pdf"
+        assert inner.find(f"{{{att_ns}}}FileLocation").get(f"{{{att_ns}}}href") == "abstract.pdf"
+
+    def test_single_with_wrapper_file_element_via_add_attachment_elements(self):
+        """add_attachment_elements uses file_element override when present in field config."""
+        form_ns = "http://apply.grants.gov/forms/Project_Abstract_1_2-V1.2"
+        att_uuid = str(self.uuid1)
+        field_config = {
+            "attachment": {
+                "xml_element": "ProjectAbstractAddAttachment",
+                "type": "single_with_wrapper",
+                "file_element": "AttachedFile",
+            }
+        }
+        nsmap = {
+            "Project_Abstract_1_2": form_ns,
+            "att": "http://apply.grants.gov/system/Attachments-V1.0",
+            "glob": "http://apply.grants.gov/system/Global-V1.0",
+        }
+        root = lxml_etree.Element(f"{{{form_ns}}}Project_Abstract_1_2", nsmap=nsmap)
+        transformer = AttachmentTransformer(
+            attachment_mapping=self.attachment_mapping,
+            attachment_field_config=field_config,
+        )
+
+        transformer.add_attachment_elements(root, {"attachment": att_uuid}, nsmap)
+
+        outer = root.find(f"{{{form_ns}}}ProjectAbstractAddAttachment")
+        assert outer is not None
+        inner = outer.find(f"{{{form_ns}}}AttachedFile")
+        assert inner is not None
+        att_ns = "http://apply.grants.gov/system/Attachments-V1.0"
+        assert inner.find(f"{{{att_ns}}}FileName").text == "test_document.pdf"

--- a/api/tests/src/services/xml_generation/test_project_abstract_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_abstract_xml_generation.py
@@ -1,0 +1,209 @@
+"""Tests for Project Abstract v1.2 form XML generation.
+
+Verifies the generated XML matches the structure required by the XSD
+
+XSD reference: https://apply07.grants.gov/apply/forms/schemas/Project_Abstract_1_2-V1.2.xsd
+"""
+
+from lxml import etree as lxml_etree
+
+from src.form_schema.forms.project_abstract import (
+    FORM_XML_TRANSFORM_RULES as PROJECT_ABSTRACT_TRANSFORM_RULES,
+)
+from src.services.xml_generation.models import XMLGenerationRequest
+from src.services.xml_generation.service import XMLGenerationService
+from src.services.xml_generation.utils.attachment_mapping import AttachmentInfo
+
+FORM_NS = "http://apply.grants.gov/forms/Project_Abstract_1_2-V1.2"
+ATT_NS = "http://apply.grants.gov/system/Attachments-V1.0"
+GLOB_NS = "http://apply.grants.gov/system/Global-V1.0"
+
+ATTACHMENT_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+ATTACHMENT_INFO = AttachmentInfo(
+    filename="project_abstract.pdf",
+    mime_type="application/pdf",
+    file_location="project_abstract.pdf",
+    hash_value="aeB1+6gdFwih51ijIRn3b8QYn24=",
+)
+
+
+def _generate(attachment_uuid: str = ATTACHMENT_UUID, attachment_info: AttachmentInfo = ATTACHMENT_INFO):  # type: ignore[assignment]
+    service = XMLGenerationService()
+    request = XMLGenerationRequest(
+        application_data={"attachment": attachment_uuid},
+        transform_config=PROJECT_ABSTRACT_TRANSFORM_RULES,
+        attachment_mapping={attachment_uuid: attachment_info},
+    )
+    response = service.generate_xml(request)
+    assert response.success, f"XML generation failed: {response.error_message}"
+    return response.xml_data
+
+
+class TestProjectAbstractXMLStructure:
+    """Verify the wrapper element hierarchy matches the XSD sequence."""
+
+    def test_root_element_is_form_namespace(self):
+        xml_data = _generate()
+        root = lxml_etree.fromstring(xml_data.encode())
+        assert root.tag == f"{{{FORM_NS}}}Project_Abstract_1_2"
+
+    def test_form_version_attribute(self):
+        xml_data = _generate()
+        root = lxml_etree.fromstring(xml_data.encode())
+        assert root.get(f"{{{FORM_NS}}}FormVersion") == "1.2"
+
+    def test_project_abstract_add_attachment_wrapper_present(self):
+        """XSD requires ProjectAbstractAddAttachment as direct child of root."""
+        xml_data = _generate()
+        root = lxml_etree.fromstring(xml_data.encode())
+        wrapper = root.find(f"{{{FORM_NS}}}ProjectAbstractAddAttachment")
+        assert wrapper is not None, "Missing ProjectAbstractAddAttachment element"
+
+    def test_attached_file_wrapper_present(self):
+        """XSD requires AttachedFile nested inside ProjectAbstractAddAttachment."""
+        xml_data = _generate()
+        root = lxml_etree.fromstring(xml_data.encode())
+        wrapper = root.find(f"{{{FORM_NS}}}ProjectAbstractAddAttachment")
+        attached_file = wrapper.find(f"{{{FORM_NS}}}AttachedFile")
+        assert attached_file is not None, "Missing AttachedFile element"
+
+    def test_attachment_content_is_not_direct_child_of_root(self):
+        """att:FileName must NOT appear as a direct child of the root form element."""
+        xml_data = _generate()
+        root = lxml_etree.fromstring(xml_data.encode())
+        # Direct child search (not recursive) must find nothing
+        direct_filename = root.find(f"{{{ATT_NS}}}FileName")
+        assert direct_filename is None, "att:FileName must be nested, not a direct child of root"
+
+
+class TestProjectAbstractXMLContent:
+    """Verify attachment field values are serialised correctly."""
+
+    def _get_attached_file(self, xml_data: str) -> lxml_etree._Element:
+        root = lxml_etree.fromstring(xml_data.encode())
+        wrapper = root.find(f"{{{FORM_NS}}}ProjectAbstractAddAttachment")
+        return wrapper.find(f"{{{FORM_NS}}}AttachedFile")
+
+    def test_filename_element(self):
+        xml_data = _generate()
+        attached_file = self._get_attached_file(xml_data)
+        filename_elem = attached_file.find(f"{{{ATT_NS}}}FileName")
+        assert filename_elem is not None
+        assert filename_elem.text == "project_abstract.pdf"
+
+    def test_mime_type_element(self):
+        xml_data = _generate()
+        attached_file = self._get_attached_file(xml_data)
+        mime_elem = attached_file.find(f"{{{ATT_NS}}}MimeType")
+        assert mime_elem is not None
+        assert mime_elem.text == "application/pdf"
+
+    def test_file_location_href(self):
+        xml_data = _generate()
+        attached_file = self._get_attached_file(xml_data)
+        loc_elem = attached_file.find(f"{{{ATT_NS}}}FileLocation")
+        assert loc_elem is not None
+        assert loc_elem.get(f"{{{ATT_NS}}}href") == "project_abstract.pdf"
+
+    def test_hash_value_element(self):
+        xml_data = _generate()
+        attached_file = self._get_attached_file(xml_data)
+        hash_elem = attached_file.find(f"{{{GLOB_NS}}}HashValue")
+        assert hash_elem is not None
+        assert hash_elem.get(f"{{{GLOB_NS}}}hashAlgorithm") == "SHA-1"
+        assert hash_elem.text == "aeB1+6gdFwih51ijIRn3b8QYn24="
+
+    def test_different_attachment_filename(self):
+        info = AttachmentInfo(
+            filename="my_abstract.docx",
+            mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            file_location="my_abstract.docx",
+            hash_value="abc123=",
+        )
+        xml_data = _generate(attachment_info=info)
+        attached_file = self._get_attached_file(xml_data)
+        assert attached_file.find(f"{{{ATT_NS}}}FileName").text == "my_abstract.docx"
+        assert "wordprocessingml" in attached_file.find(f"{{{ATT_NS}}}MimeType").text
+
+
+class TestProjectAbstractLegacyParity:
+    """Verify structural parity with the legacy Grants.gov XML format.
+
+    Legacy XML (from GrantApplication.xml downloaded from Grants.gov):
+
+        <Project_Abstract_1_2:Project_Abstract_1_2
+            xmlns:att="http://apply.grants.gov/system/Attachments-V1.0"
+            xmlns:glob="http://apply.grants.gov/system/Global-V1.0"
+            xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0"
+            Project_Abstract_1_2:FormVersion="1.2"
+            xmlns:Project_Abstract_1_2="http://apply.grants.gov/forms/Project_Abstract_1_2-V1.2">
+          <Project_Abstract_1_2:ProjectAbstractAddAttachment>
+            <Project_Abstract_1_2:AttachedFile>
+              <att:FileName>1234-PDF_TestPage.pdf</att:FileName>
+              <att:MimeType>application/pdf</att:MimeType>
+              <att:FileLocation att:href="347514.Project_Abstract_1_2_P1.mandatoryFile0"/>
+              <glob:HashValue glob:hashAlgorithm="SHA-1">aeB1+6gdFwih51ijIRn3b8QYn24=</glob:HashValue>
+            </Project_Abstract_1_2:AttachedFile>
+          </Project_Abstract_1_2:ProjectAbstractAddAttachment>
+        </Project_Abstract_1_2:Project_Abstract_1_2>
+
+    Previously, the simpler output placed att:FileName etc. as direct children of the root
+    element (missing both wrapper elements), which failed XSD validation.
+    """
+
+    def _parse(self, xml_data: str) -> lxml_etree._Element:
+        return lxml_etree.fromstring(xml_data.encode())
+
+    def test_element_hierarchy_matches_legacy(self):
+        """Generated XML must have the same three-level element hierarchy as legacy output."""
+        root = self._parse(_generate())
+
+        # Level 1: root is the form element
+        assert root.tag == f"{{{FORM_NS}}}Project_Abstract_1_2"
+
+        # Level 2: ProjectAbstractAddAttachment is a direct child of root (form namespace)
+        wrapper = root.find(f"{{{FORM_NS}}}ProjectAbstractAddAttachment")
+        assert wrapper is not None, "Missing ProjectAbstractAddAttachment (legacy level-2 wrapper)"
+
+        # Level 3: AttachedFile is a direct child of the wrapper (form namespace)
+        attached_file = wrapper.find(f"{{{FORM_NS}}}AttachedFile")
+        assert attached_file is not None, "Missing AttachedFile (legacy level-3 wrapper)"
+
+        # Content elements live inside AttachedFile, not on root
+        assert attached_file.find(f"{{{ATT_NS}}}FileName") is not None
+        assert attached_file.find(f"{{{ATT_NS}}}MimeType") is not None
+        assert attached_file.find(f"{{{ATT_NS}}}FileLocation") is not None
+        assert attached_file.find(f"{{{GLOB_NS}}}HashValue") is not None
+
+    def test_content_not_on_root_as_in_previous_simpler_output(self):
+        """Regression: previous simpler output placed att:FileName directly on root.
+
+        The legacy Grants.gov format wraps content in ProjectAbstractAddAttachment >
+        AttachedFile. Any direct child of root with the att: or glob: namespace is
+        a sign of the old broken structure.
+        """
+        root = self._parse(_generate())
+
+        assert (
+            root.find(f"{{{ATT_NS}}}FileName") is None
+        ), "att:FileName must not be a direct child of root (regression: pre-fix simpler output)"
+        assert root.find(f"{{{ATT_NS}}}MimeType") is None
+        assert root.find(f"{{{ATT_NS}}}FileLocation") is None
+        assert root.find(f"{{{GLOB_NS}}}HashValue") is None
+
+    def test_wrapper_elements_use_form_namespace_not_att_namespace(self):
+        """Legacy uses the form namespace for wrapper elements, not att: or no namespace."""
+        root = self._parse(_generate())
+
+        # Wrappers must be in the form namespace
+        assert root.find(f"{{{FORM_NS}}}ProjectAbstractAddAttachment") is not None
+        assert (
+            root.find(f"{{{FORM_NS}}}ProjectAbstractAddAttachment").find(
+                f"{{{FORM_NS}}}AttachedFile"
+            )
+            is not None
+        )
+
+        # Must not exist without the form namespace prefix
+        assert root.find("ProjectAbstractAddAttachment") is None
+        assert root.find("AttachedFile") is None


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8339

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Fixed `Project_Abstract_1_2` XML output to match Legacy format
Added `TestProjectAbstractLegacyParity` CI tests
Added Project Abstract test case to the CLI XSD validation suite (`make test-xml-validation form=Project_Abstract`)
Fixed 9 pre-existing broken tests in `test_attachment_transformer.py` — assertions used unprefixed tag strings (<FileName>) but the XML uses namespace prefixes (<att:FileName>); switched to lxml find() with full namespace URIs.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Attachment content was being placed as direct children of the root form element, missing the required ProjectAbstractAddAttachment → AttachedFile wrapper hierarchy mandated by the XSD
CLI Tests that were fixed were not being run as part of CI/CD regularly, and there is a broader ticket to address other CLI tests to all pass.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See new unit tests which pass in CI/CD.
For CLI XSD verification tests: `make fetch-xsds form=Project_Abstract && make test-xml-validation form=Project_Abstract`