### PR TITLE
[Issue #7655] Change auth on extracts endpoint User Key + JWT

### DIFF
--- a/api/src/api/extracts_v1/extract_routes.py
+++ b/api/src/api/extracts_v1/extract_routes.py
@@ -5,7 +5,7 @@ import src.adapters.db.flask_db as flask_db
 import src.api.extracts_v1.extract_schema as extract_schema
 import src.api.response as response
 from src.api.extracts_v1.extract_blueprint import extract_blueprint
-from src.auth.multi_auth import api_key_multi_auth
+from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
 from src.services.extracts_v1.get_extracts import ExtractListParams, get_extracts
 
@@ -37,7 +37,7 @@ examples = {
     examples=examples,
 )
 @extract_blueprint.output(extract_schema.ExtractMetadataListResponseSchema)
-@extract_blueprint.auth_required(api_key_multi_auth)
+@extract_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
 @flask_db.with_db_session()
 def extract_metadata_get(db_session: db.Session, raw_list_params: dict) -> response.ApiResponse:
     list_params: ExtractListParams = ExtractListParams.model_validate(raw_list_params)

--- a/api/tests/src/api/extracts_v1/test_extracts_routes.py
+++ b/api/tests/src/api/extracts_v1/test_extracts_routes.py
@@ -8,11 +8,6 @@ from src.constants.lookup_constants import ExtractType
 from src.db.models.extract_models import ExtractMetadata
 from tests.src.db.models.factories import ExtractMetadataFactory
 
-##################################################################################
-# As of the 4/24/2026 update for SGG-7655, these test cases have been modified
-# to cover both API User Key and JWT authentication (toggled one after the other).
-##################################################################################
-
 
 @pytest.fixture(autouse=True)
 def clear_extracts(db_session):

--- a/api/tests/src/api/extracts_v1/test_extracts_routes.py
+++ b/api/tests/src/api/extracts_v1/test_extracts_routes.py
@@ -8,6 +8,11 @@ from src.constants.lookup_constants import ExtractType
 from src.db.models.extract_models import ExtractMetadata
 from tests.src.db.models.factories import ExtractMetadataFactory
 
+##################################################################################
+# As of the 4/24/2026 update for SGG-7655, these test cases have been modified
+# to cover both User API Key and JWT authentication (toggled one after the other).
+##################################################################################
+
 
 @pytest.fixture(autouse=True)
 def clear_extracts(db_session):
@@ -17,7 +22,7 @@ def clear_extracts(db_session):
 
 
 def test_extract_metadata_get_default_dates(
-    client, api_auth_token, enable_factory_create, db_session
+    client, user_api_key_id, enable_factory_create, db_session
 ):
     """Test that default date range (last 7 days) is applied when no dates provided"""
 
@@ -39,7 +44,7 @@ def test_extract_metadata_get_default_dates(
             "sort_direction": "descending",
         },
     }
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-API-Key": user_api_key_id}, json=payload)
     assert response.status_code == 200
     data = response.json["data"]
     assert len(data) == 2
