### PR TITLE
[Issue #9365] Change variable name for simpler_proxy_response

### DIFF
--- a/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
@@ -244,7 +244,7 @@ def get_submission_list_expanded(
 
 def get_submission_list_expanded_response(
     simpler_submissions: list[schemas.SubmissionInfo],
-    proxy_response: SOAPResponse,
+    legacy_response: SOAPResponse,
 ) -> schemas.GetSubmissionListExpandedResponse:
     """Build the SOAP response envelope from Simpler and proxy data.
 
@@ -253,7 +253,7 @@ def get_submission_list_expanded_response(
     """
     info: list[schemas.SubmissionInfo] = []
     try:
-        info.extend(parse_submissions_from_proxy(proxy_response))
+        info.extend(parse_submissions_from_legacy(legacy_response))
     except Exception:
         logger.exception("Failed to parse submission list expanded XML response")
     info.extend(simpler_submissions)
@@ -266,8 +266,8 @@ def get_submission_list_expanded_response(
     )
 
 
-def parse_submissions_from_proxy(proxy_response: SOAPResponse) -> list[schemas.SubmissionInfo]:
-    xml_bytes = b"".join(clean_mtom_generator(proxy_response.stream()))
+def parse_submissions_from_legacy(legacy_response: SOAPResponse) -> list[schemas.SubmissionInfo]:
+    xml_bytes = b"".join(clean_mtom_generator(legacy_response.stream()))
     info = []
     if xml_bytes:
         parser = etree.XMLParser(recover=True)

--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -53,7 +53,7 @@ class BaseSOAPClient:
             self.soap_request.data.head().decode(), self.operation_config.request_operation_name
         )
 
-    def get_soap_response_dict(self, proxy_response: SOAPResponse | None = None) -> dict:
+    def get_soap_response_dict(self, legacy_response: SOAPResponse | None = None) -> dict:
         """Get Simpler SOAP response dict
 
         This method will return the validated pydantic schema returned from the
@@ -66,11 +66,11 @@ class BaseSOAPClient:
         operation_method = getattr(
             self, to_snake_case(self.operation_config.request_operation_name)
         )
-        return operation_method(proxy_response).to_soap_envelope_dict(
+        return operation_method(legacy_response).to_soap_envelope_dict(
             self.operation_config.response_operation_name
         )
 
-    def get_proxy_soap_response_dict(self, proxy_response: SOAPResponse) -> dict:
+    def get_legacy_soap_response_dict(self, legacy_response: SOAPResponse) -> dict:
         """
         This method does the following:
 
@@ -85,7 +85,7 @@ class BaseSOAPClient:
         Note: Ignoring type checking in return statement since we already check
         that the schema is not None prior to statement.
         """
-        proxy_response_schema_data = wrap_envelope_dict(
+        legacy_response_schema_data = wrap_envelope_dict(
             {}, self.operation_config.response_operation_name
         )
 
@@ -98,30 +98,30 @@ class BaseSOAPClient:
                     "response_operation_name": self.operation_config.response_operation_name,
                 },
             )
-            return proxy_response_schema_data
+            return legacy_response_schema_data
 
         try:
-            proxy_response_payload = SOAPPayload(
-                proxy_response.to_bytes().decode(errors="replace"),
+            legacy_response_payload = SOAPPayload(
+                legacy_response.to_bytes().decode(errors="replace"),
                 operation_name=self.operation_config.response_operation_name,
                 force_list_attributes=self.operation_config.force_list_attributes,
             )
 
             # The XML dict that includes namespaces and other attributes prior to normalization and schema validation.
-            proxy_response_dict = proxy_response_payload.to_dict()
+            legacy_response_dict = legacy_response_payload.to_dict()
             log_local(
                 msg="proxy response dict pre-validation",
-                data=proxy_response_dict,
+                data=legacy_response_dict,
                 formatter=json_formatter,
             )
 
             # Validated/normalized dict from pydantic schema.
-            proxy_response_schema_dict = self._get_simpler_soap_response_schema()(
+            legacy_response_schema_dict = self._get_simpler_soap_response_schema()(
                 **get_envelope_dict(
-                    proxy_response_dict, self.operation_config.response_operation_name
+                    legacy_response_dict, self.operation_config.response_operation_name
                 )
             )  # type: ignore[misc]
-            return proxy_response_schema_dict.to_soap_envelope_dict(
+            return legacy_response_schema_dict.to_soap_envelope_dict(
                 self.operation_config.response_operation_name
             )
         except ValidationError as e:
@@ -139,16 +139,16 @@ class BaseSOAPClient:
                 exc_info=True,
                 extra={"soap_api_event": LegacySoapApiEvent.UNPARSEABLE_SOAP_PROXY_RESPONSE},
             )
-        return proxy_response_schema_data
+        return legacy_response_schema_data
 
-    def log_diffs(self, proxy_response_soap_dict: dict, simpler_response_soap_dict: dict) -> None:
+    def log_diffs(self, legacy_response_soap_dict: dict, simpler_response_soap_dict: dict) -> None:
         try:
             diff_results = diff_soap_dicts(
                 sgg_dict=get_envelope_dict(
                     simpler_response_soap_dict, self.operation_config.response_operation_name
                 ),
                 gg_dict=get_envelope_dict(
-                    proxy_response_soap_dict, self.operation_config.response_operation_name
+                    legacy_response_soap_dict, self.operation_config.response_operation_name
                 ),
                 key_indexes=self.operation_config.key_indexes,
                 keys_only=True,
@@ -167,7 +167,7 @@ class BaseSOAPClient:
                 },
             )
 
-    def get_simpler_soap_response(self, proxy_response: SOAPResponse) -> SOAPResponse:
+    def get_simpler_soap_response(self, legacy_response: SOAPResponse) -> SOAPResponse:
         """
         This method is responsible getting the simpler soap xml payload.
 
@@ -190,17 +190,17 @@ class BaseSOAPClient:
         )
         log_local(msg="simpler response XML", data=simpler_response_xml, formatter=xml_formatter)
         if self.operation_config.compare_endpoints:
-            proxy_response_soap_dict = self.get_proxy_soap_response_dict(proxy_response)
+            legacy_response_soap_dict = self.get_legacy_soap_response_dict(legacy_response)
             log_local(
                 msg="proxy response validated dict",
-                data=proxy_response_soap_dict,
+                data=legacy_response_soap_dict,
                 formatter=json_formatter,
             )
             # We will only run diffs for responses that do not match.
