### PR TITLE
[unticketed]: dedupe nr api logs

### DIFF
--- a/fluentbit/fluentbit.yml
+++ b/fluentbit/fluentbit.yml
@@ -40,7 +40,7 @@ pipeline:
 
   outputs:
     - name: nrlogs # new relic logs
-      match: "**"
+      match: "${NR_DIRECT_LOGS_MATCH}"
       license_key: ${licenseKey}
 
     - name: cloudwatch_logs # aws cloudwatch logs

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -267,6 +267,7 @@ module "service" {
   newrelic_entity_guid      = local.service_config.newrelic_entity_guid
   newrelic_mtls_entity_guid = local.service_config.newrelic_mtls_entity_guid
   newrelic_host_entity_guid = local.service_config.newrelic_host_entity_guid
+  enable_nrlogs_direct      = false
 
   is_temporary = local.is_temporary
 }

--- a/infra/modules/service/main.tf
+++ b/infra/modules/service/main.tf
@@ -235,6 +235,7 @@ resource "aws_ecs_task_definition" "app" {
         { name : "aws_region", value : data.aws_region.current.name },
         { name : "container_name", value : local.container_name },
         { name : "log_group_name", value : local.log_group_name },
+        { name : "NR_DIRECT_LOGS_MATCH", value : var.enable_nrlogs_direct ? "**" : "nr_direct_disabled" },
       ],
     },
   ])

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -402,3 +402,9 @@ variable "newrelic_host_entity_guid" {
   description = "New Relic entity GUID for the ECS service, used to correlate container logs with the infrastructure entity in New Relic."
   default     = null
 }
+
+variable "enable_nrlogs_direct" {
+  type        = bool
+  description = "Whether to enable direct Fluent Bit to New Relic log forwarding. Set to false when a CloudWatch subscription filter already forwards logs to New Relic to avoid duplicates."
+  default     = true
+}


### PR DESCRIPTION
## Summary

Resolve the duplicate logs issue for the api service. Updated fluentbit and terraform to bypass sending logs directly to newrelic from the fluentbit container since we have the lambda cloudwatch subscription that is forwarding the logs. 

## Validation steps

Successfully deployed to the dev environment: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/25075766953/job/73469652136) and logs are flowing. 