### PR TITLE
[Issue #9666] Update UpdateApplicationInfo response to match legacy

### DIFF
--- a/api/src/legacy_soap_api/grantors/fault_messages.py
+++ b/api/src/legacy_soap_api/grantors/fault_messages.py
@@ -24,18 +24,3 @@ ConfirmDeliveryAlreadyRetrieved = FaultMessage(
     faultstring="This application submission has already been retrieved. Failed to confirm application delivery.",
     faultcode="soap:Server",
 )
-
-UpdateApplicationInfoSubmissionNotFound = FaultMessage(
-    faultstring="Unable to find application from tracking number. Failed to update application info.",
-    faultcode="soap:Server",
-)
-
-UpdateApplicationInfoInvalidStatus = FaultMessage(
-    faultstring="Invalid application status. Failed to update application info.",
-    faultcode="soap:Server",
-)
-
-UpdateApplicationInfoTrackingNumberAlreadyAssigned = FaultMessage(
-    faultstring="Agency tracking number has already been assigned. Failed to update application info.",
-    faultcode="soap:Server",
-)

--- a/api/src/legacy_soap_api/grantors/services/update_application_info_response.py
+++ b/api/src/legacy_soap_api/grantors/services/update_application_info_response.py
@@ -115,7 +115,7 @@ def update_application_info(
     tracking number / note records as side effects.
 
     Returns a tuple of (grants_gov_tracking_number, assign_result, notes_result).
-    Raises SOAPFaultException or SOAPClientUserDoesNotHavePermission on failure.
+    In event of failure, the <ErrorMessage> field is populated.
     """
 
     certificate = validate_certificate(

--- a/api/src/legacy_soap_api/grantors/services/update_application_info_response.py
+++ b/api/src/legacy_soap_api/grantors/services/update_application_info_response.py
@@ -11,10 +11,6 @@ from src.db.models.competition_models import (
 )
 from src.db.models.user_models import User
 from src.legacy_soap_api.grantors import schemas as grantor_schemas
-from src.legacy_soap_api.grantors.fault_messages import (
-    UpdateApplicationInfoInvalidStatus,
-    UpdateApplicationInfoSubmissionNotFound,
-)
 from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientUserDoesNotHavePermission,
     validate_certificate,
@@ -23,51 +19,10 @@ from src.legacy_soap_api.legacy_soap_api_config import SOAPOperationConfig
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
-    SOAPFaultException,
     get_application_submission_by_legacy_tracking_number,
 )
 
 logger = logging.getLogger(__name__)
-
-VALID_STATUSES_FOR_UPDATE = {ApplicationStatus.ACCEPTED}
-
-
-def _validate_application_submission(
-    db_session: db.Session, legacy_tracking_number: str
-) -> ApplicationSubmission:
-    application_submission = get_application_submission_by_legacy_tracking_number(
-        db_session, legacy_tracking_number
-    )
-
-    if not application_submission:
-        logger.info(
-            f"Unable to find submission legacy_tracking_number {legacy_tracking_number}.",
-            extra={
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-                "response_operation_name": "UpdateApplicationInfoResponse",
-            },
-        )
-        raise SOAPFaultException(
-            "Submission not found for update application info",
-            fault=UpdateApplicationInfoSubmissionNotFound,
-        )
-
-    if application_submission.application.application_status not in VALID_STATUSES_FOR_UPDATE:
-        logger.info(
-            "Application status is not valid for update application info.",
-            extra={
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-                "application_status": application_submission.application.application_status,
-                "legacy_tracking_number": legacy_tracking_number,
-                "response_operation_name": "UpdateApplicationInfoResponse",
-            },
-        )
-        raise SOAPFaultException(
-            "Application status is not valid for update application info",
-            fault=UpdateApplicationInfoInvalidStatus,
-        )
-
-    return application_submission
 
 
 def _assign_agency_tracking_number(
@@ -86,7 +41,35 @@ def _assign_agency_tracking_number(
                 "response_operation_name": "UpdateApplicationInfoResponse",
             },
         )
-        return grantor_schemas.AssignAgencyTrackingNumberResult(success="false")
+        error_message = (
+            "Exception caught assigning agency tracking number.(Expected an Application status of:"
+            f"'Received by Agency' , but found a status of 'Agency Tracking Number Assigned' for {legacy_tracking_number})"
+        )
+        return grantor_schemas.AssignAgencyTrackingNumberResult(
+            success="false", error_message=error_message
+        )
+    elif not application_submission.application_submission_retrievals:
+        logger.info(
+            "Application is in invalid status.",
+            extra={
+                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+                "legacy_tracking_number": legacy_tracking_number,
+                "response_operation_name": "UpdateApplicationInfoResponse",
+            },
+        )
+        if application_submission.application.application_status == ApplicationStatus.ACCEPTED:
+            error_message = (
+                "Exception caught assigning agency tracking number.(Expected an Application status of:"
+                f"'Received by Agency' , but found a status of 'Validated' for {legacy_tracking_number})"
+            )
+        else:
+            error_message = (
+                "Exception caught assigning agency tracking number.(Expected an Application status of:"
+                f"'Received by Agency' , but found a status of 'Received' for {legacy_tracking_number})"
+            )
+        return grantor_schemas.AssignAgencyTrackingNumberResult(
+            success="false", error_message=error_message
+        )
 
     tracking_number_record = ApplicationSubmissionTrackingNumber(
         application_submission=application_submission,
@@ -134,33 +117,57 @@ def update_application_info(
     Returns a tuple of (grants_gov_tracking_number, assign_result, notes_result).
     Raises SOAPFaultException or SOAPClientUserDoesNotHavePermission on failure.
     """
-    legacy_tracking_number = cast(str, update_application_info_request.grants_gov_tracking_number)
-
-    application_submission = _validate_application_submission(db_session, legacy_tracking_number)
 
     certificate = validate_certificate(
         db_session, soap_auth=soap_request.auth, api_name=soap_request.api_name
     )
 
-    if soap_config.privileges is None:
-        raise ValueError("Privileges must be configured for UpdateApplicationInfo")
+    legacy_tracking_number = cast(str, update_application_info_request.grants_gov_tracking_number)
 
-    if not can_access(
-        certificate.user,
-        soap_config.privileges,
-        application_submission.application.competition.opportunity.agency_record,
-    ):
+    application_submission = get_application_submission_by_legacy_tracking_number(
+        db_session, legacy_tracking_number
+    )
+
+    if not application_submission:
         logger.info(
-            "User did not have permission to update application info",
+            "Submission not found",
             extra={
                 "user_id": certificate.user.user_id,
-                "application_submission_id": application_submission.application_submission_id,
-                "privileges": soap_config.privileges,
+                "legacy_tracking_number": legacy_tracking_number,
+                "response_operation_name": "UpdateApplicationInfoResponse",
             },
         )
-        raise SOAPClientUserDoesNotHavePermission(
-            "User did not have permission to update application info"
+        return (
+            update_application_info_request.grants_gov_tracking_number,
+            grantor_schemas.AssignAgencyTrackingNumberResult(
+                success="false",
+                error_message="Exception caught assigning agency tracking number.(Authorization Failure)",
+            ),
+            grantor_schemas.SaveAgencyNotesResult(
+                success="false",
+                error_message="Exception caught saving agency notes.(Authorization Failure)",
+            ),
         )
+
+    if soap_config.privileges is not None:
+        if not can_access(
+            certificate.user,
+            soap_config.privileges,
+            application_submission.application.competition.opportunity.agency_record,
+        ):
+            logger.info(
+                "User did not have permission to update application info",
+                extra={
+                    "user_id": certificate.user.user_id,
+                    "application_submission_id": application_submission.application_submission_id,
+                    "privileges": soap_config.privileges,
+                },
+            )
+            raise SOAPClientUserDoesNotHavePermission(
+                "User did not have permission to update application info"
+            )
+    else:
+        raise ValueError("Privileges must be configured for UpdateApplicationInfo")
 
     assign_result = None
     notes_result = None

--- a/api/tests/src/legacy_soap_api/grantors/services/test_update_application_info_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_update_application_info_response.py
@@ -15,12 +15,12 @@ from src.legacy_soap_api.grantors.services.update_application_info_response impo
 from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth, SOAPClientUserDoesNotHavePermission
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI, SOAPOperationConfig
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest, SoapRequestStreamer
-from src.legacy_soap_api.legacy_soap_api_utils import SOAPFaultException
 from tests.lib.data_factories import setup_cert_user
 from tests.src.db.models.factories import (
     AgencyFactory,
     ApplicationFactory,
     ApplicationSubmissionFactory,
+    ApplicationSubmissionRetrievedFactory,
     ApplicationSubmissionTrackingNumberFactory,
     CompetitionFactory,
     OpportunityFactory,
@@ -60,28 +60,31 @@ def _make_operation_config():
     )
 
 
-def _setup_submission(agency, application_status=ApplicationStatus.ACCEPTED):
+def _setup_submission(agency, application_status=ApplicationStatus.ACCEPTED, retrieved=False):
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
     competition = CompetitionFactory.create(opportunity=opportunity)
     application = ApplicationFactory.create(
         competition=competition,
         application_status=application_status,
     )
-    return ApplicationSubmissionFactory.create(application=application)
+    submission = ApplicationSubmissionFactory.create(application=application)
+    if retrieved:
+        ApplicationSubmissionRetrievedFactory.create(application_submission=submission)
+    return submission
 
 
 class TestUpdateApplicationInfo:
     def test_successful_assign_tracking_number(self, db_session, enable_factory_create):
         agency = AgencyFactory.create()
-        submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
+        submission = _setup_submission(agency, ApplicationStatus.ACCEPTED, retrieved=True)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
         _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            AssignAgencyTrackingNumber="AGENCY-123",
+            grants_gov_tracking_number=tracking_number,
+            assign_agency_tracking_number="AGENCY-123",
         )
 
         tracking_num, assign_result, notes_result = update_application_info(
@@ -114,8 +117,8 @@ class TestUpdateApplicationInfo:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            SaveAgencyNotes="Test agency notes",
+            grants_gov_tracking_number=tracking_number,
+            save_agency_notes="Test agency notes",
         )
 
         tracking_num, assign_result, notes_result = update_application_info(
@@ -143,16 +146,16 @@ class TestUpdateApplicationInfo:
         self, db_session, enable_factory_create
     ):
         agency = AgencyFactory.create()
-        submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
+        submission = _setup_submission(agency, ApplicationStatus.ACCEPTED, retrieved=True)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
         _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            AssignAgencyTrackingNumber="AGENCY-456",
-            SaveAgencyNotes="Notes with tracking number",
+            grants_gov_tracking_number=tracking_number,
+            assign_agency_tracking_number="AGENCY-456",
+            save_agency_notes="Notes with tracking number",
         )
 
         _, assign_result, notes_result = update_application_info(
@@ -164,8 +167,10 @@ class TestUpdateApplicationInfo:
 
         assert assign_result is not None
         assert assign_result.success == "true"
+        assert assign_result.error_message is None
         assert notes_result is not None
         assert notes_result.success == "true"
+        assert notes_result.error_message is None
 
         # Verify both records were inserted
         tracking_numbers = (
@@ -182,7 +187,7 @@ class TestUpdateApplicationInfo:
         )
         assert len(notes) == 1
 
-    def test_submission_not_found_returns_fault(self, db_session, enable_factory_create):
+    def test_submission_not_found_returns_failed_response(self, db_session, enable_factory_create):
         agency = AgencyFactory.create()
 
         _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
@@ -190,20 +195,32 @@ class TestUpdateApplicationInfo:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            AssignAgencyTrackingNumber="AGENCY-123",
+            grants_gov_tracking_number=tracking_number,
+            assign_agency_tracking_number="AGENCY-123",
         )
 
-        with pytest.raises(SOAPFaultException):
-            update_application_info(
-                db_session=db_session,
-                soap_request=soap_request,
-                update_application_info_request=request_schema,
-                soap_config=_make_operation_config(),
-            )
+        _, assign_result, notes_result = update_application_info(
+            db_session=db_session,
+            soap_request=soap_request,
+            update_application_info_request=request_schema,
+            soap_config=_make_operation_config(),
+        )
 
-    def test_in_progress_status_returns_fault(self, db_session, enable_factory_create):
-        """IN_PROGRESS applications should not be updatable."""
+        assert assign_result is not None
+        assert assign_result.success == "false"
+        assert (
+            assign_result.error_message
+            == "Exception caught assigning agency tracking number.(Authorization Failure)"
+        )
+        assert notes_result is not None
+        assert notes_result.success == "false"
+        assert (
+            notes_result.error_message
+            == "Exception caught saving agency notes.(Authorization Failure)"
+        )
+
+    def test_in_progress_status_returns_failed_response(self, db_session, enable_factory_create):
+        """IN_PROGRESS applications (so implicitly not retrieved) should not be able to have their agency tracking number assigned."""
         agency = AgencyFactory.create()
         submission = _setup_submission(agency, ApplicationStatus.IN_PROGRESS)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
@@ -212,17 +229,27 @@ class TestUpdateApplicationInfo:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            AssignAgencyTrackingNumber="AGENCY-123",
+            grants_gov_tracking_number=tracking_number,
+            assign_agency_tracking_number="AGENCY-123",
+            save_agency_notes="Test agency notes",
         )
 
