### PR TITLE
[Issue #9109] Change timing and add failure Slack notification

### DIFF
--- a/.github/workflows/lint-sprint-rollover.yml
+++ b/.github/workflows/lint-sprint-rollover.yml
@@ -1,4 +1,6 @@
 name: Lint - Sprint rollover
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   workflow_dispatch: # for manual runs


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #9109 

## Changes proposed

* Change timing of the run to avoid other GitHub heavy processes potentially affecting quota
* Include a Slack notification if the job fails

## Context for reviewers

This job failed this week (for the first time in recently history) and didn't roll over all the tickets. Trying to avoid the failures and make it a little more obvious if it does fail again in the future.

## Validation steps
- [x] Test runs succeed