### PR TITLE
[Issue #10279] Fix SOAP proxy url

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -213,6 +213,8 @@ SOAP_PRIVATE_KEYS='{"e57e1c7f-cf2e-455e-9db5-3e03650174a7": "-----BEGIN CERTIFIC
 USE_SIMPLER=true
 SOAP_PARTNER_GATEWAY_URI=http://mock-applicants-soap-api
 SOAP_PARTNER_GATEWAY_AUTH_KEY=soap_partner_gateway_auth_key
+SOAP_GRANTORS_PATH=/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort
+SOAP_APPLICANTS_PATH=/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort
 
 # Enable extra logging for soap proxy locally. This will not corresponding value
 # in lower environments. Only enabled locally.

--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -31,6 +31,8 @@ class LegacySoapAPIConfig(PydanticBaseEnvConfig):
 
     soap_partner_gateway_uri: str = Field("", alias="SOAP_PARTNER_GATEWAY_URI")
     soap_partner_gateway_auth_key: str = Field("", alias="SOAP_PARTNER_GATEWAY_AUTH_KEY")
+    soap_grantors_path: str = Field("", alias="SOAP_GRANTORS_PATH")
+    soap_applicants_path: str = Field("", alias="SOAP_APPLICANTS_PATH")
 
     @property
     def gg_url(self) -> str:

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -16,7 +16,11 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientMissingCertificate,
     generate_soap_jwt,
 )
-from src.legacy_soap_api.legacy_soap_api_config import LegacySoapAPIConfig, get_soap_config
+from src.legacy_soap_api.legacy_soap_api_config import (
+    LegacySoapAPIConfig,
+    SimplerSoapAPI,
+    get_soap_config,
+)
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
@@ -55,11 +59,12 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
     should_log_response = soap_request.headers.get(LOG_LOCAL_RESPONSE_HEADER_KEY) == "1"
     proxy_headers = get_proxy_headers(soap_request, config, soap_auth)
     if soap_auth:
