### PR TITLE
Aoy/8906 failure path e2e tests project abstract summary

### DIFF
--- a/frontend/tests/e2e/apply/failure-path-project-abstract-summary.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-project-abstract-summary.spec.ts
@@ -1,8 +1,8 @@
 import {
-	test,
-	type BrowserContext,
-	type Page,
-	type TestInfo,
+  test,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
 } from "@playwright/test";
 import { getOpportunityId } from "tests/e2e/get-opportunityId-utils";
 import playwrightEnv from "tests/e2e/playwright-env";
@@ -12,13 +12,13 @@ import { createApplication } from "tests/e2e/utils/create-application-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
-	verifyFormStatusAfterSave,
-	verifyFormStatusOnApplication,
+  verifyFormStatusAfterSave,
+  verifyFormStatusOnApplication,
 } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 import {
-	PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER,
-	PROJECT_ABSTRACT_SUMMARY_REQUIRED_FIELD_ERRORS,
+  PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER,
+  PROJECT_ABSTRACT_SUMMARY_REQUIRED_FIELD_ERRORS,
 } from "./fixtures/project-abstract-summary-field-definitions";
 
 const { APPLY, CORE_REGRESSION } = VALID_TAGS;
@@ -27,50 +27,50 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-	if (targetEnv === "staging") {
-		test.skip(
-			testInfo.project.name !== "Chrome",
-			"Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-		);
-	}
+  if (targetEnv === "staging") {
+    test.skip(
+      testInfo.project.name !== "Chrome",
+      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
+    );
+  }
 });
 
 test(
-	"Project Abstract Summary - error validation on empty save",
-	{ tag: [APPLY, CORE_REGRESSION] },
-	async (
-		{ page, context }: { page: Page; context: BrowserContext },
-		testInfo: TestInfo,
-	) => {
-		test.setTimeout(300_000); // 5 min timeout
+  "Project Abstract Summary - error validation on empty save",
+  { tag: [APPLY, CORE_REGRESSION] },
+  async (
+    { page, context }: { page: Page; context: BrowserContext },
+    testInfo: TestInfo,
+  ) => {
+    test.setTimeout(300_000); // 5 min timeout
 
-		const isMobile = testInfo.project.name.match(/[Mm]obile/);
+    const isMobile = testInfo.project.name.match(/[Mm]obile/);
 
-		await authenticateE2eUser(page, context, !!isMobile);
+    await authenticateE2eUser(page, context, !!isMobile);
 
-		await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-		const applicationUrl = page.url();
+    await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
+    const applicationUrl = page.url();
 
-		const opened = await openForm(page, PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER);
-		if (!opened) {
-			throw new Error(
-				"Could not find or open Project Abstract Summary form link on the application forms page",
-			);
-		}
+    const opened = await openForm(page, PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER);
+    if (!opened) {
+      throw new Error(
+        "Could not find or open Project Abstract Summary form link on the application forms page",
+      );
+    }
 
-		await saveForm(page, true);
+    await saveForm(page, true);
 
-		await verifyFormStatusAfterSave(
-			page,
-			"incomplete",
-			PROJECT_ABSTRACT_SUMMARY_REQUIRED_FIELD_ERRORS,
-		);
+    await verifyFormStatusAfterSave(
+      page,
+      "incomplete",
+      PROJECT_ABSTRACT_SUMMARY_REQUIRED_FIELD_ERRORS,
+    );
 
-		await verifyFormStatusOnApplication(
-			page,
-			"incomplete",
-			PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER,
-			applicationUrl,
-		);
-	},
+    await verifyFormStatusOnApplication(
+      page,
+      "incomplete",
+      PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER,
+      applicationUrl,
+    );
+  },
 );