-        with pytest.raises(SOAPFaultException):
-            update_application_info(
-                db_session=db_session,
-                soap_request=soap_request,
-                update_application_info_request=request_schema,
-                soap_config=_make_operation_config(),
-            )
+        _, assign_result, notes_result = update_application_info(
+            db_session=db_session,
+            soap_request=soap_request,
+            update_application_info_request=request_schema,
+            soap_config=_make_operation_config(),
+        )
+
+        assert assign_result is not None
+        assert assign_result.success == "false"
+        assert (
+            assign_result.error_message
+            == f"Exception caught assigning agency tracking number.(Expected an Application status of:'Received by Agency' , but found a status of 'Received' for {tracking_number})"
+        )
+        assert notes_result is not None
+        assert notes_result.success == "true"
+        assert notes_result.error_message is None
 
     def test_tracking_number_already_assigned_returns_failure(
         self, db_session, enable_factory_create
@@ -247,8 +274,8 @@ class TestUpdateApplicationInfo:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            AssignAgencyTrackingNumber="NEW-AGENCY-456",
+            grants_gov_tracking_number=tracking_number,
+            assign_agency_tracking_number="NEW-AGENCY-456",
         )
 
         _, assign_result, _ = update_application_info(
@@ -260,6 +287,10 @@ class TestUpdateApplicationInfo:
 
         assert assign_result is not None
         assert assign_result.success == "false"
+        assert (
+            assign_result.error_message
+            == f"Exception caught assigning agency tracking number.(Expected an Application status of:'Received by Agency' , but found a status of 'Agency Tracking Number Assigned' for {tracking_number})"
+        )
 
         # Verify no additional tracking number record was inserted
         tracking_numbers = (
@@ -281,8 +312,8 @@ class TestUpdateApplicationInfo:
 
         # Save notes first time
         request_schema_1 = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            SaveAgencyNotes="First note",
+            grants_gov_tracking_number=tracking_number,
+            save_agency_notes="First note",
         )
         _, _, notes_result_1 = update_application_info(
             db_session=db_session,
@@ -295,8 +326,8 @@ class TestUpdateApplicationInfo:
 
         # Save notes second time
         request_schema_2 = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            SaveAgencyNotes="Second note",
+            grants_gov_tracking_number=tracking_number,
+            save_agency_notes="Second note",
         )
         _, _, notes_result_2 = update_application_info(
             db_session=db_session,
@@ -326,8 +357,8 @@ class TestUpdateApplicationInfo:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            AssignAgencyTrackingNumber="AGENCY-123",
+            grants_gov_tracking_number=tracking_number,
+            assign_agency_tracking_number="AGENCY-123",
         )
 
         with pytest.raises(SOAPClientUserDoesNotHavePermission):
@@ -338,8 +369,10 @@ class TestUpdateApplicationInfo:
                 soap_config=_make_operation_config(),
             )
 
