### PR TITLE
[unticketed]: pin tfsec version

### DIFF
--- a/.github/workflows/ci-infra.yml
+++ b/.github/workflows/ci-infra.yml
@@ -93,3 +93,4 @@ jobs:
         uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:
           github_token: ${{ github.token }}
+          tfsec_version: v1.28.14


### PR DESCRIPTION
## Summary

Pin Tfsec version, instead of default to the use the latest version. The pipeline is currently failing to fetch the latest version: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/23443736835/job/68201579201?pr=9192)

## Validation steps

Tfsec pipeline checks should be successfully running. 