-            if proxy_response_soap_dict == simpler_response_soap_dict:
+            if legacy_response_soap_dict == simpler_response_soap_dict:
                 logger.info("soap_api_diff responses match", extra={"soap_responses_match": True})
             else:
-                self.log_diffs(proxy_response_soap_dict, simpler_response_soap_dict)
+                self.log_diffs(legacy_response_soap_dict, simpler_response_soap_dict)
 
         return get_soap_response(data=simpler_response_xml)
 
@@ -219,7 +219,7 @@ class SimplerApplicantsS2SClient(BaseSOAPClient):
     """
 
     def get_opportunity_list_request(
-        self, proxy_response: SOAPResponse | None = None
+        self, legacy_response: SOAPResponse | None = None
     ) -> applicants_schemas.GetOpportunityListResponse:
         return get_opportunity_list_response(
             db_session=self.db_session,
@@ -237,7 +237,7 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
     """
 
     def get_application_zip_request(
-        self, proxy_response: SOAPResponse | None = None
+        self, legacy_response: SOAPResponse | None = None
     ) -> grantors_schemas.GetApplicationZipResponseSOAPEnvelope:
         return get_application_zip_response(
             db_session=self.db_session,
@@ -249,7 +249,7 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         )
 
     def confirm_application_delivery_request(
-        self, proxy_response: SOAPResponse | None = None
+        self, legacy_response: SOAPResponse | None = None
     ) -> grantors_schemas.ConfirmApplicationDeliveryResponseSOAPEnvelope:
         request = grantors_schemas.ConfirmApplicationDeliveryRequest(**self.get_soap_request_dict())
         tracking_number = confirm_application_delivery(
@@ -263,7 +263,7 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         )
 
     def get_submission_list_expanded_request(
-        self, proxy_response: SOAPResponse
+        self, legacy_response: SOAPResponse
     ) -> grantors_schemas.GetSubmissionListExpandedResponse:
         soap_request_dict = self.get_soap_request_dict() or {}
         simpler_submissions = get_submission_list_expanded(
@@ -274,11 +274,11 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         )
         return get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
 
     def update_application_info_request(
-        self, proxy_response: SOAPResponse | None = None
+        self, legacy_response: SOAPResponse | None = None
     ) -> grantors_schemas.UpdateApplicationInfoResponseSOAPEnvelope:
         tracking_number, assign_result, notes_result = update_application_info(
             db_session=self.db_session,
@@ -310,7 +310,7 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
             mtom_file_stream.close()
         yield b"\n" + boundary.encode("utf-8") + b"--"
 
-    def get_simpler_soap_response(self, proxy_response: SOAPResponse) -> SOAPResponse:
+    def get_simpler_soap_response(self, legacy_response: SOAPResponse) -> SOAPResponse:
         # MTOM message is assembled here
         # 1. --uuid: {boundary_uuid}\n
         # 2. headers:
@@ -321,7 +321,7 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         # 4. --uuid: {boundary_uuid}
         # 5. the file bytes from the file being attached
         # 6. --uuid: {boundary_uuid}--
-        simpler_response_soap_dict = self.get_soap_response_dict(proxy_response)
+        simpler_response_soap_dict = self.get_soap_response_dict(legacy_response)
         mtom_file_stream = simpler_response_soap_dict.pop("_mtom_file_stream", None)
         log_local(
             msg="simpler response dict", data=simpler_response_soap_dict, formatter=json_formatter
@@ -351,4 +351,4 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
                 data=self._gen_response_data(mime_message, boundary, mtom_file_stream),
                 headers=update_headers,
             )
-        return proxy_response
+        return legacy_response

--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -125,7 +125,7 @@ class BaseSOAPClient:
                 self.operation_config.response_operation_name
             )
         except ValidationError as e:
-            msg = f"Could not parse proxy response {str(simpler_response_schema)} into Simpler SOAP response pydantic schema."
+            msg = f"Could not parse legacy response {str(simpler_response_schema)} into Simpler SOAP response pydantic schema."
             error_fields = {(err["type"], err["loc"]) for err in e.errors()}
             logger.info(
                 msg=f"{msg} {error_fields}",
@@ -135,7 +135,7 @@ class BaseSOAPClient:
             )
         except Exception:
             logger.info(
-                msg="Could not parse proxy response",
+                msg="Could not parse legacy response",
                 exc_info=True,
                 extra={"soap_api_event": LegacySoapApiEvent.UNPARSEABLE_SOAP_PROXY_RESPONSE},
             )

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -55,7 +55,7 @@ def get_proxy_headers(
     }
 
 
-def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) -> SOAPResponse:
+def get_legacy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) -> SOAPResponse:
     config = get_soap_config()
 
     soap_auth = soap_request.auth

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -325,7 +325,7 @@ def get_gov_grants_tracking_number(xml_bytes: bytes) -> str | None:
     return value
 
 