--- a/frontend/tests/e2e/apply/failure-path-project-abstract-summary.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-project-abstract-summary.spec.ts
@@ -1,0 +1,76 @@
+import {
+	test,
+	type BrowserContext,
+	type Page,
+	type TestInfo,
+} from "@playwright/test";
+import { getOpportunityId } from "tests/e2e/get-opportunityId-utils";
+import playwrightEnv from "tests/e2e/playwright-env";
+import { VALID_TAGS } from "tests/e2e/tags";
+import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
+import { createApplication } from "tests/e2e/utils/create-application-utils";
+import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
+import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
+import {
+	verifyFormStatusAfterSave,
+	verifyFormStatusOnApplication,
+} from "tests/e2e/utils/forms/verify-form-status-utils";
+
+import {
+	PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER,
+	PROJECT_ABSTRACT_SUMMARY_REQUIRED_FIELD_ERRORS,
+} from "./fixtures/project-abstract-summary-field-definitions";
+
+const { APPLY, CORE_REGRESSION } = VALID_TAGS;
+const { testOrgLabel, targetEnv } = playwrightEnv;
+const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
+
+// Skip non-Chrome browsers in staging
+test.beforeEach(({ page: _ }, testInfo) => {
+	if (targetEnv === "staging") {
+		test.skip(
+			testInfo.project.name !== "Chrome",
+			"Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
+		);
+	}
+});
+
+test(
+	"Project Abstract Summary - error validation on empty save",
+	{ tag: [APPLY, CORE_REGRESSION] },
+	async (
+		{ page, context }: { page: Page; context: BrowserContext },
+		testInfo: TestInfo,
+	) => {
+		test.setTimeout(300_000); // 5 min timeout
+
+		const isMobile = testInfo.project.name.match(/[Mm]obile/);
+
+		await authenticateE2eUser(page, context, !!isMobile);
+
+		await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
+		const applicationUrl = page.url();
+
+		const opened = await openForm(page, PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER);
+		if (!opened) {
+			throw new Error(
+				"Could not find or open Project Abstract Summary form link on the application forms page",
+			);
+		}
+
+		await saveForm(page, true);
+
+		await verifyFormStatusAfterSave(
+			page,
+			"incomplete",
+			PROJECT_ABSTRACT_SUMMARY_REQUIRED_FIELD_ERRORS,
+		);
+
+		await verifyFormStatusOnApplication(
+			page,
+			"incomplete",
+			PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER,
+			applicationUrl,
+		);
+	},
+);

--- a/frontend/tests/e2e/apply/fixtures/project-abstract-summary-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/project-abstract-summary-field-definitions.ts
@@ -1,5 +1,9 @@
 import { FORM_DEFAULTS } from "tests/e2e/utils/forms/form-defaults";
 import { FormFillFieldDefinitions } from "tests/e2e/utils/forms/general-forms-filling";
+import { FieldError } from "tests/e2e/utils/forms/verify-form-errors-utils";
+
+export const PROJECT_ABSTRACT_SUMMARY_FORM_MATCHER =
+  /Project\s+Abstract\s+Summary/i;
 
 export const fieldDefinitionsProjectAbstractSummary: FormFillFieldDefinitions =
   {
@@ -25,3 +29,18 @@ export const PROJECT_ABSTRACT_SUMMARY_FORM_CONFIG = {
   formName: "Project Abstract Summary",
   fields: fieldDefinitionsProjectAbstractSummary,
 } as const;
+
+export const PROJECT_ABSTRACT_SUMMARY_REQUIRED_FIELD_ERRORS: FieldError[] = [
+  {
+    fieldId: "applicant_name",
+    message: "Applicant Name is required",
+  },
+  {
+    fieldId: "project_title",
+    message: "Descriptive Title of Applicants Project is required",
+  },
+  {
+    fieldId: "project_abstract",
+    message: "Project Abstract is required",
+  },
+];


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #8906 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->This PR adds a failure-path Playwright E2E test for Project Abstract Summary to validate empty-save behavior and incomplete status handling.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Files included

[failure-path-project-abstract-summary.spec.ts]
[project-abstract-summary-field-definitions.ts]
## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