-    def test_accepted_status_is_valid(self, db_session, enable_factory_create):
-        """ACCEPTED status applications should also be updatable."""
+    def test_application_status_does_not_impact_agency_note_creation(
+        self, db_session, enable_factory_create
+    ):
+        """An application, regardless of application_status, should be updatable for agency notes."""
         agency = AgencyFactory.create()
         submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
@@ -348,17 +381,24 @@ class TestUpdateApplicationInfo:
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
-            GrantsGovTrackingNumber=tracking_number,
-            SaveAgencyNotes="Notes for accepted app",
+            grants_gov_tracking_number=tracking_number,
+            save_agency_notes="Notes for accepted app",
+            assign_agency_tracking_number="AGENCY-123",
         )
 
-        tracking_num, _, notes_result = update_application_info(
+        tracking_num, assign_result, notes_result = update_application_info(
             db_session=db_session,
             soap_request=soap_request,
             update_application_info_request=request_schema,
             soap_config=_make_operation_config(),
         )
 
+        assert assign_result is not None
+        assert assign_result.success == "false"
+        assert (
+            assign_result.error_message
+            == f"Exception caught assigning agency tracking number.(Expected an Application status of:'Received by Agency' , but found a status of 'Validated' for {tracking_number})"
+        )
         assert tracking_num == tracking_number
         assert notes_result is not None
         assert notes_result.success == "true"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9666 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Modify check of `ApplicationSubmission`: `AgencyNotes` are only added when the `Application` is in `"Received by Agency"` status, the rest fail
- Some fail states no longer raise exceptions, just populate error messages in the schema for the `UpdateApplicationInfoSchema`

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The responses from the SOAP/Proxy from the Simpler side were not matching the legacy. This update is to match their behavior.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] hit `UpdateApplicationInfo` endpoint and observe responses
