### PR TITLE
[Issue #9247] Bump base image python to 3.14.3

### DIFF
--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -3,7 +3,7 @@
 #==============================================
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS amazonlinux-builder
 
-ARG PYTHON_VERSION=3.14.2
+ARG PYTHON_VERSION=3.14.3
 ARG PY_MM=3.14
 ARG POETRY_VERSION=2.2.1
 ARG PIP_VERSION=26.0


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9247 

## Changes proposed

Newest python has been out for about a month, so we're upgrading

## Validation steps

Will fully test one new base image is available and we can convert the API and Analytics containers and test.