### PR TITLE
[Issue #9685] Update methods that skip calling legacy soap

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -34,6 +34,8 @@ HIDDEN_VALUE = "hidden"
 class AlternateSoapOperation(StrEnum):
     GET_APPLICATION_ZIP = "GetApplicationZipRequest"
     GET_APPLICATION = "GetApplicationRequest"
+    CONFIRM_APPLICATION_DELIVERY = "ConfirmApplicationDeliveryRequest"
+    UPDATE_APPLICATION_INFO = "UpdateApplicationInfoRequest"
 
 
 def format_local_soap_response(response_data: bytes, boundary_id: str | None = None) -> bytes:
@@ -70,6 +72,82 @@ def get_soap_proxy_grant_application_not_found_response(
         f"(Grant Application not found for tracking number:{grants_gov_tracking_number})"
         "</faultstring>"
         "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    ).encode("utf-8")
+    boundary_id = str(uuid.uuid4())
+    response_data = format_local_soap_response(data, boundary_id=boundary_id)
+    response_headers = {
+        "Content-Type": (
+            "multipart/related;"
+            ' type="application/xop+xml";'
+            f' boundary="uuid:{boundary_id}";'
+            ' start="<root.message@cxf.apache.org>";'
+            ' start-info="text/xml"'
+        ),
+        "Set-Cookie": (f"{headers.get('Cookie')}; Path=/grantsws-agency; Secure; HttpOnly"),
+    }
+    return get_soap_response(response_data, 500, headers=response_headers)
+
+
+def get_soap_proxy_failed_to_confirm_delivery_response(
+    grants_gov_tracking_number: str, headers: dict, is_get_application_zip: bool = True
+) -> SOAPResponse:
+    data = (
+        '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Failed to confirm application delivery.(Authorization Failure)</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    ).encode("utf-8")
+    boundary_id = str(uuid.uuid4())
+    response_data = format_local_soap_response(data, boundary_id=boundary_id)
+    response_headers = {
+        "Content-Type": (
+            "multipart/related;"
+            ' type="application/xop+xml";'
+            f' boundary="uuid:{boundary_id}";'
+            ' start="<root.message@cxf.apache.org>";'
+            ' start-info="text/xml"'
+        ),
+        "Set-Cookie": (f"{headers.get('Cookie')}; Path=/grantsws-agency; Secure; HttpOnly"),
+    }
+    return get_soap_response(response_data, 500, headers=response_headers)
+
+
+def get_soap_proxy_failed_to_update_application_info(
+    grants_gov_tracking_number: str, headers: dict, is_get_application_zip: bool = True
+) -> SOAPResponse:
+    data = (
+        '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<ns2:UpdateApplicationInfoResponse "
+        'xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" '
+        'xmlns:ns11="http://schemas.xmlsoap.org/wsdl/" '
+        'xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" '
+        'xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" '
+        'xmlns:ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" '
+        'xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" '
+        'xmlns:ns6="http://apply.grants.gov/system/GrantsPackage-V1.0" '
+        'xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" '
+        'xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" '
+        'xmlns:ns3="http://apply.grants.gov/system/GrantsTemplate-V1.0" '
+        'xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        f"<GrantsGovTrackingNumber>{grants_gov_tracking_number}</GrantsGovTrackingNumber>"
+        "<ns2:Success>true</ns2:Success>"
+        "<ns9:AssignAgencyTrackingNumberResult>"
+        "<ns9:Success>false</ns9:Success>"
+        "<ns9:ErrorMessage>Exception caught assigning agency tracking number.(Authorization Failure)</ns9:ErrorMessage>"
+        "</ns9:AssignAgencyTrackingNumberResult>"
+        "<ns9:SaveAgencyNotesResult>"
+        "<ns9:Success>false</ns9:Success>"
+        "<ns9:ErrorMessage>Exception caught saving agency notes.(Authorization Failure)</ns9:ErrorMessage>"
+        "</ns9:SaveAgencyNotesResult>"
+        "</ns2:UpdateApplicationInfoResponse>"
         "</soap:Body>"
         "</soap:Envelope>"
     ).encode("utf-8")
@@ -336,10 +414,16 @@ def get_alternate_proxy_response(soap_request: SOAPRequest) -> SOAPResponse | No
     if soap_request.operation_name in AlternateSoapOperation:
         tracking_number = get_gov_grants_tracking_number(xml_bytes)
         is_zip = soap_request.operation_name == AlternateSoapOperation.GET_APPLICATION_ZIP
+        DEFAULT_RESPONSES = {
+            AlternateSoapOperation.GET_APPLICATION_ZIP: get_soap_proxy_grant_application_not_found_response,
+            AlternateSoapOperation.GET_APPLICATION: get_soap_proxy_grant_application_not_found_response,
+            AlternateSoapOperation.CONFIRM_APPLICATION_DELIVERY: get_soap_proxy_failed_to_confirm_delivery_response,
+            AlternateSoapOperation.UPDATE_APPLICATION_INFO: get_soap_proxy_failed_to_update_application_info,
+        }
         if tracking_number and (
             tracking_number.startswith("GRANT8") or tracking_number.startswith("GRANT9")
         ):
-            return get_soap_proxy_grant_application_not_found_response(
+            return DEFAULT_RESPONSES[AlternateSoapOperation(soap_request.operation_name)](
                 tracking_number, headers=soap_request.headers, is_get_application_zip=is_zip
             )
     return None

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -38,30 +38,6 @@ class AlternateSoapOperation(StrEnum):
     UPDATE_APPLICATION_INFO = "UpdateApplicationInfoRequest"
 
 
-def format_local_soap_response(response_data: bytes, boundary_id: str | None = None) -> bytes:
-    # This is a format string for formatting local responses from the mock
-    # soap server since it does not support manipulating the response.
-    # The grants.gov SOAP API currently includes this data.
-    # Note: /r/n is how Windows encodes a newline
-    # /r symbolizes a Carriage Return which returns to the start of the current line (holdover from typewriters)
-    # Mac just uses /n
-    # This is used to ensure the correct Content-Length
-    # see: https://en.wikipedia.org/wiki/Newline
-    response_id = boundary_id if boundary_id else str(uuid.uuid4())
-    return (
-        (
-            f"--uuid:{response_id}\r\n"
-            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
-            "Content-Transfer-Encoding: binary\r\n"
-            f"Content-ID: <root.message@cxf.apache.org>{response_data.decode()}\r\n"
-            f"--uuid:{response_id}--\r\n"
-        )
-        .replace('<?xml version="1.0" encoding="UTF-8"?>', "")
-        .strip()
-        .encode("utf-8")
-    )
-
-
 def get_soap_proxy_grant_application_not_found_response(
     grants_gov_tracking_number: str, headers: dict, is_get_application_zip: bool = True
 ) -> SOAPResponse:
@@ -91,7 +67,7 @@ def get_soap_proxy_grant_application_not_found_response(
 
 
 def get_soap_proxy_failed_to_confirm_delivery_response(
-    grants_gov_tracking_number: str, headers: dict, is_get_application_zip: bool = True
+    *args: str, headers: dict, **kwargs: dict | bool
 ) -> SOAPResponse:
     data = (
         '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
@@ -119,7 +95,7 @@ def get_soap_proxy_failed_to_confirm_delivery_response(
 
 
 def get_soap_proxy_failed_to_update_application_info(
-    grants_gov_tracking_number: str, headers: dict, is_get_application_zip: bool = True
+    grants_gov_tracking_number: str, headers: dict, **kwargs: dict | bool
 ) -> SOAPResponse:
     data = (
         '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
@@ -161,9 +137,40 @@ def get_soap_proxy_failed_to_update_application_info(
             ' start="<root.message@cxf.apache.org>";'
             ' start-info="text/xml"'
         ),
-        "Set-Cookie": (f"{headers.get('Cookie')}; Path=/grantsws-agency; Secure; HttpOnly"),
     }
     return get_soap_response(response_data, 500, headers=response_headers)
+
+
+DEFAULT_NOT_FOUND_RESPONSES: dict[AlternateSoapOperation, Callable] = {
+    AlternateSoapOperation.GET_APPLICATION_ZIP: get_soap_proxy_grant_application_not_found_response,
+    AlternateSoapOperation.GET_APPLICATION: get_soap_proxy_grant_application_not_found_response,
+    AlternateSoapOperation.CONFIRM_APPLICATION_DELIVERY: get_soap_proxy_failed_to_confirm_delivery_response,
+    AlternateSoapOperation.UPDATE_APPLICATION_INFO: get_soap_proxy_failed_to_update_application_info,
+}
+
+
+def format_local_soap_response(response_data: bytes, boundary_id: str | None = None) -> bytes:
+    # This is a format string for formatting local responses from the mock
+    # soap server since it does not support manipulating the response.
+    # The grants.gov SOAP API currently includes this data.
+    # Note: /r/n is how Windows encodes a newline
+    # /r symbolizes a Carriage Return which returns to the start of the current line (holdover from typewriters)
+    # Mac just uses /n
+    # This is used to ensure the correct Content-Length
+    # see: https://en.wikipedia.org/wiki/Newline
+    response_id = boundary_id if boundary_id else str(uuid.uuid4())
+    return (
+        (
+            f"--uuid:{response_id}\r\n"
+            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+            "Content-Transfer-Encoding: binary\r\n"
+            f"Content-ID: <root.message@cxf.apache.org>{response_data.decode()}\r\n"
+            f"--uuid:{response_id}--\r\n"
+        )
+        .replace('<?xml version="1.0" encoding="UTF-8"?>', "")
+        .strip()
+        .encode("utf-8")
+    )
 
 
 def get_soap_response(
@@ -414,16 +421,10 @@ def get_alternate_proxy_response(soap_request: SOAPRequest) -> SOAPResponse | No
     if soap_request.operation_name in AlternateSoapOperation:
         tracking_number = get_gov_grants_tracking_number(xml_bytes)
         is_zip = soap_request.operation_name == AlternateSoapOperation.GET_APPLICATION_ZIP
-        DEFAULT_RESPONSES = {
-            AlternateSoapOperation.GET_APPLICATION_ZIP: get_soap_proxy_grant_application_not_found_response,
-            AlternateSoapOperation.GET_APPLICATION: get_soap_proxy_grant_application_not_found_response,
-            AlternateSoapOperation.CONFIRM_APPLICATION_DELIVERY: get_soap_proxy_failed_to_confirm_delivery_response,
-            AlternateSoapOperation.UPDATE_APPLICATION_INFO: get_soap_proxy_failed_to_update_application_info,
-        }
         if tracking_number and (
             tracking_number.startswith("GRANT8") or tracking_number.startswith("GRANT9")
         ):
-            return DEFAULT_RESPONSES[AlternateSoapOperation(soap_request.operation_name)](
+            return DEFAULT_NOT_FOUND_RESPONSES[AlternateSoapOperation(soap_request.operation_name)](
                 tracking_number, headers=soap_request.headers, is_get_application_zip=is_zip
             )
     return None

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -137,6 +137,7 @@ def get_soap_proxy_failed_to_update_application_info(
             ' start="<root.message@cxf.apache.org>";'
             ' start-info="text/xml"'
         ),
+        "Set-Cookie": (f"{headers.get('Cookie')}; Path=/grantsws-agency; Secure; HttpOnly"),
     }
     return get_soap_response(response_data, 500, headers=response_headers)
 

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -147,6 +147,9 @@ def process_simpler_request(
             extra={"soap_request_headers": soap_request.headers.keys()},
         )
         if alternate_proxy_response := get_alternate_proxy_response(soap_request):
+            logger.info(
+                "simpler_soap_api: skipping legacy call",
+            )
             soap_proxy_response = alternate_proxy_response
         else:
             soap_proxy_response = get_proxy_response(soap_request)

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -566,6 +566,7 @@ def test_confirm_application_delivery_returns_not_found_response_if_simpler_id_i
         response.headers["Content-Type"]
         == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
     )
+    assert response.headers["Set-Cookie"] == "None; Path=/grantsws-agency; Secure; HttpOnly"
 
 
 @mock.patch("uuid.uuid4")
@@ -642,6 +643,7 @@ def test_update_application_info_returns_not_found_response_if_simpler_id_is_use
         response.headers["Content-Type"]
         == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
     )
+    assert response.headers["Set-Cookie"] == "None; Path=/grantsws-agency; Secure; HttpOnly"
 
 
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -524,7 +524,7 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
 
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
-def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is_used_for_confirm_application_delivery(
+def test_confirm_application_delivery_returns_not_found_response_if_simpler_id_is_used(
     mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch
 ) -> None:
     """
@@ -570,7 +570,7 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
 
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
-def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is_used_for_update_application_info(
+def test_update_application_info_returns_not_found_response_if_simpler_id_is_used(
     mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch
 ) -> None:
     """

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -5,6 +5,7 @@ from lxml import etree
 
 from src.constants.lookup_constants import ApplicationStatus, Privilege
 from src.db.models.competition_models import ApplicationSubmissionRetrieved
+from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
 from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth, SOAPClientCertificate
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_utils import get_invalid_path_response
@@ -29,6 +30,8 @@ SIMPLER_TRACKING_NUMBER = "GRANT80000008"
 LEGACY_TRACKING_NUMBER = "GRANT00000008"
 GET_APPLICATION_PATH = f"{{{NSMAP['envelope']}}}Body/{{{NSMAP['application_request']}}}GetApplicationRequest/{{{NSMAP['tracking_number']}}}GrantsGovTrackingNumber"
 GET_APPLICATION_ZIP_PATH = f"{{{NSMAP['envelope']}}}Body/{{{NSMAP['application_request']}}}GetApplicationZipRequest/{{{NSMAP['tracking_number']}}}GrantsGovTrackingNumber"
+CONFIRM_APPLICATION_DELIVERY_PATH = f"{{{NSMAP['envelope']}}}Body/{{{NSMAP['application_request']}}}ConfirmApplicationDeliveryRequest/{{{NSMAP['tracking_number']}}}GrantsGovTrackingNumber"
+UPDATE_APPLICATION_INFO = f"{{{NSMAP['envelope']}}}Body/{{{NSMAP['application_request']}}}UpdateApplicationInfoRequest/{{{NSMAP['tracking_number']}}}GrantsGovTrackingNumber"
 MOCK_FINGERPRINT = "123"
 MOCK_CERT = "456"
 MOCK_CERT_STR = "certstr"
@@ -512,6 +515,128 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
     mock_get_soap_response.assert_not_called()
     assert response.status_code == 500
     assert response.headers["Content-Length"] == "527"
+    assert expected == response.data
+    assert (
+        response.headers["Content-Type"]
+        == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
+    )
+
+
+@mock.patch("uuid.uuid4")
+@mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
+def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is_used_for_confirm_application_delivery(
+    mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch
+) -> None:
+    """
+    Force the response to be the legacy response and show that we do not actually call the legacy request method
+    """
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("USE_SIMPLER", "false")
+    test_uuid = "00000000-aaaa-0000-bbbb-000000000000"
+    mock_uuid.return_value = test_uuid
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = """
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">
+       <soapenv:Header/>
+       <soapenv:Body>
+          <agen:ConfirmApplicationDeliveryRequest>
+             <gran:GrantsGovTrackingNumber>GRANT80837443</gran:GrantsGovTrackingNumber>
+          </agen:ConfirmApplicationDeliveryRequest>
+       </soapenv:Body>
+    </soapenv:Envelope>
+    """
+    envelope = etree.fromstring(mock_data)
+    tracking_number = envelope.find(CONFIRM_APPLICATION_DELIVERY_PATH)
+    tracking_number.text = SIMPLER_TRACKING_NUMBER
+    response = client.post(full_path, data=etree.tostring(envelope))
+    expected = (
+        f"--uuid:{test_uuid}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n'
+        '\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault><faultcode>soap:Server</faultcode><faultstring>Failed to confirm application delivery.(Authorization Failure)</faultstring></soap:Fault>"
+        "</soap:Body></soap:Envelope>\r\n"
+        f"--uuid:{test_uuid}--"
+    ).encode("utf-8")
+    mock_get_soap_response.assert_not_called()
+    assert response.status_code == 500
+    assert response.headers["Content-Length"] == "496"
+    assert expected == response.data
+    assert (
+        response.headers["Content-Type"]
+        == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
+    )
+
+
+@mock.patch("uuid.uuid4")
+@mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
+def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is_used_for_update_application_info(
+    mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch
+) -> None:
+    """
+    Force the response to be the legacy response and show that we do not actually call the legacy request method
+    """
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("USE_SIMPLER", "false")
+    test_uuid = "00000000-aaaa-0000-bbbb-000000000000"
+    mock_uuid.return_value = test_uuid
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = f"""
+        <soapenv:Envelope
+        xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0"
+        xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0"
+        xmlns:agen1="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0">
+        <soapenv:Header/>
+        <soapenv:Body>
+        <agen:UpdateApplicationInfoRequest>
+        <gran:GrantsGovTrackingNumber>{SIMPLER_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>
+        <agen1:AssignAgencyTrackingNumber>1</agen1:AssignAgencyTrackingNumber>
+        <agen1:SaveAgencyNotes>test 1</agen1:SaveAgencyNotes>
+        </agen:UpdateApplicationInfoRequest>
+        </soapenv:Body>
+        </soapenv:Envelope>
+    """
+    envelope = etree.fromstring(mock_data)
+    tracking_number = envelope.find(UPDATE_APPLICATION_INFO)
+    tracking_number.text = SIMPLER_TRACKING_NUMBER
+    response = client.post(full_path, data=etree.tostring(envelope))
+    expected = (
+        f"--uuid:{test_uuid}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n'
+        '\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<ns2:UpdateApplicationInfoResponse "
+        'xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" '
+        'xmlns:ns11="http://schemas.xmlsoap.org/wsdl/" '
+        'xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" '
+        'xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" '
+        'xmlns:ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" '
+        'xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" '
+        'xmlns:ns6="http://apply.grants.gov/system/GrantsPackage-V1.0" '
+        'xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" '
+        'xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" '
+        'xmlns:ns3="http://apply.grants.gov/system/GrantsTemplate-V1.0" '
+        'xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        f"<GrantsGovTrackingNumber>{SIMPLER_TRACKING_NUMBER}</GrantsGovTrackingNumber>"
+        "<ns2:Success>true</ns2:Success>"
+        "<ns9:AssignAgencyTrackingNumberResult>"
+        "<ns9:Success>false</ns9:Success>"
+        "<ns9:ErrorMessage>Exception caught assigning agency tracking number.(Authorization Failure)</ns9:ErrorMessage>"
+        "</ns9:AssignAgencyTrackingNumberResult>"
+        "<ns9:SaveAgencyNotesResult>"
+        "<ns9:Success>false</ns9:Success>"
+        "<ns9:ErrorMessage>Exception caught saving agency notes.(Authorization Failure)</ns9:ErrorMessage>"
+        "</ns9:SaveAgencyNotesResult>"
+        "</ns2:UpdateApplicationInfoResponse>"
+        "</soap:Body>"
+        "</soap:Envelope>\r\n"
+        f"--uuid:{test_uuid}--"
+    ).encode("utf-8")
+    mock_get_soap_response.assert_not_called()
+    assert response.status_code == 500
+    assert response.headers["Content-Length"] == "1694"
     assert expected == response.data
     assert (
         response.headers["Content-Type"]

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_simpler_soap_api.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_simpler_soap_api.py
@@ -28,7 +28,7 @@ class TestSimplerSoapApi:
         soap_request = SOAPRequest(
             data=SoapRequestStreamer(stream=io.BytesIO(envelope)),
             full_path="x",
-            headers={},
+            headers={"Use-Simpler-Override": "1"},
             method="POST",
             api_name=SimplerSoapAPI.APPLICANTS,
             operation_name="GetOpportunityListRequest",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9685  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added more alternate SOAP operations and tests. Added methods to generate "not found" responses.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We don't want to send a request to the legacy system for two additional endpoints, ConfirmApplicationDelivery and UpdateApplicationInfo, so we added this to the list to check if we skip it, and just construct our own proxy response message.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] hit the endpoint with a simpler tracking number
- [ ] check logs to see if it gets sent to legacy
