### PR TITLE
[Issue #9418] Fix invalid markup (button inside link)

### DIFF
--- a/frontend/src/components/homepage/sections/HomepageExperimental.tsx
+++ b/frontend/src/components/homepage/sections/HomepageExperimental.tsx
@@ -2,7 +2,7 @@ import { UswdsIconNames } from "src/types/generalTypes";
 
 import { useMessages, useTranslations } from "next-intl";
 import Link from "next/link";
-import { Button, Grid } from "@trussworks/react-uswds";
+import { Grid } from "@trussworks/react-uswds";
 
 import HomePageSection from "src/components/homepage/homePageSection";
 import IconInfo from "src/components/homepage/IconInfoSection";
@@ -17,14 +17,11 @@ const ExperimentalContent = () => {
       <h3 data-testid="homepage-experimental">{t("canDoHeader")}</h3>
       <h4>{t("canDoSubHeader")}</h4>
       <p>{t("canDoParagraph")}</p>
-      <Link href="/search">
-        <Button
-          className="margin-y-2 usa-button--secondary"
-          type="button"
-          size="big"
-        >
-          {t("tryLink")}
-        </Button>
+      <Link
+        href="/search"
+        className="margin-y-2 usa-button usa-button--secondary usa-button--big"
+      >
+        {t("tryLink")}
       </Link>
       <h4>{t("cantDoHeader")}</h4>
       <p>{t("cantDoParagraph")}</p>


### PR DESCRIPTION
## Summary

Fixes #9418 

## Changes proposed

- Remove `Button` element inside `Link`
- Apply the button classes to the `Link`

### Before

When the link is focused: 
<img width="455" height="171" alt="image" src="https://github.com/user-attachments/assets/02e2c68a-b8b7-4292-bd5c-477966b7dbe1" />

When the button is focused: 
<img width="470" height="172" alt="image" src="https://github.com/user-attachments/assets/1af0f73c-c435-4aa4-b054-f20f259df9ee" />

### After

Only the link (which is styled like a button) can ever get focus: 
<img width="437" height="177" alt="image" src="https://github.com/user-attachments/assets/4054b320-21ff-4765-948f-907838337530" />

## Context for reviewers

It's invalid HTML to put a button inside a link. This caused the link to have two tab indexes (it highlighted twice when keyboard navigating: once for the link, and then again for the button). 

## Validation steps

- Load the homepage
- Tab navigate to focus the big button "Use the new simpler search" in the first section after the hero
- It should only be a link (not a button inside a link)