### PR TITLE
[Issue #9869] Update AwardRecommendationRiskRequestSchema to use proper validation

### DIFF
--- a/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
@@ -1,5 +1,3 @@
-from marshmallow import validate
-
 from src.api.schemas.extension import Schema, fields
 from src.api.schemas.extension.field_validators import Length
 from src.api.schemas.response_schema import AbstractResponseSchema, PaginationMixinSchema
@@ -447,7 +445,7 @@ class AwardRecommendationRiskRequestSchema(Schema):
     award_recommendation_application_submission_ids = fields.List(
         fields.UUID(),
         required=True,
-        validate=[validate.Length(min=1)],
+        validate=[Length(min=1)],
         metadata={
             "description": "List of award recommendation application submission IDs to link to this risk"
         },

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_risk_create.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_risk_create.py
@@ -368,3 +368,27 @@ class TestCreateAwardRecommendationRisk422:
         )
 
         assert resp.status_code == 422
+
+    def test_create_risk_empty_submissions_422(
+        self, client, db_session, agency, award_recommendation
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/risks",
+            headers={"X-SGG-Token": token},
+            json={
+                "comment": "Some risk",
+                "award_recommendation_risk_type": AwardRecommendationRiskType.ADDITIONAL_MONITORING,
+                "award_recommendation_application_submission_ids": [],
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "errors" in resp.json
+        assert any(
+            error["field"] == "award_recommendation_application_submission_ids"
+            for error in resp.json["errors"]
+        )

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_risk_update.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_risk_update.py
@@ -550,3 +550,33 @@ class TestUpdateAwardRecommendationRisk422:
         )
 
         assert resp.status_code == 422
+
+    def test_update_risk_empty_submissions_422(
+        self, client, db_session, agency, award_recommendation
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        risk = AwardRecommendationRiskFactory.create(
+            award_recommendation=award_recommendation,
+        )
+
+        resp = client.put(
+            _build_url(
+                award_recommendation.award_recommendation_id, risk.award_recommendation_risk_id
+            ),
+            headers={"X-SGG-Token": token},
+            json={
+                "comment": "Some risk",
+                "award_recommendation_risk_type": AwardRecommendationRiskType.ADDITIONAL_MONITORING,
+                "award_recommendation_application_submission_ids": [],
+            },
+        )
+
+        assert resp.status_code == 422
+        assert "errors" in resp.json
+        assert any(
+            error["field"] == "award_recommendation_application_submission_ids"
+            for error in resp.json["errors"]
+        )


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9869 

## Changes proposed

- Updated award_recommendation_schemas.py to update `AwardRecommendationRiskRequestSchema` to use `validate=[Length(min=1)]`
- Updated test_award_recommendation_risk_create.py to add empty list 422 test
- Updated test_award_recommendation_risk_update.py to add empty list 422 test

## Context for reviewers

When the `AwardRecommendationRiskRequestSchema` was first created, the validation to prevent an empty list from being passed in was using the Marshmallow validate instead of our custom validators found in `src.api.schemas.extension`. This causes a response code of 500 instead of the expected 422.

## Validation steps

Confirm tests pass. The endpoints can also be tested via Swagger, where the input of an empty list should return a 422 response.