### PR TITLE
[Issue #8950] Make new SOAP statuses filterable and returnable

### DIFF
--- a/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
@@ -40,12 +40,14 @@ STATUS_TRANSFORM = {
 }
 
 
-# This method gets the GrantsGovTrackingNumber
-# NOTE: The order of operations is VERY important to get the correct GrantsGovTrackingNumber
-# IF there's a row on the ApplicationSubmissionTrackingNumber table -> "Agency Tracking Number Assigned"
-# IF there's NOT a row on the ApplicationSubmissionTrackingNumber table but there IS a row on the ApplicationSubmissionRetrieval table -> "Received by Agency"
-# IF there's not a row on either table -> application.application_status
 def get_grants_gov_application_status(submission: ApplicationSubmission) -> str | None:
+    """
+    This method gets the GrantsGovTrackingNumber
+    NOTE: The order of operations is VERY important to get the correct GrantsGovTrackingNumber
+    IF there's a row on the ApplicationSubmissionTrackingNumber table -> "Agency Tracking Number Assigned"
+    IF there's NOT a row on the ApplicationSubmissionTrackingNumber table but there IS a row on the ApplicationSubmissionRetrieval table -> "Received by Agency"
+    IF there's not a row on either table -> application.application_status
+    """
     grants_gov_application_status = GRANTS_APPLICATION_STATUSES.get(
         submission.application.application_status
     )

--- a/api/tests/src/legacy_soap_api/grantors/services/test_get_submission_list_expanded_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_get_submission_list_expanded_response.py
@@ -77,29 +77,28 @@ def _setup_submission(agency, application_status=ApplicationStatus.ACCEPTED):
     )
 
 
-@pytest.fixture(scope="class")
-def setup_data(db_session, enable_factory_create):
-    agency = AgencyFactory.create()
-    submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
-    ApplicationSubmissionTrackingNumberFactory.create(application_submission=submission)
-    ApplicationSubmissionRetrievedFactory.create(application_submission=submission)
-    for _ in range(3):
-        sub = _setup_submission(agency, ApplicationStatus.ACCEPTED)
-        ApplicationSubmissionRetrievedFactory.create(
-            application_submission=sub,
-        )
-    _setup_submission(agency, ApplicationStatus.ACCEPTED)
-    tracking_number = f"GRANT{submission.legacy_tracking_number}"
-    _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
-    return {
-        "agency": agency,
-        "submission": submission,
-        "tracking_number": tracking_number,
-        "soap_client_certificate": soap_client_certificate,
-    }
-
-
 class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
+    @pytest.fixture(scope="class")
+    def setup_data(self, db_session, enable_factory_create):
+        agency = AgencyFactory.create()
+        submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
+        ApplicationSubmissionTrackingNumberFactory.create(application_submission=submission)
+        ApplicationSubmissionRetrievedFactory.create(application_submission=submission)
+        for _ in range(3):
+            sub = _setup_submission(agency, ApplicationStatus.ACCEPTED)
+            ApplicationSubmissionRetrievedFactory.create(
+                application_submission=sub,
+            )
+        _setup_submission(agency, ApplicationStatus.ACCEPTED)
+        tracking_number = f"GRANT{submission.legacy_tracking_number}"
+        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        return {
+            "agency": agency,
+            "submission": submission,
+            "tracking_number": tracking_number,
+            "soap_client_certificate": soap_client_certificate,
+        }
+
     def test_get_submission_list_expanded_filters_on_agency_tracking_number_assigned(
         self, db_session, enable_factory_create, setup_data
     ):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8950 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added filtering and serializing the new statuses: `Received by Agency` and `Agency Tracking Number Assigned`.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We need to add these two statuses but they aren't stored with the `ApplicationStatuses` so we need to expand the filter to filter the `ApplicationSubmissions` correctly and also return the correct status (the new ones override `ApplicationStatus`).

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] filtering on the new statuses return correct submissions
- [ ] Submissions in new statuses cannot be filtered by their application_status
- [ ] unittests pass
