### PR TITLE
[Issue #8870] In the opportunity publish workflow, flip the is_draft flag

### DIFF
--- a/api/src/workflow/state_machine/opportunity_publish_state_machine.py
+++ b/api/src/workflow/state_machine/opportunity_publish_state_machine.py
@@ -1,13 +1,18 @@
+import logging
 from enum import StrEnum
+from typing import Any
 
 from statemachine import Event
 from statemachine.states import States
 
 from src.constants.lookup_constants import WorkflowEntityType, WorkflowType
 from src.workflow.base_state_machine import BaseStateMachine
+from src.workflow.event.state_machine_event import StateMachineEvent
 from src.workflow.registry.workflow_registry import WorkflowRegistry
 from src.workflow.state_persistence.opportunity_persistence_model import OpportunityPersistenceModel
 from src.workflow.workflow_config import WorkflowConfig
+
+logger = logging.getLogger(__name__)
 
 
 class OpportunityPublishState(StrEnum):
@@ -71,3 +76,20 @@ class OpportunityPublishStateMachine(BaseStateMachine):
     finish_publish = Event(
         states.OPPORTUNITY_WRITTEN_TO_SEARCH.to(states.END),
     )
+
+    def __init__(self, model: OpportunityPersistenceModel, **kwargs: Any):
+        super().__init__(model=model, **kwargs)
+        self.opportunity = model.opportunity
+
+    @flip_is_draft.on
+    def handle_flip_is_draft(self, state_machine_event: StateMachineEvent) -> None:
+        """Flip the is_draft flag to false"""
+        # We shouldn't be using this workflow for non-drafts, but nothing
+        # will break, so leave it alone.
+        if self.opportunity.is_draft is False:
+            logger.warning(
+                "Opportunity that isn't currently a draft going through publishing flow.",
+                extra=state_machine_event.get_log_extra(),
+            )
+
+        self.opportunity.is_draft = False

--- a/api/tests/workflow/state_machine/test_opportunity_publish_state_machine.py
+++ b/api/tests/workflow/state_machine/test_opportunity_publish_state_machine.py
@@ -8,10 +8,12 @@ from tests.src.db.models.factories import OpportunityFactory, UserFactory, Workf
 from tests.workflow.workflow_test_util import build_start_workflow_event, send_process_event
 
 
-def test_opportunity_publish_happy_path(db_session, enable_factory_create):
+@pytest.mark.parametrize("is_draft", [True, False])
+def test_opportunity_publish_happy_path(db_session, enable_factory_create, is_draft, caplog):
     """Verify that sending a start_workflow event will go through the whole state machine"""
     user = UserFactory.create()
-    opportunity = OpportunityFactory.create(is_draft=True)
+    # We verify it's the same regardless of the is_draft flag
+    opportunity = OpportunityFactory.create(is_draft=is_draft)
 
     sqs_container = build_start_workflow_event(
         workflow_type=WorkflowType.OPPORTUNITY_PUBLISH,
@@ -19,7 +21,18 @@ def test_opportunity_publish_happy_path(db_session, enable_factory_create):
         entity=opportunity,
     )
 
-    state_machine = EventHandler(db_session, sqs_container).process()
+    # commit so the opportunity in the DB is updated
+    with db_session.begin():
+        state_machine = EventHandler(db_session, sqs_container).process()
+
+    db_session.refresh(opportunity)
+    assert opportunity.is_draft is False
+
+    if is_draft is False:
+        assert (
+            "Opportunity that isn't currently a draft going through publishing flow."
+            in caplog.messages
+        )
 
     workflow = state_machine.workflow
     assert workflow.current_workflow_state == OpportunityPublishState.END


### PR DESCRIPTION
## Summary
Fixes #8870

## Changes proposed
In the opportunity publish workflow, flip the is_draft flag during that transition

## Context for reviewers
Basically the most minimal workflow logic addition possible, it flips a flag. Logs a warning if it's not a draft (that is a check we'll do upstream I think).

## Validation steps

Run the API locally while running the workflow service with make cmd args="workflow workflow-main".

Find an opportunity in your local DB and you can call the PUT workflow endpoint by setting that as the entity ID in a request like below using the `internal_workflow_user_key` user API key.

```json
{
  "event_type": "start_workflow",
  "start_workflow_context": {
    "entity_id": "1b0f1981-35c4-42d9-840f-bdc7054a7842",
    "entity_type": "opportunity",
    "workflow_type": "opportunity_publish"
  }
}
```

This'll immediately run through the whole workflow - the is_draft flag should be flipped if it was a draft.
