### PR TITLE
[Unticketed] Pin version of localstack in docker-compose

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
-    image: localstack/localstack
+    image: localstack/localstack:4.14.0
     ports:
       - "127.0.0.1:4566:4566" # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559" # external services port range


### PR DESCRIPTION
## Summary

## Changes proposed
* Pin the version of localstack in our docker-compose

## Context for reviewers
Localstack now requires an account for their latest version and is effectively disallowing us to use the community edition in the way we were. We probably need to find an alternative, but as an immediate fix for our CI/CD - we'll pin the last version before this change.

https://blog.localstack.cloud/the-road-ahead-for-localstack/#why-were-making-a-change
