### PR TITLE
[Unticketed] Add linting rule to exclude imports where we've got derived implementations

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -191,6 +191,8 @@ allowed-confusables = [
 # For these libraries, we do use them, but have our own derived versions we want
 # to use instead as we've rewritten fundamental components like error messaging.
 "marshmallow.validate".msg = "Do not import marshmallow.validate directly - instead use src.api.schemas.extension.validators as we've rewritten the error messaging"
+"apiflask.validators".msg = "Do not import apiflask.validators directly - instead use src.api.schemas.extension.validators as we've rewritten the error messaging"
+"apiflask.fields".msg = "Do not import apiflask.fields directly - instead use src.api.schemas.extension.fields as we've rewritten the error messaging"
 "apiflask.Schema".msg = "Do not import apiflask.Schema directly - instead use src.api.schemas.extension"
 
 [tool.mypy]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -109,7 +109,7 @@ target-version = "py314"
 
 [tool.ruff.lint]
 # See: https://docs.astral.sh/ruff/rules/ for all possible rules
-select = ["B", "C", "E", "F", "W", "B9", "UP", "RUF", "PT"]
+select = ["B", "C", "E", "F", "W", "B9", "UP", "RUF", "PT", "TID251"]
 ignore = [
     # too many leading '#' for block comment, we can format our comments however we want
     "E266",
@@ -187,6 +187,11 @@ allowed-confusables = [
     "PT018"
 ]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# For these libraries, we do use them, but have our own derived versions we want
+# to use instead as we've rewritten fundamental components like error messaging.
+"marshmallow.validate".msg = "Do not import marshmallow.validate directly - instead use src.api.schemas.extension.validators as we've rewritten the error messaging"
+"apiflask.Schema".msg = "Do not import apiflask.Schema directly - instead use src.api.schemas.extension"
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/stable/config_file.html

--- a/api/src/api/schemas/extension/field_validators.py
+++ b/api/src/api/schemas/extension/field_validators.py
@@ -1,7 +1,7 @@
 import copy
 import typing
 
-from apiflask import validators
+from apiflask import validators  # noqa: TID251
 from marshmallow import ValidationError
 from marshmallow.validate import _SizedT  # noqa: TID251
 

--- a/api/src/api/schemas/extension/field_validators.py
+++ b/api/src/api/schemas/extension/field_validators.py
@@ -3,7 +3,7 @@ import typing
 
 from apiflask import validators
 from marshmallow import ValidationError
-from marshmallow.validate import _SizedT
+from marshmallow.validate import _SizedT  # noqa: TID251
 
 from src.api.schemas.extension.schema_common import MarshmallowErrorContainer
 from src.validation.validation_constants import ValidationErrorType

--- a/api/src/api/schemas/extension/schema.py
+++ b/api/src/api/schemas/extension/schema.py
@@ -7,7 +7,7 @@ from src.api.schemas.extension.schema_common import MarshmallowErrorContainer
 from src.validation.validation_constants import ValidationErrorType
 
 
-class Schema(apiflask.Schema):
+class Schema(apiflask.Schema):  # noqa: TID251
     # There's no clean way to override the error messages at the schema-level
     # as they get stored directly into the internal error store of the Schema object
     #

--- a/api/src/api/schemas/extension/schema_fields.py
+++ b/api/src/api/schemas/extension/schema_fields.py
@@ -2,7 +2,7 @@ import copy
 import enum
 import typing
 
-from apiflask import fields as original_fields
+from apiflask import fields as original_fields  # noqa: TID251
 from marshmallow import ValidationError
 
 from src.api.schemas.extension.field_validators import URL as CustomURL


### PR DESCRIPTION
## Summary
## Changes proposed
* Added certain imports to a configuration that will cause a linting error if used.

## Context for reviewers
We create our own derived versions of these validators and schemas with changed error handling and formatting. We don't want to mistakenly import the wrong ones as the behavior is undefined for our error handling (probably just 500s in certain cases).

Note that we do use these to make our implementation, so added an ignore where necessary.

## Validation steps
Just run `make lint`. Try adding these imports in other files and it'll complain.
