### PR TITLE
[Issue #9386] SOAP/Proxy: Fix sorting issue with GetSubmissionListExpanded

### DIFF
--- a/api/src/legacy_soap_api/grantors/schemas/get_submission_list_expanded_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/get_submission_list_expanded_schemas.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
 from src.legacy_soap_api.legacy_soap_api_schemas import BaseSOAPSchema, SOAPInvalidEnvelope
+from src.util.datetime_util import make_timezone_aware
 
 
 class SubmissionInfo(BaseSOAPSchema):
@@ -19,6 +20,13 @@ class SubmissionInfo(BaseSOAPSchema):
     delinquent_federal_debt: str | None = Field(alias="DelinquentFederalDebt")
     active_exclusions: str | None = Field(alias="ActiveExclusions")
     uei: str | None = Field(alias="UEI")
+
+    @field_validator("received_date_time", mode="before")
+    @classmethod
+    def ensure_timezone_aware(cls, received_date_time: datetime | None) -> datetime | None:
+        if isinstance(received_date_time, datetime) and received_date_time.tzinfo is None:
+            return make_timezone_aware(received_date_time, "US/Eastern")
+        return received_date_time
 
     @field_serializer("received_date_time")
     def serialize_dt(self, dt: datetime) -> str:

--- a/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Generator, Iterator
-from datetime import datetime
+from datetime import datetime, timezone
 
 import xmltodict
 from lxml import etree
@@ -241,7 +241,10 @@ def get_submission_list_expanded_response(
     for submission in submissions:
         submission_list_obj = transform_submission(submission)
         info.append(schemas.SubmissionInfo(**submission_list_obj))
-    info.sort(key=lambda x: x.received_date_time or datetime.min, reverse=True)
+    info.sort(
+        key=lambda x: x.received_date_time or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
     return schemas.GetSubmissionListExpandedResponse(
         success=True, available_application_number=len(info), submission_info=info
     )

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_api_grantor_get_submission_list_expanded_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_api_grantor_get_submission_list_expanded_schema.py
@@ -1,3 +1,6 @@
+import zoneinfo
+from datetime import datetime
+
 import pytest
 
 from src.legacy_soap_api.grantors import schemas as grantors_schemas
@@ -229,3 +232,55 @@ class TestLegacySoapGrantorGetSubmissionListExtendedSchema:
             }
         }
         assert schema.model_dump() == expected
+
+
+class TestSubmissionInfoTimezoneValidation:
+    SUBMISSION_DEFAULTS = {
+        "FundingOpportunityNumber": "OPP-001",
+        "CFDANumber": "10.001",
+        "GrantsGovTrackingNumber": "GRANT12345",
+        "GrantsGovApplicationStatus": "Received",
+        "SubmissionMethod": "web",
+        "SubmissionTitle": "Test",
+        "PackageID": "PKG-001",
+        "DelinquentFederalDebt": "No",
+        "ActiveExclusions": "No",
+        "UEI": "ABC123",
+    }
+
+    def _make_submission_info(self, received_date_time):
+        return grantors_schemas.SubmissionInfo(
+            **{**self.SUBMISSION_DEFAULTS, "ns2:ReceivedDateTime": received_date_time}
+        )
+
+    def test_naive_datetime_is_made_timezone_aware(self):
+        naive_dt = datetime(2025, 3, 15, 10, 30, 0)
+        info = self._make_submission_info(naive_dt)
+        assert info.received_date_time is not None
+        assert info.received_date_time.tzinfo is not None
+        assert info.received_date_time.tzinfo == zoneinfo.ZoneInfo("US/Eastern")
+
+    def test_aware_datetime_is_not_modified(self):
+        utc_tz = zoneinfo.ZoneInfo("UTC")
+        aware_dt = datetime(2025, 3, 15, 10, 30, 0, tzinfo=utc_tz)
+        info = self._make_submission_info(aware_dt)
+        assert info.received_date_time is not None
+        assert info.received_date_time.tzinfo == utc_tz
+
+    def test_none_datetime_stays_none(self):
+        info = self._make_submission_info(None)
+        assert info.received_date_time is None
+
+    def test_naive_and_aware_datetimes_can_be_sorted(self):
+        naive_dt = datetime(2025, 3, 15, 10, 30, 0)
+        eastern_tz = zoneinfo.ZoneInfo("US/Eastern")
+        aware_dt = datetime(2025, 6, 1, 12, 0, 0, tzinfo=eastern_tz)
+        info_naive = self._make_submission_info(naive_dt)
+        info_aware = self._make_submission_info(aware_dt)
+        # This should not raise TypeError
+        sorted_info = sorted(
+            [info_naive, info_aware],
+            key=lambda x: x.received_date_time or datetime.min.replace(tzinfo=eastern_tz),
+            reverse=True,
+        )
+        assert sorted_info[0].received_date_time == aware_dt


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9386  

## Changes proposed

- Updated get_submission_list_expanded_schemas.py to add `ensure_timezone_aware` function
- Updated get_submission_list_expanded_response.py to ensure sorting fallback is timezone aware
- Updated test_leagcy_soap_api_grantor_get_submission_list_expanded_schema.py to add tests to confirm timezone validation

## Context for reviewers

Upon adding sorting by datetime to the `GetSubmissionListExpanded` endpoint, it was discovered that not all datetimes coming from both the grants.gov and simpler grants were timezone aware, which caused an error.

## Validation steps

Confirm tests pass. Validation will be done via Postman once the change is merged.