### PR TITLE
[Issue #9699] Create privileges and roles for file upload work

### DIFF
--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -319,6 +319,8 @@ class Privilege(StrEnum):
     PROGRAM_OFFICER_APPROVAL = "program_officer_approval"
     BUDGET_OFFICER_APPROVAL = "budget_officer_approval"
 
+    INTERNAL_S3_SCAN = "internal_s3_scan"
+
 
 class RoleType(StrEnum):
     ORGANIZATION = "organization"

--- a/api/src/constants/static_role_values.py
+++ b/api/src/constants/static_role_values.py
@@ -269,6 +269,17 @@ INTERNAL_WORKFLOW_USER_ROLE = Role(
     ],
 )
 
+INTERNAL_S3_SCANNER_ROLE_ID = uuid.UUID("49388bd7-c36a-4977-b8e7-bac32c7a8f77")
+INTERNAL_S3_SCANNER_ROLE = Role(
+    role_id=INTERNAL_S3_SCANNER_ROLE_ID,
+    role_name="Internal S3 Scanner",
+    is_core=True,
+    link_privileges=get_link_privileges(INTERNAL_S3_SCANNER_ROLE_ID, [Privilege.INTERNAL_S3_SCAN]),
+    link_role_types=[
+        LinkRoleRoleType(role_id=INTERNAL_S3_SCANNER_ROLE_ID, role_type=RoleType.INTERNAL),
+    ],
+)
+
 CORE_ROLES = [
     ORG_ADMIN,
     ORG_MEMBER,
@@ -284,4 +295,5 @@ CORE_ROLES = [
     AWARD_RECOMMENDATION_USER,
     GRANTOR_PROGRAM_OFFICER,
     GRANTOR_BUDGET_OFFICER,
+    INTERNAL_S3_SCANNER_ROLE,
 ]

--- a/api/src/db/models/lookup_models.py
+++ b/api/src/db/models/lookup_models.py
@@ -333,6 +333,7 @@ PRIVILEGE_CONFIG: LookupConfig[Privilege] = LookupConfig(
         LookupStr(Privilege.CREATE_AWARD_RECOMMENDATION, 29),
         LookupStr(Privilege.UPDATE_AWARD_RECOMMENDATION, 30),
         LookupStr(Privilege.SUBMIT_AWARD_RECOMMENDATION, 31),
+        LookupStr(Privilege.INTERNAL_S3_SCAN, 32),
     ]
 )
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9699  

## Changes proposed

- Updated lookup_constants.py to add` INTERNAL_S3_SCAN = "internal_s3_scan"` to the `Privilege` enum
- Updated lookup_models.py to add `LookupStr(Privilege.INTERNAL_S3_SCAN, 32)` to `PRIVILEGE_CONFIG`
- Updated static_role_values.py to add the Internal S3 Scanner role with a single privilege of `INTERNAL_S3_SCAN`

## Context for reviewers

Simple addition of a new privilege and role for file upload scanning.

## Validation steps

Confirm role and privilege are present.