### PR TITLE
[Issue #9146] Backend - Create an endpoint to get the audit history of an award recommendation

### DIFF
--- a/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
@@ -8,6 +8,8 @@ from src.api.award_recommendations_alpha.award_recommendation_blueprint import (
     award_recommendation_blueprint,
 )
 from src.api.award_recommendations_alpha.award_recommendation_schemas import (
+    AwardRecommendationAuditRequestSchema,
+    AwardRecommendationAuditResponseSchema,
     AwardRecommendationCreateRequestSchema,
     AwardRecommendationGetResponseSchema,
     AwardRecommendationReviewUpdateRequestSchema,
@@ -27,6 +29,9 @@ from src.services.award_recommendations.create_award_recommendation_risk import 
 )
 from src.services.award_recommendations.get_award_recommendation import (
     get_award_recommendation_and_verify_access,
+)
+from src.services.award_recommendations.list_award_recommendation_audit import (
+    list_award_recommendation_audit,
 )
 from src.services.award_recommendations.list_award_recommendation_submissions import (
     list_award_recommendation_submissions,
@@ -196,3 +201,42 @@ def award_recommendation_risk_create(
         )
 
     return response.ApiResponse(message="Success", data=risk)
+
+
+@award_recommendation_blueprint.post(
+    "/award-recommendations/<uuid:award_recommendation_id>/audit_history"
+)
+@award_recommendation_blueprint.input(AwardRecommendationAuditRequestSchema(), location="json")
+@award_recommendation_blueprint.output(AwardRecommendationAuditResponseSchema())
+@award_recommendation_blueprint.doc(
+    summary="List Award Recommendation Audit History",
+    description="Get paginated audit history for an award recommendation.",
+    responses=[200, 401, 403, 404, 422],
+)
+@award_recommendation_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def award_recommendation_audit_list(
+    db_session: db.Session, award_recommendation_id: uuid.UUID, json_data: dict
+) -> response.ApiResponse:
+    add_extra_data_to_current_request_logs({"award_recommendation_id": award_recommendation_id})
+    logger.info("POST /alpha/award-recommendations/:award_recommendation_id/audit_history")
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        audit_events, pagination_info = list_award_recommendation_audit(
+            db_session, user, award_recommendation_id, json_data
+        )
+
+    add_extra_data_to_current_request_logs(
+        {
+            "response.pagination.total_pages": pagination_info.total_pages,
+            "response.pagination.total_records": pagination_info.total_records,
+        }
+    )
+    logger.info("Successfully fetched award recommendation audit history")
+
+    return response.ApiResponse(
+        message="Success", data=audit_events, pagination_info=pagination_info
+    )

--- a/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
@@ -5,7 +5,10 @@ from src.api.schemas.response_schema import AbstractResponseSchema, PaginationMi
 from src.api.schemas.search_schema import BoolSearchSchemaBuilder, StrSearchSchemaBuilder
 from src.api.schemas.shared_schema import SimpleUserSchema
 from src.constants.lookup_constants import (
+    ApprovalResponseType,
+    ApprovalType,
     AwardRecommendationAttachmentType,
+    AwardRecommendationAuditEvent,
     AwardRecommendationReviewType,
     AwardRecommendationRiskType,
     AwardRecommendationStatus,
@@ -430,3 +433,169 @@ class AwardRecommendationRiskCreateResponseSchema(AbstractResponseSchema):
         AwardRecommendationRiskCreateResponseDataSchema,
         metadata={"description": "The created award recommendation risk"},
     )
+
+
+####################################
+# List Award Recommendation Audit History
+####################################
+
+
+class AwardRecommendationAuditFilterSchema(Schema):
+    """Schema for the award recommendation audit history filters"""
+
+    award_recommendation_audit_event = fields.Nested(
+        StrSearchSchemaBuilder("AwardRecAuditEventFilterSchema")
+        .with_one_of(
+            allowed_values=AwardRecommendationAuditEvent,
+            example=AwardRecommendationAuditEvent.AWARD_RECOMMENDATION_CREATED,
+        )
+        .build()
+    )
+
+
+class AwardRecommendationAuditRequestSchema(Schema):
+    """Schema for POST /alpha/award-recommendations/:award_recommendation_id/audit_history request"""
+
+    filters = fields.Nested(AwardRecommendationAuditFilterSchema(), required=False, allow_none=True)
+
+    pagination = fields.Nested(
+        generate_pagination_schema(
+            "AwardRecAuditPaginationSchema",
+            ["created_at"],
+            default_sort_order=[{"order_by": "created_at", "sort_direction": "descending"}],
+        ),
+        required=True,
+    )
+
+
+class AwardRecommendationAuditRiskSchema(Schema):
+    """Schema for the risk data within an audit event"""
+
+    award_recommendation_risk_id = fields.UUID(
+        metadata={"description": "The risk's unique identifier"}
+    )
+    award_recommendation_risk_type = fields.Enum(
+        AwardRecommendationRiskType,
+        metadata={"description": "The type of risk"},
+    )
+    award_recommendation_risk_number = fields.String(
+        metadata={"description": "The risk number"},
+    )
+    is_deleted = fields.Boolean(metadata={"description": "Whether the risk has been deleted"})
+
+
+class AwardRecommendationAuditAttachmentSchema(Schema):
+    """Schema for the attachment data within an audit event"""
+
+    award_recommendation_attachment_id = fields.UUID(
+        metadata={"description": "The attachment's unique identifier"}
+    )
+    file_name = fields.String(
+        metadata={"description": "The file name of the attachment", "example": "my_example.pdf"},
+    )
+    award_recommendation_attachment_type = fields.Enum(
+        AwardRecommendationAttachmentType,
+        metadata={"description": "The type of the attachment"},
+    )
+    is_deleted = fields.Boolean(metadata={"description": "Whether the attachment has been deleted"})
+
+
+class AwardRecommendationAuditReviewSchema(Schema):
+    """Schema for the review data within an audit event"""
+
+    award_recommendation_review_id = fields.UUID(
+        metadata={"description": "The review's unique identifier"}
+    )
+    is_reviewed = fields.Boolean(metadata={"description": "Whether the review has been completed"})
+
+
+class AwardRecommendationAuditAppSubmissionSchema(Schema):
+    """Schema for the application submission data within an audit event"""
+
+    award_recommendation_application_submission_id = fields.UUID(
+        metadata={
+            "description": "The award recommendation application submission's unique identifier"
+        }
+    )
+    application_submission_id = fields.UUID(
+        metadata={"description": "The application submission ID"}
+    )
+    application_submission_number = fields.String(
+        allow_none=True,
+        metadata={"description": "The application submission number"},
+    )
+
+
+class AwardRecommendationAuditWorkflowApprovalSchema(Schema):
+    """Schema for the workflow approval data within an audit event"""
+
+    workflow_approval_id = fields.UUID(
+        metadata={"description": "The workflow approval's unique identifier"}
+    )
+    workflow_id = fields.UUID(metadata={"description": "The workflow ID"})
+    approval_type = fields.Enum(
+        ApprovalType,
+        metadata={"description": "The type of approval"},
+    )
+    approval_response_type = fields.Enum(
+        ApprovalResponseType,
+        metadata={"description": "The approval response type"},
+    )
+
+
+class AwardRecommendationAuditDataSchema(Schema):
+    """Schema for a single audit event in the response"""
+
+    award_recommendation_audit_id = fields.UUID(
+        metadata={"description": "The ID of the audit event"}
+    )
+    award_recommendation_audit_event = fields.Enum(
+        AwardRecommendationAuditEvent,
+        metadata={"description": "The type of audit event recorded"},
+    )
+
+    user = fields.Nested(
+        SimpleUserSchema(),
+        metadata={"description": "The user who performed the audited action"},
+    )
+
+    award_recommendation_risk = fields.Nested(
+        AwardRecommendationAuditRiskSchema(),
+        allow_none=True,
+        metadata={"description": "The risk affected by this event (if applicable)"},
+    )
+    award_recommendation_attachment = fields.Nested(
+        AwardRecommendationAuditAttachmentSchema(),
+        allow_none=True,
+        metadata={"description": "The attachment affected by this event (if applicable)"},
+    )
+    award_recommendation_review = fields.Nested(
+        AwardRecommendationAuditReviewSchema(),
+        allow_none=True,
+        metadata={"description": "The review affected by this event (if applicable)"},
+    )
+    award_recommendation_application_submission = fields.Nested(
+        AwardRecommendationAuditAppSubmissionSchema(),
+        allow_none=True,
+        metadata={
+            "description": "The application submission affected by this event (if applicable)"
+        },
+    )
+    workflow_approval = fields.Nested(
+        AwardRecommendationAuditWorkflowApprovalSchema(),
+        allow_none=True,
+        metadata={"description": "The workflow approval affected by this event (if applicable)"},
+    )
+
+    audit_metadata = fields.Dict(
+        allow_none=True,
+        metadata={"description": "Additional metadata about the audit event"},
+    )
+
+    created_at = fields.DateTime(metadata={"description": "When the audit event was created"})
+
+
+class AwardRecommendationAuditResponseSchema(AbstractResponseSchema, PaginationMixinSchema):
+    """Schema for POST /alpha/award-recommendations/:award_recommendation_id/audit_history response"""
+
+    data = fields.List(fields.Nested(AwardRecommendationAuditDataSchema()))

--- a/api/src/db/models/award_recommendation_models.py
+++ b/api/src/db/models/award_recommendation_models.py
@@ -246,6 +246,10 @@ class AwardRecommendationApplicationSubmission(ApiSchemaTable, TimestampMixin):
         )
     )
 
