### PR TITLE
[Issue #9904] Drop URLs that fail marshmallow validation in CG transformation

### DIFF
--- a/api/src/api/common_grants/schemas/pydantic/custom_fields.py
+++ b/api/src/api/common_grants/schemas/pydantic/custom_fields.py
@@ -7,15 +7,9 @@ populated by the populate_custom_fields function in the transformation layer.
 from datetime import datetime
 
 from common_grants_sdk.schemas.pydantic import CustomField, CustomFieldType
-from marshmallow import ValidationError as MarshmallowValidationError
-from marshmallow import fields as marshmallow_fields
-from pydantic import BaseModel, HttpUrl, ValidationError, field_validator
+from pydantic import BaseModel, HttpUrl, field_validator
 
-# See note in src/services/common_grants/transformation.py:_marshmallow_url_field
-# — pydantic's HttpUrl and marshmallow's fields.URL disagree on certain inputs,
-# so the AttachmentValue.downloadUrl validator (which feeds the same marshmallow
-# response load) must check both to avoid issue #9904's 500 path.
-_marshmallow_url_field = marshmallow_fields.URL()
+from src.services.common_grants.url_utils import validate_url_compatible
 
 # ===========================================================================================
 # Value Models
@@ -34,10 +28,6 @@ class AgencyValue(BaseModel):
     parentCode: str | None = None
 
 
-class _AttachmentUrlValidator(BaseModel):
-    url: HttpUrl
-
-
 class AttachmentValue(BaseModel):
     downloadUrl: str | None = None
     name: str
@@ -50,14 +40,9 @@ class AttachmentValue(BaseModel):
     @field_validator("downloadUrl", mode="before")
     @classmethod
     def validate_download_url(cls, v: object) -> object:
-        if v is None or v == "":
+        if not isinstance(v, str):
             return None
-        try:
-            _AttachmentUrlValidator.model_validate({"url": v})
-            _marshmallow_url_field.deserialize(v)
-            return v
-        except (ValidationError, MarshmallowValidationError):
-            return None
+        return validate_url_compatible(v)
 
 
 class ContactInfoValue(BaseModel):

--- a/api/src/api/common_grants/schemas/pydantic/custom_fields.py
+++ b/api/src/api/common_grants/schemas/pydantic/custom_fields.py
@@ -7,7 +7,15 @@ populated by the populate_custom_fields function in the transformation layer.
 from datetime import datetime
 
 from common_grants_sdk.schemas.pydantic import CustomField, CustomFieldType
+from marshmallow import ValidationError as MarshmallowValidationError
+from marshmallow import fields as marshmallow_fields
 from pydantic import BaseModel, HttpUrl, ValidationError, field_validator
+
+# See note in src/services/common_grants/transformation.py:_marshmallow_url_field
+# — pydantic's HttpUrl and marshmallow's fields.URL disagree on certain inputs,
+# so the AttachmentValue.downloadUrl validator (which feeds the same marshmallow
+# response load) must check both to avoid issue #9904's 500 path.
+_marshmallow_url_field = marshmallow_fields.URL()
 
 # ===========================================================================================
 # Value Models
@@ -46,8 +54,9 @@ class AttachmentValue(BaseModel):
             return None
         try:
             _AttachmentUrlValidator.model_validate({"url": v})
+            _marshmallow_url_field.deserialize(v)
             return v
-        except ValidationError:
+        except (ValidationError, MarshmallowValidationError):
             return None
 
 

--- a/api/src/services/common_grants/transformation.py
+++ b/api/src/services/common_grants/transformation.py
@@ -39,10 +39,7 @@ from src.api.common_grants.schemas.pydantic.custom_fields import (
 from src.api.response import ValidationErrorDetail
 from src.constants.lookup_constants import CommonGrantsEvent, OpportunityStatus
 from src.db.models.opportunity_models import Opportunity
-from src.services.common_grants.url_utils import (
-    redact_url_userinfo,
-    validate_url_compatible,
-)
+from src.services.common_grants.url_utils import redact_url_userinfo, validate_url_compatible
 from src.validation.validation_constants import ValidationErrorType
 
 logger = logging.getLogger(__name__)

--- a/api/src/services/common_grants/transformation.py
+++ b/api/src/services/common_grants/transformation.py
@@ -19,9 +19,7 @@ from common_grants_sdk.schemas.pydantic import (
     PaginatedBodyParams,
     SingleDateEvent,
 )
-from marshmallow import ValidationError as MarshmallowValidationError
-from marshmallow import fields as marshmallow_fields
-from pydantic import BaseModel, Field, HttpUrl, ValidationError
+from pydantic import ValidationError
 
 import src.util.datetime_util as datetime_util
 from src.api.common_grants.schemas.pydantic.custom_fields import (
@@ -41,28 +39,13 @@ from src.api.common_grants.schemas.pydantic.custom_fields import (
 from src.api.response import ValidationErrorDetail
 from src.constants.lookup_constants import CommonGrantsEvent, OpportunityStatus
 from src.db.models.opportunity_models import Opportunity
+from src.services.common_grants.url_utils import (
+    redact_url_userinfo,
+    validate_url_compatible,
+)
 from src.validation.validation_constants import ValidationErrorType
 
 logger = logging.getLogger(__name__)
-
-
-class UrlValidator(BaseModel):
-    """Validator for a URL string using Pydantic's HttpUrl with strict mode enabled.
-
-    Mirrors the HttpUrl field in OpportunityBase and other CommonGrants models.
-    TODO(@widal001): Replace this with a new field from SDK or relax strictness in SDK
-    """
-
-    url: HttpUrl = Field(strict=True)
-
-
-# Pydantic's HttpUrl and marshmallow's fields.URL disagree on a handful of
-# inputs (comma-separated URLs, scheme-only-host like "http://example", etc.).
-# Pydantic accepts and normalizes; marshmallow rejects. The CG response is
-# loaded through marshmallow on the way out, so any URL accepted by pydantic
-# but rejected by marshmallow blows up the entire batch (issue #9904). Run
-# both validators so divergent strings are dropped at the source.
-_marshmallow_url_field = marshmallow_fields.URL()
 
 
 def transform_status_to_cg(v1_status: OpportunityStatus) -> OppStatusOptions:
@@ -174,37 +157,23 @@ def _transform_date_to_cg(date_value: date | datetime | None) -> date | None:
 
 
 def validate_url(value: str | None) -> str | None:
+    """Return ``value`` normalized iff both pydantic and marshmallow accept it.
+
+    Delegates the dual-validation to ``validate_url_compatible``; this wrapper
+    adds the ops log on failure so we can spot data-quality issues (issue #9904).
+    Userinfo is stripped from the logged URL to avoid leaking ``user:password@``
+    if grants.gov data ever ships one through.
     """
-    Validate a URL string using both Pydantic's HttpUrl and marshmallow's URL field.
-
-    Both validators must accept the value. Pydantic accepts inputs marshmallow
-    rejects (e.g. comma-separated URLs, scheme-only hosts), and the CG response
-    is loaded through marshmallow on the way out — so a URL accepted only by
-    pydantic blows up the entire response batch with a 500 (issue #9904).
-    Validating with both at the source drops divergent strings cleanly.
-
-    Args:
-        value: The string to validate
-
-    Returns:
-        A valid URL string or None if validation fails
-    """
-    if value is None or value == "":
-        return None
-    try:
-        valid = UrlValidator.model_validate({"url": value})
-        normalized = str(valid.url)
-        _marshmallow_url_field.deserialize(normalized)
-        return normalized
-    except (ValidationError, MarshmallowValidationError):
+    result = validate_url_compatible(value)
+    if result is None and value not in (None, ""):
         logger.info(
-            f"URL validation failed for: {value}",
+            "URL validation failed",
             extra={
                 "cg_event": CommonGrantsEvent.URL_VALIDATION_ERROR,
-                "url": value,
+                "url": redact_url_userinfo(value),
             },
         )
-        return None
+    return result
 
 
 def transform_opportunity_to_cg(v1_opportunity: Opportunity) -> OpportunityBase | None:

--- a/api/src/services/common_grants/transformation.py
+++ b/api/src/services/common_grants/transformation.py
@@ -19,6 +19,8 @@ from common_grants_sdk.schemas.pydantic import (
     PaginatedBodyParams,
     SingleDateEvent,
 )
+from marshmallow import ValidationError as MarshmallowValidationError
+from marshmallow import fields as marshmallow_fields
 from pydantic import BaseModel, Field, HttpUrl, ValidationError
 
 import src.util.datetime_util as datetime_util
@@ -52,6 +54,15 @@ class UrlValidator(BaseModel):
     """
 
     url: HttpUrl = Field(strict=True)
+
+
+# Pydantic's HttpUrl and marshmallow's fields.URL disagree on a handful of
+# inputs (comma-separated URLs, scheme-only-host like "http://example", etc.).
+# Pydantic accepts and normalizes; marshmallow rejects. The CG response is
+# loaded through marshmallow on the way out, so any URL accepted by pydantic
+# but rejected by marshmallow blows up the entire batch (issue #9904). Run
+# both validators so divergent strings are dropped at the source.
+_marshmallow_url_field = marshmallow_fields.URL()
 
 
 def transform_status_to_cg(v1_status: OpportunityStatus) -> OppStatusOptions:
@@ -164,13 +175,13 @@ def _transform_date_to_cg(date_value: date | datetime | None) -> date | None:
 
 def validate_url(value: str | None) -> str | None:
     """
-    Validate a URL string using Pydantic's HttpUrl validation.
+    Validate a URL string using both Pydantic's HttpUrl and marshmallow's URL field.
 
-    This ensures URLs are validated with the same strict rules that Pydantic
-    uses, preventing validation errors when creating OpportunityBase objects.
-
-    We use a minimal model with the same field definition as OpportunityBase
-    to ensure we use the exact same validation rules.
+    Both validators must accept the value. Pydantic accepts inputs marshmallow
+    rejects (e.g. comma-separated URLs, scheme-only hosts), and the CG response
+    is loaded through marshmallow on the way out — so a URL accepted only by
+    pydantic blows up the entire response batch with a 500 (issue #9904).
+    Validating with both at the source drops divergent strings cleanly.
 
     Args:
         value: The string to validate
@@ -182,8 +193,10 @@ def validate_url(value: str | None) -> str | None:
         return None
     try:
         valid = UrlValidator.model_validate({"url": value})
-        return str(valid.url)
-    except ValidationError:
+        normalized = str(valid.url)
+        _marshmallow_url_field.deserialize(normalized)
+        return normalized
+    except (ValidationError, MarshmallowValidationError):
         logger.info(
             f"URL validation failed for: {value}",
             extra={

--- a/api/src/services/common_grants/url_utils.py
+++ b/api/src/services/common_grants/url_utils.py
@@ -9,7 +9,7 @@ exposes a single helper that requires both validators to accept, so divergent
 strings are dropped at the source.
 """
 
-from urllib.parse import urlunsplit, urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from marshmallow import ValidationError as MarshmallowValidationError
 from marshmallow import fields as marshmallow_fields

--- a/api/src/services/common_grants/url_utils.py
+++ b/api/src/services/common_grants/url_utils.py
@@ -17,7 +17,11 @@ from pydantic import BaseModel, Field, HttpUrl, ValidationError
 
 
 class _UrlValidator(BaseModel):
-    """Pydantic strict HttpUrl validator."""
+    """Pydantic strict HttpUrl validator.
+
+    Mirrors the HttpUrl field in OpportunityBase and other CommonGrants models.
+    TODO(@widal001): Replace this with a new field from SDK or relax strictness in SDK.
+    """
 
     url: HttpUrl = Field(strict=True)
 
@@ -55,16 +59,21 @@ def redact_url_userinfo(value: str | None) -> str:
     validation-failure logs verbatim — leaking the credentials to log
     aggregation. Strip userinfo here. Falls back to a fixed sentinel if the
     URL is unparseable so the caller always has something logger-safe.
+
+    Note: ``SplitResult.port`` lazily raises ``ValueError`` for non-numeric
+    ports (e.g. ``host:abc``), so the *entire* parse + reconstruct sequence
+    runs inside the try — re-raising here would re-introduce the fail-hard
+    behavior this module exists to remove.
     """
     if value is None:
         return "<none>"
     try:
         parts = urlsplit(value)
+        if not parts.username and not parts.password:
+            return value
+        host = parts.hostname or ""
+        if parts.port:
+            host = f"{host}:{parts.port}"
+        return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
     except ValueError:
         return "<unparseable-url>"
-    if not parts.username and not parts.password:
-        return value
-    host = parts.hostname or ""
-    if parts.port:
-        host = f"{host}:{parts.port}"
-    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))

--- a/api/src/services/common_grants/url_utils.py
+++ b/api/src/services/common_grants/url_utils.py
@@ -1,0 +1,70 @@
+"""URL validation shared across CG transformation and CG custom-field validators.
+
+Pydantic's HttpUrl and marshmallow's fields.URL disagree on a handful of inputs
+(comma-separated URLs, scheme-only-host like "http://example", etc.). Pydantic
+accepts and normalizes; marshmallow rejects. Because the CG response is loaded
+through marshmallow on the way out, any URL accepted by pydantic but rejected
+by marshmallow blows up the entire batch with a 500 (issue #9904). This module
+exposes a single helper that requires both validators to accept, so divergent
+strings are dropped at the source.
+"""
+
+from urllib.parse import urlunsplit, urlsplit
+
+from marshmallow import ValidationError as MarshmallowValidationError
+from marshmallow import fields as marshmallow_fields
+from pydantic import BaseModel, Field, HttpUrl, ValidationError
+
+
+class _UrlValidator(BaseModel):
+    """Pydantic strict HttpUrl validator."""
+
+    url: HttpUrl = Field(strict=True)
+
+
+_marshmallow_url_field = marshmallow_fields.URL()
+
+
+def validate_url_compatible(value: str | None) -> str | None:
+    """Return the normalized URL if accepted by *both* pydantic HttpUrl and
+    marshmallow's fields.URL; otherwise None.
+
+    The CG response is loaded through marshmallow on the way out, so a URL
+    accepted only by pydantic blows up the entire batch (issue #9904).
+    Returning the pydantic-normalized form means downstream callers see a
+    consistent string and that exact string is what the response load
+    re-validates.
+    """
+    if value is None or value == "":
+        return None
+    try:
+        valid = _UrlValidator.model_validate({"url": value})
+        normalized = str(valid.url)
+        _marshmallow_url_field.deserialize(normalized)
+        return normalized
+    except (ValidationError, MarshmallowValidationError):
+        return None
+
+
+def redact_url_userinfo(value: str | None) -> str:
+    """Strip ``user:password@`` from a URL before logging.
+
+    Grants.gov data occasionally puts free text or markdown into URL fields.
+    If a record contains ``https://user:secret@host/path`` (intentional or
+    accidental), the raw string flows through pydantic and lands in
+    validation-failure logs verbatim — leaking the credentials to log
+    aggregation. Strip userinfo here. Falls back to a fixed sentinel if the
+    URL is unparseable so the caller always has something logger-safe.
+    """
+    if value is None:
+        return "<none>"
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return "<unparseable-url>"
+    if not parts.username and not parts.password:
+        return value
+    host = parts.hostname or ""
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))

--- a/api/tests/src/services/common_grants/test_transformation.py
+++ b/api/tests/src/services/common_grants/test_transformation.py
@@ -715,6 +715,135 @@ class TestTransformation:
         assert old_result is not None, "_legacy_validate_url() should accept NASA URL"
         assert new_result is None, "validate_url() should reject NASA URL"
 
+    def test_validate_url_rejects_urls_that_marshmallow_url_field_rejects(self):
+        """Reproduces issue #9904: validate_url() must also reject URLs that pass
+        Pydantic's HttpUrl but fail marshmallow's URL field. The CG response is loaded
+        through marshmallow on the way out; a URL that pydantic accepts but marshmallow
+        rejects 500s the entire response (one bad record kills the batch).
+
+        Concrete divergence: comma-separated URLs — agencies sometimes paste multiple
+        URLs into one field. Pydantic's HttpUrl mangles 'https://a.gov,https://b.gov'
+        into a string ('https://a.gov,https//b.gov') it considers valid; marshmallow's
+        fields.URL rejects that string with "Not a valid URL." — producing the
+        ValidationError({'items': {N: {'customFields': {'additionalInfo': {'value':
+        {'url': [..., message='Not a valid URL.']}}}}}}) we observed in prod.
+        """
+        comma_url = "https://www.grants.gov,https://other.example"
+        assert validate_url(comma_url) is None, (
+            "validate_url() must reject URLs that fail marshmallow's URL field, "
+            "otherwise they reach the CG response load and 500 the whole batch"
+        )
+
+        no_tld_url = "http://example"
+        assert validate_url(no_tld_url) is None, (
+            "validate_url() must reject scheme-only-host URLs that pydantic accepts "
+            "but marshmallow rejects"
+        )
+
+    def test_search_response_marshmallow_load_does_not_500_on_problematic_url(self):
+        """End-to-end recreation of issue #9904.
+
+        Builds an opportunity whose summary.additional_info_url is the comma-separated
+        form that triggers the prod 500. Runs the same pipeline the route uses:
+            transform_search_result_to_cg -> build OpportunitiesSearchResponse pydantic
+            -> model_dump(by_alias=True, mode='json') -> response marshmallow load.
+        Before the fix this raises marshmallow.ValidationError on
+        items[0].customFields.additionalInfo.value.url. After the fix the record loads
+        cleanly with additionalInfo absent (because validate_url returned None).
+        """
+        from http import HTTPStatus
+
+        from common_grants_sdk.schemas.pydantic import (
+            OpportunitiesSearchResponse,
+            OppSortBy,
+            OppSorting,
+            PaginatedResultsInfo,
+            SortedResultsInfo,
+        )
+
+        from src.api.common_grants.schemas.marshmallow.schemas import (
+            OpportunitiesSearchResponse as OpportunitiesSearchResponseSchema,
+        )
+        from src.services.common_grants.transformation import build_filter_info
+
+        problematic_url = "https://www.grants.gov,https://other.example"
+        opp_data = {
+            "opportunity_id": uuid4(),
+            "opportunity_title": "Test Opportunity",
+            "opportunity_status": OpportunityStatus.POSTED,
+            "created_at": datetime(2024, 1, 1, 12, 0, 0),
+            "updated_at": datetime(2024, 1, 2, 12, 0, 0),
+            "summary": {
+                "summary_description": "Test description",
+                "post_date": date(2024, 1, 1),
+                "close_date": date(2024, 12, 31),
+                "additional_info_url": problematic_url,
+                "additional_info_url_description": "Multiple links",
+                "created_at": datetime(2024, 1, 1, 12, 0, 0),
+                "updated_at": datetime(2024, 1, 2, 12, 0, 0),
+            },
+        }
+
+        cg_opportunity = transform_search_result_to_cg(opp_data)
+        assert cg_opportunity is not None, "transform itself must not drop the record"
+
+        response = OpportunitiesSearchResponse(
+            status=HTTPStatus.OK,
+            message="ok",
+            items=[cg_opportunity],
+            pagination_info=PaginatedResultsInfo(
+                page=1, page_size=1, totalItems=1, totalPages=1
+            ),
+            sort_info=SortedResultsInfo(
+                sort_by=OppSortBy.LAST_MODIFIED_AT.value,
+                sort_order="desc",
+                errors=[],
+            ),
+            filter_info=build_filter_info(None),
+        )
+        response_json = response.model_dump(by_alias=True, mode="json")
+
+        # This is the line that raises marshmallow.ValidationError in prod (issue #9904).
+        validated = OpportunitiesSearchResponseSchema().load(response_json)
+
+        assert len(validated["items"]) == 1
+        # Once validate_url filters the bad URL, additionalInfo is absent; that's the
+        # contract — invalid URLs are dropped, not propagated.
+        custom_fields = validated["items"][0].get("customFields") or {}
+        assert custom_fields.get("additionalInfo") is None, (
+            "additionalInfo must be omitted when its url fails validation, not "
+            "passed through with an invalid URL"
+        )
+
+    def test_attachment_download_url_dual_validates(self):
+        """Sibling of issue #9904 for the attachment path. AttachmentValue.downloadUrl
+        in the CG response is loaded through marshmallow's fields.URL on the way out;
+        the field validator on the pydantic model must reject the same divergent
+        strings (comma-URLs, scheme-only-host) that validate_url rejects, otherwise
+        an attachment with a malformed download_path 500s the whole batch in the same
+        way an additional_info_url did.
+        """
+        from src.api.common_grants.schemas.pydantic.custom_fields import AttachmentValue
+
+        good_attachment = {
+            "downloadUrl": "https://example.com/file.pdf",
+            "name": "ok.pdf",
+            "sizeInBytes": 1,
+            "mimeType": "application/pdf",
+            "createdAt": datetime(2024, 1, 1, 12, 0, 0),
+            "lastModifiedAt": datetime(2024, 1, 2, 12, 0, 0),
+        }
+        validated = AttachmentValue.model_validate(good_attachment)
+        assert validated.downloadUrl == "https://example.com/file.pdf"
+
+        for divergent in ("https://www.grants.gov,https://other.example", "http://example"):
+            bad_attachment = good_attachment | {"downloadUrl": divergent}
+            validated = AttachmentValue.model_validate(bad_attachment)
+            assert validated.downloadUrl is None, (
+                f"AttachmentValue.downloadUrl must drop {divergent!r}; pydantic accepts it "
+                "but marshmallow's fields.URL — which loads the response — rejects it"
+            )
+
     def test_transform_search_result_to_cg_with_nasa_url_bug(self):
         """Test that transformation works correctly with NASA URL that Pydantic rejects.
 

--- a/api/tests/src/services/common_grants/test_transformation.py
+++ b/api/tests/src/services/common_grants/test_transformation.py
@@ -755,8 +755,6 @@ class TestTransformation:
 
         from common_grants_sdk.schemas.pydantic import (
             OpportunitiesSearchResponse,
-            OppSortBy,
-            OppSorting,
             PaginatedResultsInfo,
             SortedResultsInfo,
         )
@@ -764,7 +762,6 @@ class TestTransformation:
         from src.api.common_grants.schemas.marshmallow.schemas import (
             OpportunitiesSearchResponse as OpportunitiesSearchResponseSchema,
         )
-        from src.services.common_grants.transformation import build_filter_info
 
         problematic_url = "https://www.grants.gov,https://other.example"
         opp_data = {
@@ -814,6 +811,31 @@ class TestTransformation:
             "additionalInfo must be omitted when its url fails validation, not "
             "passed through with an invalid URL"
         )
+
+    def test_validate_url_logs_redacted_userinfo_on_failure(self, caplog):
+        """Security: a URL with user:password@ that fails validation must not leak
+        credentials to the log aggregator. validate_url() runs the value through
+        redact_url_userinfo before emitting the INFO log.
+        """
+        import logging
+
+        caplog.set_level(logging.INFO)
+
+        # Comma-URL with embedded credentials. Pydantic accepts (mangled), marshmallow
+        # rejects, validate_url returns None, INFO log fires.
+        bad_url = "https://user:secret@a.gov,https://b.gov"
+        assert validate_url(bad_url) is None
+
+        log_record = next(
+            (r for r in caplog.records if r.message == "URL validation failed"),
+            None,
+        )
+        assert log_record is not None
+        # The credential must NOT appear in the structured field …
+        assert "user:secret" not in getattr(log_record, "url", "")
+        assert "secret" not in getattr(log_record, "url", "")
+        # … nor in the rendered message
+        assert "secret" not in log_record.getMessage()
 
     def test_attachment_download_url_dual_validates(self):
         """Sibling of issue #9904 for the attachment path. AttachmentValue.downloadUrl
@@ -1043,17 +1065,18 @@ class TestTransformation:
         # Verify the URL was rejected
         assert result is None
 
-        # Verify the log was captured
+        # Verify the log was captured. The URL is in extra["url"] (and the log
+        # message itself is now a fixed string) so credentials embedded in the
+        # raw value can't leak through the message body — see redact_url_userinfo.
         assert any(
             record.levelname == "INFO"
-            and "URL validation failed for:" in record.message
-            and invalid_url in record.message
+            and record.message == "URL validation failed"
+            and getattr(record, "url", None) == invalid_url
             for record in caplog.records
         )
 
-        # Verify the extra data is present in the log record
         log_record = next(
-            (record for record in caplog.records if "URL validation failed for:" in record.message),
+            (record for record in caplog.records if record.message == "URL validation failed"),
             None,
         )
         assert log_record is not None
@@ -1136,11 +1159,12 @@ class TestTransformation:
         assert result.title == "Test Opportunity"
         assert result.source is None  # URL should be None due to validation failure
 
-        # Verify URL validation error was logged
+        # Verify URL validation error was logged with the URL in extra (not in
+        # the message body — see redact_url_userinfo / security review note).
         assert any(
             record.levelname == "INFO"
-            and "URL validation failed for:" in record.message
-            and invalid_url in record.message
+            and record.message == "URL validation failed"
+            and getattr(record, "url", None) == invalid_url
             for record in caplog.records
         )
 

--- a/api/tests/src/services/common_grants/test_transformation.py
+++ b/api/tests/src/services/common_grants/test_transformation.py
@@ -788,9 +788,7 @@ class TestTransformation:
             status=HTTPStatus.OK,
             message="ok",
             items=[cg_opportunity],
-            pagination_info=PaginatedResultsInfo(
-                page=1, page_size=1, totalItems=1, totalPages=1
-            ),
+            pagination_info=PaginatedResultsInfo(page=1, page_size=1, totalItems=1, totalPages=1),
             sort_info=SortedResultsInfo(
                 sort_by=OppSortBy.LAST_MODIFIED_AT.value,
                 sort_order="desc",

--- a/api/tests/src/services/common_grants/test_url_utils.py
+++ b/api/tests/src/services/common_grants/test_url_utils.py
@@ -1,0 +1,109 @@
+"""Direct unit tests for url_utils helpers.
+
+These cover edge cases that the integration-level tests in test_transformation.py
+exercise only indirectly — most importantly, inputs that would re-introduce
+the fail-hard behavior the module exists to remove (e.g. URLs whose port
+component lazily raises ValueError when accessed).
+"""
+
+import pytest
+
+from src.services.common_grants.url_utils import redact_url_userinfo, validate_url_compatible
+
+
+class TestValidateUrlCompatible:
+
+    def test_returns_none_for_none(self):
+        assert validate_url_compatible(None) is None
+
+    def test_returns_none_for_empty_string(self):
+        assert validate_url_compatible("") is None
+
+    def test_normalizes_valid_url(self):
+        assert validate_url_compatible("https://example.com") == "https://example.com/"
+
+    def test_rejects_comma_separated_urls(self):
+        # Pydantic accepts (mangled), marshmallow rejects → must return None.
+        assert validate_url_compatible("https://a.gov,https://b.gov") is None
+
+    def test_rejects_scheme_only_host(self):
+        # Pydantic accepts TLD-less hosts, marshmallow rejects.
+        assert validate_url_compatible("http://example") is None
+
+    def test_rejects_garbage(self):
+        assert validate_url_compatible("not-a-url") is None
+        assert validate_url_compatible("sam.gov") is None  # missing scheme
+
+
+class TestRedactUrlUserinfo:
+
+    def test_none_returns_sentinel(self):
+        assert redact_url_userinfo(None) == "<none>"
+
+    def test_no_userinfo_returns_input_unchanged(self):
+        assert redact_url_userinfo("https://example.com/path") == "https://example.com/path"
+
+    def test_empty_string_returns_input_unchanged(self):
+        # urlsplit('') yields no userinfo, no host — must not raise.
+        assert redact_url_userinfo("") == ""
+
+    def test_strips_user_and_password(self):
+        result = redact_url_userinfo("https://user:secret@host/path")
+        assert "user" not in result
+        assert "secret" not in result
+        assert result == "https://host/path"
+
+    def test_strips_username_only(self):
+        result = redact_url_userinfo("https://user@host/path")
+        assert "user@" not in result
+        assert result == "https://host/path"
+
+    def test_preserves_valid_port_when_stripping_userinfo(self):
+        result = redact_url_userinfo("https://user:secret@host:8443/path")
+        assert "user" not in result
+        assert "secret" not in result
+        assert "8443" in result
+        assert result == "https://host:8443/path"
+
+    def test_malformed_port_returns_sentinel_not_raise(self):
+        """Reviewer-flagged regression guard: SplitResult.port raises ValueError
+        on non-numeric ports. If the helper let that propagate, the redact-then-log
+        path would crash exactly the way #9904 was crashing — fail-hard on a
+        single bad URL string. Must return the sentinel, not raise.
+        """
+        # No exception:
+        result = redact_url_userinfo("https://user:secret@host:abc/path")
+        assert result == "<unparseable-url>"
+        # And of course no credential leak:
+        assert "secret" not in result
+
+    def test_unparseable_returns_sentinel(self):
+        # urlsplit is lenient — most "garbage" inputs parse without raising,
+        # they just yield empty fields. This test pins the behavior: the helper
+        # never raises on string input.
+        for garbage in ("", "://", "http:////", "javascript:alert(1)"):
+            assert isinstance(redact_url_userinfo(garbage), str)
+
+    def test_caller_never_sees_an_exception(self):
+        """End-to-end guard: redact_url_userinfo must be exception-safe for any
+        string input. The whole point of this helper is that it sits in the
+        logging path of validate_url, where raising would re-create the very
+        500 this PR fixes.
+        """
+        sample_inputs = [
+            None,
+            "",
+            "plain",
+            "https://x",
+            "https://user:pw@host/path",
+            "https://user:pw@host:abc/path",  # malformed port
+            "https://user:pw@[::1]:8080/path",  # ipv6
+            "ftp://user@host/file",
+            "mailto:foo@bar.com",
+        ]
+        for v in sample_inputs:
+            try:
+                out = redact_url_userinfo(v)
+            except Exception as e:  # pragma: no cover
+                pytest.fail(f"redact_url_userinfo raised {e!r} on input {v!r}")
+            assert isinstance(out, str)


### PR DESCRIPTION
## Summary

Fixes #9904.

`POST /common-grants/opportunities/search` was 500ing when the result page contained a URL that pydantic accepts but marshmallow rejects (most often comma-separated URLs from grants.gov data). The CG response is loaded back through marshmallow on the way out, so one bad record killed the whole batch. Fix validates URLs against both libraries at the transformation source so divergent strings get dropped instead of crashing the response.

## Changes proposed

- New `api/src/services/common_grants/url_utils.py` with `validate_url_compatible` (dual-validator) and `redact_url_userinfo` (strips `user:password@` for safe logging).
- `validate_url` and `AttachmentValue.validate_download_url` both delegate to the new helper. Removed `UrlValidator` and `_AttachmentUrlValidator` (consolidated onto one strict-mode pydantic validator). Removed the duplicate `_marshmallow_url_field` singletons.
- URL-validation log: fixed message string with the redacted URL in `extra["url"]` only.
- Tests in `test_transformation.py`: divergent-URL rejection, end-to-end reproduction through `OpportunitiesSearchResponseSchema().load(...)`, userinfo-redaction guard, attachment sibling case.

## Context for reviewers

Prod traceback (from #9904):
```
ValidationError({'items': {0: {'customFields': {'additionalInfo': {'value':
{'url': [...message='Not a valid URL.']}}}}}})
```
Stack pointed at `OpportunitiesSearchResponseSchema().load(response_json)` in [common_grants_routes.py:173](api/src/api/common_grants/common_grants_routes.py#L173).

Confirmed divergent inputs (pydantic accepts, marshmallow rejects):
- `https://a.gov,https://b.gov` — pydantic mangles to `https://a.gov,https//b.gov`
- `http://example` — pydantic accepts TLD-less hosts

Two behavior changes worth flagging:
- `AttachmentValue.downloadUrl` now stores the pydantic-normalized form (trailing slash, lowercase host) instead of raw input — matches what `validate_url` has done since #6987.
- Attachment URLs now run through strict-mode pydantic. The deleted `_AttachmentUrlValidator` was non-strict; the marshmallow load already rejected curly-brace URLs etc., this just moves the rejection earlier.

Suggested follow-ups (not in this PR):
- Lock URL schemes to `http`/`https` (default allows ftp/ftps).
- Surface a `dataWarnings` envelope so consumers can see suppressed fields.
- Apply per-record fail-soft to v1 `search_opportunities` `SCHEMA.load(many=True)` for the same atomic-batch brittleness.

## Validation steps

```bash
make test args="tests/src/services/common_grants/test_transformation.py -v"
```
46 tests, including 4 new for the failure mode.

After deploy, confirm the prod-failing payload returns 200:
```bash
curl -X POST 'https://api.simpler.grants.gov/common-grants/opportunities/search' \
  -H 'X-API-Key: <KEY>' -H 'Content-Type: application/json' \
  -d '{"filters":{"status":{"operator":"in","value":["closed"]}},"pagination":{"page":22,"pageSize":1},"search":"open data"}'
```
Expect 200, an INFO log with `cg_event=url_validation_error` and a redacted URL, and the New Relic "API Prod - Error Logs" alert to clear.
