### PR TITLE
[Issue #9723] Re-use existing Docker images for API during E2E tests

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -46,7 +46,7 @@ inputs:
     default: ""
   force-webkit-install:
     description: "webkit dependencies aren't all cached, so we need to force it to install"
-    default: false
+    default: "false"
 outputs:
   artifact-id:
     description: "artifact ids for uploaded test reports"
@@ -85,7 +85,7 @@ runs:
         npx playwright install --with-deps
 
     - name: Install Webkit dependencies
-      if: ${{ inputs.force-webkit-install == true }}
+      if: ${{ inputs.force-webkit-install == 'true' }}
       shell: bash
       working-directory: ./frontend
       run: |

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -44,6 +44,9 @@ inputs:
   workers:
     description: "number of workers to use for test run"
     default: ""
+  force-webkit-install:
+    description: "webkit dependencies aren't all cached, so we need to force it to install"
+    default: false
 outputs:
   artifact-id:
     description: "artifact ids for uploaded test reports"
@@ -80,6 +83,13 @@ runs:
       run: |
         npm install @playwright/test
         npx playwright install --with-deps
+
+    - name: Install Webkit dependencies
+      if: ${{ inputs.force-webkit-install == true }}
+      shell: bash
+      working-directory: ./frontend
+      run: |
+        npx playwright install-deps webkit
 
     - name: Run all e2e tests (Shard ${{ inputs.current_shard }}/${{ inputs.total_shards }})
       if: ${{ inputs.playwright_tags == '' }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -142,7 +142,7 @@ runs:
     - name: Upload Blob Report
       id: upload-blob-report
       if: always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: blob-report-shard-${{ inputs.target }}-${{ inputs.current_shard }}
         path: /home/runner/work/simpler-grants-gov/simpler-grants-gov/frontend/blob-report

--- a/.github/workflows/ci-frontend-a11y.yml
+++ b/.github/workflows/ci-frontend-a11y.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload screenshots to artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: screenshots
           path: ./frontend/screenshots-output

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -156,7 +156,7 @@ jobs:
           echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
           # Run init first to generate JWT keys in override.env
 
-          make init-ci-cd
+          make init-ci-cd setup-api-data
 
   build-api-when-not-cached:
     name: Build API when not cached

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -186,7 +186,7 @@ jobs:
           mkdir -p /tmp/cores
           echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
 
-          make build db-seed-local-with-agencies
+          make build
 
       - name: Save Docker image
         if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
@@ -200,13 +200,6 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-
-      - name: Save shared e2e token
-        uses: actions/upload-artifact@v4
-        with:
-          name: api-fe-shared-e2e-token
-          path: |
-            api/e2e_token.tmp
 
   build-frontend-when-not-cached:
     name: Build frontend when not cached
@@ -261,8 +254,8 @@ jobs:
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
           npm run build
 
-  e2e-tests-local:
-    name: Run Local E2E Tests
+  setup-e2e-tests-local:
+    name: Setup Local E2E Tests
     needs:
       [
         get-api-commit-hash,
@@ -271,6 +264,80 @@ jobs:
         build-frontend-when-not-cached,
         playwright-cache,
       ]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Restore Docker image cached
+        id: restore-docker-image-cached
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-image.tar
+          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
+      - name: Failed to load cache, exit
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
+        run: |
+          exit 1
+
+      - name: Load cached Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+
+      - name: Docker images before Start API
+        run: |
+          docker image ls
+
+      - name: Init API Server for e2e tests
+        run: |
+          cd ../api
+          # Enable core dumps for debugging segfaults
+          ulimit -c unlimited
+          mkdir -p /tmp/cores
+          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
+          # Run init first to generate JWT keys in override.env
+
+          make init-ci-cd
+
+      - name: Download shared key
+        uses: actions/download-artifact@v5
+        with:
+          name: api-fe-shared-key
+
+      - name: Start API Server for e2e tests
+        run: |
+          cd ../api
+          # Enable core dumps for debugging segfaults
+          ulimit -c unlimited
+          mkdir -p /tmp/cores
+          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
+
+          # Now run the seeding and populate commands
+          echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
+          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
+          cd ../frontend
+          # Ensure the API wait script is executable
+          chmod +x ../api/bin/wait-for-api.sh
+          ../api/bin/wait-for-api.sh
+        shell: bash
+
+      - name: Save shared e2e token
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-fe-shared-e2e-token
+          path: |
+            api/e2e_token.tmp
+
+      - name: Docker images after Start API
+        run: |
+          docker image ls
+
+  run-e2e-tests-local:
+    name: Run Local E2E Tests
+    needs: [setup-e2e-tests-local]
     runs-on: ubuntu-22.04
 
     strategy:
@@ -311,68 +378,15 @@ jobs:
             frontend/dist
           key: ${{ runner.os }}-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
 
-      - name: Restore Docker image cached
-        id: restore-docker-image-cached
-        uses: actions/cache/restore@v5
-        with:
-          path: /tmp/docker-image.tar
-          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-          restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-
-      - name: Failed to load cache, exit
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
-        run: |
-          exit 1
-
-      - name: Load cached Docker image
-        run: |
-          docker load < /tmp/docker-image.tar
-
-      - name: Docker images before Start API
-        run: |
-          docker image ls
-
-      - name: Init API Server for e2e tests
-        run: |
-          cd ../api
-          # Enable core dumps for debugging segfaults
-          ulimit -c unlimited
-          mkdir -p /tmp/cores
-          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
-          # Run init first to generate JWT keys in override.env
-
-          make init-ci-cd
-
       - name: Download shared key
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-key
 
-      - name: Download e2e token
+      - name: Download shared e2e token
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-e2e-token
-
-      - name: Start API Server for e2e tests
-        run: |
-          cd ../api
-          # Enable core dumps for debugging segfaults
-          ulimit -c unlimited
-          mkdir -p /tmp/cores
-          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
-
-          # Now run the seeding and populate commands
-          echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
-          make populate-search-opportunities populate-search-agencies start
-          cd ../frontend
-          # Ensure the API wait script is executable
-          chmod +x ../api/bin/wait-for-api.sh
-          ../api/bin/wait-for-api.sh
-        shell: bash
-
-      - name: Docker images after Start API
-        run: |
-          docker image ls
 
       - name: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -80,8 +80,8 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           lookup-only: true
-          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-          restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Build API Server for e2e tests (if not cached)
         if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
@@ -135,8 +135,8 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           fail-on-cache-miss: true
-          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-          restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       # if we successfully pulled a cached image, then import it into docker, otherwise we can skip this step as it won't work
       # if we cache miss, we'll build the docker image in the make commands below

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -131,7 +131,7 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: tar -cvzf node_modules.tar.gz node_modules
+      - run: tar -czf node_modules.tar.gz node_modules
 
       - name: Save node_modules
         uses: actions/upload-artifact@v7
@@ -424,11 +424,11 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: node_modules.tar.gz
-          path: frontend/node_modules.tar.gz
+          path: frontend/
 
       - name: Expand node_modules
         run: |
-          tar -xvzf node_modules.tar.gz node_modules
+          tar -xzf node_modules.tar.gz node_modules
           ls -la node_*
           rm node_modules.tar.gz
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -152,13 +152,12 @@ jobs:
 
           ls -a
 
-      - name: Save shared keys
+      - name: Save shared key
         uses: actions/upload-artifact@v4
         with:
           name: api-fe-shared-key
           path: |
             api/override.env
-            api/e2e_token.tmp
 
   build-api-when-not-cached:
     name: Build API when not cached
@@ -202,6 +201,13 @@ jobs:
           path: /tmp/docker-image.tar
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
+      - name: Save shared e2e token
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-fe-shared-e2e-token
+          path: |
+            api/e2e_token.tmp
+
   build-frontend-when-not-cached:
     name: Build frontend when not cached
     needs:
@@ -233,10 +239,15 @@ jobs:
           path: frontend/dist
           key: frontend-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
 
-      - name: Download shared keys
+      - name: Download shared key
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-key
+
+      - name: Download e2e token
+        uses: actions/download-artifact@v5
+        with:
+          name: api-fe-shared-e2e-token
 
       - name: Build a prod version of the frontend (if not cached)
         if: steps.next-build-cache.outputs.cache-matched-key == ''
@@ -332,10 +343,15 @@ jobs:
 
           make init-ci-cd
 
-      - name: Download shared keys
+      - name: Download shared key
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-key
+
+      - name: Download e2e token
+        uses: actions/download-artifact@v5
+        with:
+          name: api-fe-shared-e2e-token
 
       - name: Start API Server for e2e tests
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -192,8 +192,7 @@ jobs:
         if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
         run: |
           cd ..
-          IMAGE_TAG=$(make APP_NAME=api release-image-tag)
-          docker save simpler-grants-gov-api:${{ github.sha }} > /tmp/docker-image.tar
+          docker save api-grants-api > /tmp/docker-image.tar
 
       - name: Cache Docker image
         if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -186,7 +186,7 @@ jobs:
           mkdir -p /tmp/cores
           echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
 
-          make build
+          make build db-seed-local-with-agencies
 
       - name: Save Docker image
         if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -85,12 +85,11 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
-      - name: Check Docker image cached
-        id: check-docker-image-cached
+      - name: Restore Docker image cached
+        id: restore-docker-image-cached
         uses: actions/cache/restore@v4
         with:
           path: /tmp/docker-image.tar
-          lookup-only: true
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
           restore-keys: api-docker-img- # get any recent API container from cache if we can't find our specific one
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -243,7 +243,8 @@ jobs:
       - name: Save Docker image to file
         run: |
           docker save api-grants-api > /tmp/docker-image.tar
-          tar -czf /tmp/api-docker-image.tar.gz /tmp/docker-image.tar
+          cd /tmp
+          tar -czf api-docker-image.tar.gz docker-image.tar
 
       - name: Cache Docker image
         if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -188,6 +188,19 @@ jobs:
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
 
+      - name: Save Docker image
+        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        run: |
+          IMAGE_TAG=$(make APP_NAME=api release-image-tag)
+          docker save simpler-grants-gov-api:$IMAGE_TAG > /tmp/docker-image.tar
+
+      - name: Cache Docker image
+        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
   create-report:
     name: Create Merged Test Report
     if: ${{ !cancelled() }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           cd ..
           IMAGE_TAG=$(make APP_NAME=api release-image-tag)
-          docker save simpler-grants-gov-api > /tmp/docker-image.tar
+          docker save simpler-grants-gov-api:${{ github.sha }} > /tmp/docker-image.tar
 
       - name: Cache Docker image
         if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -116,7 +116,7 @@ jobs:
 
           make init-nobuild
       - name: Build API Server for e2e tests (if not cached)
-        if: steps.restore-docker-image-cached.outputs.cache-hit == 'false'
+        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
         run: |
           cd ../api
           # Enable core dumps for debugging segfaults

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -88,8 +88,14 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-            node_modules
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - uses: actions/cache@v5
+        id: npm-cache
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - run: npm ci
         if: steps.playwright-cache.outputs.cache-hit != 'true'
@@ -162,6 +168,20 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
+      - uses: actions/cache@v5
+        id: npm-cache
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+
+      - uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
       - name: Restore Docker image cached
         id: restore-docker-image-cached
         uses: actions/cache/restore@v5
@@ -215,9 +235,14 @@ jobs:
         run: |
           docker image ls
 
-      - name: Install dependencies and Playwright
+      - name: npm ci
+        if: steps.npm-cache.outputs.cache-hit != 'true'
         run: |
           npm ci
+
+      - name: Install dependencies and Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: |
           npx playwright install --with-deps
 
       - name: Build a prod version of the site

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -67,6 +67,27 @@ jobs:
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 
+  get-frontend-commit-hash:
+    name: Get commit hash
+    runs-on: ubuntu-22.04
+    outputs:
+      commit_hash: ${{ steps.get-frontend-commit-hash.outputs.commit_hash }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 1000
+      - name: Get commit hash
+        id: get-frontend-commit-hash
+        env:
+          CLEAN_REF: ${{ github.head_ref || github.ref }}
+        run: |
+          cd ..
+          COMMIT_HASH=$(git rev-parse "$CLEAN_REF")
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 "$CLEAN_REF" -- frontend)
+          echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
+          echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
+
   playwright-cache:
     # based on this https://justin.poehnelt.com/posts/caching-playwright-in-github-actions/
     name: Playwright caching
@@ -110,8 +131,31 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-  restore-or-build-api:
-    name: Restore or build API
+  init-api-fe-shared-secret:
+    name: API/FE shared secret generation
+    needs: [get-api-commit-hash]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Cache API/FE shared secret
+        id: cache-api-fe-shared-secret
+        uses: actions/cache/restore@v5
+        with:
+          path: api/override.env
+          key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
+      - name: Init API Server for e2e tests
+        run: |
+          cd ../api
+          # Enable core dumps for debugging segfaults
+          ulimit -c unlimited
+          mkdir -p /tmp/cores
+          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
+          # Run init first to generate JWT keys in override.env
+
+          make setup-env-override-file
+
+  build-api-when-not-cached:
+    name: Build API when not cached
     needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
 
@@ -152,9 +196,45 @@ jobs:
           path: /tmp/docker-image.tar
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
+  build-frontend-when-not-cached:
+    name: Build frontend when not cached
+    needs:
+      [get-api-commit-hash, get-frontend-commit-hash, build-api-when-not-cached]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Next build cache
+        id: next-build-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: frontend/dist
+          key: frontend-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
+
+      - name: Build a prod version of the frontend (if not cached)
+        if: steps.next-build-cache.outputs.cache-matched-key == ''
+        run: |
+          {
+            cat .env.development
+            sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
+            cat ../api/e2e_token.tmp
+          } >> .env.local
+          # Use the 127.0.0.1 url for tests (IPv4 only)
+          sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
+          npm run build
+
   e2e-tests-local:
     name: Run Local E2E Tests
-    needs: [get-api-commit-hash, restore-or-build-api, playwright-cache]
+    needs:
+      [
+        get-api-commit-hash,
+        get-frontend-commit-hash,
+        build-api-when-not-cached,
+        build-frontend-when-not-cached,
+        playwright-cache,
+      ]
     runs-on: ubuntu-22.04
 
     strategy:
@@ -188,6 +268,13 @@ jobs:
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
 
+      - uses: actions/cache@v5
+        id: next-build-cache
+        with:
+          path: |
+            frontend/dist
+          key: ${{ runner.os }}-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
+
       - name: Restore Docker image cached
         id: restore-docker-image-cached
         uses: actions/cache/restore@v5
@@ -218,7 +305,7 @@ jobs:
           echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
           # Run init first to generate JWT keys in override.env
 
-          make init-nobuild
+          make init-ci-cd
 
       - name: Start API Server for e2e tests
         run: |
@@ -250,17 +337,6 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           npx playwright install --with-deps
-
-      - name: Build a prod version of the site
-        run: |
-          {
-            cat .env.development
-            sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
-            cat ../api/e2e_token.tmp
-          } >> .env.local
-          # Use the 127.0.0.1 url for tests (IPv4 only)
-          sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
-          npm run build
 
       - name: Determine test groups to run
         shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -131,8 +131,8 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-  init-api-fe-shared-secret:
-    name: API/FE shared secret generation
+  init-ci-cd:
+    name: Iniialize for CI/CD runs
     needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
     steps:
@@ -156,11 +156,11 @@ jobs:
           echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
           # Run init first to generate JWT keys in override.env
 
-          make setup-env-override-file
+          make init-ci-cd
 
   build-api-when-not-cached:
     name: Build API when not cached
-    needs: [get-api-commit-hash, init-api-fe-shared-secret]
+    needs: [get-api-commit-hash, init-ci-cd]
     runs-on: ubuntu-22.04
 
     steps:
@@ -207,7 +207,7 @@ jobs:
         get-api-commit-hash,
         get-frontend-commit-hash,
         build-api-when-not-cached,
-        init-api-fe-shared-secret,
+        init-ci-cd,
       ]
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -87,13 +87,15 @@ jobs:
 
       - name: Restore Docker image cached
         id: restore-docker-image-cached
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-          restore-keys: api-docker-img- # get any recent API container from cache if we can't find our specific one
 
+      # if we successfully pulled a cached image, then import it into docker, otherwise we can skip this step as it won't work
+      # if we cache miss, we'll build the docker image in the make commands below
       - name: Load cached Docker image
+        if: steps.restore-docker-image-cached.outputs.cache-hit == true
         run: |
           docker load < /tmp/docker-image.tar
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Get commit hash
         id: get-api-commit-hash
         run: |
+          cd ..
           APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{inputs.ref}} api)
           COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Init API Server for e2e tests
