### PR TITLE
Issue #8989] Notifications preferences page link

### DIFF
--- a/frontend/src/app/[locale]/(base)/workspace/saved-opportunities/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/saved-opportunities/page.test.tsx
@@ -13,11 +13,18 @@ import {
   INDIVIDUAL_SAVED_OPPORTUNITIES_SCOPE,
 } from "src/utils/opportunity/savedOpportunitiesUtils";
 import { mockOpportunity } from "src/utils/testing/fixtures";
-import {
-  localeParams,
-  mockUseTranslations,
-  useTranslationsMock,
-} from "src/utils/testing/intlMocks";
+import { localeParams, useTranslationsMock } from "src/utils/testing/intlMocks";
+
+import { ReactNode } from "react";
+
+type MockRichTranslationValues = {
+  link: (chunks: string) => ReactNode;
+};
+
+type MockTranslationFunction = {
+  (key: string): string;
+  rich: (key: string, values: MockRichTranslationValues) => ReactNode;
+};
 
 const getSessionMock = jest.fn<
   Promise<{ token: string; user_id: string; email: string } | null>,
@@ -28,6 +35,7 @@ const getUserOrganizationsMock = jest.fn<
   Promise<Organization[]>,
   [string, string]
 >();
+
 jest.mock("src/services/auth/session", () => ({
   getSession: () => getSessionMock(),
 }));
@@ -42,7 +50,23 @@ jest.mock("next-intl", () => ({
 }));
 
 jest.mock("next-intl/server", () => ({
-  getTranslations: () => mockUseTranslations,
+  getTranslations: () => {
+    const translationFunction = ((key: string) =>
+      key) as MockTranslationFunction;
+
+    translationFunction.rich = (
+      key: string,
+      values: MockRichTranslationValues,
+    ) => {
+      if (key === "SavedOpportunities.toNotificationsPreferences") {
+        return values.link("Manage your notification preferences here.");
+      }
+
+      return key;
+    };
+
+    return translationFunction;
+  },
 }));
 
 const savedOpportunitiesMock = jest.fn();
