### PR TITLE
[Issue #9650] Focus management

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import { TestUser } from "src/types/userTypes";
 
 import { getTranslations, setRequestLocale } from "next-intl/server";
 
+import RouteFocusManager from "src/components/RouteFocusManager";
 import { ActivityMonitor } from "./ActivityMonitor";
 import Footer from "./Footer";
 import GrantsIdentifier from "./GrantsIdentifier";
@@ -53,12 +54,15 @@ export default async function Layout({ children, locale }: Props) {
             }
             testUsers={testUsers}
           />
-          <main
-            id="main-content"
-            className="border-top-0 simpler-page-anchor-offset"
-          >
-            {children}
-          </main>
+          <RouteFocusManager>
+            <main
+              id="main-content"
+              className="border-top-0 simpler-page-anchor-offset"
+              tabIndex={-1}
+            >
+              {children}
+            </main>
+          </RouteFocusManager>
         </LoginModalProvider>
         <Footer />
         <GrantsIdentifier />

--- a/frontend/src/components/RouteFocusManager.test.tsx
+++ b/frontend/src/components/RouteFocusManager.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+
+import "@testing-library/jest-dom";
+
+import RouteFocusManager from "./RouteFocusManager";
+
+const mockUsePathname = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockUsePathname() as string,
+}));
+
+describe("RouteFocusManager", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not move focus on initial render", () => {
+    mockUsePathname.mockReturnValue("/example-route");
+
+    render(
+      <RouteFocusManager>
+        <main id="main-content" tabIndex={-1} data-testid="main">
+          Page content (example route)
+        </main>
+      </RouteFocusManager>,
+    );
+
+    const main = screen.getByTestId("main");
+
+    expect(main).toBeInTheDocument();
+    expect(main).not.toHaveFocus();
+  });
+
+  it("moves focus to main content after route change", () => {
+    mockUsePathname.mockReturnValue("/first-route");
+
+    const { rerender } = render(
+      <RouteFocusManager>
+        <main id="main-content" tabIndex={-1} data-testid="main">
+          Page content (first route)
+        </main>
+      </RouteFocusManager>,
+    );
+
+    const main = screen.getByTestId("main");
+
+    expect(main).toBeInTheDocument();
+    expect(main).not.toHaveFocus();
+
+    mockUsePathname.mockReturnValue("/second-route");
+
+    rerender(
+      <RouteFocusManager>
+        <main id="main-content" tabIndex={-1}>
+          New page content (second route)
+        </main>
+      </RouteFocusManager>,
+    );
+
+    expect(main).toHaveFocus();
+  });
+
+  it("does not throw if main content is missing", () => {
+    mockUsePathname.mockReturnValue("/third-route");
+
+    const { rerender } = render(
+      <RouteFocusManager>
+        <div>Page content (third route)</div>
+      </RouteFocusManager>,
+    );
+
+    mockUsePathname.mockReturnValue("/fourth-route");
+
+    expect(() => {
+      rerender(
+        <RouteFocusManager>
+          <div>New page content (fourth route)</div>
+        </RouteFocusManager>,
+      );
+    }).not.toThrow();
+  });
+});

--- a/frontend/src/components/RouteFocusManager.tsx
+++ b/frontend/src/components/RouteFocusManager.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+type RouteFocusManagerProps = {
+  children: React.ReactNode;
+};
+
+export default function RouteFocusManager({
+  children,
+}: RouteFocusManagerProps): React.JSX.Element {
+  const pathname = usePathname();
+  const hasMountedReference = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!hasMountedReference.current) {
+      hasMountedReference.current = true;
+      return;
+    }
+
+    const mainContentElement = document.getElementById("main-content");
+
+    if (mainContentElement instanceof HTMLElement) {
+      mainContentElement.focus();
+    }
+  }, [pathname]);
+
+  return <>{children}</>;
+}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -1265,7 +1265,9 @@ $simpler-switch-transition-easing: ease;
   .usa-button:not([disabled]),
   .usa-nav__primary-item a,
   .usa-nav__primary-item button,
-  .usa-accordion__button:not([disabled]) {
+  .usa-accordion__button:not([disabled]),
+  #main-content[tabindex],
+  .usa-logo a {
     &:focus {
       outline-width: 0;
     }


### PR DESCRIPTION
## Summary

Fixes #9650 

## Changes proposed

- Create a new `RouteFocusManager` component that watches for the main context to remount, then changes the focus to the main content (hat tip @myduong-navapbc) 
- Wrap `main#main-content` in this new component 
- Add main-content and the header logo to the list of CSS selectors for focus-visible styles (so they only show focus outline when keyboard navigating) 

## Context for reviewers

This sets the main content as what's focused when routes change. Previously, focus remained on whichever navigation item or link you selected, which made keyboard navigation difficult — e.g. when you follow a page link in the footer. 

## Validation steps

- **In the header navigation:** 
  - Click a link in the header menu
  - Focus should move to `#main-content` without focus styles
  - Press `Tab`
  - Focus should go to the first focusable item in the main content (not remain on the header link)
  - Keyboard navigate to another link in the header and press `Enter`
  - Focus should move to `#main-content` and focus-visible styles should be visible (you can see this by scrolling down to the the bottom of the main content area (keyboard navigating to a short page like Newsletter helps) 
  - Press `Tab`
  - Focus should go to the first focusable item in the main content

- **In the footer navigation:** 
  - Follow each link in the "Explore" section of the footer
  - Focus should move to `#main-content` (when navigating via keyboard, focus-visible styles should be visible) 
  - Press `Tab`
  - Focus should go to the first focusable item in the main content (not remain on the footer link) 

- **`<Link elements>` that point to other internal pages:**
  - On the homepage, scroll to the "Community-prioritized improvements & open source" section, click the linked text "the vision"
  - Focus should move to `#main-content`

- **Hard refresh on any page**
  - Press `Tab`
  - Focus should move to the "Skip to main content" link 