### PR TITLE
Fix 404 pages returning HTTP 200 by using notFound() instead of JSX

### DIFF
--- a/frontend/src/app/[locale]/(base)/applications/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/applications/[applicationId]/form/[appFormId]/page.tsx
@@ -1,13 +1,12 @@
 import { Metadata } from "next";
 import TopLevelError from "src/app/[locale]/(base)/error/page";
-import NotFound from "src/app/[locale]/(base)/not-found";
 import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import { getApplicationDetails } from "src/services/fetch/fetchers/applicationFetcher";
 import getFormData from "src/utils/getFormData";
 
 import { getTranslations } from "next-intl/server";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { GridContainer } from "@trussworks/react-uswds";
 
 import ApplyForm from "src/components/applyForm/ApplyForm";
@@ -78,7 +77,7 @@ async function FormPage({ params }: formPageProps) {
 
   if (error || !data) {
     if (error === "UnauthorizedError") return redirect("/unauthenticated");
-    if (error === "NotFound") return <NotFound />;
+    if (error === "NotFound") notFound();
     return <TopLevelError />;
   }
 

--- a/frontend/src/app/[locale]/(base)/applications/[applicationId]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/applications/[applicationId]/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from "next";
 import TopLevelError from "src/app/[locale]/(base)/error/page";
-import NotFound from "src/app/[locale]/(base)/not-found";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
 import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
@@ -13,7 +12,7 @@ import { getOpportunityDetails } from "src/services/fetch/fetchers/opportunityFe
 import { OpportunityDetail } from "src/types/opportunity/opportunityResponseTypes";
 
 import { getTranslations } from "next-intl/server";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { GridContainer } from "@trussworks/react-uswds";
 
 import ApplicationContainer from "src/components/application/ApplicationContainer";
@@ -78,7 +77,7 @@ async function ApplicationLandingPage({ params }: ApplicationLandingPageProps) {
         `Error retrieving application details for application (${applicationId})`,
         e,
       );
-      return <NotFound />;
+      notFound();
     }
     return <TopLevelError />;
   }

--- a/frontend/src/app/[locale]/(base)/opportunity/[id]/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunity/[id]/page.test.tsx
@@ -91,12 +91,6 @@ jest.mock("src/components/user/OpportunitySaveUserControl", () => ({
   OpportunitySaveUserControl: () => <div />,
 }));
 
