### PR TITLE
[Issue #9336] Link the opportunity title to Edit Opportunity page for Drafts

### DIFF
--- a/frontend/src/app/[locale]/(base)/opportunities/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunities/page.test.tsx
@@ -538,6 +538,13 @@ describe("Opportunities", () => {
       expect(
         await screen.findByRole("link", { name: "createOpportunityButton" }),
       ).toBeVisible();
+
+      const editLink =
+        "/opportunity/" + basicOpportunity.opportunity_id + "/edit";
+      const oppTitlelink = screen.getByRole("link", {
+        name: "Test Opportunity",
+      });
+      expect(oppTitlelink).toHaveAttribute("href", editLink);
     });
 
     it("with read only privilege", async () => {
@@ -551,11 +558,15 @@ describe("Opportunities", () => {
       expect(await screen.findByText("Draft")).toBeVisible();
       // this is the span
       expect(screen.getByText("actionButtons.edit")).toBeInTheDocument();
-      // the href link should not be there
+      // the href link should not be displayed
       expect(
         screen.queryByRole("link", { name: "actionButtons.edit" }),
       ).not.toBeInTheDocument();
-
+      // the opportunity title should not have any links
+      expect(
+        screen.queryByRole("link", { name: "Test Opportunity" }),
+      ).not.toBeInTheDocument();
+      // the create button should not be displayed
       expect(
         screen.queryByRole("link", { name: "createOpportunityButton" }),
       ).not.toBeInTheDocument();
@@ -582,6 +593,32 @@ describe("Opportunities", () => {
       render(component);
 
       expect(await screen.findByTestId("alert")).toBeVisible();
+    });
+  });
+
+  describe("Non-draft opportunities", () => {
+    beforeEach(() => {
+      mockCheckUserPrivileges.mockResolvedValue(userPrivileges);
+      mockFetchUserAgencies.mockResolvedValue([agency1]);
+      mockSearchForOpportunities.mockResolvedValue([basicOpportunity]);
+    });
+
+    it("renders link to view opportunity details and no Actions", async () => {
+      const component = await OpportunitiesListPage({
+        params: localeParams,
+        searchParams: Promise.resolve({ agency: agency1.agency_id }),
+      });
+      render(component);
+
+      expect(await screen.findByText("posted")).toBeVisible();
+      const viewLink = "/opportunity/" + basicOpportunity.opportunity_id;
+      const oppTitlelink = screen.getByRole("link", {
+        name: "Test Opportunity",
+      });
+      expect(oppTitlelink).toHaveAttribute("href", viewLink);
+      expect(screen.queryByText("edit")).not.toBeInTheDocument();
+      expect(screen.queryByText("copy")).not.toBeInTheDocument();
+      expect(screen.queryByText("delete")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[locale]/(base)/opportunities/page.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunities/page.tsx
@@ -143,14 +143,18 @@ const transformTableRowData = (
     const status = opportunity.is_draft
       ? "Draft"
       : opportunity.opportunity_status;
-    const opportunityTitleUrl = canUpdate
-      ? `/opportunity/${opportunity.opportunity_id}/edit`
+    const opportunityTitleUrl = opportunity.is_draft
+      ? canUpdate
+        ? `/opportunity/${opportunity.opportunity_id}/edit`
+        : ``
       : `/opportunity/${opportunity.opportunity_id}`;
     return [
       { cellData: opportunity.agency_name },
       {
-        cellData: (
+        cellData: opportunityTitleUrl ? (
           <a href={opportunityTitleUrl}>{opportunity.opportunity_title}</a>
+        ) : (
+          <span>{opportunity.opportunity_title}</span>
         ),
       },
       {

--- a/frontend/src/app/[locale]/(base)/opportunities/page.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunities/page.tsx
@@ -143,13 +143,14 @@ const transformTableRowData = (
     const status = opportunity.is_draft
       ? "Draft"
       : opportunity.opportunity_status;
+    const opportunityTitleUrl = canUpdate
+      ? `/opportunity/${opportunity.opportunity_id}/edit`
+      : `/opportunity/${opportunity.opportunity_id}`;
     return [
       { cellData: opportunity.agency_name },
       {
         cellData: (
-          <a href={`/opportunity/${opportunity.opportunity_id}`}>
-            {opportunity.opportunity_title}
-          </a>
+          <a href={opportunityTitleUrl}>{opportunity.opportunity_title}</a>
         ),
       },
       {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9336

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
When the opportunity is in Draft and the user has update_opportunity privilege, then the link on the opportunity title should go to the Edit Opportunity page instead of the Published Opportunity view. 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
This is the last AC in task #9336 and it was missed in the sub-task #9397 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- When the opportunity is in Draft and the user has update_opportunity privilege, verify that the link on the opportunity title goes to the Edit Opportunity page
- - When the opportunity status is anything other than Draft, verify that the link on the opportunity title goes to the View Opportunity page.