### PR TITLE
Fix #9799: Fix typos in css-and-design-system.md

### DIFF
--- a/documentation/frontend/css-and-design-system.md
+++ b/documentation/frontend/css-and-design-system.md
@@ -11,7 +11,7 @@ Be mindful when adjusting the presentation of elements, styling existing compone
 
 When implementing a design pattern, first configure any available `$theme-` variables to bring the design system defaults closer to the desired pattern. These global system settings are our primary method for maintaining a unified and recognizable identity. 
 
-The design system has been customized to match the [Simpler brand guidlines](https://wiki.simpler.grants.gov/design-and-research/brand-guidelines). However, not all USWDS settings variables have been explicitly defined. It may be necessary to define additional `$theme-` variables to match design mockups and ensure brand consistency.  
+The design system has been customized to match the [Simpler brand guidelines](https://wiki.simpler.grants.gov/design-and-research/brand-guidelines). However, not all USWDS settings variables have been explicitly defined. It may be necessary to define additional `$theme-` variables to match design mockups and ensure brand consistency.  
 
 _See [USWDS Settings guidance](https://designsystem.digital.gov/documentation/settings/)_
 
@@ -37,4 +37,4 @@ _See [USWDS Design Tokens](https://designsystem.digital.gov/design-tokens/)_
 
 Do not infer design decisions that deviate from USWDS defaults. 
 
-A design system allows us to move quickly and avoid striving for pixel perfection. But it also means that mockups can sometimes be sketchy and challenging to interpret. If a mockup is similar to an existing USWDS style, the designer likely indended to use that style. If a mockup includes obvious deviations, suggest that existing patterns be used instead. Any deviations from USWDS defaults should be explicitly discussed and documented. 
+A design system allows us to move quickly and avoid striving for pixel perfection. But it also means that mockups can sometimes be sketchy and challenging to interpret. If a mockup is similar to an existing USWDS style, the designer likely intended to use that style. If a mockup includes obvious deviations, suggest that existing patterns be used instead. Any deviations from USWDS defaults should be explicitly discussed and documented. 


### PR DESCRIPTION
This PR fixes issue #9799.

**Changes:**
- Line 14: `brand guidlines` → `brand guidelines`
- Line 40: `indended` → `intended`

The existing link target is unchanged. No other content was modified.

_Disclaimer: This contribution was generated with AI assistance._