### PR TITLE
[Issue #9499] modifying the vulnerability-scans.yml to store grype output as an artifact

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -335,6 +335,11 @@ jobs:
             echo '{"matches":[],"distro":null,"source":null,"descriptor":{"name":"grype","version":"stub","db":{}}}' > "${dest}"
           fi
 
+      - name: Print output to workflow summary
+        if: always() # Runs even if there is a failure
+        run: |
+          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' "anchore-grype-${{ inputs.app_name }}.json"
+
       - name: Upload full Grype JSON
         if: always() # Runs even if there is a failure
         uses: actions/upload-artifact@v4

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -338,7 +338,7 @@ jobs:
       - name: Print output to workflow summary
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' "anchore-grype-${{ inputs.app_name }}.json"
+          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-json.outputs.json }}
 
       - name: Upload full Grype JSON
         if: always() # Runs even if there is a failure

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -322,10 +322,76 @@ jobs:
           fail-build: ${{inputs.fail_on_vulns}}
           severity-cutoff: medium
 
-      - name: Print output to workflow summary
+      - name: Copy full Grype JSON into workspace
         if: always() # Runs even if there is a failure
         run: |
-          jq '.matches | map(.artifact | { name, version, location: .locations[0].path })' ${{ steps.anchore-scan-json.outputs.json }}
+          set -euo pipefail
+          src="${{ steps.anchore-scan-json.outputs.json }}"
+          dest="anchore-grype-${{ inputs.app_name }}.json"
+          if [[ -n "${src}" && -f "${src}" ]]; then
+            cp "${src}" "${dest}"
+          else
+            echo "::warning::Anchore Grype JSON output missing at ${src:-<empty>}; writing minimal stub for artifact upload."
+            echo '{"matches":[],"distro":null,"source":null,"descriptor":{"name":"grype","version":"stub","db":{}}}' > "${dest}"
+          fi
+
+      - name: Upload full Grype JSON
+        if: always() # Runs even if there is a failure
+        uses: actions/upload-artifact@v4
+        with:
+          name: anchore-grype-json-${{ inputs.app_name }}-${{ github.run_id }}
+          path: anchore-grype-${{ inputs.app_name }}.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Write Grype report to GitHub Actions summary
+        if: always() # Runs even if there is a failure
+        env:
+          SCAN_JSON: anchore-grype-${{ inputs.app_name }}.json
+        run: |
+          set -euo pipefail
+          {
+            echo "## Anchore / Grype (${{ inputs.app_name }})"
+            echo ""
+            echo "The **complete** Grype JSON report is uploaded as workflow artifact **\`anchore-grype-json-${{ inputs.app_name }}-${{ github.run_id }}\`** (download from this job). It includes every \`matches[]\` entry with vulnerability fields, \`artifact\` locations and purls, \`matchDetails\`, \`relatedVulnerabilities\`, and image provenance under \`source\` — suitable for parser fixtures and lifecycle schema design."
+            echo ""
+            echo "### Scan metadata (subset)"
+            echo ""
+            echo '```json'
+            jq --arg app "${{ inputs.app_name }}" '{
+              scan_target_app: $app,
+              grypeVersion: .descriptor.version,
+              dbBuilt: .descriptor.db.built,
+              dbSchemaVersion: .descriptor.db.schemaVersion,
+              distro: .distro,
+              source: (.source | {type, userInput: .target.userInput, imageID: .target.imageID, manifestDigest: .target.manifestDigest, architecture: .target.architecture, os: .target.os}),
+              matchCount: (.matches | length)
+            }' "${SCAN_JSON}" || echo '{"error":"jq metadata failed"}'
+            echo '```'
+            echo ""
+            echo "### Matches (first 80, condensed; full rows only in JSON artifact)"
+            echo ""
+            echo '```json'
+            jq '.matches[:80] | map({
+              vulnerability_id: .vulnerability.id,
+              severity: .vulnerability.severity,
+              namespace: .vulnerability.namespace,
+              dataSource: .vulnerability.dataSource,
+              fix_state: .vulnerability.fix.state,
+              fix_versions: .vulnerability.fix.versions,
+              package: .artifact.name,
+              package_version: .artifact.version,
+              package_type: .artifact.type,
+              purl: .artifact.purl,
+              locations: [ .artifact.locations[]?.path ],
+              match_types: [ .matchDetails[]?.type ],
+              matchers: [ .matchDetails[]?.matcher ],
+              related_vulnerability_ids: [ .relatedVulnerabilities[]?.id ]
+            })' "${SCAN_JSON}" || echo '{"error":"jq matches failed"}'
+            echo '```'
+            echo ""
+            echo "**Total matches:** $(jq '.matches | length' "${SCAN_JSON}" 2>/dev/null || echo 0)"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   dockle-scan:
     if: inputs.skip_vuln_scans == false


### PR DESCRIPTION

## Summary

Work for [#9498](https://github.com/HHS/simpler-grants-gov/issues/9498)

## Changes proposed

1. Anchore / Grype: After the JSON scan, copy the full Grype report into the workspace and upload it as a GitHub Actions artifact (anchore-grype-json-<app>-<run_id>, file anchore-grype-<app>.json) with 90-day retention so it can be downloaded without scraping logs.
2. Anchore / Grype: Replace the minimal job-summary jq (package name/version/path only) with a richer summary (scan metadata subset + first 80 matches with CVE id, severity, fix state, package/purl/locations, matchers, related IDs). The artifact remains the full-fidelity source of truth.
3. Resilience: If the scan action does not produce a JSON path, emit a warning and upload a minimal stub so the artifact step still behaves predictably.

## Context for reviewers

Today’s workflow only surfaced a small slice of Grype output in the job summary, so there was no durable, downloadable full JSON for schema design, parser tests, or lifecycle work (#9498 / #9504).

## Validation steps

1. Push this branch and run a workflow that calls .github/workflows/vulnerability-scans.yml (e.g. workflow_dispatch on CI Cron Vulnerability Scans, or whatever path you use to exercise the reusable workflow).
2. Open each Anchore Scan job → confirm Artifacts lists anchore-grype-json-<app>-<run_id> and download the zip; unzip and verify valid JSON with top-level matches, source, descriptor, etc.
3. Open the job Summary and confirm the new Anchore / Grype section renders (metadata + condensed matches) without YAML/shell errors in the log.
4. (Optional) Confirm artifact names are unique across matrix legs (same run_id, different <app>).