### PR TITLE
[Issue #8265] Fixed different filter behavior.

### DIFF
--- a/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
@@ -1,12 +1,7 @@
-import { warn } from "console";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
-import { initial } from "lodash";
 import { initialFilterOptions } from "src/utils/testing/fixtures";
-
-import React from "react";
-import { Radio } from "@trussworks/react-uswds";
 
 import { RadioButtonFilter } from "src/components/search/Filters/RadioButtonFilter";
 

--- a/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
@@ -172,13 +172,13 @@ describe("RadioButtonFilter", () => {
 
     let anyOption = screen.getByRole("radio", {
       name: "Any test accordion",
-    }) as HTMLInputElement;
+    });
 
     expect(anyOption).toBeChecked();
 
     let cooperativeAgreementOption = screen.getByRole("radio", {
       name: "Cooperative Agreement",
-    }) as HTMLInputElement;
+    });
 
     expect(cooperativeAgreementOption).not.toBeChecked();
 

--- a/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
@@ -1,185 +1,233 @@
+import { warn } from "console";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
+import { initial } from "lodash";
 import { initialFilterOptions } from "src/utils/testing/fixtures";
 
 import React from "react";
+import { Radio } from "@trussworks/react-uswds";
 
 import { RadioButtonFilter } from "src/components/search/Filters/RadioButtonFilter";
-import { initial } from "lodash";
 
 const fakeFacetCounts = {
-	grant: 1,
-	other: 1,
-	procurement_contract: 1,
-	cooperative_agreement: 1,
+  grant: 1,
+  other: 1,
+  procurement_contract: 1,
+  cooperative_agreement: 1,
 };
 
 const mockSetQueryParam = jest.fn();
 
 jest.mock("src/hooks/useSearchParamUpdater", () => ({
-	useSearchParamUpdater: () => ({
-		setQueryParam: mockSetQueryParam,
-	}),
+  useSearchParamUpdater: () => ({
+    setQueryParam: mockSetQueryParam,
+  }),
 }));
 
 describe("RadioButtonFilter", () => {
-	const title = "Test Accordion";
-	const queryParamKey = "closeDate";
+  const title = "Test Accordion";
+  const queryParamKey = "closeDate";
 
-	it("should not have basic accessibility issues", async () => {
-		const { container } = render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set()}
-				facetCounts={fakeFacetCounts}
-			/>,
-		);
-		const results = await axe(container);
-		expect(results).toHaveNoViolations();
-	});
+  it("should not have basic accessibility issues", async () => {
+    const { container } = render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set()}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 
-	it("displays the correct radio labels", () => {
-		render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set()}
-				facetCounts={fakeFacetCounts}
-			/>,
-		);
+  it("displays the correct radio labels", () => {
+    render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set()}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
 
-		expect(screen.getByText("Cooperative Agreement")).toBeInTheDocument();
-		expect(screen.getByText("Grant")).toBeInTheDocument();
-		expect(screen.getByText("Procurement Contract")).toBeInTheDocument();
-		expect(screen.getByText("Other")).toBeInTheDocument();
-	});
+    expect(screen.getByText("Cooperative Agreement")).toBeInTheDocument();
+    expect(screen.getByText("Grant")).toBeInTheDocument();
+    expect(screen.getByText("Procurement Contract")).toBeInTheDocument();
+    expect(screen.getByText("Other")).toBeInTheDocument();
+  });
 
