### PR TITLE
[Issue #10253] Update Opportunity List to Order by Created Date

### DIFF
--- a/frontend/src/app/[locale]/(base)/opportunities/page.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunities/page.tsx
@@ -389,8 +389,8 @@ async function OpportunitiesListPage(props: OpportunitiesListProps) {
       page_size: 25,
       sort_order: [
         {
-          order_by: "opportunity_title",
-          sort_direction: "ascending",
+          order_by: "created_at",
+          sort_direction: "descending",
         },
       ],
     };

--- a/frontend/src/types/search/searchRequestTypes.ts
+++ b/frontend/src/types/search/searchRequestTypes.ts
@@ -35,7 +35,8 @@ export type PaginationOrderBy =
   | "assistance_listing_number"
   | "top_level_agency_name"
   | "post_date"
-  | "close_date";
+  | "close_date"
+  | "created_at";
 export type PaginationSortDirection = "ascending" | "descending";
 export type PaginationSortOrder = {
   order_by: PaginationOrderBy;


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10253 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
-In the Opportunities `page.tsx`, updated `order_by` and `sort_direction` to `created_at` and `descending` respectively.
-In `searchRequestTypes.ts‎`, added `created_at` to the `PaginationOrderBy` definition. 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The current behavior on the Opportunity List page is that opportunities are being ordered by the Title name in ascending order. It should be updated so that opportunities are listed in order of creation, with the most recently created opportunity on top.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] Opportunities are listed in order of creation, with the most recently created opportunity on top.