### PR TITLE
[Issue #9646] Fix Simpler soap error response

### DIFF
--- a/api/src/legacy_soap_api/grantors/fault_messages.py
+++ b/api/src/legacy_soap_api/grantors/fault_messages.py
@@ -15,11 +15,6 @@ ConfirmDeliverySubmissionNotFound = FaultMessage(
     faultcode="soap:Server",
 )
 
-ConfirmDeliveryInvalidStatus = FaultMessage(
-    faultstring="Invalid application status. Expected Accepted status. Failed to confirm application delivery.",
-    faultcode="soap:Server",
-)
-
 ConfirmDeliveryAlreadyRetrieved = FaultMessage(
     faultstring="This application submission has already been retrieved. Failed to confirm application delivery.",
     faultcode="soap:Server",

--- a/api/src/legacy_soap_api/grantors/fault_messages.py
+++ b/api/src/legacy_soap_api/grantors/fault_messages.py
@@ -11,7 +11,7 @@ MissingGrantsGovTrackingNumber = FaultMessage(
 )
 
 ConfirmDeliverySubmissionNotFound = FaultMessage(
-    faultstring="Unable to find application from tracking number. Failed to confirm application delivery.",
+    faultstring="Failed to confirm application delivery.(Authorization Failure)",
     faultcode="soap:Server",
 )
 

--- a/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
+++ b/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
@@ -2,17 +2,13 @@ import logging
 from typing import cast
 
 from apiflask.exceptions import HTTPError
-from sqlalchemy import select
 
 import src.adapters.db as db
 from src.auth.endpoint_access_util import verify_access
 from src.constants.lookup_constants import ApplicationStatus
 from src.db.models.competition_models import ApplicationSubmissionRetrieved
 from src.legacy_soap_api.grantors import schemas as grantor_schemas
-from src.legacy_soap_api.grantors.fault_messages import (
-    ConfirmDeliveryAlreadyRetrieved,
-    ConfirmDeliverySubmissionNotFound,
-)
+from src.legacy_soap_api.grantors.fault_messages import ConfirmDeliverySubmissionNotFound
 from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientUserDoesNotHavePermission,
     validate_certificate,
@@ -22,8 +18,10 @@ from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
+    AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS,
+    RECEIVED_BY_AGENCY_STATUS,
     SOAPFaultException,
-    get_application_submission_by_legacy_tracking_number,
+    get_application_submission_by_legacy_tracking_number_extended,
 )
 
 logger = logging.getLogger(__name__)
@@ -34,6 +32,25 @@ GRANTS_APPLICATION_STATUSES = {
     ApplicationStatus.SUBMITTED: "Received",
     ApplicationStatus.ACCEPTED: "Validated",
 }
+
+
+def get_soap_fault_exception(
+    application_status: str, status: str, legacy_tracking_number: str
+) -> SOAPFaultException:
+    msg = (
+        "Failed to confirm application delivery.(Expected an Application status of:'Validated' ,"
+        f" but found a status of '{status}' for {legacy_tracking_number})"
+    )
+    logger.info(
+        msg,
+        extra={
+            "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+            "application_status": application_status,
+            "legacy_tracking_number": legacy_tracking_number,
+            "response_operation_name": "ConfirmApplicationDeliveryResponse",
+        },
+    )
+    return SOAPFaultException(msg, fault=FaultMessage(faultcode="soap:Server", faultstring=msg))
 
 
 def confirm_application_delivery(
@@ -58,11 +75,12 @@ def confirm_application_delivery(
         str, confirm_application_delivery_request.grants_gov_tracking_number
     )
 
-    application_submission = get_application_submission_by_legacy_tracking_number(
-        db_session, legacy_tracking_number
+    submission_extended_dict = get_application_submission_by_legacy_tracking_number_extended(
+        db_session, legacy_tracking_number, str(certificate.user_id)
     )
-
-    if not application_submission:
+    if submission_extended_dict:
+        application_submission = submission_extended_dict["submission"]
+    else:
         logger.info(
             f"Unable to find submission legacy_tracking_number {legacy_tracking_number}.",
             extra={
@@ -98,13 +116,8 @@ def confirm_application_delivery(
             "User did not have permission to confirm application delivery"
         ) from e
 
-    if application.application_status not in VALID_STATUSES_FOR_DELIVERY:
-        msg = (
-            "Failed to confirm application delivery.(Expected an Application status of:'Validated' ,"
-            f" but found a status of '{GRANTS_APPLICATION_STATUSES.get(
-                application.application_status or ApplicationStatus.IN_PROGRESS
-            )}' for {legacy_tracking_number})"
-        )
+    if not application.application_status:
+        msg = "Application has no application_status"
         logger.info(
             msg,
             extra={
@@ -116,32 +129,19 @@ def confirm_application_delivery(
         )
         raise SOAPFaultException(msg, fault=FaultMessage(faultcode="soap:Server", faultstring=msg))
 
-    # Check if this user has already retrieved this submission.
-    existing_retrieval = (
-        db_session.execute(
-            select(ApplicationSubmissionRetrieved).where(
-                ApplicationSubmissionRetrieved.application_submission_id
-                == application_submission.application_submission_id,
-                ApplicationSubmissionRetrieved.created_by_user_id == certificate.user.user_id,
-            )
+    if submission_extended_dict["has_tracking"]:
+        raise get_soap_fault_exception(
+            application.application_status,
+            AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS,
+            legacy_tracking_number,
         )
-        .scalars()
-        .first()
-    )
-
-    if existing_retrieval:
-        logger.info(
-            "Application submission has already been retrieved by this user.",
-            extra={
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-                "user_id": certificate.user.user_id,
-                "legacy_tracking_number": legacy_tracking_number,
-                "response_operation_name": "ConfirmApplicationDeliveryResponse",
-            },
+    elif submission_extended_dict["has_retrieval"]:
+        raise get_soap_fault_exception(
+            application.application_status, RECEIVED_BY_AGENCY_STATUS, legacy_tracking_number
         )
-        raise SOAPFaultException(
-            "Application submission has already been retrieved by this user",
-            fault=ConfirmDeliveryAlreadyRetrieved,
+    elif application.application_status not in VALID_STATUSES_FOR_DELIVERY:
+        raise get_soap_fault_exception(
+            application.application_status, "Received", legacy_tracking_number
         )
 
     retrieval = ApplicationSubmissionRetrieved(

--- a/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
+++ b/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
@@ -34,12 +34,9 @@ VALID_STATUSES_FOR_DELIVERY = {ApplicationStatus.ACCEPTED}
 def get_soap_fault_exception(
     application_status: str, status: str, legacy_tracking_number: str
 ) -> SOAPFaultException:
-    msg = (
-        "Failed to confirm application delivery.(Expected an Application status of:'Validated' ,"
-        f" but found a status of '{status}' for {legacy_tracking_number})"
-    )
+    log_msg = "Application status is not valid for confirm application delivery."
     logger.info(
-        msg,
+        log_msg,
         extra={
             "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             "application_status": application_status,
@@ -47,7 +44,13 @@ def get_soap_fault_exception(
             "response_operation_name": "ConfirmApplicationDeliveryResponse",
         },
     )
-    return SOAPFaultException(msg, fault=FaultMessage(faultcode="soap:Server", faultstring=msg))
+    faultstring = (
+        "Failed to confirm application delivery.(Expected an Application status of:'Validated' ,"
+        f" but found a status of '{status}' for {legacy_tracking_number})"
+    )
+    return SOAPFaultException(
+        log_msg, fault=FaultMessage(faultcode="soap:Server", faultstring=faultstring)
+    )
 
 
 def confirm_application_delivery(
@@ -79,10 +82,11 @@ def confirm_application_delivery(
         application_submission = submission_extended_dict["submission"]
     else:
         logger.info(
-            f"Unable to find submission legacy_tracking_number {legacy_tracking_number}.",
+            "Submission not found for confirm application delivery",
             extra={
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
                 "response_operation_name": "ConfirmApplicationDeliveryResponse",
+                "legacy_tracking_number": legacy_tracking_number,
             },
         )
         raise SOAPFaultException(

--- a/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
+++ b/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
@@ -18,11 +18,10 @@ from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
-    AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS,
-    RECEIVED_BY_AGENCY_STATUS,
     SOAPFaultException,
     get_application_submission_by_legacy_tracking_number_extended,
 )
+from src.legacy_soap_api.grantors.statuses import AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS, RECEIVED_BY_AGENCY_STATUS
 
 logger = logging.getLogger(__name__)
 

--- a/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
+++ b/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
@@ -26,11 +26,6 @@ from src.legacy_soap_api.grantors.statuses import AGENCY_TRACKING_NUMBER_ASSIGNE
 logger = logging.getLogger(__name__)
 
 VALID_STATUSES_FOR_DELIVERY = {ApplicationStatus.ACCEPTED}
-GRANTS_APPLICATION_STATUSES = {
-    ApplicationStatus.IN_PROGRESS: "Received",
-    ApplicationStatus.SUBMITTED: "Received",
-    ApplicationStatus.ACCEPTED: "Validated",
-}
 
 
 def get_soap_fault_exception(

--- a/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
+++ b/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
@@ -9,6 +9,10 @@ from src.constants.lookup_constants import ApplicationStatus
 from src.db.models.competition_models import ApplicationSubmissionRetrieved
 from src.legacy_soap_api.grantors import schemas as grantor_schemas
 from src.legacy_soap_api.grantors.fault_messages import ConfirmDeliverySubmissionNotFound
+from src.legacy_soap_api.grantors.statuses import (
+    AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS,
+    RECEIVED_BY_AGENCY_STATUS,
+)
 from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientUserDoesNotHavePermission,
     validate_certificate,
@@ -21,7 +25,6 @@ from src.legacy_soap_api.legacy_soap_api_utils import (
     SOAPFaultException,
     get_application_submission_by_legacy_tracking_number_extended,
 )
-from src.legacy_soap_api.grantors.statuses import AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS, RECEIVED_BY_AGENCY_STATUS
 
 logger = logging.getLogger(__name__)
 

--- a/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
+++ b/api/src/legacy_soap_api/grantors/services/confirm_application_delivery_response.py
@@ -11,7 +11,6 @@ from src.db.models.competition_models import ApplicationSubmissionRetrieved
 from src.legacy_soap_api.grantors import schemas as grantor_schemas
 from src.legacy_soap_api.grantors.fault_messages import (
     ConfirmDeliveryAlreadyRetrieved,
-    ConfirmDeliveryInvalidStatus,
     ConfirmDeliverySubmissionNotFound,
 )
 from src.legacy_soap_api.legacy_soap_api_auth import (
@@ -20,6 +19,7 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
 )
 from src.legacy_soap_api.legacy_soap_api_config import SOAPOperationConfig
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
+from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
     SOAPFaultException,
@@ -29,6 +29,11 @@ from src.legacy_soap_api.legacy_soap_api_utils import (
 logger = logging.getLogger(__name__)
 
 VALID_STATUSES_FOR_DELIVERY = {ApplicationStatus.ACCEPTED}
+GRANTS_APPLICATION_STATUSES = {
+    ApplicationStatus.IN_PROGRESS: "Received",
+    ApplicationStatus.SUBMITTED: "Received",
+    ApplicationStatus.ACCEPTED: "Validated",
+}
 
 
 def confirm_application_delivery(
@@ -45,6 +50,10 @@ def confirm_application_delivery(
     Returns the grants_gov_tracking_number on success.
     Raises SOAPFaultException or SOAPClientUserDoesNotHavePermission on failure.
     """
+    certificate = validate_certificate(
+        db_session, soap_auth=soap_request.auth, api_name=soap_request.api_name
+    )
+
     legacy_tracking_number = cast(
         str, confirm_application_delivery_request.grants_gov_tracking_number
     )
@@ -67,35 +76,15 @@ def confirm_application_delivery(
         )
 
     application = application_submission.application
-
-    if application.application_status not in VALID_STATUSES_FOR_DELIVERY:
-        logger.info(
-            "Application status is not valid for confirm application delivery.",
-            extra={
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-                "application_status": application.application_status,
-                "legacy_tracking_number": legacy_tracking_number,
-                "response_operation_name": "ConfirmApplicationDeliveryResponse",
-            },
-        )
-        raise SOAPFaultException(
-            "Application status is not valid for confirm application delivery",
-            fault=ConfirmDeliveryInvalidStatus,
-        )
-
-    certificate = validate_certificate(
-        db_session, soap_auth=soap_request.auth, api_name=soap_request.api_name
-    )
-
-    if soap_config.privileges is None:
-        raise ValueError("Privileges must be configured for ConfirmApplicationDelivery")
-
     try:
-        verify_access(
-            certificate.user,
-            soap_config.privileges,
-            application.competition.opportunity.agency_record,
-        )
+        if soap_config.privileges:
+            verify_access(
+                certificate.user,
+                soap_config.privileges,
+                application.competition.opportunity.agency_record,
+            )
+        else:
+            raise ValueError("Privileges must be configured for ConfirmApplicationDelivery")
     except HTTPError as e:
         logger.info(
             "User did not have permission to confirm application delivery",
@@ -108,6 +97,24 @@ def confirm_application_delivery(
         raise SOAPClientUserDoesNotHavePermission(
             "User did not have permission to confirm application delivery"
         ) from e
+
+    if application.application_status not in VALID_STATUSES_FOR_DELIVERY:
+        msg = (
+            "Failed to confirm application delivery.(Expected an Application status of:'Validated' ,"
+            f" but found a status of '{GRANTS_APPLICATION_STATUSES.get(
+                application.application_status or ApplicationStatus.IN_PROGRESS
+            )}' for {legacy_tracking_number})"
+        )
+        logger.info(
+            msg,
+            extra={
+                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+                "application_status": application.application_status,
+                "legacy_tracking_number": legacy_tracking_number,
+                "response_operation_name": "ConfirmApplicationDeliveryResponse",
+            },
+        )
+        raise SOAPFaultException(msg, fault=FaultMessage(faultcode="soap:Server", faultstring=msg))
 
     # Check if this user has already retrieved this submission.
     existing_retrieval = (

--- a/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
@@ -21,10 +21,9 @@ from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import convert_bool_to_yes_no
 from src.util.datetime_util import adjust_timezone
+from src.legacy_soap_api.grantors.statuses import AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS, RECEIVED_BY_AGENCY_STATUS
 
 logger = logging.getLogger(__name__)
-AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS = "Agency Tracking Number Assigned"
-RECEIVED_BY_AGENCY_STATUS = "Received by Agency"
 GRANTS_APPLICATION_STATUSES = {
     None: None,
     ApplicationStatus.IN_PROGRESS: None,

--- a/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
@@ -33,7 +33,7 @@ GRANTS_APPLICATION_STATUSES = {
 }
 STATUS_TRANSFORM = {
     "Receiving": None,
-    "Received": None,
+    "Received": ApplicationStatus.SUBMITTED,
     "Processing": ApplicationStatus.SUBMITTED,
     "Validated": ApplicationStatus.ACCEPTED,
     "Rejected with Errors": None,

--- a/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
@@ -32,7 +32,7 @@ GRANTS_APPLICATION_STATUSES = {
 }
 STATUS_TRANSFORM = {
     "Receiving": None,
-    "Received": ApplicationStatus.SUBMITTED,
+    "Received": None,
     "Processing": ApplicationStatus.SUBMITTED,
     "Validated": ApplicationStatus.ACCEPTED,
     "Rejected with Errors": None,

--- a/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_submission_list_expanded_response.py
@@ -15,13 +15,16 @@ from src.db.models.agency_models import Agency
 from src.db.models.competition_models import Application, ApplicationSubmission, Competition
 from src.db.models.opportunity_models import Opportunity, OpportunityAssistanceListing
 from src.legacy_soap_api.grantors import schemas
+from src.legacy_soap_api.grantors.statuses import (
+    AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS,
+    RECEIVED_BY_AGENCY_STATUS,
+)
 from src.legacy_soap_api.legacy_soap_api_auth import validate_certificate, verify_certificate_access
 from src.legacy_soap_api.legacy_soap_api_config import SOAPOperationConfig
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import convert_bool_to_yes_no
 from src.util.datetime_util import adjust_timezone
-from src.legacy_soap_api.grantors.statuses import AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS, RECEIVED_BY_AGENCY_STATUS
 
 logger = logging.getLogger(__name__)
 GRANTS_APPLICATION_STATUSES = {

--- a/api/src/legacy_soap_api/grantors/statuses.py
+++ b/api/src/legacy_soap_api/grantors/statuses.py
@@ -1,0 +1,2 @@
+AGENCY_TRACKING_NUMBER_ASSIGNED_STATUS = "Agency Tracking Number Assigned"
+RECEIVED_BY_AGENCY_STATUS = "Received by Agency"

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -10,10 +10,14 @@ from typing import Any
 import requests
 from defusedxml import minidom
 from lxml import etree
-from sqlalchemy import select
+from sqlalchemy import exists, select
 
 import src.adapters.db as db
-from src.db.models.competition_models import ApplicationSubmission
+from src.db.models.competition_models import (
+    ApplicationSubmission,
+    ApplicationSubmissionRetrieved,
+    ApplicationSubmissionTrackingNumber,
+)
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
 from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage, SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
@@ -351,6 +355,34 @@ def get_application_submission_by_legacy_tracking_number(
             ApplicationSubmission.legacy_tracking_number == int(legacy_tracking_number),
         )
     ).scalar_one_or_none()
+
+
+def get_application_submission_by_legacy_tracking_number_extended(
+    db_session: db.Session, legacy_tracking_number: str, user_id: str
+) -> dict | None:
+    if legacy_tracking_number.startswith("GRANT"):
+        legacy_tracking_number = legacy_tracking_number.split("GRANT")[1]
+    combined_stmt = select(
+        ApplicationSubmission,
+        exists()
+        .where(
+            ApplicationSubmissionTrackingNumber.created_by_user_id == user_id,
+            ApplicationSubmissionTrackingNumber.application_submission_id
+            == ApplicationSubmission.application_submission_id,
+        )
+        .label("has_tracking"),
+        exists()
+        .where(
+            ApplicationSubmissionRetrieved.created_by_user_id == user_id,
+            ApplicationSubmissionRetrieved.application_submission_id
+            == ApplicationSubmission.application_submission_id,
+        )
+        .label("has_retrieval"),
+    ).where(ApplicationSubmission.legacy_tracking_number == int(legacy_tracking_number))
+    result = db_session.execute(combined_stmt).tuples().first()
+    if result:
+        return dict(submission=result[0], has_tracking=result[1], has_retrieval=result[2])
+    return None
 
 
 def convert_bool_to_yes_no(value: bool | None) -> str:

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -173,15 +173,13 @@ def process_simpler_request(
             },
         )
     except SOAPFaultException as e:
-        use_simpler = soap_request.headers.get("Use-Simpler-Override") == "1"
         logger.exception(
             msg=e.fault.faultstring,
             extra={
-                "used_simpler_response": use_simpler,
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },
         )
-        if use_simpler:
+        if soap_proxy_response.status_code == 500:
             return get_soap_error_response(
                 faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
             ).to_flask_response()

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -23,6 +23,7 @@ from src.legacy_soap_api.legacy_soap_api_schemas import (
 )
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest, SoapRequestStreamer
 from src.legacy_soap_api.legacy_soap_api_utils import (
+    SOAPFaultException,
     get_alternate_proxy_response,
     get_invalid_path_response,
     get_soap_error_response,
@@ -171,7 +172,19 @@ def process_simpler_request(
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },
         )
-        return soap_proxy_response.to_flask_response()
+    except SOAPFaultException as e:
+        use_simpler = soap_request.headers.get("Use-Simpler-Override") == "1"
+        logger.exception(
+            msg=e.fault.faultstring,
+            extra={
+                "used_simpler_response": use_simpler,
+                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+            },
+        )
+        if use_simpler:
+            return get_soap_error_response(
+                faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
+            ).to_flask_response()
     except Exception:
         msg = "Unable to process Simpler SOAP proxy response"
         logger.exception(
@@ -181,4 +194,4 @@ def process_simpler_request(
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },
         )
-        return soap_proxy_response.to_flask_response()
+    return soap_proxy_response.to_flask_response()

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -173,8 +173,9 @@ def process_simpler_request(
             },
         )
     except SOAPFaultException as e:
-        logger.exception(
+        logger.info(
             msg=e.fault.faultstring,
+            exc_info=True,
             extra={
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },

--- a/api/tests/src/legacy_soap_api/grantors/services/test_confirm_application_delivery_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_confirm_application_delivery_response.py
@@ -80,7 +80,7 @@ class TestConfirmApplicationDeliveryResponse:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.ConfirmApplicationDeliveryRequest(
-            GrantsGovTrackingNumber=tracking_number,
+            grants_gov_tracking_number=tracking_number,
         )
 
         returned_tracking_number = confirm_application_delivery(
@@ -120,7 +120,7 @@ class TestConfirmApplicationDeliveryResponse:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.ConfirmApplicationDeliveryRequest(
-            GrantsGovTrackingNumber=tracking_number,
+            grants_gov_tracking_number=tracking_number,
         )
 
         with pytest.raises(SOAPFaultException) as exc:
@@ -155,7 +155,7 @@ class TestConfirmApplicationDeliveryResponse:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.ConfirmApplicationDeliveryRequest(
-            GrantsGovTrackingNumber=tracking_number,
+            grants_gov_tracking_number=tracking_number,
         )
 
         with pytest.raises(SOAPFaultException) as exc:
@@ -203,7 +203,7 @@ class TestConfirmApplicationDeliveryResponse:
         soap_request = _make_soap_request(second_soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.ConfirmApplicationDeliveryRequest(
-            GrantsGovTrackingNumber=tracking_number,
+            grants_gov_tracking_number=tracking_number,
         )
 
         tracking_number_result = confirm_application_delivery(
@@ -240,7 +240,7 @@ class TestConfirmApplicationDeliveryResponse:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.ConfirmApplicationDeliveryRequest(
-            GrantsGovTrackingNumber=tracking_number,
+            grants_gov_tracking_number=tracking_number,
         )
 
         with pytest.raises(SOAPFaultException) as exc:
@@ -273,7 +273,7 @@ class TestConfirmApplicationDeliveryResponse:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.ConfirmApplicationDeliveryRequest(
-            GrantsGovTrackingNumber=tracking_number,
+            grants_gov_tracking_number=tracking_number,
         )
 
         with pytest.raises(SOAPFaultException) as exc:
@@ -285,7 +285,7 @@ class TestConfirmApplicationDeliveryResponse:
             )
         assert (
             exc.value.fault.faultstring
-            == "Unable to find application from tracking number. Failed to confirm application delivery."
+            == "Failed to confirm application delivery.(Authorization Failure)"
         )
 
     def test_user_without_privileges_raises_permission_error(
@@ -304,7 +304,7 @@ class TestConfirmApplicationDeliveryResponse:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.ConfirmApplicationDeliveryRequest(
-            GrantsGovTrackingNumber=tracking_number,
+            grants_gov_tracking_number=tracking_number,
         )
 
         with pytest.raises(SOAPClientUserDoesNotHavePermission) as exc:

--- a/api/tests/src/legacy_soap_api/grantors/services/test_confirm_application_delivery_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_confirm_application_delivery_response.py
@@ -123,13 +123,17 @@ class TestConfirmApplicationDeliveryResponse:
             GrantsGovTrackingNumber=tracking_number,
         )
 
-        with pytest.raises(SOAPFaultException):
+        with pytest.raises(SOAPFaultException) as exc:
             confirm_application_delivery(
                 db_session=db_session,
                 soap_request=soap_request,
                 confirm_application_delivery_request=request_schema,
                 soap_config=_make_operation_config(),
             )
+        assert (
+            exc.value.fault.faultstring
+            == f"Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received' for GRANT{submission.legacy_tracking_number})"
+        )
 
     def test_already_retrieved_by_same_user_returns_fault(self, db_session, enable_factory_create):
         """The same user calling ConfirmApplicationDelivery twice should fail."""
@@ -154,13 +158,17 @@ class TestConfirmApplicationDeliveryResponse:
             GrantsGovTrackingNumber=tracking_number,
         )
 
-        with pytest.raises(SOAPFaultException):
+        with pytest.raises(SOAPFaultException) as exc:
             confirm_application_delivery(
                 db_session=db_session,
                 soap_request=soap_request,
                 confirm_application_delivery_request=request_schema,
                 soap_config=_make_operation_config(),
             )
+        assert (
+            exc.value.fault.faultstring
+            == f"Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received by Agency' for GRANT{submission.legacy_tracking_number})"
+        )
 
         # Verify no additional retrieval record was inserted
         retrievals = (
@@ -235,13 +243,17 @@ class TestConfirmApplicationDeliveryResponse:
             GrantsGovTrackingNumber=tracking_number,
         )
 
-        with pytest.raises(SOAPFaultException):
+        with pytest.raises(SOAPFaultException) as exc:
             confirm_application_delivery(
                 db_session=db_session,
                 soap_request=soap_request,
                 confirm_application_delivery_request=request_schema,
                 soap_config=_make_operation_config(),
             )
+        assert (
+            exc.value.fault.faultstring
+            == f"Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received' for GRANT{submission.legacy_tracking_number})"
+        )
 
         # Verify NO retrieval record was inserted
         retrievals = (
@@ -264,13 +276,17 @@ class TestConfirmApplicationDeliveryResponse:
             GrantsGovTrackingNumber=tracking_number,
         )
 
-        with pytest.raises(SOAPFaultException):
+        with pytest.raises(SOAPFaultException) as exc:
             confirm_application_delivery(
                 db_session=db_session,
                 soap_request=soap_request,
                 confirm_application_delivery_request=request_schema,
                 soap_config=_make_operation_config(),
             )
+        assert (
+            exc.value.fault.faultstring
+            == "Unable to find application from tracking number. Failed to confirm application delivery."
+        )
 
     def test_user_without_privileges_raises_permission_error(
         self, db_session, enable_factory_create
@@ -291,13 +307,14 @@ class TestConfirmApplicationDeliveryResponse:
             GrantsGovTrackingNumber=tracking_number,
         )
 
-        with pytest.raises(SOAPClientUserDoesNotHavePermission):
+        with pytest.raises(SOAPClientUserDoesNotHavePermission) as exc:
             confirm_application_delivery(
                 db_session=db_session,
                 soap_request=soap_request,
                 confirm_application_delivery_request=request_schema,
                 soap_config=_make_operation_config(),
             )
+        assert str(exc.value) == "User did not have permission to confirm application delivery"
 
     def test_response_envelope_dict_structure(self):
         tracking_number = "GRANT12345678"

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -6,6 +6,7 @@ from lxml import etree
 from src.constants.lookup_constants import ApplicationStatus, Privilege
 from src.db.models.competition_models import ApplicationSubmissionRetrieved
 from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth, SOAPClientCertificate
+from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_utils import get_invalid_path_response
 from tests.lib.data_factories import setup_cert_user
 from tests.src.db.models.factories import (
@@ -250,9 +251,17 @@ def test_confirm_application_delivery_when_application_has_no_status(
     )
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
-        response = client.post(
-            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
-        )
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.get_proxy_response"
+        ) as mock_proxy_response:
+            mock_proxy_response.return_value = SOAPResponse(
+                data=b"test response", status_code=500, headers={}
+            )
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"},
+            )
     assert response.status_code == 500
     expected = (
         '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
@@ -266,7 +275,7 @@ def test_confirm_application_delivery_when_application_has_no_status(
     assert response.data.decode() == expected
 
 
-def test_if_soap_fault_exception_raised_return_correct_response_if_use_simpler_override_is_1(
+def test_if_soap_fault_exception_raised_return_correct_response_if_proxy_response_is_500(
     db_session, client, enable_factory_create
 ) -> None:
     agency = AgencyFactory.create()
@@ -318,7 +327,7 @@ def test_if_soap_fault_exception_raised_return_correct_response_if_use_simpler_o
     assert response.data.decode() == expected
 
 
-def test_if_soap_fault_exception_raised_return_proxy_response_if_use_simpler_override_is_not_1(
+def test_if_soap_fault_exception_raised_return_proxy_response_if_proxy_response_status_code_is_not_500(
     db_session, client, enable_factory_create
 ) -> None:
     agency = AgencyFactory.create()
@@ -331,7 +340,9 @@ def test_if_soap_fault_exception_raised_return_proxy_response_if_use_simpler_ove
     application = ApplicationFactory.create(
         competition=competition, application_status=ApplicationStatus.IN_PROGRESS
     )
-    submission = ApplicationSubmissionFactory.create(application=application)
+    submission = ApplicationSubmissionFactory.create(
+        application=application, legacy_tracking_number="00837443"
+    )
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     mock_data = (
         "<soapenv:Envelope "
@@ -354,18 +365,15 @@ def test_if_soap_fault_exception_raised_return_proxy_response_if_use_simpler_ove
     )
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
-        # Remove Use-Simpler-Override
-        response = client.post(full_path, data=mock_data, headers={"Use-Soap-Cert": "1"})
-    assert response.status_code == 500
-    expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "    <soap:Body>\n        <soap:Fault>\n"
-        "            <faultcode>soap:Server</faultcode>\n"
-        "            <faultstring>Client certificate not configured for Simpler SOAP.</faultstring>\n"
-        "        </soap:Fault>\n"
-        "    </soap:Body>\n"
-        "</soap:Envelope>\n"
-    )
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.get_proxy_response"
+        ) as mock_proxy_response:
+            mock_proxy_response.return_value = SOAPResponse(
+                data=b"test response", status_code=200, headers={}
+            )
+            response = client.post(full_path, data=mock_data, headers={"Use-Soap-Cert": "1"})
+    assert response.status_code == 200
+    expected = "test response"
     assert response.data.decode() == expected
 
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -9,6 +9,8 @@ from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth, SOAPClientCertifi
 from src.legacy_soap_api.legacy_soap_api_utils import get_invalid_path_response
 from tests.lib.data_factories import setup_cert_user
 from tests.src.db.models.factories import (
+    ApplicationSubmissionRetrievedFactory,
+    ApplicationSubmissionTrackingNumberFactory,
     AgencyFactory,
     ApplicationFactory,
     ApplicationSubmissionFactory,
@@ -104,7 +106,165 @@ def test_successful_confirm_application_delivery_request(
     assert len(retrieved) == 1
 
 
-def test_if_soapfaultexception_raised_return_correct_response_if_use_simpler_override_is_1(
+def test_successful_confirm_application_delivery_request_when_in_received_by_agency_status(
+    db_session, client, enable_factory_create
+) -> None:
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.ACCEPTED
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    ApplicationSubmissionRetrievedFactory.create(application_submission=submission, created_by_user=user)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        response = client.post(
+            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+        )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "    <soap:Body>\n        <soap:Fault>\n"
+        "            <faultcode>soap:Server</faultcode>\n"
+        f"            <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received by Agency' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
+        "        </soap:Fault>\n"
+        "    </soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
+
+
+def test_successful_confirm_application_delivery_request_when_in_tracking_number_assiged_status(
+    db_session, client, enable_factory_create
+) -> None:
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.ACCEPTED
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    ApplicationSubmissionTrackingNumberFactory.create(application_submission=submission, created_by_user=user)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        response = client.post(
+            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+        )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "    <soap:Body>\n        <soap:Fault>\n"
+        "            <faultcode>soap:Server</faultcode>\n"
+        f"            <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Agency Tracking Number Assigned' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
+        "        </soap:Fault>\n"
+        "    </soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
+
+
+def test_confirm_application_delivery_when_application_has_no_status(
+    db_session, client, enable_factory_create
+) -> None:
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=None
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        response = client.post(
+            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+        )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "    <soap:Body>\n        <soap:Fault>\n"
+        "            <faultcode>soap:Server</faultcode>\n"
+        "            <faultstring>Application has no application_status</faultstring>\n"
+        "        </soap:Fault>\n"
+        "    </soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
+
+
+def test_if_soap_fault_exception_raised_return_correct_response_if_use_simpler_override_is_1(
     db_session, client, enable_factory_create
 ) -> None:
     agency = AgencyFactory.create()
@@ -156,7 +316,7 @@ def test_if_soapfaultexception_raised_return_correct_response_if_use_simpler_ove
     assert response.data.decode() == expected
 
 
-def test_if_soapfaultexception_raised_return_proxy_response_if_use_simpler_override_is_not_1(
+def test_if_soap_fault_exception_raised_return_proxy_response_if_use_simpler_override_is_not_1(
     db_session, client, enable_factory_create
 ) -> None:
     agency = AgencyFactory.create()

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -9,11 +9,11 @@ from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth, SOAPClientCertifi
 from src.legacy_soap_api.legacy_soap_api_utils import get_invalid_path_response
 from tests.lib.data_factories import setup_cert_user
 from tests.src.db.models.factories import (
-    ApplicationSubmissionRetrievedFactory,
-    ApplicationSubmissionTrackingNumberFactory,
     AgencyFactory,
     ApplicationFactory,
     ApplicationSubmissionFactory,
+    ApplicationSubmissionRetrievedFactory,
+    ApplicationSubmissionTrackingNumberFactory,
     CompetitionFactory,
     OpportunityFactory,
 )
@@ -120,7 +120,9 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
         competition=competition, application_status=ApplicationStatus.ACCEPTED
     )
     submission = ApplicationSubmissionFactory.create(application=application)
-    ApplicationSubmissionRetrievedFactory.create(application_submission=submission, created_by_user=user)
+    ApplicationSubmissionRetrievedFactory.create(
+        application_submission=submission, created_by_user=user
+    )
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     mock_data = (
         "<soapenv:Envelope "
@@ -173,7 +175,9 @@ def test_successful_confirm_application_delivery_request_when_in_tracking_number
         competition=competition, application_status=ApplicationStatus.ACCEPTED
     )
     submission = ApplicationSubmissionFactory.create(application=application)
-    ApplicationSubmissionTrackingNumberFactory.create(application_submission=submission, created_by_user=user)
+    ApplicationSubmissionTrackingNumberFactory.create(
+        application_submission=submission, created_by_user=user
+    )
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     mock_data = (
         "<soapenv:Envelope "
@@ -222,9 +226,7 @@ def test_confirm_application_delivery_when_application_has_no_status(
     )
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
     user, role, soap_client_certificate = setup_cert_user(agency, privileges)
-    application = ApplicationFactory.create(
-        competition=competition, application_status=None
-    )
+    application = ApplicationFactory.create(competition=competition, application_status=None)
     submission = ApplicationSubmissionFactory.create(application=application)
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     mock_data = (

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -162,7 +162,7 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
     assert response.data.decode() == expected
 
 
-def test_successful_confirm_application_delivery_request_when_in_tracking_number_assiged_status(
+def test_successful_confirm_application_delivery_request_when_in_tracking_number_assigned_status(
     db_session, client, enable_factory_create
 ) -> None:
     agency = AgencyFactory.create()
@@ -371,7 +371,11 @@ def test_if_soap_fault_exception_raised_return_proxy_response_if_proxy_response_
             mock_proxy_response.return_value = SOAPResponse(
                 data=b"test response", status_code=200, headers={}
             )
-            response = client.post(full_path, data=mock_data, headers={"Use-Soap-Cert": "1"})
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={"Use-Soap-Cert": "1", "Use-Simpler-Override": "1"},
+            )
     assert response.status_code == 200
     expected = "test response"
     assert response.data.decode() == expected

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -57,7 +57,7 @@ def test_successful_request(client, fixture_from_file, caplog) -> None:
 
 
 def test_successful_confirm_application_delivery_request(
-    db_session, client, fixture_from_file, enable_factory_create, caplog
+    db_session, client, enable_factory_create
 ) -> None:
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
@@ -102,6 +102,109 @@ def test_successful_confirm_application_delivery_request(
         .all()
     )
     assert len(retrieved) == 1
+
+
+def test_if_soapfaultexception_raised_return_correct_response_if_use_simpler_override_is_1(
+    db_session, client, enable_factory_create
+) -> None:
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.IN_PROGRESS
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        response = client.post(
+            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+        )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "    <soap:Body>\n        <soap:Fault>\n"
+        "            <faultcode>soap:Server</faultcode>\n"
+        f"            <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
+        "        </soap:Fault>\n"
+        "    </soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
+
+
+def test_if_soapfaultexception_raised_return_proxy_response_if_use_simpler_override_is_not_1(
+    db_session, client, enable_factory_create
+) -> None:
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.IN_PROGRESS
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        # Remove Use-Simpler-Override
+        response = client.post(full_path, data=mock_data, headers={"Use-Soap-Cert": "1"})
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "    <soap:Body>\n        <soap:Fault>\n"
+        "            <faultcode>soap:Server</faultcode>\n"
+        "            <faultstring>Client certificate not configured for Simpler SOAP.</faultstring>\n"
+        "        </soap:Fault>\n"
+        "    </soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
 
 
 def test_invalid_service_name_not_found(client) -> None:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9646  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added a new exception case (`SOAPFaultException`) in the response.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The error response was defaulting to the proxy legacy response, even when there was a simpler response that is more accurate. This modifies that to return the Simpler response when a `SOAPFaultException` is raised and the Simpler response is expected.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] hit `ConfirmApplicationDelivery` with a `legacy_tracking_number` that's Simpler and in `in_progress` and observe response