@@ -109,7 +133,8 @@ function mockSavedOpportunitiesByScope({
       if (scope === INDIVIDUAL_SAVED_OPPORTUNITIES_SCOPE) {
         return Promise.resolve(individuallySavedOpportunities);
       }
-      // The page now fetches DEFAULT scope separately to determine whether the
+
+      // The page fetches DEFAULT scope separately to determine whether the
       // user has any saved opportunities at all, so always return the combined
       // list for that unfiltered request.
       if (
@@ -182,6 +207,21 @@ describe("Saved Opportunities page", () => {
         },
       ],
     });
+  });
+
+  it("renders a link to notification preferences", async () => {
+    const component = await SavedOpportunities({
+      params: localeParams,
+      searchParams: defaultSearchParams,
+    });
+    render(component);
+
+    const notificationsLink = screen.getByRole("link", {
+      name: "Manage your notification preferences here.",
+    });
+
+    expect(notificationsLink).toBeInTheDocument();
+    expect(notificationsLink).toHaveAttribute("href", "/notifications");
   });
 
   it("does not render status filter when there are no saved opportunities", async () => {
@@ -517,6 +557,7 @@ describe("Saved Opportunities page", () => {
     ).toBeInTheDocument();
     expect(screen.getByLabelText("statusFilter.label")).toBeInTheDocument();
   });
+
   it("keeps filters visible and shows filtered empty state when the selected organization has no saved opportunities", async () => {
     savedOpportunitiesMock.mockImplementation(
       (

--- a/frontend/src/app/[locale]/(base)/workspace/saved-opportunities/page.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/saved-opportunities/page.tsx
@@ -134,6 +134,11 @@ export default async function SavedOpportunities({
           ]}
         />
         <h1 className="margin-top-0">{t("SavedOpportunities.heading")}</h1>
+        <p>
+          {t.rich("SavedOpportunities.toNotificationsPreferences", {
+            link: (chunks) => <Link href="/notifications">{chunks}</Link>,
+          })}
+        </p>
       </GridContainer>
       <div className="grid-container padding-y-5">
         {hasAnySavedOpportunities ? (

--- a/frontend/src/components/Header.test.tsx
+++ b/frontend/src/components/Header.test.tsx
@@ -411,12 +411,13 @@ describe("Header", () => {
       expect(accountButton).toBeInTheDocument();
     });
 
-    it("Account dropdown contains Settings and Sign out when opened", async () => {
+    it("Account dropdown contains Settings, Notifications, and Sign out when opened", async () => {
       mockUseUser.mockReturnValue({
         user: { token: "faketoken" },
         hasBeenLoggedOut: false,
         resetHasBeenLoggedOut: jest.fn(),
       });
+
       const user = userEvent.setup();
       render(<Header {...props} />);
 
@@ -424,10 +425,36 @@ describe("Header", () => {
       await user.click(accountButton);
 
       expect(accountButton).toHaveAttribute("aria-expanded", "true");
+
       const settingsLink = screen.getByRole("link", { name: "settings" });
       expect(settingsLink).toBeInTheDocument();
       expect(settingsLink).toHaveAttribute("href", "/settings");
+
+      const notificationsLink = screen.getByRole("link", {
+        name: "notifications",
+      });
+      expect(notificationsLink).toBeInTheDocument();
+      expect(notificationsLink).toHaveAttribute("href", "/notifications");
+
       expect(screen.getByText("logout")).toBeInTheDocument();
+    });
+
+    it("does not show Notifications link when user is unauthenticated", () => {
+      mockUseUser.mockImplementation(() => ({
+        user: {
+          token: undefined,
+        },
+        hasBeenLoggedOut: false,
+        resetHasBeenLoggedOut: jest.fn(),
+      }));
+
+      render(<Header {...props} />);
+
+      const nav = screen.getByRole("navigation");
+
+      expect(
+        within(nav).queryByRole("link", { name: "notifications" }),
+      ).not.toBeInTheDocument();
     });
 
     it("does not display test application link if not for a test application user", async () => {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -281,13 +281,12 @@ const NavLinks = ({
               onClick={closeDropdownAndMobileNav}
               text={t("settings")}
             />,
-            // We can uncomment this after #8988 is implemented
-            // <NavLink
-            //   href="/notifications"
-            //   key="notifications"
-            //   onClick={closeDropdownAndMobileNav}
-            //   text={t("notifications")}
-            // />,
+            <NavLink
+              href="/notifications"
+              key="notifications"
+              onClick={closeDropdownAndMobileNav}
+              text={t("notifications")}
+            />,
             isApplicationTestUser && <TestApplicationLink />,
             <SignOutNavLink key="logout" onClick={closeDropdownAndMobileNav} />,
           ]}

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -1206,6 +1206,8 @@ export const messages = {
       showAll: "Show all",
       individual: "Individual",
     },
+    toNotificationsPreferences:
+      "Take a closer look at the opportunities you've saved and share any that feel like a good fit for your organization. Shared opportunities are saved for all members to view.  <link>Manage your notification preferences here.</link>",
   },
   Roadmap: {
     pageTitle: "Roadmap | Simpler.Grants.gov",


### PR DESCRIPTION
## Summary

Fixes / Work for #8989
 
Adds notification preferences discoverability by linking to the Notifications page from the account dropdown and Saved Opportunities page. 

## Changes proposed

- Adds Notifications link to the authenticated account dropdown
- Adds Manage notification preferences link on Saved Opportunities
- Adds translation copy for the Saved Opportunities notification preferences link
- Updates unit tests for header and Saved Opportunities page behavior

## Context for reviewers

Users can now manage notification preferences, so this PR makes that page easier to find from relevant logged-in user flows.

<img width="1187" height="1196" alt="Screenshot 2026-04-27 at 2 51 33 PM" src="https://github.com/user-attachments/assets/0cd3a8cd-b058-4dda-8506-3d8039e115cb" />

## Validation steps

- [x] [VERIFY] Logged in and confirmed Notifications link appears in account dropdown
- [x] [VERIFY] Confirmed unauthenticated users do not see account dropdown link
- [x] [VERIFY] Confirmed Saved Opportunities page links to /notifications
