### PR TITLE
[Issue #9933] Update SOAP Cert Check & Handling

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -107,9 +107,13 @@ class SessionResumptionAdapter(HTTPAdapter):
 def get_tcertificate(
     serial_number: str, db_session: db.Session
 ) -> staging.certificates.Tcertificates | None:
+    # Since we lower the input serial_number we wrap the column
+    # value in func.lower() to make the match case insensitive. In hexadecimal
+    # there is no distinction between upper and lower case. The serial number
+    # can be either upper or lower cased in the DB.
     return db_session.scalars(
         select(staging.certificates.Tcertificates).where(
-            staging.certificates.Tcertificates.serial_num == serial_number
+            func.lower(staging.certificates.Tcertificates.serial_num) == serial_number.lower()
         )
     ).one_or_none()
 
@@ -124,13 +128,15 @@ def get_soap_auth(mtls_cert: str | None, db_session: db.Session) -> SOAPAuth:
     logger.info("soap_client_certificate: certificate received header")
     cert_str = unquote(mtls_cert)
     cert = load_pem_x509_certificate(cert_str.encode(), default_backend())
+    # We convert the integer representation of the serial number to lower case hexadecimal here
+    # Note: the 'x' in '032x' returns it lower cased
     serial_number_hex = format(int(cert.serial_number), "032x")
 
     tcertificate = get_tcertificate(serial_number_hex, db_session)
     if not tcertificate:
         logger.info(
             "soap_client_certificate: no tcertificate",
-            extra={"soap_api_event": LegacySoapApiEvent.NO_HEADER_CERT},
+            extra={"soap_api_event": LegacySoapApiEvent.TCERT_NOT_FOUND},
         )
         raise SOAPClientTcertificateNotFound("No tcertificate")
     if tcertificate.expirationdate and tcertificate.expirationdate <= get_now_us_eastern_date():
@@ -141,6 +147,7 @@ def get_soap_auth(mtls_cert: str | None, db_session: db.Session) -> SOAPAuth:
         raise SOAPClientCertificateIsExpired("tcertificate is expired")
 
     legacy_certificate = get_legacy_certificate_by_serial_number(db_session, serial_number_hex)
+
     if not legacy_certificate:
         logger.info(
             "soap_client_certificate: no LegacyCertificate",
@@ -150,24 +157,36 @@ def get_soap_auth(mtls_cert: str | None, db_session: db.Session) -> SOAPAuth:
             cert=cert_str,
             fingerprint=cert.fingerprint(hashes.SHA256()).hex(),
             issuer=cert.issuer.rfc4514_string(),
-            serial_number=str(serial_number_hex),
+            serial_number=serial_number_hex,
             legacy_certificate=None,
             cert_id=tcertificate.currentcertid,
         )
         return SOAPAuth(certificate=soap_client_certificate)
 
-    if legacy_certificate and legacy_certificate.expiration_date <= get_now_us_eastern_date():
+    add_extra_data_to_current_request_logs(
+        {
+            "legacy_certificate_id": legacy_certificate.legacy_certificate_id,
+        }
+    )
+    if legacy_certificate.agency:
+        add_extra_data_to_current_request_logs(
+            {
+                "agency_code": legacy_certificate.agency.agency_code,
+            }
+        )
+
+    if legacy_certificate.expiration_date <= get_now_us_eastern_date():
         logger.info(
             "soap_client_certificate: LegacyCertificate is expired",
             extra={"soap_api_event": LegacySoapApiEvent.CERT_EXPIRED},
         )
-        raise SOAPClientCertificateIsExpired("No tcertificate or tcertificate expired")
+        raise SOAPClientCertificateIsExpired("LegacyCertificate is expired")
 
     soap_client_certificate = SOAPClientCertificate(
         cert=cert_str,
         fingerprint=cert.fingerprint(hashes.SHA256()).hex(),
         issuer=cert.issuer.rfc4514_string(),
-        serial_number=str(serial_number_hex),
+        serial_number=serial_number_hex,
         legacy_certificate=legacy_certificate,
         cert_id=str(legacy_certificate.cert_id),
     )
@@ -186,37 +205,6 @@ def get_legacy_certificate_by_serial_number(
             func.lower(LegacyCertificate.serial_number) == serial_number.lower()
         )
     ).scalar_one_or_none()