+    @property
+    def application_submission_number(self) -> str | None:
+        return self.application_submission.application_submission_number
+
 
 class AwardRecommendationRiskSubmission(ApiSchemaTable, TimestampMixin):
     """Links an award recommendation risk to an award recommendation application submission."""

--- a/api/src/services/award_recommendations/list_award_recommendation_audit.py
+++ b/api/src/services/award_recommendations/list_award_recommendation_audit.py
@@ -1,0 +1,132 @@
+import uuid
+from collections.abc import Sequence
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+from sqlalchemy.sql import Select
+
+import src.adapters.db as db
+from src.db.models.award_recommendation_models import (
+    AwardRecommendationApplicationSubmission,
+    AwardRecommendationAudit,
+)
+from src.db.models.user_models import User
+from src.pagination.pagination_models import PaginationInfo, PaginationParams
+from src.pagination.paginator import Paginator
+from src.search.search_models import StrSearchFilter
+from src.services.award_recommendations.get_award_recommendation import (
+    get_award_recommendation_and_verify_access,
+)
+from src.services.service_utils import apply_sorting
+
+
+class AwardRecommendationAuditFilters(BaseModel):
+    award_recommendation_audit_event: StrSearchFilter | None = None
+
+
+class AwardRecommendationAuditRequest(BaseModel):
+    filters: AwardRecommendationAuditFilters | None = None
+    pagination: PaginationParams
+
+
+def apply_filters(stmt: Select, filters: AwardRecommendationAuditFilters | None) -> Select:
+    """Apply filters from the request to the DB query for award recommendation audit events"""
+    if filters is None:
+        return stmt
+
+    if (
+        filters.award_recommendation_audit_event is not None
+        and filters.award_recommendation_audit_event.one_of is not None
+    ):
+        stmt = stmt.where(
+            AwardRecommendationAudit.award_recommendation_audit_event.in_(
+                filters.award_recommendation_audit_event.one_of
+            )
+        )
+
+    return stmt
+
+
+def list_award_recommendation_audit(
+    db_session: db.Session,
+    user: User,
+    award_recommendation_id: uuid.UUID,
+    request: dict,
+) -> tuple[list[dict], PaginationInfo]:
+    params = AwardRecommendationAuditRequest.model_validate(request)
+
+    # Fetch the award recommendation, verifying it exists and user has access
+    get_award_recommendation_and_verify_access(db_session, user, award_recommendation_id)
+
+    stmt = (
+        select(AwardRecommendationAudit)
+        .where(AwardRecommendationAudit.award_recommendation_id == award_recommendation_id)
+        .options(
+            # Preload the user + their profile & login.gov email
+            selectinload(AwardRecommendationAudit.user).options(
+                selectinload(User.profile), selectinload(User.linked_login_gov_external_user)
+            ),
+            # Preload related entities
+            selectinload(AwardRecommendationAudit.award_recommendation_risk),
+            selectinload(AwardRecommendationAudit.award_recommendation_attachment),
+            selectinload(AwardRecommendationAudit.award_recommendation_review),
+            selectinload(
+                AwardRecommendationAudit.award_recommendation_application_submission
+            ).selectinload(AwardRecommendationApplicationSubmission.application_submission),
+            selectinload(AwardRecommendationAudit.workflow_approval),
+        )
+    )
+    stmt = apply_filters(stmt, params.filters)
+    stmt = apply_sorting(stmt, AwardRecommendationAudit, params.pagination.sort_order)
+
+    paginator: Paginator[AwardRecommendationAudit] = Paginator(
+        AwardRecommendationAudit, stmt, db_session, page_size=params.pagination.page_size
+    )
+    paginated_results = paginator.page_at(page_offset=params.pagination.page_offset)
+    pagination_info = PaginationInfo.from_pagination_params(params.pagination, paginator)
+
+    return _transform_audit_events(paginated_results), pagination_info
+
+
+def _transform_audit_events(audit_events: Sequence[AwardRecommendationAudit]) -> list[dict]:
+    results = []
+    for audit_event in audit_events:
+        # Transform the application submission if present
+        if app_sub := audit_event.award_recommendation_application_submission:
+            submission = app_sub.application_submission
+            transformed_app_sub = {
+                "award_recommendation_application_submission_id": app_sub.award_recommendation_application_submission_id,
+                "application_submission_id": submission.application_submission_id,
+                "application_submission_number": submission.application_submission_number,
+            }
+        else:
+            transformed_app_sub = None
+
+        # Transform the workflow approval if present
+        if approval := audit_event.workflow_approval:
+            transformed_approval = {
+                "workflow_approval_id": approval.workflow_approval_id,
+                "workflow_id": approval.workflow_id,
+                "approval_type": approval.approval_type,
+                "approval_response_type": approval.approval_response_type,
+            }
+        else:
+            transformed_approval = None
+
+        results.append(
+            {
+                "award_recommendation_audit_id": audit_event.award_recommendation_audit_id,
+                "award_recommendation_audit_event": audit_event.award_recommendation_audit_event,
+                "user": audit_event.user,
+                "award_recommendation_risk": audit_event.award_recommendation_risk,
+                "award_recommendation_attachment": audit_event.award_recommendation_attachment,
+                "award_recommendation_review": audit_event.award_recommendation_review,
+                "award_recommendation_application_submission": transformed_app_sub,
+                "workflow_approval": transformed_approval,
+                "audit_metadata": audit_event.audit_metadata,
+                "created_at": audit_event.created_at,
+            }
+        )
+
+    return results

