### PR TITLE
[Issue #9798] Add Jest unit test for formatFullName

### DIFF
--- a/frontend/src/utils/userNameUtils.test.ts
+++ b/frontend/src/utils/userNameUtils.test.ts
@@ -1,0 +1,61 @@
+import { formatFullName } from "src/utils/userNameUtils";
+
+describe("formatFullName", () => {
+  it("returns a single space when user is null", () => {
+    expect(formatFullName(null)).toBe(" ");
+  });
+
+  it("returns a single space when user is undefined", () => {
+    expect(formatFullName(undefined)).toBe(" ");
+  });
+
+  it("joins first, middle, and last names", () => {
+    expect(
+      formatFullName({
+        first_name: "Ada",
+        middle_name: "Agnes",
+        last_name: "Lovelace",
+      }),
+    ).toBe("Ada Agnes Lovelace");
+  });
+
+  it("skips a missing middle name", () => {
+    expect(
+      formatFullName({
+        first_name: "Grace",
+        middle_name: null,
+        last_name: "Hopper",
+      }),
+    ).toBe("Grace Hopper");
+  });
+
+  it("skips a missing first and middle name", () => {
+    expect(
+      formatFullName({
+        first_name: null,
+        middle_name: null,
+        last_name: "Solo",
+      }),
+    ).toBe("Solo");
+  });
+
+  it("skips empty-string values", () => {
+    expect(
+      formatFullName({
+        first_name: "",
+        middle_name: null,
+        last_name: "Solo",
+      }),
+    ).toBe("Solo");
+  });
+
+  it("returns an empty string when every name part is empty", () => {
+    expect(
+      formatFullName({
+        first_name: "",
+        middle_name: "",
+        last_name: "",
+      }),
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
Resolves #9798.

`formatFullName` in `frontend/src/utils/userNameUtils.ts` had no sibling test. The function is pure, generic, and widely used in user-facing UI, so a small test suite guards against regressions in how null/undefined/empty fields are filtered.

## Test cases

Covers every acceptance-criteria case from the issue:

- `null` input returns `" "`
- `undefined` input returns `" "`
- All three name parts present joined with single spaces
- Missing middle name skipped
- Missing first and middle name skipped (last only)
- Empty-string values skipped
- All empty strings returns `""`

## Notes

- Source `userNameUtils.ts` is unchanged.
- Test placement matches the existing sibling `userUtilts.test.ts` (typo in the existing filename intentionally preserved per the issue).
- Path follows the `src/utils/...` import alias used by the rest of the suite.

## Verification

- `cd frontend && npm run test -- userNameUtils` -- all 7 tests pass locally.
- `cd frontend && npm run lint` -- no new warnings on the new file.