-def get_alternate_proxy_response(soap_request: SOAPRequest) -> SOAPResponse | None:
+def get_alternate_legacy_response(soap_request: SOAPRequest) -> SOAPResponse | None:
     xml_bytes = extract_soap_xml(soap_request.data.head())
     if not xml_bytes:
         return None

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -15,7 +15,7 @@ from src.legacy_soap_api.legacy_soap_api_client import (
 )
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI, get_soap_config
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
-from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response
+from src.legacy_soap_api.legacy_soap_api_proxy import get_legacy_response
 from src.legacy_soap_api.legacy_soap_api_schemas import (
     SOAPInvalidEnvelope,
     SOAPOperationNotSupported,
@@ -23,7 +23,7 @@ from src.legacy_soap_api.legacy_soap_api_schemas import (
 )
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest, SoapRequestStreamer
 from src.legacy_soap_api.legacy_soap_api_utils import (
-    get_alternate_proxy_response,
+    get_alternate_legacy_response,
     get_invalid_path_response,
     get_soap_error_response,
 )
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_simpler_soap_response(
-    soap_request: SOAPRequest, soap_proxy_response: SOAPResponse, db_session: db.Session
+    soap_request: SOAPRequest, soap_legacy_response: SOAPResponse, db_session: db.Session
 ) -> SOAPResponse:
     simpler_soap_client_type = (
         SimplerApplicantsS2SClient
@@ -69,7 +69,7 @@ def get_simpler_soap_response(
                 "used_simpler_response": use_simpler,
             },
         )
-        return soap_proxy_response
+        return soap_legacy_response
     except Exception:
         err = "Unable to initialize Simpler SOAP client: Unknown error"
         logger.info(
@@ -80,13 +80,13 @@ def get_simpler_soap_response(
                 "used_simpler_response": use_simpler,
             },
         )
-        return soap_proxy_response
+        return soap_legacy_response
 
     if use_simpler or simpler_soap_client.operation_config.always_call_simpler:
         logger.info(
             "simpler_soap_api: getting simpler soap response",
         )
-        simpler_soap_response = simpler_soap_client.get_simpler_soap_response(soap_proxy_response)
+        simpler_soap_response = simpler_soap_client.get_simpler_soap_response(soap_legacy_response)
 
     if use_simpler and simpler_soap_response is not None:
         logger.info(
@@ -105,7 +105,7 @@ def get_simpler_soap_response(
             "used_simpler_response": use_simpler,
         },
     )
-    return soap_proxy_response
+    return soap_legacy_response
 
 
 def process_simpler_request(
@@ -145,10 +145,10 @@ def process_simpler_request(
             "soap_client_certificate: header check",
             extra={"soap_request_headers": soap_request.headers.keys()},
         )
-        if alternate_proxy_response := get_alternate_proxy_response(soap_request):
-            soap_proxy_response = alternate_proxy_response
+        if alternate_legacy_response := get_alternate_legacy_response(soap_request):
+            soap_legacy_response = alternate_legacy_response
         else:
-            soap_proxy_response = get_proxy_response(soap_request)
+            soap_legacy_response = get_legacy_response(soap_request)
     except Exception:
         logger.exception(
             msg="Error getting soap proxy response",
@@ -161,7 +161,7 @@ def process_simpler_request(
 
     try:
         return get_simpler_soap_response(
-            soap_request, soap_proxy_response, db_session
+            soap_request, soap_legacy_response, db_session
         ).to_flask_response()
     except SOAPClientUserDoesNotHavePermission:
         msg = "soap_client_certificate: User did not have permission to access this application"
@@ -171,7 +171,7 @@ def process_simpler_request(
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },
         )
-        return soap_proxy_response.to_flask_response()
+        return soap_legacy_response.to_flask_response()
     except Exception:
         msg = "Unable to process Simpler SOAP proxy response"
         logger.exception(
@@ -181,4 +181,4 @@ def process_simpler_request(
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },
         )
-        return soap_proxy_response.to_flask_response()
+        return soap_legacy_response.to_flask_response()

--- a/api/tests/src/legacy_soap_api/grantors/services/test_get_submission_list_expanded_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_get_submission_list_expanded_response.py
@@ -119,7 +119,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=SOAPResponse(data="", status_code=200, headers={}),
+            legacy_response=SOAPResponse(data="", status_code=200, headers={}),
         )
         assert result.success is True
         assert result.available_application_number == 1
@@ -146,7 +146,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=SOAPResponse(data="", status_code=200, headers={}),
+            legacy_response=SOAPResponse(data="", status_code=200, headers={}),
         )
         assert result.success is True
         assert setup_data["tracking_number"] not in [
@@ -173,7 +173,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=SOAPResponse(data="", status_code=200, headers={}),
+            legacy_response=SOAPResponse(data="", status_code=200, headers={}),
         )
         assert result.success is True
         assert result.available_application_number == 3
@@ -200,7 +200,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=SOAPResponse(data="", status_code=200, headers={}),
+            legacy_response=SOAPResponse(data="", status_code=200, headers={}),
         )
         assert result.success is True
         assert result.available_application_number == 3
@@ -225,7 +225,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=SOAPResponse(data="", status_code=200, headers={}),
+            legacy_response=SOAPResponse(data="", status_code=200, headers={}),
         )
         assert result.success is True
         assert result.available_application_number == 1
@@ -250,7 +250,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=SOAPResponse(data="", status_code=200, headers={}),
+            legacy_response=SOAPResponse(data="", status_code=200, headers={}),
         )
         assert result.success is True
         assert result.available_application_number == 5
@@ -276,7 +276,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=SOAPResponse(data="", status_code=200, headers={}),
+            legacy_response=SOAPResponse(data="", status_code=200, headers={}),
         )
         assert result.success is True
         assert result.available_application_number == 1

