### PR TITLE
[Issue #9581] Endpoint Update - Get List of Opportunities w/Competition Forms Fix

### DIFF
--- a/api/src/services/opportunities_grantor_v1/get_opportunity_list.py
+++ b/api/src/services/opportunities_grantor_v1/get_opportunity_list.py
@@ -9,6 +9,7 @@ import src.adapters.db as db
 from src.auth.endpoint_access_util import verify_access
 from src.constants.lookup_constants import Privilege
 from src.db.models.agency_models import Agency
+from src.db.models.competition_models import Competition, CompetitionForm, Form
 from src.db.models.opportunity_models import (
     CurrentOpportunitySummary,
     Opportunity,
@@ -68,7 +69,14 @@ def list_opportunities_with_filters(
                 CurrentOpportunitySummary.opportunity_summary
             ),
             selectinload(Opportunity.opportunity_attachments),
-            selectinload(Opportunity.competitions),
+            selectinload(Opportunity.competitions).options(
+                selectinload(Competition.competition_forms)
+                .selectinload(CompetitionForm.form)
+                .selectinload(Form.form_instruction),
+                selectinload(Competition.competition_instructions),
+                selectinload(Competition.opportunity_assistance_listing),
+                selectinload(Competition.link_competition_open_to_applicant),
+            ),
         )
         # If opportunity.agency_id is null, use the opportunity.agency_code
         .outerjoin(


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9581 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
The Get List of Opportunities endpoint is throwing a 500 error when an opportunity with associated Competition Forms is included in an Agency's opportunity list. This is occurring due to a lazy load operation error in `list_opportunities_with_filters` in the `get_opportunity_list.py` file. We simply have to include additional `selectinload` statements for the additional competition form items.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- [x] Endpoint is correctly returning all opportunities for a given agency, including opportunities with associated Competition Forms, and not throwing a 500 error.