### PR TITLE
[Issue #8926] During application submission, populate fields needed for award rec

### DIFF
--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -1,16 +1,15 @@
 import logging
 from collections.abc import Callable
-from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from src.form_schema.rule_processing.json_rule_context import JsonRule, JsonRuleContext
 from src.form_schema.rule_processing.json_rule_util import get_field_values, populate_nested_value
 from src.util.datetime_util import get_now_us_eastern_date
+from src.util.decimal_util import ZERO_DECIMAL, convert_monetary_field, quantize_decimal
 
 logger = logging.getLogger(__name__)
 
 INDIVIDUAL_UEI = "00000000INDV"
-ZERO_DECIMAL = Decimal("0.00")  # For formatting and defining 0 for decimal/monetary
 EXCLUDE_VALUE = "exclude_value"
 UNKNOWN_VALUE = "unknown"
 
@@ -143,21 +142,6 @@ def get_signature(context: JsonRuleContext, json_rule: JsonRule) -> str | None:
     return UNKNOWN_VALUE
 
 
-def _convert_monetary_field(value: Any) -> Decimal:
-    # We store monetary amounts as strings, for the purposes
-    # of doing math, we want to convert those to Decimals
-    if value is None:
-        return ZERO_DECIMAL
-
-    if not isinstance(value, str):
-        raise ValueError("Cannot convert value to monetary field, is not a string")
-
-    try:
-        return Decimal(value)
-    except InvalidOperation as e:
-        raise ValueError("Invalid decimal format, cannot process") from e
-
-
 def sum_monetary_values(context: JsonRuleContext, json_rule: JsonRule) -> str:
     """Sum monetary amounts based on configuration
 
@@ -185,7 +169,7 @@ def sum_monetary_values(context: JsonRuleContext, json_rule: JsonRule) -> str:
         # we'd still want to produce "6.00" from this function as that seems
         # the most intuitive to a user.
         try:
-            monetary_value = _convert_monetary_field(value)
+            monetary_value = convert_monetary_field(value)
         except ValueError:
             logger.info("Cannot convert monetary amount entered", extra=json_rule.get_log_context())
             continue
@@ -195,7 +179,7 @@ def sum_monetary_values(context: JsonRuleContext, json_rule: JsonRule) -> str:
     # Because our validation of monetary fields limits them to 2 decimals
     # this only matters when a user enters something that would be flagged
     # for a validation issue anyways, but at least this maintains consistency.
-    return str(result.quantize(ZERO_DECIMAL))
+    return str(quantize_decimal(result))
 
 
 population_func = Callable[[JsonRuleContext, JsonRule], Any]

--- a/api/src/services/applications/get_field_from_application.py
+++ b/api/src/services/applications/get_field_from_application.py
@@ -1,0 +1,106 @@
+import dataclasses
+import logging
+import uuid
+from decimal import Decimal
+from typing import Any
+
+from src.db.models.competition_models import Application
+from src.form_schema.forms import ProjectAbstractSummary_v2_0, SF424_v4_0, SF424a_v1_0
+from src.services.applications.application_validation import is_form_required
+from src.util.decimal_util import convert_monetary_field, quantize_decimal
+from src.util.dict_util import get_nested_value
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class FormField:
+    form_id: uuid.UUID
+    field: str  # field should be defined as a path in the JSON schema of format a.b.c
+
+
+def get_field_from_application(application: Application, form_fields: list[FormField]) -> Any:
+    """
+    Function to get a field from an application's forms.
+
+    A list of forms + fields can be passed in and the first non-None value
+    will be returned. If no form has the value set, None will be returned.
+
+    Typing is not validated at this level, you should validate the value
+    in the calling function.
+
+    Form fields can be a jsonpath (eg. "a.b.c" against {"a": {"b": {"c": 123}}}" will return 123)
+    """
+
+    # Setup a mapping of form_id to application form
+    # Skipping all application forms that aren't going
+    # to be in the submission.
+    application_form_map = {}
+    for application_form in application.application_forms:
+        # If the form is required OR included in the submission then look at its values
+        # We don't want to look at a form that isn't going into the submission
+        if is_form_required(application_form) or application_form.is_included_in_submission:
+            application_form_map[application_form.form_id] = application_form
+
+    # For each of the configured form fields
+    # see if that form exists on the application
+    # and if it does, fetch the value.
+    for form_field in form_fields:
+        if form_field.form_id in application_form_map:
+            application_form = application_form_map[form_field.form_id]
+            value = get_nested_value(
+                application_form.application_response, form_field.field.split(".")
+            )
+            if value is not None:
+                return value
+
+    # Nothing was found
+    return None
+
+
+PROJECT_TITLE_FORM_FIELDS = [
+    FormField(form_id=SF424_v4_0.form_id, field="project_title"),
+    FormField(form_id=ProjectAbstractSummary_v2_0.form_id, field="project_title"),
+]
+
+
+def get_project_title_from_application(application: Application) -> str | None:
+    """Get the project title from the application's forms"""
+    project_title = get_field_from_application(application, PROJECT_TITLE_FORM_FIELDS)
+
+    if project_title is None:
+        return None
+
+    if not isinstance(project_title, str):
+        logger.warning(
+            "Project title for application is not a string",
+            extra={"application_id": application.application_id},
+        )
+        return None
+
+    return project_title
+
+
+REQUESTED_AMOUNT_FORM_FIELDS = [
+    FormField(form_id=SF424_v4_0.form_id, field="federal_estimated_funding"),
+    FormField(
+        form_id=SF424a_v1_0.form_id, field="total_budget_summary.federal_new_or_revised_amount"
+    ),
+]
+
+
+def get_requested_amount_from_application(application: Application) -> Decimal | None:
+    """Get the total requested amount from the application's forms"""
+    raw_requested_amount = get_field_from_application(application, REQUESTED_AMOUNT_FORM_FIELDS)
+
+    if raw_requested_amount is None:
+        return None
+
+    try:
+        return quantize_decimal(convert_monetary_field(raw_requested_amount))
+    except ValueError:
+        logger.warning(
+            "Unable to parse monetary amount on application",
+            extra={"application_id": application.application_id},
+        )
+        return None

--- a/api/src/task/apply/create_application_submission_task.py
+++ b/api/src/task/apply/create_application_submission_task.py
@@ -1,4 +1,6 @@
 import logging
+import secrets
+import string
 import uuid
 import zipfile
 from collections.abc import Sequence
@@ -17,6 +19,10 @@ from src.constants.lookup_constants import ApplicationAuditEvent, ApplicationSta
 from src.db.models.competition_models import Application, ApplicationForm, ApplicationSubmission
 from src.services.applications.application_audit import add_audit_event
 from src.services.applications.application_validation import is_form_required
+from src.services.applications.get_field_from_application import (
+    get_project_title_from_application,
+    get_requested_amount_from_application,
+)
 from src.services.pdf_generation.config import PdfGenerationConfig
 from src.services.pdf_generation.models import PdfGenerationResponse
 from src.services.pdf_generation.service import generate_application_form_pdf
@@ -245,6 +251,9 @@ class CreateApplicationSubmissionTask(Task):
             file_location=s3_path,
             file_size_bytes=0,
             legacy_tracking_number=tracking_number,
+            application_submission_number=get_application_submission_number(application),
+            project_title=get_project_title_from_application(application),
+            total_requested_amount=get_requested_amount_from_application(application),
         )
 
         with file_util.open_stream(s3_path, "wb") as outfile:
@@ -287,6 +296,7 @@ class CreateApplicationSubmissionTask(Task):
                 "submitted_by_user_id": application.submitted_by,
                 "is_individual": application.organization_id is None,
                 "organization_id": application.organization_id,
+                "application_submission_number": application_submission.application_submission_number,
             },
         )
 
