### PR TITLE
[Issue #9692] Add mtom wrapper to soap fault exception response

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -155,12 +155,23 @@ def get_soap_fault_error_response(
     mtom_response = (
         f"--uuid:{boundary_id}\r\n"
         f'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
-        f"Content-Transfer-Encoding: 8bit\r\n"
+        f"Content-Transfer-Encoding: binary\r\n"
         f"Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
         f"{err}\r\n"
         f"--uuid:{boundary_id}--\r\n"
     ).encode()
-    return get_soap_response(data=mtom_response, status_code=500, headers=headers)
+    response_headers = {
+        "Content-Type": (
+            "multipart/related;"
+            ' type="application/xop+xml";'
+            f' boundary="uuid:{boundary_id}";'
+            ' start="<root.message@cxf.apache.org>";'
+            ' start-info="text/xml"'
+        )
+    }
+    if headers:
+        response_headers.update(headers)
+    return get_soap_response(data=mtom_response, status_code=500, headers=response_headers)
 
 
 def get_auth_error_response() -> SOAPResponse:

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -136,6 +136,33 @@ def get_soap_error_response(
     return get_soap_response(data=err, status_code=500, headers=headers)
 
 
+def get_soap_fault_error_response(
+    faultcode: str = "soap:Server",
+    faultstring: str = "Server error has occurred",
+    headers: dict | None = None,
+) -> SOAPResponse:
+    err = f"""
+    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+            <soap:Fault>
+                <faultcode>{faultcode}</faultcode>
+                <faultstring>{faultstring}</faultstring>
+            </soap:Fault>
+        </soap:Body>
+    </soap:Envelope>
+    """.strip()
+    boundary_id = str(uuid.uuid4())
+    mtom_response = (
+        f"--uuid:{boundary_id}\r\n"
+        f'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        f"Content-Transfer-Encoding: 8bit\r\n"
+        f"Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+        f"{err}\r\n"
+        f"--uuid:{boundary_id}--\r\n"
+    ).encode()
+    return get_soap_response(data=mtom_response, status_code=500, headers=headers)
+
+
 def get_auth_error_response() -> SOAPResponse:
     return get_soap_error_response(faultstring="Authorization error")
 

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -27,6 +27,7 @@ from src.legacy_soap_api.legacy_soap_api_utils import (
     get_alternate_proxy_response,
     get_invalid_path_response,
     get_soap_error_response,
+    get_soap_fault_error_response,
 )
 from src.legacy_soap_api.soap_payload_handler import get_soap_operation_name
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
@@ -181,7 +182,7 @@ def process_simpler_request(
             },
         )
         if soap_proxy_response.status_code == 500:
-            return get_soap_error_response(
+            return get_soap_fault_error_response(
                 faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
             ).to_flask_response()
     except Exception:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -156,7 +156,7 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
     expected = (
         f"--uuid:{TEST_UUID}\r\n"
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
-        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
         '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
         "        <soap:Body>\n"
@@ -171,6 +171,10 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
         f"--uuid:{TEST_UUID}--\r\n"
     )
     assert response.data.decode() == expected
+    assert (
+        response.headers["Content-Type"]
+        == f'multipart/related; type="application/xop+xml"; boundary="uuid:{TEST_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
+    )
 
 
 @mock.patch("uuid.uuid4")
@@ -221,7 +225,7 @@ def test_successful_confirm_application_delivery_request_when_in_tracking_number
     expected = (
         f"--uuid:{TEST_UUID}\r\n"
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
-        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
         '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
         "        <soap:Body>\n"
@@ -289,7 +293,7 @@ def test_confirm_application_delivery_when_application_has_no_status(
     expected = (
         f"--uuid:{TEST_UUID}\r\n"
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
-        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
         '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
         "        <soap:Body>\n"
@@ -349,7 +353,7 @@ def test_if_soap_fault_exception_raised_return_correct_response_if_proxy_respons
     expected = (
         f"--uuid:{TEST_UUID}\r\n"
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
-        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
         '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
         "        <soap:Body>\n"

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -32,6 +32,7 @@ GET_APPLICATION_ZIP_PATH = f"{{{NSMAP['envelope']}}}Body/{{{NSMAP['application_r
 MOCK_FINGERPRINT = "123"
 MOCK_CERT = "456"
 MOCK_CERT_STR = "certstr"
+TEST_UUID = "00000000-aaaa-0000-bbbb-000000000000"
 
 
 def test_successful_request(client, fixture_from_file, caplog) -> None:
@@ -107,9 +108,11 @@ def test_successful_confirm_application_delivery_request(
     assert len(retrieved) == 1
 
 
+@mock.patch("uuid.uuid4")
 def test_successful_confirm_application_delivery_request_when_in_received_by_agency_status(
-    db_session, client, enable_factory_create
+    mock_uuid, db_session, client, enable_factory_create
 ) -> None:
+    mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
     competition = CompetitionFactory(
@@ -151,20 +154,30 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
         )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "    <soap:Body>\n        <soap:Fault>\n"
-        "            <faultcode>soap:Server</faultcode>\n"
-        f"            <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received by Agency' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
-        "        </soap:Fault>\n"
-        "    </soap:Body>\n"
-        "</soap:Envelope>\n"
+        f"--uuid:{TEST_UUID}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "        <soap:Body>\n"
+        "            <soap:Fault>\n"
+        "                <faultcode>soap:Server</faultcode>\n"
+        "                <faultstring>Failed to confirm application delivery."
+        "(Expected an Application status of:'Validated' , but found a status of "
+        f"'Received by Agency' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
+        "            </soap:Fault>\n"
+        "        </soap:Body>\n"
+        "    </soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--\r\n"
     )
     assert response.data.decode() == expected
 
 
+@mock.patch("uuid.uuid4")
 def test_successful_confirm_application_delivery_request_when_in_tracking_number_assigned_status(
-    db_session, client, enable_factory_create
+    mock_uuid, db_session, client, enable_factory_create
 ) -> None:
+    mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
     competition = CompetitionFactory(
@@ -206,20 +219,30 @@ def test_successful_confirm_application_delivery_request_when_in_tracking_number
         )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "    <soap:Body>\n        <soap:Fault>\n"
-        "            <faultcode>soap:Server</faultcode>\n"
-        f"            <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Agency Tracking Number Assigned' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
-        "        </soap:Fault>\n"
-        "    </soap:Body>\n"
-        "</soap:Envelope>\n"
+        f"--uuid:{TEST_UUID}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "        <soap:Body>\n"
+        "            <soap:Fault>\n"
+        "                <faultcode>soap:Server</faultcode>\n"
+        "                <faultstring>Failed to confirm application delivery."
+        "(Expected an Application status of:'Validated' , but found a status of "
+        f"'Agency Tracking Number Assigned' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
+        "            </soap:Fault>\n"
+        "        </soap:Body>\n"
+        "    </soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--\r\n"
     )
     assert response.data.decode() == expected
 
 
+@mock.patch("uuid.uuid4")
 def test_confirm_application_delivery_when_application_has_no_status(
-    db_session, client, enable_factory_create
+    mock_uuid, db_session, client, enable_factory_create
 ) -> None:
+    mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
     competition = CompetitionFactory(
@@ -264,20 +287,28 @@ def test_confirm_application_delivery_when_application_has_no_status(
             )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "    <soap:Body>\n        <soap:Fault>\n"
-        "            <faultcode>soap:Server</faultcode>\n"
-        "            <faultstring>Application has no application_status</faultstring>\n"
-        "        </soap:Fault>\n"
-        "    </soap:Body>\n"
-        "</soap:Envelope>\n"
+        f"--uuid:{TEST_UUID}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "        <soap:Body>\n"
+        "            <soap:Fault>\n"
+        "                <faultcode>soap:Server</faultcode>\n"
+        "                <faultstring>Application has no application_status</faultstring>\n"
+        "            </soap:Fault>\n"
+        "        </soap:Body>\n"
+        "    </soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--\r\n"
     )
     assert response.data.decode() == expected
 
 
+@mock.patch("uuid.uuid4")
 def test_if_soap_fault_exception_raised_return_correct_response_if_proxy_response_is_500(
-    db_session, client, enable_factory_create
+    mock_uuid, db_session, client, enable_factory_create
 ) -> None:
+    mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
     competition = CompetitionFactory(
@@ -316,13 +347,19 @@ def test_if_soap_fault_exception_raised_return_correct_response_if_proxy_respons
         )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "    <soap:Body>\n        <soap:Fault>\n"
-        "            <faultcode>soap:Server</faultcode>\n"
-        f"            <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
-        "        </soap:Fault>\n"
-        "    </soap:Body>\n"
-        "</soap:Envelope>\n"
+        f"--uuid:{TEST_UUID}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: 8bit\r\n"
+        "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
+        "        <soap:Body>\n"
+        "            <soap:Fault>\n"
+        "                <faultcode>soap:Server</faultcode>\n"
+        f"                <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
+        "            </soap:Fault>\n"
+        "        </soap:Body>\n"
+        "    </soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--\r\n"
     )
     assert response.data.decode() == expected
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9692  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add MTOM wrapper for `SOAPFaultException` error response and updated tests.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The response was missing the MTOM header and footer, so it was not completely mimicking the legacy behavior. This was added to make sure the responses from Simpler and Legacy math.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] hit the `ConfirmApplicationDelivery` endpoint with an invalid `GrantsGovTrackingNumber`
- [ ] see responses do not match