-
-
-def get_soap_client_certificate(
-    urlencoded_cert: str, db_session: db.Session
-) -> SOAPClientCertificate:
-    cert_str = unquote(urlencoded_cert)
-    cert = load_pem_x509_certificate(cert_str.encode(), default_backend())
-    # We convert the integer representation of the serial number to lower case hexadecimal here
-    # Note: the 'x' in '032x' returns it lower cased
-    serial_number_hex = format(int(cert.serial_number), "032x")
-    legacy_certificate = get_legacy_certificate_by_serial_number(db_session, serial_number_hex)
-    if legacy_certificate:
-        add_extra_data_to_current_request_logs(
-            {
-                "legacy_certificate_id": legacy_certificate.legacy_certificate_id,
-            }
-        )
-        if legacy_certificate.agency:
-            add_extra_data_to_current_request_logs(
-                {
-                    "agency_code": legacy_certificate.agency.agency_code,
-                }
-            )
-
-    return SOAPClientCertificate(
-        cert=cert_str,
-        fingerprint=cert.fingerprint(hashes.SHA256()).hex(),
-        issuer=cert.issuer.rfc4514_string(),
-        serial_number=str(serial_number_hex),
-        legacy_certificate=legacy_certificate,
-    )
 
 
 def validate_certificate(

--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -14,6 +14,7 @@ from sqlalchemy import func, select
 
 import src.adapters.db as db
 from src.auth.endpoint_access_util import can_access
+from src.db.models import staging
 from src.db.models.agency_models import Agency
 from src.db.models.user_models import LegacyCertificate
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI, SOAPOperationConfig
@@ -24,7 +25,6 @@ from src.util.datetime_util import get_now_us_eastern_date
 logger = logging.getLogger(__name__)
 
 MTLS_CERT_HEADER_KEY = "X-Amzn-Mtls-Clientcert"
-USE_SOAP_CERT_HEADER_KEY = "Use-Soap-Cert"
 S2S_PARTNER_CERTID_JWT_B64_HEADER_KEY = "S2S_PARTNER_CERTID_JWT_B64"
 LOG_LOCAL_RESPONSE_HEADER_KEY = "Log-Local-Response"
 USE_SIMPLER_OVERRIDE_KEY = "Use-Simpler-Override"
@@ -42,11 +42,24 @@ class SOAPClientUserDoesNotHavePermission(Exception):
     pass
 
 
+class SOAPClientTcertificateNotFound(Exception):
+    pass
+
+
+class SOAPClientMissingCertificate(Exception):
+    pass
+
+
+class SOAPClientCertificateIsExpired(Exception):
+    pass
+
+
 class SOAPClientCertificate(BaseModel):
     cert: str
     serial_number: str
     fingerprint: str
     legacy_certificate: LegacyCertificate | None = None
+    cert_id: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -91,29 +104,74 @@ class SessionResumptionAdapter(HTTPAdapter):
         super().init_poolmanager(*args, **kwargs)
 
 
-def get_soap_auth(mtls_cert: str | None, db_session: db.Session) -> SOAPAuth | None:
+def get_tcertificate(
+    serial_number: str, db_session: db.Session
+) -> staging.certificates.Tcertificates | None:
+    return db_session.scalars(
+        select(staging.certificates.Tcertificates).where(
+            staging.certificates.Tcertificates.serial_num == serial_number
+        )
+    ).one_or_none()
+
+
+def get_soap_auth(mtls_cert: str | None, db_session: db.Session) -> SOAPAuth:
     if not mtls_cert:
         logger.info(
             "soap_client_certificate: no certificate received from header",
             extra={"soap_api_event": LegacySoapApiEvent.NO_HEADER_CERT},
         )
-        return None
-
+        raise SOAPClientMissingCertificate("No certificate exception")
     logger.info("soap_client_certificate: certificate received header")
-    auth = None
-    try:
-        auth = SOAPAuth(certificate=get_soap_client_certificate(mtls_cert, db_session))
+    cert_str = unquote(mtls_cert)
+    cert = load_pem_x509_certificate(cert_str.encode(), default_backend())
+    serial_number_hex = format(int(cert.serial_number), "032x")
+
+    tcertificate = get_tcertificate(serial_number_hex, db_session)
+    if not tcertificate:
         logger.info(
-            "soap_client_certificate: successfully extracted certificate and serial number",
-            extra={"soap_api_event": LegacySoapApiEvent.PARSED_CERT},
+            "soap_client_certificate: no tcertificate",
+            extra={"soap_api_event": LegacySoapApiEvent.NO_HEADER_CERT},
         )
-    except Exception:
+        raise SOAPClientTcertificateNotFound("No tcertificate")
+    if tcertificate.expirationdate and tcertificate.expirationdate <= get_now_us_eastern_date():
         logger.info(
-            "soap_client_certificate: could not parse and extract serial number",
-            exc_info=True,
-            extra={"soap_api_event": LegacySoapApiEvent.UNPARSEABLE_CERT},
+            "soap_client_certificate: tcertificate is expired",
+            extra={"soap_api_event": LegacySoapApiEvent.CERT_EXPIRED},
         )
-    return auth
+        raise SOAPClientCertificateIsExpired("tcertificate is expired")
+
+    legacy_certificate = get_legacy_certificate_by_serial_number(db_session, serial_number_hex)
+    if not legacy_certificate:
+        logger.info(
+            "soap_client_certificate: no LegacyCertificate",
+            extra={"soap_api_event": LegacySoapApiEvent.NOT_CONFIGURED_CERT},
+        )
+        soap_client_certificate = SOAPClientCertificate(
+            cert=cert_str,
+            fingerprint=cert.fingerprint(hashes.SHA256()).hex(),
+            issuer=cert.issuer.rfc4514_string(),
+            serial_number=str(serial_number_hex),
+            legacy_certificate=None,
+            cert_id=tcertificate.currentcertid,
+        )
+        return SOAPAuth(certificate=soap_client_certificate)
+
+    if legacy_certificate and legacy_certificate.expiration_date <= get_now_us_eastern_date():
+        logger.info(
+            "soap_client_certificate: LegacyCertificate is expired",
+            extra={"soap_api_event": LegacySoapApiEvent.CERT_EXPIRED},
+        )
+        raise SOAPClientCertificateIsExpired("No tcertificate or tcertificate expired")
+
+    soap_client_certificate = SOAPClientCertificate(
+        cert=cert_str,
+        fingerprint=cert.fingerprint(hashes.SHA256()).hex(),
+        issuer=cert.issuer.rfc4514_string(),
+        serial_number=str(serial_number_hex),
+        legacy_certificate=legacy_certificate,
+        cert_id=str(legacy_certificate.cert_id),
+    )
+    return SOAPAuth(certificate=soap_client_certificate)
 
 
 def get_legacy_certificate_by_serial_number(

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -4,6 +4,7 @@ from enum import StrEnum
 class LegacySoapApiEvent(StrEnum):
 
     NO_HEADER_CERT = "no_header_cert"
+    CERT_EXPIRED = "cert_expired"
     PARSED_CERT = "parsed_cert"
     UNPARSEABLE_CERT = "unparseable_cert"
     UNKNOWN_INVALID_CLIENT_CERT = "unknown_invalid_client_cert"

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -4,6 +4,7 @@ from enum import StrEnum
 class LegacySoapApiEvent(StrEnum):
 
     NO_HEADER_CERT = "no_header_cert"
+    TCERT_NOT_FOUND = "tcert_not_found"
     CERT_EXPIRED = "cert_expired"
     PARSED_CERT = "parsed_cert"
     UNPARSEABLE_CERT = "unparseable_cert"

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -1,22 +1,18 @@
 import base64
 import logging
-import os
 from datetime import timedelta
 from os.path import join
 from tempfile import NamedTemporaryFile, _TemporaryFileWrapper
 
 from requests import Request, Session
 
-from src.db.models.user_models import LegacyCertificate
 from src.legacy_soap_api.legacy_soap_api_auth import (
     LOG_LOCAL_RESPONSE_HEADER_KEY,
     MTLS_CERT_HEADER_KEY,
     S2S_PARTNER_CERTID_JWT_B64_HEADER_KEY,
-    USE_SOAP_CERT_HEADER_KEY,
     SessionResumptionAdapter,
     SOAPAuth,
-    SOAPClientCertificateLookupError,
-    SOAPClientCertificateNotConfigured,
+    SOAPClientCertificate,
     generate_soap_jwt,
 )
 from src.legacy_soap_api.legacy_soap_api_config import LegacySoapAPIConfig, get_soap_config
@@ -25,7 +21,6 @@ from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
     filter_headers,
-    get_soap_error_response,
     get_streamed_soap_response,
     log_local,
 )
@@ -41,17 +36,14 @@ def get_proxy_headers(
     soap_request: SOAPRequest,
     config: LegacySoapAPIConfig,
     soap_auth: SOAPAuth | None,
-    use_soap_cert: bool,
 ) -> dict:
     # Exclude header keys that are utilized only in simpler soap api. Not needed for proxy request.
-    if use_soap_cert or not soap_auth or not soap_auth.certificate.legacy_certificate:
+    if not soap_auth or not soap_auth.certificate.legacy_certificate:
         return filter_headers(
             soap_request.headers, [config.gg_s2s_proxy_header_key, MTLS_CERT_HEADER_KEY]
         )
     return {
-        S2S_PARTNER_CERTID_JWT_B64_HEADER_KEY: get_soap_jwt_auth_jwt(
-            config, soap_auth.certificate.legacy_certificate
-        )
+        S2S_PARTNER_CERTID_JWT_B64_HEADER_KEY: get_soap_jwt_auth_jwt(config, soap_auth.certificate)
     }
 
 
@@ -59,75 +51,32 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
     config = get_soap_config()
 
     soap_auth = soap_request.auth
-    use_soap_cert = soap_request.headers.get(USE_SOAP_CERT_HEADER_KEY) == "1"
     should_log_response = soap_request.headers.get(LOG_LOCAL_RESPONSE_HEADER_KEY) == "1"
-    is_valid_soap_certificate = soap_auth and soap_auth.certificate.legacy_certificate
-    proxy_headers = get_proxy_headers(soap_request, config, soap_auth, use_soap_cert)
-    if use_soap_cert or not is_valid_soap_certificate:
-        # Use X-Gg-S2S-Uri header locally if passed, otherwise default to GRANTS_GOV_URI:GRANTS_GOV_PORT.
+    proxy_headers = get_proxy_headers(soap_request, config, soap_auth)
+    if soap_auth:
         proxy_url = join(
-            soap_request.headers.get(config.gg_s2s_proxy_header_key, config.gg_url),
+            config.soap_partner_gateway_uri,
             soap_request.full_path.lstrip("/"),
         )
     else:
         logger.info(
-            "soap_client_certificate: using jwt auth",
-            extra={"soap_api_event": LegacySoapApiEvent.CALLING_WITH_JWT},
-        )
-        proxy_url = join(
-            config.soap_partner_gateway_uri,
-            "grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort",
-        )
-    _request = Request(method="POST", url=proxy_url, headers=proxy_headers, data=soap_request.data)
-
-    if not soap_auth or config.soap_auth_map == {} or not use_soap_cert:
-        logger.info(
             "soap_client_certificate: Sending soap request without client certificate",
             extra={"soap_api_event": LegacySoapApiEvent.CALLING_WITHOUT_CERT},
         )
-        response = _get_soap_response(_request, timeout=timeout)
-        if not use_soap_cert and should_log_response:
-            log_local(
-                msg="soap jwt proxy response",
-                data=response.to_bytes().decode("utf-8"),
-            )
-        return response
+        proxy_url = join(
+            soap_request.headers.get(config.gg_s2s_proxy_header_key, config.gg_url),
+            soap_request.full_path.lstrip("/"),
+        )
 
-    logger.info("soap_client_certificate: Processing client certificate")
-    # Handle cert based proxy request.
-    temp_file_path = ""
-    # We intentionally do not use a context manager for this file here
-    # due to an issue with Python locking the file while open and
-    # OpenSSL throwing a PEM error and is not able to read from it as a result
-    # Issue discussed here:
-    # https://github.com/python/cpython/issues/58451
-    try:
-        temp_cert_file = get_cert_file(soap_auth, config)
-        temp_file_path = temp_cert_file.name
-        return _get_soap_response(_request, cert=temp_file_path, timeout=timeout)
-    except SOAPClientCertificateLookupError:
-        # This exception handles invalid client certs. We will continue to return the response
-        # from GG.
-        logger.info(
-            "soap_client_certificate: Unknown or invalid client certificate",
-            exc_info=True,
-            extra={"soap_api_event": LegacySoapApiEvent.UNKNOWN_INVALID_CLIENT_CERT},
+    _request = Request(method="POST", url=proxy_url, headers=proxy_headers, data=soap_request.data)
+
+    response = _get_soap_response(_request, timeout=timeout)
+    if should_log_response:
+        log_local(
+            msg="soap jwt proxy response",
+            data=response.to_bytes().decode("utf-8"),
         )
-        return _get_soap_response(_request, cert=temp_file_path, timeout=timeout)
-    except SOAPClientCertificateNotConfigured:
-        # This exception handles the case of a valid cert being passed, but not configured
-        # to use Simpler SOAP API.
-        logger.info(
-            "soap_client_certificate: Certificate validated but not configured",
-            exc_info=True,
-            extra={"soap_api_event": LegacySoapApiEvent.NOT_CONFIGURED_CERT},
-        )
-        return get_soap_error_response(
-            faultstring="Client certificate not configured for Simpler SOAP."
-        )
-    finally:
-        if temp_file_path and os.path.exists(temp_file_path):
-            os.remove(temp_file_path)
+    return response
 
 
 def get_cert_file(soap_auth: SOAPAuth, config: LegacySoapAPIConfig) -> _TemporaryFileWrapper:
@@ -155,17 +104,22 @@ def _get_soap_response(
 
 def get_soap_jwt_auth_jwt(
     config: LegacySoapAPIConfig,
-    legacy_certificate: LegacyCertificate,
+    soap_auth_certificate: SOAPClientCertificate,
 ) -> str:
     expiration_time = utcnow() + timedelta(minutes=1)
-    jwt_string = generate_soap_jwt(
-        legacy_certificate.cert_id,
-        expiration_time,
-        config.soap_partner_gateway_uri,
-        config.soap_partner_gateway_auth_key,
-    )
+    if soap_auth_certificate.cert_id is not None:
+        jwt_string = generate_soap_jwt(
+            soap_auth_certificate.cert_id,
+            expiration_time,
+            config.soap_partner_gateway_uri,
+            config.soap_partner_gateway_auth_key,
+        )
+        logger.info(
+            "soap_client_certificate: created SOAP JWT",
+            extra={"soap_api_event": LegacySoapApiEvent.JWT_CREATED},
+        )
+        return base64.b64encode(jwt_string.encode("utf-8")).decode("utf-8")
     logger.info(
-        "soap_client_certificate: created SOAP JWT",
-        extra={"soap_api_event": LegacySoapApiEvent.JWT_CREATED},
+        "soap_client_certificate: No cert_id",
     )
-    return base64.b64encode(jwt_string.encode("utf-8")).decode("utf-8")
+    return ""

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -13,6 +13,7 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
     SessionResumptionAdapter,
     SOAPAuth,
     SOAPClientCertificate,
+    SOAPClientMissingCertificate,
     generate_soap_jwt,
 )
 from src.legacy_soap_api.legacy_soap_api_config import LegacySoapAPIConfig, get_soap_config
@@ -121,5 +122,6 @@ def get_soap_jwt_auth_jwt(
         return base64.b64encode(jwt_string.encode("utf-8")).decode("utf-8")
     logger.info(
         "soap_client_certificate: No cert_id",
+        extra={"soap_api_event": LegacySoapApiEvent.CALLING_WITHOUT_CERT},
     )
-    return ""
+    raise SOAPClientMissingCertificate("soap_client_certificate: no cert_id")

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -6,6 +6,9 @@ import src.adapters.db as db
 from src.legacy_soap_api.legacy_soap_api_auth import (
     MTLS_CERT_HEADER_KEY,
     USE_SIMPLER_OVERRIDE_KEY,
+    SOAPClientCertificateIsExpired,
+    SOAPClientMissingCertificate,
+    SOAPClientTcertificateNotFound,
     SOAPClientUserDoesNotHavePermission,
     get_soap_auth,
 )
@@ -135,6 +138,27 @@ def process_simpler_request(
     )
     logger.info("SOAP request received")
 
+    is_get_opportunity_list = (
+        operation_name == "GetOpportunityListRequest" and api_name == SimplerSoapAPI.APPLICANTS
+    )
+    auth = None
+    # GetOpportunityListRequest does not have any auth
+    if not is_get_opportunity_list:
+        try:
+            auth = get_soap_auth(request.headers.get(MTLS_CERT_HEADER_KEY), db_session=db_session)
+        except SOAPClientMissingCertificate:
+            return get_soap_error_response(
+                faultstring="Missing certificate. (Authorization Failure)"
+            ).to_flask_response()
+        except SOAPClientTcertificateNotFound:
+            return get_soap_error_response(
+                faultstring="No tcertificate found. (Authorization Failure)"
+            ).to_flask_response()
+        except SOAPClientCertificateIsExpired:
+            return get_soap_error_response(
+                faultstring="Certificate is expired. (Authorization Failure)"
+            ).to_flask_response()
+
     try:
         soap_request = SOAPRequest(
             api_name=api_name,
@@ -142,18 +166,27 @@ def process_simpler_request(
             full_path=request.full_path,
             headers=dict(request.headers),
             data=soap_request_stream,
-            auth=get_soap_auth(request.headers.get(MTLS_CERT_HEADER_KEY), db_session=db_session),
+            auth=auth,
             operation_name=operation_name,
         )
         logger.info(
             "soap_client_certificate: header check",
             extra={"soap_request_headers": soap_request.headers.keys()},
         )
-        if alternate_legacy_response := get_alternate_legacy_response(soap_request):
+        is_legacy_only_certificate = (
+            auth and auth.certificate and not auth.certificate.legacy_certificate
+        )
+        # If it is GetOpportunityList or is valid legacy certificate but not configured in Simpler
+        # call legacy
+        if is_get_opportunity_list or is_legacy_only_certificate:
+            soap_legacy_response = get_legacy_response(soap_request)
+        # Check if it has a Simpler GrantsGovTrackingNumber
+        elif alternate_legacy_response := get_alternate_legacy_response(soap_request):
             logger.info(
                 "simpler_soap_api: skipping legacy call",
             )
             soap_legacy_response = alternate_legacy_response
+        # Fallback: get legacy response
         else:
             soap_legacy_response = get_legacy_response(soap_request)
     except Exception:
@@ -166,38 +199,39 @@ def process_simpler_request(
         )
         return get_soap_error_response().to_flask_response()
 
-    try:
-        return get_simpler_soap_response(
-            soap_request, soap_legacy_response, db_session
-        ).to_flask_response()
-    except SOAPClientUserDoesNotHavePermission:
-        msg = "soap_client_certificate: User did not have permission to access this application"
-        logger.info(
-            msg=msg,
-            extra={
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-            },
-        )
-    except SOAPFaultException as e:
-        logger.info(
-            msg="Soap Fault Exception raised",
-            exc_info=True,
-            extra={
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-                "faultstring": e.fault.faultstring,
-            },
-        )
-        if soap_legacy_response.status_code == 500:
-            return get_soap_fault_error_response(
-                faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
+    if is_get_opportunity_list or (auth and auth.certificate.legacy_certificate):
+        try:
+            return get_simpler_soap_response(
+                soap_request, soap_legacy_response, db_session
             ).to_flask_response()
-    except Exception:
-        msg = "Unable to process Simpler SOAP legacy response"
-        logger.exception(
-            msg=msg,
-            extra={
-                "used_simpler_response": False,
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-            },
-        )
+        except SOAPClientUserDoesNotHavePermission:
+            msg = "soap_client_certificate: User did not have permission to access this application"
+            logger.info(
+                msg=msg,
+                extra={
+                    "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+                },
+            )
+        except SOAPFaultException as e:
+            logger.info(
+                msg="Soap Fault Exception raised",
+                exc_info=True,
+                extra={
+                    "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+                    "faultstring": e.fault.faultstring,
+                },
+            )
+            if soap_legacy_response.status_code == 500:
+                return get_soap_fault_error_response(
+                    faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
+                ).to_flask_response()
+        except Exception:
+            msg = "Unable to process Simpler SOAP legacy response"
+            logger.exception(
+                msg=msg,
+                extra={
+                    "used_simpler_response": False,
+                    "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+                },
+            )
     return soap_legacy_response.to_flask_response()

--- a/api/tests/lib/data_factories.py
+++ b/api/tests/lib/data_factories.py
@@ -5,14 +5,21 @@ with only a few alterations.
 """
 
 import io
+from datetime import timedelta
+from urllib import parse
 
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+import src.util.datetime_util as datetime_util
 from src.constants.lookup_constants import Privilege
 from src.db.models.agency_models import Agency
 from src.db.models.competition_models import ApplicationForm
 from src.db.models.user_models import Role, User
 from src.legacy_soap_api.legacy_soap_api_auth import (
     LOG_LOCAL_RESPONSE_HEADER_KEY,
-    USE_SOAP_CERT_HEADER_KEY,
     SOAPAuth,
     SOAPClientCertificate,
 )
@@ -35,6 +42,7 @@ from tests.src.db.models.factories import (
     OpportunityFactory,
     OrganizationFactory,
     RoleFactory,
+    StagingTcertificatesFactory,
 )
 
 DEFAULT_VALUE = object()
@@ -133,10 +141,47 @@ def setup_application_for_form_validation(
     return application_form
 
 
+def get_mtls_urlencoded_str_and_serial_number():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "US"),
+            x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, "Oregon"),
+            x509.NameAttribute(NameOID.LOCALITY_NAME, "Portland"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "My Company"),
+            x509.NameAttribute(NameOID.COMMON_NAME, "example.com"),
+        ]
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime_util.utcnow())
+        .not_valid_after(datetime_util.utcnow() + timedelta(days=365))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName("example.com")]),
+            critical=False,
+        )
+        .sign(key, algorithm=hashes.SHA256())
+    )
+    serial_number = hex(cert.serial_number).lower().lstrip("0x")
+    pem_bytes = cert.public_bytes(serialization.Encoding.PEM)
+    return parse.quote(pem_bytes), serial_number
+
+
 def setup_cert_user(
     agency: Agency, privileges: list | set
-) -> tuple[User, Role, SOAPClientCertificate]:
-    legacy_certificate = LegacyAgencyCertificateFactory.create(agency=agency)
+) -> tuple[User, Role, SOAPClientCertificate, str]:
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
+    legacy_certificate = LegacyAgencyCertificateFactory.create(
+        agency=agency,
+        serial_number=serial_number,
+        cert_id=tcertificate.currentcertid,
+        expiration_date=tcertificate.expirationdate,
+    )
     agency_user = AgencyUserFactory.create(agency=agency, user=legacy_certificate.user)
     role = RoleFactory.create(privileges=privileges, is_agency_role=True)
     AgencyUserRoleFactory.create(agency_user=agency_user, role=role)
@@ -145,17 +190,17 @@ def setup_cert_user(
         cert="123",
         fingerprint="456",
         legacy_certificate=legacy_certificate,
+        cert_id=legacy_certificate.cert_id,
     )
-    return legacy_certificate.user, role, soap_client_certificate
+    return legacy_certificate.user, role, soap_client_certificate, mtls_cert
 
 
 def create_soap_request(
     soap_payload: bytes,
-    use_soap_cert: bool = False,
     log_local: bool = False,
     operation_name: str = "GetApplicationZipRequest",
 ) -> SOAPRequest:
-    _, _, soap_certificate = setup_cert_user(
+    _, _, soap_certificate, _ = setup_cert_user(
         AgencyFactory.create(), [Privilege.LEGACY_AGENCY_VIEWER]
     )
     headers = {
@@ -163,13 +208,11 @@ def create_soap_request(
     }
     if log_local:
         headers.update({f"{LOG_LOCAL_RESPONSE_HEADER_KEY}": "1"})
-    if use_soap_cert:
-        headers.update({f"{USE_SOAP_CERT_HEADER_KEY}": "1"})
     return SOAPRequest(
         api_name=SimplerSoapAPI.GRANTORS,
         headers=headers,
         data=SoapRequestStreamer(stream=io.BytesIO(soap_payload)),
-        full_path="/grantors/x",
+        full_path="/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort",
         method="POST",
         auth=SOAPAuth(certificate=soap_certificate),
         operation_name=operation_name,

--- a/api/tests/src/db/models/factories.py
+++ b/api/tests/src/db/models/factories.py
@@ -3474,7 +3474,7 @@ class BaseLegacyCertificateFactory(BaseFactory):
         abstract = True
 
     legacy_certificate_id = Generators.UuidObj
-    cert_id = factory.Faker("random_int", min=1000, max=10000000)
+    cert_id = factory.LazyFunction(lambda: str(random.randint(1000, 10000000)))
     serial_number = factory.Sequence(lambda n: f"{n}")
     expiration_date = factory.Faker("future_date", end_date="+2y")
     user_id = factory.LazyAttribute(lambda s: s.user.user_id)

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -32,7 +32,7 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
             opportunity=opportunity,
         )
         privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
-        user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+        user, role, soap_client_certificate, _ = setup_cert_user(agency, privileges)
         submission = ApplicationSubmissionFactory.create(
             application__application_status=ApplicationStatus.ACCEPTED,
             application__competition=competition,

--- a/api/tests/src/legacy_soap_api/grantors/services/test_confirm_application_delivery_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_confirm_application_delivery_response.py
@@ -74,7 +74,7 @@ class TestConfirmApplicationDeliveryResponse:
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
         db_session.commit()
 
-        _, _, soap_client_certificate = setup_cert_user(
+        _, _, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
@@ -114,7 +114,7 @@ class TestConfirmApplicationDeliveryResponse:
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
         db_session.commit()
 
-        _, _, soap_client_certificate = setup_cert_user(
+        _, _, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
@@ -142,7 +142,7 @@ class TestConfirmApplicationDeliveryResponse:
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
         # Pre-insert a retrieval record to simulate a prior call by this user
-        user, _, soap_client_certificate = setup_cert_user(
+        user, _, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         ApplicationSubmissionRetrievedFactory.create(
@@ -188,7 +188,7 @@ class TestConfirmApplicationDeliveryResponse:
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
         # First user retrieves the submission
-        first_user, _, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER})
+        first_user, _, _, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER})
         ApplicationSubmissionRetrievedFactory.create(
             application_submission=submission,
             created_by_user=first_user,
@@ -197,7 +197,7 @@ class TestConfirmApplicationDeliveryResponse:
         db_session.commit()
 
         # Second user attempts to retrieve the same submission
-        _, _, second_soap_client_certificate = setup_cert_user(
+        _, _, second_soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         soap_request = _make_soap_request(second_soap_client_certificate, tracking_number)
@@ -234,7 +234,7 @@ class TestConfirmApplicationDeliveryResponse:
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
         db_session.commit()
 
-        _, _, soap_client_certificate = setup_cert_user(
+        _, _, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
@@ -267,7 +267,7 @@ class TestConfirmApplicationDeliveryResponse:
         agency = AgencyFactory.create()
         tracking_number = "GRANT99999999"
 
-        _, _, soap_client_certificate = setup_cert_user(
+        _, _, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
@@ -298,7 +298,7 @@ class TestConfirmApplicationDeliveryResponse:
         db_session.commit()
 
         # User has correct privilege but for a DIFFERENT agency
-        _, _, soap_client_certificate = setup_cert_user(
+        _, _, soap_client_certificate, _ = setup_cert_user(
             other_agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)

--- a/api/tests/src/legacy_soap_api/grantors/services/test_get_submission_list_expanded_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_get_submission_list_expanded_response.py
@@ -94,7 +94,7 @@ class TestGetSubmissionListExpandedResponseStatusFilter(BaseTestClass):
             )
         _setup_submission(agency, ApplicationStatus.ACCEPTED)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         return {
             "agency": agency,
             "submission": submission,

--- a/api/tests/src/legacy_soap_api/grantors/services/test_legacy_soap_api_get_submission_list_expanded_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_legacy_soap_api_get_submission_list_expanded_response.py
@@ -94,7 +94,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             response_operation_name="GetSubmissionListExpandedResponse",
             privileges={Privilege.LEGACY_AGENCY_VIEWER},
         )
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -177,7 +177,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             privileges={Privilege.LEGACY_AGENCY_VIEWER},
         )
         WRONG_PRIVLEGES = {Privilege.GET_SUBMITTED_APPLICATIONS}
-        _, _, soap_client_certificate = setup_cert_user(agency, WRONG_PRIVLEGES)
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, WRONG_PRIVLEGES)
         request_xml = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -229,7 +229,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             response_operation_name="GetSubmissionListExpandedResponse",
         )
         WRONG_PRIVLEGES = {Privilege.GET_SUBMITTED_APPLICATIONS}
-        _, _, soap_client_certificate = setup_cert_user(agency, WRONG_PRIVLEGES)
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, WRONG_PRIVLEGES)
         request_xml = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -356,7 +356,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_package_id="PKG99999999",
             sam_gov_entity=sam_gov_entity_3,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
 
@@ -465,7 +465,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             application_status=ApplicationStatus.SUBMITTED,
             submitted_at=DT_EST_AWARE_EARLIER,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         opportunity_1 = submission_1.application.competition.opportunity
@@ -580,7 +580,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             sam_gov_entity=sam_gov_entity,
             application_status=ApplicationStatus.SUBMITTED,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         setup_application_submission(agency, legacy_package_id="PKG00000001")
@@ -666,7 +666,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_package_id="PKG00118065",
             application_status=ApplicationStatus.SUBMITTED,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -756,7 +756,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_package_id="PKG00118065",
             application_status=ApplicationStatus.SUBMITTED,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -848,7 +848,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_package_id="PKG00118065",
             application_status=ApplicationStatus.SUBMITTED,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -940,7 +940,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         submission = setup_application_submission(
             agency, application_status=ApplicationStatus.SUBMITTED, sam_gov_entity=sam_gov_entity
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1034,7 +1034,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         submission = setup_application_submission(
             agency, application_status=ApplicationStatus.SUBMITTED, sam_gov_entity=sam_gov_entity
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1128,7 +1128,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         submission = setup_application_submission(
             agency, application_status=ApplicationStatus.SUBMITTED, sam_gov_entity=sam_gov_entity
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1222,7 +1222,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         submission = setup_application_submission(
             agency, application_status=ApplicationStatus.SUBMITTED, sam_gov_entity=sam_gov_entity
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1333,7 +1333,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             organization=OrganizationFactory.create(sam_gov_entity=None),
         )
         submission = ApplicationSubmissionFactory.create(application=application)
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1439,7 +1439,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         submission = setup_application_submission(
             agency, legacy_package_id="PKG00118065", opportunity_assistance_listing=False
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1515,7 +1515,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
         application = submission.application
         competition = application.competition
         opportunity = competition.opportunity
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1618,7 +1618,9 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_package_id="PKG00118065",
             application_status=ApplicationStatus.SUBMITTED,
         )
-        _, _, soap_client_certificate = setup_cert_user(agency_2, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency_2, {Privilege.LEGACY_AGENCY_VIEWER}
+        )
         soap_config = SOAPOperationConfig(
             request_operation_name="GetSubmissionListExpandedRequest",
             response_operation_name="GetSubmissionListExpandedResponse",
@@ -1688,7 +1690,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             application_status=ApplicationStatus.SUBMITTED,
             sam_gov_entity=sam_gov_entity,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1783,7 +1785,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             application_status=ApplicationStatus.SUBMITTED,
             sam_gov_entity=sam_gov_entity,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1874,7 +1876,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_competition_id=1,
             application_status=ApplicationStatus.SUBMITTED,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -1939,7 +1941,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_package_id="PKG00118065",
             application_status=ApplicationStatus.SUBMITTED,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(
@@ -2008,7 +2010,7 @@ class TestLegacySoapApiGrantorGetSubmissionListExpanded:
             legacy_package_id="PKG00118065",
             application_status=ApplicationStatus.SUBMITTED,
         )
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_VIEWER}
         )
         soap_config = SOAPOperationConfig(

--- a/api/tests/src/legacy_soap_api/grantors/services/test_update_application_info_response.py
+++ b/api/tests/src/legacy_soap_api/grantors/services/test_update_application_info_response.py
@@ -79,7 +79,9 @@ class TestUpdateApplicationInfo:
         submission = _setup_submission(agency, ApplicationStatus.ACCEPTED, retrieved=True)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
+        )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
@@ -113,7 +115,9 @@ class TestUpdateApplicationInfo:
         submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
+        )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
@@ -149,7 +153,9 @@ class TestUpdateApplicationInfo:
         submission = _setup_submission(agency, ApplicationStatus.ACCEPTED, retrieved=True)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
+        )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
@@ -190,7 +196,9 @@ class TestUpdateApplicationInfo:
     def test_submission_not_found_returns_failed_response(self, db_session, enable_factory_create):
         agency = AgencyFactory.create()
 
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
+        )
         tracking_number = "GRANT99999999"
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
@@ -225,7 +233,9 @@ class TestUpdateApplicationInfo:
         submission = _setup_submission(agency, ApplicationStatus.IN_PROGRESS)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
+        )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
@@ -259,7 +269,7 @@ class TestUpdateApplicationInfo:
         submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
-        user, _, soap_client_certificate = setup_cert_user(
+        user, _, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
         )
 
@@ -307,7 +317,9 @@ class TestUpdateApplicationInfo:
         submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
+        )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         # Save notes first time
@@ -353,7 +365,7 @@ class TestUpdateApplicationInfo:
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
         # Give user VIEWER privilege instead of ASSIGNER
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(
@@ -377,7 +389,9 @@ class TestUpdateApplicationInfo:
         submission = _setup_submission(agency, ApplicationStatus.ACCEPTED)
         tracking_number = f"GRANT{submission.legacy_tracking_number}"
 
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_ASSIGNER})
+        _, _, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_ASSIGNER}
+        )
         soap_request = _make_soap_request(soap_client_certificate, tracking_number)
 
         request_schema = grantor_schemas.UpdateApplicationInfoRequest(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import date, timedelta
-from unittest.mock import Mock, patch
 
 import pytest
 
@@ -17,7 +16,6 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientUserDoesNotHavePermission,
     get_legacy_certificate_by_serial_number,
     get_soap_auth,
-    get_soap_client_certificate,
     validate_certificate,
     verify_certificate_access,
 )
@@ -43,49 +41,7 @@ class AlternateErrorDict(dict):
             raise Exception("Not a KeyError") from e
 
 
-def test_get_soap_client_certificate_legacy_certificate_can_be_none(db_session):
-    with patch(
-        "src.legacy_soap_api.legacy_soap_api_auth.load_pem_x509_certificate"
-    ) as mock_load_pem_x509:
-        mock_load_pem_x509.return_value = Mock(serial_number="1234")
-        mock_load_pem_x509.return_value.fingerprint.return_value.hex.return_value = "5677"
-        soap_client_certificate = get_soap_client_certificate(MOCK_CERT_STR, db_session)
-        assert soap_client_certificate.legacy_certificate is None
-
-
-def test_get_soap_client_certificate_legacy_certificate_gets_hex_serial_number(
-    db_session, enable_factory_create
-):
-    legacy_certificate = LegacyAgencyCertificateFactory.create(
-        serial_number="53bce80f6b5eb0e8daf727a8f2b58000"
-    )
-    with patch(
-        "src.legacy_soap_api.legacy_soap_api_auth.load_pem_x509_certificate"
-    ) as mock_load_pem_x509:
-        mock_load_pem_x509.return_value = Mock(
-            serial_number="111306782200232420456534570058862919680"
-        )
-        mock_load_pem_x509.return_value.fingerprint.return_value.hex.return_value = "5677"
-        soap_client_certificate = get_soap_client_certificate(MOCK_CERT_STR, db_session)
-        assert soap_client_certificate.legacy_certificate == legacy_certificate
-
-
-def test_get_soap_client_certificate_legacy_certificate_gets_hex_serial_number_handles_leading_zeroes(
-    db_session, enable_factory_create
-):
-    legacy_certificate = LegacyAgencyCertificateFactory.create(
-        serial_number="0000000000002799dbb5e1700fa12210"
-    )
-    with patch(
-        "src.legacy_soap_api.legacy_soap_api_auth.load_pem_x509_certificate"
-    ) as mock_load_pem_x509:
-        mock_load_pem_x509.return_value = Mock(serial_number="187010476483130230383120")
-        mock_load_pem_x509.return_value.fingerprint.return_value.hex.return_value = "5677"
-        soap_client_certificate = get_soap_client_certificate(MOCK_CERT_STR, db_session)
-        assert soap_client_certificate.legacy_certificate == legacy_certificate
-
-
-def test_get_soap_client_certificate_legacy_certificate_search_ignores_case_in_serial_number(
+def test_get_legacy_certificate_search_ignores_case_in_serial_number(
     db_session, enable_factory_create
 ):
     SERIAL_NUMBER = "000000000000ABBBBBCCCCCCCCC12210"

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
@@ -1,15 +1,19 @@
 import logging
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
 
+import src.util.datetime_util as datetime_util
 from src.constants.lookup_constants import Privilege
 from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPAuth,
     SOAPClientCertificate,
+    SOAPClientCertificateIsExpired,
     SOAPClientCertificateLookupError,
     SOAPClientCertificateNotConfigured,
+    SOAPClientMissingCertificate,
+    SOAPClientTcertificateNotFound,
     SOAPClientUserDoesNotHavePermission,
     get_legacy_certificate_by_serial_number,
     get_soap_auth,
@@ -18,12 +22,17 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
     verify_certificate_access,
 )
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI, SOAPOperationConfig
-from tests.lib.data_factories import setup_cert_user
-from tests.src.db.models.factories import AgencyFactory, LegacyAgencyCertificateFactory
+from tests.lib.data_factories import get_mtls_urlencoded_str_and_serial_number, setup_cert_user
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    LegacyAgencyCertificateFactory,
+    StagingTcertificatesFactory,
+)
 
 MOCK_FINGERPRINT = "123"
 MOCK_CERT = "456"
 MOCK_CERT_STR = "certstr"
+UTC_NOW = datetime_util.utcnow()
 
 
 class AlternateErrorDict(dict):
@@ -32,22 +41,6 @@ class AlternateErrorDict(dict):
             return super().__getitem__(key)
         except KeyError as e:
             raise Exception("Not a KeyError") from e
-
-
-def test_get_soap_auth(db_session, enable_factory_create):
-    legacy_certificate = LegacyAgencyCertificateFactory.create()
-    mock_client_cert = SOAPClientCertificate(
-        cert=MOCK_CERT_STR,
-        fingerprint=MOCK_FINGERPRINT,
-        serial_number=legacy_certificate.serial_number,
-        legacy_certificate=legacy_certificate,
-    )
-    with patch(
-        "src.legacy_soap_api.legacy_soap_api_auth.get_soap_client_certificate"
-    ) as mock_get_soap_client_certificate:
-        mock_get_soap_client_certificate.return_value = mock_client_cert
-        assert get_soap_auth(MOCK_CERT, db_session) == SOAPAuth(certificate=mock_client_cert)
-        assert get_soap_auth(None, db_session) is None
 
 
 def test_get_soap_client_certificate_legacy_certificate_can_be_none(db_session):
@@ -229,7 +222,7 @@ def test_verify_certificate_access_fails_if_there_is_no_agency(
 ) -> None:
     caplog.set_level(logging.INFO)
     agency = AgencyFactory.create()
-    _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+    _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
     legacy_certificate = soap_client_certificate.legacy_certificate
     assert legacy_certificate
     soap_config = SOAPOperationConfig(
@@ -248,7 +241,7 @@ def test_verify_certificate_access_fails_if_there_are_no_privileges_set(
 ) -> None:
     caplog.set_level(logging.INFO)
     agency = AgencyFactory.create()
-    _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+    _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
     legacy_certificate = soap_client_certificate.legacy_certificate
     assert legacy_certificate
     soap_config = SOAPOperationConfig(
@@ -271,7 +264,7 @@ def test_verify_certificate_access_fails_if_users_do_not_have_privileges(
 ) -> None:
     caplog.set_level(logging.INFO)
     agency = AgencyFactory.create()
-    _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.MANAGE_ORG_MEMBERS})
+    _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.MANAGE_ORG_MEMBERS})
     legacy_certificate = soap_client_certificate.legacy_certificate
     assert legacy_certificate
     soap_config = SOAPOperationConfig(
@@ -301,7 +294,7 @@ def test_verify_certificate_access_does_not_raise_exception_if_user_has_correct_
 ) -> None:
     caplog.set_level(logging.INFO)
     agency = AgencyFactory.create()
-    _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+    _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
     legacy_certificate = soap_client_certificate.legacy_certificate
     assert legacy_certificate
     soap_config = SOAPOperationConfig(
@@ -314,3 +307,100 @@ def test_verify_certificate_access_does_not_raise_exception_if_user_has_correct_
         soap_config,
         agency,
     )
+
+
+def test_get_soap_auth_when_no_cert_sent(db_session, caplog) -> None:
+    caplog.set_level(logging.INFO)
+    with pytest.raises(SOAPClientMissingCertificate):
+        get_soap_auth(None, db_session)
+    records = [
+        r
+        for r in caplog.records
+        if "soap_client_certificate: no certificate received from header" in r.message
+    ]
+    assert len(records) == 1
+
+
+def test_get_soap_auth_when_no_tcertificate(db_session, caplog) -> None:
+    caplog.set_level(logging.INFO)
+    mtls_cert, _ = get_mtls_urlencoded_str_and_serial_number()
+    with pytest.raises(SOAPClientTcertificateNotFound):
+        get_soap_auth(mtls_cert, db_session)
+    records = [r for r in caplog.records if "soap_client_certificate: no tcertificate" in r.message]
+    assert len(records) == 1
+
+
+def test_get_soap_auth_when_tcertificate_is_expired(
+    enable_factory_create, db_session, caplog
+) -> None:
+    caplog.set_level(logging.INFO)
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    StagingTcertificatesFactory(serial_num=serial_number, expirationdate=date(2000, 1, 1))
+    with pytest.raises(SOAPClientCertificateIsExpired):
+        get_soap_auth(mtls_cert, db_session)
+    records = [
+        r for r in caplog.records if "soap_client_certificate: tcertificate is expired" in r.message
+    ]
+    assert len(records) == 1
+
+
+def test_get_soap_auth_when_legacy_certificate_is_expired(
+    enable_factory_create, db_session, caplog
+) -> None:
+    caplog.set_level(logging.INFO)
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcert = StagingTcertificatesFactory.create(
+        serial_num=serial_number, expirationdate=(UTC_NOW + timedelta(days=100)).date()
+    )
+    LegacyAgencyCertificateFactory.create(
+        serial_number=tcert.serial_num, expiration_date=date(2000, 1, 1)
+    )
+    with pytest.raises(SOAPClientCertificateIsExpired):
+        get_soap_auth(mtls_cert, db_session)
+    records = [
+        r
+        for r in caplog.records
+        if "soap_client_certificate: LegacyCertificate is expired" in r.message
+    ]
+    assert len(records) == 1
+
+
+def test_get_soap_auth_with_valid_tcertificate(enable_factory_create, db_session, caplog) -> None:
+    caplog.set_level(logging.INFO)
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(
+        serial_num=serial_number, expirationdate=(UTC_NOW + timedelta(days=100)).date()
+    )
+    soap_auth = get_soap_auth(mtls_cert, db_session)
+    assert soap_auth
+    assert soap_auth.certificate.legacy_certificate is None
+    assert soap_auth.certificate.cert_id is tcertificate.currentcertid
+    records = [
+        r for r in caplog.records if "soap_client_certificate: no LegacyCertificate" in r.message
+    ]
+    assert len(records) == 1
+
+
+def test_get_soap_auth_with_valid_tcertificate_and_valid_legacy_certificate(
+    enable_factory_create, db_session, caplog
+) -> None:
+    caplog.set_level(logging.INFO)
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(
+        serial_num=serial_number, expirationdate=(UTC_NOW + timedelta(days=100)).date()
+    )
+    legacy_certificate = LegacyAgencyCertificateFactory.create(
+        cert_id=tcertificate.currentcertid,
+        serial_number=tcertificate.serial_num,
+        expiration_date=tcertificate.expirationdate,
+    )
+    soap_auth = get_soap_auth(mtls_cert, db_session)
+    assert soap_auth
+    assert soap_auth.certificate.legacy_certificate is legacy_certificate
+    assert soap_auth.certificate.cert_id is legacy_certificate.cert_id
+    records = [
+        r
+        for r in caplog.records
+        if "soap_client_certificate: certificate received header" in r.message
+    ]
+    assert len(records) == 1

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -419,7 +419,7 @@ class TestSimplerSOAPGetApplicationZip:
         self, db_session, enable_factory_create, mock_s3_bucket
     ):
         agency = AgencyFactory.create()
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
@@ -478,7 +478,7 @@ class TestSimplerSOAPGetApplicationZip:
         self, db_session, enable_factory_create, mock_s3_bucket
     ):
         agency = AgencyFactory.create()
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
@@ -521,7 +521,7 @@ class TestSimplerSOAPGetApplicationZip:
     ):
         agency = AgencyFactory.create()
         wrong_privileges = {Privilege.START_APPLICATION}
-        user, role, soap_client_certificate = setup_cert_user(agency, wrong_privileges)
+        user, role, soap_client_certificate, _ = setup_cert_user(agency, wrong_privileges)
         opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
         competition = CompetitionFactory(
             opportunity=opportunity,
@@ -559,7 +559,7 @@ class TestSimplerSOAPGetApplicationZip:
     ):
         caplog.set_level(logging.INFO)
         agency = AgencyFactory.create()
-        user, role, soap_client_certificate = setup_cert_user(
+        user, role, soap_client_certificate, _ = setup_cert_user(
             agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
         )
         opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
@@ -685,7 +685,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
         )
         submission = self.setup_application_submission(agency, sam_gov_entity=sam_gov_entity)
         application = submission.application
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -767,7 +767,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             agency, sam_gov_entity=sam_gov_entity_2, submitted_at=DT_EST_AWARE_EARLIER
         )
         application_2 = submission_2.application
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -867,7 +867,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             agency, sam_gov_entity=sam_gov_entity_2, submitted_at=DT_EST_AWARE_EARLIER
         )
         application_2 = submission_2.application
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -1004,7 +1004,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
         self, db_session, enable_factory_create, mock_s3_bucket
     ):
         agency = AgencyFactory.create()
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -1120,7 +1120,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
         )
         submission = self.setup_application_submission(agency, sam_gov_entity=sam_gov_entity)
         application = submission.application
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -1192,7 +1192,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
         )
         submission = self.setup_application_submission(agency, sam_gov_entity=sam_gov_entity)
         application = submission.application
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"
@@ -1269,7 +1269,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
         )
         submission = self.setup_application_submission(agency, sam_gov_entity=sam_gov_entity)
         application = submission.application
-        _, _, soap_client_certificate = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
+        _, _, soap_client_certificate, _ = setup_cert_user(agency, {Privilege.LEGACY_AGENCY_VIEWER})
         request_xml_bytes = (
             '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
             "<soapenv:Header/>"

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -3,9 +3,14 @@ import logging
 from unittest.mock import ANY, patch
 
 import jwt
+import pytest
 from freezegun import freeze_time
 
 import tests.src.db.models.factories as factories
+from src.legacy_soap_api.legacy_soap_api_auth import (
+    SOAPClientCertificate,
+    SOAPClientMissingCertificate,
+)
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
 from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response, get_soap_jwt_auth_jwt
 from tests.lib.data_factories import create_soap_request
@@ -40,9 +45,17 @@ def test_get_soap_jwt_auth_jwt(enable_factory_create, caplog):
     caplog.set_level(logging.INFO)
     legacy_certificate = factories.LegacyAgencyCertificateFactory.create()
     config = get_soap_config()
+    soap_client_certificate = SOAPClientCertificate(
+        cert="x",
+        fingerprint="1234",
+        issuer="issuer_string",
+        serial_number=legacy_certificate.serial_number,
+        legacy_certificate=legacy_certificate,
+        cert_id=legacy_certificate.cert_id,
+    )
     s2s_partner_certid_jwt_b64 = get_soap_jwt_auth_jwt(
         config,
-        legacy_certificate,
+        soap_client_certificate,
     )
     decoded_base64 = base64.b64decode(s2s_partner_certid_jwt_b64).decode("utf-8")
     original_claims = jwt.decode(
@@ -56,6 +69,27 @@ def test_get_soap_jwt_auth_jwt(enable_factory_create, caplog):
     }
     assert original_claims == expected
     assert "soap_client_certificate: created SOAP JWT" in caplog.messages
+
+
+@freeze_time("2024-04-03 12:00:00", tz_offset=0)
+def test_get_soap_jwt_auth_jwt_throws_exception_when_no_cert_id(enable_factory_create, caplog):
+    caplog.set_level(logging.INFO)
+    legacy_certificate = factories.LegacyAgencyCertificateFactory.create()
+    config = get_soap_config()
+    soap_client_certificate = SOAPClientCertificate(
+        cert="x",
+        fingerprint="1234",
+        issuer="issuer_string",
+        serial_number=legacy_certificate.serial_number,
+        legacy_certificate=legacy_certificate,
+        cert_id=None,
+    )
+    with pytest.raises(SOAPClientMissingCertificate):
+        get_soap_jwt_auth_jwt(
+            config,
+            soap_client_certificate,
+        )
+    assert "soap_client_certificate: No cert_id" in caplog.messages
 
 
 def test_request_gets_correct_proxy_url_when_no_auth(enable_factory_create):

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -1,22 +1,13 @@
 import base64
 import logging
-import os
 from unittest.mock import ANY, patch
 
 import jwt
 from freezegun import freeze_time
 
 import tests.src.db.models.factories as factories
-from src.legacy_soap_api.legacy_soap_api_auth import (
-    SOAPClientCertificateLookupError,
-    SOAPClientCertificateNotConfigured,
-)
-from src.legacy_soap_api.legacy_soap_api_config import LegacySoapAPIConfig, get_soap_config
-from src.legacy_soap_api.legacy_soap_api_proxy import (
-    get_cert_file,
-    get_proxy_response,
-    get_soap_jwt_auth_jwt,
-)
+from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
+from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response, get_soap_jwt_auth_jwt
 from tests.lib.data_factories import create_soap_request
 
 SOAP_PAYLOAD = (
@@ -33,64 +24,15 @@ SOAP_PAYLOAD = (
 ).encode("utf-8")
 
 
-def test_get_cert_file_returns_cert_data_from_soap_request(enable_factory_create):
-    soap_request = create_soap_request(SOAP_PAYLOAD)
-    legacy_certificate = soap_request.auth.certificate.legacy_certificate
-    cert_str = "-----BEGIN CERTIFICATE-----\nFAKE_CERT\n-----END CERTIFICATE-----"
-    config = LegacySoapAPIConfig()
-    config.soap_auth_map = {f"{legacy_certificate.legacy_certificate_id}": f"{cert_str}"}
-    tmp = get_cert_file(soap_request.auth, config)
-    assert os.path.exists(tmp.name) is True
-    with open(tmp.name) as f:
-        assert f.read() == f"{cert_str}\n\n{soap_request.auth.certificate.cert}"
-
-
 def test_get_proxy_response(enable_factory_create, monkeypatch, db_session):
-    soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=True)
+    soap_request = create_soap_request(SOAP_PAYLOAD)
     legacy_certificate = soap_request.auth.certificate.legacy_certificate
     with db_session.begin():
         legacy_certificate.legacy_certificate_id = "e57e1c7f-cf2e-455e-9db5-3e03650174a7"
         db_session.add(legacy_certificate)
     with patch("src.legacy_soap_api.legacy_soap_api_proxy.Session.send") as mock_send:
         get_proxy_response(soap_request)
-        args, kwargs = mock_send.call_args
-        cert_path = kwargs.get("cert")
-        assert os.path.exists(cert_path) is False
-        mock_send.assert_called_once_with(ANY, stream=True, cert=cert_path, timeout=3600)
-
-
-def test_get_proxy_response_logs_soap_client_lookup_error_and_returns_proxy_response(
-    caplog, enable_factory_create
-):
-    caplog.set_level(logging.INFO)
-    soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=True)
-    with patch("src.legacy_soap_api.legacy_soap_api_proxy.Session.send") as mock_send, patch(
-        "src.legacy_soap_api.legacy_soap_api_proxy.get_cert_file"
-    ) as mock_cert_file:
-        mock_cert_file.side_effect = SOAPClientCertificateLookupError()
-        get_proxy_response(soap_request)
-        assert "soap_client_certificate: Unknown or invalid client certificate" in caplog.messages
-        mock_send.assert_called_once_with(ANY, stream=True, cert="", timeout=3600)
-
-
-def test_get_proxy_response_logs_soap_client_certificate_not_configured_error_and_returns_error_response(
-    caplog, enable_factory_create
-):
-    caplog.set_level(logging.INFO)
-    soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=True)
-    with patch(
-        "src.legacy_soap_api.legacy_soap_api_proxy.get_soap_error_response"
-    ) as mock_error_response, patch(
-        "src.legacy_soap_api.legacy_soap_api_proxy.get_cert_file"
-    ) as mock_cert_file:
-        mock_cert_file.side_effect = SOAPClientCertificateNotConfigured()
-        get_proxy_response(soap_request)
-        assert (
-            "soap_client_certificate: Certificate validated but not configured" in caplog.messages
-        )
-        mock_error_response.assert_called_once_with(
-            faultstring="Client certificate not configured for Simpler SOAP."
-        )
+        mock_send.assert_called_once_with(ANY, stream=True, cert=None, timeout=3600)
 
 
 @freeze_time("2024-04-03 12:00:00", tz_offset=0)
@@ -116,60 +58,20 @@ def test_get_soap_jwt_auth_jwt(enable_factory_create, caplog):
     assert "soap_client_certificate: created SOAP JWT" in caplog.messages
 
 
-@freeze_time("2024-04-03 12:00:00", tz_offset=0)
-def test_get_soap_jwt_auth_request_when_use_soap_cert_is_not_on_headers(
-    enable_factory_create, caplog
-):
-    caplog.set_level(logging.INFO)
-    soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=False)
-    legacy_certificate = soap_request.auth.certificate.legacy_certificate
-    with patch(
-        "src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response"
-    ) as mock_get_soap_response:
+def test_request_gets_correct_proxy_url_when_no_auth(enable_factory_create):
+    soap_request = create_soap_request(SOAP_PAYLOAD)
+    soap_request.auth = None
+    with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as mock_request:
         get_proxy_response(soap_request)
-        encoded = mock_get_soap_response.call_args_list[0][0][0].headers.get(
-            "S2S_PARTNER_CERTID_JWT_B64"
+        expected = (
+            "https://google.com/xyz/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort"
         )
-        decoded_base64 = base64.b64decode(encoded).decode("utf-8")
-        original_payload = jwt.decode(
-            decoded_base64, key="soap_partner_gateway_auth_key", algorithms=["HS256"]
-        )
-        config = get_soap_config()
-        expected = {
-            "sub": "partner_soap_call",
-            "iss": config.soap_partner_gateway_uri,
-            "exp": 1712145660,
-            "certId": legacy_certificate.cert_id,
-        }
-        assert original_payload == expected
-        assert "soap_client_certificate: using jwt auth" in caplog.messages
+        assert mock_request.call_args_list[0][0][0].url == expected
 
 
-def test_request_without_use_soap_cert_header_gets_correct_proxy_url(enable_factory_create):
-    soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=False)
-    with patch(
-        "src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response"
-    ) as mock_get_soap_response:
-        get_proxy_response(soap_request)
-        config = get_soap_config()
-        expected = f"{config.soap_partner_gateway_uri}/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort"
-        assert mock_get_soap_response.call_args_list[0][0][0].url == expected
-
-
-def test_request_without_use_soap_cert_header_does_not_log_locally_if_log_local_header_not_included(
-    enable_factory_create,
-):
-    soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=False)
-    with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as _, patch(
-        "src.legacy_soap_api.legacy_soap_api_proxy.log_local"
-    ) as mock_log_local:
-        get_proxy_response(soap_request)
-        mock_log_local.assert_not_called()
-
-
-def test_request_logs_locally_when_use_soap_cert_header_is_disabled(enable_factory_create, caplog):
+def test_request_logs_locally(enable_factory_create, caplog):
     caplog.set_level(logging.INFO)
-    soap_request = create_soap_request(SOAP_PAYLOAD, use_soap_cert=False, log_local=True)
+    soap_request = create_soap_request(SOAP_PAYLOAD, log_local=True)
     config = get_soap_config()
     config.enable_verbose_logging = True
     response_bytes = (

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from unittest import mock
 
 from lxml import etree
@@ -6,10 +7,14 @@ from lxml import etree
 from src.constants.lookup_constants import ApplicationStatus, Privilege
 from src.db.models.competition_models import ApplicationSubmissionRetrieved
 from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
-from src.legacy_soap_api.legacy_soap_api_auth import SOAPAuth, SOAPClientCertificate
+from src.legacy_soap_api.legacy_soap_api_auth import (
+    MTLS_CERT_HEADER_KEY,
+    SOAPAuth,
+    SOAPClientCertificate,
+)
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_utils import get_invalid_path_response
-from tests.lib.data_factories import setup_cert_user
+from tests.lib.data_factories import get_mtls_urlencoded_str_and_serial_number, setup_cert_user
 from tests.src.db.models.factories import (
     AgencyFactory,
     ApplicationFactory,
@@ -17,7 +22,9 @@ from tests.src.db.models.factories import (
     ApplicationSubmissionRetrievedFactory,
     ApplicationSubmissionTrackingNumberFactory,
     CompetitionFactory,
+    LegacyAgencyCertificateFactory,
     OpportunityFactory,
+    StagingTcertificatesFactory,
 )
 
 NSMAP = {
@@ -38,7 +45,7 @@ MOCK_CERT_STR = "certstr"
 TEST_UUID = "00000000-aaaa-0000-bbbb-000000000000"
 
 
-def test_successful_request(client, fixture_from_file, caplog) -> None:
+def test_successful_request(client, enable_factory_create, fixture_from_file, caplog) -> None:
     full_path = "/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort"
     fixture_path = (
         "/legacy_soap_api/applicants/get_opportunity_list_by_funding_opportunity_number_request.xml"
@@ -72,7 +79,7 @@ def test_successful_confirm_application_delivery_request(
         opportunity=opportunity,
     )
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
-    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     application = ApplicationFactory.create(
         competition=competition, application_status=ApplicationStatus.ACCEPTED
     )
@@ -96,11 +103,17 @@ def test_successful_confirm_application_delivery_request(
         fingerprint=MOCK_FINGERPRINT,
         serial_number="1235",
         legacy_certificate=soap_client_certificate.legacy_certificate,
+        cert_id=soap_client_certificate.legacy_certificate.cert_id,
     )
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
         response = client.post(
-            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+            full_path,
+            data=mock_data,
+            headers={
+                "Use-Simpler-Override": "1",
+                MTLS_CERT_HEADER_KEY: mtls_cert,
+            },
         )
     assert response.status_code == 200
     retrieved = (
@@ -122,7 +135,7 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
         opportunity=opportunity,
     )
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
-    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     application = ApplicationFactory.create(
         competition=competition, application_status=ApplicationStatus.ACCEPTED
     )
@@ -153,7 +166,12 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
         response = client.post(
-            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+            full_path,
+            data=mock_data,
+            headers={
+                "Use-Simpler-Override": "1",
+                MTLS_CERT_HEADER_KEY: mtls_cert,
+            },
         )
     assert response.status_code == 500
     expected = (
@@ -196,7 +214,7 @@ def test_successful_confirm_application_delivery_request_when_in_tracking_number
         opportunity=opportunity,
     )
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
-    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     application = ApplicationFactory.create(
         competition=competition, application_status=ApplicationStatus.ACCEPTED
     )
@@ -227,7 +245,12 @@ def test_successful_confirm_application_delivery_request_when_in_tracking_number
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
         response = client.post(
-            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+            full_path,
+            data=mock_data,
+            headers={
+                "Use-Simpler-Override": "1",
+                MTLS_CERT_HEADER_KEY: mtls_cert,
+            },
         )
     assert response.status_code == 500
     expected = (
@@ -266,7 +289,7 @@ def test_confirm_application_delivery_when_application_has_no_status(
         opportunity=opportunity,
     )
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
-    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     application = ApplicationFactory.create(competition=competition, application_status=None)
     submission = ApplicationSubmissionFactory.create(application=application)
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
@@ -300,7 +323,10 @@ def test_confirm_application_delivery_when_application_has_no_status(
             response = client.post(
                 full_path,
                 data=mock_data,
-                headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"},
+                headers={
+                    "Use-Simpler-Override": "1",
+                    MTLS_CERT_HEADER_KEY: mtls_cert,
+                },
             )
     assert response.status_code == 500
     expected = (
@@ -332,7 +358,7 @@ def test_if_soap_fault_exception_raised_return_correct_response_if_proxy_respons
         opportunity=opportunity,
     )
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
-    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     application = ApplicationFactory.create(
         competition=competition, application_status=ApplicationStatus.IN_PROGRESS
     )
@@ -360,7 +386,12 @@ def test_if_soap_fault_exception_raised_return_correct_response_if_proxy_respons
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
         response = client.post(
-            full_path, data=mock_data, headers={"Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+            full_path,
+            data=mock_data,
+            headers={
+                "Use-Simpler-Override": "1",
+                MTLS_CERT_HEADER_KEY: mtls_cert,
+            },
         )
     assert response.status_code == 500
     expected = (
@@ -390,7 +421,7 @@ def test_if_soap_fault_exception_raised_return_proxy_response_if_proxy_response_
         opportunity=opportunity,
     )
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
-    user, role, soap_client_certificate = setup_cert_user(agency, privileges)
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     application = ApplicationFactory.create(
         competition=competition, application_status=ApplicationStatus.IN_PROGRESS
     )
@@ -428,7 +459,10 @@ def test_if_soap_fault_exception_raised_return_proxy_response_if_proxy_response_
             response = client.post(
                 full_path,
                 data=mock_data,
-                headers={"Use-Soap-Cert": "1", "Use-Simpler-Override": "1"},
+                headers={
+                    "Use-Simpler-Override": "1",
+                    MTLS_CERT_HEADER_KEY: mtls_cert,
+                },
             )
     assert response.status_code == 200
     expected = "test response"
@@ -457,7 +491,7 @@ def test_invalid_xml_server_error_500(client) -> None:
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_getapplication_operation_returns_not_found_response_if_simpler_id_is_used(
-    mock_get_soap_response, mock_uuid, client, fixture_from_file
+    mock_get_soap_response, mock_uuid, client, fixture_from_file, enable_factory_create
 ) -> None:
     test_uuid = "00000000-aaaa-0000-bbbb-000000000000"
     mock_uuid.return_value = test_uuid
@@ -467,8 +501,13 @@ def test_getapplication_operation_returns_not_found_response_if_simpler_id_is_us
     envelope = etree.fromstring(mock_data)
     tracking_number = envelope.find(GET_APPLICATION_PATH)
     tracking_number.text = SIMPLER_TRACKING_NUMBER
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     response = client.post(
-        full_path, data=etree.tostring(envelope), headers={"Connection": "close"}
+        full_path,
+        data=etree.tostring(envelope),
+        headers={"Connection": "close", MTLS_CERT_HEADER_KEY: mtls_cert},
     )
     expected = (
         f"--uuid:{test_uuid}\r\n"
@@ -495,7 +534,7 @@ def test_getapplication_operation_returns_not_found_response_if_simpler_id_is_us
 
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_getapplicationzip_operation_calls_soap_proxy_if_tracking_number_is_a_legacy_id(
-    mock_get_soap_response, client, fixture_from_file
+    mock_get_soap_response, client, fixture_from_file, enable_factory_create
 ) -> None:
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     fixture_path = "/legacy_soap_api/grantors/get_application_zip_request.xml"
@@ -503,13 +542,16 @@ def test_getapplicationzip_operation_calls_soap_proxy_if_tracking_number_is_a_le
     envelope = etree.fromstring(mock_data)
     tracking_number = envelope.find(GET_APPLICATION_ZIP_PATH)
     tracking_number.text = LEGACY_TRACKING_NUMBER
-    client.post(full_path, data=etree.tostring(envelope))
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    client.post(full_path, data=etree.tostring(envelope), headers={MTLS_CERT_HEADER_KEY: mtls_cert})
     mock_get_soap_response.assert_called_once()
 
 
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_getapplication_operation_calls_soap_proxy_if_tracking_number_is_a_legacy_id(
-    mock_get_soap_response, client, fixture_from_file
+    mock_get_soap_response, client, fixture_from_file, enable_factory_create
 ) -> None:
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     fixture_path = "/legacy_soap_api/grantors/get_application_request.xml"
@@ -517,13 +559,16 @@ def test_getapplication_operation_calls_soap_proxy_if_tracking_number_is_a_legac
     envelope = etree.fromstring(mock_data)
     tracking_number = envelope.find(GET_APPLICATION_PATH)
     tracking_number.text = LEGACY_TRACKING_NUMBER
-    client.post(full_path, data=etree.tostring(envelope))
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    client.post(full_path, data=etree.tostring(envelope), headers={MTLS_CERT_HEADER_KEY: mtls_cert})
     mock_get_soap_response.assert_called_once()
 
 
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_getapplication_operation_calls_proxy_if_xml_throws_parsing_error(
-    mock_get_soap_response, client, fixture_from_file
+    mock_get_soap_response, client, fixture_from_file, enable_factory_create
 ) -> None:
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     data = """
@@ -533,14 +578,17 @@ def test_getapplication_operation_calls_proxy_if_xml_throws_parsing_error(
               <agen:GetApplicationRequest>
                    <gran:GrantsGovTrackingNumber>GRAN
     """
-    client.post(full_path, data=data)
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    client.post(full_path, data=data, headers={MTLS_CERT_HEADER_KEY: mtls_cert})
     mock_get_soap_response.assert_called_once()
 
 
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is_used(
-    mock_get_soap_response, mock_uuid, client, fixture_from_file
+    mock_get_soap_response, mock_uuid, client, fixture_from_file, enable_factory_create
 ) -> None:
     test_uuid = "00000000-aaaa-0000-bbbb-000000000000"
     mock_uuid.return_value = test_uuid
@@ -550,7 +598,12 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
     envelope = etree.fromstring(mock_data)
     tracking_number = envelope.find(GET_APPLICATION_ZIP_PATH)
     tracking_number.text = SIMPLER_TRACKING_NUMBER
-    response = client.post(full_path, data=etree.tostring(envelope))
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    response = client.post(
+        full_path, data=etree.tostring(envelope), headers={MTLS_CERT_HEADER_KEY: mtls_cert}
+    )
     expected = (
         f"--uuid:{test_uuid}\r\n"
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
@@ -576,7 +629,7 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_confirm_application_delivery_returns_not_found_response_if_simpler_id_is_used(
-    mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch
+    mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch, enable_factory_create
 ) -> None:
     """
     Force the response to be the legacy response and show that we do not actually call the legacy request method
@@ -599,31 +652,41 @@ def test_confirm_application_delivery_returns_not_found_response_if_simpler_id_i
     envelope = etree.fromstring(mock_data)
     tracking_number = envelope.find(CONFIRM_APPLICATION_DELIVERY_PATH)
     tracking_number.text = SIMPLER_TRACKING_NUMBER
-    response = client.post(full_path, data=etree.tostring(envelope))
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    response = client.post(
+        full_path, data=etree.tostring(envelope), headers={MTLS_CERT_HEADER_KEY: mtls_cert}
+    )
     expected = (
-        f"--uuid:{test_uuid}\r\n"
-        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n'
-        '\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
-        "<soap:Body>"
-        "<soap:Fault><faultcode>soap:Server</faultcode><faultstring>Failed to confirm application delivery.(Authorization Failure)</faultstring></soap:Fault>"
-        "</soap:Body></soap:Envelope>\r\n"
-        f"--uuid:{test_uuid}--"
-    ).encode("utf-8")
+        b"--uuid:00000000-aaaa-0000-bbbb-000000000000\r\n"
+        b'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\n'
+        b"Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+        b'<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n        '
+        b"<soap:Body>\n            "
+        b"<soap:Fault>\n                "
+        b"<faultcode>soap:Server</faultcode>\n                "
+        b"<faultstring>Failed to confirm application delivery.(Authorization Failure)"
+        b"</faultstring>\n            "
+        b"</soap:Fault>\n        "
+        b"</soap:Body>\n    "
+        b"</soap:Envelope>\r\n"
+        b"--uuid:00000000-aaaa-0000-bbbb-000000000000--\r\n"
+    )
     mock_get_soap_response.assert_not_called()
     assert response.status_code == 500
-    assert response.headers["Content-Length"] == "496"
+    assert response.headers["Content-Length"] == "581"
     assert expected == response.data
     assert (
         response.headers["Content-Type"]
         == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
     )
-    assert response.headers["Set-Cookie"] == "None; Path=/grantsws-agency; Secure; HttpOnly"
 
 
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_update_application_info_returns_not_found_response_if_simpler_id_is_used(
-    mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch
+    mock_get_soap_response, mock_uuid, client, fixture_from_file, monkeypatch, enable_factory_create
 ) -> None:
     """
     Force the response to be the legacy response and show that we do not actually call the legacy request method
@@ -652,7 +715,12 @@ def test_update_application_info_returns_not_found_response_if_simpler_id_is_use
     envelope = etree.fromstring(mock_data)
     tracking_number = envelope.find(UPDATE_APPLICATION_INFO)
     tracking_number.text = SIMPLER_TRACKING_NUMBER
-    response = client.post(full_path, data=etree.tostring(envelope))
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    response = client.post(
+        full_path, data=etree.tostring(envelope), headers={MTLS_CERT_HEADER_KEY: mtls_cert}
+    )
     expected = (
         f"--uuid:{test_uuid}\r\n"
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>\r\n'
@@ -699,7 +767,7 @@ def test_update_application_info_returns_not_found_response_if_simpler_id_is_use
 
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_simpler_getapplicationzip_operation_returns_not_found_response_includes_cookie(
-    mock_get_soap_response, client, fixture_from_file
+    mock_get_soap_response, client, fixture_from_file, enable_factory_create
 ) -> None:
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
     fixture_path = "/legacy_soap_api/grantors/get_application_zip_request.xml"
@@ -708,7 +776,12 @@ def test_simpler_getapplicationzip_operation_returns_not_found_response_includes
     tracking_number = envelope.find(GET_APPLICATION_ZIP_PATH)
     tracking_number.text = SIMPLER_TRACKING_NUMBER
     client.set_cookie("JSESSIONID", "xyz")
-    response = client.post(full_path, data=etree.tostring(envelope))
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    response = client.post(
+        full_path, data=etree.tostring(envelope), headers={MTLS_CERT_HEADER_KEY: mtls_cert}
+    )
     mock_get_soap_response.assert_not_called()
     assert response.status_code == 500
     assert (
@@ -725,7 +798,7 @@ def test_simpler_getapplicationzip_operation_raising_httperror_due_to_privileges
         opportunity=opportunity,
     )
     WRONG_PRIVILEGES = {Privilege.READ_TEST_USER_TOKEN}
-    user, role, soap_client_certificate = setup_cert_user(agency, WRONG_PRIVILEGES)
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, WRONG_PRIVILEGES)
     application = ApplicationFactory.create(competition=competition)
     submission = ApplicationSubmissionFactory.create(application=application)
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
@@ -743,7 +816,9 @@ def test_simpler_getapplicationzip_operation_raising_httperror_due_to_privileges
     with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
         mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
         response = client.post(
-            full_path, data=etree.tostring(envelope), headers={"Use-Simpler-Override": "1"}
+            full_path,
+            data=etree.tostring(envelope),
+            headers={"Use-Simpler-Override": "1", MTLS_CERT_HEADER_KEY: mtls_cert},
         )
     assert response.status_code == 500
     info_messages = [
@@ -755,3 +830,232 @@ def test_simpler_getapplicationzip_operation_raising_httperror_due_to_privileges
     assert len(info_messages) == 1
     error_records = [record for record in caplog.records if record.levelno >= logging.ERROR]
     assert len(error_records) == 0
+
+
+def test_request_fails_if_no_mtls_cert_is_attached(
+    db_session, client, enable_factory_create
+) -> None:
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        "<gran:GrantsGovTrackingNumber>GRANT</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    response = client.post(
+        full_path,
+        data=mock_data,
+        headers={
+            "Use-Simpler-Override": "1",
+        },
+    )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
+        "<soap:Body>\n        "
+        "<soap:Fault>\n            "
+        "<faultcode>soap:Server</faultcode>\n            "
+        "<faultstring>Missing certificate. (Authorization Failure)</faultstring>\n        "
+        "</soap:Fault>\n    "
+        "</soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
+
+
+def test_request_fails_if_no_tcertificate(db_session, client, enable_factory_create) -> None:
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        "<gran:GrantsGovTrackingNumber>GRANT</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    response = client.post(
+        full_path,
+        data=mock_data,
+        headers={"Use-Simpler-Override": "1", MTLS_CERT_HEADER_KEY: mtls_cert},
+    )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
+        "<soap:Body>\n        "
+        "<soap:Fault>\n            "
+        "<faultcode>soap:Server</faultcode>\n            "
+        "<faultstring>No tcertificate found. (Authorization Failure)</faultstring>\n        "
+        "</soap:Fault>\n    "
+        "</soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
+
+
+def test_request_fails_if_tcertificate_is_expired(
+    db_session, client, enable_factory_create
+) -> None:
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    StagingTcertificatesFactory.create(
+        serial_num=serial_number, expirationdate=datetime(2000, 1, 1).date()
+    )
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        "<gran:GrantsGovTrackingNumber>GRANT</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    response = client.post(
+        full_path,
+        data=mock_data,
+        headers={"Use-Simpler-Override": "1", MTLS_CERT_HEADER_KEY: mtls_cert},
+    )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
+        "<soap:Body>\n        "
+        "<soap:Fault>\n            "
+        "<faultcode>soap:Server</faultcode>\n            "
+        "<faultstring>Certificate is expired. (Authorization Failure)</faultstring>\n        "
+        "</soap:Fault>\n    "
+        "</soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected
+
+
+def test_request_only_calls_legacy_when_only_valid_tcertificate_exists(
+    db_session, client, enable_factory_create
+) -> None:
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    StagingTcertificatesFactory.create(serial_num=serial_number)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>{LEGACY_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    with mock.patch(
+        "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
+    ) as mock_get_legacy_response:
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
+        ) as mock_get_simpler_response:
+            client.post(
+                full_path,
+                data=mock_data,
+                headers={"Use-Simpler-Override": "1", MTLS_CERT_HEADER_KEY: mtls_cert},
+            )
+            mock_get_legacy_response.assert_called_once()
+            mock_get_simpler_response.assert_not_called()
+
+
+def test_request_only_calls_simpler_and_legacy_when_there_are_both_valid_tcertificate_and_valid_legacy_certificate(
+    db_session, client, enable_factory_create
+) -> None:
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
+    LegacyAgencyCertificateFactory.create(
+        serial_number=serial_number,
+        cert_id=tcertificate.currentcertid,
+        expiration_date=tcertificate.expirationdate,
+    )
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>{LEGACY_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    with mock.patch(
+        "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
+    ) as mock_get_legacy_response:
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
+        ) as mock_get_simpler_response:
+            client.post(
+                full_path,
+                data=mock_data,
+                headers={"Use-Simpler-Override": "1", MTLS_CERT_HEADER_KEY: mtls_cert},
+            )
+            mock_get_legacy_response.assert_called_once()
+            mock_get_simpler_response.assert_called_once()
+
+
+def test_request_fails_if_legacy_certificate_is_expired(
+    db_session, client, enable_factory_create
+) -> None:
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
+    LegacyAgencyCertificateFactory.create(
+        serial_number=serial_number,
+        cert_id=tcertificate.currentcertid,
+        expiration_date=datetime(2000, 1, 1).date(),
+    )
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        "<gran:GrantsGovTrackingNumber>GRANT</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    response = client.post(
+        full_path,
+        data=mock_data,
+        headers={"Use-Simpler-Override": "1", MTLS_CERT_HEADER_KEY: mtls_cert},
+    )
+    assert response.status_code == 500
+    expected = (
+        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
+        "<soap:Body>\n        "
+        "<soap:Fault>\n            "
+        "<faultcode>soap:Server</faultcode>\n            "
+        "<faultstring>Certificate is expired. (Authorization Failure)</faultstring>\n        "
+        "</soap:Fault>\n    "
+        "</soap:Body>\n"
+        "</soap:Envelope>\n"
+    )
+    assert response.data.decode() == expected

--- a/api/tests/validate_legacy_soap_api/validate_soap_endpoints.py
+++ b/api/tests/validate_legacy_soap_api/validate_soap_endpoints.py
@@ -42,7 +42,7 @@ class SOAPValidationEnvConfig(PydanticBaseEnvConfig):
 
 _config = SOAPValidationEnvConfig()
 
-HEADERS = {"Content-Type": "application/xml", "Use-Simpler-Override": "1", "Use-Soap-Cert": "1"}
+HEADERS = {"Content-Type": "application/xml", "Use-Simpler-Override": "1"}
 
 
 @dataclass


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9933  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added checks/handling for scenarios:
1. `GetOpportunityList` - no auth checking
2. No mtls cert on request -> short circuit error response
3. No tcertificate -> short circuit error response
4. tcertificate expired -> short circuit error response
5. valid tcertificate, no legacy certificate -> only call legacy
6. valid tcertificate, legacy certificate expired -> short circuit error response
7. valid tcertificate, valid legacy certificate -> call both simpler and legacy

Remove legacy `use-soap-cert` path, now only use JWT or certificate-less call to the original url.

Tests updated.


## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We need to be able to facilitate users that are not configured in Simpler (they have tcertificates but no legacy certificate) as well as handling calls to `GetOpportunityList` (no auth). Throw error responses unless caller has a valid tcertificate and/or a valid legacy certificate. Remove the soap-cert path file writing.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] Hit the endpoints, note that the Use-Soap-Cert header no longer works.
- [ ] Notice that unless tcert and legacycert are set up you'll get correct errors
