### PR TITLE
[Issue #10224] Ensure we use a committed DB model for JWT creation (login) logging.

### DIFF
--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -160,8 +160,8 @@ def user_token_logout(db_session: db.Session) -> response.ApiResponse:
     logger.info(
         "Logged out a user",
         extra={
-            "user_token_session.token_id": str(user_token_session.token_id),
-            "user_token_session.user_id": str(user_token_session.user_id),
+            "user_token_session.token_id": user_token_session.token_id,
+            "user_token_session.user_id": user_token_session.user_id,
         },
     )
 

--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -89,8 +89,8 @@ def create_jwt_for_user(
     logger.info(
         "Created JWT token",
         extra={
-            "auth.user_id": str(user_token_session.user_id),
-            "auth.token_id": str(user_token_session.token_id),
+            "auth.user_id": user.user_id,
+            "auth.token_id": user_token_session.token_id,
         },
     )
     return jwt_str, user_token_session


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10224 

## Changes proposed

Get user_id from the committed user object not the uncommitted token object were the value doesn't resolve until commit. Remove str so we get nulls not "None" in NR

## Context for reviewers

We're not currently outputting the user_id on Login ("JWT Created") events because we haven't committed the token record yet.

## Validation steps

- Checks pass
- Value logged