+      - name: Have docker pre-pull the images
         run: |
           cd ../api
           docker compose pull -q
@@ -161,6 +161,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Docker images
+        run: |
+          docker image ls
 
       - name: Init API Server for e2e tests
         run: |
@@ -174,6 +178,10 @@ jobs:
           make init-ci-cd
 
           ls -a
+
+      - name: Docker images
+        run: |
+          docker image ls
 
       - name: Save shared key
         uses: actions/upload-artifact@v7
@@ -207,11 +215,12 @@ jobs:
       - name: Load cached Docker image
         run: |
           docker load < /tmp/docker-image.tar
+          # alias the live docker container name simpler-grants-gov-api to the locally build name api-grants-api so that we don't rebuild it in later steps.
           IMAGE_ID=$(docker image ls -q simpler-grants-gov-api)
           echo $IMAGE_ID
           docker tag $IMAGE_ID api-grants-api:latest || true
 
-      - name: Docker images before Start API
+      - name: Docker images
         run: |
           docker image ls
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -131,6 +131,7 @@ jobs:
       - name: Build API Server for e2e tests (if not cached)
         if: steps.restore-docker-image-cached.outputs.cache-matched-key != ''
         run: |
+          echo **${{ steps.restore-docker-image-cached.outputs.cache-matched-key }}**${{ steps.restore-docker-image-cached.outputs.cache-hit }}**
           cd ../api
           # Enable core dumps for debugging segfaults
           ulimit -c unlimited

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/cache@v5
         id: npm-cache
         with:
-          lookup-only: true
+          #lookup-only: true
           path: |
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -133,7 +133,7 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - name: Expand API Docker image
+      - name: Package node_modules
         run: |
           cd node_modules
           tar -czf /tmp/node_modules.tar.gz .

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -54,14 +54,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.ref_name }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-api-commit-hash
         run: |
           cd ..
-          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.ref }} api)
-          COMMIT_HASH=$(git rev-parse ${{ github.ref }})
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.ref_name }} api)
+          COMMIT_HASH=$(git rev-parse ${{ github.ref_name }})
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -335,15 +335,14 @@ jobs:
           # Use the 127.0.0.1 url for tests (IPv4 only)
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
           npm run build
-          ls -al .
-          ls -al dist
-          ls -al .next
 
       - name: Save next build
         uses: actions/upload-artifact@v5
         with:
           name: next-build
-          path: frontend/.next
+          path: |
+            frontend/.next
+            frontend/public
 
   run-e2e-tests-local:
     name: Run Local E2E Tests
@@ -405,7 +404,7 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: next-build
-          path: frontend/.next/standalone
+          path: frontend/
 
       - name: ls frontend
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -97,8 +97,14 @@ jobs:
             node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
-      - run: npm ci
+      - id: id-install-npm-packages
         if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          npm ci
+          pwd
+          ls . -l
+          ls node_modules -l
+
       - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: npx playwright install-deps
@@ -123,7 +129,7 @@ jobs:
           restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Build API Server for e2e tests (if not cached)
-        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key != ''
         run: |
           cd ../api
           # Enable core dumps for debugging segfaults

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/cache@v5
         id: playwright-cache
         with:
-          lookup-only: true
+          # lookup-only: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -71,6 +71,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Restore Docker image cached
         id: restore-docker-image-cached
         uses: actions/cache/restore@v5

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -160,7 +160,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           path: |
-            node_modules
+            frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - uses: actions/cache@v5

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -142,21 +142,9 @@ jobs:
           path: |
             frontend/node_modules.tar.gz
 
-  pre-pull-images:
-    name: Pre-pull images we'll need for Docker compose
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Have docker pre-pull the images
-        run: |
-          cd ../api
-          docker compose pull -q
-
   init-ci-cd:
     name: Initialize for CI/CD runs
-    needs: [get-api-commit-hash, pre-pull-images, build-api-when-not-cached]
+    needs: [get-api-commit-hash, build-api-when-not-cached]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -468,6 +456,10 @@ jobs:
       #   if: steps.playwright-cache.outputs.cache-hit != 'true'
       #   run: |
       #     npx playwright install --with-deps
+
+      - name: Docker images
+        run: |
+          docker image ls
 
       - name: Determine test groups to run
         shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -214,14 +214,14 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
 
       - name: Download Playwright artifact
-        if: steps.npm-cache.outputs.cache-hit != 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: playwright.tar.gz
           path: /tmp/playwright.tar.gz
 
       - name: Expand Playwright
-        if: steps.npm-cache.outputs.cache-hit != 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           ls -la ~
           tar -xzf /tmp/playwright.tar.gz ~/.cache/ms-playwright

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -191,6 +191,7 @@ jobs:
       - name: Save Docker image
         if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
         run: |
+          cd ..
           IMAGE_TAG=$(make APP_NAME=api release-image-tag)
           docker save simpler-grants-gov-api:$IMAGE_TAG > /tmp/docker-image.tar
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -200,7 +200,7 @@ jobs:
         run: |
           ls -la .
           ls -la ./node_modules
-          tar -xzf /tmp/node_modules.tar.gz
+          tar -xzf /tmp/node_modules.tar.gz -C ./node_modules
           ls -la .
           ls -la ./node_modules
 
@@ -225,7 +225,7 @@ jobs:
         run: |
           ls -la ~
           cd ~
-          tar -xzf /tmp/playwright.tar.gz
+          tar -xzf /tmp/playwright.tar.gz -C ~/.cache/ms-playwright
           ls -la ~
           ls -la ~/.cache/ms-playwright
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -54,14 +54,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.sha }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-api-commit-hash
         run: |
           cd ..
-          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.ref_name }} api)
-          COMMIT_HASH=$(git rev-parse ${{ github.ref_name }})
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.sha }} api)
+          COMMIT_HASH=$(git rev-parse ${{ github.sha }})
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -54,19 +54,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-api-commit-hash
         run: |
           cd ..
-          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{inputs.ref}} api)
-          COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.ref }} api)
+          COMMIT_HASH=$(git rev-parse ${{ github.ref }})
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 
   e2e-tests-local:
     name: Run Local E2E Tests
+    needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -423,14 +423,14 @@ jobs:
       - name: Download node_modules
         uses: actions/download-artifact@v8
         with:
-          name: node-modules-tar-gz
+          name: node_modules.tar.gz
           path: frontend/node_modules.tar.gz
 
       - name: Expand node_modules
         run: |
           tar -xvzf node_modules.tar.gz node_modules
           ls -la node_*
-          rm node_modules.tar
+          rm node_modules.tar.gz
 
       - name: ls frontend
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -217,6 +217,7 @@ jobs:
 
       - name: Docker images
         run: |
+          echo |${{ steps.restore-docker-image-cached.outputs.cache-matched-key }}|
           docker image ls
 
       - name: Build API Server for e2e tests (if not cached)

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -54,14 +54,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-api-commit-hash
         run: |
           cd ..
-          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.sha }} api)
-          COMMIT_HASH=$(git rev-parse ${{ github.sha }})
+          pwd
+          git log -n 1 ${{ github.head_ref || github.ref }} -- api
+          COMMIT_HASH=$(git rev-parse ${{ github.head_ref || github.ref }})
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.head_ref || github.ref }} -- api)
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -344,6 +344,13 @@ jobs:
             frontend/.next
             frontend/public
 
+      - name: Save node_modules
+        uses: actions/upload-artifact@v5
+        with:
+          name: node-modules
+          path: |
+            frontend/node_modules
+
   run-e2e-tests-local:
     name: Run Local E2E Tests
     needs: [setup-e2e-tests-local, build-frontend-when-not-cached]
