### PR TITLE
[Issue #9425] Add `focus-visible` styles

### DIFF
--- a/frontend/src/components/NavDropdown.tsx
+++ b/frontend/src/components/NavDropdown.tsx
@@ -87,12 +87,7 @@ export default function NavDropdown({
           "text-bold": true,
         })}
       />
-      <Menu
-        id={linkText}
-        items={menuItems}
-        isOpen={isOpen}
-        className="margin-top-05"
-      />
+      <Menu id={linkText} items={menuItems} isOpen={isOpen} />
     </>
   );
 }

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -1100,8 +1100,8 @@ dl {
   // [contentEditable="true"]:focus
 
   .usa-button:not([disabled]),
-  .usa-nav__primary-item > a,
-  .usa-nav__primary-item > button,
+  .usa-nav__primary-item a,
+  .usa-nav__primary-item button,
   .usa-accordion__button:not([disabled]) {
     &:focus {
       outline-width: 0;


### PR DESCRIPTION
## Summary

Fixes #9425 

## Changes proposed

This change follows the new best practice of using `:focus-visible` rules to hide focus styles (the blue outlines on focused elements) when you're navigating with a mouse, but keep them accessible/visible when navigating with a keyboard. 

- Add styles that prevent the single page app's persistent `:focus` styles for mouse users
  - Rules are in a `@supports selector(:focus-visible)` block so older browsers are not affected (they will fall back to using `:focus` styles as they currently are) 
  - Note: `:focus-visible` styles are not applied globally; they're only added to select elements: buttons, header nav, accordion buttons, checkbox inputs, radio inputs
  - Inline comments indicate how to add other elements, and the specificity selectors need in order to override the default `:focus` styles 
- Remove `className="margin-top-05"` from the dropdown menus
  - We had this margin (I think) so that the dropdown menu would align flush with the header's bottom border. But without the focus styles, there's a visual gap. Design decided to remove the margin (see [Slack thread](https://betagrantsgov.slack.com/archives/C05TGEL3C6Q/p1775568776714269), which has instructions for replicating the gap/bug in prod/main).

https://www.loom.com/share/4d3698ca19ab457e9a0cad2e3396edbb


## Context for reviewers

In a single-page app, buttons that remain on the page after clicking them become focused. This is currently evident on almost every button / input in the app — e.g. changing pages in the header navigation, submitting search terms, toggling a search filter accordion. The current focus styles add unnecessary visual noise for mouse users. 

Some browsers (Safari) try to get smart and only show `:focus` styles if they determine via heuristics that the user is navigating via keyboard. This is contentious. Most browsers rely on you explicitly using `:focus-visible` styles, which is the new standard way for making focus outlines accessible. 

## Validation steps

- Using the mouse, go to multiple pages using the header navigation; there should be no outline styles on menu items
- Using the keyboard, tab through the header navigation; you should see outline styles as you tab
- Submit search terms using the mouse to click the "Search" button; it should not have an outline 
- Submit search terms using the keyboard to tab to and select the "Search" button; it should remain focused w/ an outline
- Open/close the search filter drawer using the mouse; the "Filters" button should not have an outline
- Open the search filter drawer using the keyboard (tab to it, press `Enter`), then hit `ESC` to close the drawer; the "Filters" button should remain focused w/ an outline
- Select a filter option checkbox w/ the mouse (no outline) and keyboard (has outline)
- Toggle the AND/OR radio under the search terms w/ the mouse (no outline) and keyboard (has outline)