### PR TITLE
[Issue #9590] Edit opportunity page followups

### DIFF
--- a/frontend/src/components/manageUsers/RoleManager.tsx
+++ b/frontend/src/components/manageUsers/RoleManager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useClientFetch } from "src/hooks/useClientFetch";
+import { LabelValueOption } from "src/types/generalTypes";
 
 import { useTranslations } from "next-intl";
 import { useRef, useState, type ChangeEvent } from "react";
@@ -13,16 +14,11 @@ import {
 
 import { RoleChangeModal } from "./RoleChangeModal";
 
-interface RoleOption {
-  value: string;
-  label: string;
-}
-
 interface RoleManagerProps {
   organizationId: string;
   userId: string;
   currentRoleId: string;
-  roleOptions: RoleOption[];
+  roleOptions: LabelValueOption[];
   disabled?: boolean;
 }
 

--- a/frontend/src/components/opportunity/OpportunityEditForm.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.tsx
@@ -4,11 +4,11 @@ import {
   saveOpportunityEditAction,
   type OpportunityEditValidationErrors,
 } from "src/app/[locale]/(base)/opportunity/[id]/edit/actions";
-import { eligibilityTypes } from "src/constants/opportunity";
 import {
   categoryOptions,
+  eligibilityTypes,
   fundingOptions,
-} from "src/constants/searchFilterOptions";
+} from "src/constants/opportunity";
 import { OpportunityAttachment } from "src/types/opportunity/opportunityAttachmentTypes";
 
 import { useTranslations } from "next-intl";