-	it("updates heading background color when options are selected", () => {
-		const { rerender } = render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set("")}
-				facetCounts={fakeFacetCounts}
-			/>,
-		);
+  it("updates heading background color when options are selected", () => {
+    const { rerender } = render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
 
-		const updatedQuery = new Set("");
-		updatedQuery.add("Cooperative Agreement");
-		updatedQuery.add("Grant");
+    const updatedQuery = new Set("");
+    updatedQuery.add("Cooperative Agreement");
+    updatedQuery.add("Grant");
 
-		rerender(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={updatedQuery}
-				facetCounts={fakeFacetCounts}
-			/>,
-		);
+    rerender(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={updatedQuery}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
 
-		// Verify the background updates after selecting options
-		// actual checkbox state is tested in AccordionContent
-		const titleHeading = screen.getByRole("heading");
-		expect(titleHeading).toHaveClass("simpler-selected-filter");
-	});
-	it("adds an any option radio by default", async () => {
-		render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set("")}
-				facetCounts={fakeFacetCounts}
-			/>,
-		);
-		const accordionToggleButton = screen.getByRole("button");
-		await userEvent.click(accordionToggleButton);
-		const anyRadio = screen.getByRole("radio", {
-			name: "Any test accordion",
-		});
-		expect(anyRadio).toBeInTheDocument();
-		expect(anyRadio).toBeChecked();
-	});
+    // Verify the background updates after selecting options
+    // actual checkbox state is tested in AccordionContent
+    const titleHeading = screen.getByRole("heading");
+    expect(titleHeading).toHaveClass("simpler-selected-filter");
+  });
+  it("adds an any option radio by default", async () => {
+    render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={fakeFacetCounts}
+      />,
+    );
+    const accordionToggleButton = screen.getByRole("button");
+    await userEvent.click(accordionToggleButton);
+    const anyRadio = screen.getByRole("radio", {
+      name: "Any test accordion",
+    });
+    expect(anyRadio).toBeInTheDocument();
+    expect(anyRadio).toBeChecked();
+  });
 
-	it("should be expanded by default if there are selected options", () => {
-		render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set("Cooperative Agreement")}
-				facetCounts={fakeFacetCounts}
-				includeAnyOption={false}
-			/>,
-		);
+  it("should be expanded by default if there are selected options", () => {
+    render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("Cooperative Agreement")}
+        facetCounts={fakeFacetCounts}
+        includeAnyOption={false}
+      />,
+    );
 
-		const radio = screen.getByText("Cooperative Agreement");
+    const radio = screen.getByText("Cooperative Agreement");
 
-		expect(radio).toBeVisible();
-	});
+    expect(radio).toBeVisible();
+  });
 
-	it("should not be expanded by default if there no are selected options", () => {
-		render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set()}
-				facetCounts={fakeFacetCounts}
-				includeAnyOption={false}
-			/>,
-		);
+  it("should not be expanded by default if there no are selected options", () => {
+    render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set()}
+        facetCounts={fakeFacetCounts}
+        includeAnyOption={false}
+      />,
+    );
 
-		const radio = screen.queryByText("Cooperative Agreement");
+    const radio = screen.queryByText("Cooperative Agreement");
 
