### PR TITLE
[Unticketed] Migrate Terraform state locking from DynamoDB to S3

### DIFF
--- a/bin/create-tfbackend
+++ b/bin/create-tfbackend
@@ -22,12 +22,10 @@ tf_state_key="${3:-${module_dir}/${backend_config_name}.tfstate}"
 # The local tfbackend config file that will store the terraform backend config
 backend_config_file="${module_dir}/${backend_config_name}.s3.tfbackend"
 
-# Get the name of the S3 bucket that was created to store the tf state
-# and the name of the DynamoDB table that was created for tf state locks.
+# Get the name of the S3 bucket that was created to store the tf state.
 # This will be used to configure the S3 backends in all the application
 # modules
 tf_state_bucket_name=$(terraform -chdir="infra/accounts" output --raw tf_state_bucket_name)
-tf_locks_table_name=$(terraform -chdir="infra/accounts" output --raw tf_locks_table_name)
 region=$(terraform -chdir="infra/accounts" output --raw region)
 
 echo "===================================="
@@ -44,7 +42,6 @@ cp infra/example.s3.tfbackend "${backend_config_file}"
 # Replace the placeholder values
 sed -i.bak "s/<TF_STATE_BUCKET_NAME>/${tf_state_bucket_name}/g" "${backend_config_file}"
 sed -i.bak "s|<TF_STATE_KEY>|${tf_state_key}|g" "${backend_config_file}"
-sed -i.bak "s/<TF_LOCKS_TABLE_NAME>/${tf_locks_table_name}/g" "${backend_config_file}"
 sed -i.bak "s/<REGION>/${region}/g" "${backend_config_file}"
 
 # Remove the backup file created by sed

