### PR TITLE
[Issue #8914] Project Narrative Attachment: Failure path

### DIFF
--- a/frontend/tests/e2e/apply/failure-path-project-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-project-narrative-attachment.spec.ts
@@ -1,0 +1,89 @@
+import {
+  test,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+import playwrightEnv from "tests/e2e/playwright-env";
+import { VALID_TAGS } from "tests/e2e/tags";
+import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
+import { createApplication } from "tests/e2e/utils/create-application-utils";
+import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
+import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
+import {
+  verifyFormStatusAfterSave,
+  verifyFormStatusOnApplication,
+} from "tests/e2e/utils/forms/verify-form-status-utils";
+
+import {
+  PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER,
+  PROJECT_NARRATIVE_ATTACHMENT_REQUIRED_FIELD_ERRORS,
+} from "./fixtures/project-narrative-attachment-field-definitions";
+
+const { APPLY, CORE_REGRESSION } = VALID_TAGS;
+const { testOrgLabel, targetEnv } = playwrightEnv;
+
+// Environment-specific opportunity IDs
+// Staging: 39df8091-6e99-4b0f-9db7-1f3aca9cb6e5
+// Local:   c3c59562-a54f-4203-b0f6-98f2f0383481
+const OPPORTUNITY_ID =
+  targetEnv === "staging"
+    ? "39df8091-6e99-4b0f-9db7-1f3aca9cb6e5"
+    : "c3c59562-a54f-4203-b0f6-98f2f0383481";
+const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
+
+// Skip non-Chrome browsers in staging
+test.beforeEach(({ page: _ }, testInfo) => {
+  if (targetEnv === "staging") {
+    test.skip(
+      testInfo.project.name !== "Chrome",
+      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
+    );
+  }
+});
+
+test(
+  "Project Narrative Attachment Form - error validation on empty save",
+  { tag: [APPLY, CORE_REGRESSION] },
+  async (
+    { page, context }: { page: Page; context: BrowserContext },
+    testInfo: TestInfo,
+  ) => {
+    test.setTimeout(300_000); // 5 min timeout
+
+    const isMobile = testInfo.project.name.match(/[Mm]obile/);
+
+    await authenticateE2eUser(page, context, !!isMobile);
+
+    await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
+    const applicationUrl = page.url();
+
+    const openedProjectNarrativeAttachmentForm = await openForm(
+      page,
+      PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER,
+    );
+    if (!openedProjectNarrativeAttachmentForm) {
+      throw new Error(
+        "Could not find or open Project Narrative Attachment Form link on the application forms page",
+      );
+    }
+
+    // Save without uploading any file
+    await saveForm(page, true); // expect validation errors
+
+    // Checks error alert list at top of form page and inline field errors
+    await verifyFormStatusAfterSave(
+      page,
+      "incomplete",
+      PROJECT_NARRATIVE_ATTACHMENT_REQUIRED_FIELD_ERRORS,
+    );
+
+    // Return to application and verify form row shows "Some issues found"
+    await verifyFormStatusOnApplication(
+      page,
+      "incomplete",
+      "Project Narrative Attachment",
+      applicationUrl,
+    );
+  },
+);

--- a/frontend/tests/e2e/apply/fixtures/project-narrative-attachment-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/project-narrative-attachment-field-definitions.ts
@@ -1,5 +1,6 @@
 import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-filling";
+import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
 // Matches "Project Narrative Attachment" link/heading on the application page
 export const PROJECT_NARRATIVE_ATTACHMENT_FORM_MATCHER =
@@ -19,3 +20,12 @@ export const PROJECT_NARRATIVE_ATTACHMENT_FORM_CONFIG = {
   formName: "Project Narrative Attachment",
   fields: fieldDefinitionsProjectNarrativeAttachment,
 } as const;
+
+// Required field validation errors for Project Narrative Attachments form
+export const PROJECT_NARRATIVE_ATTACHMENT_REQUIRED_FIELD_ERRORS: FieldError[] =
+  [
+    {
+      fieldId: "attachments",
+      message: "Project Narrative Files is required",
+    },
+  ];


### PR DESCRIPTION
## Summary
Work for: Task #8914 

## Changes proposed
Automate failure path Project Narrative Attachment form

## Context for reviewers
The structure allows standalone Playwright tests to run independently and in CI

## Validation steps
Run the standalone Playwright test and it should complete the workflow per requirement in #8914 