-		expect(radio).not.toBeVisible();
-	});
-	it("calls setQueryParam correctly on toggle", async () => {
-		render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set()}
-				facetCounts={undefined}
-				includeAnyOption={false}
-			/>,
-		);
-		const accordionToggleButton = screen.getByRole("button");
-		await userEvent.click(accordionToggleButton);
-		const radioOption = screen.getByRole("radio", {
-			name: "Grant",
-		});
-		expect(radioOption).toBeInTheDocument();
-		await userEvent.click(radioOption);
-		expect(mockSetQueryParam).toHaveBeenCalledWith(queryParamKey, "grant");
-	});
-	it("sets selection back to any radio option on second consecutive selection of the same non-default option", async () => {
-		const { rerender } = render(
-			<RadioButtonFilter
-				filterOptions={initialFilterOptions}
-				title={title}
-				queryParamKey={queryParamKey}
-				query={new Set("")}
-				facetCounts={undefined}
-			/>,
-		);
-		const accordionToggleButton = screen.getByRole("button");
-		await userEvent.click(accordionToggleButton);
+    expect(radio).not.toBeVisible();
+  });
+  it("calls setQueryParam correctly on toggle", async () => {
+    render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set()}
+        facetCounts={undefined}
+        includeAnyOption={false}
+      />,
+    );
+    const accordionToggleButton = screen.getByRole("button");
+    await userEvent.click(accordionToggleButton);
+    const radioOption = screen.getByRole("radio", {
+      name: "Grant",
+    });
+    expect(radioOption).toBeInTheDocument();
+    await userEvent.click(radioOption);
+    expect(mockSetQueryParam).toHaveBeenCalledWith(queryParamKey, "grant");
+  });
+  it("sets selection back to any radio option on second consecutive selection of the same non-default option", async () => {
+    const { rerender } = render(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set("")}
+        facetCounts={undefined}
+      />,
+    );
+    const accordionToggleButton = screen.getByRole("button");
+    await userEvent.click(accordionToggleButton);
 
+    let anyOption = screen.getByRole("radio", {
+      name: "Any test accordion",
+    }) as HTMLInputElement;
 
-		let anyTargetOption = screen.getByRole("radio", {
-			name: "Cooperative Agreement",
-		}) as HTMLInputElement;
-		
-		await userEvent.click(anyTargetOption); // clicked once
-		
-		expect(anyTargetOption).toBeChecked();
-	});
+    expect(anyOption).toBeChecked();
+
+    let cooperativeAgreementOption = screen.getByRole("radio", {
+      name: "Cooperative Agreement",
+    }) as HTMLInputElement;
+
+    expect(cooperativeAgreementOption).not.toBeChecked();
+
+    await userEvent.click(cooperativeAgreementOption);
+
+    let updatedQuery = "cooperative_agreement";
+
+    expect(mockSetQueryParam).toHaveBeenCalledWith(queryParamKey, updatedQuery);
+
+    rerender(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set([updatedQuery])}
+        facetCounts={undefined}
+      />,
+    );
+
+    cooperativeAgreementOption = screen.getByRole("radio", {
+      name: "Cooperative Agreement",
+    });
+
+    expect(cooperativeAgreementOption).toBeChecked();
+
+    await userEvent.click(cooperativeAgreementOption);
+
+    updatedQuery = "";
+    expect(mockSetQueryParam).toHaveBeenCalledWith(queryParamKey, updatedQuery);
+
+    rerender(
+      <RadioButtonFilter
+        filterOptions={initialFilterOptions}
+        title={title}
+        queryParamKey={queryParamKey}
+        query={new Set(updatedQuery)}
+        facetCounts={undefined}
+      />,
+    );
+
+    anyOption = screen.getByRole("radio", {
+      name: "Any test accordion",
+    });
+
+    expect(anyOption).toBeChecked();
+  });
 });

--- a/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.test.tsx
@@ -6,157 +6,180 @@ import { initialFilterOptions } from "src/utils/testing/fixtures";
 import React from "react";
 
 import { RadioButtonFilter } from "src/components/search/Filters/RadioButtonFilter";
+import { initial } from "lodash";
 
 const fakeFacetCounts = {
-  grant: 1,
-  other: 1,
-  procurement_contract: 1,
-  cooperative_agreement: 1,
+	grant: 1,
+	other: 1,
+	procurement_contract: 1,
+	cooperative_agreement: 1,
 };
 
 const mockSetQueryParam = jest.fn();
 
 jest.mock("src/hooks/useSearchParamUpdater", () => ({
-  useSearchParamUpdater: () => ({
-    setQueryParam: mockSetQueryParam,
-  }),
+	useSearchParamUpdater: () => ({
+		setQueryParam: mockSetQueryParam,
+	}),
 }));
 
 describe("RadioButtonFilter", () => {
-  const title = "Test Accordion";
-  const queryParamKey = "closeDate";
+	const title = "Test Accordion";
+	const queryParamKey = "closeDate";
 
-  it("should not have basic accessibility issues", async () => {
-    const { container } = render(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={new Set()}
-        facetCounts={fakeFacetCounts}
-      />,
-    );
-    const results = await axe(container);
-    expect(results).toHaveNoViolations();
-  });
+	it("should not have basic accessibility issues", async () => {
+		const { container } = render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set()}
+				facetCounts={fakeFacetCounts}
+			/>,
+		);
+		const results = await axe(container);
+		expect(results).toHaveNoViolations();
+	});
 
