### PR TITLE
[Issue #9768] Phase 1 - Defer assistance_listing_record_id FK before rename

### DIFF
--- a/api/src/db/models/opportunity_models.py
+++ b/api/src/db/models/opportunity_models.py
@@ -361,7 +361,7 @@ class OpportunityAssistanceListing(ApiSchemaTable, TimestampMixin):
     program_title: Mapped[str | None]
 
     assistance_listing_record_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID, ForeignKey(AssistanceListing.assistance_listing_record_id), index=True
+        UUID, ForeignKey(AssistanceListing.assistance_listing_record_id), index=True, deferred=True
     )
     assistance_listing: Mapped[AssistanceListing | None] = relationship(AssistanceListing)
 


### PR DESCRIPTION
## Summary

Work for #9768

## Changes proposed

- Mark `assistance_listing_record_id` on `OpportunityAssistanceListing` as `deferred=True` in the SQLAlchemy model

## Context for reviewers

This is Phase 1 of a two-PR approach to safely rename the `assistance_listing_record_id` primary key to `assistance_listing_id` (issue #9768).

**Why two phases?** 
The deployment pipeline runs migrations before the API service restarts, creating a ~5-10 minute window where old code runs against the new schema. SQLAlchemy generates explicit `SELECT` statements referencing every column (e.g. `SELECT ... assistance_listing_record_id ...`). If the rename migration runs before the service restarts, live endpoints like `get_opportunity` (which uses `selectinload(opportunity_assistance_listings)`) would 500 during that window.

**What `deferred=True` does:** 
Tells SQLAlchemy to exclude this column from its default `SELECT` queries. Once this is deployed, the column is no longer referenced by active API code, making it safe to rename in Phase 2.

**Why only the FK column and not the PK on `AssistanceListing`?** 
SQLAlchemy does not allow deferring a primary key column. It's safe to leave as-is because `AssistanceListing` is only reachable through this FK relationship - once the FK column is deferred, SQLAlchemy will not instantiate `AssistanceListing` objects through the relationship either.

Phase 2 PR (the actual rename migration) will follow after this is deployed.

## Validation steps

- `make format && make lint` pass locally
- No migration needed - schema is unchanged
- Verify `get_opportunity` still returns assistance listing data correctly (the deferred column is still accessible when explicitly loaded)