### PR TITLE
[Issue #8934] Ignore case in legacy certificate search

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -10,7 +10,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.x509 import load_pem_x509_certificate
 from pydantic import BaseModel, ConfigDict
 from requests.adapters import HTTPAdapter
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 import src.adapters.db as db
 from src.db.models.user_models import LegacyCertificate
@@ -109,15 +109,29 @@ def get_soap_auth(mtls_cert: str | None, db_session: db.Session) -> SOAPAuth | N
     return auth
 
 
+def get_legacy_certificate_by_serial_number(
+    db_session: db.Session, serial_number: str
+) -> LegacyCertificate | None:
+    # Since we lower the input serial_number we wrap the column
+    # value in func.lower() to make the match case insensitive. In hexadecimal
+    # there is no distinction between upper and lower case. The serial number
+    # can be either upper or lower cased in the DB.
+    return db_session.execute(
+        select(LegacyCertificate).where(
+            func.lower(LegacyCertificate.serial_number) == serial_number.lower()
+        )
+    ).scalar_one_or_none()
+
+
 def get_soap_client_certificate(
     urlencoded_cert: str, db_session: db.Session
 ) -> SOAPClientCertificate:
     cert_str = unquote(urlencoded_cert)
     cert = load_pem_x509_certificate(cert_str.encode(), default_backend())
+    # We convert the integer representation of the serial number to lower case hexadecimal here
+    # Note: the 'x' in '032x' returns it lower cased
     serial_number_hex = format(int(cert.serial_number), "032x")
-    legacy_certificate = db_session.execute(
-        select(LegacyCertificate).where(LegacyCertificate.serial_number == str(serial_number_hex))
-    ).scalar_one_or_none()
+    legacy_certificate = get_legacy_certificate_by_serial_number(db_session, serial_number_hex)
     if legacy_certificate:
         add_extra_data_to_current_request_logs(
             {

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
@@ -8,6 +8,7 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientCertificate,
     SOAPClientCertificateLookupError,
     SOAPClientCertificateNotConfigured,
+    get_legacy_certificate_by_serial_number,
     get_soap_auth,
     get_soap_client_certificate,
     validate_certificate,
@@ -84,6 +85,18 @@ def test_get_soap_client_certificate_legacy_certificate_gets_hex_serial_number_h
         mock_load_pem_x509.return_value.fingerprint.return_value.hex.return_value = "5677"
         soap_client_certificate = get_soap_client_certificate(MOCK_CERT_STR, db_session)
         assert soap_client_certificate.legacy_certificate == legacy_certificate
+
+
+def test_get_soap_client_certificate_legacy_certificate_search_ignores_case_in_serial_number(
+    db_session, enable_factory_create
+):
+    SERIAL_NUMBER = "000000000000ABBBBBCCCCCCCCC12210"
+    legacy_certificate = LegacyAgencyCertificateFactory.create(serial_number=SERIAL_NUMBER.upper())
+    result = get_legacy_certificate_by_serial_number(
+        db_session, serial_number=SERIAL_NUMBER.lower()
+    )
+    assert result is not None
+    assert result.legacy_certificate_id == legacy_certificate.legacy_certificate_id
 
 
 def test_client_auth(db_session, enable_factory_create):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8934  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Update the `LegacyCertificate` search to ignore case of `serial_number`.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Serial numbers can be upper case or lower case, but when they are extracted from an incoming cert they are lower case. This makes it so that the `LegacyCertificate` search ignores case.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] Can curl the training env with
```
--cert "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/localsetup/staging_grantors_soap_api.crt" \
--key "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/localsetup/staging_grantors_soap_api.key" \
```
And get a valid response.