-  it("displays the correct radio labels", () => {
-    render(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={new Set()}
-        facetCounts={fakeFacetCounts}
-      />,
-    );
+	it("displays the correct radio labels", () => {
+		render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set()}
+				facetCounts={fakeFacetCounts}
+			/>,
+		);
 
-    expect(screen.getByText("Cooperative Agreement")).toBeInTheDocument();
-    expect(screen.getByText("Grant")).toBeInTheDocument();
-    expect(screen.getByText("Procurement Contract")).toBeInTheDocument();
-    expect(screen.getByText("Other")).toBeInTheDocument();
-  });
+		expect(screen.getByText("Cooperative Agreement")).toBeInTheDocument();
+		expect(screen.getByText("Grant")).toBeInTheDocument();
+		expect(screen.getByText("Procurement Contract")).toBeInTheDocument();
+		expect(screen.getByText("Other")).toBeInTheDocument();
+	});
 
-  it("updates heading background color when options are selected", () => {
-    const { rerender } = render(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={new Set("")}
-        facetCounts={fakeFacetCounts}
-      />,
-    );
+	it("updates heading background color when options are selected", () => {
+		const { rerender } = render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set("")}
+				facetCounts={fakeFacetCounts}
+			/>,
+		);
 
-    const updatedQuery = new Set("");
-    updatedQuery.add("Cooperative Agreement");
-    updatedQuery.add("Grant");
+		const updatedQuery = new Set("");
+		updatedQuery.add("Cooperative Agreement");
+		updatedQuery.add("Grant");
 
-    rerender(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={updatedQuery}
-        facetCounts={fakeFacetCounts}
-      />,
-    );
+		rerender(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={updatedQuery}
+				facetCounts={fakeFacetCounts}
+			/>,
+		);
 
-    // Verify the background updates after selecting options
-    // actual checkbox state is tested in AccordionContent
-    const titleHeading = screen.getByRole("heading");
-    expect(titleHeading).toHaveClass("simpler-selected-filter");
-  });
-  it("adds an any option radio by default", async () => {
-    render(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={new Set("")}
-        facetCounts={fakeFacetCounts}
-      />,
-    );
-    const accordionToggleButton = screen.getByRole("button");
-    await userEvent.click(accordionToggleButton);
-    const anyRadio = screen.getByRole("radio", {
-      name: "Any test accordion",
-    });
-    expect(anyRadio).toBeInTheDocument();
-    expect(anyRadio).toBeChecked();
-  });
+		// Verify the background updates after selecting options
+		// actual checkbox state is tested in AccordionContent
+		const titleHeading = screen.getByRole("heading");
+		expect(titleHeading).toHaveClass("simpler-selected-filter");
+	});
+	it("adds an any option radio by default", async () => {
+		render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set("")}
+				facetCounts={fakeFacetCounts}
+			/>,
+		);
+		const accordionToggleButton = screen.getByRole("button");
+		await userEvent.click(accordionToggleButton);
+		const anyRadio = screen.getByRole("radio", {
+			name: "Any test accordion",
+		});
+		expect(anyRadio).toBeInTheDocument();
+		expect(anyRadio).toBeChecked();
+	});
 
-  it("should be expanded by default if there are selected options", () => {
-    render(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={new Set("Cooperative Agreement")}
-        facetCounts={fakeFacetCounts}
-        includeAnyOption={false}
-      />,
-    );
+	it("should be expanded by default if there are selected options", () => {
+		render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set("Cooperative Agreement")}
+				facetCounts={fakeFacetCounts}
+				includeAnyOption={false}
+			/>,
+		);
 
-    const radio = screen.getByText("Cooperative Agreement");
+		const radio = screen.getByText("Cooperative Agreement");
 
-    expect(radio).toBeVisible();
-  });
+		expect(radio).toBeVisible();
+	});
 