@@ -366,12 +373,13 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
-      - uses: actions/cache@v5
-        id: npm-cache
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+      # get this from downloading the artifact since we are passing it job to job
+      # - uses: actions/cache@v5
+      #   id: npm-cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #     key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - uses: actions/cache@v5
         id: playwright-cache
@@ -406,13 +414,20 @@ jobs:
           name: next-build
           path: frontend/
 
+      - name: Download node_modules
+        uses: actions/download-artifact@v5
+        with:
+          name: node-modules
+          path: frontend/
+
       - name: ls frontend
         run: |
-          ls -la frontend
+          pwd
+          ls -la .
           echo *****
-          ls -la frontend/.next
+          ls -la ./.next
           echo *****
-          ls -la frontend/.next/standalone
+          ls -la ./.next/standalone
 
       - name: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -193,7 +193,7 @@ jobs:
         run: |
           cd ..
           IMAGE_TAG=$(make APP_NAME=api release-image-tag)
-          docker save simpler-grants-gov-api:$IMAGE_TAG > /tmp/docker-image.tar
+          docker save simpler-grants-gov-api > /tmp/docker-image.tar
 
       - name: Cache Docker image
         if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -213,6 +213,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Cache API/FE shared secret
+        id: cache-api-fe-shared-secret
+        uses: actions/cache/restore@v5
+        with:
+          path: api/override.env
+          key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
       - name: Next build cache
         id: next-build-cache
         uses: actions/cache/restore@v5

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -47,7 +47,7 @@ concurrency:
 
 jobs:
   get-api-commit-hash:
-    name: Get commit hash
+    name: Get API commit hash
     runs-on: ubuntu-22.04
     outputs:
       commit_hash: ${{ steps.get-api-commit-hash.outputs.commit_hash }}
@@ -68,7 +68,7 @@ jobs:
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 
   get-frontend-commit-hash:
-    name: Get commit hash
+    name: Get frontend commit hash
     runs-on: ubuntu-22.04
     outputs:
       commit_hash: ${{ steps.get-frontend-commit-hash.outputs.commit_hash }}
@@ -138,14 +138,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-      - name: Cache API/FE shared secret
-        id: cache-api-fe-shared-secret
-        uses: actions/cache@v5
-        with:
-          path: |
-            api/override.env
-            api/e2e_token.tmp
-          key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Init API Server for e2e tests
         run: |
@@ -156,7 +148,17 @@ jobs:
           echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
           # Run init first to generate JWT keys in override.env
 
-          make init-ci-cd setup-api-data
+          make init-ci-cd
+
+          ls -a
+
+      - name: Save shared keys
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-fe-shared-key
+          path: |
+            api/override.env
+            api/e2e_token.tmp
 
   build-api-when-not-cached:
     name: Build API when not cached
@@ -230,6 +232,11 @@ jobs:
         with:
           path: frontend/dist
           key: frontend-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
+
+      - name: Download shared keys
+        uses: actions/download-artifact@v5
+        with:
+          name: api-fe-shared-key
 
       - name: Build a prod version of the frontend (if not cached)
         if: steps.next-build-cache.outputs.cache-matched-key == ''
@@ -325,6 +332,11 @@ jobs:
 
           make init-ci-cd
 
+      - name: Download shared keys
+        uses: actions/download-artifact@v5
+        with:
+          name: api-fe-shared-key
+
       - name: Start API Server for e2e tests
         run: |
           cd ../api
@@ -335,7 +347,7 @@ jobs:
 
           # Now run the seeding and populate commands
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
-          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
+          make populate-search-opportunities populate-search-agencies start
           cd ../frontend
           # Ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -296,15 +296,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache API/FE shared secret
-        id: cache-api-fe-shared-secret
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            api/override.env
-            api/e2e_token.tmp
-          key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-
       # Don't try to cache this until we figure out injecting E2E token to existing next build
       # - name: Next build cache
       #   id: next-build-cache
@@ -317,11 +308,13 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-key
+          path: api/
 
       - name: Download e2e token
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-e2e-token
+          path: api/
 
       - name: Build a prod version of the frontend (if not cached)
         #always build for now until we can sort out getting e2e key
@@ -390,16 +383,27 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-key
+          path: api/
 
       - name: Download shared e2e token
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-e2e-token
+          path: api/
 
       - name: Download next build
         uses: actions/download-artifact@v5
         with:
           name: next-build
+          path: frontend/.next/standalone
+
+      - name: ls frontend
+        run: |
+          ls -la frontend
+          echo *****
+          ls -la frontend/.next
+          echo *****
+          ls -la frontend/.next/standalone
 
       - name: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -207,9 +207,9 @@ jobs:
       - name: Load cached Docker image
         run: |
           docker load < /tmp/docker-image.tar
-          KEY=(docker image ls -q simpler-grants-gov-api)
-          echo $KEY
-          docker tag simpler-grants-gov-api:$KEY api-grants-api:latest || true
+          IMAGE_ID=$(docker image ls -q simpler-grants-gov-api)
+          echo $IMAGE_ID
+          docker tag $IMAGE_ID api-grants-api:latest || true
 
       - name: Docker images before Start API
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -98,11 +98,11 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - run: npm ci
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: steps.npm-cache.outputs.cache-hit != 'true'
       - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: npx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
 
   restore-or-build-api:
     name: Restore or build API

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -136,6 +136,8 @@ jobs:
     needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
       - name: Cache API/FE shared secret
         id: cache-api-fe-shared-secret
         uses: actions/cache/restore@v5

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -160,7 +160,7 @@ jobs:
           ls -a
 
       - name: Save shared key
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-fe-shared-key
           path: |
@@ -278,7 +278,7 @@ jobs:
         shell: bash
 
       - name: Save shared e2e token
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: api-fe-shared-e2e-token
           path: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -208,7 +208,6 @@ jobs:
         get-api-commit-hash,
         get-frontend-commit-hash,
         build-api-when-not-cached,
-        build-frontend-when-not-cached,
         playwright-cache,
       ]
     runs-on: ubuntu-22.04
@@ -288,7 +287,7 @@ jobs:
       [
         get-api-commit-hash,
         get-frontend-commit-hash,
-        build-api-when-not-cached,
+        setup-e2e-tests-local,
         init-ci-cd,
       ]
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -94,7 +94,7 @@ jobs:
         id: npm-cache
         with:
           path: |
-            node_modules
+            frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - id: id-install-npm-packages

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -154,6 +154,25 @@ jobs:
         run: |
           docker image ls
 
+      - name: Download API docker image
+        uses: actions/download-artifact@v8
+        with:
+          name: api-docker-image.tar.gz
+          path: /tmp
+
+      - name: Expand API Docker image
+        run: |
+          tar -xzf /tmp/api-docker-image.tar.gz /tmp
+          ls /tmp
+
+      - name: Load API Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+
+      - name: Docker images
+        run: |
+          docker image ls
+
       - name: Init API Server for e2e tests
         run: |
           cd ../api
@@ -200,7 +219,7 @@ jobs:
         run: |
           exit 1
 
-      - name: Load cached Docker image
+      - name: Load cached Docker image (alias it if needed)
         run: |
           docker load < /tmp/docker-image.tar
           # alias the live docker container name simpler-grants-gov-api to the locally build name api-grants-api so that we don't rebuild it in later steps.
@@ -223,11 +242,11 @@ jobs:
 
           make build
 
-      - name: Save Docker image
+      - name: Save Docker image to file
         if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         run: |
-          cd ..
           docker save api-grants-api > /tmp/docker-image.tar
+          tar -czf /tmp/api-docker-image.tar.gz /tmp/docker-image.tar
 
       - name: Cache Docker image
         if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
@@ -235,6 +254,15 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: error
+          include-hidden-files: true
+          archive: false
+          path: |
+            /tmp/api-docker-image.tar.gz
 
   setup-e2e-tests-local:
     name: Setup Local E2E Tests
@@ -266,6 +294,29 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: api-fe-shared-key
+
+      - name: Docker images
+        run: |
+          docker image ls
+
+      - name: Download API docker image
+        uses: actions/download-artifact@v8
+        with:
+          name: api-docker-image.tar.gz
+          path: /tmp
+
+      - name: Expand API Docker image
+        run: |
+          tar -xzf /tmp/api-docker-image.tar.gz /tmp
+          ls /tmp
+
+      - name: Load API Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+
+      - name: Docker images
+        run: |
+          docker image ls
 
       - name: Start API Server for e2e tests
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -335,6 +335,9 @@ jobs:
           # Use the 127.0.0.1 url for tests (IPv4 only)
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
           npm run build
+          ls -al .
+          ls -al dist
+          ls -al .next
 
       - name: Save next build
         uses: actions/upload-artifact@v5

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -335,6 +335,7 @@ jobs:
         #always build for now until we can sort out getting e2e key
         # if: steps.next-build-cache.outputs.cache-matched-key == ''
         run: |
