### PR TITLE
`documentation/frontend/testing.md` has three code blocks missing their language tag

### DIFF
--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -51,7 +51,7 @@ If you're using VSCode you have a couple of options for debugging tests using th
 
 Create or edit a launch.json file in frontend/.vscode to include a configuration with this definition
 
-```
+```jsonc
     {
       "type": "node",
       "request": "launch",
@@ -92,7 +92,7 @@ The easiest thing to do in these cases is to:
 - render the returned value from the component function call
 - [example usage](https://github.com/HHS/simpler-grants-gov/blob/f92baefc1b8409f12057240d98fa68d20946593b/frontend/tests/components/organization/manage-users/ActiveUsersSection.test.tsx#L44)
 
-```
+```tsx
     const component = await ActiveUsersSection({
       organizationId: "org-123",
       activeUsers,
@@ -106,7 +106,7 @@ The easiest thing to do in these cases is to:
 
 Route tests will not work correctly unless we specify that Jest should use Node rather than JSdom with this at the top of the test file
 
-```
+```js
 /**
  * @jest-environment node
  */


### PR DESCRIPTION
## Summary\n\nAdds missing language tags to three code blocks in `documentation/frontend/testing.md` so they render with proper syntax highlighting in GitHub and other Markdown renderers.\n\n## Changes\n\n- Line 54 (launch.json snippet): added `jsonc`\n- Line 95 (async component render example): added `tsx`\n- Line 109 (@jest-environment node pragma): added `js`\n\n## Testing\n\n- Verified in GitHub preview that each block now renders with syntax colors\n- No example text inside the blocks was modified\n\nFixes #9802