### PR TITLE
[Issue #9898] Add USE_SIMPLER env variable

### DIFF
--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -109,6 +109,11 @@ locals {
       secret_store_name = "/api/${var.environment}/soap-partner-gateway-auth-key"
     }
 
+    USE_SIMPLER = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/use-simpler"
+    }
+
     SAM_GOV_API_KEY = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/sam-gov-api-key"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9898  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add `USE_SIMPLER` to environment variables in terraform file.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We currently check for a `USE_SIMPLER` env variable but we actually haven't set it yet because if it wasn't found it defaulted to `False`. But we actually want it set to `True` in the training env. So this is adding it to the terraform file. We also need to add it, on the AWS Parameter store, for the other envs because once it actually looks for it, if it doesn't find it the deploy will break.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] Hit training endpoint without `Use-Simpler-Override` header
- [ ] Get Simpler data
