### PR TITLE
[Issue #10121] Create search core filters - state persistence feature file

### DIFF
--- a/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
+++ b/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
@@ -28,7 +28,7 @@ Scenario: Retain status filter after refresh
     And the browser URL contains query param "status" with values "<expected statuses>"
 
 Examples:
-    | Opportunity status | expected statuses           |
+    | Opportunity status | expected statuses          |
     | Closed             | forecasted,posted,closed   |
     | Posted             | forecasted,posted          |
 

--- a/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
+++ b/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
@@ -85,3 +85,4 @@ Examples:
   | category        | expected values |
   | Agriculture     | agriculture     |
   | Recovery Act    | recovery_act    |
+ 

--- a/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
+++ b/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
@@ -6,82 +6,82 @@
 */
 
 Feature: Search page - state persistence after refresh
- As a grantee searching for opportunities
- I want my search filters and inputs to be preserved in the URL
- So that I can refresh the page and return to the same search state
+  As a grantee searching for opportunities
+  I want my search filters and inputs to be preserved in the URL
+  So that I can refresh the page and return to the same search state
 
 Background:
- Given I am on the search page
- And the search results have loaded
+  Given I am on the search page
+  And the search results have loaded
  
 /* @tags GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION */
 Scenario: Retain status filter after refresh
-    When I open the filter drawer
-    And the "Opportunity status" accordion is expanded
-    When I check the "<Opportunity status>" checkbox
-    Then the browser URL contains query param "status" with values "<expected statuses>"
-    When I refresh the page
-    Then the search results load
-    And the filter drawer is open
-    And the "Opportunity status" accordion is expanded
-    And the "<Opportunity status>" checkbox should be checked
-    And the browser URL contains query param "status" with values "<expected statuses>"
+  When I open the filter drawer
+  And the "Opportunity status" accordion is expanded
+  When I check the "<Opportunity status>" checkbox
+  Then the browser URL contains query param "status" with values "<expected statuses>"
+  When I refresh the page
+  Then the search results load
+  And the filter drawer is open
+  And the "Opportunity status" accordion is expanded
+  And the "<Opportunity status>" checkbox should be checked
+  And the browser URL contains query param "status" with values "<expected statuses>"
 
 Examples:
-    | Opportunity status | expected statuses          |
-    | Closed             | forecasted,posted,closed   |
-    | Posted             | forecasted,posted          |
+  | Opportunity status | expected statuses          |
+  | Closed             | forecasted,posted,closed   |
+  | Posted             | forecasted,posted          |
 
 /* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
 Scenario: Retain funding instrument filter after refresh
-    When I open the filter drawer
-    And the "Funding instrument" accordion is expanded
-    When I check the "<funding instrument>" checkbox
-    Then the browser URL contains query param "fundingInstrument" with values "<expected values>"
-    When I refresh the page
-    Then the search results load
-    And the filter drawer is open
-    And the "Funding instrument" accordion is expanded
-    And the "<funding instrument>" checkbox should be checked
-    And the browser URL contains query param "fundingInstrument" with values "<expected values>"
+  When I open the filter drawer
+  And the "Funding instrument" accordion is expanded
+  When I check the "<funding instrument>" checkbox
+  Then the browser URL contains query param "fundingInstrument" with values "<expected values>"
+  When I refresh the page
+  Then the search results load
+  And the filter drawer is open
+  And the "Funding instrument" accordion is expanded
+  And the "<funding instrument>" checkbox should be checked
+  And the browser URL contains query param "fundingInstrument" with values "<expected values>"
 
 Examples:
-    | funding instrument | expected values |
-    | Grant              | grant           |
-    | Other              | other           |
+  | funding instrument | expected values |
+  | Grant              | grant           |
+  | Other              | other           |
 
 /* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
 Scenario: Retain eligibility filter after refresh
-    When I open the filter drawer
-    And the "Eligibility" accordion is expanded
-    When I check the "<eligibility>" checkbox
-    Then the browser URL contains query param "eligibility" with values "<expected values>"
-    When I refresh the page
-    Then the search results load
-    And the filter drawer is open
-    And the "Eligibility" accordion is expanded
-    And the "<eligibility>" checkbox should be checked
-    And the browser URL contains query param "eligibility" with values "<expected values>"
+  When I open the filter drawer
+  And the "Eligibility" accordion is expanded
+  When I check the "<eligibility>" checkbox
+  Then the browser URL contains query param "eligibility" with values "<expected values>"
+  When I refresh the page
+  Then the search results load
+  And the filter drawer is open
+  And the "Eligibility" accordion is expanded
+  And the "<eligibility>" checkbox should be checked
+  And the browser URL contains query param "eligibility" with values "<expected values>"
 
 Examples:
-    | eligibility         | expected values        |
-    | County Governments  | county_governments     |
-    | State Governments   | state_governments      |
+  | eligibility         | expected values     |
+  | County Governments  | county_governments  |
+  | State Governments   | state_governments   |
 
 /* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
 Scenario: Retain category filter after refresh
-    When I open the filter drawer
-    And the "Category" accordion is expanded
-    When I check the "<category>" checkbox
-    Then the browser URL contains query param "category" with values "<expected values>"
-    When I refresh the page
-    Then the search results load
-    And the filter drawer is open
-    And the "Category" accordion is expanded
-    And the "<category>" checkbox should be checked
-    And the browser URL contains query param "category" with values "<expected values>"
+  When I open the filter drawer
+  And the "Category" accordion is expanded
+  When I check the "<category>" checkbox
+  Then the browser URL contains query param "category" with values "<expected values>"
+  When I refresh the page
+  Then the search results load
+  And the filter drawer is open
+  And the "Category" accordion is expanded
+  And the "<category>" checkbox should be checked
+  And the browser URL contains query param "category" with values "<expected values>"
 
 Examples:
-    | category        | expected values |
-    | Agriculture     | agriculture     |
-    | Recovery Act    | recovery_act    |
+  | category        | expected values |
+  | Agriculture     | agriculture     |
+  | Recovery Act    | recovery_act    |

--- a/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
+++ b/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
@@ -14,8 +14,8 @@ Background:
   Given I am on the search page
   And the search results have loaded
  
- /* @tags GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION */
- Scenario: Retain status filter after refresh
+/* @tags GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION */
+Scenario: Retain status filter after refresh
     When I open the filter drawer
     And the "Opportunity status" accordion is expanded
     When I check the "<Opportunity status>" checkbox
@@ -27,13 +27,13 @@ Background:
     And the "<Opportunity status>" checkbox should be checked
     And the browser URL contains query param "status" with values "<expected statuses>"
 
-  Examples:
-      | Opportunity status | expected statuses           |
-      | Closed             | forecasted,posted,closed   |
-      | Posted             | forecasted,posted          |
+Examples:
+    | Opportunity status | expected statuses           |
+    | Closed             | forecasted,posted,closed   |
+    | Posted             | forecasted,posted          |
 
- /* @tags @GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
- Scenario: Retain funding instrument filter after refresh
+/* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+Scenario: Retain funding instrument filter after refresh
     When I open the filter drawer
     And the "Funding instrument" accordion is expanded
     When I check the "<funding instrument>" checkbox
@@ -45,13 +45,13 @@ Background:
     And the "<funding instrument>" checkbox should be checked
     And the browser URL contains query param "fundingInstrument" with values "<expected values>"
 
- Examples:
-      | funding instrument | expected values |
-      | Grant              | grant           |
-      | Other              | other           |
+Examples:
+    | funding instrument | expected values |
+    | Grant              | grant           |
+    | Other              | other           |
 
- /* @tags @GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
- Scenario Outline: Retain eligibility filter after refresh
+/* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+Scenario: Retain eligibility filter after refresh
     When I open the filter drawer
     And the "Eligibility" accordion is expanded
     When I check the "<eligibility>" checkbox
@@ -63,13 +63,13 @@ Background:
     And the "<eligibility>" checkbox should be checked
     And the browser URL contains query param "eligibility" with values "<expected values>"
 
-   Examples:
-      | eligibility         | expected values        |
-      | County Governments  | county_governments     |
-      | State Governments   | state_governments      |
+Examples:
+    | eligibility         | expected values        |
+    | County Governments  | county_governments     |
+    | State Governments   | state_governments      |
 
- /* @tags @GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
- Scenario Outline: Retain category filter after refresh
+/* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+Scenario: Retain category filter after refresh
     When I open the filter drawer
     And the "Category" accordion is expanded
     When I check the "<category>" checkbox
@@ -81,7 +81,7 @@ Background:
     And the "<category>" checkbox should be checked
     And the browser URL contains query param "category" with values "<expected values>"
 
-   Examples:
-      | category        | expected values |
-      | Agriculture     | agriculture     |
-      | Recovery Act    | recovery_act    |
+Examples:
+    | category        | expected values |
+    | Agriculture     | agriculture     |
+    | Recovery Act    | recovery_act    |

--- a/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
+++ b/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
@@ -1,0 +1,87 @@
+/**
+* @featureArea Search
+* @feature Search State Persistence
+* @specFile e2e/search/search-state/specs/search-state-persistence.spec.ts
+* @description Validates persistence of core filters after page refresh
+*/
+
+Feature: Search page - state persistence after refresh
+  As a grantee searching for opportunities
+  I want my search filters and inputs to be preserved in the URL
+  So that I can refresh the page and return to the same search state
+
+Background:
+  Given I am on the search page
+  And the search results have loaded
+ 
+ /* @tags GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION */
+ Scenario: Retain status filter after refresh
+    When I open the filter drawer
+    And the "Opportunity status" accordion is expanded
+    When I check the "<Opportunity status>" checkbox
+    Then the browser URL contains query param "status" with values "<expected statuses>"
+    When I refresh the page
+    Then the search results load
+    And the filter drawer is open
+    And the "Opportunity status" accordion is expanded
+    And the "<Opportunity status>" checkbox should be checked
+    And the browser URL contains query param "status" with values "<expected statuses>"
+
+  Examples:
+      | Opportunity status | expected statuses           |
+      | Closed             | forecasted,posted,closed   |
+      | Posted             | forecasted,posted          |
+
+ /* @tags @GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+ Scenario: Retain funding instrument filter after refresh
+    When I open the filter drawer
+    And the "Funding instrument" accordion is expanded
+    When I check the "<funding instrument>" checkbox
+    Then the browser URL contains query param "fundingInstrument" with values "<expected values>"
+    When I refresh the page
+    Then the search results load
+    And the filter drawer is open
+    And the "Funding instrument" accordion is expanded
+    And the "<funding instrument>" checkbox should be checked
+    And the browser URL contains query param "fundingInstrument" with values "<expected values>"
+
+ Examples:
+      | funding instrument | expected values |
+      | Grant              | grant           |
+      | Other              | other           |
+
+ /* @tags @GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+ Scenario Outline: Retain eligibility filter after refresh
+    When I open the filter drawer
+    And the "Eligibility" accordion is expanded
+    When I check the "<eligibility>" checkbox
+    Then the browser URL contains query param "eligibility" with values "<expected values>"
+    When I refresh the page
+    Then the search results load
+    And the filter drawer is open
+    And the "Eligibility" accordion is expanded
+    And the "<eligibility>" checkbox should be checked
+    And the browser URL contains query param "eligibility" with values "<expected values>"
+
+   Examples:
+      | eligibility         | expected values        |
+      | County Governments  | county_governments     |
+      | State Governments   | state_governments      |
+
+ /* @tags @GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+ Scenario Outline: Retain category filter after refresh
+    When I open the filter drawer
+    And the "Category" accordion is expanded
+    When I check the "<category>" checkbox
+    Then the browser URL contains query param "category" with values "<expected values>"
+    When I refresh the page
+    Then the search results load
+    And the filter drawer is open
+    And the "Category" accordion is expanded
+    And the "<category>" checkbox should be checked
+    And the browser URL contains query param "category" with values "<expected values>"
+
+   Examples:
+      | category        | expected values |
+      | Agriculture     | agriculture     |
+      | Recovery Act    | recovery_act    |

--- a/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
+++ b/frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
@@ -6,13 +6,13 @@
 */
 
 Feature: Search page - state persistence after refresh
-  As a grantee searching for opportunities
-  I want my search filters and inputs to be preserved in the URL
-  So that I can refresh the page and return to the same search state
+ As a grantee searching for opportunities
+ I want my search filters and inputs to be preserved in the URL
+ So that I can refresh the page and return to the same search state
 
 Background:
-  Given I am on the search page
-  And the search results have loaded
+ Given I am on the search page
+ And the search results have loaded
  
 /* @tags GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION */
 Scenario: Retain status filter after refresh


### PR DESCRIPTION
## Summary
Work for : Issue #10121 

## Changes proposed
- Created draft feature file that covers the existing spec file for search-state-persistence (core filters)
- Added folder : frontend/tests/e2e/search/search-state/features
- Added feature file : frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature

## Context for reviewers
- Reviewers should verify that the feature file covers the spec file

## Validation steps
- Confirm the feature file exists at: frontend/tests/e2e/search/search-state/features/search-core-filters-persistence.feature
