### PR TITLE
[Issue #9514] Endpoint Update - Get List of Opportunities Missing Agency ID

### DIFF
--- a/api/src/services/opportunities_grantor_v1/get_opportunity_list.py
+++ b/api/src/services/opportunities_grantor_v1/get_opportunity_list.py
@@ -70,7 +70,13 @@ def list_opportunities_with_filters(
             selectinload(Opportunity.opportunity_attachments),
             selectinload(Opportunity.competitions),
         )
-        .where(Opportunity.agency_id == agency_id)
+        # If opportunity.agency_id is null, use the opportunity.agency_code
+        .outerjoin(
+            Agency,
+            (Opportunity.agency_id == Agency.agency_id)
+            | ((Opportunity.agency_id.is_(None)) & (Opportunity.agency_code == Agency.agency_code)),
+        )
+        .where(Agency.agency_id == agency_id)
     )
 
     # Apply sorting in the database query

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_get.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_get.py
@@ -329,3 +329,41 @@ def test_get_opportunity_list_pagination(client, db_session, grantor_auth_data):
 
     # Verify first and second pages have different opportunities
     assert not first_page_ids.intersection(second_page_ids)
+
+
+def test_get_opportunity_list_with_null_agency_id(client, db_session, grantor_auth_data):
+    """Test that opportunities with null agency_id but matching agency_code are included in results"""
+    user, agency, token, _ = grantor_auth_data
+
+    # Create regular opportunities with agency_id set
+    regular_opportunities = OpportunityFactory.create_batch(
+        size=2,
+        agency_id=agency.agency_id,
+        agency_code=agency.agency_code,
+    )
+
+    # Create opportunities with null agency_id but matching agency_code
+    null_agency_id_opportunities = OpportunityFactory.create_batch(
+        size=2,
+        agency_id=None,
+        agency_code=agency.agency_code,
+    )
+
+    request_json = build_opportunity_list_request_body()
+    response = client.post(
+        f"/v1/grantors/agencies/{agency.agency_id}/opportunities",
+        headers={"X-SGG-Token": token},
+        json=request_json,
+    )
+
+    # Verify response
+    assert response.status_code == 200
+    response_json = response.get_json()
+    assert response_json["message"] == "Success"
+
+    # Verify that all opportunities are included
+    returned_ids = {opp["opportunity_id"] for opp in response_json["data"]}
+    assert len(returned_ids) == 4
+    regular_ids = {str(opp.opportunity_id) for opp in regular_opportunities}
+    null_agency_ids = {str(opp.opportunity_id) for opp in null_agency_id_opportunities}
+    assert returned_ids == regular_ids.union(null_agency_ids)


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9514 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added a join statement on the SQL of the Endpoint Get logic to grab opportunities using the `agency_code` as reference if the `agency_id` field is null.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
With the way the POST
 /v1/grantors/agencies/{agency_id}/opportunities
 -Get paginated list of opportunities by agency

endpoint is set up currently, it will not return any opportunities that have a null `agency_id` field. This isn't an issue for new opportunities created in Simpler Grants, but existing opportunities from grants.gov all have this field null. The purpose of this PR is to adjust the WHERE condition and add an Outer JOIN condition that will first check for the `agency_id` of the opportunity, and if it is null, it will reference the `agency_code` field instead and then reference the Agency table to determine the correct agency the opportunity belongs to.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- [x] Confirmed that the endpoint is now returning all opportunities for a given agency, including opportunities where the `agency_id` field is null.
- [x] On the Opportunity List Page all opportunities for a given agency are being populated.
- [x] Added a unit test `test_get_opportunity_list_with_null_agency_id`
