### PR TITLE
[Issue #9753] Update SOAP/Proxy logging

### DIFF
--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -178,10 +178,11 @@ def process_simpler_request(
         )
     except SOAPFaultException as e:
         logger.info(
-            msg=e.fault.faultstring,
+            msg="Soap Fault Exception raised",
             exc_info=True,
             extra={
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+                "faultstring": e.fault.faultstring,
             },
         )
         if soap_proxy_response.status_code == 500:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -113,7 +113,7 @@ def test_successful_confirm_application_delivery_request(
 
 @mock.patch("uuid.uuid4")
 def test_successful_confirm_application_delivery_request_when_in_received_by_agency_status(
-    mock_uuid, db_session, client, enable_factory_create
+    mock_uuid, db_session, client, enable_factory_create, caplog
 ) -> None:
     mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
@@ -178,11 +178,16 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
         response.headers["Content-Type"]
         == f'multipart/related; type="application/xop+xml"; boundary="uuid:{TEST_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
     )
+    log = next(r for r in caplog.records if r.message == "Soap Fault Exception raised")
+    assert (
+        log.faultstring
+        == f"Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received by Agency' for GRANT{submission.legacy_tracking_number})"
+    )
 
 
 @mock.patch("uuid.uuid4")
 def test_successful_confirm_application_delivery_request_when_in_tracking_number_assigned_status(
-    mock_uuid, db_session, client, enable_factory_create
+    mock_uuid, db_session, client, enable_factory_create, caplog
 ) -> None:
     mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
@@ -243,6 +248,11 @@ def test_successful_confirm_application_delivery_request_when_in_tracking_number
         f"--uuid:{TEST_UUID}--\r\n"
     )
     assert response.data.decode() == expected
+    log = next(r for r in caplog.records if r.message == "Soap Fault Exception raised")
+    assert (
+        log.faultstring
+        == f"Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Agency Tracking Number Assigned' for GRANT{submission.legacy_tracking_number})"
+    )
 
 
 @mock.patch("uuid.uuid4")


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9753 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Modify logging for `SOAPFaultException`.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Best practice is to use a generic message that allows for searches in the New Relic logs. This was currently using a message that has the identifying `GrantsGovTrackingNumber` on it. That was moved down to `faultstring` and is put on the `extra` attribute on the log.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] trigger the `SOAPFaultException` and check the New Relic logs