@@ -517,3 +527,30 @@ def create_manifest_text(submission: SubmissionContainer) -> str:
 
     # Return all sections
     return "\n\n".join(sections)
+
+
+def get_application_submission_number(application: Application) -> str:
+    """
+    Create an application submission number which is calculated as:
+        {opportunity_number}-{6 random uppercase characters/numbers}
+    """
+    opportunity_number = application.competition.opportunity.opportunity_number
+
+    # This can technically happen due to the data model
+    # but shouldn't ever happen in practice.
+    if opportunity_number is None:
+        logger.error(
+            "Opportunity does not have an opportunity number",
+            extra={
+                "opportunity_id": application.competition.opportunity_id,
+                "application_id": application.application_id,
+            },
+        )
+        opportunity_number = "APP"
+
+    # The submission number will a random
+    submission_number = "".join(
+        secrets.choice(string.ascii_uppercase + string.digits) for _ in range(6)
+    )
+
+    return f"{opportunity_number}-{submission_number}"

--- a/api/src/util/decimal_util.py
+++ b/api/src/util/decimal_util.py
@@ -1,0 +1,31 @@
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+ZERO_DECIMAL = Decimal("0.00")  # For formatting and defining 0 for decimal/monetary
+
+
+def convert_monetary_field(value: Any) -> Decimal:
+    """Convert a monetary string to a decimal number. Can raise ValueError for invalid values."""
+
+    # We store monetary amounts as strings, for the purposes
+    # of doing math, we want to convert those to Decimals
+    if value is None:
+        return ZERO_DECIMAL
+
+    if not isinstance(value, str):
+        raise ValueError("Cannot convert value to monetary field, is not a string")
+
+    try:
+        return Decimal(value)
+    except InvalidOperation as e:
+        raise ValueError("Invalid decimal format, cannot process") from e
+
+
+def quantize_decimal(value: Decimal) -> Decimal:
+    """
+    Quantize a decimal number to always contain 2 values after the decimal.
+
+    This uses the default behavior of quantizing and rounds UP
+    See: https://docs.python.org/3/library/decimal.html#decimal.ROUND_HALF_UP
+    """
+    return value.quantize(ZERO_DECIMAL)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import uuid
 from os import path
