### PR TITLE
[Issue #9452]: added logout endpoint to api gateway

### DIFF
--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -72,6 +72,7 @@ locals {
       "grantsws-agency/services/v2"         = [],
       "grantsws-applicant/services/v2"      = [],
       "v1/users/login"                      = [{ "method" : "GET" }],
+      "v1/users/logout"                     = [{ "method" : "GET" }],
       "v1/users/token"                      = [],
   }][var.enable_api_gateway ? 1 : 0]
 


### PR DESCRIPTION
## Summary

Added the new route: `/v1/users/logout` to the api gateway endpoint which doesn't require an API key header. 

## Validation steps

Deployed to dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/24365413399)
