### PR TITLE
[Issue #9029] Don't exit other scheduled E2E test shards if one test fails

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -25,7 +25,7 @@ jobs:
   e2e-tests-deployed:
     runs-on: ubuntu-22.04
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         shard: [1, 2, 3, 4]
         total_shards: [4]


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9029 

## Changes proposed

Don't fail fast, so that a single test run will report all E2E failures, not just the first ones that fail.

## Context for reviewers

When running in PRs/deploys it makes sense to fail fast so we get developers information about the failures sooner. But for scheduled runs we should prioritize completeness over speed.

## Validation steps

- [ ] Jobs run more fully, despite failures, after merging to main
