### PR TITLE
[unticketed]: Fix ssl cert lookup. 

### DIFF
--- a/infra/analytics/metabase/main.tf
+++ b/infra/analytics/metabase/main.tf
@@ -69,8 +69,10 @@ data "aws_rds_cluster" "db_cluster" {
 }
 
 data "aws_acm_certificate" "certificate" {
-  count  = local.service_config.enable_https ? 1 : 0
-  domain = local.service_config.domain_name
+  count       = local.service_config.enable_https ? 1 : 0
+  domain      = local.service_config.domain_name
+  key_types   = ["RSA_4096", "RSA_2048"]
+  most_recent = true
 }
 
 module "service" {

--- a/infra/analytics/service/main.tf
+++ b/infra/analytics/service/main.tf
@@ -121,8 +121,10 @@ data "aws_security_groups" "aws_services" {
 }
 
 data "aws_acm_certificate" "certificate" {
-  count  = local.service_config.enable_https ? 1 : 0
-  domain = local.service_config.domain_name
+  count       = local.service_config.enable_https ? 1 : 0
+  domain      = local.service_config.domain_name
+  key_types   = ["RSA_4096", "RSA_2048"]
+  most_recent = true
 }
 
 data "aws_ssm_parameter" "incident_management_service_integration_url" {

--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -112,9 +112,10 @@ data "aws_security_groups" "aws_services" {
 }
 
 data "aws_acm_certificate" "certificate" {
-  count     = local.service_config.enable_https ? 1 : 0
-  domain    = local.service_config.domain_name
-  key_types = ["RSA_4096", "RSA_2048"]
+  count       = local.service_config.enable_https ? 1 : 0
+  domain      = local.service_config.domain_name
+  key_types   = ["RSA_4096", "RSA_2048"]
+  most_recent = true
 }
 
 # data "aws_route53_zone" "zone" {

--- a/infra/nofos/service/main.tf
+++ b/infra/nofos/service/main.tf
@@ -121,8 +121,10 @@ data "aws_security_groups" "aws_services" {
 }
 
 data "aws_acm_certificate" "certificate" {
-  count  = local.service_config.enable_https ? 1 : 0
-  domain = local.service_config.domain_name
+  count       = local.service_config.enable_https ? 1 : 0
+  domain      = local.service_config.domain_name
+  key_types   = ["RSA_4096", "RSA_2048"]
+  most_recent = true
 }
 
 module "service" {


### PR DESCRIPTION
## Summary

Updated the acm cert lookups to pick up the latest valid ssl cert. 

## Validation steps

Successfully deployed to dev frontend: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/25224578138)