### PR TITLE
[Issue #9365] Refactor name of variable in simpler_soap_api.py file

### DIFF
--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -103,7 +103,7 @@ def get_simpler_soap_response(
         return simpler_soap_response
 
     logger.info(
-        "simpler_soap_api: Successfully processed request and returning SOAP proxy response",
+        "simpler_soap_api: Successfully processed request and returning SOAP legacy response",
         extra={
             "soap_api_event": LegacySoapApiEvent.RETURNING_LEGACY_SOAP_RESPONSE,
             "used_simpler_response": use_simpler,
@@ -158,7 +158,7 @@ def process_simpler_request(
             soap_legacy_response = get_legacy_response(soap_request)
     except Exception:
         logger.exception(
-            msg="Error getting soap proxy response",
+            msg="Error getting soap legacy response",
             extra={
                 "used_simpler_response": False,
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_LEGACY_SOAP,
@@ -192,7 +192,7 @@ def process_simpler_request(
                 faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
             ).to_flask_response()
     except Exception:
-        msg = "Unable to process Simpler SOAP proxy response"
+        msg = "Unable to process Simpler SOAP legacy response"
         logger.exception(
             msg=msg,
             extra={

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -15,16 +15,18 @@ from src.legacy_soap_api.legacy_soap_api_client import (
 )
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI, get_soap_config
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
-from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response
+from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response as get_legacy_response
 from src.legacy_soap_api.legacy_soap_api_schemas import (
     SOAPInvalidEnvelope,
     SOAPOperationNotSupported,
     SOAPResponse,
 )
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest, SoapRequestStreamer
+from src.legacy_soap_api.legacy_soap_api_utils import SOAPFaultException
 from src.legacy_soap_api.legacy_soap_api_utils import (
-    SOAPFaultException,
-    get_alternate_proxy_response,
+    get_alternate_proxy_response as get_alternate_legacy_response,
+)
+from src.legacy_soap_api.legacy_soap_api_utils import (
     get_invalid_path_response,
     get_soap_error_response,
     get_soap_fault_error_response,
@@ -36,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_simpler_soap_response(
-    soap_request: SOAPRequest, soap_proxy_response: SOAPResponse, db_session: db.Session
+    soap_request: SOAPRequest, soap_legacy_response: SOAPResponse, db_session: db.Session
 ) -> SOAPResponse:
     simpler_soap_client_type = (
         SimplerApplicantsS2SClient
@@ -71,7 +73,7 @@ def get_simpler_soap_response(
                 "used_simpler_response": use_simpler,
             },
         )
-        return soap_proxy_response
+        return soap_legacy_response
     except Exception:
         err = "Unable to initialize Simpler SOAP client: Unknown error"
         logger.info(
@@ -82,13 +84,13 @@ def get_simpler_soap_response(
                 "used_simpler_response": use_simpler,
             },
         )
-        return soap_proxy_response
+        return soap_legacy_response
 
     if use_simpler or simpler_soap_client.operation_config.always_call_simpler:
         logger.info(
             "simpler_soap_api: getting simpler soap response",
         )
-        simpler_soap_response = simpler_soap_client.get_simpler_soap_response(soap_proxy_response)
+        simpler_soap_response = simpler_soap_client.get_simpler_soap_response(soap_legacy_response)
 
     if use_simpler and simpler_soap_response is not None:
         logger.info(
@@ -107,7 +109,7 @@ def get_simpler_soap_response(
             "used_simpler_response": use_simpler,
         },
     )
-    return soap_proxy_response
+    return soap_legacy_response
 
 
 def process_simpler_request(
@@ -147,13 +149,13 @@ def process_simpler_request(
             "soap_client_certificate: header check",
             extra={"soap_request_headers": soap_request.headers.keys()},
         )
-        if alternate_proxy_response := get_alternate_proxy_response(soap_request):
+        if alternate_legacy_response := get_alternate_legacy_response(soap_request):
             logger.info(
                 "simpler_soap_api: skipping legacy call",
             )
-            soap_proxy_response = alternate_proxy_response
+            soap_legacy_response = alternate_legacy_response
         else:
-            soap_proxy_response = get_proxy_response(soap_request)
+            soap_legacy_response = get_legacy_response(soap_request)
     except Exception:
         logger.exception(
             msg="Error getting soap proxy response",
@@ -166,7 +168,7 @@ def process_simpler_request(
 
     try:
         return get_simpler_soap_response(
-            soap_request, soap_proxy_response, db_session
+            soap_request, soap_legacy_response, db_session
         ).to_flask_response()
     except SOAPClientUserDoesNotHavePermission:
         msg = "soap_client_certificate: User did not have permission to access this application"
@@ -185,7 +187,7 @@ def process_simpler_request(
                 "faultstring": e.fault.faultstring,
             },
         )
-        if soap_proxy_response.status_code == 500:
+        if soap_legacy_response.status_code == 500:
             return get_soap_fault_error_response(
                 faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
             ).to_flask_response()
@@ -198,4 +200,4 @@ def process_simpler_request(
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             },
         )
-    return soap_proxy_response.to_flask_response()
+    return soap_legacy_response.to_flask_response()

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -292,9 +292,9 @@ def test_confirm_application_delivery_when_application_has_no_status(
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
         with mock.patch(
-            "src.legacy_soap_api.simpler_soap_api.get_proxy_response"
-        ) as mock_proxy_response:
-            mock_proxy_response.return_value = SOAPResponse(
+            "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
+        ) as mock_legacy_response:
+            mock_legacy_response.return_value = SOAPResponse(
                 data=b"test response", status_code=500, headers={}
             )
             response = client.post(
@@ -420,9 +420,9 @@ def test_if_soap_fault_exception_raised_return_proxy_response_if_proxy_response_
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
         with mock.patch(
-            "src.legacy_soap_api.simpler_soap_api.get_proxy_response"
-        ) as mock_proxy_response:
-            mock_proxy_response.return_value = SOAPResponse(
+            "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
+        ) as mock_legacy_response:
+            mock_legacy_response.return_value = SOAPResponse(
                 data=b"test response", status_code=200, headers={}
             )
             response = client.post(


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9365 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Update `soap_proxy_response` to `soap_legacy_response`. Import methods like `get_proxy_response` to `get_legacy_response` through `import get_proxy_response as get_legacy_response`.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
To clarify what `soap_proxy_response` is but to keep the scope small, I just made changes in one file. This is to help communicate what the `soap_proxy_response` actually is.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