+          chmod +x node_modules/.bin/*
           {
             cat .env.development
             sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -132,7 +132,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
   init-ci-cd:
-    name: Iniialize for CI/CD runs
+    name: Initialize for CI/CD runs
     needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -46,6 +46,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  get-api-commit-hash:
+    name: Get commit hash
+    runs-on: ubuntu-22.04
+    outputs:
+      commit_hash: ${{ steps.get-api-commit-hash.outputs.commit_hash }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1000
+      - name: Get commit hash
+        id: get-api-commit-hash
+        run: |
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{inputs.ref}} api)
+          COMMIT_HASH=$(git rev-parse ${{ inputs.ref }})
+          echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
+          echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
+
   e2e-tests-local:
     name: Run Local E2E Tests
     runs-on: ubuntu-22.04
@@ -67,6 +85,23 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
+      - name: Check Docker image cached
+        id: check-docker-image-cached
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/docker-image.tar
+          lookup-only: true
+          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          restore-keys: api-docker-img- # get any recent API container from cache if we can't find our specific one
+
+      - name: Load cached Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+
+      - name: Docker images before Start API
+        run: |
+          docker image ls
+
       - name: Start API Server for e2e tests
         run: |
           cd ../api
@@ -84,6 +119,10 @@ jobs:
           chmod +x ../api/bin/wait-for-api.sh
           ../api/bin/wait-for-api.sh
         shell: bash
+
+      - name: Docker images after Start API
+        run: |
+          docker image ls
 
       - name: Install dependencies and Playwright
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -142,6 +142,18 @@ jobs:
           path: |
             frontend/node_modules.tar.gz
 
+  pre-pull-images:
+    name: Pre-pull images we'll need for Docker compose
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Init API Server for e2e tests
+        run: |
+          cd ../api
+          docker compose pull -q
+
   init-ci-cd:
     name: Initialize for CI/CD runs
     needs: [get-api-commit-hash]
@@ -243,6 +255,7 @@ jobs:
       - name: Load cached Docker image
         run: |
           docker load < /tmp/docker-image.tar
+          docker tag simpler-grants-gov-api api-grants-api || true
 
       - name: Docker images before Start API
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -80,7 +80,8 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           lookup-only: true
-          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Build API Server for e2e tests (if not cached)
         if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
@@ -104,7 +105,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: /tmp/docker-image.tar
-          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
   e2e-tests-local:
     name: Run Local E2E Tests
@@ -134,7 +135,8 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           fail-on-cache-miss: true
-          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       # if we successfully pulled a cached image, then import it into docker, otherwise we can skip this step as it won't work
       # if we cache miss, we'll build the docker image in the make commands below

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -105,7 +105,7 @@ jobs:
         run: |
           docker image ls
 
-      - name: Start API Server for e2e tests
+      - name: Init API Server for e2e tests
         run: |
           cd ../api
           # Enable core dumps for debugging segfaults
@@ -113,7 +113,27 @@ jobs:
           mkdir -p /tmp/cores
           echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
           # Run init first to generate JWT keys in override.env
-          make init
+
+          make init-nobuild
+      - name: Build API Server for e2e tests (if not cached)
+        if: steps.restore-docker-image-cached.outputs.cache-hit == 'false'
+        run: |
+          cd ../api
+          # Enable core dumps for debugging segfaults
+          ulimit -c unlimited
+          mkdir -p /tmp/cores
+          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
+
+          make build
+
+      - name: Start API Server for e2e tests
+        run: |
+          cd ../api
+          # Enable core dumps for debugging segfaults
+          ulimit -c unlimited
+          mkdir -p /tmp/cores
+          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
+
           # Now run the seeding and populate commands
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
           make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -56,16 +56,14 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 1000
-        env:
-          clean_ref: ${{ github.head_ref || github.ref }}
       - name: Get commit hash
         id: get-api-commit-hash
+        env:
+          CLEAN_REF: ${{ github.head_ref || github.ref }}
         run: |
           cd ..
-          pwd
-          git log -n 1 $clean_ref -- api
-          COMMIT_HASH=$(git rev-parse $clean_ref)
-          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 $clean_ref -- api)
+          COMMIT_HASH=$(git rev-parse "$CLEAN_REF")
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 "$CLEAN_REF" -- api)
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -334,8 +334,6 @@ jobs:
         #always build for now until we can sort out getting e2e key
         # if: steps.next-build-cache.outputs.cache-matched-key == ''
         run: |
-          # webkit installs itself outside the cache folder maybe?
-          npx playwright install-deps webkit
           {
             cat .env.development
             sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
@@ -444,6 +442,11 @@ jobs:
       #   if: steps.playwright-cache.outputs.cache-hit != 'true'
       #   run: |
       #     npx playwright install --with-deps
+
+      # webkit installs itself outside the cache folder maybe?
+      - name: Install Webkit dependencies
+        run: |
+          npx playwright install-deps webkit
 
       - name: Determine test groups to run
         shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -195,9 +195,6 @@ jobs:
         run: |
           docker image ls
 
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
       - name: Restore Docker image cached
         id: restore-docker-image-cached
         uses: actions/cache@v5

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -118,7 +118,7 @@ jobs:
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
-      - id: id-install-npm-packages
+      - id: install-npm-packages
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: |
           npm ci
@@ -130,6 +130,13 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
+
+      - name: Save node_modules
+        uses: actions/upload-artifact@v7
+        with:
+          name: node-modules
+          path: |
+            frontend/node_modules
 
   init-ci-cd:
     name: Initialize for CI/CD runs
@@ -249,7 +256,7 @@ jobs:
           make init-ci-cd
 
       - name: Download shared key
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: api-fe-shared-key
 
@@ -305,13 +312,13 @@ jobs:
       #     key: frontend-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
 
       - name: Download shared key
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: api-fe-shared-key
           path: api/
 
       - name: Download e2e token
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: api-fe-shared-e2e-token
           path: api/
@@ -337,19 +344,14 @@ jobs:
           npm run build
 
       - name: Save next build
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: next-build
+          if-no-files-found: error
+          include-hidden-files: true
           path: |
-            frontend/.next
-            frontend/public
-
-      - name: Save node_modules
-        uses: actions/upload-artifact@v5
-        with:
-          name: node-modules
-          path: |
-            frontend/node_modules
+            frontend/.next/
+            frontend/public/
 
   run-e2e-tests-local:
     name: Run Local E2E Tests
@@ -397,28 +399,28 @@ jobs:
       #     key: ${{ runner.os }}-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
 
       - name: Download shared key
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: api-fe-shared-key
           path: api/
 
       - name: Download shared e2e token
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: api-fe-shared-e2e-token
           path: api/
 
       - name: Download next build
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: next-build
           path: frontend/
 
       - name: Download node_modules
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: node-modules
-          path: frontend/
+          path: frontend/node_modules
 
       - name: ls frontend
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -142,69 +142,59 @@ jobs:
           path: |
             frontend/node_modules.tar.gz
 
-  init-ci-cd:
+  run-e2e-tests-local:
     name: Initialize for CI/CD runs
-    needs: [get-api-commit-hash, build-api-when-not-cached]
+    needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [1, 2, 3, 4]
+        total_shards: [4]
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Docker images
-        run: |
-          docker image ls
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: ${{ env.PACKAGE_MANAGER }}
+          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
-      - name: Download API docker image
+      # get this from downloading the artifact since we are passing it job to job
+      # - uses: actions/cache@v5
+      #   id: npm-cache
+      #   with:
+      #     path: |
+      #       node_modules
+      #     key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+
+      - uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Download node_modules
         uses: actions/download-artifact@v8
         with:
-          name: api-docker-image.tar.gz
-          path: /tmp
+          name: node_modules.tar.gz
+          path: frontend/
 
-      - name: Expand API Docker image
+      - name: Expand node_modules
         run: |
-          pushd /tmp
-          ls -la .
-          tar -xzf /tmp/api-docker-image.tar.gz
-          ls -la .
-
-      - name: Load API Docker image
-        run: |
-          docker load < /tmp/docker-image.tar
+          tar -xzf node_modules.tar.gz node_modules
+          ls -la node_*
+          rm node_modules.tar.gz
 
       - name: Docker images
         run: |
           docker image ls
 
-      - name: Init API Server for e2e tests
-        run: |
-          cd ../api
-          # Enable core dumps for debugging segfaults
-          ulimit -c unlimited
-          mkdir -p /tmp/cores
-          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
-          # Run init first to generate JWT keys in override.env
-
-          make init-ci-cd
-
-          ls -a
-
-      - name: Docker images
-        run: |
-          docker image ls
-
-      - name: Save shared key
-        uses: actions/upload-artifact@v7
-        with:
-          name: api-fe-shared-key
-          path: |
-            api/override.env
-
-  build-api-when-not-cached:
-    name: Build API when not cached
-    needs: [get-api-commit-hash]
-    runs-on: ubuntu-22.04
-
-    steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -262,21 +252,6 @@ jobs:
           path: |
             /tmp/api-docker-image.tar.gz
 
-  setup-e2e-tests-local:
-    name: Setup Local E2E Tests
-    needs:
-      [
-        get-api-commit-hash,
-        get-frontend-commit-hash,
-        build-api-when-not-cached,
-        playwright-cache,
-      ]
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
       - name: Init API Server for e2e tests
         run: |
           cd ../api
@@ -288,35 +263,7 @@ jobs:
 
           make init-ci-cd
 
-      - name: Download shared key
-        uses: actions/download-artifact@v8
-        with:
-          name: api-fe-shared-key
-
-      - name: Docker images
-        run: |
-          docker image ls
-
-      - name: Download API docker image
-        uses: actions/download-artifact@v8
-        with:
-          name: api-docker-image.tar.gz
-          path: /tmp
-
-      - name: Expand API Docker image
-        run: |
-          pushd /tmp
-          ls -la .
-          tar -xzf /tmp/api-docker-image.tar.gz
-          ls -la .
-
-      - name: Load API Docker image
-        run: |
-          docker load < /tmp/docker-image.tar
-
-      - name: Docker images
-        run: |
-          docker image ls
+          ls -a
 
       - name: Start API Server for e2e tests
         run: |
@@ -328,58 +275,12 @@ jobs:
 
           # Now run the seeding and populate commands
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
-          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
+          make init-ci-cd db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
           cd ../frontend
           # Ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh
           ../api/bin/wait-for-api.sh
         shell: bash
-
-      - name: Save shared e2e token
-        uses: actions/upload-artifact@v7
-        with:
-          name: api-fe-shared-e2e-token
-          path: |
-            api/e2e_token.tmp
-
-      - name: Docker images after Start API
-        run: |
-          docker image ls
-
-  build-frontend-when-not-cached:
-    name: Build frontend when not cached
-    needs:
-      [
-        get-api-commit-hash,
-        get-frontend-commit-hash,
-        setup-e2e-tests-local,
-        init-ci-cd,
-      ]
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      # Don't try to cache this until we figure out injecting E2E token to existing next build
-      # - name: Next build cache
-      #   id: next-build-cache
-      #   uses: actions/cache/restore@v5
-      #   with:
-      #     path: .next/standalone
-      #     key: frontend-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
-
-      - name: Download shared key
-        uses: actions/download-artifact@v8
-        with:
-          name: api-fe-shared-key
-          path: api/
-
-      - name: Download e2e token
-        uses: actions/download-artifact@v8
-        with:
-          name: api-fe-shared-e2e-token
-          path: api/
 
       - uses: actions/cache@v5
         id: npm-cache
@@ -388,9 +289,7 @@ jobs:
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
-      - name: Build a prod version of the frontend (if not cached)
-        #always build for now until we can sort out getting e2e key
-        # if: steps.next-build-cache.outputs.cache-matched-key == ''
+      - name: Build a prod version of the frontend
         run: |
           {
             cat .env.development
@@ -400,91 +299,6 @@ jobs:
           # Use the 127.0.0.1 url for tests (IPv4 only)
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
           npm run build
-
-      - name: Save next build
-        uses: actions/upload-artifact@v7
-        with:
-          name: next-build
-          if-no-files-found: error
-          include-hidden-files: true
-          path: |
-            frontend/.next/
-            frontend/public/
-
-  run-e2e-tests-local:
-    name: Run Local E2E Tests
-    needs: [setup-e2e-tests-local, build-frontend-when-not-cached]
-    runs-on: ubuntu-22.04
-
-    strategy:
-      fail-fast: true
-      matrix:
-        shard: [1, 2, 3, 4]
-        total_shards: [4]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: ${{ env.PACKAGE_MANAGER }}
-          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
-
-      # get this from downloading the artifact since we are passing it job to job
-      # - uses: actions/cache@v5
-      #   id: npm-cache
-      #   with:
-      #     path: |
-      #       node_modules
-      #     key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
-
-      - uses: actions/cache@v5
-        id: playwright-cache
-        with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-
-      # Don't try to cache this until we figure out injecting E2E token to existing next build
-      # - uses: actions/cache@v5
-      #   id: next-build-cache
-      #   with:
-      #     path: |
-      #       frontend/dist
-      #     key: ${{ runner.os }}-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
-
-      - name: Download shared key
-        uses: actions/download-artifact@v8
-        with:
-          name: api-fe-shared-key
-          path: api/
-
-      - name: Download shared e2e token
-        uses: actions/download-artifact@v8
-        with:
-          name: api-fe-shared-e2e-token
-          path: api/
-
-      - name: Download next build
-        uses: actions/download-artifact@v8
-        with:
-          name: next-build
-          path: frontend/
-
-      - name: Download node_modules
-        uses: actions/download-artifact@v8
-        with:
-          name: node_modules.tar.gz
-          path: frontend/
-
-      - name: Expand node_modules
-        run: |
-          tar -xzf node_modules.tar.gz node_modules
-          ls -la node_*
-          rm node_modules.tar.gz
 
       - name: ls frontend
         run: |
@@ -496,6 +310,7 @@ jobs:
           ls -la ./.next/standalone
           echo ========
           ls -la ./node_modules/.bin
+
       # we shouldn't ever need to do this
       # - name: npm ci
       #   if: steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -142,7 +142,9 @@ jobs:
         id: cache-api-fe-shared-secret
         uses: actions/cache@v5
         with:
-          path: api/override.env
+          path: |
+            api/override.env
+            api/e2e_token.tmp
           key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Init API Server for e2e tests
@@ -217,7 +219,9 @@ jobs:
         id: cache-api-fe-shared-secret
         uses: actions/cache/restore@v5
         with:
-          path: api/override.env
+          path: |
+            api/override.env
+            api/e2e_token.tmp
           key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Next build cache

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -241,7 +241,6 @@ jobs:
           make build
 
       - name: Save Docker image to file
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         run: |
           docker save api-grants-api > /tmp/docker-image.tar
           tar -czf /tmp/api-docker-image.tar.gz /tmp/docker-image.tar
@@ -253,7 +252,7 @@ jobs:
           path: /tmp/docker-image.tar
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
-      - name: Upload Docker image artifact
+      - name: Upload API Docker image artifact
         uses: actions/upload-artifact@v7
         with:
           if-no-files-found: error

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -334,6 +334,8 @@ jobs:
         #always build for now until we can sort out getting e2e key
         # if: steps.next-build-cache.outputs.cache-matched-key == ''
         run: |
+          # webkit installs itself outside the cache folder maybe?
+          npx playwright install-deps webkit
           {
             cat .env.development
             sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
@@ -431,15 +433,17 @@ jobs:
           echo *****
           ls -la ./.next/standalone
 
-      - name: npm ci
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          npm ci
+      # we shouldn't ever need to do this
+      # - name: npm ci
+      #   if: steps.npm-cache.outputs.cache-hit != 'true'
+      #   run: |
+      #     npm ci
 
-      - name: Install dependencies and Playwright
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          npx playwright install --with-deps
+      # we shouldn't ever need to do this
+      # - name: Install dependencies and Playwright
+      #   if: steps.playwright-cache.outputs.cache-hit != 'true'
+      #   run: |
+      #     npx playwright install --with-deps
 
       - name: Determine test groups to run
         shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -131,13 +131,16 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
+      - run: tar -cvf node_modules.tar node_modules
+
       - name: Save node_modules
         uses: actions/upload-artifact@v7
         with:
           include-hidden-files: true
-          name: node-modules
+          archive: false
+          name: node-modules-tar
           path: |
-            frontend/node_modules
+            frontend/node_modules.tar
 
   init-ci-cd:
     name: Initialize for CI/CD runs
@@ -420,19 +423,25 @@ jobs:
       - name: Download node_modules
         uses: actions/download-artifact@v8
         with:
-          name: node-modules
-          path: frontend/node_modules
+          name: node-modules-tar
+          path: frontend/node_modules.tar
+
+      - name: Expand node_modules
+        run: |
+          tar -cvf node_modules.tar node_modules
+          ls -la node_*
+          rm node_modules.tar
 
       - name: ls frontend
         run: |
-          chmod +x node_modules/.bin/*
           pwd
           ls -la .
-          echo *****
+          echo ====
           ls -la ./.next
-          echo *****
+          echo ======
           ls -la ./.next/standalone
-
+          echo ========
+          ls -la ./node_modules/.bin
       # we shouldn't ever need to do this
       # - name: npm ci
       #   if: steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -56,14 +56,16 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 1000
+        env:
+          clean_ref: ${{ github.head_ref || github.ref }}
       - name: Get commit hash
         id: get-api-commit-hash
         run: |
           cd ..
           pwd
-          git log -n 1 ${{ github.head_ref || github.ref }} -- api
-          COMMIT_HASH=$(git rev-parse ${{ github.head_ref || github.ref }})
-          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 ${{ github.head_ref || github.ref }} -- api)
+          git log -n 1 $clean_ref -- api
+          COMMIT_HASH=$(git rev-parse $clean_ref)
+          APP_COMMIT_HASH=$(git log --pretty=format:'%H' -n 1 $clean_ref -- api)
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -200,6 +200,7 @@ jobs:
         run: |
           ls -la .
           ls -la ./node_modules
+          mkdir -p ./node_modules
           tar -xzf /tmp/node_modules.tar.gz -C ./node_modules
           ls -la .
           ls -la ./node_modules
@@ -225,6 +226,7 @@ jobs:
         run: |
           ls -la ~
           cd ~
+          mkdir -p .cache/ms-playwright
           tar -xzf /tmp/playwright.tar.gz -C ~/.cache/ms-playwright
           ls -la ~
           ls -la ~/.cache/ms-playwright

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -214,12 +214,8 @@ jobs:
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
           restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
-      - name: Failed to load cache, exit
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
-        run: |
-          exit 1
-
       - name: Load cached Docker image (alias it if needed)
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key != ''
         run: |
           docker load < /tmp/docker-image.tar
           # alias the live docker container name simpler-grants-gov-api to the locally build name api-grants-api so that we don't rebuild it in later steps.

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -443,11 +443,6 @@ jobs:
       #   run: |
       #     npx playwright install --with-deps
 
-      # webkit installs itself outside the cache folder maybe?
-      - name: Install Webkit dependencies
-        run: |
-          npx playwright install-deps webkit
-
       - name: Determine test groups to run
         shell: bash
         run: |
@@ -472,6 +467,7 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
+          force-webkit-install: true
 
   create-report:
     name: Create Merged Test Report

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -129,9 +129,8 @@ jobs:
           restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Build API Server for e2e tests (if not cached)
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key != ''
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         run: |
-          echo **${{ steps.restore-docker-image-cached.outputs.cache-matched-key }}**${{ steps.restore-docker-image-cached.outputs.cache-hit }}**
           cd ../api
           # Enable core dumps for debugging segfaults
           ulimit -c unlimited

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -134,6 +134,7 @@ jobs:
       - name: Save node_modules
         uses: actions/upload-artifact@v7
         with:
+          include-hidden-files: true
           name: node-modules
           path: |
             frontend/node_modules

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -200,7 +200,7 @@ jobs:
 
       - name: Restore Docker image cached
         id: restore-docker-image-cached
-        uses: actions/cache/restore@v5
+        uses: actions/cache@v5
         with:
           path: /tmp/docker-image.tar
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
@@ -233,24 +233,6 @@ jobs:
       - name: Save Docker image to file
         run: |
           docker save api-grants-api > /tmp/docker-image.tar
-          cd /tmp
-          tar -czf api-docker-image.tar.gz docker-image.tar
-
-      - name: Cache Docker image
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/docker-image.tar
-          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-
-      - name: Upload API Docker image artifact
-        uses: actions/upload-artifact@v7
-        with:
-          if-no-files-found: error
-          include-hidden-files: true
-          archive: false
-          path: |
-            /tmp/api-docker-image.tar.gz
 
       - name: Init API Server for e2e tests
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -316,6 +316,13 @@ jobs:
           name: api-fe-shared-e2e-token
           path: api/
 
+      - uses: actions/cache@v5
+        id: npm-cache
+        with:
+          path: |
+            frontend/node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+
       - name: Build a prod version of the frontend (if not cached)
         #always build for now until we can sort out getting e2e key
         # if: steps.next-build-cache.outputs.cache-matched-key == ''

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -193,7 +193,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: node_modules.tar.gz
-          path: /tmp/node_modules.tar.gz
+          path: /tmp
 
       - name: Expand node_modules
         if: steps.npm-cache.outputs.cache-hit != 'true'
@@ -218,7 +218,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: playwright.tar.gz
-          path: /tmp/playwright.tar.gz
+          path: /tmp
 
       - name: Expand Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -143,8 +143,8 @@ jobs:
             frontend/node_modules.tar.gz
 
   run-e2e-tests-local:
-    name: Initialize for CI/CD runs
-    needs: [get-api-commit-hash]
+    name: Prepare infra and run E2E tests
+    needs: [get-api-commit-hash, get-frontend-commit-hash, playwright-cache]
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -335,7 +335,6 @@ jobs:
         #always build for now until we can sort out getting e2e key
         # if: steps.next-build-cache.outputs.cache-matched-key == ''
         run: |
-          chmod +x node_modules/.bin/*
           {
             cat .env.development
             sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
@@ -426,6 +425,7 @@ jobs:
 
       - name: ls frontend
         run: |
+          chmod +x node_modules/.bin/*
           pwd
           ls -la .
           echo *****

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -145,6 +145,18 @@ jobs:
           archive: false
           path: /tmp/node_modules.tar.gz
 
+      - name: Package Playwright artifact
+        run: |
+          cd ~/.cache/ms-playwright
+          tar -czf /tmp/playwright.tar.gz .
+          ls /tmp
+
+      - name: Upload Playwright artifact
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          path: /tmp/playwright.tar.gz
+
   run-e2e-tests-local:
     name: Prepare infra and run E2E tests
     needs: [get-api-commit-hash, get-frontend-commit-hash, playwright-cache]
@@ -183,22 +195,38 @@ jobs:
           name: node_modules.tar.gz
           path: /tmp/node_modules.tar.gz
 
-      - name: Expand API Docker image
+      - name: Expand node_modules
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: |
           ls -la .
           ls -la ./node_modules
-          tar -xzf /tmp/api-docker-image.tar.gz ./node_modules
+          tar -xzf /tmp/node_modules.tar.gz ./node_modules
           ls -la .
           ls -la ./node_modules
 
       - uses: actions/cache@v5
         id: playwright-cache
         with:
-          fail-on-cache-miss: true
+          # don't fail for now as we're backing this up with an artifact download
+          # fail-on-cache-miss: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Download Playwright artifact
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: playwright.tar.gz
+          path: /tmp/playwright.tar.gz
+
+      - name: Expand Playwright
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          ls -la ~
+          tar -xzf /tmp/playwright.tar.gz ~/.cache/ms-playwright
+          ls -la ~
+          ls -la ~/.cache/ms-playwright
 
       - name: Docker images
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -156,7 +156,7 @@ jobs:
 
   init-ci-cd:
     name: Initialize for CI/CD runs
-    needs: [get-api-commit-hash, build-api-when-not-cached]
+    needs: [get-api-commit-hash, pre-pull-images, build-api-when-not-cached]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -196,9 +196,24 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
-          lookup-only: true
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
           restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
+      - name: Failed to load cache, exit
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
+        run: |
+          exit 1
+
+      - name: Load cached Docker image
+        run: |
+          docker load < /tmp/docker-image.tar
+          KEY=(docker image ls -q simpler-grants-gov-api)
+          echo $KEY
+          docker tag simpler-grants-gov-api:$KEY api-grants-api:latest || true
+
+      - name: Docker images before Start API
+        run: |
+          docker image ls
 
       - name: Build API Server for e2e tests (if not cached)
         if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
@@ -238,28 +253,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Restore Docker image cached
-        id: restore-docker-image-cached
-        uses: actions/cache/restore@v5
-        with:
-          path: /tmp/docker-image.tar
-          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-          restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-
-      - name: Failed to load cache, exit
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
-        run: |
-          exit 1
-
-      - name: Load cached Docker image
-        run: |
-          docker load < /tmp/docker-image.tar
-          docker tag simpler-grants-gov-api:${{ needs.get-api-commit-hash.outputs.commit_hash }} api-grants-api:latest || true
-
-      - name: Docker images before Start API
-        run: |
-          docker image ls
 
       - name: Init API Server for e2e tests
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -156,7 +156,7 @@ jobs:
 
   init-ci-cd:
     name: Initialize for CI/CD runs
-    needs: [get-api-commit-hash]
+    needs: [get-api-commit-hash, build-api-when-not-cached]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -184,7 +184,7 @@ jobs:
 
   build-api-when-not-cached:
     name: Build API when not cached
-    needs: [get-api-commit-hash, init-ci-cd]
+    needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
 
     steps:
@@ -255,7 +255,7 @@ jobs:
       - name: Load cached Docker image
         run: |
           docker load < /tmp/docker-image.tar
-          docker tag simpler-grants-gov-api api-grants-api || true
+          docker tag simpler-grants-gov-api:${{ needs.get-api-commit-hash.outputs.commit_hash }} api-grants-api:latest || true
 
       - name: Docker images before Start API
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -201,59 +201,6 @@ jobs:
           path: /tmp/docker-image.tar
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
-  build-frontend-when-not-cached:
-    name: Build frontend when not cached
-    needs:
-      [
-        get-api-commit-hash,
-        get-frontend-commit-hash,
-        build-api-when-not-cached,
-        init-ci-cd,
-      ]
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Cache API/FE shared secret
-        id: cache-api-fe-shared-secret
-        uses: actions/cache/restore@v5
-        with:
-          path: |
-            api/override.env
-            api/e2e_token.tmp
-          key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-
-      - name: Next build cache
-        id: next-build-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: frontend/dist
-          key: frontend-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
-
-      - name: Download shared key
-        uses: actions/download-artifact@v5
-        with:
-          name: api-fe-shared-key
-
-      - name: Download e2e token
-        uses: actions/download-artifact@v5
-        with:
-          name: api-fe-shared-e2e-token
-
-      - name: Build a prod version of the frontend (if not cached)
-        if: steps.next-build-cache.outputs.cache-matched-key == ''
-        run: |
-          {
-            cat .env.development
-            sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
-            cat ../api/e2e_token.tmp
-          } >> .env.local
-          # Use the 127.0.0.1 url for tests (IPv4 only)
-          sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
-          npm run build
-
   setup-e2e-tests-local:
     name: Setup Local E2E Tests
     needs:
@@ -335,9 +282,70 @@ jobs:
         run: |
           docker image ls
 
+  build-frontend-when-not-cached:
+    name: Build frontend when not cached
+    needs:
+      [
+        get-api-commit-hash,
+        get-frontend-commit-hash,
+        build-api-when-not-cached,
+        init-ci-cd,
+      ]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Cache API/FE shared secret
+        id: cache-api-fe-shared-secret
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            api/override.env
+            api/e2e_token.tmp
+          key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
+      # Don't try to cache this until we figure out injecting E2E token to existing next build
+      # - name: Next build cache
+      #   id: next-build-cache
+      #   uses: actions/cache/restore@v5
+      #   with:
+      #     path: .next/standalone
+      #     key: frontend-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
+
+      - name: Download shared key
+        uses: actions/download-artifact@v5
+        with:
+          name: api-fe-shared-key
+
+      - name: Download e2e token
+        uses: actions/download-artifact@v5
+        with:
+          name: api-fe-shared-e2e-token
+
+      - name: Build a prod version of the frontend (if not cached)
+        #always build for now until we can sort out getting e2e key
+        # if: steps.next-build-cache.outputs.cache-matched-key == ''
+        run: |
+          {
+            cat .env.development
+            sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
+            cat ../api/e2e_token.tmp
+          } >> .env.local
+          # Use the 127.0.0.1 url for tests (IPv4 only)
+          sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
+          npm run build
+
+      - name: Save next build
+        uses: actions/upload-artifact@v5
+        with:
+          name: next-build
+          path: frontend/.next
+
   run-e2e-tests-local:
     name: Run Local E2E Tests
-    needs: [setup-e2e-tests-local]
+    needs: [setup-e2e-tests-local, build-frontend-when-not-cached]
     runs-on: ubuntu-22.04
 
     strategy:
@@ -371,12 +379,13 @@ jobs:
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
 
-      - uses: actions/cache@v5
-        id: next-build-cache
-        with:
-          path: |
-            frontend/dist
-          key: ${{ runner.os }}-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
+      # Don't try to cache this until we figure out injecting E2E token to existing next build
+      # - uses: actions/cache@v5
+      #   id: next-build-cache
+      #   with:
+      #     path: |
+      #       frontend/dist
+      #     key: ${{ runner.os }}-next-build-${{ needs.get-frontend-commit-hash.outputs.commit_hash }}
 
       - name: Download shared key
         uses: actions/download-artifact@v5
@@ -387,6 +396,11 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: api-fe-shared-e2e-token
+
+      - name: Download next build
+        uses: actions/download-artifact@v5
+        with:
+          name: next-build
 
       - name: npm ci
         if: steps.npm-cache.outputs.cache-hit != 'true'
@@ -426,7 +440,7 @@ jobs:
   create-report:
     name: Create Merged Test Report
     if: ${{ !cancelled() }}
-    needs: e2e-tests-local
+    needs: run-e2e-tests-local
     uses: ./.github/workflows/e2e-create-report.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -65,9 +65,47 @@ jobs:
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 
+  restore-or-build-api:
+    name: Restore or build API
+    needs: [get-api-commit-hash]
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Restore Docker image cached
+        id: restore-docker-image-cached
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-image.tar
+          lookup-only: true
+          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
+      - name: Build API Server for e2e tests (if not cached)
+        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        run: |
+          cd ../api
+          # Enable core dumps for debugging segfaults
+          ulimit -c unlimited
+          mkdir -p /tmp/cores
+          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
+
+          make build
+
+      - name: Save Docker image
+        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        run: |
+          cd ..
+          docker save api-grants-api > /tmp/docker-image.tar
+
+      - name: Cache Docker image
+        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/docker-image.tar
+          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
   e2e-tests-local:
     name: Run Local E2E Tests
-    needs: [get-api-commit-hash]
+    needs: [get-api-commit-hash, restore-or-build-api]
     runs-on: ubuntu-22.04
 
     strategy:
@@ -92,12 +130,12 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
+          fail-on-cache-miss: true
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       # if we successfully pulled a cached image, then import it into docker, otherwise we can skip this step as it won't work
       # if we cache miss, we'll build the docker image in the make commands below
       - name: Load cached Docker image
-        if: steps.restore-docker-image-cached.outputs.cache-hit == 'true'
         run: |
           docker load < /tmp/docker-image.tar
 
@@ -115,16 +153,6 @@ jobs:
           # Run init first to generate JWT keys in override.env
 
           make init-nobuild
-      - name: Build API Server for e2e tests (if not cached)
-        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
-        run: |
-          cd ../api
-          # Enable core dumps for debugging segfaults
-          ulimit -c unlimited
-          mkdir -p /tmp/cores
-          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
-
-          make build
 
       - name: Start API Server for e2e tests
         run: |
@@ -187,19 +215,6 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
-
-      - name: Save Docker image
-        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
-        run: |
-          cd ..
-          docker save api-grants-api > /tmp/docker-image.tar
-
-      - name: Cache Docker image
-        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/docker-image.tar
-          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
   create-report:
     name: Create Merged Test Report

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -156,7 +156,7 @@ jobs:
 
   build-api-when-not-cached:
     name: Build API when not cached
-    needs: [get-api-commit-hash]
+    needs: [get-api-commit-hash, init-api-fe-shared-secret]
     runs-on: ubuntu-22.04
 
     steps:
@@ -199,7 +199,12 @@ jobs:
   build-frontend-when-not-cached:
     name: Build frontend when not cached
     needs:
-      [get-api-commit-hash, get-frontend-commit-hash, build-api-when-not-cached]
+      [
+        get-api-commit-hash,
+        get-frontend-commit-hash,
+        build-api-when-not-cached,
+        init-api-fe-shared-secret,
+      ]
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -67,6 +67,37 @@ jobs:
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 
+  playwright-cache:
+    # based on this https://justin.poehnelt.com/posts/caching-playwright-in-github-actions/
+    name: Playwright caching
+    needs: [get-api-commit-hash]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: ${{ env.PACKAGE_MANAGER }}
+          cache-dependency-path: ${{ env.LOCKFILE_PATH }}
+
+      - uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            node_modules
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - run: npm ci
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - run: npx playwright install-deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+
   restore-or-build-api:
     name: Restore or build API
     needs: [get-api-commit-hash]
@@ -111,7 +142,7 @@ jobs:
 
   e2e-tests-local:
     name: Run Local E2E Tests
-    needs: [get-api-commit-hash, restore-or-build-api]
+    needs: [get-api-commit-hash, restore-or-build-api, playwright-cache]
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -467,7 +467,7 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
-          force-webkit-install: true
+          force-webkit-install: "true"
 
   create-report:
     name: Create Merged Test Report

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Cache API/FE shared secret
         id: cache-api-fe-shared-secret
-        uses: actions/cache/restore@v5
+        uses: actions/cache@v5
         with:
           path: api/override.env
           key: api-fe-shared-secret-${{ needs.get-api-commit-hash.outputs.commit_hash }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -107,6 +107,7 @@ jobs:
       - uses: actions/cache@v5
         id: playwright-cache
         with:
+          lookup-only: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
@@ -114,6 +115,7 @@ jobs:
       - uses: actions/cache@v5
         id: npm-cache
         with:
+          lookup-only: true
           path: |
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -156,6 +158,7 @@ jobs:
       - uses: actions/cache@v5
         id: npm-cache
         with:
+          fail-on-cache-miss: true
           path: |
             node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -163,6 +166,7 @@ jobs:
       - uses: actions/cache@v5
         id: playwright-cache
         with:
+          fail-on-cache-miss: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
@@ -239,6 +243,18 @@ jobs:
           ../api/bin/wait-for-api.sh
         shell: bash
 
+      # we shouldn't ever need to do this
+      # - name: npm ci
+      #   if: steps.npm-cache.outputs.cache-hit != 'true'
+      #   run: |
+      #     npm ci
+
+      # we shouldn't ever need to do this
+      # - name: Install dependencies and Playwright
+      #   if: steps.playwright-cache.outputs.cache-hit != 'true'
+      #   run: |
+      #     npx playwright install --with-deps
+
       - name: Build a prod version of the frontend
         run: |
           {
@@ -260,18 +276,6 @@ jobs:
           ls -la ./.next/standalone
           echo ========
           ls -la ./node_modules/.bin
-
-      # we shouldn't ever need to do this
-      # - name: npm ci
-      #   if: steps.npm-cache.outputs.cache-hit != 'true'
-      #   run: |
-      #     npm ci
-
-      # we shouldn't ever need to do this
-      # - name: Install dependencies and Playwright
-      #   if: steps.playwright-cache.outputs.cache-hit != 'true'
-      #   run: |
-      #     npx playwright install --with-deps
 
       - name: Docker images
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -162,8 +162,10 @@ jobs:
 
       - name: Expand API Docker image
         run: |
-          tar -xzf /tmp/api-docker-image.tar.gz /tmp
-          ls /tmp
+          pushd /tmp
+          ls -la .
+          tar -xzf /tmp/api-docker-image.tar.gz
+          ls -la .
 
       - name: Load API Docker image
         run: |
@@ -303,8 +305,10 @@ jobs:
 
       - name: Expand API Docker image
         run: |
-          tar -xzf /tmp/api-docker-image.tar.gz /tmp
-          ls /tmp
+          pushd /tmp
+          ls -la .
+          tar -xzf /tmp/api-docker-image.tar.gz
+          ls -la .
 
       - name: Load API Docker image
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -134,12 +134,14 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
-          fail-on-cache-miss: true
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
           restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
-      # if we successfully pulled a cached image, then import it into docker, otherwise we can skip this step as it won't work
-      # if we cache miss, we'll build the docker image in the make commands below
+      - name: Failed to load cache, exit
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
+        run: |
+          exit 1
+
       - name: Load cached Docker image
         run: |
           docker load < /tmp/docker-image.tar

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -133,6 +133,18 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
+      - name: Expand API Docker image
+        run: |
+          cd node_modules
+          tar -czf /tmp/node_modules.tar.gz .
+          ls /tmp
+
+      - name: Upload node_modules artifact
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          path: /tmp/node_modules.tar.gz
+
   run-e2e-tests-local:
     name: Prepare infra and run E2E tests
     needs: [get-api-commit-hash, get-frontend-commit-hash, playwright-cache]
@@ -158,10 +170,27 @@ jobs:
       - uses: actions/cache@v5
         id: npm-cache
         with:
-          fail-on-cache-miss: true
+          # don't fail for now as we're backing this up with an artifact download
+          # fail-on-cache-miss: true
           path: |
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Download node_modules artifact
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: node_modules.tar.gz
+          path: /tmp/node_modules.tar.gz
+
+      - name: Expand API Docker image
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: |
+          ls -la .
+          ls -la ./node_modules
+          tar -xzf /tmp/api-docker-image.tar.gz ./node_modules
+          ls -la .
+          ls -la ./node_modules
 
       - uses: actions/cache@v5
         id: playwright-cache

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -97,7 +97,7 @@ jobs:
       # if we successfully pulled a cached image, then import it into docker, otherwise we can skip this step as it won't work
       # if we cache miss, we'll build the docker image in the make commands below
       - name: Load cached Docker image
-        if: steps.restore-docker-image-cached.outputs.cache-hit == true
+        if: steps.restore-docker-image-cached.outputs.cache-hit == 'true'
         run: |
           docker load < /tmp/docker-image.tar
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -200,7 +200,7 @@ jobs:
         run: |
           ls -la .
           ls -la ./node_modules
-          tar -xzf /tmp/node_modules.tar.gz ./node_modules
+          tar -xzf /tmp/node_modules.tar.gz
           ls -la .
           ls -la ./node_modules
 
@@ -224,7 +224,8 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
           ls -la ~
-          tar -xzf /tmp/playwright.tar.gz ~/.cache/ms-playwright
+          cd ~
+          tar -xzf /tmp/playwright.tar.gz
           ls -la ~
           ls -la ~/.cache/ms-playwright
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -186,13 +186,13 @@ jobs:
           make build
 
       - name: Save Docker image
-        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         run: |
           cd ..
           docker save api-grants-api > /tmp/docker-image.tar
 
       - name: Cache Docker image
-        if: steps.restore-docker-image-cached.outputs.cache-hit != 'true'
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         uses: actions/cache/save@v4
         with:
           path: /tmp/docker-image.tar

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -131,17 +131,6 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: tar -czf node_modules.tar.gz node_modules
-
-      - name: Save node_modules
-        uses: actions/upload-artifact@v7
-        with:
-          include-hidden-files: true
-          archive: false
-          name: node-modules-tar-gz
-          path: |
-            frontend/node_modules.tar.gz
-
   run-e2e-tests-local:
     name: Prepare infra and run E2E tests
     needs: [get-api-commit-hash, get-frontend-commit-hash, playwright-cache]
@@ -164,13 +153,12 @@ jobs:
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
 
-      # get this from downloading the artifact since we are passing it job to job
-      # - uses: actions/cache@v5
-      #   id: npm-cache
-      #   with:
-      #     path: |
-      #       node_modules
-      #     key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+      - uses: actions/cache@v5
+        id: npm-cache
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - uses: actions/cache@v5
         id: playwright-cache
@@ -178,18 +166,6 @@ jobs:
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Download node_modules
-        uses: actions/download-artifact@v8
-        with:
-          name: node_modules.tar.gz
-          path: frontend/
-
-      - name: Expand node_modules
-        run: |
-          tar -xzf node_modules.tar.gz node_modules
-          ls -la node_*
-          rm node_modules.tar.gz
 
       - name: Docker images
         run: |
@@ -229,6 +205,7 @@ jobs:
           make build
 
       - name: Save Docker image to file
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         run: |
           docker save api-grants-api > /tmp/docker-image.tar
 
@@ -261,13 +238,6 @@ jobs:
           chmod +x ../api/bin/wait-for-api.sh
           ../api/bin/wait-for-api.sh
         shell: bash
-
-      - uses: actions/cache@v5
-        id: npm-cache
-        with:
-          path: |
-            frontend/node_modules
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - name: Build a prod version of the frontend
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -135,8 +135,7 @@ jobs:
 
       - name: Package node_modules
         run: |
-          cd node_modules
-          tar -czf /tmp/node_modules.tar.gz .
+          tar -czf /tmp/node_modules.tar.gz ./node_modules/
           ls /tmp
 
       - name: Upload node_modules artifact
@@ -200,8 +199,7 @@ jobs:
         run: |
           ls -la .
           ls -la ./node_modules
-          mkdir -p ./node_modules
-          tar -xzf /tmp/node_modules.tar.gz -C ./node_modules
+          tar -xzf /tmp/node_modules.tar.gz
           ls -la .
           ls -la ./node_modules
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -131,16 +131,16 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-      - run: tar -cvf node_modules.tar node_modules
+      - run: tar -cvzf node_modules.tar.gz node_modules
 
       - name: Save node_modules
         uses: actions/upload-artifact@v7
         with:
           include-hidden-files: true
           archive: false
-          name: node-modules-tar
+          name: node-modules-tar-gz
           path: |
-            frontend/node_modules.tar
+            frontend/node_modules.tar.gz
 
   init-ci-cd:
     name: Initialize for CI/CD runs
@@ -423,12 +423,12 @@ jobs:
       - name: Download node_modules
         uses: actions/download-artifact@v8
         with:
-          name: node-modules-tar
-          path: frontend/node_modules.tar
+          name: node-modules-tar-gz
+          path: frontend/node_modules.tar.gz
 
       - name: Expand node_modules
         run: |
-          tar -cvf node_modules.tar node_modules
+          tar -xvzf node_modules.tar.gz node_modules
           ls -la node_*
           rm node_modules.tar
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -108,8 +108,8 @@ jobs:
       - uses: actions/cache@v5
         id: playwright-cache
         with:
-          # cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job
-          # lookup-only: true
+          # if cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job, by commenting the lookup-only out
+          lookup-only: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
@@ -117,8 +117,8 @@ jobs:
       - uses: actions/cache@v5
         id: npm-cache
         with:
-          # cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job
-          #lookup-only: true
+          # if cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job, by commenting the lookup-only out
+          lookup-only: true
           path: |
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -127,9 +127,6 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: |
           npm ci
-          pwd
-          ls . -l
-          ls node_modules -l
 
       - run: npx playwright install --with-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
@@ -137,29 +134,29 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
-      - name: Package node_modules
-        run: |
-          tar -czf /tmp/node_modules.tar.gz ./node_modules/
-          ls /tmp
+      # - name: Package node_modules
+      #   run: |
+      #     tar -czf /tmp/node_modules.tar.gz ./node_modules/
+      #     ls /tmp
 
-      - name: Upload node_modules artifact
-        uses: actions/upload-artifact@v7
-        with:
-          archive: false
-          path: /tmp/node_modules.tar.gz
+      # - name: Upload node_modules artifact
+      #   uses: actions/upload-artifact@v7
+      #   with:
+      #     archive: false
+      #     path: /tmp/node_modules.tar.gz
 
       # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
-      - name: Package Playwright artifact
-        run: |
-          cd ~/.cache/ms-playwright
-          tar -czf /tmp/playwright.tar.gz .
-          ls /tmp
+      # - name: Package Playwright artifact
+      #   run: |
+      #     cd ~/.cache/ms-playwright
+      #     tar -czf /tmp/playwright.tar.gz .
+      #     ls /tmp
 
-      - name: Upload Playwright artifact
-        uses: actions/upload-artifact@v7
-        with:
-          archive: false
-          path: /tmp/playwright.tar.gz
+      # - name: Upload Playwright artifact
+      #   uses: actions/upload-artifact@v7
+      #   with:
+      #     archive: false
+      #     path: /tmp/playwright.tar.gz
 
   build-api-if-not-cached:
     name: Build API if not cached
@@ -170,7 +167,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Restore Docker image cached
+      - name: Restore API Docker image cached
         id: restore-docker-image-cached
         uses: actions/cache/restore@v5
         with:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -109,7 +109,7 @@ jobs:
         id: playwright-cache
         with:
           # if cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job, by commenting the lookup-only out
-          lookup-only: true
+          # lookup-only: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
@@ -118,7 +118,7 @@ jobs:
         id: npm-cache
         with:
           # if cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job, by commenting the lookup-only out
-          lookup-only: true
+          # lookup-only: true
           path: |
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
@@ -134,29 +134,29 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
-      # - name: Package node_modules
-      #   run: |
-      #     tar -czf /tmp/node_modules.tar.gz ./node_modules/
-      #     ls /tmp
+      - name: Package node_modules
+        run: |
+          tar -czf /tmp/node_modules.tar.gz ./node_modules/
+          ls /tmp
 
-      # - name: Upload node_modules artifact
-      #   uses: actions/upload-artifact@v7
-      #   with:
-      #     archive: false
-      #     path: /tmp/node_modules.tar.gz
+      - name: Upload node_modules artifact
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          path: /tmp/node_modules.tar.gz
 
       # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
-      # - name: Package Playwright artifact
-      #   run: |
-      #     cd ~/.cache/ms-playwright
-      #     tar -czf /tmp/playwright.tar.gz .
-      #     ls /tmp
+      - name: Package Playwright artifact
+        run: |
+          cd ~/.cache/ms-playwright
+          tar -czf /tmp/playwright.tar.gz .
+          ls /tmp
 
-      # - name: Upload Playwright artifact
-      #   uses: actions/upload-artifact@v7
-      #   with:
-      #     archive: false
-      #     path: /tmp/playwright.tar.gz
+      - name: Upload Playwright artifact
+        uses: actions/upload-artifact@v7
+        with:
+          archive: false
+          path: /tmp/playwright.tar.gz
 
   build-api-if-not-cached:
     name: Build API if not cached

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -246,9 +246,8 @@ jobs:
         run: |
           docker load < /tmp/docker-image.tar
           # alias the live docker container name simpler-grants-gov-api to the locally build name api-grants-api so that we don't rebuild it in later steps.
-          IMAGE_ID=$(docker image ls -q simpler-grants-gov-api)
-          echo $IMAGE_ID
-          docker tag $IMAGE_ID api-grants-api:latest || true
+          IMAGE_ID="$(docker image ls -q simpler-grants-gov-api)"
+          docker tag "$IMAGE_ID" api-grants-api:latest || true
 
       - name: Docker images
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -161,9 +161,49 @@ jobs:
           archive: false
           path: /tmp/playwright.tar.gz
 
+  build-api-if-not-cached:
+    name: Build API if not cached
+    needs: [get-api-commit-hash]
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Restore Docker image cached
+        id: restore-docker-image-cached
+        uses: actions/cache/restore@v5
+        with:
+          path: /tmp/docker-image.tar
+          lookup-only: true
+          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          # disable this for now as it seems like we can't actually use the live images, flask not found?
+          #restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
+      - name: Build API Server for e2e tests (if not cached)
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
+        run: |
+          cd ../api
+          # Enable core dumps for debugging segfaults
+          ulimit -c unlimited
+          mkdir -p /tmp/cores
+          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
+
+          make build
+
+      - name: Restore Docker image cached
+        id: save-docker-image-cache
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/docker-image.tar
+          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+
   run-e2e-tests-local:
     name: Prepare infra and run E2E tests
-    needs: [get-api-commit-hash, get-frontend-commit-hash, playwright-cache]
+    needs:
+      [
+        get-api-commit-hash,
+        get-frontend-commit-hash,
+        playwright-cache,
+        build-api-if-not-cached,
+      ]
     runs-on: ubuntu-22.04
 
     strategy:
@@ -231,12 +271,9 @@ jobs:
       - name: Expand Playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: |
-          ls -la ~
           cd ~
           mkdir -p .cache/ms-playwright
           tar -xzf /tmp/playwright.tar.gz -C ~/.cache/ms-playwright
-          ls -la ~
-          ls -la ~/.cache/ms-playwright
 
       - name: Docker images
         run: |
@@ -251,11 +288,18 @@ jobs:
           # disable this for now as it seems like we can't actually use the live images, flask not found?
           #restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
-      - name: Upload API artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: api-docker.tar
-          path: /tmp/docker-image.tar
+      # leaving this for troubleshooting why images don't work in the future (you can't download a cache item)
+      # - name: Upload API artifact
+      #   uses: actions/upload-artifact@v7
+      #   with:
+      #     name: api-docker.tar
+      #     path: /tmp/docker-image.tar
+
+      - name: Fail if cache miss on API
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
+        run: |
+          echo "Failing because we couldn't load the API image from cache"
+          exit 1
 
       - name: Load cached Docker image (alias it if needed)
         if: steps.restore-docker-image-cached.outputs.cache-matched-key != ''
@@ -268,17 +312,6 @@ jobs:
       - name: Docker images
         run: |
           docker image ls
-
-      - name: Build API Server for e2e tests (if not cached)
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
-        run: |
-          cd ../api
-          # Enable core dumps for debugging segfaults
-          ulimit -c unlimited
-          mkdir -p /tmp/cores
-          echo "/tmp/cores/core.%e.%p.%t" | sudo tee /proc/sys/kernel/core_pattern
-
-          make build
 
       - name: Init API Server for e2e tests
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -250,6 +250,12 @@ jobs:
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
           restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
+      - name: Upload API artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: api-docker.tar
+          path: /tmp/docker-image.tar
+
       - name: Load cached Docker image (alias it if needed)
         if: steps.restore-docker-image-cached.outputs.cache-matched-key != ''
         run: |

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -266,7 +266,6 @@ jobs:
 
       - name: Docker images
         run: |
-          echo |${{ steps.restore-docker-image-cached.outputs.cache-matched-key }}|
           docker image ls
 
       - name: Build API Server for e2e tests (if not cached)

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -167,6 +167,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Restore Docker image cached
         id: restore-docker-image-cached
         uses: actions/cache/restore@v5

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -88,8 +88,9 @@ jobs:
           echo "Commit hash: $COMMIT_HASH, App: $APP_COMMIT_HASH"
           echo "commit_hash=$APP_COMMIT_HASH" >> "$GITHUB_OUTPUT"
 
+  # do this in it's own step so that each parallel process in the matrix job below isn't having to download and install stuff
+  # based on this https://justin.poehnelt.com/posts/caching-playwright-in-github-actions/
   playwright-cache:
-    # based on this https://justin.poehnelt.com/posts/caching-playwright-in-github-actions/
     name: Playwright caching
     needs: [get-api-commit-hash]
     runs-on: ubuntu-22.04
@@ -107,6 +108,7 @@ jobs:
       - uses: actions/cache@v5
         id: playwright-cache
         with:
+          # cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job
           # lookup-only: true
           path: |
             ~/.cache/ms-playwright
@@ -115,6 +117,7 @@ jobs:
       - uses: actions/cache@v5
         id: npm-cache
         with:
+          # cache is missing randomly so instead of being able to just trust the cache existing, we have to download here and push it to an artifact for the next job
           #lookup-only: true
           path: |
             frontend/node_modules
@@ -133,6 +136,7 @@ jobs:
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
+      # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
       - name: Package node_modules
         run: |
           tar -czf /tmp/node_modules.tar.gz ./node_modules/
@@ -144,6 +148,7 @@ jobs:
           archive: false
           path: /tmp/node_modules.tar.gz
 
+      # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
       - name: Package Playwright artifact
         run: |
           cd ~/.cache/ms-playwright
@@ -181,12 +186,14 @@ jobs:
       - uses: actions/cache@v5
         id: npm-cache
         with:
-          # don't fail for now as we're backing this up with an artifact download
+          # don't fail for now as we're backing this up with an artifact download since the cache hit is sketchy
           # fail-on-cache-miss: true
           path: |
             frontend/node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
+      # We download because the cache is not reliably hitting even when it exists
+      # We expand the tar.gz manually because this preserves permissions that a regular artifact upload/download does not.
       - name: Download node_modules artifact
         if: steps.npm-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v8
@@ -206,12 +213,14 @@ jobs:
       - uses: actions/cache@v5
         id: playwright-cache
         with:
-          # don't fail for now as we're backing this up with an artifact download
+          # don't fail for now as we're backing this up with an artifact download because the cache hit is sketchy
           # fail-on-cache-miss: true
           path: |
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
 
+      # We download because the cache is not reliably hitting even when it exists
+      # We expand the tar.gz manually because this preserves permissions that a regular artifact upload/download does not.
       - name: Download Playwright artifact
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Restore Docker image cached
         id: restore-docker-image-cached
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
           key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -274,11 +274,6 @@ jobs:
 
           make build
 
-      - name: Save Docker image to file
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
-        run: |
-          docker save api-grants-api > /tmp/docker-image.tar
-
       - name: Init API Server for e2e tests
         run: |
           cd ../api
@@ -346,6 +341,18 @@ jobs:
       - name: Docker images
         run: |
           docker image ls
+
+      - name: Save Docker image to file
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
+        run: |
+          docker save api-grants-api > /tmp/docker-image.tar
+
+      - name: save Docker image cache
+        id: save-docker-image-cache
+        uses: actions/cache/save@v5
+        with:
+          path: /tmp/docker-image.tar
+          key: api-docker-test-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Determine test groups to run
         shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -188,17 +188,17 @@ jobs:
 
           make build
 
-      - name: Save Docker image to file
+      - name: Save API Docker image to file
         if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         run: |
           docker save api-grants-api > /tmp/docker-image.tar
 
-      - name: save Docker image cache
+      - name: Save API Docker image cache
         id: save-docker-image-cache
         uses: actions/cache/save@v5
         with:
           path: /tmp/docker-image.tar
-          key: api-docker-test-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
   run-e2e-tests-local:
     name: Prepare infra and run E2E tests

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -191,12 +191,17 @@ jobs:
 
           make build
 
-      - name: Restore Docker image cached
+      - name: Save Docker image to file
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
+        run: |
+          docker save api-grants-api > /tmp/docker-image.tar
+
+      - name: save Docker image cache
         id: save-docker-image-cache
         uses: actions/cache/save@v5
         with:
           path: /tmp/docker-image.tar
-          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-docker-test-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
   run-e2e-tests-local:
     name: Prepare infra and run E2E tests
@@ -339,7 +344,7 @@ jobs:
 
           # Now run the seeding and populate commands
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
-          make init-ci-cd db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
+          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
           cd ../frontend
           # Ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh
@@ -383,18 +388,6 @@ jobs:
       - name: Docker images
         run: |
           docker image ls
-
-      - name: Save Docker image to file
-        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
-        run: |
-          docker save api-grants-api > /tmp/docker-image.tar
-
-      - name: save Docker image cache
-        id: save-docker-image-cache
-        uses: actions/cache/save@v5
-        with:
-          path: /tmp/docker-image.tar
-          key: api-docker-test-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Determine test groups to run
         shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -248,7 +248,8 @@ jobs:
         with:
           path: /tmp/docker-image.tar
           key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-          restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          # disable this for now as it seems like we can't actually use the live images, flask not found?
+          #restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Upload API artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -247,8 +247,8 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
-          key: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
-          restore-keys: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          key: api-test-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
+          restore-keys: api-docker-img-${{ needs.get-api-commit-hash.outputs.commit_hash }}
 
       - name: Load cached Docker image (alias it if needed)
         if: steps.restore-docker-image-cached.outputs.cache-matched-key != ''

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -194,6 +194,7 @@ jobs:
           docker save api-grants-api > /tmp/docker-image.tar
 
       - name: Save API Docker image cache
+        if: steps.restore-docker-image-cached.outputs.cache-matched-key == ''
         id: save-docker-image-cache
         uses: actions/cache/save@v5
         with:

--- a/.github/workflows/e2e-create-report.yml
+++ b/.github/workflows/e2e-create-report.yml
@@ -45,15 +45,15 @@ jobs:
             ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
 
-      - name: npm ci
-        if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          npm ci
+      # - name: npm ci
+      #   if: steps.npm-cache.outputs.cache-hit != 'true'
+      #   run: |
+      #     npm ci
 
-      - name: Install dependencies and Playwright
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          npx playwright install --with-deps
+      # - name: Install dependencies and Playwright
+      #   if: steps.playwright-cache.outputs.cache-hit != 'true'
+      #   run: |
+      #     npx playwright install --with-deps
 
       - name: Download All Blob Reports
         uses: actions/download-artifact@v7

--- a/.github/workflows/e2e-create-report.yml
+++ b/.github/workflows/e2e-create-report.yml
@@ -35,7 +35,7 @@ jobs:
         id: npm-cache
         with:
           path: |
-            node_modules
+            ./node_modules
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
 
       - uses: actions/cache@v5

--- a/.github/workflows/e2e-create-report.yml
+++ b/.github/workflows/e2e-create-report.yml
@@ -30,10 +30,31 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: ${{ env.PACKAGE_MANAGER }}
           cache-dependency-path: ${{ env.LOCKFILE_PATH }}
-      - name: Install Playwright Dependencies
+
+      - uses: actions/cache@v5
+        id: npm-cache
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+
+      - uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - name: npm ci
+        if: steps.npm-cache.outputs.cache-hit != 'true'
         run: |
           npm ci
+
+      - name: Install dependencies and Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: |
           npx playwright install --with-deps
+
       - name: Download All Blob Reports
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/e2e-create-report.yml
+++ b/.github/workflows/e2e-create-report.yml
@@ -73,7 +73,7 @@ jobs:
           echo "Contents of all-blob-reports after download:"
           ls -R playwright*
       - name: Upload Merged HTML Report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: merged-html-report-${{ inputs.target }}
           path: frontend/playwright-report

--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -342,7 +342,7 @@ jobs:
 
       - name: Upload full Grype JSON
         if: always() # Runs even if there is a failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: anchore-grype-json-${{ inputs.app_name }}-${{ github.run_id }}
           path: anchore-grype-${{ inputs.app_name }}.json

--- a/api/Makefile
+++ b/api/Makefile
@@ -106,9 +106,11 @@ start-debug:
 run-logs: start ## Start the API and follow the logs
 	docker compose logs --follow --no-color $(APP_NAME)
 
-init: setup-env-override-file build init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Run all of the init tasks (including build) to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init-components: init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services
 
-init-nobuild: setup-env-override-file init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init: setup-env-override-file build init-components ## Run all of the init tasks (including build) to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+
+init-nobuild: setup-env-override-file init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes

--- a/api/Makefile
+++ b/api/Makefile
@@ -110,7 +110,7 @@ init-components: init-db init-opensearch init-s3mock init-sqsmock init-mock-soap
 
 init: setup-env-override-file build init-components ## Run all of the init tasks (including build) to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
-init-ci-cd: init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init-ci-cd: setup-env-override-file init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes

--- a/api/Makefile
+++ b/api/Makefile
@@ -110,7 +110,7 @@ init-components: init-db init-opensearch init-s3mock init-sqsmock init-mock-soap
 
 init: setup-env-override-file build init-components ## Run all of the init tasks (including build) to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
-init-ci-cd: setup-env-override-file init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init-ci-cd: setup-env-override-file db-seed-local-with-agencies init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes

--- a/api/Makefile
+++ b/api/Makefile
@@ -106,9 +106,9 @@ start-debug:
 run-logs: start ## Start the API and follow the logs
 	docker compose logs --follow --no-color $(APP_NAME)
 
-init: setup-env-override-file build init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init: setup-env-override-file build init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Run all of the init tasks (including build) to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
-init-nobuild: setup-env-override-file init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init-nobuild: setup-env-override-file init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes

--- a/api/Makefile
+++ b/api/Makefile
@@ -110,7 +110,7 @@ init-components: init-db init-opensearch init-s3mock init-sqsmock init-mock-soap
 
 init: setup-env-override-file build init-components ## Run all of the init tasks (including build) to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
-init-ci-cd: setup-env-override-file db-seed-local-with-agencies init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init-ci-cd: setup-env-override-file init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes

--- a/api/Makefile
+++ b/api/Makefile
@@ -110,7 +110,7 @@ init-components: init-db init-opensearch init-s3mock init-sqsmock init-mock-soap
 
 init: setup-env-override-file build init-components ## Run all of the init tasks (including build) to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
-init-nobuild: setup-env-override-file init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+init-ci-cd: init-components ## Do not build, but do run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes

--- a/api/Makefile
+++ b/api/Makefile
@@ -108,6 +108,8 @@ run-logs: start ## Start the API and follow the logs
 
 init: setup-env-override-file build init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
 
+init-nobuild: setup-env-override-file init-db init-opensearch init-s3mock init-sqsmock init-mock-soap-services ## Run all of the init tasks to set up DB, Search, s3/sqs mocks, and Mock services. To do this "from scratch" use remake-backend instead
+
 clean-volumes: ## Remove project docker volumes - which includes the DB, and OpenSearch state
 	docker compose down --volumes
 

--- a/api/README.md
+++ b/api/README.md
@@ -91,3 +91,4 @@ Poetry CLI commands are of the form `<task group> <task name> <any other params>
 * [Writing Tests](../documentation/api/writing-tests.md)
 * [Logging configuration](../documentation/api/monitoring-and-observability/logging-configuration.md)
 * [Logging conventions](../documentation/api/monitoring-and-observability/logging-conventions.md)
+a

--- a/api/README.md
+++ b/api/README.md
@@ -91,4 +91,3 @@ Poetry CLI commands are of the form `<task group> <task name> <any other params>
 * [Writing Tests](../documentation/api/writing-tests.md)
 * [Logging configuration](../documentation/api/monitoring-and-observability/logging-configuration.md)
 * [Logging conventions](../documentation/api/monitoring-and-observability/logging-conventions.md)
-a


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9723 

## Changes proposed

1. During CI/CD make the API start/build smarter about using existing API container images if they already are cached in GH Actions Cache.
2. Do the NPM/Playwright installs and build the API outside the matrix job and then pass them in
3. We can't move the FE build outside the matrix because it needs data from the BE image (the Shared Key and Testing Token)

## Context for reviewers

1. As we lean into E2E we're trying to ensure stuff is running efficiently and is using already built images for stuff a branch or merge doesn't change. 
2. Things are complicated a bit by the fact that these playwright and npm caches in particular GH seems to like to fake cache miss on, so we back the caches (which will survive run to run) with the artifacts (that will survive only job to job). Unfortunately that slows stuff down, but otherwise either npm or playwright would fail to load from cache 100% of test runs.

## Validation steps

- Checks pass
- Builds build