### PR TITLE
[Issue #10111] Better checkout logic for fork PRs

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -54,8 +54,10 @@ jobs:
     steps:
       - name: Troubleshoot shas and refs
         working-directory: ./
+        env:
+          CLEAN_HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "${{ github.event.pull_request.head.sha}}|${{ github.head_ref }}|${{github.ref }}"
+          echo "${{ github.event.pull_request.head.sha}}|$CLEAN_HEAD_REF|${{github.ref }}"
           echo "${{ github.event.repository.full_name }}"
 
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -56,12 +56,12 @@ jobs:
         working-directory: ./
         run: |
           echo "${{ github.event.pull_request.head.sha}}|${{ github.head_ref }}|${{github.ref }}"
-          echo "${{ github.event.pull_request.repository }}"
+          echo "${{ github.event.repository.full_name }}"
 
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha  || github.head_ref || github.ref }}
-          repository: ${{ github.event.pull_request.repository }}
+          repository: ${{ github.event.repository.full_name }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-api-commit-hash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -52,14 +52,21 @@ jobs:
     outputs:
       commit_hash: ${{ steps.get-api-commit-hash.outputs.commit_hash }}
     steps:
+      - name: Troubleshoot shas and refs
+        working-directory: ./
+        run: |
+          echo "${{ github.event.pull_request.head.sha}}|${{ github.head_ref }}|${{github.ref }}"
+          echo "${{ github.event.pull_request.repository }}"
+
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref || github.ref }}
+          ref: ${{ github.event.pull_request.head.sha  || github.head_ref || github.ref }}
+          repository: ${{ github.event.pull_request.repository }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-api-commit-hash
         env:
-          CLEAN_REF: ${{ github.head_ref || github.ref }}
+          CLEAN_REF: ${{ github.event.pull_request.head.sha  || github.head_ref || github.ref }}
         run: |
           cd ..
           COMMIT_HASH=$(git rev-parse "$CLEAN_REF")


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10111  

## Changes proposed

Be more explicit about where we get the commit to checkout and the repo to reference it from so that this doesn't break on PRs bringing forked branches back into the mainline repo.

## Context for reviewers

Fork PRs were failing on the checkout steps based on changes we made to get them working fully on our mainline repo PRs.

## Validation steps

- Tests pass
- Checks pass
- We need to test against Fork PRs once we have taken this to main
