### PR TITLE
[Unticketed] Upgrade uuid

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18234,16 +18234,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -123,6 +123,7 @@
     "axios": "^1.15.0",
     "follow-redirects": "^1.16.0",
     "protobufjs": "^7.5.5",
+    "uuid": "^14.0.0",
     "devEngines": {
       "packageManager": {
         "name": "npm"


### PR DESCRIPTION
## Changes proposed

uuid 9.0.1 is installed (via @types/uuid or something) it has a vulnerability that is fixed in 14.0.0.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Attempting to install uuid@^14.0.0 doesn't do anything, so we override instead.

Noting the oddity that `npm list -a` says were only installing uuid via the types package and that's only a Dev Dependency but somehow this works fine in builds/deployed as well. 

So sticking with the override for now since it's not clear how to upgrade it otherwise.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- My has tested the change on his local
- Scans pass