@@ -10,7 +11,7 @@ import pytest
 from apiflask import APIFlask
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from sqlalchemy import text
+from sqlalchemy import select, text
 
 import src.adapters.db as db
 import src.app as app_entry
@@ -24,11 +25,14 @@ from src.constants.schema import Schemas
 from src.constants.static_role_values import NAVA_INTERNAL_ROLE
 from src.db import models
 from src.db.models.agency_models import Agency
+from src.db.models.competition_models import FormInstruction
 from src.db.models.foreign import metadata as foreign_metadata
 from src.db.models.lookup.sync_lookup_values import sync_lookup_values
 from src.db.models.opportunity_models import Opportunity
 from src.db.models.staging import metadata as staging_metadata
 from src.db.models.user_models import AgencyUser, UserApiKey
+from src.form_schema.forms import get_active_forms
+from src.form_schema.jsonschema_resolver import resolve_jsonschema
 from src.util.local import load_local_env_vars
 from tests.lib import db_testing
 from tests.lib.auth_test_utils import mock_oauth_endpoint
@@ -609,3 +613,52 @@ def fixture_file_path():
         return path.join(FILE_FIXTURE_DIR, fixture_path_relative_to_fixture_dir.lstrip("/"))
 
     return _get_fixture_file_path
+
+
+########################
+# Forms
+########################
+
+
+@pytest.fixture
+def load_active_forms(db_session, enable_factory_create) -> None:
+    """
+    Load the active forms into the DB.
+
+    This will make it so a test can explicitly use one of our defined forms
+    without needing to define a new form like it.
+
+    To use this do the following with whatever form you want to use
+
+    def test_example(db_session, load_active_forms):
+        sf424 = db_session.merge(SF424_v4_0, load=True)
+
+        # use the form object returned from the merge function
+        # it'll actually work with our DB / factories
+        CompetitionFormFactory.create(form=sf424)
+
+    Note that because these are all in the same DB, don't
+    modify these forms otherwise you might break other tests that use them.
+    """
+
+    existing_form_instruction_ids = set(
+        db_session.execute(select(FormInstruction.form_instruction_id)).scalars()
+    )
+
+    for form in get_active_forms():
+
+        form_instruction_id = form.form_instruction_id
+        if (
+            form_instruction_id is not None
+            and form_instruction_id not in existing_form_instruction_ids
+        ):
+            # Note that we make these text files as generating valid PDFs is surprisingly complex.
+            factories.FormInstructionFactory.create(
+                form_instruction_id=form.form_instruction_id,
+                file_name=f"{form.short_form_name}.txt",
+            )
+
+        # do a copy so we aren't modifying a global form object
+        copied_form = copy.deepcopy(form)
+        copied_form.form_json_schema = resolve_jsonschema(form.form_json_schema)
+        db_session.merge(copied_form, load=True)

