### PR TITLE
[Issue #9579] E2E tests: Update radio button selection logic

### DIFF
--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -153,7 +153,10 @@ export async function fillField(
       field.type === "radiobutton" &&
       (field.testId || field.selector || field.getByText || field.useDataAsText)
     ) {
-      if (shouldActivateField(data)) {
+      // If getByText is specified, the field definition already encodes which
+      // specific radio option to click (eg - "No"), so always activate it
+      // regardless of the data value. Otherwise, rely on shouldActivateField.
+      if (field.getByText !== undefined || shouldActivateField(data)) {
         let locator = field.getByText
           ? page.getByText(field.getByText, {
               exact: field.textExact ?? false,


### PR DESCRIPTION
## Summary
Work for: Task #9579 

## Changes proposed
- Updated the radio button fill logic in general-forms-filling.ts so that when a field definition specifies getByText (e.g., for a "No" or "Yes" radio option), the corresponding radio button is always clicked, regardless of the data value.
- This ensures that required radio fields are always filled during E2E tests, even when the test data is "false" (for "No").
- The change prevents form validation failures caused by unselected radio buttons when the value is "falsy" but the field definition explicitly encodes which option to select.

## Context for reviewers
- Previously, the code only clicked a radio button if the test data was "truthy" (e.g., "true" or "Yes"). If the data was "false", the radio was not clicked, even if the field definition specified a label to select.
- This caused E2E tests to fail for forms that required a "No" radio selection, as the field was left empty and validation failed.
- The new logic always clicks the radio button when getByText is set, making the test behavior match the intent of the field definition and test data.

## Validation steps
- Run the E2E test suite in Local and Staging and confirm that all tests pass
