### PR TITLE
[unticketed]: update api acm data lookup to use RSA_4096

### DIFF
--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -116,6 +116,7 @@ data "aws_acm_certificate" "cert" {
   count       = local.service_config.enable_https ? 1 : 0
   domain      = local.service_config.domain_name
   most_recent = true
+  key_types   = ["RSA_2048", "RSA_4096"]
 }
 
 data "aws_acm_certificate" "secondary_certs" {


### PR DESCRIPTION
## Summary

The new prod api cert is RSA_4096, the terraform plan data lookup is defaulting to 2048. 

## Validation steps

Confirming below, in the prod api terraform plan it's picking up the new certificate. So, in the next terraform deploy it will use the new one. 

```
  # module.service.aws_lb_listener.alb_listener_https[0] will be updated in-place
  ~ resource "aws_lb_listener" "alb_listener_https" {
      ~ certificate_arn                                                       = "arn:aws:acm:us-east-1:xx:certificate/e6444713-560c-4149-8e61-6dcde21d66e7" -> "arn:aws:acm:us-east-1:xxx:certificate/eaa89792-eb9e-4ce1-89d5-40660efd83cd"
        id                                                                    = "arn:aws:elasticloadbalancing:us-east-1:xxx:listener/app/api-prod/907c98bbc1e14f4e/7f542b0e76be7582"
        tags                                                                  = {}
        # (25 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }
```