### PR TITLE
[Issue #8997] SOAP/Proxy: handle HTTPError Privilege issue without logging exception

### DIFF
--- a/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
@@ -9,7 +9,10 @@ import src.adapters.db as db
 from src.auth.endpoint_access_util import verify_access
 from src.db.models.competition_models import ApplicationSubmission
 from src.legacy_soap_api.grantors import schemas as grantor_schemas
-from src.legacy_soap_api.legacy_soap_api_auth import validate_certificate
+from src.legacy_soap_api.legacy_soap_api_auth import (
+    SOAPClientUserDoesNotHavePermission,
+    validate_certificate,
+)
 from src.legacy_soap_api.legacy_soap_api_config import SOAPOperationConfig
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPRequest
@@ -66,7 +69,9 @@ def get_application_zip_response(
                         "privileges": soap_config.privileges,
                     },
                 )
-                raise e
+                raise SOAPClientUserDoesNotHavePermission(
+                    "User did not have permission to access this application"
+                ) from e
 
         try:
             filestream = file_util.open_stream(application_submission.download_path, mode="rb")

--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -36,6 +36,10 @@ class SOAPClientCertificateLookupError(Exception):
     pass
 
 
+class SOAPClientUserDoesNotHavePermission(Exception):
+    pass
+
+
 class SOAPClientCertificate(BaseModel):
     cert: str
     serial_number: str

--- a/api/src/legacy_soap_api/legacy_soap_api_routes.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_routes.py
@@ -1,6 +1,5 @@
 import logging
 
-from apiflask.exceptions import HTTPError
 from flask import request
 
 import src.adapters.db as db
@@ -8,6 +7,7 @@ import src.adapters.db.flask_db as flask_db
 from src.legacy_soap_api.legacy_soap_api_auth import (
     MTLS_CERT_HEADER_KEY,
     USE_SOAP_JWT_HEADER_KEY,
+    SOAPClientUserDoesNotHavePermission,
     get_soap_auth,
 )
 from src.legacy_soap_api.legacy_soap_api_blueprint import legacy_soap_api_blueprint
@@ -99,7 +99,7 @@ def simpler_soap_api_route(
         return get_simpler_soap_response(
             soap_request, soap_proxy_response, db_session
         ).to_flask_response()
-    except HTTPError:
+    except SOAPClientUserDoesNotHavePermission:
         msg = "soap_client_certificate: User did not have permission to access this application"
         logger.info(
             msg=msg,

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 import pytz
 import requests
-from apiflask import HTTPError
 from botocore.exceptions import ClientError
 from sqlalchemy import update
 
@@ -21,7 +20,7 @@ from src.legacy_soap_api.applicants.schemas import (
     GetOpportunityListResponse,
     OpportunityDetails,
 )
-from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth
+from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth, SOAPClientUserDoesNotHavePermission
 from src.legacy_soap_api.legacy_soap_api_client import (
     BaseSOAPClient,
     SimplerApplicantsS2SClient,
@@ -552,7 +551,7 @@ class TestSimplerSOAPGetApplicationZip:
         )
         mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
         client = SimplerGrantorsS2SClient(soap_request, db_session)
-        with pytest.raises(HTTPError):
+        with pytest.raises(SOAPClientUserDoesNotHavePermission):
             client.get_simpler_soap_response(mock_proxy_response)
 
     def test_get_simpler_soap_response_logging_if_downloading_the_file_from_s3_fails(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -266,7 +266,6 @@ def test_simpler_getapplicationzip_operation_returns_not_found_response_includes
 def test_simpler_getapplicationzip_operation_raising_httperror_due_to_privileges_logs_info(
     client, fixture_from_file, enable_factory_create, caplog
 ) -> None:
-    caplog.set_level(logging.INFO)
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
     competition = CompetitionFactory(
@@ -294,9 +293,12 @@ def test_simpler_getapplicationzip_operation_raising_httperror_due_to_privileges
             full_path, data=etree.tostring(envelope), headers={"Use-Simpler-Override": "true"}
         )
     assert response.status_code == 500
-    post_message = next(
+    info_messages = [
         record
         for record in caplog.records
-        if record.message == "User did not have permission to access this application"
-    )
-    assert post_message.message == "User did not have permission to access this application"
+        if record.message
+        == "soap_client_certificate: User did not have permission to access this application"
+    ]
+    assert len(info_messages) == 1
+    error_records = [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert len(error_records) == 0


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8997 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Handled the HTTPError that results when user does not have Privilege to access an application.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Previously this was being logged as an exception which was setting off alarms in New Relic. This handles it more gracefully and lessens alarm noise.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
