### PR TITLE
[Issue #10232] Reorder Cascade Delete calls to Resolve Unit Test Prod Errors

### DIFF
--- a/api/tests/src/search/backend/test_load_agencies_to_index.py
+++ b/api/tests/src/search/backend/test_load_agencies_to_index.py
@@ -16,8 +16,8 @@ class TestLoadAgenciesToIndex(BaseTestClass):
     def cleanup_agencies(self, db_session):
         db_session.execute(update(LegacyCertificate).values(agency_id=None))
         cascade_delete_from_db_table(db_session, AgencyUser)
-        cascade_delete_from_db_table(db_session, Agency)
         cascade_delete_from_db_table(db_session, Opportunity)
+        cascade_delete_from_db_table(db_session, Agency)
 
     @pytest.fixture(scope="class")
     def load_agencies_to_index(self, db_session, search_client, agency_index_alias):

--- a/api/tests/src/services/opportunities_v1/test_opportunity_version.py
+++ b/api/tests/src/services/opportunities_v1/test_opportunity_version.py
@@ -16,11 +16,8 @@ from tests.src.db.models.factories import (
 
 @pytest.fixture(autouse=True)
 def clear_data(db_session, test_api_schema):
-    # Set all opportunity agency_id to NULL before deleting agencies
-    db_session.execute(update(Opportunity).values(agency_id=None))
-    db_session.commit()
-    cascade_delete_from_db_table(db_session, Agency)
     cascade_delete_from_db_table(db_session, Opportunity)
+    cascade_delete_from_db_table(db_session, Agency)
 
 
 def test_save_opportunity_version(db_session, enable_factory_create):

--- a/api/tests/src/services/opportunities_v1/test_opportunity_version.py
+++ b/api/tests/src/services/opportunities_v1/test_opportunity_version.py
@@ -1,5 +1,4 @@
 import pytest
-from sqlalchemy import update
 
 from src.constants.lookup_constants import OpportunityCategory
 from src.db.models.agency_models import Agency


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10232 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Updating unit test fixtures to call `cascade_delete_from_db_table(db_session, Opportunity)` before `cascade_delete_from_db_table(db_session, Agency)` to resolve foreign key constraint issues.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Error log from prod - https://github.com/HHS/simpler-grants-gov/actions/runs/25446450762/job/74651764986


## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- [x] All tests passing.
