### PR TITLE
[Issue #8739] Annotate subscribe.spec.ts with feature references

### DIFF
--- a/frontend/tests/e2e/subscribe.feature
+++ b/frontend/tests/e2e/subscribe.feature
@@ -22,6 +22,7 @@ Feature: Newsletter subscription
     Then I should see "Subscribed" heading
 
   Scenario: Show error when subscription fails
+    Given the subscription service is unavailable
     When I fill "First Name (required)" with "Apple"
     And I fill "Email (required)" with "name@example.com"
     And I click "Subscribe" button

--- a/frontend/tests/e2e/subscribe.spec.ts
+++ b/frontend/tests/e2e/subscribe.spec.ts
@@ -1,3 +1,12 @@
+/**
+ * @feature Newsletter subscription
+ * @featureFile frontend/tests/e2e/subscribe.feature
+ * @scenario Show the subscription page title
+ * @scenario Show errors when submitting empty form
+ * @scenario Subscribe with valid name and email
+ * @scenario Show error when subscription fails
+ */
+
 import { VALID_TAGS } from "tests/e2e/tags";
 
 import {
@@ -26,8 +35,11 @@ const { targetEnv } = playwrightEnv;
 //     return "abort";
 //   });
 // }
+
 test.beforeEach(async ({ page }) => {
   const timeout = targetEnv === "staging" ? 180000 : 60000;
+
+  // Background: Given I open "/newsletter"
   await page.goto("/newsletter", { waitUntil: "domcontentloaded", timeout });
   await page.route("**/newsletter", async (route) => {
     if (route.request().method() === "POST") {
@@ -41,7 +53,11 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
+/**
+ * @scenario Show the subscription page title
+ */
 test("has title", { tag: [FULL_REGRESSION] }, async ({ page }) => {
+  // Then the page title should match "Subscribe | Simpler.Grants.gov"
   await expect(page).toHaveTitle(/Subscribe | Simpler.Grants.gov/);
 });
 
@@ -55,41 +71,68 @@ test("has title", { tag: [FULL_REGRESSION] }, async ({ page }) => {
   through a normal API call or something.
 */
 
+/**
+ * @scenario Show errors when submitting empty form
+ */
 test.skip("client side errors", async ({ page }) => {
+  // When I click "Subscribe" button
   await page.getByRole("button", { name: /subscribe/i }).click();
 
   // Verify client-side errors for required fields
+  // Then I should see 2 error messages
   await expect(page.getByTestId("errorMessage")).toHaveCount(2);
+
+  // And I should see "Please enter a name."
   await expect(page.getByText("Please enter a name.")).toBeVisible();
+
+  // And I should see "Please enter an email address."
   await expect(page.getByText("Please enter an email address.")).toBeVisible();
 });
 
+/**
+ * @scenario Subscribe with valid name and email
+ */
 test.skip("successful signup", async ({ /* next */ page }) => {
   // mockAPIEndpoints(next);
 
+  // When I fill "First Name (required)" with "Apple"
   await page.getByLabel("First Name (required)").fill("Apple");
+
+  // And I fill "Email (required)" with "name@example.com"
   await page.getByLabel("Email (required)").fill("name@example.com");
 
+  // And I click "Subscribe" button
   const subscribeButton = page.getByRole("button", {
     name: /subscribe/i,
   });
   await expect(subscribeButton).toBeVisible();
   await subscribeButton.click();
 
+  // Then I should see "Subscribed" heading
   await expect(
     page.getByRole("heading", { name: /subscribed/i }),
   ).toBeVisible();
 });
 
+/**
+ * @scenario Show error when subscription fails
+ */
 test.skip("error during signup", async ({ /* next */ page }) => {
   // mockAPIEndpoints(next, "Error with subscribing");
 
+  // When I fill "First Name (required)" with "Apple"
   await page.getByLabel("First Name (required)").fill("Apple");
+
+  // And I fill "Email (required)" with "name@example.com"
   await page.getByLabel("Email (required)").fill("name@example.com");
 
+  // And I click "Subscribe" button
   await page.getByRole("button", { name: /subscribe/i }).click();
 
+  // Then I should see 1 error message
   await expect(page.getByTestId("errorMessage")).toHaveCount(1);
+
+  // And I should see "An error occurred when trying to save your subscription."
   await expect(
     page.getByText(/an error occurred when trying to save your subscription./i),
   ).toBeVisible();

--- a/frontend/tests/e2e/subscribe.spec.ts
+++ b/frontend/tests/e2e/subscribe.spec.ts
@@ -118,6 +118,8 @@ test.skip("successful signup", async ({ /* next */ page }) => {
  * @scenario Show error when subscription fails
  */
 test.skip("error during signup", async ({ /* next */ page }) => {
+  // TODO: Determine network error simulation strategy
+  // Given the subscription service is unavailable
   // mockAPIEndpoints(next, "Error with subscribing");
 
   // When I fill "First Name (required)" with "Apple"


### PR DESCRIPTION
## Summary
Work for: Task #8739 

## Changes proposed
- Update /workspaces/simpler-grants-gov/frontend/tests/e2e/subscribe.spec.ts to add annotation header with references to feature file
- Add inline comments consistent with feature file

## Context for reviewers
- Reviewers should make sure that the spec file has annotation header and inline comments in spec file reflects the flow in feature file.

## Validation steps
- Confirm the spec file references the feature file
