### PR TITLE
[Issue #9680] Move alert errors to verifyFormStatusAfterSave

### DIFF
--- a/frontend/tests/e2e/apply/failure-path-sf424a.spec.ts
+++ b/frontend/tests/e2e/apply/failure-path-sf424a.spec.ts
@@ -14,7 +14,6 @@ import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils
 import { createApplication } from "tests/e2e/utils/create-application-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
-import { verifyAlertErrors } from "tests/e2e/utils/forms/verify-form-errors-utils";
 import {
   verifyFormStatusAfterSave,
   verifyFormStatusOnApplication,
@@ -70,12 +69,11 @@ test(
 
     await saveForm(page, true);
 
-    await verifyAlertErrors(page, SF424A_ALERT_ERRORS);
-
     await verifyFormStatusAfterSave(
       page,
       "incomplete",
       SF424A_REQUIRED_FIELD_ERRORS,
+      SF424A_ALERT_ERRORS,
     );
 
     await verifyFormStatusOnApplication(

--- a/frontend/tests/e2e/utils/forms/verify-form-errors-utils.ts
+++ b/frontend/tests/e2e/utils/forms/verify-form-errors-utils.ts
@@ -25,7 +25,11 @@ export async function verifyAlertErrors(
   const alertItems = alertList.getByRole("listitem");
 
   // 1) Exact count check: catches unexpected extra/missing alert errors.
-  await expect(alertItems).toHaveCount(expectedErrors.length);
+  // Use a generous timeout — mobile CI runners render alert list items more
+  // slowly than desktop, and the Playwright default (5000ms) is insufficient.
+  await expect(alertItems).toHaveCount(expectedErrors.length, {
+    timeout: 10000,
+  });
 
   // 2) Set-equality check on alert messages: catches wrong messages even when
   // the count happens to match.
@@ -76,7 +80,11 @@ export async function verifyInlineErrors(
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   // 1) Exact count check: catches unexpected extra/missing inline errors.
-  const inlineErrors = page.locator('[id^="error-for-"]');
+  // Filter to visible elements only — hidden duplicate DOM nodes (e.g. from
+  // mobile-specific hidden sections) must not inflate the count.
+  const inlineErrors = page
+    .locator('[id^="error-for-"]')
+    .filter({ visible: true });
   await expect(inlineErrors).toHaveCount(expectedErrors.length);
 
   // 2) Set-equality check on inline field IDs: catches wrong fields even when

--- a/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
+++ b/frontend/tests/e2e/utils/forms/verify-form-status-utils.ts
@@ -74,12 +74,16 @@ export async function verifyFormStatusOnApplication(
  *
  * @param page Playwright Page object
  * @param status Expected status: "complete" or "incomplete"
- * @param expectedErrors Required when status is "incomplete" — list of field errors to verify
+ * @param expectedErrors Required when status is "incomplete" — list of field errors to verify inline
+ * @param alertErrors Optional override for the alert banner error list. Defaults to expectedErrors.
+ *   Use when a form's alert-level errors differ from its inline field errors (e.g. array-level
+ *   validation errors that appear in the alert but have no corresponding inline element).
  */
 export async function verifyFormStatusAfterSave(
   page: Page,
   status: FormStatus,
   expectedErrors?: FieldError[],
+  alertErrors?: FieldError[],
 ): Promise<void> {
   if (status === "complete") {
     const alert = page.getByTestId("alert");
@@ -100,7 +104,7 @@ export async function verifyFormStatusAfterSave(
         "expectedErrors must be provided when status is 'incomplete'",
       );
     }
-    await verifyAlertErrors(page, expectedErrors);
+    await verifyAlertErrors(page, alertErrors ?? expectedErrors);
     await verifyInlineErrors(page, expectedErrors);
   }
 }


### PR DESCRIPTION
## Summary
Work for: Task #9680 

## Changes proposed
Remove standalone verifyAlertErrors call from failure-path-sf424a.spec.ts
Add optional alertErrors parameter - verifyFormStatusAfterSave in verify-form-status-utils.ts

## Context for reviewers
The structure allows standalone Playwright tests to run independently and in CI

Note: This test failure-path-sf424a.spec.ts previously passed in both local and staging CI runs, however the recent scheduled job run exposed this failure

## Validation steps
Run the standalone Playwright tests and they should complete the workflow without any issues
