### PR TITLE
[Issue #9788] Remove user count guard from get_local_users

### DIFF
--- a/api/src/services/local/get_local_users.py
+++ b/api/src/services/local/get_local_users.py
@@ -26,12 +26,6 @@ def get_local_users(db_session: db.Session) -> list[dict]:
         .all()
     )
 
-    # This is an extra check to make certain we aren't running
-    # in any other environment. At the time of writing this (Oct 2025)
-    # we have nearly 8000 users in prod, so this would always fail.
-    if len(users) > 500:
-        raise Exception(f"Too many users ({len(users)}), this isn't local, is it?")
-
     user_dicts = []
 
     for user in users:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9788  

## Changes proposed

- Updated get_local_users.py to remove the user count check

## Context for reviewers

The `get_local_users` service in get_local_users.py has a check that raises an exception if more than 500 users exist in the database. This was intended as a safety net to prevent accidental execution in production, but it's redundant as `error_if_not_local()` already guards against non-local environments.

The check is now causing `test_get_local_users_200` to fail in the full test suite because the session-scoped DB schema accumulates users across all tests, and recent feature work has pushed the count past 500.

## Validation steps

Confirm `make test` passes with the full suite
