### PR TITLE
[Issue #9463] Set organization saved opportunity environment variable to enabled by default

### DIFF
--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -89,7 +89,8 @@ module "prod_config" {
     SAM_GOV_BASE_URL = "https://api.sam.gov"
 
     # Email notification
-    RESET_EMAILS_WITHOUT_SENDING = "false"
+    RESET_EMAILS_WITHOUT_SENDING               = "false"
+    ENABLE_ORG_SAVED_OPPORTUNITY_NOTIFICATIONS = "true"
 
     # PDF Generation - Production overrides
     FRONTEND_URL             = "https://simpler.grants.gov"

--- a/infra/api/app-config/training.tf
+++ b/infra/api/app-config/training.tf
@@ -51,7 +51,8 @@ module "training_config" {
     SAM_GOV_BASE_URL = "https://api.sam.gov"
 
     # Email notification
-    RESET_EMAILS_WITHOUT_SENDING = "false"
+    RESET_EMAILS_WITHOUT_SENDING               = "false"
+    ENABLE_ORG_SAVED_OPPORTUNITY_NOTIFICATIONS = "true"
   }
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #9463

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Set `ENABLE_ORG_SAVED_OPPORTUNITY_NOTIFICATIONS` to default true in training and prod (matching dev and staging)

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The environment variable `ENABLE_ORG_SAVED_OPPORTUNITY_NOTIFICATIONS` was introduced as part of https://github.com/HHS/simpler-grants-gov/issues/8976. We need to update this to default to true instead of false in production and training.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See changes update in ECS tasks.