--- a/bin/migrate-terraform-state-locking-to-s3
+++ b/bin/migrate-terraform-state-locking-to-s3
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# Migrate .s3.tfbackend files from DynamoDB state locking to S3 native locking.
+#
+# This script:
+#   1. Checks for active DynamoDB locks
+#   2. Finds all .s3.tfbackend files under infra/
+#   3. Removes the dynamodb_table line
+#   4. Adds use_lockfile = true
+#   5. Optionally reinitializes each root module and runs terraform plan
+#
+# Usage:
+#   bin/migrate-terraform-state-locking-to-s3              # Update backend files only
+#   bin/migrate-terraform-state-locking-to-s3 --reinit     # Also run terraform init + plan for each module
+#
+# Run this from the project root before applying the accounts layer.
+# After running, you still need to:
+#   - Apply the accounts layer to remove the DynamoDB table
+#   - Commit and push the updated .s3.tfbackend files
+# -----------------------------------------------------------------------------
+set -euo pipefail
+
+reinit=false
+if [[ "${1:-}" == "--reinit" ]]; then
+  reinit=true
+fi
+
+echo "===================================="
+echo "Migrate to S3 native state locking"
+echo "===================================="
+
+# Find all .s3.tfbackend files under infra/
+tfbackend_files=$(find infra -name '*.s3.tfbackend' -not -name 'example.*' | sort)
+
+# Check for active DynamoDB locks before proceeding
+first_file=$(echo "${tfbackend_files}" | head -1)
+if [ -n "${first_file}" ]; then
+  lock_table=$(grep 'dynamodb_table' "${first_file}" | sed 's/.*= *"\(.*\)"/\1/' | tr -d ' ')
+  if [ -n "${lock_table}" ]; then
+    echo "Checking for active locks in DynamoDB table: ${lock_table}"
+    active_count=$(aws dynamodb scan \
+      --table-name "${lock_table}" \
+      --filter-expression "attribute_exists(LockID) AND attribute_exists(Info)" \
+      --select "COUNT" \
+      --query "Count" \
+      --output text 2>/dev/null || echo "")
+    if [ -n "${active_count}" ] && [ "${active_count}" -gt 0 ] 2>/dev/null; then
+      echo "ERROR: Found ${active_count} active lock(s) in ${lock_table}"
+      echo "Someone is running Terraform. Wait for them to finish before proceeding."
+      exit 1
+    elif [ -n "${active_count}" ]; then
+      echo "No active locks found. Proceeding with migration."
+    else
+      echo "WARNING: Could not check for locks (AWS access issue?)."
+      read -r -p "Continue without checking locks? (y/N) " response
+      if [[ ! "${response}" =~ ^[Yy]$ ]]; then
+        echo "Aborting."
+        exit 1
+      fi
+    fi
+    echo
+  fi
+fi
+file_count=$(echo "${tfbackend_files}" | wc -l | tr -d ' ')
+
+echo "Found ${file_count} .s3.tfbackend files to migrate"
+echo
+
+migrated=0
+skipped=0
+
+for file in ${tfbackend_files}; do
+  # Check if file still has dynamodb_table
+  if grep -q 'dynamodb_table' "${file}"; then
+    # Remove the dynamodb_table line
+    sed -i.bak '/dynamodb_table/d' "${file}"
+
+    # Add use_lockfile = true if not already present
+    if ! grep -q 'use_lockfile' "${file}"; then
+      echo "use_lockfile   = true" >> "${file}"
+    fi
+
+    # Remove the backup file created by sed
+    rm -f "${file}.bak"
+
+    echo "  Migrated: ${file}"
+    migrated=$((migrated + 1))
+  else
+    echo "  Skipped (already migrated): ${file}"
+    skipped=$((skipped + 1))
+  fi
+done
+
+# Update example.s3.tfbackend if needed (normally handled by the template update,
+# but included here for completeness)
+example_file="infra/example.s3.tfbackend"
+if [ -f "${example_file}" ] && grep -q 'dynamodb_table' "${example_file}"; then
+  sed -i.bak '/dynamodb_table/d' "${example_file}"
+  if ! grep -q 'use_lockfile' "${example_file}"; then
+    echo "use_lockfile   = true" >> "${example_file}"
+  fi
+  rm -f "${example_file}.bak"
+  echo "  Updated: ${example_file}"
+fi
+
+echo
+echo "===================================="
+echo "Migration complete"
+echo "  Migrated: ${migrated} files"
+echo "  Skipped:  ${skipped} files"
+echo "===================================="
+
+if [[ "${reinit}" == true ]]; then
+  echo
+  echo "===================================="
+  echo "Reinitializing root modules"
+  echo "===================================="
+
+  errors=0
+
+  for file in ${tfbackend_files}; do
+    # Derive module_dir and config_name from the file path
+    # e.g. infra/networks/dev.s3.tfbackend -> module_dir=infra/networks, config_name=dev
+    module_dir=$(dirname "${file}")
+    config_name=$(basename "${file}" .s3.tfbackend)
+
+    echo
+    echo "--- ${module_dir} (${config_name}) ---"
+    echo "Running: terraform init -reconfigure"
+    if ! ./bin/terraform-init "${module_dir}" "${config_name}"; then
+      echo "  ERROR: terraform init failed for ${module_dir} ${config_name}"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    echo "Running: terraform plan"
+    tf_vars_file="${module_dir}/${config_name}.tfvars"
+    tf_vars_args=()
+    if [ -f "${tf_vars_file}" ]; then
+      tf_vars_args+=("-var-file=${config_name}.tfvars")
+    fi
+    if ! terraform -chdir="${module_dir}" plan -input=false ${tf_vars_args[@]+"${tf_vars_args[@]}"}; then
+      echo "  ERROR: terraform plan failed for ${module_dir} ${config_name}"
+      errors=$((errors + 1))
+      continue
+    fi
+
+    echo "  OK: ${module_dir} (${config_name})"
+  done
+
+  echo
+  echo "===================================="
+  echo "Reinit complete"
+  if [[ ${errors} -gt 0 ]]; then
+    echo "  ERRORS: ${errors} module(s) had failures"
+    exit 1
+  else
+    echo "  All modules initialized and verified successfully"
+  fi
+  echo "===================================="
+fi
+
+echo
+echo "Next steps:"
+if [[ "${reinit}" == false ]]; then
+  echo "  1. Run 'terraform init -reconfigure' for each root module"
+  echo "     Or re-run this script with --reinit to automate this"
+  echo "  2. Run 'terraform plan' to verify no unexpected changes"
+  echo "  3. Apply the accounts layer for each account to remove the DynamoDB table"
+  echo "  4. Commit and push the updated .s3.tfbackend files"
+else
+  echo "  1. Apply the accounts layer for each account to remove the DynamoDB table"
+  echo "  2. Commit and push the updated .s3.tfbackend files"
+fi

