### PR TITLE
[Issue #8918] SF-424a: Section B not fitting in print screen view

### DIFF
--- a/frontend/src/components/applyForm/widgets/budget/Budget424aSectionA.tsx
+++ b/frontend/src/components/applyForm/widgets/budget/Budget424aSectionA.tsx
@@ -245,7 +245,7 @@ function Budget424aSectionA<
                     {row + 1}.
                   </span>
                   <div className="margin-top-05 padding-top-0">
-                    <div className="sf424a-screen-only">
+                    <div className="sf424a-application-view-only">
                       <TextWidget
                         schema={activityTitleSchema}
                         id={`activity_line_items[${row}]--activity_title`}
@@ -266,7 +266,7 @@ function Budget424aSectionA<
                     due to the unpredictability of what the activity names may be, 
                     it might get cut off and impossible to read.
                     */}
-                    <div className="sf424a-print-only sf424a-section-a__activity-print-value">
+                    <div className="sf424a-print-only-view sf424a-section-a__activity-print-value">
                       {getItemVal(row, "activity_title") || "—"}
                     </div>
                   </div>
@@ -277,7 +277,7 @@ function Budget424aSectionA<
               <DataCell className="sf424a-section-a__assistance-cell">
                 <div className="display-flex flex-align-end">
                   <div className="margin-top-05 padding-top-0">
-                    <div className="sf424a-screen-only">
+                    <div className="sf424a-application-view-only">
                       <TextWidget
                         schema={assistanceListingNumberSchema}
                         id={`activity_line_items[${row}]--assistance_listing_number`}
@@ -292,8 +292,12 @@ function Budget424aSectionA<
                       />
                     </div>
 
-                    {/* Print only value - see comment above */}
-                    <div className="sf424a-print-only sf424a-section-a__activity-print-value">
+                    {/* 
+                    Print only value - we hide the input only for print and show the value here- 
+                    due to the unpredictability of what the activity names may be, 
+                    it might get cut off and impossible to read.
+                    */}
+                    <div className="sf424a-print-only-view sf424a-section-a__activity-print-value">
                       {getItemVal(row, "assistance_listing_number") || "—"}
                     </div>
                   </div>

--- a/frontend/src/components/applyForm/widgets/budget/Budget424aSectionB.tsx
+++ b/frontend/src/components/applyForm/widgets/budget/Budget424aSectionB.tsx
@@ -276,7 +276,7 @@ function Budget424aSectionB<
                   );
                 })}
 
-                <td className="sf424a__equals-cell border-bottom-0 border-top-0 verticle-align-bottom">
+                <td className="sf424a__equal-sign-wrapper-cell border-bottom-0 border-top-0 verticle-align-bottom">
                   <div className="display-flex flex-column">=</div>
                 </td>
 

--- a/frontend/src/components/applyForm/widgets/budget/Budget424aSectionC.tsx
+++ b/frontend/src/components/applyForm/widgets/budget/Budget424aSectionC.tsx
@@ -320,7 +320,7 @@ function Budget424aSectionC<
 
               {/* Visual equals column */}
               <td
-                className="sf424a__equals-cell border-bottom-0 border-top-0 verticle-align-bottom"
+                className="sf424a__equal-sign-wrapper-cell border-bottom-0 border-top-0 verticle-align-bottom"
                 aria-hidden="true"
               >
                 =