@@ -47,7 +52,7 @@ def test_extract_metadata_get_default_dates(
 
 
 def test_extract_metadata_get_with_custom_dates(
-    client, api_auth_token, enable_factory_create, db_session, mock_s3_bucket
+    client, user_auth_token, enable_factory_create, db_session, mock_s3_bucket
 ):
     """Test with explicitly provided date range"""
     ExtractMetadataFactory.create_batch(
@@ -72,7 +77,7 @@ def test_extract_metadata_get_with_custom_dates(
         },
     }
 
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-SGG-Token": user_auth_token}, json=payload)
 
     assert response.status_code == 200
     data = response.json["data"]
@@ -81,7 +86,7 @@ def test_extract_metadata_get_with_custom_dates(
 
 
 def test_extract_metadata_get_with_type_filter(
-    client, api_auth_token, enable_factory_create, db_session
+    client, user_api_key_id, enable_factory_create, db_session
 ):
     """Test filtering by extract_type"""
     ExtractMetadataFactory(extract_type=ExtractType.OPPORTUNITIES_JSON)
@@ -98,7 +103,7 @@ def test_extract_metadata_get_with_type_filter(
         },
     }
 
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-API-Key": user_api_key_id}, json=payload)
 
     assert response.status_code == 200
     data = response.json["data"]
@@ -106,7 +111,9 @@ def test_extract_metadata_get_with_type_filter(
     assert data[0]["extract_type"] == "opportunities_json"
 
 
-def test_extract_metadata_get_pagination(client, api_auth_token, enable_factory_create, db_session):
+def test_extract_metadata_get_pagination(
+    client, user_auth_token, enable_factory_create, db_session
+):
     """Test pagination of results"""
     ExtractMetadataFactory.create_batch(2)
 
@@ -120,7 +127,7 @@ def test_extract_metadata_get_pagination(client, api_auth_token, enable_factory_
         },
     }
 
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-SGG-Token": user_auth_token}, json=payload)
 
     assert response.status_code == 200
     data = response.json["data"]
@@ -128,14 +135,14 @@ def test_extract_metadata_get_pagination(client, api_auth_token, enable_factory_
 
     # Test second page
     payload["pagination"]["page"] = 2
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-SGG-Token": user_auth_token}, json=payload)
     assert response.status_code == 200
     data = response.json["data"]
     assert len(data) == 1
 
 
 def test_extract_metadata_get_pagination_info(
-    client, api_auth_token, enable_factory_create, db_session
+    client, user_api_key_id, enable_factory_create, db_session
 ):
     """Test pagination information in response"""
     # Create 5 extracts to test pagination
@@ -153,7 +160,7 @@ def test_extract_metadata_get_pagination_info(
         },
     }
 
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-API-Key": user_api_key_id}, json=payload)
 
     assert response.status_code == 200
 
@@ -168,7 +175,7 @@ def test_extract_metadata_get_pagination_info(
     assert pagination["page_size"] == 2
     # Test last page
     payload["pagination"]["page_offset"] = 3
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-API-Key": user_api_key_id}, json=payload)
 
     assert response.status_code == 200
     data = response.json["data"]
@@ -178,7 +185,7 @@ def test_extract_metadata_get_pagination_info(
 
 
 def test_extract_metadata_presigned_url(
-    client, api_auth_token, monkeypatch, enable_factory_create, db_session, mock_s3_bucket
+    client, user_auth_token, monkeypatch, enable_factory_create, db_session, mock_s3_bucket
 ):
     """Test that pre-signed URLs are generated correctly and can be used to download files"""
 
@@ -210,7 +217,7 @@ def test_extract_metadata_presigned_url(
         },
     }
 
-    response = client.post("/v1/extracts", headers={"X-Auth": api_auth_token}, json=payload)
+    response = client.post("/v1/extracts", headers={"X-SGG-Token": user_auth_token}, json=payload)
 
     assert response.status_code == 200
     data = response.json["data"]

--- a/api/tests/src/api/extracts_v1/test_extracts_routes.py
+++ b/api/tests/src/api/extracts_v1/test_extracts_routes.py
@@ -10,7 +10,7 @@ from tests.src.db.models.factories import ExtractMetadataFactory
 
 ##################################################################################
 # As of the 4/24/2026 update for SGG-7655, these test cases have been modified
-# to cover both User API Key and JWT authentication (toggled one after the other).
+# to cover both API User Key and JWT authentication (toggled one after the other).
 ##################################################################################
 
 


### PR DESCRIPTION
## Summary

Fixes #7655 

## Changes proposed

We want to modify our POST /v1/extracts endpoint to remove the legacy API key auth, we should instead make it support JWT auth + our new api key auth.

## Context for reviewers

Task is within Epic #7393 

## Validation steps

- Adjust the endpoint to use the new jwt_or_user_api_key_multi_auth auth which has JWT + the new API User Auth
- Replace existing tests that use the legacy auth, and add support for the new auth approach
