### PR TITLE
[unticketed]: enable api gateway w/ ssl for grantee environments

### DIFF
--- a/infra/api/app-config/grantee1.tf
+++ b/infra/api/app-config/grantee1.tf
@@ -6,7 +6,7 @@ module "grantee1_config" {
   environment                       = "grantee1"
   network_name                      = "grantee1"
   domain_name                       = "api.grantee1.teams.simpler.grants.gov"
-  secondary_domain_names            = []
+  secondary_domain_names            = ["alb.grantee1.teams.simpler.grants.gov"]
   s3_cdn_domain_name                = "files.grantee1.teams.simpler.grants.gov"
   mtls_domain_name                  = null
   enable_https                      = true

--- a/infra/api/app-config/grantee2.tf
+++ b/infra/api/app-config/grantee2.tf
@@ -6,7 +6,7 @@ module "grantee2_config" {
   environment                       = "grantee2"
   network_name                      = "grantee2"
   domain_name                       = "api.grantee2.teams.simpler.grants.gov"
-  secondary_domain_names            = []
+  secondary_domain_names            = ["alb.grantee2.teams.simpler.grants.gov"]
   s3_cdn_domain_name                = "files.grantee2.teams.simpler.grants.gov"
   mtls_domain_name                  = null
   enable_https                      = true

--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -123,6 +123,7 @@ data "aws_acm_certificate" "secondary_certs" {
   for_each    = local.service_config.enable_https ? toset(lookup(local.service_config, "secondary_domain_names", [])) : toset([])
   domain      = each.value
   most_recent = true
+  key_types   = ["RSA_2048", "RSA_4096"]
 }
 
 data "aws_acm_certificate" "s3_cdn_cert" {


### PR DESCRIPTION
## Summary

enable api gateway w/ ssl for grantee environments

## Validation steps

Successfully deployed the api service module for both grantee1 and grantee2 from local. 


<img width="614" height="300" alt="Screenshot 2026-04-29 at 5 02 41 PM" src="https://github.com/user-attachments/assets/5f8e6ccf-fd46-45f3-801b-78e55a3db62a" />

<br/>
<img width="630" height="239" alt="Screenshot 2026-04-29 at 5 03 40 PM" src="https://github.com/user-attachments/assets/bb7414e5-90e8-4ef6-8cc9-f974c8e99f0e" />