### PR TITLE
[Issue #9079] Stabilize 404.spec.ts for E2E staging run

### DIFF
--- a/frontend/tests/e2e/404.spec.ts
+++ b/frontend/tests/e2e/404.spec.ts
@@ -6,12 +6,19 @@ const { targetEnv } = playwrightEnv;
 test.beforeEach(async ({ page }) => {
   const timeout = targetEnv === "staging" ? 180000 : 60000;
   await page.goto("/imnothere", {
-    waitUntil: "domcontentloaded",
+    waitUntil: "load",
     timeout,
   });
   // Wait for staging to stabilize
   if (targetEnv === "staging") {
     await page.waitForTimeout(3000);
+    // Skip if staging is unhealthy
+    const isUnhealthy = await page.evaluate(() =>
+      ["502", "503", "504"].some((code) =>
+        document.body.innerText.includes(code),
+      ),
+    );
+    test.skip(isUnhealthy, "Staging server is unhealthy, skipping test");
   }
 });
 
@@ -23,7 +30,8 @@ test("has title", async ({ page }) => {
 });
 
 test("can view the home button", async ({ page }) => {
+  const timeout = targetEnv === "staging" ? 30000 : 5000;
   await expect(
     page.getByRole("link", { name: "Visit our homepage" }),
-  ).toHaveText("Visit our homepage");
+  ).toHaveText("Visit our homepage", { timeout });
 });


### PR DESCRIPTION
## Summary
Work for : Issue #9079 

## Changes proposed
Updated waitUntil from domcontentloaded to load and added explicit timeouts to assertions. Added a health check in beforeEach to skip the test rather than fail when staging is unhealthy.