--- a/api/tests/src/services/applications/test_get_field_from_application.py
+++ b/api/tests/src/services/applications/test_get_field_from_application.py
@@ -1,0 +1,225 @@
+from decimal import Decimal
+
+from src.adapters import db
+from src.db.models.competition_models import Application, ApplicationForm, Form
+from src.form_schema.forms import (
+    ProjectAbstractSummary_v2_0,
+    SF424_v4_0,
+    SF424a_v1_0,
+    SF424b_v1_1,
+    SF424d_v1_1,
+)
+from src.services.applications.get_field_from_application import (
+    get_project_title_from_application,
+    get_requested_amount_from_application,
+)
+from tests.src.db.models.factories import (
+    ApplicationFactory,
+    ApplicationFormFactory,
+    CompetitionFormFactory,
+)
+
+
+def add_form_to_application(
+    db_session: db.Session,
+    application: Application,
+    form: Form,
+    application_response: dict,
+    is_required_form: bool = True,
+    is_included_in_submission: bool = True,
+) -> ApplicationForm:
+    # We do this so the form is attached to the session
+    # and uses whatever is already in the DB
+    attached_form = db_session.merge(form, load=True)
+    competition_form = CompetitionFormFactory.create(
+        competition=application.competition, form=attached_form, is_required=is_required_form
+    )
+    application_form = ApplicationFormFactory.create(
+        application=application,
+        competition_form=competition_form,
+        application_response=application_response,
+        is_included_in_submission=is_included_in_submission,
+    )
+    return application_form
+
+
+def test_get_project_title_from_application_sf424(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    add_form_to_application(
+        db_session, application, SF424_v4_0, {"project_title": "my fun project"}
+    )
+    assert get_project_title_from_application(application) == "my fun project"
+
+
+def test_get_project_title_from_project_abstract_summary(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    add_form_to_application(
+        db_session,
+        application,
+        ProjectAbstractSummary_v2_0,
+        {"project_title": "another fun project"},
+    )
+    assert get_project_title_from_application(application) == "another fun project"
+
+
+def test_get_project_title_no_form_with_value_present(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    # Add a few forms with various fields
+    add_form_to_application(db_session, application, SF424a_v1_0, {"activity_line_items": []})
+    add_form_to_application(db_session, application, SF424b_v1_1, {"title": "a different title"})
+    add_form_to_application(db_session, application, SF424d_v1_1, {"title": "yet another title"})
+    # Add the two forms that can have this, but don't set it
+    add_form_to_application(db_session, application, SF424_v4_0, {"sam_uei": "123456789012"})
+    add_form_to_application(
+        db_session, application, ProjectAbstractSummary_v2_0, {"applicant_name": "Bob"}
+    )
+    assert get_project_title_from_application(application) is None
+
+
+def test_get_project_title_both_forms_present(db_session, enable_factory_create, load_active_forms):
+    application = ApplicationFactory.create()
+    # Both forms are present, so the first one in the list is used
+    add_form_to_application(
+        db_session, application, SF424_v4_0, {"project_title": "my fun project"}
+    )
+    add_form_to_application(
+        db_session,
+        application,
+        ProjectAbstractSummary_v2_0,
+        {"project_title": "another fun project"},
+    )
+    assert get_project_title_from_application(application) == "my fun project"
+
+
+def test_get_project_title_both_forms_present_null_on_first(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    # Both forms are present, so the first one in the list is used
+    add_form_to_application(db_session, application, SF424_v4_0, {"project_title": None})
+    add_form_to_application(
+        db_session,
+        application,
+        ProjectAbstractSummary_v2_0,
+        {"project_title": "another fun project"},
+    )
+    assert get_project_title_from_application(application) == "another fun project"
+
+
+def test_get_project_title_from_application_bad_title(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    add_form_to_application(db_session, application, SF424_v4_0, {"project_title": 123})
+    assert get_project_title_from_application(application) is None
+
+
+def test_get_requested_amount_sf424(db_session, enable_factory_create, load_active_forms):
+    application = ApplicationFactory.create()
+    add_form_to_application(
+        db_session, application, SF424_v4_0, {"federal_estimated_funding": "100.12"}
+    )
+    assert get_requested_amount_from_application(application) == Decimal("100.12")
+
+
+def test_get_requested_amount_sf424a(db_session, enable_factory_create, load_active_forms):
+    application = ApplicationFactory.create()
+    add_form_to_application(
+        db_session,
+        application,
+        SF424a_v1_0,
+        {"total_budget_summary": {"federal_new_or_revised_amount": "55.23"}},
+    )
+    assert get_requested_amount_from_application(application) == Decimal("55.23")
+
+
+def test_get_requested_amount_both_forms_present(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    # Both forms are present, so the first one in the list is used
+    add_form_to_application(
+        db_session, application, SF424_v4_0, {"federal_estimated_funding": "35.45"}
+    )
+    add_form_to_application(
+        db_session,
+        application,
+        SF424a_v1_0,
+        {"total_budget_summary": {"federal_new_or_revised_amount": "77.54"}},
+    )
+    assert get_requested_amount_from_application(application) == Decimal("35.45")
+
+
+def test_get_requested_amount_both_forms_present_null_on_first(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    add_form_to_application(
+        db_session, application, SF424_v4_0, {"non_federal_estimated_funding": "123.45"}
+    )
+    add_form_to_application(
+        db_session,
+        application,
+        SF424a_v1_0,
+        {"total_budget_summary": {"federal_new_or_revised_amount": "55.55"}},
+    )
+    assert get_requested_amount_from_application(application) == Decimal("55.55")
+
+
+def test_get_requested_amount_no_form_with_value_present(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    # Add a few forms with various fields
+    add_form_to_application(db_session, application, SF424b_v1_1, {"title": "a different title"})
+    add_form_to_application(db_session, application, SF424d_v1_1, {"title": "yet another title"})
+    add_form_to_application(
+        db_session, application, ProjectAbstractSummary_v2_0, {"applicant_name": "Bob"}
+    )
+    # Add the two forms that can have this, but don't set it
+    add_form_to_application(
+        db_session,
+        application,
+        SF424a_v1_0,
+        {"total_budget_summary": {"non_federal_new_or_revised_amount": "1.20"}},
+    )
+    add_form_to_application(db_session, application, SF424_v4_0, {"sam_uei": "123456789012"})
+    assert get_requested_amount_from_application(application) is None
+
+
+def test_get_requested_amount_bad_monetary_amount(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    add_form_to_application(
+        db_session,
+        application,
+        SF424a_v1_0,
+        {"total_budget_summary": {"federal_new_or_revised_amount": "hello"}},
+    )
+    assert get_requested_amount_from_application(application) is None
+
+
+def test_get_project_title_in_non_included_form(
+    db_session, enable_factory_create, load_active_forms
+):
+    application = ApplicationFactory.create()
+    # The first form won't be used because it's not included in the submission and isn't required
+    add_form_to_application(
+        db_session,
+        application,
+        SF424_v4_0,
+        {"project_title": "the first one"},
+        is_required_form=False,
+        is_included_in_submission=False,
+    )
+    add_form_to_application(
+        db_session, application, ProjectAbstractSummary_v2_0, {"project_title": "the second one"}
+    )
+    assert get_project_title_from_application(application) == "the second one"

--- a/api/tests/src/task/apply/test_create_application_submission_task.py
+++ b/api/tests/src/task/apply/test_create_application_submission_task.py
@@ -1,4 +1,5 @@
 import zipfile
+from decimal import Decimal
 from io import BytesIO
 
 import pytest
@@ -6,6 +7,7 @@ from sqlalchemy import update
 
 from src.constants.lookup_constants import ApplicationAuditEvent, ApplicationStatus
 from src.db.models.competition_models import Application
+from src.form_schema.forms import SF424_v4_0
 from src.services.pdf_generation.config import PdfGenerationConfig
 from src.task.apply.create_application_submission_task import (
     ApplicationSubmissionConfig,
@@ -21,6 +23,7 @@ from tests.src.db.models.factories import (
     ApplicationFactory,
     ApplicationFormFactory,
     ApplicationSubmissionFactory,
+    CompetitionFormFactory,
 )
 
 
@@ -146,6 +149,9 @@ class TestCreateApplicationSubmissionTask(BaseTestClass):
             | {f: None for f in app_without_attachments_form_file_names},
         )
         assert no_attachment_submission.file_size_bytes > 0
+        assert no_attachment_submission.application_submission_number.startswith(
+            application_without_attachments.competition.opportunity.opportunity_number
+        )
 
         # Verify audit event added
         assert len(application_without_attachments.application_audits) == 1
@@ -182,6 +188,10 @@ class TestCreateApplicationSubmissionTask(BaseTestClass):
         )
         # No user attached, no audit event added
         assert len(application_with_attachments.application_audits) == 0
+
+        assert no_attachment_submission.application_submission_number.startswith(
+            application_without_attachments.competition.opportunity.opportunity_number
+        )
 
         # These weren't picked up
         assert len(not_picked_up_app1.application_submissions) == 0
@@ -259,6 +269,47 @@ class TestCreateApplicationSubmissionTask(BaseTestClass):
                 assert "GrantApplication.xml" not in file_names
                 # Should only have PDF and manifest
                 assert "manifest.txt" in file_names
+
+    def test_project_title_and_requested_amount_set(
+        self,
+        db_session,
+        enable_factory_create,
+        s3_config,
+        load_active_forms,
+        create_submission_task,
+    ):
+        """Test that project title and requested amount are set from values in application forms."""
+        application = ApplicationFactory.create(
+            application_status=ApplicationStatus.SUBMITTED,
+            # Add some other forms that we won't use for this
+            with_forms=True,
+        )
+
+        sf424 = db_session.merge(SF424_v4_0, load=True)
+        competition_form = CompetitionFormFactory.create(
+            competition=application.competition, form=sf424, is_required=True
+        )
+        ApplicationFormFactory.create(
+            application=application,
+            competition_form=competition_form,
+            application_response={
+                "project_title": "my fun title",
+                "federal_estimated_funding": "456.78",
+            },
+            is_included_in_submission=True,
+        )
+
+        create_submission_task.run()
+
+        assert application.application_status == ApplicationStatus.ACCEPTED
+        assert len(application.application_submissions) == 1
+        submission = application.application_submissions[0]
+
+        assert submission.application_submission_number.startswith(
+            application.competition.opportunity.opportunity_number
+        )
+        assert submission.project_title == "my fun title"
+        assert submission.total_requested_amount == Decimal("456.78")
 
 
 def test_get_file_name_in_zip():

--- a/api/tests/src/util/test_decimal_util.py
+++ b/api/tests/src/util/test_decimal_util.py
@@ -1,0 +1,27 @@
+from decimal import Decimal
+
+import pytest
+
+from src.util.decimal_util import ZERO_DECIMAL, convert_monetary_field, quantize_decimal
+
+
+def test_convert_monetary_field():
+    assert convert_monetary_field(None) == ZERO_DECIMAL
+    assert convert_monetary_field("1") == Decimal("1")
+    assert convert_monetary_field("1.0005") == Decimal("1.0005")
+
+
+@pytest.mark.parametrize("value", [10, "hello", {}, "1.2.3.4.5"])
+def test_convert_monetary_field_error_cases(value):
+    with pytest.raises(ValueError):
+        convert_monetary_field(value)
+
+
+def test_quantize_decimal():
+    assert quantize_decimal(Decimal("1.00")) == Decimal("1.00")
+    assert quantize_decimal(Decimal("1.456")) == Decimal("1.46")
+    assert quantize_decimal(Decimal("1.351")) == Decimal("1.35")
+    assert quantize_decimal(Decimal("-.56")) == Decimal("-.56")
+    assert quantize_decimal(Decimal("-1000.000001")) == Decimal("-1000.00")
+    assert quantize_decimal(Decimal("100")) == Decimal("100")
+    assert quantize_decimal(Decimal("20.1")) == Decimal("20.1")


### PR DESCRIPTION
## Summary
Fixes #8926 

## Changes proposed
* Populate `application_submission_number` / `project_title` / `total_requested_amount` when creating the application submission
* Added a simple util for fetching a field from the forms that may be on an application.

## Context for reviewers
These are all fields we want for award recommendation work as they're needed in the UI we display to grantors. They're all nullable, although with the way this is written, the new submission number won't ever be. The others can be null if the fields for them aren't present.

https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/2735046679/Tech+Spec+-+Award+Recommendation+Data+Model+Initial+Endpoints#Application-Submission

## Validation steps
Will test manually (besides the tests written) once it's in staging - my local setup needs a bit of fixing to work with the frontend / handle submission all the way through.
