### PR TITLE
[Issue #9313] Create an endpoint that given an event ID will return the workflow

### DIFF
--- a/api/src/api/workflows/workflow_routes.py
+++ b/api/src/api/workflows/workflow_routes.py
@@ -14,7 +14,10 @@ from src.api.workflows.workflow_schemas import (
 )
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
-from src.services.workflows.get_workflow import get_workflow_and_verify_access
+from src.services.workflows.get_workflow import (
+    get_workflow_and_verify_access,
+    get_workflow_by_event_id_and_verify_access,
+)
 from src.services.workflows.get_workflow_audits import get_workflow_audits
 from src.services.workflows.ingest_workflow_event import ingest_workflow_event
 
@@ -63,6 +66,28 @@ def workflow_get(db_session: db.Session, workflow_id: uuid.UUID) -> response.Api
         db_session.add(user)
 
         workflow = get_workflow_and_verify_access(db_session, user, workflow_id)
+
+    return response.ApiResponse(message="Success", data=workflow)
+
+
+@workflow_blueprint.get("/events/<uuid:event_id>")
+@workflow_blueprint.output(WorkflowGetResponseSchema)
+@workflow_blueprint.doc(
+    summary="Get Workflow by Event ID",
+    description="Retrieve detailed information about a workflow associated with a specific event. Access is controlled by entity-based privileges (VIEW_OPPORTUNITY or VIEW_APPLICATION).",
+    responses=[200, 401, 403, 404],
+)
+@workflow_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def workflow_get_by_event_id(db_session: db.Session, event_id: uuid.UUID) -> response.ApiResponse:
+    add_extra_data_to_current_request_logs({"event_id": str(event_id)})
+    logger.info("GET /v1/workflows/events/:event_id")
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        workflow = get_workflow_by_event_id_and_verify_access(db_session, user, event_id)
 
     return response.ApiResponse(message="Success", data=workflow)
 

--- a/api/src/services/workflows/get_workflow.py
+++ b/api/src/services/workflows/get_workflow.py
@@ -12,7 +12,12 @@ from src.db.models.agency_models import Agency
 from src.db.models.competition_models import Application, ApplicationSubmission, Competition
 from src.db.models.opportunity_models import Opportunity
 from src.db.models.user_models import User
-from src.db.models.workflow_models import Workflow, WorkflowApproval, WorkflowAudit
+from src.db.models.workflow_models import (
+    Workflow,
+    WorkflowApproval,
+    WorkflowAudit,
+    WorkflowEventHistory,
+)
 from src.workflow.registry.workflow_registry import WorkflowRegistry
 from src.workflow.service.approval_service import get_agency_for_workflow
 from src.workflow.workflow_errors import OpportunityWithoutAgencyError
@@ -73,32 +78,24 @@ def _get_workflow(db_session: db.Session, workflow_id: uuid.UUID) -> Workflow | 
     return workflow
 
 
-def get_workflow_and_verify_access(
-    db_session: db.Session, user: User, workflow_id: uuid.UUID
+def _verify_workflow_access_and_build_config(
+    db_session: db.Session, user: User, workflow: Workflow
 ) -> Workflow:
     """
-    Public function to fetch a workflow with authorization checks.
+    Verify user access to a workflow and build its approval config.
 
     Args:
         db_session: Database session
-        user: User requesting the workflow
-        workflow_id: UUID of the workflow to fetch
+        user: User requesting access
+        workflow: Workflow to verify access for
 
     Returns:
-        Workflow object if user has access
+        Workflow object with approval config attached
 
     Raises:
-        404: If workflow doesn't exist
         403: If user doesn't have required privilege or entity type not supported
     """
-    log_extra: dict = {"user_id": user.user_id, "workflow_id": workflow_id}
-    logger.info("Fetching workflow for user", extra=log_extra)
-
-    workflow = _get_workflow(db_session, workflow_id)
-
-    if workflow is None:
-        logger.info("Workflow not found", extra=log_extra)
-        raise_flask_error(404, message=f"Could not find Workflow with ID {workflow_id}")
+    log_extra: dict = {"user_id": user.user_id, "workflow_id": workflow.workflow_id}
 
     try:
         agency = get_agency_for_workflow(workflow)
@@ -138,6 +135,78 @@ def get_workflow_and_verify_access(
     workflow.workflow_approval_config = approval_config  # type: ignore[attr-defined]
 
     return workflow
+
+
+def get_workflow_and_verify_access(
+    db_session: db.Session, user: User, workflow_id: uuid.UUID
+) -> Workflow:
+    """
+    Public function to fetch a workflow with authorization checks.
+
+    Args:
+        db_session: Database session
+        user: User requesting the workflow
+        workflow_id: UUID of the workflow to fetch
+
+    Returns:
+        Workflow object if user has access
+
+    Raises:
+        404: If workflow doesn't exist
+        403: If user doesn't have required privilege or entity type not supported
+    """
+    log_extra: dict = {"user_id": user.user_id, "workflow_id": workflow_id}
+    logger.info("Fetching workflow for user", extra=log_extra)
+
+    workflow = _get_workflow(db_session, workflow_id)
+
+    if workflow is None:
+        logger.info("Workflow not found", extra=log_extra)
+        raise_flask_error(404, message=f"Could not find Workflow with ID {workflow_id}")
+
+    return _verify_workflow_access_and_build_config(db_session, user, workflow)
+
+
+def get_workflow_by_event_id_and_verify_access(
+    db_session: db.Session, user: User, event_id: uuid.UUID
+) -> Workflow:
+    """
+    Fetch a workflow via its event ID with authorization checks.
+
+    Args:
+        db_session: Database session
+        user: User requesting the workflow
+        event_id: UUID of the workflow event history entry
+
+    Returns:
+        Workflow object if user has access
+
+    Raises:
+        404: If event or its associated workflow doesn't exist
+        403: If user doesn't have required privilege or entity type not supported
+    """
+    log_extra: dict = {"user_id": user.user_id, "event_id": event_id}
+    logger.info("Fetching workflow by event ID for user", extra=log_extra)
+
+    event = db_session.execute(
+        select(WorkflowEventHistory).where(WorkflowEventHistory.event_id == event_id)
+    ).scalar_one_or_none()
+
+    if event is None:
+        logger.info("Event not found", extra=log_extra)
+        raise_flask_error(404, message=f"Could not find Event with ID {event_id}")
+
+    if event.workflow_id is None:
+        logger.info("Event has no associated workflow", extra=log_extra)
+        raise_flask_error(404, message=f"Could not find Workflow for Event with ID {event_id}")
+
+    workflow = _get_workflow(db_session, event.workflow_id)
+
+    if workflow is None:
+        logger.info("Workflow not found for event", extra=log_extra)
+        raise_flask_error(404, message=f"Could not find Workflow for Event with ID {event_id}")
+
+    return _verify_workflow_access_and_build_config(db_session, user, workflow)
 
 
 def build_workflow_approval_config(

--- a/api/src/services/workflows/get_workflow.py
+++ b/api/src/services/workflows/get_workflow.py
@@ -25,9 +25,47 @@ from src.workflow.workflow_errors import OpportunityWithoutAgencyError
 logger = logging.getLogger(__name__)
 
 
+def _workflow_load_options() -> list:
+    """Return the selectinload options needed to fully load a Workflow for the GET response."""
+    return [
+        # Load audit events with acting user details
+        selectinload(Workflow.workflow_audits).options(
+            selectinload(WorkflowAudit.acting_user).options(
+                selectinload(User.linked_login_gov_external_user),
+                selectinload(User.profile),
+            ),
+            selectinload(WorkflowAudit.event),
+        ),
+        # Load approvals with approving user details
+        selectinload(Workflow.workflow_approvals)
+        .selectinload(WorkflowApproval.approving_user)
+        .options(
+            selectinload(User.linked_login_gov_external_user),
+            selectinload(User.profile),
+        ),
+        # Load entity relationships for auth checks
+        selectinload(Workflow.opportunity).selectinload(Opportunity.agency_record),
+        selectinload(Workflow.application)
+        .selectinload(Application.competition)
+        .selectinload(Competition.opportunity)
+        .selectinload(Opportunity.agency_record),
+        selectinload(Workflow.application_submission)
+        .selectinload(ApplicationSubmission.application)
+        .selectinload(Application.competition)
+        .selectinload(Competition.opportunity)
+        .selectinload(Opportunity.agency_record),
+    ]
+
+
+def _sort_workflow_collections(workflow: Workflow) -> None:
+    """Sort audit and approval collections on a workflow by created_at."""
+    workflow.workflow_audits.sort(key=lambda a: a.created_at)
+    workflow.workflow_approvals.sort(key=lambda a: a.created_at)
+
+
 def _get_workflow(db_session: db.Session, workflow_id: uuid.UUID) -> Workflow | None:
     """
-    Internal function to fetch workflow with comprehensive eager loading.
+    Internal function to fetch workflow.
 
     Args:
         db_session: Database session
@@ -39,41 +77,13 @@ def _get_workflow(db_session: db.Session, workflow_id: uuid.UUID) -> Workflow | 
     stmt = (
         select(Workflow)
         .where(Workflow.workflow_id == workflow_id)
-        .options(
-            # Load audit events with acting user details
-            selectinload(Workflow.workflow_audits).options(
-                selectinload(WorkflowAudit.acting_user).options(
-                    selectinload(User.linked_login_gov_external_user),
-                    selectinload(User.profile),
-                ),
-                selectinload(WorkflowAudit.event),
-            ),
-            # Load approvals with approving user details
-            selectinload(Workflow.workflow_approvals)
-            .selectinload(WorkflowApproval.approving_user)
-            .options(
-                selectinload(User.linked_login_gov_external_user),
-                selectinload(User.profile),
-            ),
-            # Load entity relationships for auth checks
-            selectinload(Workflow.opportunity).selectinload(Opportunity.agency_record),
-            selectinload(Workflow.application)
-            .selectinload(Application.competition)
-            .selectinload(Competition.opportunity)
-            .selectinload(Opportunity.agency_record),
-            selectinload(Workflow.application_submission)
-            .selectinload(ApplicationSubmission.application)
-            .selectinload(Application.competition)
-            .selectinload(Competition.opportunity)
-            .selectinload(Opportunity.agency_record),
-        )
+        .options(*_workflow_load_options())
     )
 
     workflow = db_session.execute(stmt).scalar_one_or_none()
 
     if workflow is not None:
-        workflow.workflow_audits.sort(key=lambda a: a.created_at)
-        workflow.workflow_approvals.sort(key=lambda a: a.created_at)
+        _sort_workflow_collections(workflow)
 
     return workflow
 
@@ -188,25 +198,25 @@ def get_workflow_by_event_id_and_verify_access(
     log_extra: dict = {"user_id": user.user_id, "event_id": event_id}
     logger.info("Fetching workflow by event ID for user", extra=log_extra)
 
-    event = db_session.execute(
-        select(WorkflowEventHistory).where(WorkflowEventHistory.event_id == event_id)
-    ).scalar_one_or_none()
+    stmt = (
+        select(WorkflowEventHistory)
+        .where(WorkflowEventHistory.event_id == event_id)
+        .options(selectinload(WorkflowEventHistory.workflow).options(*_workflow_load_options()))
+    )
+
+    event = db_session.execute(stmt).scalar_one_or_none()
 
     if event is None:
         logger.info("Event not found", extra=log_extra)
         raise_flask_error(404, message=f"Could not find Event with ID {event_id}")
 
-    if event.workflow_id is None:
+    if event.workflow is None:
         logger.info("Event has no associated workflow", extra=log_extra)
         raise_flask_error(404, message=f"Could not find Workflow for Event with ID {event_id}")
 
-    workflow = _get_workflow(db_session, event.workflow_id)
+    _sort_workflow_collections(event.workflow)
 
-    if workflow is None:
-        logger.info("Workflow not found for event", extra=log_extra)
-        raise_flask_error(404, message=f"Could not find Workflow for Event with ID {event_id}")
-
-    return _verify_workflow_access_and_build_config(db_session, user, workflow)
+    return _verify_workflow_access_and_build_config(db_session, user, event.workflow)
 
 
 def build_workflow_approval_config(

--- a/api/tests/src/api/workflows/test_workflow_routes.py
+++ b/api/tests/src/api/workflows/test_workflow_routes.py
@@ -923,3 +923,160 @@ class TestWorkflowGet:
 
         assert response.status_code == 404
         assert f"Could not find Workflow with ID {non_existent_id}" in response.json["message"]
+
+
+class TestWorkflowGetByEventId:
+    """Tests for GET /v1/workflows/events/:event_id endpoint."""
+
+    def test_get_workflow_by_event_id_200(
+        self, client, db_session, enable_factory_create, agency, opportunity
+    ):
+        """Test successfully fetching a workflow by event ID."""
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_OPPORTUNITY]
+        )
+
+        workflow = WorkflowFactory.create(
+            workflow_type=WorkflowType.BASIC_TEST_WORKFLOW,
+            current_workflow_state=BasicState.MIDDLE,
+            is_active=True,
+            opportunity=opportunity,
+        )
+
+        event = WorkflowEventHistoryFactory.create(workflow=workflow)
+
+        audit = WorkflowAuditFactory.create(
+            workflow=workflow,
+            acting_user=user,
+            transition_event="start_workflow",
+            source_state=BasicState.START,
+            target_state=BasicState.MIDDLE,
+            event_id=event.event_id,
+        )
+
+        response = client.get(
+            f"/v1/workflows/events/{event.event_id}", headers={"X-SGG-Token": token}
+        )
+
+        assert response.status_code == 200
+        data = response.json["data"]
+
+        # Verify workflow fields match what GET /v1/workflows/:workflow_id returns
+        assert data["workflow_id"] == str(workflow.workflow_id)
+        assert data["workflow_type"] == WorkflowType.BASIC_TEST_WORKFLOW
+        assert data["current_workflow_state"] == BasicState.MIDDLE
+        assert data["is_active"] is True
+        assert data["opportunity_id"] == str(opportunity.opportunity_id)
+
+        # Verify audit events are included
+        assert len(data["workflow_audit_events"]) == 1
+        assert data["workflow_audit_events"][0]["workflow_audit_id"] == str(audit.workflow_audit_id)
+
+        # Verify approval config exists
+        assert "workflow_approval_config" in data
+        assert isinstance(data["workflow_approval_config"], dict)
+
+    def test_get_application_workflow_by_event_id_200(
+        self, client, db_session, enable_factory_create, agency
+    ):
+        """Test successfully fetching an application workflow by event ID."""
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_APPLICATION]
+        )
+
+        application = ApplicationFactory.create()
+        application.competition.opportunity.agency_code = agency.agency_code
+        db_session.flush()
+
+        workflow = WorkflowFactory.create(
+            workflow_type=WorkflowType.BASIC_TEST_WORKFLOW,
+            current_workflow_state=BasicState.START,
+            is_active=True,
+            application=application,
+            opportunity=None,
+        )
+
+        event = WorkflowEventHistoryFactory.create(workflow=workflow)
+
+        response = client.get(
+            f"/v1/workflows/events/{event.event_id}", headers={"X-SGG-Token": token}
+        )
+
+        assert response.status_code == 200
+        data = response.json["data"]
+        assert data["application_id"] == str(application.application_id)
+        assert data["opportunity_id"] is None
+
+    def test_get_workflow_by_event_id_no_token_401(self, client):
+        """Test that requests without auth token are rejected."""
+        response = client.get(f"/v1/workflows/events/{uuid.uuid4()}")
+
+        assert response.status_code == 401
+        assert response.json["message"] == "Unauthorized"
+
+    def test_get_workflow_by_event_id_invalid_token_401(self, client):
+        """Test that requests with invalid JWT are rejected."""
+        response = client.get(
+            f"/v1/workflows/events/{uuid.uuid4()}", headers={"X-SGG-Token": "invalid-token"}
+        )
+
+        assert response.status_code == 401
+        assert response.json["message"] == "Unable to process token"
+
+    def test_get_workflow_by_event_id_wrong_agency_403(
+        self, client, db_session, enable_factory_create, opportunity
+    ):
+        """Test that users from different agency cannot access workflow."""
+        other_agency = AgencyFactory.create()
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=other_agency, privileges=[Privilege.VIEW_OPPORTUNITY]
+        )
+
+        workflow = WorkflowFactory.create(
+            workflow_type=WorkflowType.BASIC_TEST_WORKFLOW, opportunity=opportunity
+        )
+        event = WorkflowEventHistoryFactory.create(workflow=workflow)
+
+        response = client.get(
+            f"/v1/workflows/events/{event.event_id}", headers={"X-SGG-Token": token}
+        )
+
+        assert response.status_code == 403
+        assert response.json["message"] == "Forbidden"
+
+    def test_get_workflow_by_event_id_not_found_404(
+        self, client, db_session, enable_factory_create, agency
+    ):
+        """Test that non-existent event ID returns 404."""
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_OPPORTUNITY]
+        )
+
+        non_existent_id = uuid.uuid4()
+        response = client.get(
+            f"/v1/workflows/events/{non_existent_id}", headers={"X-SGG-Token": token}
+        )
+
+        assert response.status_code == 404
+        assert f"Could not find Event with ID {non_existent_id}" in response.json["message"]
+
+    def test_get_workflow_by_event_id_no_workflow_404(
+        self, client, db_session, enable_factory_create, agency
+    ):
+        """Test that event with no associated workflow returns 404."""
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_OPPORTUNITY]
+        )
+
+        # Create event with no workflow (workflow_id=None)
+        event = WorkflowEventHistoryFactory.create(workflow=None)
+
+        response = client.get(
+            f"/v1/workflows/events/{event.event_id}", headers={"X-SGG-Token": token}
+        )
+
+        assert response.status_code == 404
+        assert (
+            f"Could not find Workflow for Event with ID {event.event_id}"
+            in response.json["message"]
+        )


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9313 

## Changes proposed

- Updated get_workflow.py to extract `_verify_workflow_access_and_build_config()` from `get_workflow_and_verify_access()` to make the auth/access logic reusable and added `get_workflow_by_event_id_and_verify_access()`
- Updated workflow_routes.py to add `GET /v1/workflows/events/<uuid:event_id>` endpoint
- Updated test_workflow_routes.py to add tests for new endpoint

## Context for reviewers

One slight complexity with our workflow logic is that events are processed asynchronously so when a workflow is started, it can be hard to find the workflow that was created by that event.

We want to make an endpoint of `GET /v1/workflows/events/:event_id` that given an event ID will return a workflow.

## Validation steps

Confirm tests pass.