-  it("should not be expanded by default if there no are selected options", () => {
-    render(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={new Set()}
-        facetCounts={fakeFacetCounts}
-        includeAnyOption={false}
-      />,
-    );
+	it("should not be expanded by default if there no are selected options", () => {
+		render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set()}
+				facetCounts={fakeFacetCounts}
+				includeAnyOption={false}
+			/>,
+		);
 
-    const radio = screen.queryByText("Cooperative Agreement");
+		const radio = screen.queryByText("Cooperative Agreement");
 
-    expect(radio).not.toBeVisible();
-  });
-  it("calls setQueryParam correctly on toggle", async () => {
-    render(
-      <RadioButtonFilter
-        filterOptions={initialFilterOptions}
-        title={title}
-        queryParamKey={queryParamKey}
-        query={new Set()}
-        facetCounts={undefined}
-        includeAnyOption={false}
-      />,
-    );
-    const accordionToggleButton = screen.getByRole("button");
-    await userEvent.click(accordionToggleButton);
-    const radioOption = screen.getByRole("radio", {
-      name: "Grant",
-    });
-    expect(radioOption).toBeInTheDocument();
-    await userEvent.click(radioOption);
-    expect(mockSetQueryParam).toHaveBeenCalledWith(queryParamKey, "grant");
-  });
+		expect(radio).not.toBeVisible();
+	});
+	it("calls setQueryParam correctly on toggle", async () => {
+		render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set()}
+				facetCounts={undefined}
+				includeAnyOption={false}
+			/>,
+		);
+		const accordionToggleButton = screen.getByRole("button");
+		await userEvent.click(accordionToggleButton);
+		const radioOption = screen.getByRole("radio", {
+			name: "Grant",
+		});
+		expect(radioOption).toBeInTheDocument();
+		await userEvent.click(radioOption);
+		expect(mockSetQueryParam).toHaveBeenCalledWith(queryParamKey, "grant");
+	});
+	it("sets selection back to any radio option on second consecutive selection of the same non-default option", async () => {
+		const { rerender } = render(
+			<RadioButtonFilter
+				filterOptions={initialFilterOptions}
+				title={title}
+				queryParamKey={queryParamKey}
+				query={new Set("")}
+				facetCounts={undefined}
+			/>,
+		);
+		const accordionToggleButton = screen.getByRole("button");
+		await userEvent.click(accordionToggleButton);
+
+
+		let anyTargetOption = screen.getByRole("radio", {
+			name: "Cooperative Agreement",
+		}) as HTMLInputElement;
+		
+		await userEvent.click(anyTargetOption); // clicked once
+		
+		expect(anyTargetOption).toBeChecked();
+	});
 });

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -21,8 +21,15 @@ export function RadioButtonFilter({
 }: SearchFilterProps) {
   const { setQueryParam } = useSearchParamUpdater();
 
-  const toggleRadioSelection = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setQueryParam(queryParamKey, event.target.value);
+  const toggleRadioSelection = (event: React.MouseEvent<HTMLInputElement>) => {
+    const value = event.currentTarget.value;
+
+    if (query.has(value)) {
+      setQueryParam(queryParamKey, "");
+      event.currentTarget.checked = false;
+    } else {
+      setQueryParam(queryParamKey, value);
+    }
   };
 
   const isNoneSelected = useMemo(() => query.size === 0, [query]);
@@ -44,7 +51,7 @@ export function RadioButtonFilter({
                 id={`${title}-any-radio`}
                 name={`Any ${title}`}
                 label={`Any ${title.toLowerCase()}`}
-                onChange={toggleRadioSelection}
+                onClick={toggleRadioSelection}
                 value={undefined}
                 facetCount={undefined}
                 checked={isNoneSelected}
@@ -57,7 +64,7 @@ export function RadioButtonFilter({
                 id={option.id}
                 name={option.label}
                 label={option.label}
-                onChange={toggleRadioSelection}
+                onClick={toggleRadioSelection}
                 value={option.value}
                 facetCount={facetCounts && (facetCounts?.[option.value] || 0)}
                 checked={query.has(option.value)}

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -21,16 +21,21 @@ export function RadioButtonFilter({
 }: SearchFilterProps) {
   const { setQueryParam } = useSearchParamUpdater();
 
-  const toggleRadioSelection = (event: React.MouseEvent<HTMLInputElement>) => {
-    const value = event.currentTarget.value;
-
-    if (query.has(value)) {
-      setQueryParam(queryParamKey, "");
-      event.currentTarget.checked = false;
-    } else {
-      setQueryParam(queryParamKey, value);
-    }
+  const toggleRadioSelection = (event: React.ChangeEvent<HTMLInputElement>) => {
+		  const value = event.target.value;
+		  if(!query.has(value)){
+				  setQueryParam(queryParamKey, event.target.value);
+		  }
   };
+
+  const handleRadioClickedTwice = (event: React.MouseEvent<HTMLInputElement>) => {
+		const value = event.currentTarget.value; 
+		if((event.currentTarget as HTMLInputElement).checked && query.has(value)){
+				setQueryParam(queryParamKey, "");
+				event.currentTarget.checked = false;
+		}
+
+  }
 
   const isNoneSelected = useMemo(() => query.size === 0, [query]);
 
@@ -51,7 +56,7 @@ export function RadioButtonFilter({
                 id={`${title}-any-radio`}
                 name={`Any ${title}`}
                 label={`Any ${title.toLowerCase()}`}
-                onClick={toggleRadioSelection}
+                onChange={toggleRadioSelection}
                 value={undefined}
                 facetCount={undefined}
                 checked={isNoneSelected}
@@ -64,7 +69,8 @@ export function RadioButtonFilter({
                 id={option.id}
                 name={option.label}
                 label={option.label}
-                onClick={toggleRadioSelection}
+                onChange={toggleRadioSelection}
+				onClick={handleRadioClickedTwice}
                 value={option.value}
                 facetCount={facetCounts && (facetCounts?.[option.value] || 0)}
                 checked={query.has(option.value)}

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -22,20 +22,21 @@ export function RadioButtonFilter({
   const { setQueryParam } = useSearchParamUpdater();
 
   const toggleRadioSelection = (event: React.ChangeEvent<HTMLInputElement>) => {
-		  const value = event.target.value;
-		  if(!query.has(value)){
-				  setQueryParam(queryParamKey, event.target.value);
-		  }
+    const value = event.target.value;
+    if (!query.has(value)) {
+      setQueryParam(queryParamKey, event.target.value);
+    }
   };
 
-  const handleRadioClickedTwice = (event: React.MouseEvent<HTMLInputElement>) => {
-		const value = event.currentTarget.value; 
-		if((event.currentTarget as HTMLInputElement).checked && query.has(value)){
-				setQueryParam(queryParamKey, "");
-				event.currentTarget.checked = false;
-		}
-
-  }
+  const handleRadioClickedTwice = (
+    event: React.MouseEvent<HTMLInputElement>,
+  ) => {
+    const value = event.currentTarget.value;
+    if ((event.currentTarget as HTMLInputElement).checked && query.has(value)) {
+      setQueryParam(queryParamKey, "");
+      event.currentTarget.checked = false;
+    }
+  };
 
   const isNoneSelected = useMemo(() => query.size === 0, [query]);
 
@@ -70,7 +71,7 @@ export function RadioButtonFilter({
                 name={option.label}
                 label={option.label}
                 onChange={toggleRadioSelection}
-				onClick={handleRadioClickedTwice}
+                onClick={handleRadioClickedTwice}
                 value={option.value}
                 facetCount={facetCounts && (facetCounts?.[option.value] || 0)}
                 checked={query.has(option.value)}

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -31,7 +31,7 @@ export function RadioButtonFilter({
   const handleRadioClickedTwice = (
     event: React.MouseEvent<HTMLInputElement>,
   ) => {
-    if ((event.currentTarget as HTMLInputElement).checked) {
+    if ((event.currentTarget as HTMLInputElement).checked) { // focused only on checking the radio button to see if its checked.
       setQueryParam(queryParamKey, "");
       event.currentTarget.checked = false;
     }

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -31,7 +31,8 @@ export function RadioButtonFilter({
   const handleRadioClickedTwice = (
     event: React.MouseEvent<HTMLInputElement>,
   ) => {
-    if ((event.currentTarget as HTMLInputElement).checked) { // focused only on checking the radio button to see if its checked.
+    if ((event.currentTarget as HTMLInputElement).checked) {
+      // focused only on checking the radio button to see if its checked.
       setQueryParam(queryParamKey, "");
       event.currentTarget.checked = false;
     }

--- a/frontend/src/components/search/Filters/RadioButtonFilter.tsx
+++ b/frontend/src/components/search/Filters/RadioButtonFilter.tsx
@@ -31,8 +31,7 @@ export function RadioButtonFilter({
   const handleRadioClickedTwice = (
     event: React.MouseEvent<HTMLInputElement>,
   ) => {
-    const value = event.currentTarget.value;
-    if ((event.currentTarget as HTMLInputElement).checked && query.has(value)) {
+    if ((event.currentTarget as HTMLInputElement).checked) {
       setQueryParam(queryParamKey, "");
       event.currentTarget.checked = false;
     }

--- a/frontend/src/components/search/SearchFilterRadio.tsx
+++ b/frontend/src/components/search/SearchFilterRadio.tsx
@@ -8,6 +8,7 @@ interface FilterRadioProps {
   name?: string;
   label: ReactNode;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onClick?: (event: React.MouseEvent<HTMLInputElement>) => void;
   disabled?: boolean;
   checked?: boolean;
   value?: string;
@@ -20,6 +21,7 @@ export const SearchFilterRadio = ({
   name,
   label,
   onChange,
+  onClick,
   disabled = false,
   checked = false,
   value,
@@ -39,6 +41,7 @@ export const SearchFilterRadio = ({
       </>
     }
     onChange={onChange}
+    onClick={onClick}
     disabled={disabled}
     checked={checked}
     value={value || ""}


### PR DESCRIPTION

## Summary

The difference in filter behavior documented in #8265 was due to the difference in the selection toggle functions declared in `CheckboxFilter.tsx` (functioning correctly) and in `RadioButtonFilter.tsx` (minimal functionality). Two changes were made to fix the behavior of `RadioButtonFilter.tsx` to mirror `CheckboxFilter.tsx`

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8265 

## Changes proposed

1) In `src/components/search/SearchFilterRadio.tsx` the toggle selection function was assigned to an `onChange` prop. This caused issues since the toggle selection function was not getting triggered the second time for the selected radio button because nothing was being changed to trigger the event handler. An `onClick` prop was added to fix this issue and the `toggleRadioSelection` function was changed to take `React.MouseEvent` instead of `React.ChangeEvent`.

2) The `toggleRadioSelection` function was changed to de-select the clicked radio button and assign empty string as the value for `setQueryParam()`. This causes the default radio button to be selected.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The `RadioButtonFilter.tsx` did not have a completed toggle selection function. This caused a difference between the selection behavior compared to `CheckboxFilter.tsx`. The difference was that for a selected selection, selecting it the second time would cause the default selection to be automatically selected. This was not happening in the filters that used radio buttons. 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Clicking on a radio button filter twice will now select the default selection automatically. 