--- a/api/src/services/award_recommendations/list_award_recommendation_audit.py
+++ b/api/src/services/award_recommendations/list_award_recommendation_audit.py
@@ -92,28 +92,6 @@ def list_award_recommendation_audit(
 def _transform_audit_events(audit_events: Sequence[AwardRecommendationAudit]) -> list[dict]:
     results = []
     for audit_event in audit_events:
-        # Transform the application submission if present
-        if app_sub := audit_event.award_recommendation_application_submission:
-            submission = app_sub.application_submission
-            transformed_app_sub = {
-                "award_recommendation_application_submission_id": app_sub.award_recommendation_application_submission_id,
-                "application_submission_id": submission.application_submission_id,
-                "application_submission_number": submission.application_submission_number,
-            }
-        else:
-            transformed_app_sub = None
-
-        # Transform the workflow approval if present
-        if approval := audit_event.workflow_approval:
-            transformed_approval = {
-                "workflow_approval_id": approval.workflow_approval_id,
-                "workflow_id": approval.workflow_id,
-                "approval_type": approval.approval_type,
-                "approval_response_type": approval.approval_response_type,
-            }
-        else:
-            transformed_approval = None
-
         results.append(
             {
                 "award_recommendation_audit_id": audit_event.award_recommendation_audit_id,
@@ -122,8 +100,8 @@ def _transform_audit_events(audit_events: Sequence[AwardRecommendationAudit]) ->
                 "award_recommendation_risk": audit_event.award_recommendation_risk,
                 "award_recommendation_attachment": audit_event.award_recommendation_attachment,
                 "award_recommendation_review": audit_event.award_recommendation_review,
-                "award_recommendation_application_submission": transformed_app_sub,
-                "workflow_approval": transformed_approval,
+                "award_recommendation_application_submission": audit_event.award_recommendation_application_submission,
+                "workflow_approval": audit_event.workflow_approval,
                 "audit_metadata": audit_event.audit_metadata,
                 "created_at": audit_event.created_at,
             }

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_audit_list.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_audit_list.py
@@ -1,0 +1,446 @@
+import random
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.constants.lookup_constants import (
+    AwardRecommendationAuditEvent,
+    AwardRecommendationStatus,
+    Privilege,
+)
+from src.db.models.opportunity_models import Opportunity
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    AwardRecommendationAuditFactory,
+    AwardRecommendationFactory,
+    LinkExternalUserFactory,
+    OpportunityFactory,
+    UserFactory,
+)
+
+API_URL = "/alpha/award-recommendations"
+
+DEFAULT_PAGINATION = {"pagination": {"page_offset": 1, "page_size": 25}}
+
+
+def _make_datetime(hour: int) -> datetime:
+    return datetime(2026, 4, 1, hour, 0, 0, tzinfo=timezone.utc)
+
+
+####################################
+# Fixtures
+####################################
+
+
+@pytest.fixture
+def agency(enable_factory_create):
+    return AgencyFactory.create()
+
+
+@pytest.fixture
+def opportunity(agency) -> Opportunity:
+    return OpportunityFactory.create(agency_code=agency.agency_code)
+
+
+@pytest.fixture
+def award_recommendation(opportunity):
+    return AwardRecommendationFactory.create(
+        opportunity=opportunity,
+        award_recommendation_status=AwardRecommendationStatus.DRAFT,
+        is_deleted=False,
+        review_workflow=None,
+        review_workflow_id=None,
+    )
+
+
+####################################
+# Happy Path Tests
+####################################
+
+
+class TestListAwardRecommendationAudit200:
+
+    def test_audit_list_empty_200(self, client, db_session, agency, award_recommendation):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json["data"] == []
+        assert resp.json["pagination_info"]["total_records"] == 0
+        assert resp.json["pagination_info"]["total_pages"] == 0
+
+    def test_audit_list_with_various_events_200(
+        self, client, db_session, agency, award_recommendation
+    ):
+        user_with_profile = UserFactory.create(with_profile=True)
+        user_with_email = LinkExternalUserFactory.create().user
+
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        # Create events with different types and ascending timestamps
+        create_event = AwardRecommendationAuditFactory.create(
+            award_recommendation=award_recommendation,
+            user=user_with_profile,
+            is_created=True,
+            created_at=_make_datetime(hour=1),
+        )
+
+        attachment_event = AwardRecommendationAuditFactory.create(
+            award_recommendation=award_recommendation,
+            user=user_with_email,
+            is_attachment_created=True,
+            created_at=_make_datetime(hour=2),
+        )
+
+        risk_event = AwardRecommendationAuditFactory.create(
+            award_recommendation=award_recommendation,
+            user=user_with_profile,
+            is_risk_created=True,
+            created_at=_make_datetime(hour=3),
+        )
+
+        review_event = AwardRecommendationAuditFactory.create(
+            award_recommendation=award_recommendation,
+            user=user_with_email,
+            is_review_created=True,
+            created_at=_make_datetime(hour=4),
+        )
+
+        app_sub_event = AwardRecommendationAuditFactory.create(
+            award_recommendation=award_recommendation,
+            user=user_with_profile,
+            is_application_submission_updated=True,
+            created_at=_make_datetime(hour=5),
+        )
+
+        events = [
+            create_event,
+            attachment_event,
+            risk_event,
+            review_event,
+            app_sub_event,
+        ]
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 200
+        results = resp.json["data"]
+        assert len(results) == len(events)
+
+        # Default sort is descending by created_at, so reverse the events
+        for result, event in zip(results, events[::-1], strict=True):
+            assert result["award_recommendation_audit_id"] == str(
+                event.award_recommendation_audit_id
+            )
+            assert (
+                result["award_recommendation_audit_event"] == event.award_recommendation_audit_event
+            )
+            assert result["created_at"] == event.created_at.isoformat()
+            assert result["user"] == {
+                "user_id": str(event.user_id),
+                "email": event.user.email,
+                "first_name": event.user.first_name,
+                "last_name": event.user.last_name,
+            }
+
+        # Verify the create event has no related entities
+        create_result = results[-1]
+        assert create_result["award_recommendation_risk"] is None
+        assert create_result["award_recommendation_attachment"] is None
+        assert create_result["award_recommendation_review"] is None
+        assert create_result["award_recommendation_application_submission"] is None
+        assert create_result["workflow_approval"] is None
+
+        # Verify the attachment event has attachment data
+        attachment_result = results[-2]
+        assert attachment_result["award_recommendation_attachment"] is not None
+        assert (
+            "award_recommendation_attachment_id"
+            in attachment_result["award_recommendation_attachment"]
+        )
+        assert "file_name" in attachment_result["award_recommendation_attachment"]
+
+        # Verify the risk event has risk data
+        risk_result = results[-3]
+        assert risk_result["award_recommendation_risk"] is not None
+        assert "award_recommendation_risk_id" in risk_result["award_recommendation_risk"]
+
+        # Verify the review event has review data
+        review_result = results[-4]
+        assert review_result["award_recommendation_review"] is not None
+        assert "award_recommendation_review_id" in review_result["award_recommendation_review"]
+
+        # Verify the application submission event has submission data
+        app_sub_result = results[-5]
+        assert app_sub_result["award_recommendation_application_submission"] is not None
+        assert (
+            "application_submission_id"
+            in app_sub_result["award_recommendation_application_submission"]
+        )
+
+        pagination = resp.json["pagination_info"]
+        assert pagination["total_records"] == len(events)
+        assert pagination["sort_order"] == [
+            {"order_by": "created_at", "sort_direction": "descending"}
+        ]
+
+    def test_audit_list_filter_event_200(self, client, db_session, agency, award_recommendation):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        # Create a variable number of events for each type except REVIEW_DELETED
+        events_map = {}
+        for event_type in AwardRecommendationAuditEvent:
+            if event_type != AwardRecommendationAuditEvent.REVIEW_DELETED:
+                audit_events = AwardRecommendationAuditFactory.create_batch(
+                    size=random.randint(1, 3),
+                    award_recommendation=award_recommendation,
+                    award_recommendation_audit_event=event_type,
+                )
+                events_map[event_type] = audit_events
+
+        event_groups = [
+            # All events
+            list(AwardRecommendationAuditEvent),
+            # Two specific events
+            [
+                AwardRecommendationAuditEvent.AWARD_RECOMMENDATION_CREATED,
+                AwardRecommendationAuditEvent.ATTACHMENT_CREATED,
+            ],
+            # Single event
+            [AwardRecommendationAuditEvent.RISK_CREATED],
+            # No results expected
+            [AwardRecommendationAuditEvent.REVIEW_DELETED],
+        ]
+
+        for event_group in event_groups:
+            resp = client.post(
+                f"{API_URL}/{award_recommendation.award_recommendation_id}/audit_history",
+                json={
+                    "pagination": {"page_offset": 1, "page_size": 250},
+                    "filters": {"award_recommendation_audit_event": {"one_of": event_group}},
+                },
+                headers={"X-SGG-Token": token},
+            )
+
+            assert resp.status_code == 200
+            results = resp.json["data"]
+
+            audit_ids = {audit_event["award_recommendation_audit_id"] for audit_event in results}
+
+            expected_audit_ids = set()
+            for event_type in event_group:
+                expected_audit_ids.update(
+                    str(audit_event.award_recommendation_audit_id)
+                    for audit_event in events_map.get(event_type, [])
+                )
+
+            assert len(audit_ids) == len(expected_audit_ids)
+            assert audit_ids == expected_audit_ids
+
+    def test_audit_list_pagination_200(self, client, db_session, agency, award_recommendation):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        audit_events = []
+        # Count down so it matches the default descending sort
+        for i in range(10, 1, -1):
+            audit_events.append(
+                AwardRecommendationAuditFactory.create(
+                    award_recommendation=award_recommendation,
+                    created_at=_make_datetime(hour=i),
+                )
+            )
+
+        scenarios = [
+            # Fetch everything
+            ({"page_offset": 1, "page_size": 25}, audit_events),
+            # Fetch everything, reversed
+            (
+                {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [{"order_by": "created_at", "sort_direction": "ascending"}],
+                },
+                audit_events[::-1],
+            ),
+            # Second page
+            ({"page_offset": 2, "page_size": 3}, audit_events[3:6]),
+            # Past all events
+            ({"page_offset": 10, "page_size": 10}, []),
+        ]
+
+        for pagination, expected_audit_events in scenarios:
+            resp = client.post(
+                f"{API_URL}/{award_recommendation.award_recommendation_id}/audit_history",
+                json={"pagination": pagination},
+                headers={"X-SGG-Token": token},
+            )
+
+            assert resp.status_code == 200
+            results = resp.json["data"]
+
+            audit_ids = [e["award_recommendation_audit_id"] for e in results]
+            expected_audit_ids = [
+                str(e.award_recommendation_audit_id) for e in expected_audit_events
+            ]
+            assert len(audit_ids) == len(
+                expected_audit_ids
+            ), f"Mismatch for scenario with pagination {pagination}"
+            assert (
+                audit_ids == expected_audit_ids
+            ), f"Mismatch for scenario with pagination {pagination}"
+
+
+####################################
+# 404 Tests
+####################################
+
+
+class TestListAwardRecommendationAudit404:
+
+    def test_audit_list_not_found_404(self, client, db_session, agency, enable_factory_create):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 404
+
+    def test_audit_list_deleted_award_rec_404(self, client, db_session, agency, opportunity):
+        ar = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            is_deleted=True,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{ar.award_recommendation_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 404
+
+
+####################################
+# 401 Tests
+####################################
+
+
+class TestListAwardRecommendationAudit401:
+
+    def test_audit_list_no_token_401(self, client, enable_factory_create):
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 401
+
+    def test_audit_list_invalid_token_401(self, client, enable_factory_create):
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            headers={"X-SGG-Token": "invalid-token"},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 401
+
+
+####################################
+# 403 Tests
+####################################
+
+
+class TestListAwardRecommendationAudit403:
+
+    def test_audit_list_wrong_agency_403(
+        self, client, db_session, award_recommendation, enable_factory_create
+    ):
+        other_agency = AgencyFactory.create()
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=other_agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+    def test_audit_list_wrong_privilege_403(self, client, db_session, agency, award_recommendation):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_OPPORTUNITY]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+
+####################################
+# 422 Tests
+####################################
+
+
+class TestListAwardRecommendationAudit422:
+
+    def test_audit_list_missing_pagination_422(
+        self, client, db_session, agency, enable_factory_create
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            json={},
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 422
+        assert resp.json["message"] == "Validation error"
+        assert resp.json["errors"] == [
+            {
+                "field": "pagination",
+                "message": "Missing data for required field.",
+                "type": "required",
+                "value": None,
+            }
+        ]


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9146 

## Changes proposed

- Updated award_recommendation_schemas.py to add the request/response schemas
- Updated award_recommendation_routes.py to add the POST route handler for the new endpoint
- Created list_award_recommendation_audit.py to house the service layer for the new endpoint
- Created test_award_recommendation_audit_list.py to test the new endpoint

## Context for reviewers

Endpoint to get the audit history of an award recommendation.

## Validation steps

1. Get JWT token of user with `view_award_recommendation`
2. Create an award recommendation if needed - grab the `award_recommendation_id` from the response
3. Call the new endpoint `POST /alpha/award-recommendations/{award_recommendation_id}/audit_history` with:
```
{
  "pagination": {
    "page_offset": 1,
    "page_size": 25
  }
}
```
and verify a 200 response with at least the `award_recommendation_created` audit event
5. Test filtering by re-running with filters:
```
{
  "filters": {
    "award_recommendation_audit_event": {
      "one_of": ["award_recommendation_created"]
    }
  },
  "pagination": { "page_offset": 1, "page_size": 25 }
}
```
6. Confirm tests pass