### PR TITLE
[Issue #9530] Add search query length log metric to be pushed to new relic

### DIFF
--- a/frontend/src/components/search/SearchAnalytics.tsx
+++ b/frontend/src/components/search/SearchAnalytics.tsx
@@ -45,6 +45,12 @@ function SearchAnalytics({
         // only pass on valid query params to NR
         if ((expectedQueryParamKeys as readonly string[]).includes(key)) {
           setNewRelicCustomAttribute(key, value || "");
+
+          // New relic does not support certain functionalities such as  calculating string
+          // lengths. This conditional is needed to log and gain insights into search query length.
+          if (key === "query") {
+            setNewRelicCustomAttribute("query_length", value?.length ?? 0);
+          }
         }
       });
     }
@@ -55,7 +61,6 @@ function SearchAnalytics({
     };
   }, [params, newRelicEnabled, newRelicInitialized]);
 
-  //
   useEffect(() => {
     // send list of filters defined in page query params on each page load
     sendGAEvent("event", "search_attempt", {

--- a/frontend/src/utils/analyticsUtil.ts
+++ b/frontend/src/utils/analyticsUtil.ts
@@ -40,7 +40,7 @@ const getNewRelicBrowserInstance = (): NewRelicBrowser | null => {
 
 export const setNewRelicCustomAttribute = (
   key: string,
-  value: string,
+  value: string | number,
 ): undefined => {
   const newRelic = getNewRelicBrowserInstance();
   if (!newRelic) {
@@ -56,4 +56,5 @@ export const unsetAllNewRelicQueryAttributes = () => {
   validSearchQueryParamKeys.forEach((key) => {
     setNewRelicCustomAttribute(key, "");
   });
+  setNewRelicCustomAttribute("query_length", 0);
 };

--- a/frontend/src/utils/analyticsUtils.test.ts
+++ b/frontend/src/utils/analyticsUtils.test.ts
@@ -82,7 +82,7 @@ describe("unsetAllNewRelicQueryAttributes", () => {
 
     unsetAllNewRelicQueryAttributes();
     expect(mockSetCustomAttribute).toHaveBeenCalledTimes(
-      validSearchQueryParamKeys.length,
+      [...validSearchQueryParamKeys, "query_length"].length,
     );
     validSearchQueryParamKeys.forEach((key) => {
       expect(mockSetCustomAttribute).toHaveBeenCalledWith(
@@ -90,5 +90,9 @@ describe("unsetAllNewRelicQueryAttributes", () => {
         "",
       );
     });
+    expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+      "search_param_query_length",
+      0,
+    );
   });
 });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9530 

## Changes proposed

This pr adds a custom new relic log metric for search query length.

## Context for reviewers

As part of #9358, we need to capture how the length/character count of search queries impacts user engagement. New relic  does not support calculating string metric lengths so this pr ensures we have insights into that.
 
## Validation steps
Run the following query in new relic: 
```
FROM BrowserInteraction SELECT search_param_query, search_param_query_length WHERE search_param_query_length IS NOT NULL
```

This pr has already been deployed and tested during dev testing. To validate this pr you can either deploy this branch to lower environments and make some search queries or just run the above since they already exist in rew relic.