### PR TITLE
Fix `documentation/api/feature-flags.md` using four H1 headings

### DIFF
--- a/documentation/api/feature-flags.md
+++ b/documentation/api/feature-flags.md
@@ -1,11 +1,13 @@
-# Overview
+# API Feature Flags
+
+## Overview
 
 Feature flags are setup in the API to allow for configuring behavior of the endpoints.
 
 The flags have a default value which can be adjusted by an environment variable per environment,
 and also allow for overriding it via headers in the API endpoints.
 
-## Naming Convention
+### Naming Convention
 
 Naming of feature flags has the following convention:
 * Environment variables are always snake-case all-caps like `ENABLE_OPPORTUNITY_LOG_MSG`
@@ -14,7 +16,7 @@ Naming of feature flags has the following convention:
 The configuration internally within the API helps setup these values and maintain consistency.
 
 
-# Adding a New Feature Flag
+## Adding a New Feature Flag
 
 Add the flag to the `FeatureFlag` enum. The value of the enum will be used
 to generate the environment variable name as well as the header field name as described above.
@@ -103,14 +105,14 @@ def opportunity_search(
       # ... the rest of the route implementation
 ```
 
-# Current Feature Flags
+## Current Feature Flags
 
 | Environment Variable       | Header Field | Description |
 |----------------------------| ------------ |-------------|
 | ENABLE_OPPORTUNITY_LOG_MSG | X-FF-Enable-Opportunity-Log-Msg | Placeholder for the implementation of the feature flag logic, just causes a small log message. |
 
 
-# Future Enhancements
+## Future Enhancements
 
 A few rough ideas for how we might expand feature flags in the future:
 * Make it possible to update the configuration of a running API (ie. loading feature flags from another configurable location periodically)


### PR DESCRIPTION
## Summary\n\nNormalizes the headings in `documentation/api/feature-flags.md` so the file has a single H1 document title and section labels use proper nesting.\n\n## Changes\n\n- Inserted `# API Feature Flags` as the document title on line 1\n- Demoted `# Overview`, `# Adding a New Feature Flag`, `# Current Feature Flags`, and `# Future Enhancements` to `##`\n- Demoted `## Naming Convention` to `###`\n\n## Testing\n\n- Verified in GitHub preview that the outline now shows one title with nested sections\n- No prose content or code blocks were modified\n\nFixes #9805