### PR TITLE
Aoy/8903 failure path e2e tests sf 424a v2

### DIFF
--- a/frontend/tests/e2e/apply/failure-path-sf424a.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-sf424a.spec.ts
@@ -1,0 +1,88 @@
+import {
+  test,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+import {
+  testdata_local_environment,
+  testdata_staging_environment,
+} from "tests/e2e/opportunity-id-data";
+import playwrightEnv from "tests/e2e/playwright-env";
+import { VALID_TAGS } from "tests/e2e/tags";
+import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
+import { createApplication } from "tests/e2e/utils/create-application-utils";
+import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
+import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
+import { verifyAlertErrors } from "tests/e2e/utils/forms/verify-form-errors-utils";
+import {
+  verifyFormStatusAfterSave,
+  verifyFormStatusOnApplication,
+} from "tests/e2e/utils/forms/verify-form-status-utils";
+
+import {
+  SF424A_ALERT_ERRORS,
+  SF424A_FORM_MATCHER,
+  SF424A_REQUIRED_FIELD_ERRORS,
+} from "./fixtures/sf424a-field-definitions";
+
+const { APPLY, CORE_REGRESSION } = VALID_TAGS;
+
+const { testOrgLabel, targetEnv } = playwrightEnv;
+const OPPORTUNITY_ID =
+  targetEnv === "staging"
+    ? testdata_staging_environment.opportunityID
+    : testdata_local_environment.opportunityID;
+const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
+
+// Skip non-Chrome browsers in staging
+test.beforeEach(({ page: _ }, testInfo) => {
+  if (targetEnv === "staging") {
+    test.skip(
+      testInfo.project.name !== "Chrome",
+      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
+    );
+  }
+});
+
+test(
+  "SF-424A error validation - required fields and inline errors",
+  { tag: [APPLY, CORE_REGRESSION] },
+  async (
+    { page, context }: { page: Page; context: BrowserContext },
+    testInfo: TestInfo,
+  ) => {
+    test.setTimeout(300_000); // 5 min timeout
+
+    const isMobile = testInfo.project.name.match(/[Mm]obile/);
+
+    await authenticateE2eUser(page, context, !!isMobile);
+
+    await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
+    const applicationUrl = page.url();
+
+    const openedSf424aForValidation = await openForm(page, SF424A_FORM_MATCHER);
+    if (!openedSf424aForValidation) {
+      throw new Error(
+        "Could not find or open SF-424A form link on the application forms page",
+      );
+    }
+
+    await saveForm(page, true);
+
+    await verifyAlertErrors(page, SF424A_ALERT_ERRORS);
+
+    await verifyFormStatusAfterSave(
+      page,
+      "incomplete",
+      SF424A_REQUIRED_FIELD_ERRORS,
+    );
+
+    await verifyFormStatusOnApplication(
+      page,
+      "incomplete",
+      SF424A_FORM_MATCHER,
+      applicationUrl,
+    );
+  },
+);

--- a/frontend/tests/e2e/apply/fixtures/sf424a-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424a-field-definitions.ts
@@ -1,10 +1,11 @@
 import { numberToTwoDecimalString } from "tests/e2e/utils/forms/form-number-utils";
 import { type FillFormConfig } from "tests/e2e/utils/forms/general-forms-filling";
+import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
 
 // Uses regex matcher tolerant of hyphen/dash variants for SF-424A,
 // to be compatible with both local and staging environments.
 export const SF424A_FORM_MATCHER =
-  "SF\\s*[-\u2011\u2013\u2014]?\\s*424A|Budget\\s+Information\\s+for\\s+Non\\s*[-\u2011\u2013\u2014]?\\s*Construction\\s+Programs";
+  /^Budget Information for Non-Construction Programs \(SF-424A\)$/;
 
 // ---------------------------------------------------------------------------
 // Expected post-save computed values - derived from FORM_RULE_SCHEMA
@@ -393,3 +394,24 @@ export const SF424A_FORM_CONFIG: FillFormConfig = {
     },
   },
 };
+
+// Top alert validation errors for SF-424A blank-save behavior.
+export const SF424A_ALERT_ERRORS: FieldError[] = [
+  {
+    fieldId: "activity_line_items",
+    message: "[] should be non-empty",
+  },
+  {
+    fieldId: "confirmation",
+    message: "'confirmation' is a required property",
+  },
+];
+
+// Inline errors validated through the shared failure-path helper.
+// Restrict this list to field IDs that map to stable inline error elements.
+export const SF424A_REQUIRED_FIELD_ERRORS: FieldError[] = [
+  {
+    fieldId: "confirmation",
+    message: "'confirmation' is a required property",
+  },
+];

--- a/frontend/tests/e2e/utils/forms/general-forms-filling.ts
+++ b/frontend/tests/e2e/utils/forms/general-forms-filling.ts
@@ -396,9 +396,14 @@ export async function fillForm(
  */
 export async function verifyFormLinkVisible(
   page: Page,
-  formName: string,
+  formName: string | RegExp,
 ): Promise<void> {
-  await getFormLink(page, formName).waitFor({
+  const formLink =
+    formName instanceof RegExp
+      ? page.locator("a, button").filter({ hasText: formName })
+      : getFormLink(page, formName);
+
+  await formLink.waitFor({
     state: "visible",
     timeout: 60000,
   });

--- a/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
+++ b/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
@@ -27,12 +27,17 @@ export async function assertFormRowStatus(
     formName instanceof RegExp
       ? formName
       : buildFlexibleFormNameRegex(formName);
+  const formsTable = page.locator(".simpler-application-forms-table");
+  await formsTable.first().waitFor({ state: "visible", timeout: 10000 });
+
   const formRow = page
-    .locator("tr", {
-      hasText: rowPattern,
-    })
+    .locator(".simpler-application-forms-table tbody tr")
     .filter({
-      has: page.locator('a[href*="/form/"]'),
+      has: page
+        .locator(
+          '[data-testid="application-form-link"], a[href*="/form/"], button',
+        )
+        .filter({ hasText: rowPattern }),
     });
 
   await expect(formRow).toBeVisible({ timeout: 10000 });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8903 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->Add automated failure-path coverage for Budget Information for Non-Construction Programs (SF-424A) using the repo’s existing reusable e2e form validation framework.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This PR adds automated failure-path test coverage for SF-424A in the frontend apply e2e suite. It includes:

a new Playwright spec to verify blank-save validation behavior and incomplete form status
updates to the SF-424A field-definition fixture to define alert-level and inline required-field errors
reuse of the shared apply-form helpers for authentication, application creation, form navigation, save behavior, and status verification
This follows the same reusable validation pattern as the existing apply form failure-path tests, so the change is scoped to test coverage only.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

The staging run failure exposed a locator brittleness issue, so we applied framework-level hardening to make form matching both stable and type-safe. The updates were made in verify-form-status-utils.ts and general-forms-filling.ts.

## Note:
Failed: https://github.com/HHS/simpler-grants-gov/actions/runs/24418203557
Passed: https://github.com/HHS/simpler-grants-gov/actions/runs/24474529862