--- a/bin/set-up-current-account
+++ b/bin/set-up-current-account
@@ -82,7 +82,7 @@ if [[ -z "${github_arn}" ]]; then
 fi
 
 # Create the infrastructure for the terraform backend such as the S3 bucket
-# for storing tfstate files and the DynamoDB table for tfstate locks.
+# for storing tfstate files (state locking is handled natively by S3).
 # -reconfigure is used in case this isn't the first account being set up
 # and there is already a .terraform directory
 terraform init \

--- a/docs/infra/migrate-terraform-state-locking-to-s3.md
+++ b/docs/infra/migrate-terraform-state-locking-to-s3.md
@@ -1,0 +1,123 @@
+# Upgrade Terraform state locking from DynamoDB to S3
+
+Terraform 1.10+ supports [native S3 state locking](https://developer.hashicorp.com/terraform/language/backend/s3#state-locking) via `use_lockfile = true`, replacing the older DynamoDB-based locking. This guide walks through migrating an existing project that uses DynamoDB state locks to S3 native locking.
+
+## Prerequisites
+
+- Terraform >= 1.10.0
+- Your project's template-infra has been updated to include the S3 locking changes (i.e., the `terraform-backend-s3` module no longer creates a DynamoDB table)
+
+## Overview
+
+The migration has three phases:
+
+1. **Update backend config files** — Replace `dynamodb_table` with `use_lockfile = true` in all `.s3.tfbackend` files
+2. **Reinitialize and verify** — Run `terraform init -reconfigure` and `terraform plan` for each root module
+3. **Apply the accounts layer** (for every account) — Remove the DynamoDB table and related resources from AWS
+
+## Step-by-step instructions
+
+### 1. Update your project's template-infra
+
+Follow the standard process for [keeping your infrastructure up to date](https://github.com/navapbc/template-infra/blob/main/README.md#keeping-your-infrastructure-up-to-date) to pull in the template changes that remove DynamoDB locking. The change is in `v0.17.0` of the template.
+
+> **Important:** Do NOT run `terraform apply` on `infra/accounts` yet — the DynamoDB table must remain until all `.s3.tfbackend` files have been updated.
+
+### 2. Run the migration script
+
+The `bin/migrate-terraform-state-locking-to-s3` script automates updating all `.s3.tfbackend` files. It removes the `dynamodb_table` line and adds `use_lockfile = true`.
+
+```bash
+./bin/migrate-terraform-state-locking-to-s3
+```
+
+The script will report which files were migrated and which were already up to date.
+
+To also reinitialize each module and run `terraform plan` automatically, use the `--reinit` flag:
+
+```bash
+./bin/migrate-terraform-state-locking-to-s3 --reinit
+```
+
+This combines steps 2, 3, and 4 below. The script will iterate over each `.s3.tfbackend` file, run `terraform init -reconfigure` and `terraform plan` for the corresponding module, and report any failures.
+
+If you prefer to do this manually, edit each `.s3.tfbackend` file under `infra/` to:
+- Remove the `dynamodb_table = "..."` line
+- Add `use_lockfile   = true`
+
+Then follow steps 3 and 4 below.
+
+### 3. Reinitialize each root module
+
+> **Note:** If you used `--reinit` in step 2, skip to step 5.
+
+Run `terraform init -reconfigure` for each root module to pick up the new backend configuration. Use the existing `bin/terraform-init` script:
+
+```bash
+# For each account (replace with your account alias)
+./bin/terraform-init infra/accounts <account_alias>
+
+# For each network
+./bin/terraform-init infra/networks <NETWORK_NAME>
+
+# For each application module and environment
+./bin/terraform-init infra/<APP_NAME>/build-repository shared
+./bin/terraform-init infra/<APP_NAME>/database <ENVIRONMENT>
+./bin/terraform-init infra/<APP_NAME>/service <ENVIRONMENT>
+```
+
+### 4. Verify with terraform plan
+
+Run `terraform plan` for each module to confirm there are no unexpected changes. For the accounts module specifically, you should see the DynamoDB table marked for destruction:
+
+```bash
+terraform -chdir=infra/accounts plan -out=tfplan
+```
+
+Expected output for accounts:
+
+```
+Plan: 0 to add, 0 to change, 1 to destroy.
+```
+
+The one resource to destroy is `aws_dynamodb_table.terraform_lock`.
+
+For all other modules (networks, app modules), the plan should show **no changes**.
+
+### 5. Apply the accounts layer
+
+Once you've verified the plans, apply the accounts layer to remove the DynamoDB table:
+
+```bash
+make infra-update-current-account
+```
+
+### 6. Update active pull requests
+
+If your project has open pull requests with preview environments, rebase them onto the latest main branch so they pick up the migrated `.s3.tfbackend` files. Otherwise, those PR environments will still reference the old DynamoDB-based backend configuration.
+
+### 7. Commit the updated backend files
+
+Commit and push the updated `.s3.tfbackend` files:
+
+```bash
+git add infra/**/*.s3.tfbackend
+git commit -m "Migrate terraform state locking from DynamoDB to S3"
+git push
+```
+
+## Repeat for each AWS account
+
+If your project uses multiple AWS accounts (e.g., separate accounts for lower environments and prod), repeat steps 1–7 for each account. You'll need to assume the appropriate role or configure AWS credentials for each account before running the commands.
+
+## Rollback
+
+If you need to roll back, you can re-add the `dynamodb_table` line to your `.s3.tfbackend` files and run `terraform init -reconfigure`. The DynamoDB table will need to be recreated by reverting the accounts module changes and applying.
+
+## Cleanup
+
+After confirming everything works in all environments:
+
+- Verify no `.s3.tfbackend` files reference `dynamodb_table`
+- Verify `terraform plan` shows no changes for all modules
+- The DynamoDB table has been destroyed and the KMS key will be deleted after its waiting period (10 days by default)

--- a/infra/accounts/outputs.tf
+++ b/infra/accounts/outputs.tf
@@ -14,10 +14,6 @@ output "tf_log_bucket_name" {
   value = module.backend.tf_log_bucket_name
 }
 
-output "tf_locks_table_name" {
-  value = module.backend.tf_locks_table_name
-}
-
 output "tf_state_bucket_name" {
   value = module.backend.tf_state_bucket_name
 }

--- a/infra/accounts/simpler-grants-gov.315341936575.s3.tfbackend
+++ b/infra/accounts/simpler-grants-gov.315341936575.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/account.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/build-repository/shared.s3.tfbackend
+++ b/infra/analytics/build-repository/shared.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/build-repository/shared.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/database/dev.s3.tfbackend
+++ b/infra/analytics/database/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/database/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/database/grantee1.s3.tfbackend
+++ b/infra/analytics/database/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/database/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/database/prod.s3.tfbackend
+++ b/infra/analytics/database/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/database/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/database/staging.s3.tfbackend
+++ b/infra/analytics/database/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/database/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/database/training.s3.tfbackend
+++ b/infra/analytics/database/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/database/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/metabase/dev.s3.tfbackend
+++ b/infra/analytics/metabase/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/metabase/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/metabase/grantee1.s3.tfbackend
+++ b/infra/analytics/metabase/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/metabase/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/metabase/prod.s3.tfbackend
+++ b/infra/analytics/metabase/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/metabase/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/metabase/staging.s3.tfbackend
+++ b/infra/analytics/metabase/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/metabase/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/metabase/training.s3.tfbackend
+++ b/infra/analytics/metabase/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/metabase/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/service/dev.s3.tfbackend
+++ b/infra/analytics/service/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/service/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/service/grantee1.s3.tfbackend
+++ b/infra/analytics/service/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/service/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/service/prod.s3.tfbackend
+++ b/infra/analytics/service/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/service/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/service/staging.s3.tfbackend
+++ b/infra/analytics/service/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/service/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/service/training.s3.tfbackend
+++ b/infra/analytics/service/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/analytics/service/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/build-repository/shared.s3.tfbackend
+++ b/infra/api/build-repository/shared.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/build-repository/shared.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/dev.s3.tfbackend
+++ b/infra/api/database/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/database/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/grantee1.s3.tfbackend
+++ b/infra/api/database/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/database/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/prod.s3.tfbackend
+++ b/infra/api/database/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/database/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/staging.s3.tfbackend
+++ b/infra/api/database/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/database/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/training.s3.tfbackend
+++ b/infra/api/database/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/database/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/dev.s3.tfbackend
+++ b/infra/api/service/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/service/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/grantee1.s3.tfbackend
+++ b/infra/api/service/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/service/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/prod.s3.tfbackend
+++ b/infra/api/service/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/service/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/staging.s3.tfbackend
+++ b/infra/api/service/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/service/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/training.s3.tfbackend
+++ b/infra/api/service/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/api/service/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/example.s3.tfbackend
+++ b/infra/example.s3.tfbackend
@@ -1,4 +1,4 @@
-bucket         = "<TF_STATE_BUCKET_NAME>"
-key            = "<TF_STATE_KEY>"
-dynamodb_table = "<TF_LOCKS_TABLE_NAME>"
-region         = "<REGION>"
+bucket       = "<TF_STATE_BUCKET_NAME>"
+key          = "<TF_STATE_KEY>"
+region       = "<REGION>"
+use_lockfile = true

--- a/infra/fluentbit/build-repository/shared.s3.tfbackend
+++ b/infra/fluentbit/build-repository/shared.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/fluentbit/build-repository/shared.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/build-repository/shared.s3.tfbackend
+++ b/infra/frontend/build-repository/shared.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/frontend/build-repository/shared.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/dev.s3.tfbackend
+++ b/infra/frontend/service/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/frontend/service/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/grantee1.s3.tfbackend
+++ b/infra/frontend/service/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/frontend/service/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/prod.s3.tfbackend
+++ b/infra/frontend/service/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/frontend/service/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/staging.s3.tfbackend
+++ b/infra/frontend/service/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/frontend/service/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/training.s3.tfbackend
+++ b/infra/frontend/service/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/frontend/service/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/modules/terraform-backend-s3/main.tf
+++ b/infra/modules/terraform-backend-s3/main.tf
@@ -5,43 +5,18 @@ data "aws_partition" "current" {}
 locals {
   tf_state_bucket_name = var.name
   tf_logs_bucket_name  = "${var.name}-logs"
-  tf_locks_table_name  = "${var.name}-state-locks"
 }
-
-# Create the dynamodb table required for state locking.
 
 # Options for encryption are an AWS owned key, which is not unique to your account; AWS managed; or customer managed. The latter two options are more secure, and customer managed gives
 # control over the key. This allows for ability to restrict access by key as well as policies attached to roles or users.
 # https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html
 resource "aws_kms_key" "tf_backend" {
-  description = "KMS key for DynamoDB table ${local.tf_locks_table_name}"
+  description = "KMS key for s3 backend server side encryption"
   # The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key.
   deletion_window_in_days = "10"
   # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
   enable_key_rotation = "true"
   # checkov:skip=CKV2_AWS_64:TODO: https://github.com/HHS/simpler-grants-gov/issues/2366
-}
-
-resource "aws_dynamodb_table" "terraform_lock" {
-  name                        = local.tf_locks_table_name
-  hash_key                    = "LockID"
-  billing_mode                = "PAY_PER_REQUEST"
-  deletion_protection_enabled = true
-
-  attribute {
-    name = "LockID"
-    type = "S"
-  }
-
-  server_side_encryption {
-    enabled     = true
-    kms_key_arn = aws_kms_key.tf_backend.arn
-  }
-
-  point_in_time_recovery {
-    enabled = true
-  }
-
 }
 
 # Create the S3 bucket used to store terraform state remotely.

--- a/infra/modules/terraform-backend-s3/outputs.tf
+++ b/infra/modules/terraform-backend-s3/outputs.tf
@@ -1,7 +1,3 @@
-output "tf_locks_table_name" {
-  value = aws_dynamodb_table.terraform_lock.name
-}
-
 output "tf_log_bucket_name" {
   value = aws_s3_bucket.tf_log.bucket
 }

--- a/infra/networks/dev.s3.tfbackend
+++ b/infra/networks/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/networks/default.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/grantee1.s3.tfbackend
+++ b/infra/networks/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/networks/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/prod.s3.tfbackend
+++ b/infra/networks/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/networks/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/staging.s3.tfbackend
+++ b/infra/networks/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/networks/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/training.s3.tfbackend
+++ b/infra/networks/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/networks/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/build-repository/shared.s3.tfbackend
+++ b/infra/nofos/build-repository/shared.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/build-repository/shared.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/database/dev.s3.tfbackend
+++ b/infra/nofos/database/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/database/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/database/grantee1.s3.tfbackend
+++ b/infra/nofos/database/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/database/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/database/prod.s3.tfbackend
+++ b/infra/nofos/database/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/database/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/database/staging.s3.tfbackend
+++ b/infra/nofos/database/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/database/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/database/training.s3.tfbackend
+++ b/infra/nofos/database/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/database/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/service/dev.s3.tfbackend
+++ b/infra/nofos/service/dev.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/service/dev.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/service/grantee1.s3.tfbackend
+++ b/infra/nofos/service/grantee1.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/service/grantee1.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/service/prod.s3.tfbackend
+++ b/infra/nofos/service/prod.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/service/prod.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/service/staging.s3.tfbackend
+++ b/infra/nofos/service/staging.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/service/staging.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/service/training.s3.tfbackend
+++ b/infra/nofos/service/training.s3.tfbackend
@@ -1,4 +1,4 @@
 bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
 key            = "infra/nofos/service/training.tfstate"
-dynamodb_table = "simpler-grants-gov-315341936575-us-east-1-tf-state-locks"
 region         = "us-east-1"
+use_lockfile   = true

--- a/infra/project-config/aws_services.tf
+++ b/infra/project-config/aws_services.tf
@@ -23,9 +23,6 @@ locals {
     // Amazon Cognito Identity Provider – Manages authentication and authorization for applications.
     "cognito-idp",
 
-    // Amazon DynamoDB – A NoSQL database for key-value and document storage. Used for Terraform state locks.
-    "dynamodb",
-
     // Amazon EC2 – Provides compute capacity in the cloud with virtual servers.
     "ec2",
 


### PR DESCRIPTION
## Summary
- Adopts Terraform 1.10+ native S3 state locking (`use_lockfile = true`) and removes the DynamoDB state-lock table.
- This is the subset of [template-infra v0.17.0](https://github.com/navapbc/template-infra/releases/tag/v0.17.0) directly related to the locking migration; the remaining v0.17.0 template changes will land in a separate PR.

## Changes
**Module / account layer**
- `infra/modules/terraform-backend-s3/main.tf` — drop `aws_dynamodb_table.terraform_lock` + `tf_locks_table_name` local; update KMS key description.
- `infra/modules/terraform-backend-s3/outputs.tf` — drop `tf_locks_table_name` output.
- `infra/accounts/outputs.tf` — drop pass-through `tf_locks_table_name` output.
- `infra/project-config/aws_services.tf` — drop `"dynamodb"` from the allowed-services list (it was only used for the state-lock table).

**Backend config files (51 files)**
- Replaced `dynamodb_table = "..."` with `use_lockfile = true` in every `infra/**/*.s3.tfbackend` plus `infra/example.s3.tfbackend`.

**Tooling**
- `bin/create-tfbackend` — drop `tf_locks_table_name` lookup and `<TF_LOCKS_TABLE_NAME>` substitution.
- `bin/set-up-current-account` — update stale comment referencing the DynamoDB lock table.
- **New** `bin/migrate-terraform-state-locking-to-s3` (from template-infra v0.17.0) — script that checks for active DynamoDB locks and rewrites any remaining `.s3.tfbackend` files; useful for future accounts.
- **New** `docs/infra/migrate-terraform-state-locking-to-s3.md` (from template-infra v0.17.0) — operator migration guide.

## Execution order for the operator
This PR rewrites the backend config files but does **not** destroy the DynamoDB table — that happens on the next `terraform apply` of `infra/accounts`. Suggested order:

1. Merge this PR (do NOT apply `infra/accounts` yet).
2. For every root module (`infra/accounts`, `infra/networks/*`, `infra/{api,frontend,analytics,nofos}/*`, `infra/fluentbit/build-repository`), run `terraform init -reconfigure` followed by `terraform plan` — expect no resource changes (just a backend reconfiguration).
3. Apply `infra/accounts` for each account — this destroys `aws_dynamodb_table.terraform_lock` (and updates outputs). Exactly 1 resource should be destroyed.
4. Coordinate with other contributors to rebase open PRs onto the updated `main`.

## Test plan
- [ ] `terraform init -reconfigure` succeeds for each root module with the new `use_lockfile` backend
- [ ] `terraform plan` in each root module shows no resource drift
- [ ] `terraform plan` in `infra/accounts` shows exactly 1 destroy (`aws_dynamodb_table.terraform_lock`) + output removal
- [ ] `bin/create-tfbackend` still produces a valid `.s3.tfbackend` for a new module
- [ ] No references to `tf_locks_table_name`, `aws_dynamodb_table.terraform_lock`, or `<TF_LOCKS_TABLE_NAME>` remain in the tree