### PR TITLE
[Issue #7769] bypass staging login

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -47,6 +47,13 @@ inputs:
   force-webkit-install:
     description: "webkit dependencies aren't all cached, so we need to force it to install"
     default: "false"
+  staging_test_user_api_key:
+    description: "test user API key used in spoofing staging user logins"
+    default: ""
+  staging_client_session_secret:
+    description: "encode key for client side JWTs, used in spoofing staging user logins"
+    default: ""
+
 outputs:
   artifact-id:
     description: "artifact ids for uploaded test reports"

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -111,7 +111,7 @@ runs:
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
         STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
-        SESSION_SECRET: ${{ inputs.staging_client_session_secret }}
+        SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
 
       run: |
         npm run test:e2e
@@ -130,7 +130,7 @@ runs:
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
         STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
-        SESSION_SECRET: ${{ inputs.staging_client_session_secret }}
+        SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
 
       run: |
         npm run test:e2e -- --grep "${{ inputs.playwright_tags }}"

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -110,6 +110,9 @@ runs:
         STAGING_TEST_USER_EMAIL: ${{ inputs.staging_test_user_email }}
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
+        STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
+        SESSION_SECRET: ${{ inputs.staging_client_session_secret }}
+
       run: |
         npm run test:e2e
       shell: bash
@@ -126,6 +129,9 @@ runs:
         STAGING_TEST_USER_EMAIL: ${{ inputs.staging_test_user_email }}
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
+        STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
+        SESSION_SECRET: ${{ inputs.staging_client_session_secret }}
+
       run: |
         npm run test:e2e -- --grep "${{ inputs.playwright_tags }}"
       shell: bash

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -63,6 +63,8 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
+          staging_test_user_api_key: ${{ secrets.STAGING_TEST_USER_API_KEY }}
+          staging_client_session_secret: ${{ secrets.STAGING_CLIENT_SESSION_SECRET }}
   create-report:
     name: Create Merged Test Report
     if: ${{ !cancelled() }}

--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -1,24 +1,28 @@
 # Testing
 
-## E2E testing
+## End to End (E2E) testing
+
+E2E tests are run using Playwright. See [development.md](/DEVELOPMENT.md) for more general info!
 
 ### Spoofing logins
 
-There are situations where we want to be able to test a "logged in" experience without having to script the test through the full login flow. In order to support this we have built a system to spoof the user login by placing a session cookie into the browser context. THis system works by creating a client side cookie on the browser context within Playwright that will effectively log in a fake user with the API.
+There are situations where we want to be able to test a "logged in" experience without having to script the test through the full login flow. In order to support this we have built a system to spoof the user login by placing a session cookie into the browser context. This system works by creating a client side cookie on the browser context within Playwright that will function the same as the session cookie. produced as the output of the real login process.
 
-#### With a local server
+The system is defined in [Login Utils](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/tests/e2e/loginUtils.ts)
 
-This system is based on a `createSpoofedSessionCookie` function which:
+#### Local setup
 
--
-
-Using this function, tests should work automatically in CI, but they will require a bit of manual setup to work locally.
-
-##### Local setup
+Local spoofed logins depend on an auth token for a test user that is generated each time the local database is seeded. During seed a file is created containing the key, which you can then reference in the Playwright process. Steps to implement:
 
 - run `make db-seed-local` in the /api directory. This will create the necessary DB records for the spoofed user and spit out an API auth token in a file at /api/e2e_token.tmp.
-- copy the token variable declaration from the e2e_token.tmp file into your frontend .env.local file
-- that's it! Running e2e tests using the functionality mentioned above should now work locally
+- copy the token variable declaration from the e2e_token.tmp file into the `E2E_USER_AUTH_TOKEN` env var declaration in your frontend .env.local file
+- that's it! Running e2e tests using spoofing should now work. [This process is encapsulated in our CI process here](https://github.com/HHS/simpler-grants-gov/blob/c5f29978c45d658329f2466d652da743d83d6a73/.github/workflows/ci-frontend-e2e.yml#L97).
+
+#### Staging setup
+
+Since staging tests run on a deployed server that does not expose a testing token directly, to spoof a login is a bit more involved, but only requires proper env vars to be set in order to work. A test user is set up in staging that can be spoofed. In order to obtain a session token for this user, Playwright needs to request it from a staging-only internal endpoint.
+
+To run spoofed logins (locally or in CI), you will too have the SESSION_SECRET and STAGING_TEST_USER_API_KEY env vars are correctly set in .env.local. Values can be found 1password, or ask a team member.
 
 ### Test groups
 
@@ -46,6 +50,8 @@ Current testing cadences are defined as:
 - We expect engineers to write unit tests for any changes they make in the same PR that contains the code changes
 - We use data fixtures when relevant (see https://github.com/HHS/simpler-grants-gov/blob/main/frontend/src/utils/testing/fixtures.ts)
 - We strive to include axe tests on all components
+
+See [development.md](/DEVELOPMENT.md) for more general info!
 
 ### Debugging
 

--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -4,13 +4,17 @@
 
 ### Spoofing logins
 
-There are situations where we want to be able to test a "logged in" experience without having to script the test through the full login flow. In order to support this we have built a system to spoof the user login by placing a session cookie into the browser context.
+There are situations where we want to be able to test a "logged in" experience without having to script the test through the full login flow. In order to support this we have built a system to spoof the user login by placing a session cookie into the browser context. THis system works by creating a client side cookie on the browser context within Playwright that will effectively log in a fake user with the API.
 
-This system is based on a `createSpoofedSessionCookie` which will create a client side cookie on the browser context that will effectively log in a fake user with the API.
+#### With a local server
+
+This system is based on a `createSpoofedSessionCookie` function which:
+
+-
 
 Using this function, tests should work automatically in CI, but they will require a bit of manual setup to work locally.
 
-#### Local setup
+##### Local setup
 
 - run `make db-seed-local` in the /api directory. This will create the necessary DB records for the spoofed user and spit out an API auth token in a file at /api/e2e_token.tmp.
 - copy the token variable declaration from the e2e_token.tmp file into your frontend .env.local file

--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -6,7 +6,7 @@ E2E tests are run using Playwright. See [development.md](/DEVELOPMENT.md) for mo
 
 ### Spoofing logins
 
-There are situations where we want to be able to test a "logged in" experience without having to script the test through the full login flow. In order to support this we have built a system to spoof the user login by placing a session cookie into the browser context. This system works by creating a client side cookie on the browser context within Playwright that will function the same as the session cookie. produced as the output of the real login process.
+There are situations where we want to be able to test a "logged in" experience without having to script the test through the full login flow. In order to support this we have built a system to spoof the user login by placing a session cookie into the browser context. This system works by creating a client side cookie on the browser context within Playwright that will function the same as the session cookie produced as the output of the real login process.
 
 The system is defined in [Login Utils](https://github.com/HHS/simpler-grants-gov/blob/main/frontend/tests/e2e/loginUtils.ts)
 
@@ -22,7 +22,7 @@ Local spoofed logins depend on an auth token for a test user that is generated e
 
 Since staging tests run on a deployed server that does not expose a testing token directly, to spoof a login is a bit more involved, but only requires proper env vars to be set in order to work. A test user is set up in staging that can be spoofed. In order to obtain a session token for this user, Playwright needs to request it from a staging-only internal endpoint.
 
-To run spoofed logins (locally or in CI), you will too have the SESSION_SECRET and STAGING_TEST_USER_API_KEY env vars are correctly set in .env.local. Values can be found 1password, or ask a team member.
+To run spoofed logins (locally or in CI), SESSION_SECRET and STAGING_TEST_USER_API_KEY env vars must be correctly set in .env.local. Values for these env vars can be found 1password, AWS SSM, or ask a team member.
 
 ### Test groups
 

--- a/frontend/tests/e2e/loginUtils.ts
+++ b/frontend/tests/e2e/loginUtils.ts
@@ -21,6 +21,20 @@ let clientJwtKey: Uint8Array;
 const encodeText = (valueToEncode: string) =>
   new TextEncoder().encode(valueToEncode);
 
+const fetchTokenForStagingUser = async (apiKey: string): Promise<string> => {
+  const response = await fetch(
+    `${playwrightEnv.apiUrl}/v1/internal/e2e-token`,
+    {
+      method: "POST",
+      headers: {
+        "X-API-Key": apiKey,
+      },
+    },
+  );
+  const json = await response.json();
+  return json.data?.token;
+};
+
 export const initializePlaywrightSessionSecrets = () => {
   if (!playwrightEnv.clientSessionSecret) {
     // eslint-disable-next-line
@@ -29,7 +43,17 @@ export const initializePlaywrightSessionSecrets = () => {
   }
   // eslint-disable-next-line
   console.debug("Initializing TESTING Session Secrets");
-  clientJwtKey = encodeText(playwrightEnv.clientSessionSecret);
+  if (playwrightEnv.targetEnv === "local") {
+    clientJwtKey = encodeText(playwrightEnv.clientSessionSecret);
+  } else if (playwrightEnv.targetEnv === "staging") {
+    fetchTokenForStagingUser(playwrightEnv.stagingTestUserApiKey)
+      .then((authToken) => {
+        clientJwtKey = encodeText(authToken);
+      })
+      .catch((e) => {
+        console.warn("error fetching token for test staging user", e);
+      });
+  }
 };
 
 // 12 hour expiration for test tokens to avoid expiration issues
@@ -39,16 +63,20 @@ export const newExpirationDate = () =>
 /*
   encrypts an API token passed as an env var into a fake client token
 */
-export const generateSpoofedSession = async (): Promise<string> => {
+export const generateSpoofedSession = async (
+  manualToken?: string,
+): Promise<string> => {
   if (!clientJwtKey) {
     throw new Error("Unable to spoof login, missing auth key");
   }
 
-  if (!playwrightEnv.fakeServerToken) {
+  if (!playwrightEnv.fakeServerToken && !manualToken) {
     throw new Error("Unable to spoof login, missing server token");
   }
 
-  const fakeToken = await new SignJWT({ token: playwrightEnv.fakeServerToken })
+  const fakeToken = await new SignJWT({
+    token: manualToken || playwrightEnv.fakeServerToken,
+  })
     .setProtectedHeader({ alg: CLIENT_JWT_ENCRYPTION_ALGORITHM })
     .setIssuedAt()
     .setExpirationTime(newExpirationDate())
@@ -60,8 +88,11 @@ export const generateSpoofedSession = async (): Promise<string> => {
 // For bypassing login in LOCAL test runs
 // sets a spoofed login token on the cookie in order to allow for logging in without
 // clicking through the login process
-export const createSpoofedSessionCookie = async (context: BrowserContext) => {
-  const token = await generateSpoofedSession();
+export const createSpoofedSessionCookie = async (
+  context: BrowserContext,
+  manualToken?: string,
+) => {
+  const token = await generateSpoofedSession(manualToken);
   await context.addCookies([
     {
       name: "session",
@@ -71,6 +102,6 @@ export const createSpoofedSessionCookie = async (context: BrowserContext) => {
   ]);
 };
 
-if (playwrightEnv.targetEnv === "local") {
-  initializePlaywrightSessionSecrets();
-}
+// if (playwrightEnv.targetEnv === "local") {
+initializePlaywrightSessionSecrets();
+// })

--- a/frontend/tests/e2e/loginUtils.ts
+++ b/frontend/tests/e2e/loginUtils.ts
@@ -21,20 +21,6 @@ let clientJwtKey: Uint8Array;
 const encodeText = (valueToEncode: string) =>
   new TextEncoder().encode(valueToEncode);
 
-const fetchTokenForStagingUser = async (apiKey: string): Promise<string> => {
-  const response = await fetch(
-    `${playwrightEnv.apiUrl}/v1/internal/e2e-token`,
-    {
-      method: "POST",
-      headers: {
-        "X-API-Key": apiKey,
-      },
-    },
-  );
-  const json = await response.json();
-  return json.data?.token;
-};
-
 export const initializePlaywrightSessionSecrets = () => {
   if (!playwrightEnv.clientSessionSecret) {
     // eslint-disable-next-line
@@ -43,17 +29,7 @@ export const initializePlaywrightSessionSecrets = () => {
   }
   // eslint-disable-next-line
   console.debug("Initializing TESTING Session Secrets");
-  if (playwrightEnv.targetEnv === "local") {
-    clientJwtKey = encodeText(playwrightEnv.clientSessionSecret);
-  } else if (playwrightEnv.targetEnv === "staging") {
-    fetchTokenForStagingUser(playwrightEnv.stagingTestUserApiKey)
-      .then((authToken) => {
-        clientJwtKey = encodeText(authToken);
-      })
-      .catch((e) => {
-        console.warn("error fetching token for test staging user", e);
-      });
-  }
+  clientJwtKey = encodeText(playwrightEnv.clientSessionSecret);
 };
 
 // 12 hour expiration for test tokens to avoid expiration issues

--- a/frontend/tests/e2e/loginUtils.ts
+++ b/frontend/tests/e2e/loginUtils.ts
@@ -78,6 +78,4 @@ export const createSpoofedSessionCookie = async (
   ]);
 };
 
-// if (playwrightEnv.targetEnv === "local") {
 initializePlaywrightSessionSecrets();
-// })

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -14,6 +14,13 @@ const BASE_URLS: Record<string, string> = {
   staging: process.env.STAGING_BASE_URL || "https://staging.simpler.grants.gov",
 };
 
+// API URLs for each environment, read from .env.local if present, else fallback to defaults
+const API_URLS: Record<string, string> = {
+  local: process.env.LOCAL_BASE_URL || "http://127.0.0.1:8080",
+  staging:
+    process.env.STAGING_BASE_URL || "https://api.staging.simpler.grants.gov",
+};
+
 // Determine environment: can be overridden via PLAYWRIGHT_TARGET_ENV
 const targetEnv = process.env.PLAYWRIGHT_TARGET_ENV || "local";
 
@@ -23,7 +30,15 @@ if (!Object.prototype.hasOwnProperty.call(BASE_URLS, targetEnv)) {
   );
 }
 
+if (!Object.prototype.hasOwnProperty.call(API_URLS, targetEnv)) {
+  throw new Error(
+    `Unsupported PLAYWRIGHT_TARGET_ENV: ${targetEnv}. Allowed values: ${Object.keys(BASE_URLS).join(", ")}`,
+  );
+}
+
 const baseUrl = BASE_URLS[targetEnv];
+
+const apiUrl = API_URLS[targetEnv];
 
 // Label used to select the test user from the local dev quick-login dropdown.
 // Must match the OAuth login name defined in seed_orgs_and_users.py.
@@ -53,6 +68,7 @@ const webServerEnv: Record<string, string> = Object.fromEntries(
 const playwrightEnv = {
   webServerEnv,
   baseUrl,
+  apiUrl,
   targetEnv,
   testUserLabel,
   testOrgLabel,
@@ -64,6 +80,7 @@ const playwrightEnv = {
   testUserEmail: process.env.STAGING_TEST_USER_EMAIL || "",
   testUserPassword: process.env.STAGING_TEST_USER_PASSWORD || "",
   testUserAuthKey: process.env.STAGING_TEST_USER_MFA_KEY || "",
+  stagingTestUserApiKey: process.env.STAGING_TEST_USER_API_KEY || "",
 };
 
 export default playwrightEnv;

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -8,6 +8,8 @@ if (fs.existsSync(envPath)) {
   dotenv.config({ path: envPath, quiet: true });
 }
 
+const SUPPORTED_ENVS = ["local", "staging"];
+
 // Base URLs for each environment, read from .env.local if present, else fallback to defaults
 const BASE_URLS: Record<string, string> = {
   local: process.env.LOCAL_BASE_URL || "http://127.0.0.1:3000",
@@ -16,23 +18,16 @@ const BASE_URLS: Record<string, string> = {
 
 // API URLs for each environment, read from .env.local if present, else fallback to defaults
 const API_URLS: Record<string, string> = {
-  local: process.env.LOCAL_BASE_URL || "http://127.0.0.1:8080",
+  local: process.env.LOCAL_API_URL || "http://127.0.0.1:8080",
   staging:
-    process.env.STAGING_BASE_URL || "https://api.staging.simpler.grants.gov",
+    process.env.STAGING_API_URL || "https://api.staging.simpler.grants.gov",
 };
 
-// Determine environment: can be overridden via PLAYWRIGHT_TARGET_ENV
 const targetEnv = process.env.PLAYWRIGHT_TARGET_ENV || "local";
 
-if (!Object.prototype.hasOwnProperty.call(BASE_URLS, targetEnv)) {
+if (SUPPORTED_ENVS.indexOf(targetEnv) === -1) {
   throw new Error(
-    `Unsupported PLAYWRIGHT_TARGET_ENV: ${targetEnv}. Allowed values: ${Object.keys(BASE_URLS).join(", ")}`,
-  );
-}
-
-if (!Object.prototype.hasOwnProperty.call(API_URLS, targetEnv)) {
-  throw new Error(
-    `Unsupported PLAYWRIGHT_TARGET_ENV: ${targetEnv}. Allowed values: ${Object.keys(BASE_URLS).join(", ")}`,
+    `Unsupported PLAYWRIGHT_TARGET_ENV: ${targetEnv}. Allowed values: ${SUPPORTED_ENVS.join(", ")}`,
   );
 }
 

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -71,7 +71,8 @@ const playwrightEnv = {
   totalShards: process.env.TOTAL_SHARDS,
   currentShard: process.env.CURRENT_SHARD,
   fakeServerToken: process.env.E2E_USER_AUTH_TOKEN,
-  clientSessionSecret: process.env.SESSION_SECRET,
+  clientSessionSecret:
+    process.env.SESSION_SECRET_OVERRIDE || process.env.SESSION_SECRET,
   testUserEmail: process.env.STAGING_TEST_USER_EMAIL || "",
   testUserPassword: process.env.STAGING_TEST_USER_PASSWORD || "",
   testUserAuthKey: process.env.STAGING_TEST_USER_MFA_KEY || "",

--- a/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
+++ b/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
@@ -2,8 +2,10 @@
  * authenticateE2eUser is a high-level helper for E2E test authentication.
  *
  * - Local: spoofs a session using loginUtils.ts with a fake JWT cookie.
- * - Staging (standalone run): performs a real login with credentials and MFA
- *   using perform-login-utils.ts.
+ * - Staging (standalone run): spoofs a session using loginUtils.ts with a
+ *   fake JWT cookie or if spoofing is turned off (in the case where we want
+ *   to specifically test the login process, for example, performs a real login
+ *   with credentials and MFA using perform-login-utils.ts.
  * - Staging (full suite / CI run): if the user is already logged in (session
  *   persisted from the previous test because --workers=1 reuses the browser,
  *   or storageState was injected via playwright.config.ts), the full MFA login
@@ -22,13 +24,17 @@ import { selectLocalTestUser } from "tests/e2e/utils/select-local-test-user-util
 
 const { baseUrl, targetEnv, testUserLabel } = playwrightEnv;
 
+// used to simulate a staging login without performing any login actions
+// calls dedicated API endpoint to fetch session token for a test user
+// and creates a frontend session based on the token from the response
+// requires STAGING_TEST_USER_API_KEY to be set in env vars
 const attemptStagingSpoof = async (
   context: BrowserContext,
 ): Promise<boolean> => {
   if (!playwrightEnv.stagingTestUserApiKey) {
     return false;
   }
-  // get staging user token
+  // get server side staging user JWT token
   try {
     const response = await fetch(
       `${playwrightEnv.apiUrl}/v1/internal/e2e-token`,
@@ -42,7 +48,8 @@ const attemptStagingSpoof = async (
         `unable to fetch e2e staging user token: ${response.status}`,
       );
     }
-    const json = await response.json();
+    const json = (await response.json()) as { data: { token: string } };
+    // encode it as a client JWT and set it on cookies
     await createSpoofedSessionCookie(context, json.data.token);
     return true;
   } catch (e) {
@@ -71,6 +78,7 @@ export async function authenticateE2eUser(
       try {
         const spoofSuccessful = await attemptStagingSpoof(context);
         if (spoofSuccessful) {
+          await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
           return;
         }
       } catch (e) {

--- a/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
+++ b/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
@@ -22,10 +22,40 @@ import { selectLocalTestUser } from "tests/e2e/utils/select-local-test-user-util
 
 const { baseUrl, targetEnv, testUserLabel } = playwrightEnv;
 
+const attemptStagingSpoof = async (
+  context: BrowserContext,
+): Promise<boolean> => {
+  if (!playwrightEnv.stagingTestUserApiKey) {
+    return false;
+  }
+  // get staging user token
+  try {
+    const response = await fetch(
+      `${playwrightEnv.apiUrl}/v1/internal/e2e-token`,
+      {
+        headers: { "X-API-Key": playwrightEnv.stagingTestUserApiKey },
+        method: "POST",
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `unable to fetch e2e staging user token: ${response.status}`,
+      );
+    }
+    const json = await response.json();
+    await createSpoofedSessionCookie(context, json.data.token);
+    return true;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
 export async function authenticateE2eUser(
   page: Page,
   context: BrowserContext,
   isMobile: boolean,
+  attemptSpoof = true,
 ): Promise<void> {
   if (targetEnv === "local") {
     await createSpoofedSessionCookie(context);
@@ -37,6 +67,16 @@ export async function authenticateE2eUser(
     await selectLocalTestUser(page, testUserLabel);
     await page.waitForTimeout(2000);
   } else if (targetEnv === "staging") {
+    if (attemptSpoof) {
+      try {
+        const spoofSuccessful = await attemptStagingSpoof(context);
+        if (spoofSuccessful) {
+          return;
+        }
+      } catch (e) {
+        console.warn("unable to spoof staging login", (e as Error).message);
+      }
+    }
     await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
 
     // Check whether the user is already logged in before attempting MFA login.

--- a/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
+++ b/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
@@ -6,10 +6,6 @@
  *   fake JWT cookie or if spoofing is turned off (in the case where we want
  *   to specifically test the login process, for example, performs a real login
  *   with credentials and MFA using perform-login-utils.ts.
- * - Staging (full suite / CI run): if the user is already logged in (session
- *   persisted from the previous test because --workers=1 reuses the browser,
- *   or storageState was injected via playwright.config.ts), the full MFA login
- *   flow is skipped automatically.
  *
  * This means tests can be run individually or as part of the full suite
  * without any changes — authentication is handled correctly in both cases.
@@ -53,7 +49,7 @@ const attemptStagingSpoof = async (
     await createSpoofedSessionCookie(context, json.data.token);
     return true;
   } catch (e) {
-    console.error(e);
+    console.error(`unable to spoof session cookie: ${(e as Error).message}`);
     throw e;
   }
 };

--- a/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
+++ b/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
@@ -31,27 +31,22 @@ const attemptStagingSpoof = async (
     return false;
   }
   // get server side staging user JWT token
-  try {
-    const response = await fetch(
-      `${playwrightEnv.apiUrl}/v1/internal/e2e-token`,
-      {
-        headers: { "X-API-Key": playwrightEnv.stagingTestUserApiKey },
-        method: "POST",
-      },
+  const response = await fetch(
+    `${playwrightEnv.apiUrl}/v1/internal/e2e-token`,
+    {
+      headers: { "X-API-Key": playwrightEnv.stagingTestUserApiKey },
+      method: "POST",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `unable to fetch e2e staging user token: ${response.status}`,
     );
-    if (!response.ok) {
-      throw new Error(
-        `unable to fetch e2e staging user token: ${response.status}`,
-      );
-    }
-    const json = (await response.json()) as { data: { token: string } };
-    // encode it as a client JWT and set it on cookies
-    await createSpoofedSessionCookie(context, json.data.token);
-    return true;
-  } catch (e) {
-    console.error(`unable to spoof session cookie: ${(e as Error).message}`);
-    throw e;
   }
+  const json = (await response.json()) as { data: { token: string } };
+  // encode it as a client JWT and set it on cookies
+  await createSpoofedSessionCookie(context, json.data.token);
+  return true;
 };
 
 export async function authenticateE2eUser(

--- a/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
+++ b/frontend/tests/e2e/utils/authenticate-e2e-user-utils.ts
@@ -73,7 +73,10 @@ export async function authenticateE2eUser(
           return;
         }
       } catch (e) {
-        console.warn("unable to spoof staging login", (e as Error).message);
+        console.error(
+          "Unable to spoof staging login, falling back to manual login flow:",
+          (e as Error).message,
+        );
       }
     }
     await page.goto(baseUrl, { waitUntil: "domcontentloaded" });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #7769 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Allows playwright to spoof a login to staging, resulting in a logged in state for a test user without going through the full login UX.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Using this system in staging requires setting some environment variables:

* `STAGING_TEST_USER_API_KEY` - a special API key used to authenticate a special test user created in the staging database
* `SESSION_SECRET` - the secret used to encode server side JWTs as client side JWTs. Previously this was only needed for local test processes - the staging spoof process will need the staging secret

If you need these values for testing, obtain them from 1pass or ask a team member

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. ensure that STAGING_TEST_USER_API_KEY and SESSION_SECRET are set in .env.local with the correct values for testing against staging, and that PLAYWRIGHT_TARGET_ENV is set to "staging"
2. run `npx playwright test --config ./tests/playwright.config.ts`
3. _VERIFY_: tests pass (this was flaky on my end, likely fine as long as the CI versions pass)
4. _VERIFY_: staging test run passes https://github.com/HHS/simpler-grants-gov/actions/runs/25322401661/job/74234457188
5. _VERIFY_: local test run passes https://github.com/HHS/simpler-grants-gov/actions/runs/25322436069/job/74234961317