--- a/api/tests/src/legacy_soap_api/grantors/services/test_legacy_soap_api_get_submission_list_expanded_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_legacy_soap_api_get_submission_list_expanded_response.py
@@ -121,7 +121,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_request_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_request_schema,
@@ -130,7 +130,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -389,7 +389,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_request_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_request_schema,
@@ -398,7 +398,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected_1 = {
@@ -497,7 +497,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_request_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_request_schema,
@@ -506,7 +506,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected_1 = {
@@ -618,7 +618,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -627,7 +627,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -708,7 +708,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -717,7 +717,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -800,7 +800,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -809,7 +809,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -891,7 +891,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -900,7 +900,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -985,7 +985,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -994,7 +994,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1079,7 +1079,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -1088,7 +1088,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1173,7 +1173,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -1182,7 +1182,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1275,7 +1275,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -1284,7 +1284,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1398,7 +1398,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -1407,7 +1407,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1477,7 +1477,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_request_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_request_schema,
@@ -1486,7 +1486,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1572,7 +1572,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -1581,7 +1581,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1650,7 +1650,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_request_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_request_schema,
@@ -1659,7 +1659,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1731,7 +1731,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -1740,7 +1740,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {
@@ -1825,7 +1825,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         get_submission_list_expanded_rquest_schema = schemas.GetSubmissionListExpandedRequest(
             **value
         )
-        proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
         simpler_submissions = get_submission_list_expanded(
             db_session=db_session,
             request=get_submission_list_expanded_rquest_schema,
@@ -1834,7 +1834,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         )
         result = get_submission_list_expanded_response(
             simpler_submissions=simpler_submissions,
-            proxy_response=proxy_response,
+            legacy_response=legacy_response,
         )
         soap_envelope_dict = result.to_soap_envelope_dict("GetSubmissionListExpandedResponse")
         expected = {

--- a/api/tests/src/legacy_soap_api/test_empty_response_pipeline_normalization.py
+++ b/api/tests/src/legacy_soap_api/test_empty_response_pipeline_normalization.py
@@ -5,7 +5,7 @@ This module tests the assertion that both S2S and Simpler responses
 are properly normalized through the existing pipeline (Pydantic validation) and
 do not require additional comparison-level normalization.
 
-Key insight: Both get_proxy_soap_response_dict and get_soap_response_dict use
+Key insight: Both get_legacy_soap_response_dict and get_soap_response_dict use
 the same Pydantic schema (GetOpportunityListResponse), so they should produce
 identical results for equivalent empty responses.
 """
@@ -22,7 +22,7 @@ class TestPipelineNormalization:
 
     def test_grants_gov_empty_xml_through_pipeline(self):
         """Test that Grants.gov empty XML produces correct result through pipeline"""
-        # This simulates the get_proxy_soap_response_dict pipeline
+        # This simulates the get_legacy_soap_response_dict pipeline
         grants_gov_xml = """<?xml version="1.0" encoding="UTF-8"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
     <soap:Body>
@@ -81,15 +81,15 @@ class TestPipelineNormalization:
             force_list_attributes=["OpportunityDetails"],
         )
         body_dict = get_envelope_dict(payload.to_dict(), "GetOpportunityListResponse")
-        proxy_response = GetOpportunityListResponse(**body_dict)
-        proxy_envelope = proxy_response.to_soap_envelope_dict("GetOpportunityListResponse")
+        legacy_response = GetOpportunityListResponse(**body_dict)
+        legacy_envelope = legacy_response.to_soap_envelope_dict("GetOpportunityListResponse")
 
         # Simpler pipeline
         simpler_response = GetOpportunityListResponse()
         simpler_envelope = simpler_response.to_soap_envelope_dict("GetOpportunityListResponse")
 
         # Both pipelines should produce identical results
-        assert proxy_envelope == simpler_envelope
+        assert legacy_envelope == simpler_envelope
 
     def test_different_xml_formats_same_pipeline_result(self):
         """Test that different XML formats for empty responses produce same result"""
@@ -152,7 +152,7 @@ class TestIssue5858AcceptanceCriteria:
     </soap:Body>
 </soap:Envelope>"""
 
-        # Simulate get_proxy_soap_response_dict
+        # Simulate get_legacy_soap_response_dict
         payload = SOAPPayload(
             s2s_xml,
             operation_name="GetOpportunityListResponse",

--- a/api/tests/src/legacy_soap_api/test_legacy_response_parsing.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_response_parsing.py
@@ -1,5 +1,5 @@
 """
-Integration test to verify that proxy responses with grants.gov date format
+Integration test to verify that legacy responses with grants.gov date format
 are parsed correctly, addressing issue #5744.
 """
 
@@ -12,21 +12,21 @@ from src.legacy_soap_api.applicants.schemas.get_opportunity_list_schemas import 
 from src.legacy_soap_api.soap_payload_handler import SOAPPayload, get_envelope_dict
 
 
-class TestProxyResponseParsing:
+class TestLegacyResponseParsing:
     """
-    Test that proxy responses with grants.gov date formats parse correctly.
+    Test that legacy responses with grants.gov date formats parse correctly.
 
     This addresses issue #5744 where dates like "2025-09-16-04:00" were causing
     validation errors with the error type "date_from_datetime_parsing".
     """
 
-    def test_proxy_response_with_grants_gov_date_format(self):
+    def test_legacy_response_with_grants_gov_date_format(self):
         """
-        Test that a proxy response with grants.gov formatted dates can be parsed
+        Test that a legacy response with grants.gov formatted dates can be parsed
         without validation errors.
         """
         # This simulates the actual XML response from grants.gov training environment
-        proxy_response_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        legacy_response_xml = """<?xml version="1.0" encoding="UTF-8"?>
         <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
             <soap:Body>
                 <app:GetOpportunityListResponse
@@ -49,7 +49,7 @@ class TestProxyResponseParsing:
 
         # Parse the XML into a dictionary (simulating what happens in the proxy handler)
         soap_payload = SOAPPayload(
-            proxy_response_xml,
+            legacy_response_xml,
             operation_name="GetOpportunityListResponse",
             force_list_attributes=["OpportunityDetails"],
         )
@@ -73,11 +73,11 @@ class TestProxyResponseParsing:
         assert opportunity.opening_date == date(2025, 8, 15)
         assert opportunity.closing_date == date(2025, 9, 16)
 
-    def test_proxy_response_with_positive_timezone_offset(self):
+    def test_legacy_response_with_positive_timezone_offset(self):
         """
         Test parsing with positive timezone offset format.
         """
-        proxy_response_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        legacy_response_xml = """<?xml version="1.0" encoding="UTF-8"?>
         <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
             <soap:Body>
                 <app:GetOpportunityListResponse
@@ -94,7 +94,7 @@ class TestProxyResponseParsing:
         </soap:Envelope>"""
 
         soap_payload = SOAPPayload(
-            proxy_response_xml,
+            legacy_response_xml,
             operation_name="GetOpportunityListResponse",
             force_list_attributes=["OpportunityDetails"],
         )
@@ -107,11 +107,11 @@ class TestProxyResponseParsing:
         assert opportunity.opening_date == date(2025, 8, 15)
         assert opportunity.closing_date == date(2025, 9, 16)
 
-    def test_proxy_response_mixed_date_formats(self):
+    def test_legacy_response_mixed_date_formats(self):
         """
         Test that we can handle mixed date formats in the same response.
         """
-        proxy_response_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        legacy_response_xml = """<?xml version="1.0" encoding="UTF-8"?>
         <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
             <soap:Body>
                 <app:GetOpportunityListResponse
@@ -133,7 +133,7 @@ class TestProxyResponseParsing:
         </soap:Envelope>"""
 
         soap_payload = SOAPPayload(
-            proxy_response_xml,
+            legacy_response_xml,
             operation_name="GetOpportunityListResponse",
             force_list_attributes=["OpportunityDetails"],
         )
@@ -161,7 +161,7 @@ class TestProxyResponseParsing:
         Before our fix, this would have raised a ValidationError with
         error type "date_from_datetime_parsing" for the fields with timezone suffixes.
         """
-        # Create the exact data structure that would come from the proxy response
+        # Create the exact data structure that would come from the legacy response
         opportunity_data = {
             "FundingOpportunityNumber": "O-BJA-2025-202930-STG",
             "OpeningDate": "2025-08-15-04:00",  # This format caused the original issue

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -84,9 +84,9 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
         cascade_delete_from_db_table(db_session, Opportunity)
 
     @patch("src.legacy_soap_api.legacy_soap_api_proxy.get_legacy_response")
-    def test_get_opportunity_list_response(self, mock_proxy_request, db_session):
-        mock_proxy_request_response = MagicMock()
-        mock_proxy_request.return_value = mock_proxy_request_response
+    def test_get_opportunity_list_response(self, mock_legacy_request, db_session):
+        mock_legacy_request_response = MagicMock()
+        mock_legacy_request.return_value = mock_legacy_request_response
         client = get_simpler_applicants_soap_client(
             mock_requests.get_opportunity_list_by_opportunity_number_request(
                 opportunity_number="HDTRA1-25-S-0001"
@@ -96,20 +96,20 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
         assert client.operation_config.request_operation_name == "GetOpportunityListRequest"
         assert client.operation_config.response_operation_name == "GetOpportunityListResponse"
         assert client.get_opportunity_list_request() is not None
-        simpler_soap_response = client.get_simpler_soap_response(mock_proxy_request_response)
+        simpler_soap_response = client.get_simpler_soap_response(mock_legacy_request_response)
         assert isinstance(simpler_soap_response, SOAPResponse)
 
     @patch("src.legacy_soap_api.legacy_soap_api_proxy.get_legacy_response")
     def test_get_opportunity_list_response_by_package_id(
-        self, mock_proxy_request, db_session, enable_factory_create
+        self, mock_legacy_request, db_session, enable_factory_create
     ):
         # Create an opportunity with a competition
         package_id = "PKG-SOAPCLIENT11"
         CompetitionFactory.create(
             opportunity=OpportunityFactory.create(), legacy_package_id=package_id
         )
-        mock_proxy_request_response = MagicMock()
-        mock_proxy_request.return_value = mock_proxy_request_response
+        mock_legacy_request_response = MagicMock()
+        mock_legacy_request.return_value = mock_legacy_request_response
         client = get_simpler_applicants_soap_client(
             mock_requests.get_opportunity_list_by_package_id_request(package_id).encode(),
             db_session=db_session,
@@ -271,8 +271,8 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
         )
 
         # This is only testing the simpler soap response so we can leave proxy response empty.
-        mock_proxy_response = SOAPResponse(data=b"", status_code=200, headers={})
-        simpler_response = simpler_soap_client.get_simpler_soap_response(mock_proxy_response)
+        mock_legacy_response = SOAPResponse(data=b"", status_code=200, headers={})
+        simpler_response = simpler_soap_client.get_simpler_soap_response(mock_legacy_response)
 
         assert simpler_response.data == expected_simpler_soap_response_xml.encode()
         assert (
@@ -290,7 +290,7 @@ class TestSimplerBaseSOAPClient:
         yield (b"<ns5:OpeningDate>2025-07-20-04:00</ns5:OpeningDate>")
         yield b"</OpportunityDetails></GetOpportunityListResponse></Body></soap:Envelope>"
 
-    def test_get_proxy_soap_response_dict_handles_data_that_is_generator(self, db_session):
+    def test_get_legacy_soap_response_dict_handles_data_that_is_generator(self, db_session):
         soap_request = SOAPRequest(
             data=SoapRequestStreamer(
                 stream=io.BytesIO(
@@ -304,8 +304,8 @@ class TestSimplerBaseSOAPClient:
             operation_name="GetOpportunityListRequest",
         )
         client = BaseSOAPClient(soap_request, db_session)
-        proxy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
-        proxy_soap_response_dict = client.get_proxy_soap_response_dict(proxy_response)
+        legacy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
+        legacy_soap_response_dict = client.get_legacy_soap_response_dict(legacy_response)
         expected = {
             "Envelope": {
                 "Body": {
@@ -315,7 +315,7 @@ class TestSimplerBaseSOAPClient:
                 }
             }
         }
-        assert proxy_soap_response_dict == expected
+        assert legacy_soap_response_dict == expected
 
     def test_client_get_soap_request_dict_handles_streaming_data(self, db_session):
         request_data = (
@@ -353,19 +353,19 @@ class TestSimplerBaseSOAPClient:
             operation_name="GetOpportunityListRequest",
         )
         client = BaseSOAPClient(soap_request, db_session)
-        proxy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
+        legacy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_soap_response_dict"
         ) as mock_soap_response_dict:
             caplog.set_level(logging.DEBUG)
             mock_soap_response_dict.return_value = {}
             with patch(
-                "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_proxy_soap_response_dict"
-            ) as mock_get_proxy_soap_response_dict:
-                client.get_simpler_soap_response(proxy_response)
+                "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_legacy_soap_response_dict"
+            ) as mock_get_legacy_soap_response_dict:
+                client.get_simpler_soap_response(legacy_response)
                 assert len(caplog.records) == 1
                 assert caplog.records[0].message == "soap_api_diff complete"
-                mock_get_proxy_soap_response_dict.assert_called_once_with(proxy_response)
+                mock_get_legacy_soap_response_dict.assert_called_once_with(legacy_response)
 
     def test_get_simpler_soap_response_when_operation_is_not_get_opportunity_list_request_does_not_compare_responses(
         self, db_session, caplog
@@ -400,17 +400,19 @@ class TestSimplerBaseSOAPClient:
                 "src.legacy_soap_api.legacy_soap_api_client.build_xml_from_dict"
             ) as mock_build_xml_from_dict:
                 mock_build_xml_from_dict.return_value = b""
-                proxy_response = SOAPResponse(data=self.xml_streamer(), status_code=200, headers={})
+                legacy_response = SOAPResponse(
+                    data=self.xml_streamer(), status_code=200, headers={}
+                )
                 with patch(
                     "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_soap_response_dict"
                 ) as mock_soap_response_dict:
                     caplog.set_level(logging.DEBUG)
                     mock_soap_response_dict.return_value = {}
                     with patch(
-                        "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_proxy_soap_response_dict"
-                    ) as mock_get_proxy_soap_response_dict:
-                        mock_get_proxy_soap_response_dict.assert_not_called()
-                    client.get_simpler_soap_response(proxy_response)
+                        "src.legacy_soap_api.legacy_soap_api_client.BaseSOAPClient.get_legacy_soap_response_dict"
+                    ) as mock_get_legacy_soap_response_dict:
+                        mock_get_legacy_soap_response_dict.assert_not_called()
+                    client.get_simpler_soap_response(legacy_response)
                     assert len(caplog.records) == 0
 
 
@@ -451,11 +453,11 @@ class TestSimplerSOAPGetApplicationZip:
             operation_name="GetApplicationZipRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
+        mock_legacy_response = SOAPResponse(data=b"", status_code=500, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, ADDITIONAL_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 '--uuid:cccccccc-1111-2222-3333-dddddddddddd\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org'
                 '>\n\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:GetApplicationZipResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns11="htt'
@@ -508,12 +510,12 @@ class TestSimplerSOAPGetApplicationZip:
             operation_name="GetApplicationZipRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
+        mock_legacy_response = SOAPResponse(data=b"", status_code=500, headers={})
         client = SimplerGrantorsS2SClient(soap_request, db_session)
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, ADDITIONAL_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             assert result.status_code == 200
 
     def test_get_simpler_soap_response_cannot_access_endpoint_if_certificate_user_does_not_have_privileges(
@@ -549,10 +551,10 @@ class TestSimplerSOAPGetApplicationZip:
             operation_name="GetApplicationZipRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
+        mock_legacy_response = SOAPResponse(data=b"", status_code=500, headers={})
         client = SimplerGrantorsS2SClient(soap_request, db_session)
         with pytest.raises(SOAPClientUserDoesNotHavePermission):
-            client.get_simpler_soap_response(mock_proxy_response)
+            client.get_simpler_soap_response(mock_legacy_response)
 
     def test_get_simpler_soap_response_logging_if_downloading_the_file_from_s3_fails(
         self, db_session, enable_factory_create, caplog
@@ -589,18 +591,18 @@ class TestSimplerSOAPGetApplicationZip:
             operation_name="GetApplicationZipRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(data=b"soap", status_code=500, headers={})
+        mock_legacy_response = SOAPResponse(data=b"soap", status_code=500, headers={})
         client = SimplerGrantorsS2SClient(soap_request, db_session)
         with patch("src.util.file_util.smart_open.open") as mock_smart_open:
             mock_smart_open.side_effect = ClientError(
                 {"Error": {"Code": "NoSuchKey", "Message": "The specified key does not exist."}},
                 "GetObject",
             )
-            response = client.get_simpler_soap_response(mock_proxy_response)
+            response = client.get_simpler_soap_response(mock_legacy_response)
             msg = f"Unable to retrieve file legacy_tracking_number {submission.legacy_tracking_number} from s3 file location."
             assert msg in caplog.messages
-            assert response.data == mock_proxy_response.data
-            assert response.status_code == mock_proxy_response.status_code
+            assert response.data == mock_legacy_response.data
+            assert response.status_code == mock_legacy_response.status_code
 
     def test_get_simpler_soap_response_logging_if_submission_not_found(
         self, db_session, enable_factory_create, caplog
@@ -627,14 +629,14 @@ class TestSimplerSOAPGetApplicationZip:
             api_name=SimplerSoapAPI.GRANTORS,
             operation_name="GetApplicationZipRequest",
         )
-        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
+        mock_legacy_response = SOAPResponse(data=b"", status_code=500, headers={})
         client = SimplerGrantorsS2SClient(soap_request, db_session)
-        response = client.get_simpler_soap_response(mock_proxy_response)
+        response = client.get_simpler_soap_response(mock_legacy_response)
         grants_gov_tracking_number = FAKE_GRANTS_GOV_TRACKING_NUMBER
         msg = f"Unable to find submission legacy_tracking_number {grants_gov_tracking_number}."
         assert msg in caplog.messages
-        assert response.data == mock_proxy_response.data
-        assert response.status_code == mock_proxy_response.status_code
+        assert response.data == mock_legacy_response.data
+        assert response.status_code == mock_legacy_response.status_code
 
 
 class TestSimplerSOAPGetSubmissionListExpanded:
@@ -704,11 +706,11 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             operation_name="GetSubmissionListExpandedRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
+        mock_legacy_response = SOAPResponse(data=b"", status_code=500, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
                 "\nContent-Type: application/xop+xml; charset=UTF-8; type"
@@ -786,11 +788,11 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             operation_name="GetSubmissionListExpandedRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
+        mock_legacy_response = SOAPResponse(data=b"", status_code=500, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
                 'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
@@ -886,7 +888,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             operation_name="GetSubmissionListExpandedRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        proxy_data = (
+        legacy_data = (
             "--uuid:0c77147e-7650-436c-baa1-553f2df8d6ca"
             'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
             "Content-Transfer-Encoding: binary"
@@ -927,11 +929,11 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             "</soap:Envelope>"
             "--uuid:0c77147e-7650-436c-baa1-553f2df8d6ca--"
         )
-        mock_proxy_response = SOAPResponse(data=proxy_data, status_code=200, headers={})
+        mock_legacy_response = SOAPResponse(data=legacy_data, status_code=200, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
                 'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
@@ -1023,7 +1025,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             operation_name="GetSubmissionListExpandedRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        proxy_data = (
+        legacy_data = (
             "--uuid:0c77147e-7650-436c-baa1-553f2df8d6ca"
             'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
             "Content-Transfer-Encoding: binary"
@@ -1064,11 +1066,11 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             "</soap:Envelope>"
             "--uuid:0c77147e-7650-436c-baa1-553f2df8d6ca--"
         )
-        mock_proxy_response = SOAPResponse(data=proxy_data, status_code=200, headers={})
+        mock_legacy_response = SOAPResponse(data=legacy_data, status_code=200, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
                 'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
@@ -1139,13 +1141,13 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             operation_name="GetSubmissionListExpandedRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(
+        mock_legacy_response = SOAPResponse(
             data=b"<somegarbage>1235</somegarbage>", status_code=200, headers={}
         )
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
                 "\nContent-Type: application/xop+xml; charset=UTF-8; type"
@@ -1211,17 +1213,17 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             operation_name="GetSubmissionListExpandedRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        mock_proxy_response = SOAPResponse(
+        mock_legacy_response = SOAPResponse(
             data=b"<somegarbage>1235</somegarbage>", status_code=200, headers={}
         )
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             with patch(
-                "src.legacy_soap_api.grantors.services.get_submission_list_expanded_response.parse_submissions_from_proxy"
+                "src.legacy_soap_api.grantors.services.get_submission_list_expanded_response.parse_submissions_from_legacy"
             ) as mock_parse:
                 mock_parse.side_effect = Exception()
-                result = client.get_simpler_soap_response(mock_proxy_response)
+                result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
                 "\nContent-Type: application/xop+xml; charset=UTF-8; type"
@@ -1260,7 +1262,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             assert result.data == expected
             assert "Failed to parse submission list expanded XML response" in caplog.messages
 
-    def test_get_simpler_soap_response_returns_valid_submission_info_from_proxy_and_skips_invalid(
+    def test_get_simpler_soap_response_returns_valid_submission_info_from_legacy_and_skips_invalid(
         self, db_session, enable_factory_create, mock_s3_bucket, caplog
     ):
         agency = AgencyFactory.create()
@@ -1288,7 +1290,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             operation_name="GetSubmissionListExpandedRequest",
             auth=SOAPAuth(certificate=soap_client_certificate),
         )
-        proxy_data = (
+        legacy_data = (
             "--uuid:0c77147e-7650-436c-baa1-553f2df8d6ca"
             'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
             "Content-Transfer-Encoding: binary"
@@ -1332,11 +1334,11 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             "</soap:Envelope>"
             "--uuid:0c77147e-7650-436c-baa1-553f2df8d6ca--"
         )
-        mock_proxy_response = SOAPResponse(data=proxy_data, status_code=200, headers={})
+        mock_legacy_response = SOAPResponse(data=legacy_data, status_code=200, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
             mock_uuid4.side_effect = [CID_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_simpler_soap_response(mock_proxy_response)
+            result = client.get_simpler_soap_response(mock_legacy_response)
             expected = (
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
                 "\nContent-Type: application/xop+xml; charset=UTF-8; type"

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -83,7 +83,7 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
         cascade_delete_from_db_table(db_session, Competition)
         cascade_delete_from_db_table(db_session, Opportunity)
 
-    @patch("src.legacy_soap_api.legacy_soap_api_proxy.get_proxy_response")
+    @patch("src.legacy_soap_api.legacy_soap_api_proxy.get_legacy_response")
     def test_get_opportunity_list_response(self, mock_proxy_request, db_session):
         mock_proxy_request_response = MagicMock()
         mock_proxy_request.return_value = mock_proxy_request_response
@@ -99,7 +99,7 @@ class TestSimplerSOAPApplicantsClientGetOpportunityList:
         simpler_soap_response = client.get_simpler_soap_response(mock_proxy_request_response)
         assert isinstance(simpler_soap_response, SOAPResponse)
 
-    @patch("src.legacy_soap_api.legacy_soap_api_proxy.get_proxy_response")
+    @patch("src.legacy_soap_api.legacy_soap_api_proxy.get_legacy_response")
     def test_get_opportunity_list_response_by_package_id(
         self, mock_proxy_request, db_session, enable_factory_create
     ):

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -59,7 +59,7 @@ def test_get_legacy_response(enable_factory_create, monkeypatch, db_session):
         mock_send.assert_called_once_with(ANY, stream=True, cert=cert_path, timeout=3600)
 
 
-def test_get_legacy_response_logs_soap_client_lookup_error_and_returns_proxy_response(
+def test_get_legacy_response_logs_soap_client_lookup_error_and_returns_legacy_response(
     caplog, enable_factory_create
 ):
     caplog.set_level(logging.INFO)

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -14,7 +14,7 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
 from src.legacy_soap_api.legacy_soap_api_config import LegacySoapAPIConfig, get_soap_config
 from src.legacy_soap_api.legacy_soap_api_proxy import (
     get_cert_file,
-    get_proxy_response,
+    get_legacy_response,
     get_soap_jwt_auth_jwt,
 )
 from tests.lib.data_factories import create_soap_request
@@ -45,21 +45,21 @@ def test_get_cert_file_returns_cert_data_from_soap_request(enable_factory_create
         assert f.read() == f"{cert_str}\n\n{soap_request.auth.certificate.cert}"
 
 
-def test_get_proxy_response(enable_factory_create, monkeypatch, db_session):
+def test_get_legacy_response(enable_factory_create, monkeypatch, db_session):
     soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=True)
     legacy_certificate = soap_request.auth.certificate.legacy_certificate
     with db_session.begin():
         legacy_certificate.legacy_certificate_id = "e57e1c7f-cf2e-455e-9db5-3e03650174a7"
         db_session.add(legacy_certificate)
     with patch("src.legacy_soap_api.legacy_soap_api_proxy.Session.send") as mock_send:
-        get_proxy_response(soap_request)
+        get_legacy_response(soap_request)
         args, kwargs = mock_send.call_args
         cert_path = kwargs.get("cert")
         assert os.path.exists(cert_path) is False
         mock_send.assert_called_once_with(ANY, stream=True, cert=cert_path, timeout=3600)
 
 
-def test_get_proxy_response_logs_soap_client_lookup_error_and_returns_proxy_response(
+def test_get_legacy_response_logs_soap_client_lookup_error_and_returns_proxy_response(
     caplog, enable_factory_create
 ):
     caplog.set_level(logging.INFO)
@@ -68,12 +68,12 @@ def test_get_proxy_response_logs_soap_client_lookup_error_and_returns_proxy_resp
         "src.legacy_soap_api.legacy_soap_api_proxy.get_cert_file"
     ) as mock_cert_file:
         mock_cert_file.side_effect = SOAPClientCertificateLookupError()
-        get_proxy_response(soap_request)
+        get_legacy_response(soap_request)
         assert "soap_client_certificate: Unknown or invalid client certificate" in caplog.messages
         mock_send.assert_called_once_with(ANY, stream=True, cert="", timeout=3600)
 
 
-def test_get_proxy_response_logs_soap_client_certificate_not_configured_error_and_returns_error_response(
+def test_get_legacy_response_logs_soap_client_certificate_not_configured_error_and_returns_error_response(
     caplog, enable_factory_create
 ):
     caplog.set_level(logging.INFO)
@@ -84,7 +84,7 @@ def test_get_proxy_response_logs_soap_client_certificate_not_configured_error_an
         "src.legacy_soap_api.legacy_soap_api_proxy.get_cert_file"
     ) as mock_cert_file:
         mock_cert_file.side_effect = SOAPClientCertificateNotConfigured()
-        get_proxy_response(soap_request)
+        get_legacy_response(soap_request)
         assert (
             "soap_client_certificate: Certificate validated but not configured" in caplog.messages
         )
@@ -126,7 +126,7 @@ def test_get_soap_jwt_auth_request_when_use_soap_cert_is_not_on_headers(
     with patch(
         "src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response"
     ) as mock_get_soap_response:
-        get_proxy_response(soap_request)
+        get_legacy_response(soap_request)
         encoded = mock_get_soap_response.call_args_list[0][0][0].headers.get(
             "S2S_PARTNER_CERTID_JWT_B64"
         )
@@ -150,7 +150,7 @@ def test_request_without_use_soap_cert_header_gets_correct_proxy_url(enable_fact
     with patch(
         "src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response"
     ) as mock_get_soap_response:
-        get_proxy_response(soap_request)
+        get_legacy_response(soap_request)
         config = get_soap_config()
         expected = f"{config.soap_partner_gateway_uri}/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort"
         assert mock_get_soap_response.call_args_list[0][0][0].url == expected
@@ -163,7 +163,7 @@ def test_request_without_use_soap_cert_header_does_not_log_locally_if_log_local_
     with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as _, patch(
         "src.legacy_soap_api.legacy_soap_api_proxy.log_local"
     ) as mock_log_local:
-        get_proxy_response(soap_request)
+        get_legacy_response(soap_request)
         mock_log_local.assert_not_called()
 
 
@@ -179,5 +179,5 @@ def test_request_logs_locally_when_use_soap_cert_header_is_disabled(enable_facto
     )
     with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as mock_get_response:
         mock_get_response.return_value.to_bytes.return_value = response_bytes
-        get_proxy_response(soap_request)
+        get_legacy_response(soap_request)
         assert f"\nsoap jwt proxy response:\n{response_bytes.decode('utf-8')}" in caplog.messages

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_simpler_soap_api.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_simpler_soap_api.py
@@ -33,14 +33,14 @@ class TestSimplerSoapApi:
             api_name=SimplerSoapAPI.APPLICANTS,
             operation_name="GetOpportunityListRequest",
         )
-        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        soap_legacy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.SimplerApplicantsS2SClient.get_simpler_soap_response"
         ) as mock_get_simpler_soap_response:
             mock_get_simpler_soap_response.return_value = SOAPResponse(
                 data=b"simpler", status_code=500, headers={}
             )
-            response = get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            response = get_simpler_soap_response(soap_request, soap_legacy_response, db_session)
             assert response.data == b"simpler"
 
     def test_get_simpler_response_when_use_simpler_can_be_overrided_by_header_is_true_returns_simpler_response(
@@ -68,17 +68,17 @@ class TestSimplerSoapApi:
             api_name=SimplerSoapAPI.APPLICANTS,
             operation_name="GetOpportunityListRequest",
         )
-        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        soap_legacy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.SimplerApplicantsS2SClient.get_simpler_soap_response"
         ) as mock_get_simpler_soap_response:
             mock_get_simpler_soap_response.return_value = SOAPResponse(
                 data=b"simpler", status_code=500, headers={}
             )
-            response = get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            response = get_simpler_soap_response(soap_request, soap_legacy_response, db_session)
             assert response.data == b"simpler"
 
-    def test_get_simpler_response_when_use_simpler_is_false_returns_proxy_response(
+    def test_get_simpler_response_when_use_simpler_is_false_returns_legacy_response(
         self, monkeypatch, db_session
     ):
         soap_api_config.get_soap_config.cache_clear()
@@ -103,14 +103,14 @@ class TestSimplerSoapApi:
             api_name=SimplerSoapAPI.APPLICANTS,
             operation_name="GetOpportunityListRequest",
         )
-        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        soap_legacy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.SimplerApplicantsS2SClient.get_simpler_soap_response"
         ) as mock_get_simpler_soap_response:
             mock_get_simpler_soap_response.return_value = SOAPResponse(
                 data=b"simpler", status_code=500, headers={}
             )
-            response = get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            response = get_simpler_soap_response(soap_request, soap_legacy_response, db_session)
             assert response.data == b"proxy"
 
     def test_calls_get_simpler_soap_response_when_always_call_simpler_is_true_and_use_simpler_is_true(
@@ -136,11 +136,11 @@ class TestSimplerSoapApi:
             api_name=SimplerSoapAPI.APPLICANTS,
             operation_name="GetOpportunityListRequest",
         )
-        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        soap_legacy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.SimplerApplicantsS2SClient.get_simpler_soap_response"
         ) as mock_get_simpler_soap_response:
-            get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            get_simpler_soap_response(soap_request, soap_legacy_response, db_session)
             mock_get_simpler_soap_response.assert_called_once()
 
     def test_calls_get_simpler_soap_response_when_always_call_simpler_is_true_and_use_simpler_is_false(
@@ -168,11 +168,11 @@ class TestSimplerSoapApi:
             api_name=SimplerSoapAPI.APPLICANTS,
             operation_name="GetOpportunityListRequest",
         )
-        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        soap_legacy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.SimplerApplicantsS2SClient.get_simpler_soap_response"
         ) as mock_get_simpler_soap_response:
-            get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            get_simpler_soap_response(soap_request, soap_legacy_response, db_session)
             mock_get_simpler_soap_response.assert_called_once()
 
     def test_calls_get_simpler_soap_response_when_always_call_simpler_is_false_and_use_simpler_is_true(
@@ -200,11 +200,11 @@ class TestSimplerSoapApi:
             api_name=SimplerSoapAPI.GRANTORS,
             operation_name="GetApplicationZipRequest",
         )
-        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        soap_legacy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.SimplerGrantorsS2SClient.get_simpler_soap_response"
         ) as mock_get_simpler_soap_response:
-            get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            get_simpler_soap_response(soap_request, soap_legacy_response, db_session)
             mock_get_simpler_soap_response.assert_called_once()
 
     def test_calls_get_simpler_soap_response_when_always_call_simpler_is_false_and_use_simpler_is_false(
@@ -232,9 +232,9 @@ class TestSimplerSoapApi:
             api_name=SimplerSoapAPI.GRANTORS,
             operation_name="GetApplicationZipRequest",
         )
-        soap_proxy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
+        soap_legacy_response = SOAPResponse(data=b"proxy", status_code=200, headers={})
         with patch(
             "src.legacy_soap_api.legacy_soap_api_client.SimplerGrantorsS2SClient.get_simpler_soap_response"
         ) as mock_get_simpler_soap_response:
-            get_simpler_soap_response(soap_request, soap_proxy_response, db_session)
+            get_simpler_soap_response(soap_request, soap_legacy_response, db_session)
             mock_get_simpler_soap_response.assert_not_called()


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9365  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Swap out variable name `simpler_proxy_response` for `simpler_legacy_response` and updated some method names to reflect this.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
`simpler_proxy_response` was a vague name that wasn't clear that it was the _legacy_ response, so we udpated the variable.
  
## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing