### PR TITLE
[Issue #9724] Drop opensearch-dashboard from CI/CD runs of docker

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -78,7 +78,7 @@ jobs:
           make init
           # Now run the seeding and populate commands
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
-          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start-test
+          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
           cd ../frontend
           # Ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -78,7 +78,7 @@ jobs:
           make init
           # Now run the seeding and populate commands
           echo "LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback" >> override.env
-          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start
+          make db-seed-local-with-agencies populate-search-opportunities populate-search-agencies start-test
           cd ../frontend
           # Ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh

--- a/api/Makefile
+++ b/api/Makefile
@@ -94,11 +94,11 @@ setup-env-override-file:
 build:
 	docker compose build
 
-start: ## Start the API
-	docker compose up --detach
-
-start-test: ## Start the API for CI/CD where we don't need OpenSearch Dashboard
+start: ## Start the API for CI/CD or local Dev work where we don't need OpenSearch Dashboard
 	docker compose up grants-api --detach
+
+start-full: ## Start the API including OpenSearch Dashboard
+	docker compose up --detach
 
 start-debug:
 	docker compose -f docker-compose.yml -f docker-compose.debug.yml up --detach

--- a/api/Makefile
+++ b/api/Makefile
@@ -97,6 +97,9 @@ build:
 start: ## Start the API
 	docker compose up --detach
 
+start-test: ## Start the API for CI/CD where we don't need OpenSearch Dashboard
+	docker compose up grants-api --detach
+
 start-debug:
 	docker compose -f docker-compose.yml -f docker-compose.debug.yml up --detach
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #9724 

Replaces #9732 

## Changes proposed

- Remove opensearch-dashboard from the make entry CI/CD uses to do `docker compose up` 
- Keeps local behavior the same so make start still includes the search dashboard for any search development that needs it.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

- Checks/tests still work in CI/CD
- Tested that `docker compose up` still works if someone doesn't know about our make commands