-        proxy_url = join(
-            config.soap_partner_gateway_uri,
-            soap_request.full_path.lstrip("/"),
+        path = (
+            config.soap_grantors_path
+            if soap_request.api_name == SimplerSoapAPI.GRANTORS
+            else config.soap_applicants_path
         )
-        proxy_url = proxy_url.replace("grantsws-agency", "grantsws-agency-partner")
+        proxy_url = join(config.soap_partner_gateway_uri, path.lstrip("/"))
     else:
         logger.info(
             "soap_client_certificate: Sending soap request without client certificate",

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -39,7 +39,7 @@ def get_proxy_headers(
     soap_auth: SOAPAuth | None,
 ) -> dict:
     # Exclude header keys that are utilized only in simpler soap api. Not needed for proxy request.
-    if not soap_auth or not soap_auth.certificate.legacy_certificate:
+    if not soap_auth:
         return filter_headers(
             soap_request.headers, [config.gg_s2s_proxy_header_key, MTLS_CERT_HEADER_KEY]
         )
@@ -59,6 +59,7 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
             config.soap_partner_gateway_uri,
             soap_request.full_path.lstrip("/"),
         )
+        proxy_url = proxy_url.replace("grantsws-agency", "grantsws-agency-partner")
     else:
         logger.info(
             "soap_client_certificate: Sending soap request without client certificate",
@@ -68,7 +69,6 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
             soap_request.headers.get(config.gg_s2s_proxy_header_key, config.gg_url),
             soap_request.full_path.lstrip("/"),
         )
-
     _request = Request(method="POST", url=proxy_url, headers=proxy_headers, data=soap_request.data)
 
     response = _get_soap_response(_request, timeout=timeout)

--- a/api/tests/lib/data_factories.py
+++ b/api/tests/lib/data_factories.py
@@ -212,7 +212,7 @@ def create_soap_request(
         api_name=SimplerSoapAPI.GRANTORS,
         headers=headers,
         data=SoapRequestStreamer(stream=io.BytesIO(soap_payload)),
-        full_path="/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort",
+        full_path="/grantsws-agency/services/v2/AgencyWebServicesSoapPort",
         method="POST",
         auth=SOAPAuth(certificate=soap_certificate),
         operation_name=operation_name,

--- a/api/tests/lib/data_factories.py
+++ b/api/tests/lib/data_factories.py
@@ -199,6 +199,8 @@ def create_soap_request(
     soap_payload: bytes,
     log_local: bool = False,
     operation_name: str = "GetApplicationZipRequest",
+    full_path="/grantsws-agency/services/v2/AgencyWebServicesSoapPort",
+    api_name=SimplerSoapAPI.GRANTORS,
 ) -> SOAPRequest:
     _, _, soap_certificate, _ = setup_cert_user(
         AgencyFactory.create(), [Privilege.LEGACY_AGENCY_VIEWER]
@@ -209,10 +211,10 @@ def create_soap_request(
     if log_local:
         headers.update({f"{LOG_LOCAL_RESPONSE_HEADER_KEY}": "1"})
     return SOAPRequest(
-        api_name=SimplerSoapAPI.GRANTORS,
+        api_name=api_name,
         headers=headers,
         data=SoapRequestStreamer(stream=io.BytesIO(soap_payload)),
-        full_path="/grantsws-agency/services/v2/AgencyWebServicesSoapPort",
+        full_path=full_path,
         method="POST",
         auth=SOAPAuth(certificate=soap_certificate),
         operation_name=operation_name,

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -12,7 +12,11 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientMissingCertificate,
 )
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
-from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response, get_soap_jwt_auth_jwt
+from src.legacy_soap_api.legacy_soap_api_proxy import (
+    get_proxy_headers,
+    get_proxy_response,
+    get_soap_jwt_auth_jwt,
+)
 from tests.lib.data_factories import create_soap_request
 
 SOAP_PAYLOAD = (
@@ -97,10 +101,39 @@ def test_request_gets_correct_proxy_url_when_no_auth(enable_factory_create):
     soap_request.auth = None
     with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as mock_request:
         get_proxy_response(soap_request)
-        expected = (
-            "https://google.com/xyz/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort"
-        )
+        expected = f"https://google.com/xyz/{soap_request.full_path.lstrip('/')}"
         assert mock_request.call_args_list[0][0][0].url == expected
+
+
+def test_request_gets_correct_proxy_url_when_request_has_auth(enable_factory_create, monkeypatch):
+    soap_request = create_soap_request(SOAP_PAYLOAD)
+    with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as mock_request:
+        get_proxy_response(soap_request)
+        config = get_soap_config()
+        expected = f"{config.soap_partner_gateway_uri}/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort"
+        assert mock_request.call_args_list[0][0][0].url == expected
+
+
+def test_request_gets_correct_proxy_headers_when_no_auth(enable_factory_create):
+    soap_request = create_soap_request(SOAP_PAYLOAD)
+    soap_request.auth = None
+    soap_request.headers = {"X-Gg-S2S-Uri": "https://google.com/xyz", "x": "1"}
+    config = get_soap_config()
+    headers = get_proxy_headers(soap_request, config, soap_request.auth)
+    expected = {"x": "1"}
+    assert headers == expected
+
+
+def test_request_gets_correct_proxy_headers_when_there_is_auth(enable_factory_create):
+    soap_request = create_soap_request(SOAP_PAYLOAD)
+    config = get_soap_config()
+    with patch(
+        "src.legacy_soap_api.legacy_soap_api_proxy.generate_soap_jwt"
+    ) as mock_generate_soap_jwt:
+        mock_generate_soap_jwt.return_value = "123456"
+        headers = get_proxy_headers(soap_request, config, soap_request.auth)
+        expected = {"S2S_PARTNER_CERTID_JWT_B64": "MTIzNDU2"}
+        assert headers == expected
 
 
 def test_request_logs_locally(enable_factory_create, caplog):

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -11,7 +11,7 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
     SOAPClientCertificate,
     SOAPClientMissingCertificate,
 )
-from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
+from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI, get_soap_config
 from src.legacy_soap_api.legacy_soap_api_proxy import (
     get_proxy_headers,
     get_proxy_response,
@@ -101,16 +101,40 @@ def test_request_gets_correct_proxy_url_when_no_auth(enable_factory_create):
     soap_request.auth = None
     with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as mock_request:
         get_proxy_response(soap_request)
-        expected = f"https://google.com/xyz/{soap_request.full_path.lstrip('/')}"
+        expected = "https://google.com/xyz/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
         assert mock_request.call_args_list[0][0][0].url == expected
 
 
-def test_request_gets_correct_proxy_url_when_request_has_auth(enable_factory_create, monkeypatch):
+def test_request_gets_correct_proxy_url_when_request_has_auth_for_grantors(enable_factory_create):
     soap_request = create_soap_request(SOAP_PAYLOAD)
     with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as mock_request:
         get_proxy_response(soap_request)
         config = get_soap_config()
         expected = f"{config.soap_partner_gateway_uri}/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort"
+        assert mock_request.call_args_list[0][0][0].url == expected
+
+
+def test_request_gets_correct_proxy_url_when_request_has_auth_for_applicants(enable_factory_create):
+    soap_payload = """
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:app="http://apply.grants.gov/services/ApplicantWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0" xmlns:app1="http://apply.grants.gov/system/ApplicantCommonElements-V1.0">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <app:GetOpportunityListRequest>
+     <gran:PackageID>PKG00116771</gran:PackageID>
+      </app:GetOpportunityListRequest>
+   </soapenv:Body>
+</soapenv:Envelope>
+""".encode()
+    soap_request = create_soap_request(
+        soap_payload,
+        operation_name="GetOpportunityList",
+        full_path="/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort",
+        api_name=SimplerSoapAPI.APPLICANTS,
+    )
+    with patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response") as mock_request:
+        get_proxy_response(soap_request)
+        config = get_soap_config()
+        expected = f"{config.soap_partner_gateway_uri}/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort"
         assert mock_request.call_args_list[0][0][0].url == expected
 
 

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -104,6 +104,16 @@ locals {
       secret_store_name = "/api/${var.environment}/soap-partner-gateway-uri"
     }
 
+    SOAP_GRANTORS_PATH = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/soap-grantors-path"
+    }
+
+    SOAP_APPLICANTS_PATH = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/soap-applicants-path"
+    }
+
     SOAP_PARTNER_GATEWAY_AUTH_KEY = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/soap-partner-gateway-auth-key"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10279  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Updated the `proxy_url` calculated from data in the AWS Parameter Store.
Removed check for `legacy_certificate` on the headers. This is no longer functionality we want to check. 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The url was incorrect so JWT path was failing. This should correct that.
If there's no `legacy_certificate` on on the `SOAPAuth` it should still use JWT.

If we go with env variables, these will need to be added to each env before merge and deploy.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] hit url in lower env and get correct response