--- a/frontend/src/components/opportunity/OpportunityEditForm.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.tsx
@@ -7,6 +7,7 @@ import {
 import {
   categoryOptions,
   eligbilityValueToGroup,
+  ELIGIBILITY_OPTIONS,
   fundingOptions,
 } from "src/constants/opportunity";
 import { OpportunityAttachment } from "src/types/opportunity/opportunityAttachmentTypes";
@@ -29,7 +30,6 @@ import {
 import { DynamicFieldLabel } from "src/components/applyForm/widgets/DynamicFieldLabel";
 import { OpportunityAttachmentUploadInput } from "src/components/opportunity/OpportunityAttachmentUploadInput";
 import {
-  ELIGIBILITY_OPTIONS,
   OPPORTUNITY_CATEGORY_OPTIONS,
   OpportunityEditFormValues,
 } from "./opportunityEditFormConfig";

--- a/frontend/src/components/opportunity/OpportunityEditForm.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.tsx
@@ -5,6 +5,10 @@ import {
   type OpportunityEditValidationErrors,
 } from "src/app/[locale]/(base)/opportunity/[id]/edit/actions";
 import { eligibilityTypes } from "src/constants/opportunity";
+import {
+  categoryOptions,
+  fundingOptions,
+} from "src/constants/searchFilterOptions";
 import { OpportunityAttachment } from "src/types/opportunity/opportunityAttachmentTypes";
 
 import { useTranslations } from "next-intl";
@@ -26,8 +30,6 @@ import { DynamicFieldLabel } from "src/components/applyForm/widgets/DynamicField
 import { OpportunityAttachmentUploadInput } from "src/components/opportunity/OpportunityAttachmentUploadInput";
 import {
   ELIGIBILITY_OPTIONS,
-  FUNDING_CATEGORY_OPTIONS,
-  FUNDING_INSTRUMENT_OPTIONS,
   OPPORTUNITY_CATEGORY_OPTIONS,
   OpportunityEditFormValues,
 } from "./opportunityEditFormConfig";
@@ -404,7 +406,7 @@ export default function OpportunityEditForm({
                   disabled={!isDraft}
                 >
                   <option value="">{t("content.select")}</option>
-                  {FUNDING_INSTRUMENT_OPTIONS.map((option) => (
+                  {fundingOptions.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>
@@ -472,7 +474,7 @@ export default function OpportunityEditForm({
                   disabled={!isDraft}
                 >
                   <option value="">{t("content.selectFundingCategory")}</option>
-                  {FUNDING_CATEGORY_OPTIONS.map((option) => (
+                  {categoryOptions.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>

--- a/frontend/src/components/opportunity/OpportunityEditForm.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.tsx
@@ -9,6 +9,7 @@ import {
   eligbilityValueToGroup,
   ELIGIBILITY_OPTIONS,
   fundingOptions,
+  OPPORTUNITY_CATEGORY_OPTIONS,
 } from "src/constants/opportunity";
 import { OpportunityAttachment } from "src/types/opportunity/opportunityAttachmentTypes";
 
@@ -29,10 +30,7 @@ import {
 
 import { DynamicFieldLabel } from "src/components/applyForm/widgets/DynamicFieldLabel";
 import { OpportunityAttachmentUploadInput } from "src/components/opportunity/OpportunityAttachmentUploadInput";
-import {
-  OPPORTUNITY_CATEGORY_OPTIONS,
-  OpportunityEditFormValues,
-} from "./opportunityEditFormConfig";
+import { OpportunityEditFormValues } from "./opportunityEditFormConfig";
 
 function formatNumber(value: string): string {
   const raw = value.replace(/,/g, "");

--- a/frontend/src/components/opportunity/OpportunityEditForm.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.tsx
@@ -6,7 +6,7 @@ import {
 } from "src/app/[locale]/(base)/opportunity/[id]/edit/actions";
 import {
   categoryOptions,
-  eligibilityTypes,
+  eligbilityValueToGroup,
   fundingOptions,
 } from "src/constants/opportunity";
 import { OpportunityAttachment } from "src/types/opportunity/opportunityAttachmentTypes";
@@ -227,8 +227,9 @@ export default function OpportunityEditForm({
 
   const leftColumnItems = keyInformationItems.slice(0, 3);
   const rightColumnItems = keyInformationItems.slice(3);
-  const eligibilityGroups = eligibilityTypes.reduce(
-    (acc, { group, label, value }) => {
+  const eligibilityGroups = ELIGIBILITY_OPTIONS.reduce(
+    (acc, { label, value }) => {
+      const group = eligbilityValueToGroup[value];
       if (!acc[group]) acc[group] = [];
       acc[group].push({ label, value });
       return acc;

--- a/frontend/src/components/opportunity/OpportunityEditForm.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.tsx
@@ -4,6 +4,7 @@ import {
   saveOpportunityEditAction,
   type OpportunityEditValidationErrors,
 } from "src/app/[locale]/(base)/opportunity/[id]/edit/actions";
+import { eligibilityTypes } from "src/constants/opportunity";
 import { OpportunityAttachment } from "src/types/opportunity/opportunityAttachmentTypes";
 
 import { useTranslations } from "next-intl";
@@ -224,41 +225,14 @@ export default function OpportunityEditForm({
 
   const leftColumnItems = keyInformationItems.slice(0, 3);
   const rightColumnItems = keyInformationItems.slice(3);
-  const eligibilityGroups = {
-    business: ELIGIBILITY_OPTIONS.filter((option) =>
-      [
-        "for_profit_organizations_other_than_small_businesses",
-        "small_businesses",
-      ].includes(option.value),
-    ),
-    education: ELIGIBILITY_OPTIONS.filter((option) =>
-      [
-        "independent_school_districts",
-        "private_institutions_of_higher_education",
-        "public_and_state_institutions_of_higher_education",
-      ].includes(option.value),
-    ),
-    government: ELIGIBILITY_OPTIONS.filter((option) =>
-      [
-        "city_or_township_governments",
-        "county_governments",
-        "special_district_governments",
-        "state_governments",
-        "federally_recognized_native_american_tribal_governments",
-        "public_and_indian_housing_authorities",
-      ].includes(option.value),
-    ),
-    nonprofit: ELIGIBILITY_OPTIONS.filter((option) =>
-      [
-        "other_native_american_tribal_organizations",
-        "nonprofits_non_higher_education_with_501c3",
-        "nonprofits_non_higher_education_without_501c3",
-      ].includes(option.value),
-    ),
-    misc: ELIGIBILITY_OPTIONS.filter((option) =>
-      ["individuals", "other", "unrestricted"].includes(option.value),
-    ),
-  };
+  const eligibilityGroups = eligibilityTypes.reduce(
+    (acc, { group, label, value }) => {
+      if (!acc[group]) acc[group] = [];
+      acc[group].push({ label, value });
+      return acc;
+    },
+    {} as Record<string, { label: string; value: string }[]>,
+  );
   return (
     <form
       id="opportunity-edit-form"
@@ -793,7 +767,7 @@ export default function OpportunityEditForm({
                 />
                 <EligibilityCheckboxGroup
                   title={t("labels.eligibilityMiscellaneous")}
-                  options={eligibilityGroups.misc}
+                  options={eligibilityGroups.miscellaneous}
                   baseId="eligible-misc"
                   selectedValues={values.eligibleApplicants}
                   onToggle={(value) =>

--- a/frontend/src/components/opportunity/opportunityEditFormConfig.ts
+++ b/frontend/src/components/opportunity/opportunityEditFormConfig.ts
@@ -1,8 +1,4 @@
-import {
-  eligibilityTypes,
-  OPPORTUNITY_CATEGORY_OPTIONS,
-} from "src/constants/opportunity";
-import { LabelValueOption } from "src/types/generalTypes";
+import { OPPORTUNITY_CATEGORY_OPTIONS } from "src/constants/opportunity";
 import {
   OpportunityDetail,
   OpportunitySummaryUpdateRequest,
@@ -38,8 +34,6 @@ const emptyString = (value: string | null | undefined) => value ?? "";
 
 const numberToString = (value: number | null | undefined) =>
   value === null || value === undefined ? "" : String(value);
-
-export const ELIGIBILITY_OPTIONS: LabelValueOption[] = eligibilityTypes;
 
 export { OPPORTUNITY_CATEGORY_OPTIONS };
 

--- a/frontend/src/components/opportunity/opportunityEditFormConfig.ts
+++ b/frontend/src/components/opportunity/opportunityEditFormConfig.ts
@@ -1,8 +1,7 @@
-import { eligibilityTypes } from "src/constants/opportunity";
 import {
-  categoryOptions,
-  fundingOptions,
-} from "src/constants/searchFilterOptions";
+  eligibilityTypes,
+  OPPORTUNITY_CATEGORY_OPTIONS,
+} from "src/constants/opportunity";
 import { LabelValueOption } from "src/types/generalTypes";
 import {
   OpportunityDetail,
@@ -42,18 +41,7 @@ const numberToString = (value: number | null | undefined) =>
 
 export const ELIGIBILITY_OPTIONS: LabelValueOption[] = eligibilityTypes;
 
-export const OPPORTUNITY_CATEGORY_OPTIONS: LabelValueOption[] = [
-  { label: "Discretionary", value: "discretionary" },
-  { label: "Mandatory", value: "mandatory" },
-  { label: "Continuation", value: "continuation" },
-  { label: "Earmark", value: "earmark" },
-  { label: "Other", value: "other" },
-];
-
-export const FUNDING_INSTRUMENT_OPTIONS: LabelValueOption[] =
-  fundingOptions.map(({ label, value }) => ({ label: label.trim(), value }));
-
-export const FUNDING_CATEGORY_OPTIONS: LabelValueOption[] = categoryOptions;
+export { OPPORTUNITY_CATEGORY_OPTIONS };
 
 export const buildOpportunityEditInitialValues = (
   opportunity: OpportunityDetail,

--- a/frontend/src/components/opportunity/opportunityEditFormConfig.ts
+++ b/frontend/src/components/opportunity/opportunityEditFormConfig.ts
@@ -3,6 +3,7 @@ import {
   categoryOptions,
   fundingOptions,
 } from "src/constants/searchFilterOptions";
+import { LabelValueOption } from "src/types/generalTypes";
 import {
   OpportunityDetail,
   OpportunitySummaryUpdateRequest,
@@ -34,21 +35,14 @@ export type OpportunityEditFormValues = {
   contactEmailText: string;
 };
 
-export type SelectOption = {
-  label: string;
-  value: string;
-};
-
-export type CheckboxOption = SelectOption;
-
 const emptyString = (value: string | null | undefined) => value ?? "";
 
 const numberToString = (value: number | null | undefined) =>
   value === null || value === undefined ? "" : String(value);
 
-export const ELIGIBILITY_OPTIONS: CheckboxOption[] = eligibilityTypes;
+export const ELIGIBILITY_OPTIONS: LabelValueOption[] = eligibilityTypes;
 
-export const OPPORTUNITY_CATEGORY_OPTIONS: SelectOption[] = [
+export const OPPORTUNITY_CATEGORY_OPTIONS: LabelValueOption[] = [
   { label: "Discretionary", value: "discretionary" },
   { label: "Mandatory", value: "mandatory" },
   { label: "Continuation", value: "continuation" },
@@ -56,11 +50,10 @@ export const OPPORTUNITY_CATEGORY_OPTIONS: SelectOption[] = [
   { label: "Other", value: "other" },
 ];
 
-export const FUNDING_INSTRUMENT_OPTIONS: CheckboxOption[] = fundingOptions.map(
-  ({ label, value }) => ({ label: label.trim(), value }),
-);
+export const FUNDING_INSTRUMENT_OPTIONS: LabelValueOption[] =
+  fundingOptions.map(({ label, value }) => ({ label: label.trim(), value }));
 
-export const FUNDING_CATEGORY_OPTIONS: CheckboxOption[] = categoryOptions;
+export const FUNDING_CATEGORY_OPTIONS: LabelValueOption[] = categoryOptions;
 
 export const buildOpportunityEditInitialValues = (
   opportunity: OpportunityDetail,

--- a/frontend/src/components/opportunity/opportunityEditFormConfig.ts
+++ b/frontend/src/components/opportunity/opportunityEditFormConfig.ts
@@ -1,4 +1,3 @@
-import { OPPORTUNITY_CATEGORY_OPTIONS } from "src/constants/opportunity";
 import {
   OpportunityDetail,
   OpportunitySummaryUpdateRequest,
@@ -34,8 +33,6 @@ const emptyString = (value: string | null | undefined) => value ?? "";
 
 const numberToString = (value: number | null | undefined) =>
   value === null || value === undefined ? "" : String(value);
-
-export { OPPORTUNITY_CATEGORY_OPTIONS };
 
 export const buildOpportunityEditInitialValues = (
   opportunity: OpportunityDetail,

--- a/frontend/src/components/saved-opportunities/SavedOpportunityOwnershipFilter.tsx
+++ b/frontend/src/components/saved-opportunities/SavedOpportunityOwnershipFilter.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParamUpdater } from "src/hooks/useSearchParamUpdater";
 import { Organization } from "src/types/applicationResponseTypes";
+import { LabelValueOption } from "src/types/generalTypes";
 
 import { useTranslations } from "next-intl";
 import { useCallback, useMemo } from "react";
@@ -12,11 +13,6 @@ interface SavedOpportunityOwnershipFilterProps {
   savedBy: string | null;
 }
 
-interface SavedOpportunityOwnershipFilterOption {
-  value: string;
-  label: string;
-}
-
 export default function SavedOpportunityOwnershipFilter({
   organizations,
   savedBy,
@@ -24,7 +20,7 @@ export default function SavedOpportunityOwnershipFilter({
   const { setQueryParam, removeQueryParam } = useSearchParamUpdater();
   const t = useTranslations("SavedOpportunities");
 
-  const options = useMemo<SavedOpportunityOwnershipFilterOption[]>(() => {
+  const options = useMemo<LabelValueOption[]>(() => {
     const sortedOrganizations = [...organizations].sort(
       (firstOrganization, secondOrganization) => {
         const firstOrganizationName =

--- a/frontend/src/components/search/SearchDrawerFilters.tsx
+++ b/frontend/src/components/search/SearchDrawerFilters.tsx
@@ -1,10 +1,9 @@
+import { categoryOptions, fundingOptions } from "src/constants/opportunity";
 import { SEARCH_NO_STATUS_VALUE } from "src/constants/search";
 import {
-  categoryOptions,
   closeDateOptions,
   costSharingOptions,
   eligibilityOptions,
-  fundingOptions,
   postedDateOptions,
   statusOptions,
 } from "src/constants/searchFilterOptions";

--- a/frontend/src/constants/opportunity.ts
+++ b/frontend/src/constants/opportunity.ts
@@ -1,3 +1,5 @@
+import { FilterOption } from "src/types/search/searchFilterTypes";
+
 export const eligibilityTypes = [
   {
     id: "eligibility-state_governments",
@@ -121,3 +123,133 @@ export const eligbilityValueToGroup = eligibilityTypes.reduce(
   },
   {} as { [key: string]: string },
 );
+
+export const fundingOptions: FilterOption[] = [
+  {
+    id: "funding-instrument-cooperative_agreement",
+    label: "Cooperative Agreement",
+    value: "cooperative_agreement",
+    tooltip:
+      "Involves active agency participation in a project, while grants provide funds and oversight without direct involvement.",
+  },
+  {
+    id: "funding-instrument-grant",
+    label: "Grant",
+    value: "grant",
+  },
+  {
+    id: "funding-instrument-procurement_contract",
+    label: "Procurement Contract",
+    value: "procurement_contract",
+    tooltip:
+      "Allows the government to purchase goods and services for its benefit, while grants provide financial support to advance a public purpose.",
+  },
+  {
+    id: "funding-instrument-other",
+    label: "Other",
+    value: "other",
+  },
+];
+
+export const categoryOptions: FilterOption[] = [
+  { id: "category-recovery_act", label: "Recovery Act", value: "recovery_act" },
+  { id: "category-agriculture", label: "Agriculture", value: "agriculture" },
+  { id: "category-arts", label: "Arts", value: "arts" },
+  {
+    id: "category-business_and_commerce",
+    label: "Business and Commerce",
+    value: "business_and_commerce",
+  },
+  {
+    id: "category-community_development",
+    label: "Community Development",
+    value: "community_development",
+  },
+  {
+    id: "category-consumer_protection",
+    label: "Consumer Protection",
+    value: "consumer_protection",
+  },
+  {
+    id: "category-disaster_prevention_and_relief",
+    label: "Disaster Prevention and Relief",
+    value: "disaster_prevention_and_relief",
+  },
+  { id: "category-education", label: "Education", value: "education" },
+  {
+    id: "category-employment_labor_and_training",
+    label: "Employment, Labor, and Training",
+    value: "employment_labor_and_training",
+  },
+  { id: "category-energy", label: "Energy", value: "energy" },
+  {
+    id: "category-energy_infrastructure_and_critical_mineral_and_materials",
+    label: "Energy Infrastructure and Critical Mineral and Materials (EICMM)",
+    value: "energy_infrastructure_and_critical_mineral_and_materials",
+  },
+  { id: "category-environment", label: "Environment", value: "environment" },
+  {
+    id: "category-food_and_nutrition",
+    label: "Food and Nutrition",
+    value: "food_and_nutrition",
+  },
+  { id: "category-health", label: "Health", value: "health" },
+  { id: "category-housing", label: "Housing", value: "housing" },
+  { id: "category-humanities", label: "Humanities", value: "humanities" },
+  {
+    id: "category-information_and_statistics",
+    label: "Information and Statistics",
+    value: "information_and_statistics",
+  },
+  {
+    id: "category-infrastructure_investment_and_jobs_act",
+    label: "Infrastructure Investment and Jobs Act",
+    value: "infrastructure_investment_and_jobs_act",
+  },
+  {
+    id: "category-income_security_and_social_services",
+    label: "Income Security and Social Services",
+    value: "income_security_and_social_services",
+  },
+  {
+    id: "category-law_justice_and_legal_services",
+    label: "Law, Justice, and Legal Services",
+    value: "law_justice_and_legal_services",
+  },
+  {
+    id: "category-natural_resources",
+    label: "Natural Resources",
+    value: "natural_resources",
+  },
+  {
+    id: "category-opportunity_zone_benefits",
+    label: "Opportunity Zone Benefits",
+    value: "opportunity_zone_benefits",
+  },
+  {
+    id: "category-recreation_and_tourism",
+    label: "Recreation and Tourism",
+    value: "recreation_and_tourism",
+  },
+  {
+    id: "category-regional_development",
+    label: "Regional Development",
+    value: "regional_development",
+  },
+  {
+    id: "category-science_technology_and_other_research_and_development",
+    label: "Science, Technology, and Other Research and Development",
+    value: "science_technology_and_other_research_and_development",
+  },
+  {
+    id: "category-transportation",
+    label: "Transportation",
+    value: "transportation",
+  },
+  {
+    id: "category-affordable_care_act",
+    label: "Affordable Care Act",
+    value: "affordable_care_act",
+  },
+  { id: "category-other", label: "Other", value: "other" },
+];

--- a/frontend/src/constants/opportunity.ts
+++ b/frontend/src/constants/opportunity.ts
@@ -106,7 +106,7 @@ export const eligibilityTypes = [
   },
 ];
 
-export const OPPORTUNITY_CATEGORY_OPTIONS = [
+export const OPPORTUNITY_CATEGORY_OPTIONS: LabelValueOption[] = [
   { label: "Discretionary", value: "discretionary" },
   { label: "Mandatory", value: "mandatory" },
   { label: "Continuation", value: "continuation" },

--- a/frontend/src/constants/opportunity.ts
+++ b/frontend/src/constants/opportunity.ts
@@ -1,3 +1,4 @@
+import { LabelValueOption } from "src/types/generalTypes";
 import { FilterOption } from "src/types/search/searchFilterTypes";
 
 export const eligibilityTypes = [
@@ -253,3 +254,5 @@ export const categoryOptions: FilterOption[] = [
   },
   { id: "category-other", label: "Other", value: "other" },
 ];
+
+export const ELIGIBILITY_OPTIONS: LabelValueOption[] = eligibilityTypes;

--- a/frontend/src/constants/opportunity.ts
+++ b/frontend/src/constants/opportunity.ts
@@ -103,6 +103,14 @@ export const eligibilityTypes = [
   },
 ];
 
+export const OPPORTUNITY_CATEGORY_OPTIONS = [
+  { label: "Discretionary", value: "discretionary" },
+  { label: "Mandatory", value: "mandatory" },
+  { label: "Continuation", value: "continuation" },
+  { label: "Earmark", value: "earmark" },
+  { label: "Other", value: "other" },
+];
+
 // these are used to more easily format a UI based on eligibility values
 
 // represents a map of { value: group }

--- a/frontend/src/constants/searchFilterOptions.ts
+++ b/frontend/src/constants/searchFilterOptions.ts
@@ -1,5 +1,11 @@
-import { eligibilityTypes } from "src/constants/opportunity";
+import {
+  categoryOptions,
+  eligibilityTypes,
+  fundingOptions,
+} from "src/constants/opportunity";
 import { FilterOption } from "src/types/search/searchFilterTypes";
+
+export { categoryOptions, fundingOptions };
 
 // Note that these labels are not translated currently
 // To translate them we would want to list the translation key in the label
@@ -33,140 +39,6 @@ export const statusOptions: FilterOption[] = [
     label: "Archived",
     value: "archived",
   },
-];
-
-export const fundingOptions: FilterOption[] = [
-  {
-    id: "funding-instrument-cooperative_agreement",
-    label: "Cooperative Agreement",
-    value: "cooperative_agreement",
-    tooltip:
-      "Involves active agency participation in a project, while grants provide funds and oversight without direct involvement.",
-  },
-  {
-    id: "funding-instrument-grant",
-    label: "Grant",
-    value: "grant",
-  },
-  {
-    id: "funding-instrument-procurement_contract",
-    label: "Procurement Contract",
-    value: "procurement_contract",
-    tooltip:
-      "Allows the government to purchase goods and services for its benefit, while grants provide financial support to advance a public purpose.",
-  },
-  {
-    id: "funding-instrument-other",
-    label: "Other",
-    value: "other",
-  },
-];
-
-export const categoryOptions: FilterOption[] = [
-  {
-    id: "category-recovery_act",
-    label: "Recovery Act",
-    value: "recovery_act",
-  },
-  { id: "category-agriculture", label: "Agriculture", value: "agriculture" },
-  { id: "category-arts", label: "Arts", value: "arts" },
-  {
-    id: "category-business_and_commerce",
-    label: "Business and Commerce",
-    value: "business_and_commerce",
-  },
-  {
-    id: "category-community_development",
-    label: "Community Development",
-    value: "community_development",
-  },
-  {
-    id: "category-consumer_protection",
-    label: "Consumer Protection",
-    value: "consumer_protection",
-  },
-  {
-    id: "category-disaster_prevention_and_relief",
-    label: "Disaster Prevention and Relief",
-    value: "disaster_prevention_and_relief",
-  },
-  { id: "category-education", label: "Education", value: "education" },
-  {
-    id: "category-employment_labor_and_training",
-    label: "Employment, Labor, and Training",
-    value: "employment_labor_and_training",
-  },
-  { id: "category-energy", label: "Energy", value: "energy" },
-  {
-    id: "category-energy_infrastructure_and_critical_mineral_and_materials",
-    label: "Energy Infrastructure and Critical Mineral and Materials (EICMM)",
-    value: "energy_infrastructure_and_critical_mineral_and_materials",
-  },
-  { id: "category-environment", label: "Environment", value: "environment" },
-  {
-    id: "category-food_and_nutrition",
-    label: "Food and Nutrition",
-    value: "food_and_nutrition",
-  },
-  { id: "category-health", label: "Health", value: "health" },
-  { id: "category-housing", label: "Housing", value: "housing" },
-  { id: "category-humanities", label: "Humanities", value: "humanities" },
-  {
-    id: "category-information_and_statistics",
-    label: "Information and Statistics",
-    value: "information_and_statistics",
-  },
-  {
-    id: "category-infrastructure_investment_and_jobs_act",
-    label: "Infrastructure Investment and Jobs Act",
-    value: "infrastructure_investment_and_jobs_act",
-  },
-  {
-    id: "category-income_security_and_social_services",
-    label: "Income Security and Social Services",
-    value: "income_security_and_social_services",
-  },
-  {
-    id: "category-law_justice_and_legal_services",
-    label: "Law, Justice, and Legal Services",
-    value: "law_justice_and_legal_services",
-  },
-  {
-    id: "category-natural_resources",
-    label: "Natural Resources",
-    value: "natural_resources",
-  },
-  {
-    id: "category-opportunity_zone_benefits",
-    label: "Opportunity Zone Benefits",
-    value: "opportunity_zone_benefits",
-  },
-  {
-    id: "category-recreation_and_tourism",
-    label: "Recreation and Tourism",
-    value: "recreation_and_tourism",
-  },
-  {
-    id: "category-regional_development",
-    label: "Regional Development",
-    value: "regional_development",
-  },
-  {
-    id: "category-science_technology_and_other_research_and_development",
-    label: "Science, Technology, and Other Research and Development",
-    value: "science_technology_and_other_research_and_development",
-  },
-  {
-    id: "category-transportation",
-    label: "Transportation",
-    value: "transportation",
-  },
-  {
-    id: "category-affordable_care_act",
-    label: "Affordable Care Act",
-    value: "affordable_care_act",
-  },
-  { id: "category-other", label: "Other", value: "other" },
 ];
 
 export const closeDateOptions: FilterOption[] = [

--- a/frontend/src/constants/searchFilterOptions.ts
+++ b/frontend/src/constants/searchFilterOptions.ts
@@ -50,7 +50,7 @@ export const fundingOptions: FilterOption[] = [
   },
   {
     id: "funding-instrument-procurement_contract",
-    label: "Procurement Contract ",
+    label: "Procurement Contract",
     value: "procurement_contract",
     tooltip:
       "Allows the government to purchase goods and services for its benefit, while grants provide financial support to advance a public purpose.",

--- a/frontend/src/constants/searchFilterOptions.ts
+++ b/frontend/src/constants/searchFilterOptions.ts
@@ -5,8 +5,6 @@ import {
 } from "src/constants/opportunity";
 import { FilterOption } from "src/types/search/searchFilterTypes";
 
-export { categoryOptions, fundingOptions };
-
 // Note that these labels are not translated currently
 // To translate them we would want to list the translation key in the label
 // And have the translation system consume that key wherever the value is needed

--- a/frontend/src/types/generalTypes.ts
+++ b/frontend/src/types/generalTypes.ts
@@ -15,6 +15,11 @@ type Only<T, U> = {
 
 // exported Types ----
 
+export type LabelValueOption = {
+  label: string;
+  value: string;
+};
+
 export type Either<T, U> = Only<T, U> | Only<U, T>;
 
 export type IndexType = number | null;

--- a/frontend/src/types/search/searchFilterTypes.ts
+++ b/frontend/src/types/search/searchFilterTypes.ts
@@ -1,3 +1,5 @@
+import { LabelValueOption } from "src/types/generalTypes";
+
 export const backendFilterNames = [
   "opportunity_status",
   "funding_instrument",
@@ -30,12 +32,10 @@ export type HardcodedFrontendFilterNames = Exclude<
   "agency" | "topLevelAgency" | "assistanceListingNumber"
 >;
 
-export interface FilterOption {
+export interface FilterOption extends LabelValueOption {
   children?: FilterOption[];
   id: string;
   isChecked?: boolean;
-  label: string;
-  value: string;
   tooltip?: string;
 }
 


### PR DESCRIPTION
## Summary

Fixes #9590

## Changes proposed

**AC1 - Single canonical type for `{ label, value }`**
- Added `LabelValueOption` to `generalTypes.ts` as the single shared definition
- `FilterOption` in `searchFilterTypes.ts` now extends `LabelValueOption` instead of redeclaring `label` and `value`
- Removed the local `SelectOption` / `CheckboxOption` definitions from `opportunityEditFormConfig.ts`

**AC2 - Eligibility grouping driven by data**
- Replaced 5 hardcoded `filter()` calls in `OpportunityEditForm.tsx` with a single `reduce()` over `eligibilityTypes`, which already carries a `group` field per entry
- Fixed a pre-existing mismatch: the form was keying the miscellaneous group as `misc` while `eligibilityTypes` uses `miscellaneous`

**AC3 - Static options defined once, at the source**
- Moved `OPPORTUNITY_CATEGORY_OPTIONS` from `opportunityEditFormConfig.ts` to `constants/opportunity.ts`
- Removed `FUNDING_INSTRUMENT_OPTIONS` and `FUNDING_CATEGORY_OPTIONS` wrapper re-exports from `opportunityEditFormConfig.ts` - `OpportunityEditForm.tsx` now imports `fundingOptions` / `categoryOptions` directly from `searchFilterOptions.ts`
- Fixed a pre-existing trailing space in the "Procurement Contract" label in `fundingOptions`

**AC4 - Shared input components and `DynamicFieldLabel`**
- `DynamicFieldLabel` (from `applyForm/widgets`) is already used consistently across every interactive field in `OpportunityEditForm.tsx` - no changes needed here
- `CommonTextInput`, `CommonSelectInput`, `CommonTextArea`, and `CommonCharacterCount` from `CommonFormFields.tsx` were intentionally not adopted in this PR. These components originated in the Create Opportunity flow and are not yet established as a shared component library (no formal API, docs, or Storybook coverage at the `frontend/` level). When a proper shared USWDS wrapper library is ready, all pages using raw USWDS primitives - including this one - will be migrated in one deliberate pass. Adopting these components prematurely would mean the edit form goes through that migration twice, which is the tech debt we are trying to avoid.

## Context for reviewers

These changes are purely organizational - no new behavior is introduced. The goal across all four ACs is to establish a single source of truth: one type definition for `{ label, value }`, one place for each options array, and eligibility grouping driven by the data that already exists in `constants/opportunity.ts`. The edit form's logic is unchanged; only where things are defined and imported from has moved.

## Validation steps

1. Navigate to an opportunity edit page (e.g. `/opportunity/<id>/edit`)
2. Verify all sections render correctly: Funding Details, Dates, Eligibility, Description, Contact
3. Verify eligibility checkboxes are correctly grouped (Government, Education, Business, Nonprofit, Miscellaneous) and the Miscellaneous group is populated
4. Make edits and save - confirm changes persist
5. Run `npm run all-checks` from `frontend/` - all 280 test suites pass