### PR TITLE
[Issue #9139] Backend - Create an endpoint to update reviews on an award recommendation

### DIFF
--- a/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
@@ -10,6 +10,8 @@ from src.api.award_recommendations_alpha.award_recommendation_blueprint import (
 from src.api.award_recommendations_alpha.award_recommendation_schemas import (
     AwardRecommendationCreateRequestSchema,
     AwardRecommendationGetResponseSchema,
+    AwardRecommendationReviewUpdateRequestSchema,
+    AwardRecommendationReviewUpdateResponseSchema,
     AwardRecommendationSubmissionListRequestSchema,
     AwardRecommendationSubmissionListResponseSchema,
 )
@@ -23,6 +25,9 @@ from src.services.award_recommendations.get_award_recommendation import (
 )
 from src.services.award_recommendations.list_award_recommendation_submissions import (
     list_award_recommendation_submissions,
+)
+from src.services.award_recommendations.update_award_recommendation_review import (
+    update_award_recommendation_review,
 )
 
 logger = logging.getLogger(__name__)
@@ -116,3 +121,46 @@ def award_recommendation_submission_list(
     return response.ApiResponse(
         message="Success", data=submissions, pagination_info=pagination_info
     )
+
+
+@award_recommendation_blueprint.put(
+    "/award-recommendations/<uuid:award_recommendation_id>/reviews/<uuid:award_recommendation_review_id>"
+)
+@award_recommendation_blueprint.input(AwardRecommendationReviewUpdateRequestSchema, location="json")
+@award_recommendation_blueprint.output(AwardRecommendationReviewUpdateResponseSchema)
+@award_recommendation_blueprint.doc(
+    summary="Update Award Recommendation Review",
+    description="Update a review on an award recommendation.",
+    responses=[200, 401, 403, 404, 422],
+)
+@award_recommendation_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def award_recommendation_review_update(
+    db_session: db.Session,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_review_id: uuid.UUID,
+    json_data: dict,
+) -> response.ApiResponse:
+    add_extra_data_to_current_request_logs(
+        {
+            "award_recommendation_id": award_recommendation_id,
+            "award_recommendation_review_id": award_recommendation_review_id,
+        }
+    )
+    logger.info(
+        "PUT /alpha/award-recommendations/:award_recommendation_id/reviews/:award_recommendation_review_id"
+    )
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        review = update_award_recommendation_review(
+            db_session,
+            user,
+            award_recommendation_id,
+            award_recommendation_review_id,
+            json_data,
+        )
+
+    return response.ApiResponse(message="Success", data=review)

--- a/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
@@ -193,6 +193,22 @@ class AwardRecommendationGetResponseSchema(AbstractResponseSchema):
     )
 
 
+class AwardRecommendationReviewUpdateRequestSchema(Schema):
+    """Schema for PUT /alpha/award-recommendations/:id/reviews/:review_id request"""
+
+    is_reviewed = fields.Boolean(
+        required=True,
+        metadata={"description": "Whether the review has been completed"},
+    )
+
+
+class AwardRecommendationReviewUpdateResponseSchema(AbstractResponseSchema):
+    data = fields.Nested(
+        AwardRecommendationReviewSchema,
+        metadata={"description": "The updated review"},
+    )
+
+
 ####################################
 # List Award Recommendation Submissions
 ####################################

--- a/api/src/services/award_recommendations/update_award_recommendation_review.py
+++ b/api/src/services/award_recommendations/update_award_recommendation_review.py
@@ -1,0 +1,68 @@
+import logging
+import uuid
+
+import src.adapters.db as db
+from src.api.route_utils import raise_flask_error
+from src.auth.endpoint_access_util import verify_access
+from src.constants.lookup_constants import AwardRecommendationAuditEvent, Privilege
+from src.db.models.award_recommendation_models import (
+    AwardRecommendationAudit,
+    AwardRecommendationReview,
+)
+from src.db.models.user_models import User
+from src.services.award_recommendations.get_award_recommendation import (
+    get_award_recommendation_and_verify_access,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def update_award_recommendation_review(
+    db_session: db.Session,
+    user: User,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_review_id: uuid.UUID,
+    review_data: dict,
+) -> AwardRecommendationReview:
+    award_recommendation = get_award_recommendation_and_verify_access(
+        db_session, user, award_recommendation_id
+    )
+
+    # Verify the user has update privilege (get_award_recommendation_and_verify_access
+    # checks VIEW; we additionally need UPDATE)
+    agency = award_recommendation.opportunity.agency_record
+    verify_access(user, {Privilege.UPDATE_AWARD_RECOMMENDATION}, agency)
+
+    # Find the review on this award recommendation
+    review: AwardRecommendationReview | None = None
+    for r in award_recommendation.award_recommendation_reviews:
+        if r.award_recommendation_review_id == award_recommendation_review_id:
+            review = r
+            break
+
+    if review is None:
+        raise_flask_error(
+            404,
+            message=f"Could not find Award Recommendation Review with ID {award_recommendation_review_id}",
+        )
+
+    review.is_reviewed = review_data["is_reviewed"]
+
+    award_recommendation.award_recommendation_audit_events.append(
+        AwardRecommendationAudit(
+            user=user,
+            award_recommendation_audit_event=AwardRecommendationAuditEvent.REVIEW_UPDATED,
+            award_recommendation_review=review,
+        )
+    )
+
+    logger.info(
+        "Updated award recommendation review",
+        extra={
+            "award_recommendation_id": award_recommendation_id,
+            "award_recommendation_review_id": award_recommendation_review_id,
+            "is_reviewed": review.is_reviewed,
+        },
+    )
+
+    return review

--- a/api/src/services/award_recommendations/update_award_recommendation_review.py
+++ b/api/src/services/award_recommendations/update_award_recommendation_review.py
@@ -1,6 +1,8 @@
 import logging
 import uuid
 
+from sqlalchemy import select
+
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
 from src.auth.endpoint_access_util import verify_access
@@ -33,12 +35,13 @@ def update_award_recommendation_review(
     agency = award_recommendation.opportunity.agency_record
     verify_access(user, {Privilege.UPDATE_AWARD_RECOMMENDATION}, agency)
 
-    # Find the review on this award recommendation
-    review: AwardRecommendationReview | None = None
-    for r in award_recommendation.award_recommendation_reviews:
-        if r.award_recommendation_review_id == award_recommendation_review_id:
-            review = r
-            break
+    review = db_session.execute(
+        select(AwardRecommendationReview).where(
+            AwardRecommendationReview.award_recommendation_review_id
+            == award_recommendation_review_id,
+            AwardRecommendationReview.award_recommendation_id == award_recommendation_id,
+        )
+    ).scalar_one_or_none()
 
     if review is None:
         raise_flask_error(

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_review_update.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_review_update.py
@@ -1,0 +1,358 @@
+import uuid
+
+import pytest
+
+from src.constants.lookup_constants import (
+    AwardRecommendationAuditEvent,
+    AwardRecommendationReviewType,
+    AwardRecommendationStatus,
+    AwardSelectionMethod,
+    Privilege,
+)
+from src.db.models.opportunity_models import Opportunity
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    AwardRecommendationFactory,
+    AwardRecommendationReviewFactory,
+    OpportunityFactory,
+)
+
+API_URL = "/alpha/award-recommendations"
+
+
+####################################
+# Fixtures
+####################################
+
+
+@pytest.fixture
+def agency(enable_factory_create):
+    return AgencyFactory.create()
+
+
+@pytest.fixture
+def opportunity(agency) -> Opportunity:
+    return OpportunityFactory.create(agency_code=agency.agency_code)
+
+
+@pytest.fixture
+def award_recommendation(opportunity):
+    return AwardRecommendationFactory.create(
+        opportunity=opportunity,
+        award_recommendation_status=AwardRecommendationStatus.DRAFT,
+        award_selection_method=AwardSelectionMethod.MERIT_REVIEW_RANKING_ONLY,
+        is_deleted=False,
+        review_workflow=None,
+        review_workflow_id=None,
+    )
+
+
+@pytest.fixture
+def review(award_recommendation):
+    return AwardRecommendationReviewFactory.create(
+        award_recommendation=award_recommendation,
+        award_recommendation_review_type=AwardRecommendationReviewType.MERIT_REVIEW,
+        is_reviewed=False,
+    )
+
+
+def _url(award_recommendation_id: uuid.UUID, review_id: uuid.UUID) -> str:
+    return f"{API_URL}/{award_recommendation_id}/reviews/{review_id}"
+
+
+####################################
+# Happy Path Tests
+####################################
+
+
+class TestUpdateAwardRecommendationReview200:
+
+    def test_set_is_reviewed_true(self, client, db_session, agency, award_recommendation, review):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(
+                award_recommendation.award_recommendation_id, review.award_recommendation_review_id
+            ),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json["data"]
+        assert data["award_recommendation_review_id"] == str(review.award_recommendation_review_id)
+        assert (
+            data["award_recommendation_review_type"] == AwardRecommendationReviewType.MERIT_REVIEW
+        )
+        assert data["is_reviewed"] is True
+
+    def test_set_is_reviewed_false(self, client, db_session, agency, opportunity):
+        ar = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            is_deleted=False,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        rev = AwardRecommendationReviewFactory.create(
+            award_recommendation=ar,
+            award_recommendation_review_type=AwardRecommendationReviewType.PROGRAMMATIC_REVIEW,
+            is_reviewed=True,
+        )
+
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(ar.award_recommendation_id, rev.award_recommendation_review_id),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": False},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json["data"]
+        assert data["is_reviewed"] is False
+
+    def test_creates_audit_event(self, client, db_session, agency, award_recommendation, review):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(
+                award_recommendation.award_recommendation_id, review.award_recommendation_review_id
+            ),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 200
+
+        # Verify audit event was created
+        db_session.expire_all()
+        audit_events = award_recommendation.award_recommendation_audit_events
+        review_audit = [
+            e
+            for e in audit_events
+            if e.award_recommendation_audit_event == AwardRecommendationAuditEvent.REVIEW_UPDATED
+        ]
+        assert len(review_audit) == 1
+        assert (
+            review_audit[0].award_recommendation_review_id == review.award_recommendation_review_id
+        )
+
+
+####################################
+# 404 Tests
+####################################
+
+
+class TestUpdateAwardRecommendationReview404:
+
+    def test_award_recommendation_not_found(
+        self, client, db_session, agency, enable_factory_create
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(uuid.uuid4(), uuid.uuid4()),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 404
+
+    def test_review_not_found(self, client, db_session, agency, award_recommendation):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(award_recommendation.award_recommendation_id, uuid.uuid4()),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 404
+        assert "Could not find Award Recommendation Review" in resp.json["message"]
+
+    def test_deleted_award_recommendation(self, client, db_session, agency, opportunity):
+        ar = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            is_deleted=True,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        rev = AwardRecommendationReviewFactory.create(award_recommendation=ar)
+
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(ar.award_recommendation_id, rev.award_recommendation_review_id),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 404
+
+
+####################################
+# 401 Tests
+####################################
+
+
+class TestUpdateAwardRecommendationReview401:
+
+    def test_no_token(self, client, enable_factory_create):
+        resp = client.put(
+            _url(uuid.uuid4(), uuid.uuid4()),
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 401
+        assert resp.json["message"] == "Unauthorized"
+
+    def test_invalid_token(self, client, enable_factory_create):
+        resp = client.put(
+            _url(uuid.uuid4(), uuid.uuid4()),
+            headers={"X-SGG-Token": "invalid-token"},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 401
+        assert resp.json["message"] == "Unable to process token"
+
+
+####################################
+# 403 Tests
+####################################
+
+
+class TestUpdateAwardRecommendationReview403:
+
+    def test_wrong_agency(
+        self, client, db_session, award_recommendation, review, enable_factory_create
+    ):
+        other_agency = AgencyFactory.create()
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=other_agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(
+                award_recommendation.award_recommendation_id, review.award_recommendation_review_id
+            ),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+    def test_missing_update_privilege(
+        self, client, db_session, agency, award_recommendation, review
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[Privilege.VIEW_AWARD_RECOMMENDATION],
+        )
+
+        resp = client.put(
+            _url(
+                award_recommendation.award_recommendation_id, review.award_recommendation_review_id
+            ),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+    def test_wrong_privilege(self, client, db_session, agency, award_recommendation, review):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[Privilege.VIEW_OPPORTUNITY],
+        )
+
+        resp = client.put(
+            _url(
+                award_recommendation.award_recommendation_id, review.award_recommendation_review_id
+            ),
+            headers={"X-SGG-Token": token},
+            json={"is_reviewed": True},
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+
+####################################
+# 422 Tests
+####################################
+
+
+class TestUpdateAwardRecommendationReview422:
+
+    def test_missing_is_reviewed(self, client, db_session, agency, award_recommendation, review):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        resp = client.put(
+            _url(
+                award_recommendation.award_recommendation_id, review.award_recommendation_review_id
+            ),
+            headers={"X-SGG-Token": token},
+            json={},
+        )
+
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9139  

## Changes proposed

- Updated award_recommendation_schemas.py to add `AwardRecommendationReviewUpdateRequestSchema` and `AwardRecommendationReviewUpdateResponseSchema`
- Updated award_recommendation_routes.py to add the PUT route handler for the new endpoint
- Created update_award_recommendation_review.py to house the service layer for the new endpoint
- Created test_award_recommendation_review_update.py to test the new endpoint

## Context for reviewers

Basic update endpoint to update a review.

## Validation steps

1. Get JWT token of user with `update_award_recommendation`
2. Create an award recommendation - grab the `award_recommendation_id` and `award_recommendation_review_id` from the response
3. Call the new endpoint `PUT /alpha/award-recommendations/{award_recommendation_id}/reviews/{award_recommendation_review_id}` with `{"is_reviewed": true}` and verify a 200 response with the updated review object
4. Confirm tests pass