### PR TITLE
test(frontend): add unit tests for useSnackbar hook (closes #9812)

### DIFF
--- a/frontend/src/hooks/useSnackbar.test.ts
+++ b/frontend/src/hooks/useSnackbar.test.ts
@@ -1,0 +1,98 @@
+import { act, renderHook } from "@testing-library/react";
+import { useSnackbar } from "src/hooks/useSnackbar";
+
+describe("useSnackbar", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it("starts hidden", () => {
+    const { result } = renderHook(() => useSnackbar());
+
+    expect(result.current.snackbarIsVisible).toBe(false);
+  });
+
+  it("becomes visible when showSnackbar is called", () => {
+    const { result } = renderHook(() => useSnackbar());
+
+    act(() => {
+      result.current.showSnackbar();
+    });
+
+    expect(result.current.snackbarIsVisible).toBe(true);
+  });
+
+  it("auto-hides after the default visible time (6000 ms)", () => {
+    const { result } = renderHook(() => useSnackbar());
+
+    act(() => {
+      result.current.showSnackbar();
+    });
+    expect(result.current.snackbarIsVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(5999);
+    });
+    expect(result.current.snackbarIsVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.snackbarIsVisible).toBe(false);
+  });
+
+  it("respects a custom visible time", () => {
+    const { result } = renderHook(() => useSnackbar());
+
+    act(() => {
+      result.current.showSnackbar(2000);
+    });
+    expect(result.current.snackbarIsVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.snackbarIsVisible).toBe(false);
+  });
+
+  it("does not schedule auto-hide when visibleTime is zero", () => {
+    const { result } = renderHook(() => useSnackbar());
+
+    act(() => {
+      result.current.showSnackbar(0);
+    });
+    expect(result.current.snackbarIsVisible).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+    expect(result.current.snackbarIsVisible).toBe(true);
+  });
+
+  it("hideSnackbar sets visibility to false", () => {
+    const { result } = renderHook(() => useSnackbar());
+
+    act(() => {
+      result.current.showSnackbar();
+    });
+    expect(result.current.snackbarIsVisible).toBe(true);
+
+    act(() => {
+      result.current.hideSnackbar();
+    });
+    expect(result.current.snackbarIsVisible).toBe(false);
+  });
+
+  it("exposes the Snackbar component on the returned object", () => {
+    const { result } = renderHook(() => useSnackbar());
+
+    expect(result.current.Snackbar).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #9812

`src/hooks/useSnackbar.ts` had no sibling test, so the auto-hide-after-timeout behavior was uncovered. This PR adds `src/hooks/useSnackbar.test.ts`, modeled on the existing `src/hooks/usePrevious.test.ts`, using `renderHook` + `jest.useFakeTimers()`. Coverage on the source goes from 0 to 100% (statements, branches, functions, lines).

## Changes proposed

Adds 7 unit tests covering:

- starts hidden
- becomes visible when `showSnackbar` is called
- auto-hides at exactly the default 6000 ms boundary (5999 ms still visible, 6000 ms hidden)
- respects a custom `visibleTime`
- skips auto-hide when `visibleTime` is 0 (waits 60 s, still visible)
- `hideSnackbar` returns to hidden
- exposes the `Snackbar` component on the returned object

## Context for reviewers

- File path matches the issue ask exactly: `frontend/src/hooks/useSnackbar.test.ts`.
- Pattern mirrors `frontend/src/hooks/usePrevious.test.ts`: `renderHook` from `@testing-library/react`, no extra setup hooks beyond `jest.useFakeTimers`.
- No source change; only the new spec file. `lint` is clean for the new file (the 32 pre-existing project-wide warnings are unrelated). `format-check` passes on the whole tree.

## Validation steps

```
cd frontend
npm install
npm run test -- useSnackbar
```

Expected: `Tests: 7 passed, 7 total` and coverage `useSnackbar.ts | 100 | 100 | 100 | 100`.

## Linked issue

Closes #9812
