### PR TITLE
[Issue #9249] Fix missing UpdateApplicationInfo SOAP prefixes

### DIFF
--- a/api/src/legacy_soap_api/grantors/schemas/update_application_info_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/update_application_info_schemas.py
@@ -22,22 +22,22 @@ class UpdateApplicationInfoRequest(GrantsGovTrackingNumberRequiredSchema):
 
 
 class SaveAgencyNotesResult(BaseSOAPSchema):
-    success: str | None = Field(default=None, alias="Success")
-    error_message: str | None = Field(default=None, alias="ErrorMessage")
+    success: str | None = Field(default=None, alias="ns9:Success")
+    error_message: str | None = Field(default=None, alias="ns9:ErrorMessage")
 
 
 class AssignAgencyTrackingNumberResult(BaseSOAPSchema):
-    success: str | None = Field(default=None, alias="Success")
-    error_message: str | None = Field(default=None, alias="ErrorMessage")
+    success: str | None = Field(default=None, alias="ns9:Success")
+    error_message: str | None = Field(default=None, alias="ns9:ErrorMessage")
 
 
 class UpdateApplicationInfoResponse(GrantsGovTrackingNumberRequiredSchema):
-    success: str | None = Field(default=None, alias="Success")
+    success: str | None = Field(default=None, alias="ns2:Success")
     assign_agency_tracking_number_result: AssignAgencyTrackingNumberResult | None = Field(
-        default=None, alias="AssignAgencyTrackingNumberResult"
+        default=None, alias="ns9:AssignAgencyTrackingNumberResult"
     )
     save_agency_notes_result: SaveAgencyNotesResult | None = Field(
-        default=None, alias="SaveAgencyNotesResult"
+        default=None, alias="ns9:SaveAgencyNotesResult"
     )
 
 

--- a/api/tests/src/legacy_soap_api/grantors/operations/test_update_application_info.py
+++ b/api/tests/src/legacy_soap_api/grantors/operations/test_update_application_info.py
@@ -1,4 +1,6 @@
 from src.legacy_soap_api.grantors.schemas.update_application_info_schemas import (
+    AssignAgencyTrackingNumberResult,
+    SaveAgencyNotesResult,
     UpdateApplicationInfoRequest,
     UpdateApplicationInfoResponse,
 )
@@ -52,7 +54,7 @@ def test_update_application_info_request_xml_parsing() -> None:
     assert schema.save_agency_notes == save_agency_notes
 
 
-def test_update_application_info_response_xml_parsing() -> None:
+def test_update_application_info_response_xml_parsing_to_dict() -> None:
     grants_gov_tracking_number = "GRANT12345678"
     response_xml = get_mock_update_application_info_response_xml(grants_gov_tracking_number)
     response_xml_dict = SOAPPayload(
@@ -83,8 +85,30 @@ def test_update_application_info_response_xml_parsing() -> None:
             },
         }
     }
-
+    # The way this is actually used is for the key values to be assigned based on the dictionary provided as opposed
+    # to just **dict and so it correctly preserves the aliases
+    envelope_dict = get_envelope_dict(response_xml_dict, "UpdateApplicationInfoResponse")
     schema = UpdateApplicationInfoResponse(
-        **get_envelope_dict(response_xml_dict, "UpdateApplicationInfoResponse")
+        grants_gov_tracking_number=envelope_dict["GrantsGovTrackingNumber"],
+        success=envelope_dict["Success"],
+        assign_agency_tracking_number_result=AssignAgencyTrackingNumberResult(
+            success=envelope_dict["AssignAgencyTrackingNumberResult"]["Success"]
+        ),
+        save_agency_notes_result=SaveAgencyNotesResult(
+            success=envelope_dict["SaveAgencyNotesResult"]["Success"]
+        ),
     )
     assert schema.grants_gov_tracking_number == grants_gov_tracking_number
+    expected = {
+        "Envelope": {
+            "Body": {
+                "UpdateApplicationInfoResponse": {
+                    "GrantsGovTrackingNumber": "GRANT12345678",
+                    "ns2:Success": "true",
+                    "ns9:AssignAgencyTrackingNumberResult": {"ns9:Success": "true"},
+                    "ns9:SaveAgencyNotesResult": {"ns9:Success": "true"},
+                }
+            }
+        }
+    }
+    assert schema.to_soap_envelope_dict("UpdateApplicationInfoResponse") == expected

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -4,11 +4,20 @@ from unittest.mock import patch
 
 import pytest
 
+from src.constants.lookup_constants import ApplicationStatus, Privilege
 from src.legacy_soap_api.grantors import schemas as grantors_schemas
+from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth
 from src.legacy_soap_api.legacy_soap_api_client import SimplerGrantorsS2SClient
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest, SoapRequestStreamer
 from src.legacy_soap_api.legacy_soap_api_utils import SOAPFaultException
+from tests.lib.data_factories import setup_cert_user
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    ApplicationSubmissionFactory,
+    CompetitionFactory,
+    OpportunityFactory,
+)
 
 GRANTS_GOV_TRACKING_NUMBER = "GRANT80000000"
 CID_UUID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
@@ -16,17 +25,29 @@ BOUNDARY_UUID = "cccccccc-1111-2222-3333-dddddddddddd"
 
 
 class TestLegacySoapGrantorGetApplicationZipSchema:
-    def test_to_soap_envelop_dicts_transforms_xml_to_dict(self, db_session):
+    def test_to_soap_envelop_dicts_transforms_xml_to_dict(self, db_session, enable_factory_create):
+        agency = AgencyFactory.create()
+        opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+        competition = CompetitionFactory(
+            opportunity=opportunity,
+        )
+        privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+        user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+        submission = ApplicationSubmissionFactory.create(
+            application__application_status=ApplicationStatus.ACCEPTED,
+            application__competition=competition,
+        )
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
             "<soapenv:Body>"
             "<agen:GetApplicationZipRequest>"
-            f"<gran:GrantsGovTrackingNumber>{GRANTS_GOV_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>"
+            f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
             "</soapenv:Envelope>"
         ).encode("utf-8")
+        auth = SOAPAuth(certificate=soap_client_certificate)
         soap_request = SOAPRequest(
             data=SoapRequestStreamer(stream=io.BytesIO(request_xml_bytes)),
             full_path="x",
@@ -34,12 +55,14 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
             method="POST",
             api_name=SimplerSoapAPI.GRANTORS,
             operation_name="GetApplicationZipRequest",
+            auth=auth,
         )
         with patch.object(uuid, "uuid4", return_value=CID_UUID):
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_application_zip_request().to_soap_envelope_dict(
                 operation_name="GetApplicationZipResponse"
             )
+            result.pop("_mtom_file_stream")
             expected = {
                 "Envelope": {
                     "Body": {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9429  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added prefixes for the `UpdateApplicationInfo` response schema.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We were missing some prefixes needed for validation, so we're adding them here and updating some tests.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] validation tests pass
- [ ] unit tests pass