### PR TITLE
[Issue #8959] Add header override for USE_SIMPLER

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -25,6 +25,7 @@ MTLS_CERT_HEADER_KEY = "X-Amzn-Mtls-Clientcert"
 USE_SOAP_JWT_HEADER_KEY = "Use-Soap-Jwt"
 S2S_PARTNER_CERTID_JWT_B64_HEADER_KEY = "S2S_PARTNER_CERTID_JWT_B64"
 LOG_LOCAL_RESPONSE_HEADER_KEY = "Log-Local-Response"
+USE_SIMPLER_OVERRIDE_KEY = "Use-Simpler-Override"
 
 
 class SOAPClientCertificateNotConfigured(Exception):

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -1,6 +1,7 @@
 import logging
 
 import src.adapters.db as db
+from src.legacy_soap_api.legacy_soap_api_auth import USE_SIMPLER_OVERRIDE_KEY
 from src.legacy_soap_api.legacy_soap_api_client import (
     SimplerApplicantsS2SClient,
     SimplerGrantorsS2SClient,
@@ -29,6 +30,8 @@ def get_simpler_soap_response(
     )
 
     use_simpler = get_soap_config().use_simpler
+    if soap_request.headers.get(USE_SIMPLER_OVERRIDE_KEY, None) == "true":
+        use_simpler = True
 
     try:
         simpler_soap_client = simpler_soap_client_type(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_simpler_soap_api.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_simpler_soap_api.py
@@ -2,6 +2,7 @@ import io
 from unittest.mock import patch
 
 from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
+from src.legacy_soap_api.legacy_soap_api_auth import USE_SIMPLER_OVERRIDE_KEY
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI
 from src.legacy_soap_api.legacy_soap_api_schemas import (
     SOAPRequest,
@@ -31,6 +32,41 @@ class TestSimplerSoapApi:
             data=SoapRequestStreamer(stream=io.BytesIO(envelope)),
             full_path="x",
             headers={},
+            method="POST",
+            api_name=SimplerSoapAPI.APPLICANTS,
+            operation_name="GetOpportunityListRequest",
+        )
+        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        with patch(
+            "src.legacy_soap_api.legacy_soap_api_client.SimplerApplicantsS2SClient.get_simpler_soap_response"
+        ) as mock_get_simpler_soap_response:
+            mock_get_simpler_soap_response.return_value = SOAPResponse(
+                data=b"simpler", status_code=500, headers={}
+            )
+            response = get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            assert response.data == b"simpler"
+
+    def test_get_simpler_response_when_use_simpler_can_be_overrided_by_header_is_true_returns_simpler_response(
+        self, monkeypatch, db_session
+    ):
+        soap_api_config.get_soap_config.cache_clear()
+        monkeypatch.setenv("USE_SIMPLER", "false")
+        envelope = """
+            <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:app="http://apply.grants.gov/services/ApplicantWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0" xmlns:app1="http://apply.grants.gov/system/ApplicantCommonElements-V1.0">
+               <soapenv:Header/>
+               <soapenv:Body>
+                    <app:GetOpportunityListRequest>
+                        <gran:PackageID>PKG-00260155</gran:PackageID>
+                    </app:GetOpportunityListRequest>
+               </soapenv:Body>
+            </soapenv:Envelope>
+        """.encode(
+            "utf-8"
+        )
+        soap_request = SOAPRequest(
+            data=SoapRequestStreamer(stream=io.BytesIO(envelope)),
+            full_path="x",
+            headers={USE_SIMPLER_OVERRIDE_KEY: "true"},
             method="POST",
             api_name=SimplerSoapAPI.APPLICANTS,
             operation_name="GetOpportunityListRequest",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8959  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added check for `Use-Simpler-Override` header to override `use_simpler` value.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
To help testing we need a way to force a request to an endpoint to use the simpler response. This allows us to control by request if proxy or simpler responses are returned.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] Can add the simpler override to a request and get a valid response from simpler
