### PR TITLE
[Issue #9359] Refactor: Have fillForm delegate navigation to openForm

### DIFF
--- a/frontend/tests/e2e/apply/failure-path-budget-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-budget-narrative-attachment.spec.ts
@@ -82,7 +82,7 @@ test(
     await verifyFormStatusOnApplication(
       page,
       "incomplete",
-      "Budget Narrative Attachment",
+      BUDGET_NARRATIVE_ATTACHMENT_FORM_MATCHER,
       applicationUrl,
     );
   },

--- a/frontend/tests/e2e/apply/failure-path-epa4700-4.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-epa4700-4.spec.ts
@@ -52,11 +52,8 @@ test(
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
     const applicationUrl = page.url();
 
-    const openedEpa47004ForValidation = await openForm(
-      page,
-      EPA4700_4_FORM_MATCHER,
-    );
-    if (!openedEpa47004ForValidation) {
+    const opened = await openForm(page, EPA4700_4_FORM_MATCHER);
+    if (!opened) {
       throw new Error(
         "Could not find or open EPA Form 4700-4 form link on the application forms page",
       );
@@ -73,7 +70,7 @@ test(
     await verifyFormStatusOnApplication(
       page,
       "incomplete",
-      "EPA Form 4700-4",
+      EPA4700_4_FORM_MATCHER,
       applicationUrl,
     );
   },

--- a/frontend/tests/e2e/apply/failure-path-other-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-other-narrative-attachment.spec.ts
@@ -58,11 +58,11 @@ test(
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
     const applicationUrl = page.url();
 
-    const openedOtherNarrativeAttachmentForValidation = await openForm(
+    const opened = await openForm(
       page,
       OTHER_NARRATIVE_ATTACHMENT_FORM_MATCHER,
     );
-    if (!openedOtherNarrativeAttachmentForValidation) {
+    if (!opened) {
       throw new Error(
         "Could not find or open Other Narrative Attachments link on the application forms page",
       );
@@ -82,7 +82,7 @@ test(
     await verifyFormStatusOnApplication(
       page,
       "incomplete",
-      "Other Narrative Attachments",
+      OTHER_NARRATIVE_ATTACHMENT_FORM_MATCHER,
       applicationUrl,
     );
   },

--- a/frontend/tests/e2e/apply/failure-path-project-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-project-narrative-attachment.spec.ts
@@ -58,11 +58,11 @@ test(
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
     const applicationUrl = page.url();
 
-    const openedProjectNarrativeAttachmentForm = await openForm(
+    const opened = await openForm(
       page,
       PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER,
     );
-    if (!openedProjectNarrativeAttachmentForm) {
+    if (!opened) {
       throw new Error(
         "Could not find or open Project Narrative Attachment Form link on the application forms page",
       );
@@ -82,7 +82,7 @@ test(
     await verifyFormStatusOnApplication(
       page,
       "incomplete",
-      "Project Narrative Attachment",
+      PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER,
       applicationUrl,
     );
   },

--- a/frontend/tests/e2e/apply/failure-path-sf424.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-sf424.spec.ts
@@ -52,8 +52,8 @@ test(
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
     const applicationUrl = page.url();
 
-    const openedSf424ForValidation = await openForm(page, SF424_FORM_MATCHER);
-    if (!openedSf424ForValidation) {
+    const opened = await openForm(page, SF424_FORM_MATCHER);
+    if (!opened) {
       throw new Error(
         "Could not find or open SF-424 form link on the application forms page",
       );
@@ -70,7 +70,7 @@ test(
     await verifyFormStatusOnApplication(
       page,
       "incomplete",
-      "Application for Federal Assistance (SF-424)",
+      SF424_FORM_MATCHER,
       applicationUrl,
     );
   },

--- a/frontend/tests/e2e/apply/failure-path-sf424a.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-sf424a.spec.ts
@@ -60,8 +60,8 @@ test(
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
     const applicationUrl = page.url();
 
-    const openedSf424aForValidation = await openForm(page, SF424A_FORM_MATCHER);
-    if (!openedSf424aForValidation) {
+    const opened = await openForm(page, SF424A_FORM_MATCHER);
+    if (!opened) {
       throw new Error(
         "Could not find or open SF-424A form link on the application forms page",
       );

--- a/frontend/tests/e2e/apply/failure-path-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-sf424b.spec.ts
@@ -52,8 +52,8 @@ test(
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
     const applicationUrl = page.url();
 
-    const openedSf424bForValidation = await openForm(page, SF424B_FORM_MATCHER);
-    if (!openedSf424bForValidation) {
+    const opened = await openForm(page, SF424B_FORM_MATCHER);
+    if (!opened) {
       throw new Error(
         "Could not find or open SF-424B form link on the application forms page",
       );
@@ -73,7 +73,7 @@ test(
     await verifyFormStatusOnApplication(
       page,
       "incomplete",
-      "SF-424B",
+      SF424B_FORM_MATCHER,
       applicationUrl,
     );
   },

--- a/frontend/tests/e2e/apply/failure-path-suppcoversheet-neh-grantsprogram.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-suppcoversheet-neh-grantsprogram.spec.ts
@@ -79,7 +79,7 @@ test(
     await verifyFormStatusOnApplication(
       page,
       "incomplete",
-      "Supplementary Cover Sheet",
+      SUPP_COVER_SHEET_NEH_FORM_MATCHER,
       applicationUrl,
     );
   },

--- a/frontend/tests/e2e/apply/fixtures/attachment-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/attachment-field-definitions.ts
@@ -14,6 +14,6 @@ export const fieldDefinitionsAttachment: FormFillFieldDefinitions = {
 
 export const ATTACHMENT_FORM_CONFIG = {
   ...FORM_DEFAULTS,
-  formName: /^Attachment Form$/, // regex exact match for "Attachment Form"
+  formName: ATTACHMENT_FORM_MATCHER,
   fields: fieldDefinitionsAttachment,
 } as const;

--- a/frontend/tests/e2e/apply/fixtures/attachment-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/attachment-field-definitions.ts
@@ -2,7 +2,7 @@ import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-filling";
 
 // Matches "Attachment Form" link/heading on the application page
-export const ATTACHMENT_FORM_MATCHER = "^Attachment Form$";
+export const ATTACHMENT_FORM_MATCHER = /^Attachment Form$/i;
 
 export const fieldDefinitionsAttachment: FormFillFieldDefinitions = {
   att1: {

--- a/frontend/tests/e2e/apply/fixtures/budget-narrative-attachment-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/budget-narrative-attachment-field-definitions.ts
@@ -4,7 +4,7 @@ import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
 // Matches "Budget Narrative Attachment Form" link/heading on the application page
 export const BUDGET_NARRATIVE_ATTACHMENT_FORM_MATCHER =
-  "^Budget Narrative Attachment Form$";
+  /Budget Narrative Attachment Form/i;
 
 export const fieldDefinitionsBudgetNarrativeAttachment: FormFillFieldDefinitions =
   {

--- a/frontend/tests/e2e/apply/fixtures/epa4700-4-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/epa4700-4-field-definitions.ts
@@ -2,7 +2,7 @@ import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-filling";
 import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
-export const EPA4700_4_FORM_MATCHER = "^EPA\\s+Form\\s+4700-4(?:\\s+.*)?$";
+export const EPA4700_4_FORM_MATCHER = /EPA\s+Form\s+4700-4/i;
 
 export const fieldDefinitionsEPA47004: FormFillFieldDefinitions = {
   applicant_name: {

--- a/frontend/tests/e2e/apply/fixtures/other-narrative-attachment-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/other-narrative-attachment-field-definitions.ts
@@ -4,7 +4,7 @@ import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
 // Matches "Other Narrative Attachments" link/heading on the application page
 export const OTHER_NARRATIVE_ATTACHMENT_FORM_MATCHER =
-  "^Other Narrative Attachments$";
+  /Other Narrative Attachments/i;
 
 export const fieldDefinitionsOtherNarrativeAttachment: FormFillFieldDefinitions =
   {

--- a/frontend/tests/e2e/apply/fixtures/project-narrative-attachment-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/project-narrative-attachment-field-definitions.ts
@@ -2,9 +2,9 @@ import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-filling";
 import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
-// Matches "Project Narrative Attachment" link/heading on the application page
+// Matches "Project Narrative Attachment Form" link/heading on the application page
 export const PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER =
-  "^Project Narrative Attachment Form$";
+  /Project Narrative Attachment Form/i;
 
 export const fieldDefinitionsProjectNarrativeAttachment: FormFillFieldDefinitions =
   {

--- a/frontend/tests/e2e/apply/fixtures/sf424-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424-field-definitions.ts
@@ -3,7 +3,7 @@ import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-fi
 import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
 export const SF424_FORM_MATCHER =
-  "SF\\s*[-‑–—]?\\s*424(?![A-Za-z0-9])|Application\\s+for\\s+Federal\\s+Assistance";
+  /SF\s*[-‑–—]?\s*424(?![A-Za-z0-9])|Application\s+for\s+Federal\s+Assistance/i;
 
 export const fieldDefinitionsSF424: FormFillFieldDefinitions = {
   submission_type: {

--- a/frontend/tests/e2e/apply/fixtures/sf424b-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424b-field-definitions.ts
@@ -5,7 +5,7 @@ import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 // Regex matcher tolerant of hyphen/dash variants for SF-424B,
 // compatible with both local and staging environments.
 export const SF424B_FORM_MATCHER =
-  "SF\\s*[-‑–—]?\\s*424B|Assurances\\s+for\\s+Non\\s*[-‑–—]?\\s*Construction\\s+Programs";
+  /SF\s*[-‑–—]?\s*424B|Assurances\s+for\s+Non\s*[-‑–—]?\s*Construction\s+Programs/i;
 
 export const fieldDefinitionsSF424B: FormFillFieldDefinitions = {
   title: {

--- a/frontend/tests/e2e/apply/fixtures/sf424b-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424b-field-definitions.ts
@@ -22,7 +22,7 @@ export const fieldDefinitionsSF424B: FormFillFieldDefinitions = {
 
 export const SF424B_FORM_CONFIG = {
   ...FORM_DEFAULTS,
-  formName: new RegExp(SF424B_FORM_MATCHER, "i"),
+  formName: SF424B_FORM_MATCHER,
   fields: fieldDefinitionsSF424B,
 } as const;
 

--- a/frontend/tests/e2e/apply/fixtures/sf424b-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424b-field-definitions.ts
@@ -22,7 +22,7 @@ export const fieldDefinitionsSF424B: FormFillFieldDefinitions = {
 
 export const SF424B_FORM_CONFIG = {
   ...FORM_DEFAULTS,
-  formName: "Assurances for Non-Construction Programs (SF-424B)",
+  formName: new RegExp(SF424B_FORM_MATCHER, "i"),
   fields: fieldDefinitionsSF424B,
 } as const;
 

--- a/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
@@ -10,7 +10,16 @@ export const SF424D_FORM_MATCHER =
   "SF\\s*[-‑–—]?\\s*424D|Assurances\\s+for\\s+Construction\\s+Programs";
 
 export const fieldDefinitionsSF424D: FormFillFieldDefinitions = {
-  // Add actual field definitions here as needed
+  title: {
+    testId: "title",
+    type: "text",
+    field: "Title",
+  },
+  applicant_organization: {
+    testId: "applicant_organization",
+    type: "text",
+    field: "Applicant Organization",
+  },
 };
 
 export const SF424D_FORM_CONFIG = {

--- a/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
@@ -5,22 +5,17 @@ import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 export const SF424D_FORM_MATCHER =
   /SF\s*[-‑–—]?\s*424D|Assurances\s+for\s+Construction\s+Programs/i;
 
+// Regex matcher for SF-424D: matches both "SF-424D" and "Assurances for Construction Programs"
+export const SF424D_FORM_MATCHER =
+  "SF\\s*[-‑–—]?\\s*424D|Assurances\\s+for\\s+Construction\\s+Programs";
+
 export const fieldDefinitionsSF424D: FormFillFieldDefinitions = {
-  title: {
-    testId: "title",
-    type: "text",
-    field: "Title",
-  },
-  applicant_organization: {
-    testId: "applicant_organization",
-    type: "text",
-    field: "Applicant Organization",
-  },
+  // Add actual field definitions here as needed
 };
 
 export const SF424D_FORM_CONFIG = {
   ...FORM_DEFAULTS,
-  formName: "Assurances for Construction Programs (SF-424D)",
+  formName: new RegExp(SF424D_FORM_MATCHER, "i"),
   fields: fieldDefinitionsSF424D,
 } as const;
 

--- a/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
@@ -3,7 +3,7 @@ import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-fi
 import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
 export const SF424D_FORM_MATCHER =
-  "SF\\s*[-\u2011\u2013\u2014]?\\s*424D|Assurances\\s+for\\s+Construction\\s+Programs";
+  /SF\s*[-‑–—]?\s*424D|Assurances\s+for\s+Construction\s+Programs/i;
 
 export const fieldDefinitionsSF424D: FormFillFieldDefinitions = {
   title: {

--- a/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424d-field-definitions.ts
@@ -3,11 +3,7 @@ import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-fi
 import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
 export const SF424D_FORM_MATCHER =
-  /SF\s*[-‑–—]?\s*424D|Assurances\s+for\s+Construction\s+Programs/i;
-
-// Regex matcher for SF-424D: matches both "SF-424D" and "Assurances for Construction Programs"
-export const SF424D_FORM_MATCHER =
-  "SF\\s*[-‑–—]?\\s*424D|Assurances\\s+for\\s+Construction\\s+Programs";
+  "SF\\s*[-\u2011\u2013\u2014]?\\s*424D|Assurances\\s+for\\s+Construction\\s+Programs";
 
 export const fieldDefinitionsSF424D: FormFillFieldDefinitions = {
   title: {
@@ -24,7 +20,7 @@ export const fieldDefinitionsSF424D: FormFillFieldDefinitions = {
 
 export const SF424D_FORM_CONFIG = {
   ...FORM_DEFAULTS,
-  formName: new RegExp(SF424D_FORM_MATCHER, "i"),
+  formName: SF424D_FORM_MATCHER,
   fields: fieldDefinitionsSF424D,
 } as const;
 

--- a/frontend/tests/e2e/apply/fixtures/sfLLL-fill-data.ts
+++ b/frontend/tests/e2e/apply/fixtures/sfLLL-fill-data.ts
@@ -1,6 +1,10 @@
 import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-filling";
 
+// Regex matcher for SF-LLL: matches both "SF-LLL" and "Disclosure of Lobbying Activities"
+export const SFLLL_FORM_MATCHER =
+  "SF\\s*[-‑–—]?\\s*LLL|Disclosure\\s+of\\s+Lobbying\\s+Activities";
+
 const fieldDefinitionsSFLLL: FormFillFieldDefinitions = {
   federalAction_type: {
     selector: "#federal_action_type",
@@ -332,6 +336,6 @@ const fieldDefinitionsSFLLL: FormFillFieldDefinitions = {
 
 export const SFLLL_FORM_CONFIG = {
   ...FORM_DEFAULTS,
-  formName: "Disclosure of Lobbying Activities (SF-LLL)",
+  formName: new RegExp(SFLLL_FORM_MATCHER, "i"),
   fields: fieldDefinitionsSFLLL,
 } as const;

--- a/frontend/tests/e2e/apply/fixtures/sfLLL-fill-data.ts
+++ b/frontend/tests/e2e/apply/fixtures/sfLLL-fill-data.ts
@@ -3,7 +3,7 @@ import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-fi
 
 // Regex matcher for SF-LLL: matches both "SF-LLL" and "Disclosure of Lobbying Activities"
 export const SFLLL_FORM_MATCHER =
-  "SF\\s*[-‑–—]?\\s*LLL|Disclosure\\s+of\\s+Lobbying\\s+Activities";
+  /SF\s*[-‑–—]?\s*LLL|Disclosure\s+of\s+Lobbying\s+Activities/i;
 
 const fieldDefinitionsSFLLL: FormFillFieldDefinitions = {
   federalAction_type: {

--- a/frontend/tests/e2e/apply/fixtures/sfLLL-fill-data.ts
+++ b/frontend/tests/e2e/apply/fixtures/sfLLL-fill-data.ts
@@ -336,6 +336,6 @@ const fieldDefinitionsSFLLL: FormFillFieldDefinitions = {
 
 export const SFLLL_FORM_CONFIG = {
   ...FORM_DEFAULTS,
-  formName: new RegExp(SFLLL_FORM_MATCHER, "i"),
+  formName: SFLLL_FORM_MATCHER,
   fields: fieldDefinitionsSFLLL,
 } as const;

--- a/frontend/tests/e2e/apply/fixtures/supp-cover-sheet-neh-grantsprogram-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/supp-cover-sheet-neh-grantsprogram-field-definitions.ts
@@ -2,10 +2,9 @@ import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-filling";
 import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
-// Regex matcher tolerant of hyphen/dash variants for the NEH Supplementary Cover Sheet,
-// compatible with both local and staging environments.
+// Matches the NEH Supplementary Cover Sheet link/heading on the application page
 export const SUPP_COVER_SHEET_NEH_FORM_MATCHER =
-  "Supplementary\\s+Cover\\s+Sheet\\s+for\\s+NEH\\s+Grant\\s+Programs";
+  /Supplementary\s+Cover\s+Sheet\s+for\s+NEH\s+Grant\s+Programs/i;
 
 // Required field validation errors for failure-path tests
 export const SUPP_COVER_SHEET_NEH_REQUIRED_FIELD_ERRORS: FieldError[] = [

--- a/frontend/tests/e2e/apply/happy-path-application-submission.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-application-submission.spec.ts
@@ -19,10 +19,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { selectFormInclusionOption } from "tests/e2e/utils/forms/select-form-inclusion-utils";
 import {
   verifyFormStatusAfterSave,
@@ -30,10 +27,7 @@ import {
 } from "tests/e2e/utils/forms/verify-form-status-utils";
 import { submitApplicationAndVerify } from "tests/e2e/utils/submit-application-utils";
 
-import {
-  SF424B_FORM_CONFIG,
-  SF424B_FORM_MATCHER,
-} from "./fixtures/sf424b-field-definitions";
+import { SF424B_FORM_CONFIG } from "./fixtures/sf424b-field-definitions";
 import { sf424BHappyPathTestData } from "./fixtures/sf424b-fill-data";
 
 const { APPLY, SMOKE, GRANTEE } = VALID_TAGS;
@@ -73,9 +67,6 @@ test(
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
     const applicationUrl = page.url();
-
-    // And the Application landing page loads with the form link visible
-    await verifyFormLinkVisible(page, SF424B_FORM_MATCHER);
 
     // When the user clicks on a form link
     // Then the form opens

--- a/frontend/tests/e2e/apply/happy-path-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-attachment.spec.ts
@@ -68,7 +68,7 @@ test(
     // When the user clicks on a form link
     // Then the form opens
     // And the user fills out the form with valid test data
-    // And the user clicks Save
+    // And the user clicks Save    
     await fillForm(
       testInfo,
       page,
@@ -76,8 +76,6 @@ test(
       attachmentHappyPathTestData,
       false,
     );
-
-    await page.waitForTimeout(2000);
 
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.

--- a/frontend/tests/e2e/apply/happy-path-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-attachment.spec.ts
@@ -68,7 +68,7 @@ test(
     // When the user clicks on a form link
     // Then the form opens
     // And the user fills out the form with valid test data
-    // And the user clicks Save    
+    // And the user clicks Save
     await fillForm(
       testInfo,
       page,

--- a/frontend/tests/e2e/apply/happy-path-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-attachment.spec.ts
@@ -14,16 +14,10 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
-import {
-  ATTACHMENT_FORM_CONFIG,
-  ATTACHMENT_FORM_MATCHER,
-} from "./fixtures/attachment-field-definitions";
+import { ATTACHMENT_FORM_CONFIG } from "./fixtures/attachment-field-definitions";
 import { attachmentHappyPathTestData } from "./fixtures/attachment-fill-data";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -70,13 +64,11 @@ test(
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
 
-    // Verify the Attachment Form link is visible on the application page
-    await verifyFormLinkVisible(page, ATTACHMENT_FORM_MATCHER);
-
+    // Fill Attachment 1 — the form requires at least one attachment to be complete
     // When the user clicks on a form link
     // Then the form opens
     // And the user fills out the form with valid test data
-    // And the user clicks Save
+    // And the user clicks Save    
     await fillForm(
       testInfo,
       page,

--- a/frontend/tests/e2e/apply/happy-path-budget-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-budget-narrative-attachment.spec.ts
@@ -75,8 +75,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-budget-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-budget-narrative-attachment.spec.ts
@@ -14,16 +14,10 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
-import {
-  BUDGET_NARRATIVE_ATTACHMENT_FORM_CONFIG,
-  BUDGET_NARRATIVE_ATTACHMENT_FORM_MATCHER,
-} from "./fixtures/budget-narrative-attachment-field-definitions";
+import { BUDGET_NARRATIVE_ATTACHMENT_FORM_CONFIG } from "./fixtures/budget-narrative-attachment-field-definitions";
 import { budgetNarrativeAttachmentHappyPathTestData } from "./fixtures/budget-narrative-attachment-fill-data";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -68,9 +62,6 @@ test(
      * (includes modal interaction, organization selection, and application creation)
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-
-    // And the Application landing page loads with the form link visible
-    await verifyFormLinkVisible(page, BUDGET_NARRATIVE_ATTACHMENT_FORM_MATCHER);
 
     // When the user clicks on a form link
     // Then the form opens

--- a/frontend/tests/e2e/apply/happy-path-cd511.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-cd511.spec.ts
@@ -68,8 +68,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-epa-keycontacts.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-epa-keycontacts.spec.ts
@@ -68,8 +68,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-epa4700-4.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-epa4700-4.spec.ts
@@ -69,8 +69,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-grantsgov-lobbying.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-grantsgov-lobbying.spec.ts
@@ -58,8 +58,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-other-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-other-narrative-attachment.spec.ts
@@ -76,8 +76,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-other-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-other-narrative-attachment.spec.ts
@@ -14,16 +14,10 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
-import {
-  OTHER_NARRATIVE_ATTACHMENT_FORM_CONFIG,
-  OTHER_NARRATIVE_ATTACHMENT_FORM_MATCHER,
-} from "./fixtures/other-narrative-attachment-field-definitions";
+import { OTHER_NARRATIVE_ATTACHMENT_FORM_CONFIG } from "./fixtures/other-narrative-attachment-field-definitions";
 import { otherNarrativeAttachmentHappyPathTestData } from "./fixtures/other-narrative-attachment-fill-data";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -69,9 +63,6 @@ test(
      * (includes modal interaction, organization selection, and application creation)
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-
-    // And the Application landing page loads with the <form name> form link visible
-    await verifyFormLinkVisible(page, OTHER_NARRATIVE_ATTACHMENT_FORM_MATCHER);
 
     // When the user clicks on a form link
     // Then the form opens

--- a/frontend/tests/e2e/apply/happy-path-project-abstract-summary.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-project-abstract-summary.spec.ts
@@ -68,8 +68,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-project-abstract.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-project-abstract.spec.ts
@@ -74,6 +74,7 @@ test(
       projectAbstractHappyPathTestData,
       false,
     );
+    
     await page.waitForTimeout(5000);
 
     /* Covers "Form status validation" flow in the feature file,

--- a/frontend/tests/e2e/apply/happy-path-project-abstract.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-project-abstract.spec.ts
@@ -75,8 +75,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(5000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-project-abstract.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-project-abstract.spec.ts
@@ -74,7 +74,7 @@ test(
       projectAbstractHappyPathTestData,
       false,
     );
-    
+
     await page.waitForTimeout(5000);
 
     /* Covers "Form status validation" flow in the feature file,

--- a/frontend/tests/e2e/apply/happy-path-project-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-project-narrative-attachment.spec.ts
@@ -14,16 +14,10 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
-import {
-  PROJECT_NARRATIVE_ATTACHMENT_FORM_CONFIG,
-  PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER,
-} from "./fixtures/project-narrative-attachment-field-definitions";
+import { PROJECT_NARRATIVE_ATTACHMENT_FORM_CONFIG } from "./fixtures/project-narrative-attachment-field-definitions";
 import { projectNarrativeAttachmentHappyPathTestData } from "./fixtures/project-narrative-attachment-fill-data";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -69,12 +63,6 @@ test(
      * (includes modal interaction, organization selection, and application creation)
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-
-    // And the Application landing page loads with the form link visible
-    await verifyFormLinkVisible(
-      page,
-      PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER,
-    );
 
     // When the user clicks on a form link
     // Then the form opens

--- a/frontend/tests/e2e/apply/happy-path-project-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-project-narrative-attachment.spec.ts
@@ -76,8 +76,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-sf424.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-sf424.spec.ts
@@ -70,8 +70,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-sf424a.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-sf424a.spec.ts
@@ -76,8 +76,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/apply/happy-path-sf424a.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-sf424a.spec.ts
@@ -14,16 +14,10 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
-import {
-  SF424A_FORM_CONFIG,
-  SF424A_FORM_MATCHER,
-} from "./fixtures/sf424a-field-definitions";
+import { SF424A_FORM_CONFIG } from "./fixtures/sf424a-field-definitions";
 import { sf424aHappyPathTestData } from "./fixtures/sf424a-fill-data";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -69,9 +63,6 @@ test(
      * (includes modal interaction, organization selection, and application creation)
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-
-    // And the Application landing page loads with the form link visible
-    await verifyFormLinkVisible(page, SF424A_FORM_MATCHER);
 
     // When the user clicks on a form link
     // Then the form opens

--- a/frontend/tests/e2e/apply/happy-path-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-sf424b.spec.ts
@@ -67,7 +67,6 @@ test(
       sf424BHappyPathTestData(testOrgLabel),
       false,
     );
-    await page.waitForTimeout(2000);
 
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.

--- a/frontend/tests/e2e/apply/happy-path-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-sf424b.spec.ts
@@ -14,16 +14,10 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
-import {
-  SF424B_FORM_CONFIG,
-  SF424B_FORM_MATCHER,
-} from "./fixtures/sf424b-field-definitions";
+import { SF424B_FORM_CONFIG } from "./fixtures/sf424b-field-definitions";
 import { sf424BHappyPathTestData } from "./fixtures/sf424b-fill-data";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -61,9 +55,6 @@ test(
      * (includes modal interaction, organization selection, and application creation)
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-
-    // And the Application landing page loads with the form link visible
-    await verifyFormLinkVisible(page, SF424B_FORM_MATCHER);
 
     // When the user clicks on a form link
     // Then the form opens

--- a/frontend/tests/e2e/apply/happy-path-sf424d.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-sf424d.spec.ts
@@ -66,7 +66,6 @@ test(
       sf424DHappyPathTestData,
       false,
     );
-    await page.waitForTimeout(2000);
 
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.

--- a/frontend/tests/e2e/apply/happy-path-sfLLL.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-sfLLL.spec.ts
@@ -65,8 +65,6 @@ test.describe("Application form completion happy path - SFLLL", () => {
       // And the user clicks Save
       await fillForm(testInfo, page, SFLLL_FORM_CONFIG, SFLLL_TEST_DATA, false);
 
-      await page.waitForTimeout(5000);
-
       /* Covers "Form status validation" flow in the feature file,
        * which includes verification of the status in form and application landing page after saving a completed form.
        */

--- a/frontend/tests/e2e/apply/happy-path-suppcoversheet-neh-grantsprogram.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-suppcoversheet-neh-grantsprogram.spec.ts
@@ -14,16 +14,10 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
 import { createApplication } from "tests/e2e/utils/create-application-utils";
-import {
-  fillForm,
-  verifyFormLinkVisible,
-} from "tests/e2e/utils/forms/general-forms-filling";
+import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
-import {
-  SUPP_COVER_SHEET_NEH_FORM_CONFIG,
-  SUPP_COVER_SHEET_NEH_FORM_MATCHER,
-} from "./fixtures/supp-cover-sheet-neh-grantsprogram-field-definitions";
+import { SUPP_COVER_SHEET_NEH_FORM_CONFIG } from "./fixtures/supp-cover-sheet-neh-grantsprogram-field-definitions";
 import { suppCoverSheetNEHHappyPathTestData } from "./fixtures/supp-cover-sheet-neh-grantsprogram-fill-data";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -69,9 +63,6 @@ test(
      * (includes modal interaction, organization selection, and application creation)
      */
     await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-
-    // And the Application landing page loads with the form link visible
-    await verifyFormLinkVisible(page, SUPP_COVER_SHEET_NEH_FORM_MATCHER);
 
     // When the user clicks on a form link
     // Then the form opens

--- a/frontend/tests/e2e/apply/happy-path-suppcoversheet-neh-grantsprogram.spec.ts
+++ b/frontend/tests/e2e/apply/happy-path-suppcoversheet-neh-grantsprogram.spec.ts
@@ -76,8 +76,6 @@ test(
       false,
     );
 
-    await page.waitForTimeout(2000);
-
     /* Covers "Form status validation" flow in the feature file,
      * which includes verification of the status in form and application landing page after saving a completed form.
      */

--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -1,7 +1,7 @@
 import { Page, TestInfo } from "@playwright/test";
 import { selectDropdownByValueOrLabel } from "tests/e2e/utils/select-dropdown-utils";
 
-import { getFormLink } from "./form-navigation-utils";
+import { openForm } from "./form-navigation-utils";
 
 export interface FillFieldDefinition {
   testId?: string;
@@ -326,11 +326,15 @@ export async function fillFormPartial(
 }
 
 /**
- * Navigates into a form from the application page, fills all fields listed in 'data' fixture,
- * saves the form, and optionally returns to the application page.
+ * Opens and fills a form from the application page, then saves it.
+ * Delegates navigation to `openForm`, which owns all navigation reliability:
+ * table-scoped row lookup, scroll-to-reveal, testId/href/button/global
+ * fallback selectors, trial-click check, force-click retry, direct href
+ * goto last resort, and URL pattern + load-state verification.
+ *
  * Does NOT perform assertions - those are done in the test.
- * Assumes the current page is already an application page
- * where the form link (`formName`) is visible and clickable.
+ * Assumes the current page is already an application page where the forms
+ * table is reachable.
  */
 export async function fillForm(
   testInfo: TestInfo,
@@ -349,22 +353,30 @@ export async function fillForm(
     contentType: "text/plain",
   });
 
+  // Derive a string matcher for openForm: if formName is already a string use
+  // it directly; if it is a RegExp, use its source pattern so openForm can
+  // construct the case-insensitive regex it expects.
+  const formMatcher = formName instanceof RegExp ? formName.source : formName;
+
   try {
-    await page.getByRole("link", { name: formName }).click();
+    // ── Navigation ──────────────────────────────────────────────────────────
+    // Delegate to openForm, which owns all navigation reliability:
+    // table-scoped row lookup, scroll-to-reveal, testId/href/button/global
+    // fallback selectors, trial-click check, force-click retry, direct href
+    // goto last resort, and URL pattern + load-state verification.
+    const opened = await openForm(page, formMatcher);
+    if (!opened) {
+      throw new Error(`Could not find or open form: ${formMatcher}`);
+    }
 
-    // Wait for the URL to change away from the application page before
-    // checking for form content - without this, getByText(formName) may
-    // immediately resolve against the link text on the application list page,
-    // causing fillField to run before navigation completes.
-    // Mobile Chrome where navigation is slower.
-    await page.waitForURL((url) => url.href !== applicationURL, {
-      timeout: 35000,
-    });
-
+    // ── Form ready check ───────────────────────────────────────────────────
+    // Confirm the form heading is visible before filling any fields.
     await page
       .getByText(formName)
       .first()
       .waitFor({ state: "visible", timeout: 35000 });
+
+    // ── Fill fields ────────────────────────────────────────────────────────
 
     for (const fieldDefinition of Object.entries(fields)) {
       const [fieldIdentifier, fieldConfig] = fieldDefinition;
@@ -406,26 +418,4 @@ export async function fillForm(
     });
     throw error;
   }
-}
-
-/**
- * Verifies that a form link or button is visible on the page.
- * Use after application creation to confirm the forms table has fully rendered
- * before attempting to navigate into a form.
- * @param page Playwright Page object
- * @param formName Form name or pipe-separated pattern to match (e.g. "SF-424B|Assurances for Non-Construction Programs")
- */
-export async function verifyFormLinkVisible(
-  page: Page,
-  formName: string | RegExp,
-): Promise<void> {
-  const formLink =
-    formName instanceof RegExp
-      ? page.locator("a, button").filter({ hasText: formName })
-      : getFormLink(page, formName);
-
-  await formLink.waitFor({
-    state: "visible",
-    timeout: 60000,
-  });
 }

--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -1,7 +1,7 @@
 import { Page, TestInfo } from "@playwright/test";
 import { selectDropdownByValueOrLabel } from "tests/e2e/utils/select-dropdown-utils";
 
-import { openForm } from "./form-navigation-utils";
+import { buildFlexibleFormNameRegex, openForm } from "./form-navigation-utils";
 import { clickSaveButton } from "./save-form-utils";
 
 export interface FillFieldDefinition {
@@ -353,10 +353,10 @@ export async function fillForm(
     contentType: "text/plain",
   });
 
-  // Derive a string matcher for openForm: if formName is already a string use
-  // it directly; if it is a RegExp, use its source pattern so openForm can
-  // construct the case-insensitive regex it expects.
-  const formMatcher = formName instanceof RegExp ? formName.source : formName;
+  // Derive a regex matcher for openForm. For plain strings (e.g. "SF-424 (Form)"),
+  // use buildFlexibleFormNameRegex so special chars like () are properly escaped
+  // and hyphens/spaces become flexible. For RegExp formNames, pass through directly.
+  const formMatcher = formName instanceof RegExp ? formName : buildFlexibleFormNameRegex(formName);
 
   try {
     // ── Navigation ──────────────────────────────────────────────────────────
@@ -371,10 +371,10 @@ export async function fillForm(
 
     // ── Form ready check ───────────────────────────────────────────────────
     // Confirm the form heading is visible before filling any fields.
-    // Convert string formName to RegExp so getByText does a regex match rather
-    // than a literal text search (important when formName is a regex pattern string).
+    // Use buildFlexibleFormNameRegex for plain strings so special chars (parens,
+    // hyphens) are properly escaped rather than treated as regex syntax.
     const formReadyMatcher =
-      formName instanceof RegExp ? formName : new RegExp(formName, "i");
+      formName instanceof RegExp ? formName : buildFlexibleFormNameRegex(formName);
     await page
       .getByText(formReadyMatcher)
       .first()

--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -2,6 +2,7 @@ import { Page, TestInfo } from "@playwright/test";
 import { selectDropdownByValueOrLabel } from "tests/e2e/utils/select-dropdown-utils";
 
 import { openForm } from "./form-navigation-utils";
+import { clickSaveButton } from "./save-form-utils";
 
 export interface FillFieldDefinition {
   testId?: string;
@@ -343,7 +344,6 @@ export async function fillForm(
   data: Record<string, string | boolean>,
   returnToApplication = true,
 ): Promise<void> {
-  const SAVE_BUTTON_TIMEOUT_MS = 30000;
   const { formName, fields, saveButtonTestId } = config;
 
   const applicationURL = page.url();
@@ -359,7 +359,7 @@ export async function fillForm(
   const formMatcher = formName instanceof RegExp ? formName.source : formName;
 
   try {
-    // *********** Navigation ***********
+    // ── Navigation ──────────────────────────────────────────────────────────
     // Delegate to openForm, which owns all navigation reliability:
     // table-scoped row lookup, scroll-to-reveal, testId/href/button/global
     // fallback selectors, trial-click check, force-click retry, direct href
@@ -369,14 +369,14 @@ export async function fillForm(
       throw new Error(`Could not find or open form: ${formMatcher}`);
     }
 
-    // *********** Form ready check ***********
+    // ── Form ready check ───────────────────────────────────────────────────
     // Confirm the form heading is visible before filling any fields.
     await page
       .getByText(formName)
       .first()
       .waitFor({ state: "visible", timeout: 35000 });
 
-    // *********** Fill fields ***********
+    // ── Fill fields ────────────────────────────────────────────────────────
 
     for (const fieldDefinition of Object.entries(fields)) {
       const [fieldIdentifier, fieldConfig] = fieldDefinition;
@@ -400,13 +400,7 @@ export async function fillForm(
       await config.beforeSave(page);
     }
 
-    await page.waitForTimeout(500);
-    const saveButton = page.getByTestId(saveButtonTestId);
-    await saveButton.waitFor({
-      state: "visible",
-      timeout: SAVE_BUTTON_TIMEOUT_MS,
-    });
-    await saveButton.click({ timeout: SAVE_BUTTON_TIMEOUT_MS });
+    await clickSaveButton(page, saveButtonTestId);
 
     if (returnToApplication) {
       await page.goto(applicationURL);

--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -359,7 +359,7 @@ export async function fillForm(
   const formMatcher = formName instanceof RegExp ? formName.source : formName;
 
   try {
-    // ── Navigation ──────────────────────────────────────────────────────────
+    // *********** Navigation ***********
     // Delegate to openForm, which owns all navigation reliability:
     // table-scoped row lookup, scroll-to-reveal, testId/href/button/global
     // fallback selectors, trial-click check, force-click retry, direct href
@@ -369,14 +369,14 @@ export async function fillForm(
       throw new Error(`Could not find or open form: ${formMatcher}`);
     }
 
-    // ── Form ready check ───────────────────────────────────────────────────
+    // *********** Form ready check ***********
     // Confirm the form heading is visible before filling any fields.
     await page
       .getByText(formName)
       .first()
       .waitFor({ state: "visible", timeout: 35000 });
 
-    // ── Fill fields ────────────────────────────────────────────────────────
+    // *********** Fill fields ***********
 
     for (const fieldDefinition of Object.entries(fields)) {
       const [fieldIdentifier, fieldConfig] = fieldDefinition;

--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -356,7 +356,10 @@ export async function fillForm(
   // Derive a regex matcher for openForm. For plain strings (e.g. "SF-424 (Form)"),
   // use buildFlexibleFormNameRegex so special chars like () are properly escaped
   // and hyphens/spaces become flexible. For RegExp formNames, pass through directly.
-  const formMatcher = formName instanceof RegExp ? formName : buildFlexibleFormNameRegex(formName);
+  const formMatcher =
+    formName instanceof RegExp
+      ? formName
+      : buildFlexibleFormNameRegex(formName);
 
   try {
     // ── Navigation ──────────────────────────────────────────────────────────
@@ -374,7 +377,9 @@ export async function fillForm(
     // Use buildFlexibleFormNameRegex for plain strings so special chars (parens,
     // hyphens) are properly escaped rather than treated as regex syntax.
     const formReadyMatcher =
-      formName instanceof RegExp ? formName : buildFlexibleFormNameRegex(formName);
+      formName instanceof RegExp
+        ? formName
+        : buildFlexibleFormNameRegex(formName);
     await page
       .getByText(formReadyMatcher)
       .first()

--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -371,8 +371,12 @@ export async function fillForm(
 
     // ── Form ready check ───────────────────────────────────────────────────
     // Confirm the form heading is visible before filling any fields.
+    // Convert string formName to RegExp so getByText does a regex match rather
+    // than a literal text search (important when formName is a regex pattern string).
+    const formReadyMatcher =
+      formName instanceof RegExp ? formName : new RegExp(formName, "i");
     await page
-      .getByText(formName)
+      .getByText(formReadyMatcher)
       .first()
       .waitFor({ state: "visible", timeout: 35000 });
 

--- a/frontend/tests/e2e/utils/forms/save-form-utils.ts
+++ b/frontend/tests/e2e/utils/forms/save-form-utils.ts
@@ -1,8 +1,8 @@
 import { expect, Page } from "@playwright/test";
-import playwrightEnv from "tests/e2e/playwright-env";
 import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 
-const SAVE_TIMEOUT = playwrightEnv.targetEnv === "staging" ? 30000 : 10000;
+// 30s accommodates both staging (slow under load) and Mobile Chrome in CI (slow rendering).
+const SAVE_TIMEOUT = 30000;
 
 /**
  * Waits for the save button to be visible and clicks it.

--- a/frontend/tests/e2e/utils/forms/save-form-utils.ts
+++ b/frontend/tests/e2e/utils/forms/save-form-utils.ts
@@ -2,9 +2,24 @@ import { expect, Page } from "@playwright/test";
 import playwrightEnv from "tests/e2e/playwright-env";
 import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 
-// Staging can be slow under load; Firefox tends to be slower than Chrome in CI.
-// Use 30s for staging, 20s for local to accommodate both.
-const SAVE_TIMEOUT = playwrightEnv.targetEnv === "staging" ? 30000 : 20000;
+const SAVE_TIMEOUT = playwrightEnv.targetEnv === "staging" ? 30000 : 10000;
+
+/**
+ * Waits for the save button to be visible and clicks it.
+ * Does NOT assert any post-save state; use saveForm() or verifyFormStatusAfterSave() for that.
+ * @param page Playwright Page object
+ * @param saveButtonTestId Test ID for the save button (defaults to the standard apply-form-save button)
+ */
+export async function clickSaveButton(
+  page: Page,
+  saveButtonTestId: string = FORM_DEFAULTS.saveButtonTestId,
+): Promise<void> {
+  const saveButton = page
+    .getByTestId(saveButtonTestId)
+    .or(page.getByRole("button", { name: /save/i }).first());
+  await saveButton.waitFor({ state: "visible", timeout: SAVE_TIMEOUT });
+  await saveButton.click();
+}
 
 /**
  * Clicks the save button and verifies form save result.
@@ -12,45 +27,22 @@ const SAVE_TIMEOUT = playwrightEnv.targetEnv === "staging" ? 30000 : 20000;
  * @param expectErrors When true, expect validation errors instead of success
  */
 export async function saveForm(page: Page, expectErrors = false) {
-  const saveButton = page
-    .getByTestId(FORM_DEFAULTS.saveButtonTestId)
-    .or(page.getByRole("button", { name: /save/i }).first());
+  await clickSaveButton(page);
 
-  if (await saveButton.isVisible()) {
-    // Set up a listener for the Next.js Server Action POST request BEFORE
-    // clicking, so we don't miss a fast response. The save button submits an
-    // HTML form that triggers a Server Action - in the browser this appears as a
-    // POST to the current page URL with a "next-action" request header.
-    const saveResponsePromise = page.waitForResponse(
-      (response) =>
-        response.request().method() === "POST" &&
-        !!response.request().headers()["next-action"],
-      { timeout: SAVE_TIMEOUT },
-    );
+  // Always check for form saved message, which appears for both validation
+  // and successful saves. Use a generous timeout on staging — the save API
+  // can be slow under load.
+  await expect(
+    page.getByText(FORM_DEFAULTS.formSavedHeading, { exact: false }),
+  ).toBeVisible({ timeout: SAVE_TIMEOUT });
 
-    await saveButton.click();
-
-    // Wait for the Server Action round-trip to complete before asserting UI state.
-    await saveResponsePromise.catch(() => {
-      // If we can't match the server-action response (e.g., env differences),
-      // fall back to a static wait so the test can still proceed.
-    });
-
-    // Always check for form saved message, which appears for both validation
-    // and successful saves. Use a generous timeout - the save API can be slow
-    // under load, and Firefox renders UI updates more slowly than Chrome.
+  if (expectErrors) {
     await expect(
-      page.getByText(FORM_DEFAULTS.formSavedHeading, { exact: false }),
+      page.getByText(FORM_DEFAULTS.validationErrorText, { exact: false }),
     ).toBeVisible({ timeout: SAVE_TIMEOUT });
-
-    if (expectErrors) {
-      await expect(
-        page.getByText(FORM_DEFAULTS.validationErrorText, { exact: false }),
-      ).toBeVisible({ timeout: SAVE_TIMEOUT });
-    } else {
-      await expect(
-        page.getByText(FORM_DEFAULTS.noErrorsText, { exact: false }),
-      ).toBeVisible({ timeout: SAVE_TIMEOUT });
-    }
+  } else {
+    await expect(
+      page.getByText(FORM_DEFAULTS.noErrorsText, { exact: false }),
+    ).toBeVisible({ timeout: SAVE_TIMEOUT });
   }
 }

--- a/frontend/tests/e2e/utils/forms/select-form-inclusion-utils.ts
+++ b/frontend/tests/e2e/utils/forms/select-form-inclusion-utils.ts
@@ -1,5 +1,7 @@
 import { expect, Locator, Page } from "@playwright/test";
 
+import { buildFlexibleFormNameRegex } from "./form-navigation-utils";
+
 async function clickInclusionOption(
   page: Page,
   label: Locator,
@@ -42,10 +44,8 @@ export async function selectFormInclusionOption(
   formName: string,
   option: "Yes" | "No" = "Yes",
 ): Promise<void> {
-  const escapedFormName = formName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const flexiblePattern = escapedFormName.replace(/\s+/g, "\\s*");
   const formRow = page.locator("tr", {
-    hasText: new RegExp(flexiblePattern, "i"),
+    hasText: buildFlexibleFormNameRegex(formName),
   });
 
   await expect(formRow).toBeVisible({ timeout: 12000 });

--- a/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
+++ b/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
@@ -19,18 +19,19 @@ export type FormStatus = "complete" | "incomplete";
 export async function assertFormRowStatus(
   page: Page,
   status: FormStatus,
-  formName: string,
+  formName: string | RegExp,
 ): Promise<void> {
-  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await page.waitForTimeout(5000);
-
-  const escapedFormName = formName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const flexiblePattern = escapedFormName
-    .replace(/\s+/g, "\\s*")
-    .replace(/-/g, "-?");
+  let rowPattern: RegExp;
+  if (formName instanceof RegExp) {
+    rowPattern = formName;
+  } else {
+    const escaped = formName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const flexible = escaped.replace(/\s+/g, "\\s*").replace(/-/g, "-?");
+    rowPattern = new RegExp(flexible, "i");
+  }
   const formRow = page
     .locator("tr", {
-      hasText: new RegExp(flexiblePattern, "i"),
+      hasText: rowPattern,
     })
     .filter({
       has: page.locator('a[href*="/form/"]'),
@@ -57,7 +58,7 @@ export async function assertFormRowStatus(
 export async function verifyFormStatusOnApplication(
   page: Page,
   status: FormStatus,
-  formName: string,
+  formName: string | RegExp,
   applicationUrl: string,
 ): Promise<void> {
   await gotoWithRetry(page, applicationUrl, { waitUntil: "domcontentloaded" });
@@ -82,12 +83,16 @@ export async function verifyFormStatusOnApplication(
  *
  * @param page Playwright Page object
  * @param status Expected status: "complete" or "incomplete"
- * @param expectedErrors Required when status is "incomplete" — list of field errors to verify
+ * @param expectedErrors Required when status is "incomplete" — list of field errors to verify inline
+ * @param alertErrors Optional override for the alert banner error list. Defaults to expectedErrors.
+ *   Use when a form's alert-level errors differ from its inline field errors (e.g. array-level
+ *   validation errors that appear in the alert but have no corresponding inline element).
  */
 export async function verifyFormStatusAfterSave(
   page: Page,
   status: FormStatus,
   expectedErrors?: FieldError[],
+  alertErrors?: FieldError[],
 ): Promise<void> {
   if (status === "complete") {
     const alert = page.getByTestId("alert");
@@ -109,7 +114,7 @@ export async function verifyFormStatusAfterSave(
         "expectedErrors must be provided when status is 'incomplete'",
       );
     }
-    await verifyAlertErrors(page, expectedErrors);
+    await verifyAlertErrors(page, alertErrors ?? expectedErrors);
     await verifyInlineErrors(page, expectedErrors);
   }
 }

--- a/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
+++ b/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
@@ -7,8 +7,6 @@ import {
 } from "tests/e2e/utils/forms/verify-form-errors-utils";
 import { gotoWithRetry } from "tests/e2e/utils/lifecycle-utils";
 
-import { buildFlexibleFormNameRegex } from "./form-navigation-utils";
-
 export type FormStatus = "complete" | "incomplete";
 
 /**
@@ -21,15 +19,18 @@ export type FormStatus = "complete" | "incomplete";
 export async function assertFormRowStatus(
   page: Page,
   status: FormStatus,
-  formName: string | RegExp,
+  formName: string,
 ): Promise<void> {
-  const rowPattern =
-    formName instanceof RegExp
-      ? formName
-      : buildFlexibleFormNameRegex(formName);
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await page.waitForTimeout(5000);
+
+  const escapedFormName = formName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const flexiblePattern = escapedFormName
+    .replace(/\s+/g, "\\s*")
+    .replace(/-/g, "-?");
   const formRow = page
     .locator("tr", {
-      hasText: rowPattern,
+      hasText: new RegExp(flexiblePattern, "i"),
     })
     .filter({
       has: page.locator('a[href*="/form/"]'),
@@ -56,11 +57,18 @@ export async function assertFormRowStatus(
 export async function verifyFormStatusOnApplication(
   page: Page,
   status: FormStatus,
-  formName: string | RegExp,
+  formName: string,
   applicationUrl: string,
 ): Promise<void> {
   await gotoWithRetry(page, applicationUrl, { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(10000);
+  // Wait for the forms table to be populated before asserting row status.
+  // domcontentloaded fires before async data is fetched; this replaces the
+  // old static 10s wait with a dynamic wait that is both faster on fast
+  // machines and more reliable on slow ones (e.g. Mobile Chrome in CI).
+  await page
+    .locator('a[href*="/form/"]')
+    .first()
+    .waitFor({ state: "visible", timeout: 30000 });
   await assertFormRowStatus(page, status, formName);
 }
 
@@ -74,16 +82,12 @@ export async function verifyFormStatusOnApplication(
  *
  * @param page Playwright Page object
  * @param status Expected status: "complete" or "incomplete"
- * @param expectedErrors Required when status is "incomplete" — list of field errors to verify inline
- * @param alertErrors Optional override for the alert banner error list. Defaults to expectedErrors.
- *   Use when a form's alert-level errors differ from its inline field errors (e.g. array-level
- *   validation errors that appear in the alert but have no corresponding inline element).
+ * @param expectedErrors Required when status is "incomplete" — list of field errors to verify
  */
 export async function verifyFormStatusAfterSave(
   page: Page,
   status: FormStatus,
   expectedErrors?: FieldError[],
-  alertErrors?: FieldError[],
 ): Promise<void> {
   if (status === "complete") {
     const alert = page.getByTestId("alert");
@@ -105,7 +109,7 @@ export async function verifyFormStatusAfterSave(
         "expectedErrors must be provided when status is 'incomplete'",
       );
     }
-    await verifyAlertErrors(page, alertErrors ?? expectedErrors);
+    await verifyAlertErrors(page, expectedErrors);
     await verifyInlineErrors(page, expectedErrors);
   }
 }

--- a/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
+++ b/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
@@ -90,6 +90,7 @@ export async function verifyFormStatusAfterSave(
     // Use a generous timeout: Webkit renders the save-confirmation alert more
     // slowly than Chrome/Firefox, and the Playwright default (5000ms) is
     // insufficient on some CI runners.
+    await expect(alert).toBeVisible({ timeout: 30000 });
     await expect(alert.locator(".usa-alert__heading")).toContainText(
       FORM_DEFAULTS.formSavedHeading,
       { timeout: 15000 },

--- a/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
+++ b/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
@@ -7,6 +7,8 @@ import {
 } from "tests/e2e/utils/forms/verify-form-errors-utils";
 import { gotoWithRetry } from "tests/e2e/utils/lifecycle-utils";
 
+import { buildFlexibleFormNameRegex } from "./form-navigation-utils";
+
 export type FormStatus = "complete" | "incomplete";
 
 /**
@@ -21,14 +23,10 @@ export async function assertFormRowStatus(
   status: FormStatus,
   formName: string | RegExp,
 ): Promise<void> {
-  let rowPattern: RegExp;
-  if (formName instanceof RegExp) {
-    rowPattern = formName;
-  } else {
-    const escaped = formName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const flexible = escaped.replace(/\s+/g, "\\s*").replace(/-/g, "-?");
-    rowPattern = new RegExp(flexible, "i");
-  }
+  const rowPattern =
+    formName instanceof RegExp
+      ? formName
+      : buildFlexibleFormNameRegex(formName);
   const formRow = page
     .locator("tr", {
       hasText: rowPattern,

--- a/frontend/tests/e2e/utils/post-submission-utils.ts
+++ b/frontend/tests/e2e/utils/post-submission-utils.ts
@@ -64,7 +64,7 @@ export async function verifyPostSubmission(
  */
 export async function verifyFormFieldsAreReadonlyAfterSubmission(
   page: Page,
-  formMatcher: string,
+  formMatcher: string | RegExp,
   formName: string,
   fields: ReadonlyFieldCheck[],
 ): Promise<void> {


### PR DESCRIPTION
## Summary
Work for task: #9359 

## Changes proposed
This PR refactors fillForm to delegate its navigation step to openForm, making openForm the single source of truth for navigation reliability. openForm continues to be used directly in tests that navigate to a form without filling it.

Remove any redundant calls and their imports from the spec and utility files.

## Context for reviewers
The structure allows standalone Playwright tests to run independently and in CI

## Validation steps
Run the standalone Playwright test and it should complete the workflow without any issues
