### PR TITLE
[Unticketed] Fix queries to fetch opportunities to fetch only what we need

### DIFF
--- a/api/src/search/backend/load_opportunities_to_index.py
+++ b/api/src/search/backend/load_opportunities_to_index.py
@@ -7,14 +7,18 @@ from opensearchpy.exceptions import ConnectionTimeout, TransportError
 from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 from sqlalchemy import select
-from sqlalchemy.orm import noload, selectinload
+from sqlalchemy.orm import selectinload
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 import src.adapters.db as db
 import src.adapters.search as search
 from src.api.opportunities_v1.opportunity_schemas import OpportunityV1Schema
 from src.db.models.agency_models import Agency
-from src.db.models.opportunity_models import CurrentOpportunitySummary, Opportunity
+from src.db.models.opportunity_models import (
+    CurrentOpportunitySummary,
+    Opportunity,
+    OpportunitySummary,
+)
 from src.task.task import Task
 from src.util.datetime_util import get_now_us_eastern_datetime, utcnow
 from src.util.env_config import PydanticBaseEnvConfig
@@ -101,13 +105,19 @@ class LoadOpportunitiesToIndex(Task):
                     Opportunity.is_draft.is_(False),
                     CurrentOpportunitySummary.opportunity_status.isnot(None),
                 )
-                .options(selectinload("*"), noload(Opportunity.all_opportunity_summaries))
-                # Top level agency won't be automatically fetched up front unless we add this
-                # due to the odd nature of the relationship we have setup for the agency table
-                # Adding it here improves performance when serializing to JSON as we won't need to
-                # call out to the DB repeatedly.
                 .options(
-                    selectinload(Opportunity.agency_record).selectinload(Agency.top_level_agency)
+                    # Opportunity summary
+                    selectinload(Opportunity.current_opportunity_summary)
+                    .selectinload(CurrentOpportunitySummary.opportunity_summary)
+                    .options(
+                        selectinload(OpportunitySummary.link_funding_instruments),
+                        selectinload(OpportunitySummary.link_funding_categories),
+                        selectinload(OpportunitySummary.link_applicant_types),
+                    ),
+                    # Assistance listing number
+                    selectinload(Opportunity.opportunity_assistance_listings),
+                    # Agency
+                    selectinload(Opportunity.agency_record).selectinload(Agency.top_level_agency),
                 )
                 .execution_options(yield_per=1000)
             )

--- a/api/src/services/opportunities_v1/get_opportunity.py
+++ b/api/src/services/opportunities_v1/get_opportunity.py
@@ -1,12 +1,17 @@
 import uuid
 
 from sqlalchemy import ColumnExpressionArgument, select
-from sqlalchemy.orm import lazyload, selectinload
+from sqlalchemy.orm import selectinload
 
 import src.adapters.db as db
 from src.api.route_utils import raise_flask_error
 from src.db.models.agency_models import Agency
