### PR TITLE
[Unticketed] Fix a flaky test for opportunity search

### DIFF
--- a/api/tests/src/search/backend/test_load_opportunities_to_index.py
+++ b/api/tests/src/search/backend/test_load_opportunities_to_index.py
@@ -103,9 +103,10 @@ class TestLoadOpportunitiesToIndexFullRefresh(BaseTestClass):
             [record["opportunity_id"] for record in resp.records]
         )
 
-        first_record = resp.records[0]
-        assert "top_level_agency_code" in first_record
-        assert first_record["top_level_agency_code"] == parent_agency.agency_code
+        # The posted opportunities should have the top level agency code set
+        for record in resp.records:
+            if record.get("opportunity_status") == "posted":
+                assert record.get("top_level_agency_code") == parent_agency.agency_code
 
         # Rerunning without changing anything about the data in the DB doesn't meaningfully change anything
         load_opportunities_to_index.index_name = load_opportunities_to_index.index_name + "-another"


### PR DESCRIPTION
## Summary

## Changes proposed
* Fix a flakey test in the opportunity search load tests

## Context for reviewers
Was assuming the first item of an unsorted list would be the same, it generally is, but had a recent failure on merging. Adjusted it to check a bit different.

