### PR TITLE
[unticketed]: update workflow service to send logs into newrelic

### DIFF
--- a/infra/api/service/workflow.tf
+++ b/infra/api/service/workflow.tf
@@ -122,6 +122,7 @@ resource "aws_ecs_task_definition" "workflow" {
         { name : "aws_region", value : data.aws_region.current.name },
         { name : "container_name", value : local.workflow_service_name },
         { name : "log_group_name", value : "service/${local.workflow_service_name}" },
+        { name : "NR_DIRECT_LOGS_MATCH", value : "nr_direct_disabled" },
       ],
     },
   ])
@@ -137,6 +138,31 @@ resource "aws_ecs_task_definition" "workflow" {
     aws_cloudwatch_log_group.workflow,
     aws_cloudwatch_log_group.workflow_fluentbit,
   ]
+}
+
+#-------------------------------
+# Workflow New Relic Log Forwarding
+#-------------------------------
+
+resource "aws_lambda_permission" "allow_cloudwatch_workflow" {
+  count = local.enable_workflow_service ? 1 : 0
+
+  statement_id  = "AllowCloudWatchWorkflow"
+  action        = "lambda:InvokeFunction"
+  function_name = module.service.nr_host_log_forwarder_name
+  principal     = "logs.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_log_group.workflow[0].arn}:*"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "workflow_to_newrelic" {
+  count = local.enable_workflow_service ? 1 : 0
+
+  name            = "${local.workflow_service_name}-to-newrelic"
+  log_group_name  = aws_cloudwatch_log_group.workflow[0].name
+  filter_pattern  = ""
+  destination_arn = module.service.nr_host_log_forwarder_arn
+
+  depends_on = [aws_lambda_permission.allow_cloudwatch_workflow]
 }
 
 #-------------------------------

--- a/infra/modules/service/outputs.tf
+++ b/infra/modules/service/outputs.tf
@@ -78,3 +78,13 @@ output "environment_variables" {
   description = "environment variable for the app container"
   value       = local.environment_variables
 }
+
+output "nr_host_log_forwarder_arn" {
+  description = "ARN of the New Relic host log forwarder Lambda"
+  value       = aws_lambda_function.nr_host_log_forwarder.arn
+}
+
+output "nr_host_log_forwarder_name" {
+  description = "Name of the New Relic host log forwarder Lambda"
+  value       = aws_lambda_function.nr_host_log_forwarder.function_name
+}


### PR DESCRIPTION
## Summary

Updated the workflow service to send logs into newrelic. 

## Validation steps

Successfully deployed into api dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/25456645000/job/74690896128)

Verified the workflow logs are showing up in newrelic with the query below: 

`select count(*) from Log where environment = 'dev' and message = 'Fetched SQS messages' since 2 week ago timeseries 1 hour`

https://onenr.io/0BQ1r2xrVwx