-from src.db.models.opportunity_models import Opportunity
+from src.db.models.competition_models import Competition, CompetitionForm, Form
+from src.db.models.opportunity_models import (
+    CurrentOpportunitySummary,
+    Opportunity,
+    OpportunitySummary,
+)
 
 
 def _get_opportunity(
@@ -16,24 +21,30 @@ def _get_opportunity(
         select(Opportunity)
         .where(where_clause)
         .where(Opportunity.is_draft.is_(False))
-        .options(selectinload("*"))
-        # To get the top_level_agency field set properly upfront,
-        # we need to explicitly join here as the "*" approach doesn't
-        # seem to work with the way our agency relationships are setup
-        .options(selectinload(Opportunity.agency_record).selectinload(Agency.top_level_agency))
-        # Do not load the following relationships, they aren't necessary for
-        # our opportunity endpoints, and would make the query much larger/slower
-        # if we were to fetch them.
-        # This effectively undoes the `selectinload("*")` above for these relationships
-        # and makes them lazily loaded (the default for relationships) - keeping them out of the query entirely.
         .options(
-            lazyload(Opportunity.opportunity_change_audit),
-            lazyload(Opportunity.all_opportunity_summaries),
-            lazyload(Opportunity.all_opportunity_notification_logs),
-            lazyload(Opportunity.saved_opportunities_by_users),
-            lazyload(Opportunity.versions),
-            lazyload(Opportunity.saved_opportunities_by_organizations),
-            lazyload(Opportunity.workflows),
+            # Opportunity summary
+            selectinload(Opportunity.current_opportunity_summary)
+            .selectinload(CurrentOpportunitySummary.opportunity_summary)
+            .options(
+                selectinload(OpportunitySummary.link_funding_instruments),
+                selectinload(OpportunitySummary.link_funding_categories),
+                selectinload(OpportunitySummary.link_applicant_types),
+            ),
+            # Attachments
+            selectinload(Opportunity.opportunity_attachments),
+            # Competitions
+            selectinload(Opportunity.competitions).options(
+                selectinload(Competition.competition_instructions),
+                selectinload(Competition.opportunity_assistance_listing),
+                selectinload(Competition.link_competition_open_to_applicant),
+                selectinload(Competition.competition_forms)
+                .selectinload(CompetitionForm.form)
+                .selectinload(Form.form_instruction),
+            ),
+            # Assistance listing number
+            selectinload(Opportunity.opportunity_assistance_listings),
+            # Agency
+            selectinload(Opportunity.agency_record).selectinload(Agency.top_level_agency),
         )
     )
 

--- a/api/src/task/opportunities/export_opportunity_data_task.py
+++ b/api/src/task/opportunities/export_opportunity_data_task.py
@@ -6,15 +6,20 @@ from enum import StrEnum
 
 from pydantic import Field
 from sqlalchemy import select
-from sqlalchemy.orm import noload, selectinload
+from sqlalchemy.orm import selectinload
 
 import src.adapters.db as db
 import src.adapters.db.flask_db as flask_db
 import src.util.file_util as file_util
 from src.api.opportunities_v1.opportunity_schemas import OpportunityV1Schema
 from src.constants.lookup_constants import ExtractType
+from src.db.models.agency_models import Agency
 from src.db.models.extract_models import ExtractMetadata
-from src.db.models.opportunity_models import CurrentOpportunitySummary, Opportunity
+from src.db.models.opportunity_models import (
+    CurrentOpportunitySummary,
+    Opportunity,
+    OpportunitySummary,
+)
 from src.services.opportunities_v1.opportunity_to_csv import opportunities_to_csv
 from src.task.ecs_background_task import ecs_background_task
 from src.task.task import Task
@@ -125,7 +130,20 @@ class ExportOpportunityDataTask(Task):
                     Opportunity.is_draft.is_(False),
                     CurrentOpportunitySummary.opportunity_status.isnot(None),
                 )
-                .options(selectinload("*"), noload(Opportunity.all_opportunity_summaries))
+                .options(
+                    # Opportunity summary
+                    selectinload(Opportunity.current_opportunity_summary)
+                    .selectinload(CurrentOpportunitySummary.opportunity_summary)
+                    .options(
+                        selectinload(OpportunitySummary.link_funding_instruments),
+                        selectinload(OpportunitySummary.link_funding_categories),
+                        selectinload(OpportunitySummary.link_applicant_types),
+                    ),
+                    # Assistance listing number
+                    selectinload(Opportunity.opportunity_assistance_listings),
+                    # Agency
+                    selectinload(Opportunity.agency_record).selectinload(Agency.top_level_agency),
+                )
                 .execution_options(yield_per=5000)
             )
             .scalars()


### PR DESCRIPTION
## Summary

## Changes proposed
* Remove usage of `selectinload("*")` which recursively fetches all relationships from the attached record

## Context for reviewers
Noticed that in staging, the queries to GET an opportunity were taking 10-15 seconds. I've known this query was poorly written, but I hadn't realized how bad it had gotten. For awareness, any of the loading techniques like `selectinload` tell SQLAlchemy not to lazily evaluate the relationship (eg. wait until you do `opportunity.opportunity_attachments` to emit the query to that table) and to fetch them upfront. If you do `selectinload("*")` it gets all relationships recursively. If you are familiar with our data model, you know everything connects to an opportunity.

Looking at New Relic, we can see how much time it spent in each part of the query when taking 15 seconds. The number of calls is massive, but a few highlights:
* 378ms to fetch applications
* 277ms to fetch application attachments
* 5.58 seconds to fetch application forms
* 1.3 seconds to fetch every audit record associated with applications
* 510ms to fetch more application forms
* 331ms to fetch even more application attachments (it gets a bit lost in application since an app connects to a competion to more apps)
* 747ms doing 136 more "fast" calls to user / agency / org tables

As a reminder - we use none of these tables to populate the response for this endpoint. The changes I made correct it to directly tell the logic what we want to fetch rather than "everything".

## Validation steps
Our tests are written to create opportunities with competitions already so that verifies the commands are right. I also tested two ECS task jobs that had the same query. Testing with 5000 opportunities that all have applications locally, the two jobs both went from about 5s to 2s locally.