--- a/frontend/src/components/applyForm/widgets/budget/Budget424aSectionD.tsx
+++ b/frontend/src/components/applyForm/widgets/budget/Budget424aSectionD.tsx
@@ -222,7 +222,7 @@ function Budget424aSectionD<
                   {/* "=" for row 1 & 2, empty for row 3 (totals) */}
                   {quarterIndex === 3 && (
                     <td
-                      className="sf424a__equals-cell border-bottom-0 border-top-0 verticle-align-bottom text-center text-bold"
+                      className="sf424a__equal-sign-wrapper-cell border-bottom-0 border-top-0 verticle-align-bottom text-center text-bold"
                       aria-hidden="true"
                     >
                       {rowIndex < 2 ? "=" : ""}

--- a/frontend/src/components/applyForm/widgets/budget/Budget424aSectionE.tsx
+++ b/frontend/src/components/applyForm/widgets/budget/Budget424aSectionE.tsx
@@ -256,7 +256,7 @@ function Budget424aSectionE<
         <tbody>
           {ACTIVITY_ITEMS.map((rowIndex) => (
             <tr key={`row-${rowIndex}`} className="sf424a__row">
-              <td className="sf424a__equals-cell border-bottom-0 border-top-0 verticle-align-bottom">
+              <td className="sf424a__equal-sign-wrapper-cell border-bottom-0 border-top-0 verticle-align-bottom">
                 {rowIndex + 16}.
               </td>
 

--- a/frontend/src/components/applyForm/widgets/budget/budgetUiComponents.tsx
+++ b/frontend/src/components/applyForm/widgets/budget/budgetUiComponents.tsx
@@ -209,7 +209,7 @@ export function ActivityTitlesRow({
         return (
           <td
             key={`occ-title-${columnIndex}`}
-            className="sf424a__equals-cell padding-05 border-bottom-0 border-top-0 verticle-align-bottom"
+            className="sf424a__equal-sign-wrapper-cell padding-05 border-bottom-0 border-top-0 verticle-align-bottom"
           >
             <div className="minw-15 font-sans-sm text-italic text-center">
               {displayText}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -748,16 +748,16 @@ dl {
 
 // Print Styles
 // SF424-A
-.sf424a-print-only {
+.sf424a-print-only-view {
   display: none;
 }
 
 @media print {
-  .sf424a-screen-only {
+  .sf424a-application-view-only {
     display: none !important;
   }
 
-  .sf424a-print-only {
+  .sf424a-print-only-view {
     display: block !important;
   }
 
@@ -854,13 +854,13 @@ dl {
     box-sizing: border-box;
   }
 
-  .sf424a__equals-cell {
+  .sf424a__equal-sign-wrapper-cell {
     width: 16px !important;
     padding: 0 2px !important;
     vertical-align: middle !important;
   }
 
-  .sf424a__equals {
+  .sf424a__equal-sign-wrapper {
     display: block !important;
     text-align: center !important;
     line-height: 1 !important;


### PR DESCRIPTION
## Summary

Fixes Work for #8918  

## Changes proposed

- added classes `sf424a__equals-cell`,  to:
  - Budget424aSectionA.tsx
  - Budget424aSectionB.tsx
  - Budget424aSectionC.tsx
  - Budget424aSectionD.tsx
  - Budget424aSectionE.tsx
  - budgetUiComponents.tsx

added
```
<div className="sf424a-print-only sf424a-section-a__activity-print-value">
  {getItemVal(row, "activity_title") || "—"}
</div>
```

and

```
<div className="sf424a-print-only sf424a-section-a__activity-print-value">
 {getItemVal(row, "assistance_listing_number") || "—"}
</div>
```

to hide the input during print preview (actual printing)

## Context for reviewers

Section B needs to fit in the print view screen and resulting PDF generated.
As seen in this screenshot, the column 5 in section B is getting cut off:

<img width="902" height="477" alt="a" src="https://github.com/user-attachments/assets/1d2690d6-ae7a-46da-904e-6f064ddf6454" />

---
[doc-590830351.pdf](https://github.com/user-attachments/files/25850215/doc-590830351.pdf)

the updated styles look like this:

[Budget Information for Non-Construction Programs (SF-424A).pdf](https://github.com/user-attachments/files/25849768/Budget.Information.for.Non-Construction.Programs.SF-424A.pdf)

below is the doc raptor example
[doc-590830351.pdf](https://github.com/user-attachments/files/25850215/doc-590830351.pdf)

## Validation steps

1. to run locally, you would need to `run npm run build && npm start`
2. `make remake-backend && docker compose up`
3. navigate to `search`
4. search for `test`
5. you should see an opportunity called `Test Opportunity for SF424A 1.0`
6. sign in
7. start new application
8. navigate to form table of the application
9. click Budget Information for Non-Construction Programs (SF-424A)
10. VERIFY the form loads
11. fill out the form, save
12. run `make generate-internal-token` from `api` directory
13. grab the token and place in request header "X-SGG-Internal-Token" and the token (I use a plugin called Modheader)
14. navigate to `http://localhost:3000/print/application/APP_ID/form/FORM_ID`
15. VERIFY the form data saves correctly & matches in print preview
16. VERIFY press print (`command + p`) and verify that no values are cut off from section A or B


### DocRaptor Test

- Follow Steps above
- expose your tunnel `lt --port 3000 --subdomain simpler-grants-dev-yourname`
  - i use localtunnel (https://theboroer.github.io/localtunnel-www/)
- when ready submit your application
  - double check to make sure that your local.env or overrides.env has these two values set properly
    - FRONTEND_URL=[your tunnle address]
    - DOCRAPTOR_API_KEY=[your api key]
  - submit your appliocation 
- run `make cmd args="task create-application-submission"`
- verify that your local copy matches the docraptors (https://app.docraptor.com/doc_logs)
