### PR TITLE
[Issue #8826] Adjust SQS/s3 configurations to have a consistent/shared pattern for common fields

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -107,7 +107,7 @@ IS_LOCAL_AWS=1
 
 # Note: AWS_REGION is intentionally NOT set here because OpensearchConfig and
 # PostgresDBConfig use it as an IAM auth toggle (None = no IAM auth).
-# The default region (us-east-1) is defined in BaseAwsConfig.
+# The default region (us-east-1) is defined in AwsConfig.
 
 ############################
 # S3 Mock

--- a/api/local.env
+++ b/api/local.env
@@ -99,19 +99,30 @@ SEARCH_USE_SSL=FALSE
 SEARCH_VERIFY_CERTS=FALSE
 
 ############################
+# AWS
+############################
+
+# This env var is used to set local AWS credentials
+IS_LOCAL_AWS=1
+
+# Note: AWS_REGION is intentionally NOT set here because OpensearchConfig and
+# PostgresDBConfig use it as an IAM auth toggle (None = no IAM auth).
+# The default region (us-east-1) is defined in BaseAwsConfig.
+
+############################
 # S3 Mock
 ############################
 
 # If you want to connect to s3mock outside of docker, use localhost instead of sqsmock
 # use localhost:9090 instead
-S3_ENDPOINT_URL=http://s3mock:9090
+AWS_S3_ENDPOINT_URL=http://s3mock:9090
 
 ############################
 # SQS Mock
 ############################
 
 # If you want to connect to sqsmock outside of docker, use localhost instead of sqsmock
-SQS_ENDPOINT_URL=http://sqsmock:9324
+AWS_SQS_ENDPOINT_URL=http://sqsmock:9324
 WORKFLOW_QUEUE_URL=http://sqsmock:9324/000000000000/local_workflow_queue
 
 ############################
@@ -121,9 +132,6 @@ WORKFLOW_QUEUE_URL=http://sqsmock:9324/000000000000/local_workflow_queue
 # Our terraform sets these as s3 paths, so include s3:// on the bucket name
 PUBLIC_FILES_BUCKET=s3://local-mock-public-bucket
 DRAFT_FILES_BUCKET=s3://local-mock-draft-bucket
-
-# This env var is used to set local AWS credentials
-IS_LOCAL_AWS=1
 
 ############################
 # AWS API Gateway

--- a/api/src/adapters/aws/__init__.py
+++ b/api/src/adapters/aws/__init__.py
@@ -1,9 +1,9 @@
-from .aws_session import get_base_aws_config, get_boto_session
+from .aws_session import get_aws_config, get_boto_session
 from .s3_adapter import S3Config, get_s3_client
 from .sqs_adapter import SQSConfig, get_boto_sqs_client
 
 __all__ = [
-    "get_base_aws_config",
+    "get_aws_config",
     "get_boto_session",
     "get_s3_client",
     "S3Config",

--- a/api/src/adapters/aws/__init__.py
+++ b/api/src/adapters/aws/__init__.py
@@ -1,5 +1,12 @@
-from .aws_session import get_boto_session
+from .aws_session import get_base_aws_config, get_boto_session
 from .s3_adapter import S3Config, get_s3_client
 from .sqs_adapter import SQSConfig, get_boto_sqs_client
 
-__all__ = ["get_s3_client", "S3Config", "get_boto_sqs_client", "SQSConfig", "get_boto_session"]
+__all__ = [
+    "get_base_aws_config",
+    "get_boto_session",
+    "get_s3_client",
+    "S3Config",
+    "get_boto_sqs_client",
+    "SQSConfig",
+]

--- a/api/src/adapters/aws/aws_session.py
+++ b/api/src/adapters/aws/aws_session.py
@@ -4,29 +4,29 @@ from pydantic import Field
 from src.util.env_config import PydanticBaseEnvConfig
 
 
-class BaseAwsConfig(PydanticBaseEnvConfig):
+class AwsConfig(PydanticBaseEnvConfig):
     is_local_aws: bool = False
     aws_region: str = Field(alias="AWS_REGION", default="us-east-1")
 
 
-_base_aws_config: BaseAwsConfig | None = None
+_aws_config: AwsConfig | None = None
 
 
-def get_base_aws_config() -> BaseAwsConfig:
-    global _base_aws_config
-    if _base_aws_config is None:
-        _base_aws_config = BaseAwsConfig()
+def get_aws_config() -> AwsConfig:
+    global _aws_config
+    if _aws_config is None:
+        _aws_config = AwsConfig()
 
-    return _base_aws_config
+    return _aws_config
 
 
 def is_local_aws() -> bool:
     """Whether we are running against local AWS which affects the credentials we use (forces them to be not real)"""
-    return get_base_aws_config().is_local_aws
+    return get_aws_config().is_local_aws
 
 
 def get_boto_session() -> boto3.Session:
-    config = get_base_aws_config()
+    config = get_aws_config()
     if is_local_aws():
         # Locally, set fake creds so we can't hit actual AWS resources
         return boto3.Session(

--- a/api/src/adapters/aws/aws_session.py
+++ b/api/src/adapters/aws/aws_session.py
@@ -1,10 +1,12 @@
 import boto3
+from pydantic import Field
 
 from src.util.env_config import PydanticBaseEnvConfig
 
 
 class BaseAwsConfig(PydanticBaseEnvConfig):
     is_local_aws: bool = False
+    aws_region: str = Field(alias="AWS_REGION", default="us-east-1")
 
 
 _base_aws_config: BaseAwsConfig | None = None
@@ -24,10 +26,13 @@ def is_local_aws() -> bool:
 
 
 def get_boto_session() -> boto3.Session:
+    config = get_base_aws_config()
     if is_local_aws():
-        # Locally, set fake creds in a region we don't actually use so we can't hit actual AWS resources
+        # Locally, set fake creds so we can't hit actual AWS resources
         return boto3.Session(
-            aws_access_key_id="NO_CREDS", aws_secret_access_key="NO_CREDS", region_name="us-west-2"
+            aws_access_key_id="NO_CREDS",
+            aws_secret_access_key="NO_CREDS",
+            region_name=config.aws_region,
         )
 
-    return boto3.Session()
+    return boto3.Session(region_name=config.aws_region)

--- a/api/src/adapters/aws/s3_adapter.py
+++ b/api/src/adapters/aws/s3_adapter.py
@@ -3,14 +3,14 @@ import botocore.client
 import botocore.config
 from pydantic import Field
 
-from src.adapters.aws import get_boto_session
+from src.adapters.aws import get_base_aws_config, get_boto_session
 from src.util.env_config import PydanticBaseEnvConfig
 
 
 class S3Config(PydanticBaseEnvConfig):
     # We should generally not need to set this except
     # locally to use s3mock
-    s3_endpoint_url: str | None = None
+    aws_s3_endpoint_url: str | None = Field(alias="AWS_S3_ENDPOINT_URL", default=None)
     presigned_s3_duration: int = 7200  # 2 hours in seconds
 
     # CDN URL for public files - if set, will be used instead of presigned URLs
@@ -35,8 +35,8 @@ def get_s3_client(
         s3_config = S3Config()
 
     params = {}
-    if s3_config.s3_endpoint_url is not None:
-        params["endpoint_url"] = s3_config.s3_endpoint_url
+    if s3_config.aws_s3_endpoint_url is not None:
+        params["endpoint_url"] = s3_config.aws_s3_endpoint_url
 
     if boto_config is None:
         boto_config = botocore.config.Config(
@@ -50,4 +50,4 @@ def get_s3_client(
     if session is None:
         session = get_boto_session()
 
-    return session.client("s3", **params)
+    return session.client("s3", region_name=get_base_aws_config().aws_region, **params)

--- a/api/src/adapters/aws/s3_adapter.py
+++ b/api/src/adapters/aws/s3_adapter.py
@@ -3,7 +3,7 @@ import botocore.client
 import botocore.config
 from pydantic import Field
 
-from src.adapters.aws import get_base_aws_config, get_boto_session
+from src.adapters.aws import get_aws_config, get_boto_session
 from src.util.env_config import PydanticBaseEnvConfig
 
 
@@ -50,4 +50,4 @@ def get_s3_client(
     if session is None:
         session = get_boto_session()
 
-    return session.client("s3", region_name=get_base_aws_config().aws_region, **params)
+    return session.client("s3", region_name=get_aws_config().aws_region, **params)

--- a/api/src/adapters/aws/sqs_adapter.py
+++ b/api/src/adapters/aws/sqs_adapter.py
@@ -5,7 +5,7 @@ import boto3
 import botocore.client
 from pydantic import BaseModel, Field
 
-from src.adapters.aws import get_boto_session
+from src.adapters.aws import get_base_aws_config, get_boto_session
 from src.util.env_config import PydanticBaseEnvConfig
 from src.util.json_util import json_encoder
 
@@ -14,8 +14,7 @@ logger = logging.getLogger(__name__)
 
 class SQSConfig(PydanticBaseEnvConfig):
     workflow_queue_url: str = Field(alias="WORKFLOW_QUEUE_URL")
-    sqs_endpoint_url: str | None = Field(alias="SQS_ENDPOINT_URL", default=None)
-    aws_region: str = Field(alias="AWS_REGION", default="us-east-1")
+    aws_sqs_endpoint_url: str | None = Field(alias="AWS_SQS_ENDPOINT_URL", default=None)
 
 
 class SQSMessage(BaseModel):
@@ -53,13 +52,13 @@ def get_boto_sqs_client(
         sqs_config = SQSConfig()
 
     params = {}
-    if sqs_config.sqs_endpoint_url is not None:
-        params["endpoint_url"] = sqs_config.sqs_endpoint_url
+    if sqs_config.aws_sqs_endpoint_url is not None:
+        params["endpoint_url"] = sqs_config.aws_sqs_endpoint_url
 
     if session is None:
         session = get_boto_session()
 
-    return session.client("sqs", region_name=sqs_config.aws_region, **params)
+    return session.client("sqs", region_name=get_base_aws_config().aws_region, **params)
 
 
 class SQSClient:

--- a/api/src/adapters/aws/sqs_adapter.py
+++ b/api/src/adapters/aws/sqs_adapter.py
@@ -5,7 +5,7 @@ import boto3
 import botocore.client
 from pydantic import BaseModel, Field
 
-from src.adapters.aws import get_base_aws_config, get_boto_session
+from src.adapters.aws import get_aws_config, get_boto_session
 from src.util.env_config import PydanticBaseEnvConfig
 from src.util.json_util import json_encoder
 
@@ -58,7 +58,7 @@ def get_boto_sqs_client(
     if session is None:
         session = get_boto_session()
 
-    return session.client("sqs", region_name=get_base_aws_config().aws_region, **params)
+    return session.client("sqs", region_name=get_aws_config().aws_region, **params)
 
 
 class SQSClient:

--- a/api/src/util/file_util.py
+++ b/api/src/util/file_util.py
@@ -107,10 +107,10 @@ def pre_sign_file_location(file_path: str, s3_config: S3Config | None = None) ->
         Params={"Bucket": bucket, "Key": key},
         ExpiresIn=s3_config.presigned_s3_duration,
     )
-    if s3_config.s3_endpoint_url:
+    if s3_config.aws_s3_endpoint_url:
         # Only relevant when local, due to docker path issues
         pre_sign_file_loc = pre_sign_file_loc.replace(
-            s3_config.s3_endpoint_url, "http://localhost:9090"
+            s3_config.aws_s3_endpoint_url, "http://localhost:9090"
         )
 
     return pre_sign_file_loc

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -467,7 +467,7 @@ def reset_aws_env_vars(monkeypatch):
     monkeypatch.delenv("AWS_S3_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("AWS_SQS_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("CDN_URL", raising=False)
-    monkeypatch.setattr("src.adapters.aws.aws_session._base_aws_config", None)
+    monkeypatch.setattr("src.adapters.aws.aws_session._aws_config", None)
 
 
 @pytest.fixture

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -464,8 +464,8 @@ def reset_aws_env_vars(monkeypatch):
     monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
-    monkeypatch.delenv("S3_ENDPOINT_URL", raising=False)
-    monkeypatch.delenv("SQS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_S3_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_SQS_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("CDN_URL", raising=False)
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -467,6 +467,7 @@ def reset_aws_env_vars(monkeypatch):
     monkeypatch.delenv("AWS_S3_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("AWS_SQS_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("CDN_URL", raising=False)
+    monkeypatch.setattr("src.adapters.aws.aws_session._base_aws_config", None)
 
 
 @pytest.fixture

--- a/api/tests/src/adapters/aws/test_sqs_adapter.py
+++ b/api/tests/src/adapters/aws/test_sqs_adapter.py
@@ -43,7 +43,7 @@ class TestGetBotoSQSClient:
         get_boto_sqs_client()
         mock_get_session.assert_called_once()
         mock_session.client.assert_called_once_with(
-            "sqs", region_name="us-east-1", endpoint_url=SQSConfig().sqs_endpoint_url
+            "sqs", region_name="us-east-1", endpoint_url=SQSConfig().aws_sqs_endpoint_url
         )
 
     def test_uses_provided_session(self):
@@ -51,7 +51,7 @@ class TestGetBotoSQSClient:
         mock_session = Mock()
         get_boto_sqs_client(session=mock_session)
         mock_session.client.assert_called_once_with(
-            "sqs", region_name="us-east-1", endpoint_url=SQSConfig().sqs_endpoint_url
+            "sqs", region_name="us-east-1", endpoint_url=SQSConfig().aws_sqs_endpoint_url
         )
 
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #8826 

## Changes proposed

- Updated local.env to rename environment variables
- Updated init.py to add `get_base_aws_config` to exports
- Updated aws_session.py to incorporate `aws_region`
- Updated s3_adapter.py to change variable name to `aws_s3_endpoint_url` and incorporate `get_base_aws_config()`
- Updated sqs_adapter.py to change variable name to `aws_sqs_endpoint_url` and incorporate `get_base_aws_config()`
- Updated file_util.py to change variable names
- Updated conftest.py to change environment variable names and reset `base_aws_config` with other env vars
- Updated test_sqs_adapter.py to correctly call url variable 

## Context for reviewers

For connecting to SQS and s3 we have configurations that load environment variables for a variety of cases that we wanted to centralize and standardize.

## Validation steps

Confirm full test suite passes.