-const mockOpportunityData = {
-  data: mockOpportunityDetail,
-  message: "Success",
-  status_code: 200,
-};
-
 const opportunityParams = Promise.resolve({
   locale: "en",
   id: mockOpportunityDetail.opportunity_id,

--- a/frontend/src/app/[locale]/(base)/opportunity/[id]/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunity/[id]/page.test.tsx
@@ -1,0 +1,137 @@
+import { identity } from "lodash";
+import OpportunityListing from "src/app/[locale]/(base)/opportunity/[id]/page";
+import * as opportunityFetcher from "src/services/fetch/fetchers/opportunityFetcher";
+import { wrapForExpectedError } from "src/utils/testing/commonTestUtils";
+import { mockOpportunityDetail } from "src/utils/testing/fixtures";
+
+jest.mock("next-intl/server", () => ({
+  getTranslations: () => identity,
+}));
+
+jest.mock("react", () => ({
+  ...jest.requireActual<typeof import("react")>("react"),
+  use: jest.fn(() => ({
+    locale: "en",
+  })),
+}));
+
+const mockNotFound = jest.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+const mockRedirect = jest.fn((..._args: unknown[]) => {
+  throw new Error("NEXT_REDIRECT");
+});
+
+jest.mock("next/navigation", () => ({
+  notFound: (...args: unknown[]) => mockNotFound(...args),
+  redirect: (...args: unknown[]) => mockRedirect(...args),
+  RedirectType: { push: "push" },
+}));
+
+jest.mock("src/services/auth/session", () => ({
+  getSession: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock("src/services/fetch/fetchers/opportunityFetcher");
+jest.mock("src/services/fetch/fetchers/savedOpportunityFetcher");
+
+jest.mock("src/components/ContentLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock("src/components/opportunity/OpportunityIntro", () => ({
+  __esModule: true,
+  default: () => <div data-testid="opportunity-intro" />,
+}));
+
+jest.mock("src/components/opportunity/OpportunityDescription", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("src/components/opportunity/OpportunityDocuments", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("src/components/opportunity/OpportunityLink", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("src/components/opportunity/OpportunityStatusWidget", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("src/components/opportunity/OpportunityCTA", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("src/components/opportunity/OpportunityAwardInfo", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("src/components/opportunity/OpportunityHistory", () => ({
+  __esModule: true,
+  default: () => <div />,
+}));
+
+jest.mock("src/components/user/OpportunityCompetitionStart", () => ({
+  OpportunityCompetitionStart: () => <div />,
+}));
+
+jest.mock("src/components/user/OpportunitySaveUserControl", () => ({
+  OpportunitySaveUserControl: () => <div />,
+}));
+
+const mockOpportunityData = {
+  data: mockOpportunityDetail,
+  message: "Success",
+  status_code: 200,
+};
+
+const opportunityParams = Promise.resolve({
+  locale: "en",
+  id: mockOpportunityDetail.opportunity_id,
+});
+
+describe("OpportunityListing", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls notFound() when opportunity returns 404", async () => {
+    jest
+      .spyOn(opportunityFetcher, "getOpportunityDetails")
+      .mockRejectedValue(new Error(JSON.stringify({ status: 404 })));
+
+    await wrapForExpectedError(() =>
+      OpportunityListing({
+        params: opportunityParams,
+      }),
+    );
+
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it("throws non-404 errors without calling notFound()", async () => {
+    jest
+      .spyOn(opportunityFetcher, "getOpportunityDetails")
+      .mockRejectedValue(new Error("Internal Server Error"));
+
+    await expect(
+      OpportunityListing({
+        params: opportunityParams,
+      }),
+    ).rejects.toThrow("Internal Server Error");
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/[locale]/(base)/opportunity/[id]/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunity/[id]/page.test.tsx
@@ -24,7 +24,7 @@ const mockRedirect = jest.fn((..._args: unknown[]) => {
 });
 
 jest.mock("next/navigation", () => ({
-  notFound: (...args: unknown[]) => mockNotFound(...args),
+  notFound: () => mockNotFound(),
   redirect: (...args: unknown[]) => mockRedirect(...args),
   RedirectType: { push: "push" },
 }));

--- a/frontend/src/app/[locale]/(base)/opportunity/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunity/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { Metadata } from "next";
-import NotFound from "src/app/[locale]/(base)/not-found";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
 import { getSession } from "src/services/auth/session";
 import { getOpportunityDetails } from "src/services/fetch/fetchers/opportunityFetcher";
@@ -103,7 +102,7 @@ async function OpportunityListing({ params }: OpportunityListingProps) {
     opportunityData = response.data;
   } catch (error) {
     if (parseErrorStatus(error as ApiRequestError) === 404) {
-      return <NotFound />;
+      notFound();
     }
     throw error;
   }

--- a/frontend/src/app/[locale]/(base)/search/page.tsx
+++ b/frontend/src/app/[locale]/(base)/search/page.tsx
@@ -13,6 +13,7 @@ import { useTranslations } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Suspense, use } from "react";
 
+import Loading from "src/components/Loading";
 import { DrawerUnit } from "src/components/drawer/DrawerUnit";
 import { AndOrPanel } from "src/components/search/AndOrPanel";
 import { ClassicSearchBanner } from "src/components/search/ClassicSearchBanner";
@@ -98,11 +99,15 @@ function Search({ searchParams, params }: SearchPageProps) {
                   iconName="filter_list"
                   buttonClass="tablet:margin-x-auto"
                 >
-                  <SearchDrawerFilters
-                    searchParams={convertedSearchParams}
-                    searchResultsPromise={searchResultsPromise}
-                    agencyListPromise={filteredAgencyListPromise}
-                  />
+                  <Suspense
+                    fallback={<Loading message={t("drawer.loading")} />}
+                  >
+                    <SearchDrawerFilters
+                      searchParams={convertedSearchParams}
+                      searchResultsPromise={searchResultsPromise}
+                      agencyListPromise={filteredAgencyListPromise}
+                    />
+                  </Suspense>
                 </DrawerUnit>
               </div>
               <div className="flex-3 flex-align-self-end display-none desktop:display-block">

--- a/frontend/src/app/[locale]/(base)/search/page.tsx
+++ b/frontend/src/app/[locale]/(base)/search/page.tsx
@@ -13,8 +13,8 @@ import { useTranslations } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Suspense, use } from "react";
 
-import Loading from "src/components/Loading";
 import { DrawerUnit } from "src/components/drawer/DrawerUnit";
+import Loading from "src/components/Loading";
 import { AndOrPanel } from "src/components/search/AndOrPanel";
 import { ClassicSearchBanner } from "src/components/search/ClassicSearchBanner";
 import { FilterPillPanel } from "src/components/search/FilterPillPanel";

--- a/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(print)/print/application/[applicationId]/form/[appFormId]/page.tsx
@@ -1,9 +1,9 @@
 import { Metadata } from "next";
 import TopLevelError from "src/app/[locale]/(base)/error/page";
-import NotFound from "src/app/[locale]/(base)/not-found";
 import getFormData from "src/utils/getFormData";
 
 import { headers } from "next/headers";
+import { notFound } from "next/navigation";
 
 import PrintForm from "src/components/applyForm/PrintForm";
 import { addPrintWidgetToFields } from "src/components/applyForm/utils";
@@ -65,7 +65,7 @@ export default async function FormPage({ params }: FormPageProps) {
   });
 
   if (error || !data) {
-    if (error === "NotFound") return <NotFound />;
+    if (error === "NotFound") notFound();
     return <TopLevelError />;
   }
 

--- a/frontend/src/components/search/SearchResultsView.tsx
+++ b/frontend/src/components/search/SearchResultsView.tsx
@@ -15,8 +15,6 @@ type SearchResultsViewProps = {
   savedOpportunities: MinimalOpportunity[];
 };
 
-// given the issues with suspense mentioned in this ticket, this won't show up
-// https://github.com/HHS/simpler-grants-gov/issues/4930
 export const SearchResultsSkeleton = () => {
   return (
     <>

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -874,6 +874,7 @@ export const messages = {
       submit: "View results",
       clearFilters: "Clear filters",
       toggleButton: "Filters",
+      loading: "Loading filters",
     },
     callToAction: {
       shareWithOrganization: "Share with organizations",


### PR DESCRIPTION
## Summary
- Pages for opportunities, applications, and forms were returning **HTTP 200** instead of **404** when resources weren't found
- Root cause: components used `return <NotFound />` (renders JSX) instead of calling `notFound()` (Next.js function that sets the 404 status code)
- Fixed across **4 pages** that had the same bug pattern

## Root cause

```tsx
// Before — renders "not found" UI but HTTP status stays 200
if (parseErrorStatus(error) === 404) {
  return <NotFound />;
}

// After — Next.js sets HTTP 404 and renders the nearest not-found.tsx boundary
if (parseErrorStatus(error) === 404) {
  notFound();
}
```

In Next.js App Router, `notFound()` from `next/navigation` throws a special error that Next.js catches to:
1. Set the HTTP response status to 404
2. Render the nearest `not-found.tsx` boundary

Simply returning a `<NotFound />` component as JSX renders the UI but skips the status code — the response is still 200.

## Files changed

| File | Change |
|------|--------|
| `opportunity/[id]/page.tsx` | `return <NotFound />` → `notFound()`, remove unused import |
| `applications/[applicationId]/page.tsx` | Same fix, add `notFound` to import |
| `applications/[applicationId]/form/[appFormId]/page.tsx` | Same fix, add `notFound` to import |
| `print/.../form/[appFormId]/page.tsx` | Same fix, add `notFound` to import |

## Test plan
- [ ] Visit `/opportunity/359212` (nonexistent int ID) → verify HTTP 404 in Network tab
- [ ] Visit `/opportunity/00000000-0000-0000-0000-000000000000` (nonexistent UUID) → verify HTTP 404
- [ ] Visit a valid opportunity → verify HTTP 200 and content loads normally
- [ ] Visit `/applications/nonexistent-id` → verify HTTP 404
- [ ] Verify the "not found" UI still renders correctly on all pages

Fixes #5774
