### PR TITLE
[Issue #9587] Upgrade Python to 3.14.4

### DIFF
--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -3,7 +3,7 @@
 #==============================================
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS amazonlinux-builder
 
-ARG PYTHON_VERSION=3.14.3
+ARG PYTHON_VERSION=3.14.4
 ARG PY_MM=3.14
 ARG POETRY_VERSION=2.3.3
 ARG PIP_VERSION=26.0


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9587

## Changes proposed

Upgrade Python from 3.14.3 to 3.14.4 to address vulnerabilities skipped in the last release.

## Validation steps

- Scans pass
- Tests pass