### PR TITLE
[Issue #9510] Allow checks and scans to be skipped for Analytics and FE manual deploys

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -28,12 +28,32 @@ on:
         required: true
         default: "main"
         description: Tag or branch or SHA to deploy
+      skip_checks:
+        type: boolean
+        default: false
+        description: Skip unit tests, lint, etc
+      skip_vuln_scans:
+        type: boolean
+        default: false
+        description: Skip vulnerability scans
+  workflow_call:
+    inputs:
+      skip_checks:
+        type: boolean
+        default: false
+        description: Skip unit tests, lint, etc while deploying
+      skip_vuln_scans:
+        type: boolean
+        default: false
+        description: Skip vulnerability scans while deploying
 
 jobs:
   analytics-checks:
     name: Run Analytics Checks
     uses: ./.github/workflows/ci-analytics.yml
     secrets: inherit
+    with:
+      skip_checks: ${{ inputs.skip_checks != null && inputs.skip_checks != false }}
 
   vulnerability-scans:
     name: Vulnerability Scans
@@ -41,6 +61,7 @@ jobs:
     with:
       app_name: analytics
       fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment != null && format('["{0}"]', inputs.environment) || github.ref_name == 'main' && '["staging"]' || '["dev"]'), 'staging') }}
+      skip_vuln_scans: ${{ inputs.skip_vuln_scans != null && inputs.skip_vuln_scans != false }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -28,11 +28,31 @@ on:
         required: true
         default: "main"
         description: Tag or branch or SHA to deploy
+      skip_checks:
+        type: boolean
+        default: false
+        description: Skip unit tests, lint, etc
+      skip_vuln_scans:
+        type: boolean
+        default: false
+        description: Skip vulnerability scans
+  workflow_call:
+    inputs:
+      skip_checks:
+        type: boolean
+        default: false
+        description: Skip unit tests, lint, etc while deploying
+      skip_vuln_scans:
+        type: boolean
+        default: false
+        description: Skip vulnerability scans while deploying
 
 jobs:
   frontend-checks:
     name: Run Frontend Checks
     uses: ./.github/workflows/ci-frontend.yml
+    with:
+      skip_checks: ${{ inputs.skip_checks != null && inputs.skip_checks != false }}
 
   vulnerability-scans:
     name: Vulnerability Scans
@@ -40,6 +60,7 @@ jobs:
     with:
       app_name: frontend
       fail_on_vulns: ${{ ! contains(fromJSON(inputs.environment != null && format('["{0}"]', inputs.environment) || github.ref_name == 'main' && '["staging"]' || '["dev"]'), 'staging') }}
+      skip_vuln_scans: ${{ inputs.skip_vuln_scans != null && inputs.skip_vuln_scans != false }}
 
   deploy:
     name: Deploy

--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -2,6 +2,11 @@ name: Analytics Checks
 
 on:
   workflow_call:
+    inputs:
+      skip_checks:
+        type: boolean
+        default: false
+        description: Skip the guts of this workflow, but we have to run the workflow for dependency reasons when calling from CD workflows
   pull_request:
     paths:
       - analytics/**
@@ -13,6 +18,7 @@ defaults:
 
 jobs:
   lint-test:
+    if: ${{ inputs.skip_checks == null || inputs.skip_checks == false }}
     name: Analytics Lint, Format & Tests
     runs-on: ubuntu-22.04
     env:
@@ -51,3 +57,11 @@ jobs:
 
       # - name: Run reports
       #   run: make sprint-reports
+  skip-checks:
+    if: ${{ inputs.skip_checks != null && inputs.skip_checks == true }}
+    name: Skip Checks
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checks skipped
+        working-directory: ./
+        run: exit 0

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -2,6 +2,11 @@ name: Frontend Checks
 
 on:
   workflow_call:
+    inputs:
+      skip_checks:
+        type: boolean
+        default: false
+        description: Skip the guts of this workflow, but we have to run the workflow for dependency reasons when calling from CD workflows
   pull_request:
     paths:
       - frontend/**
@@ -22,6 +27,7 @@ concurrency:
 
 jobs:
   tests:
+    if: ${{ inputs.skip_checks == null || inputs.skip_checks == false }}
     name: FE Lint, Type Check, Format & Tests
     runs-on: ubuntu-22.04
 
@@ -57,6 +63,7 @@ jobs:
 
   # Confirms the front end still builds successfully
   check-frontend-builds:
+    if: ${{ inputs.skip_checks == null || inputs.skip_checks == false }}
     name: FE Build Check
     runs-on: ubuntu-22.04
 
@@ -85,6 +92,7 @@ jobs:
 
   # Confirms Storybook still builds successfully
   check-storybook-builds:
+    if: ${{ inputs.skip_checks == null || inputs.skip_checks == false }}
     name: FE Storybook Build Check
     runs-on: ubuntu-22.04
 
@@ -97,3 +105,12 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
       - run: npm ci
       - run: npm run storybook-build
+
+  skip-checks:
+    if: ${{ inputs.skip_checks != null && inputs.skip_checks == true }}
+    name: Skip Checks
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checks skipped
+        working-directory: ./
+        run: exit 0


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9510 

## Changes proposed

Implements the ability for a developer to tell the manual deploy of a branch to an environment to skip checks (lint, format, unit tests, etc.) and independently vulnerability scans. This has already been implemented and tested in the API Deploy, this just extends those options to Analytics and FE.

## Context for reviewers

This changes nothing for the automated deploys. It just exposes these options, defaulted to still run everything, when manually deploying.

## Validation steps

- I have manually executed the actions from this feature branch to force test deploys into Dev and validate the process works.
-  - Analytics with checks on (default) and vuln scans skipped (user skipped): https://github.com/HHS/simpler-grants-gov/actions/runs/24249198189
-  - FE with checks skipped (user skipped) and vuln scans on (default) (and failed but that proves they ran so 🤷🏻 ): https://github.com/HHS/simpler-grants-gov/actions/runs/24249164894