### PR TITLE
Add community resources to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ Thank you for considering contributing to an Open Source project of the US
 Government! For more information about our contribution guidelines, see
 [CONTRIBUTING.md](CONTRIBUTING.md) to learn more and join our community see our [wiki](https://wiki.simpler.hhs.gov).
 
+## Community
+
+To better understand how this project is governed and how to participate beyond code contributions, please review the following community resources:
+
+- [Community Guidelines](./COMMUNITY_GUIDELINES.md)
+- [Code of Conduct](./CODE_OF_CONDUCT.md)
+- [Architecture Decision Records](./documentation/architecture/)
+- [Project Wiki](https://wiki.simpler.hhs.gov)
+
 ## Security
 
 For more information about our Security, Vulnerability, and Responsible


### PR DESCRIPTION
## Description

### Added community resources section with guidelines and links

## Summary

Fixes #9555

## Changes proposed

This PR adds a new **“Community” section** to the root `README.md`, placed between the “Contributing” and “Security” sections.

The new section consolidates key community resources in one place, including:

* Community Guidelines
* Code of Conduct
* Architecture Decision Records (ADRs)
* Project Wiki

No existing content has been modified or removed.

## Context for reviewers

Previously, community-related resources were scattered across different parts of the repository and not clearly surfaced in the README.

This change improves discoverability for new contributors by providing a single, centralized section for community participation, governance, and design documentation.

The update follows the existing README structure and maintains consistency with current documentation style.

## Validation steps

* Verified the new “Community” section is placed between “Contributing” and “Security”
* Confirmed all links resolve correctly from repository root:

  * `COMMUNITY_GUIDELINES.md`
  * `CODE_OF_CONDUCT.md`
  * `documentation/architecture/`
  * [https://wiki.simpler.hhs.gov/](https://wiki.simpler.hhs.gov)
* Checked that no existing sections were modified or reordered
* Confirmed README renders correctly in preview

