### PR TITLE
[Issue #7960] Audit and adjust our DB user privileges

### DIFF
--- a/bin/create-or-update-database-roles
+++ b/bin/create-or-update-database-roles
@@ -21,7 +21,14 @@ terraform -chdir="infra/${app_name}/app-config" apply -auto-approve > /dev/null
 ./bin/terraform-init "infra/${app_name}/database" "${environment}"
 db_role_manager_function_name=$(terraform -chdir="infra/${app_name}/database" output -raw role_manager_function_name)
 db_config=$(terraform -chdir="infra/${app_name}/app-config" output -json environment_configs | jq -r ".${environment}.database_config")
-payload="{\"action\":\"manage\",\"config\":${db_config}}"
+
+# Build list of schemas to configure: primary schema + any additional schemas
+primary_schema=$(echo "${db_config}" | jq -r '.schema_name')
+additional_schemas=$(echo "${db_config}" | jq -r '.additional_schema_names // [] | .[]')
+all_schemas="${primary_schema}"
+if [ -n "${additional_schemas}" ]; then
+  all_schemas=$(printf '%s\n%s' "${primary_schema}" "${additional_schemas}")
+fi
 
 echo "================================"
 echo "Creating/updating database users"
@@ -29,27 +36,39 @@ echo "================================"
 echo "Input parameters"
 echo "  app_name=${app_name}"
 echo "  environment=${environment}"
+echo "  schemas=${all_schemas//$'\n'/, }"
 echo
-echo "Invoking Lambda function: ${db_role_manager_function_name}"
-echo "  Payload: ${payload}"
-echo
-cli_response=$(aws lambda invoke \
-  --function-name "${db_role_manager_function_name}" \
-  --no-cli-pager \
-  --log-type Tail \
-  --payload "$(echo -n "${payload}" | base64)" \
-  --output json \
-  response.json)
 
-# Print logs out (they are returned base64 encoded)
-echo "${cli_response}" | jq -r '.LogResult' | base64 --decode
-echo
-echo "Lambda function response:"
-cat response.json
-rm response.json
+# Invoke the role manager lambda once per schema
+for schema in ${all_schemas}; do
+  schema_config=$(echo "${db_config}" | jq --arg schema "${schema}" '.schema_name = $schema')
+  payload="{\"action\":\"manage\",\"config\":${schema_config}}"
 
-# Exit with nonzero status if function failed
-function_error=$(echo "${cli_response}" | jq -r '.FunctionError')
-if [ "${function_error}" != "null" ]; then
-  exit 1
-fi
+  echo "--------------------------------"
+  echo "Configuring schema: ${schema}"
+  echo "--------------------------------"
+  echo "Invoking Lambda function: ${db_role_manager_function_name}"
+  echo "  Payload: ${payload}"
+  echo
+  cli_response=$(aws lambda invoke \
+    --function-name "${db_role_manager_function_name}" \
+    --no-cli-pager \
+    --log-type Tail \
+    --payload "$(echo -n "${payload}" | base64)" \
+    --output json \
+    response.json)
+
+  # Print logs out (they are returned base64 encoded)
+  echo "${cli_response}" | jq -r '.LogResult' | base64 --decode
+  echo
+  echo "Lambda function response:"
+  cat response.json
+  rm response.json
+
+  # Exit with nonzero status if function failed
+  function_error=$(echo "${cli_response}" | jq -r '.FunctionError')
+  if [ "${function_error}" != "null" ]; then
+    exit 1
+  fi
+  echo
+done

--- a/bin/run-setup-foreign-tables
+++ b/bin/run-setup-foreign-tables
@@ -20,12 +20,21 @@ echo "  app_name=${app_name}"
 echo "  environment=${environment}"
 echo
 
+./bin/terraform-init "infra/${app_name}/app-config" "${environment}"
+db_migrator_user=$(terraform -chdir="infra/${app_name}/app-config" output -json environment_configs | jq -r ".${environment}.database_config.migrator_username")
+
 ./bin/terraform-init "infra/${app_name}/service" "${environment}"
 migrator_role_arn=$(terraform -chdir="infra/${app_name}/service" output -raw migrator_role_arn)
 
 echo "Using migrator role: ${migrator_role_arn}"
+echo "Using migrator DB user: ${db_migrator_user}"
 echo
 
 command='["poetry", "run", "flask", "data-migration", "setup-foreign-tables"]'
 
-./bin/run-command --task-role-arn "${migrator_role_arn}" "${app_name}" "${environment}" "${command}"
+environment_variables=$(cat << EOF
+[{ "name" : "DB_USER", "value" : "${db_migrator_user}" }]
+EOF
+)
+
+./bin/run-command --task-role-arn "${migrator_role_arn}" --environment-variables "${environment_variables}" "${app_name}" "${environment}" "${command}"

--- a/infra/api/app-config/env-config/database.tf
+++ b/infra/api/app-config/env-config/database.tf
@@ -5,6 +5,7 @@ locals {
     app_username                = "app"
     migrator_username           = "migrator"
     schema_name                 = "app"
+    additional_schema_names     = ["legacy", "staging"]
     instance_count              = var.database_instance_count
     max_capacity                = var.database_max_capacity
     enable_http_endpoint        = var.database_enable_http_endpoint

--- a/infra/modules/database/role_manager/manage.py
+++ b/infra/modules/database/role_manager/manage.py
@@ -17,7 +17,7 @@ def manage(config: dict):
         roles, schema_privileges = print_current_db_config(master_conn)
         roles_with_groups = get_roles_with_groups(master_conn)
 
-    configure_default_privileges()
+    configure_default_privileges(config)
 
     return {
         "roles": roles,
@@ -75,33 +75,12 @@ def get_schema_privileges(conn: Connection) -> list[tuple[str, str]]:
     ]
 
 
-def get_all_schema_names(conn: Connection, primary_schema: str) -> list[str]:
-    """Discover all application schemas in the database.
-
-    Returns the primary schema first, followed by any other non-system schemas.
-    """
-    rows = db.execute(
-        conn,
-        """
-        SELECT nspname
-        FROM pg_namespace
-        WHERE nspname NOT LIKE 'pg_%'
-        AND nspname NOT IN ('information_schema', 'public')
-        ORDER BY nspname
-        """,
-        print_query=False,
-    )
-    schemas = [row[0] for row in rows]
-    if primary_schema in schemas:
-        schemas.remove(primary_schema)
-    return [primary_schema] + schemas
-
-
 def configure_database(conn: Connection, config: dict) -> None:
     print("-- Configuring database")
     app_username = os.environ.get("APP_USER")
     migrator_username = os.environ.get("MIGRATOR_USER")
-    schema_name = os.environ.get("DB_SCHEMA")
+    schema_name = config.get("schema_name", os.environ.get("DB_SCHEMA"))
+    primary_schema = os.environ.get("DB_SCHEMA")
     database_name = os.environ.get("DB_NAME")
 
     # In Postgres 15 and higher, the CREATE privilege on the public
@@ -113,17 +92,17 @@ def configure_database(conn: Connection, config: dict) -> None:
 
     print("---- Revoking database access from public role")
     db.execute(conn, f"REVOKE ALL ON DATABASE {identifier(database_name)} FROM PUBLIC")
-    print(f"---- Setting default search path to schema {schema_name}")
-    db.execute(
-        conn,
-        f"ALTER DATABASE {identifier(database_name)} SET search_path TO {identifier(schema_name)}",
-    )
+
+    # Only set the search path for the primary schema
+    if schema_name == primary_schema:
+        print(f"---- Setting default search path to schema {schema_name}")
+        db.execute(
+            conn,
+            f"ALTER DATABASE {identifier(database_name)} SET search_path TO {identifier(schema_name)}",
+        )
 
     configure_roles(conn, [migrator_username, app_username], database_name)
-
-    for s in get_all_schema_names(conn, schema_name):
-        configure_schema(conn, s, migrator_username, app_username)
-
+    configure_schema(conn, schema_name, migrator_username, app_username)
     configure_superuser_extensions(conn, config["superuser_extensions"])
 
 
@@ -225,7 +204,7 @@ def fix_schema_object_ownership(conn: Connection, schema_name: str, migrator_use
     )
 
 
-def configure_default_privileges():
+def configure_default_privileges(config: dict):
     """
     Configure default privileges so that future tables, sequences, and routines
     created by the migrator user can be accessed by the app user.
@@ -233,23 +212,22 @@ def configure_default_privileges():
     run these SQL queries as the migrator user rather than as the master user.
     """
     migrator_username = os.environ.get("MIGRATOR_USER")
-    schema_name = os.environ.get("DB_SCHEMA")
+    schema_name = config.get("schema_name", os.environ.get("DB_SCHEMA"))
     app_username = os.environ.get("APP_USER")
     with db.connect_using_iam(migrator_username) as conn:
-        for s in get_all_schema_names(conn, schema_name):
-            print(f"------ Granting default privileges for future objects in schema {s}: grantee={app_username}")
-            db.execute(
-                conn,
-                f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(s)} GRANT ALL ON TABLES TO {identifier(app_username)}",
-            )
-            db.execute(
-                conn,
-                f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(s)} GRANT ALL ON SEQUENCES TO {identifier(app_username)}",
-            )
-            db.execute(
-                conn,
-                f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(s)} GRANT ALL ON ROUTINES TO {identifier(app_username)}",
-            )
+        print(f"------ Granting default privileges for future objects in schema {schema_name}: grantee={app_username}")
+        db.execute(
+            conn,
+            f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON TABLES TO {identifier(app_username)}",
+        )
+        db.execute(
+            conn,
+            f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON SEQUENCES TO {identifier(app_username)}",
+        )
+        db.execute(
+            conn,
+            f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON ROUTINES TO {identifier(app_username)}",
+        )
 
 
 def print_current_db_config(

--- a/infra/modules/database/role_manager/manage.py
+++ b/infra/modules/database/role_manager/manage.py
@@ -75,6 +75,28 @@ def get_schema_privileges(conn: Connection) -> list[tuple[str, str]]:
     ]
 
 
+def get_all_schema_names(conn: Connection, primary_schema: str) -> list[str]:
+    """Discover all application schemas in the database.
+
+    Returns the primary schema first, followed by any other non-system schemas.
+    """
+    rows = db.execute(
+        conn,
+        """
+        SELECT nspname
+        FROM pg_namespace
+        WHERE nspname NOT LIKE 'pg_%'
+        AND nspname NOT IN ('information_schema', 'public')
+        ORDER BY nspname
+        """,
+        print_query=False,
+    )
+    schemas = [row[0] for row in rows]
+    if primary_schema in schemas:
+        schemas.remove(primary_schema)
+    return [primary_schema] + schemas
+
+
 def configure_database(conn: Connection, config: dict) -> None:
     print("-- Configuring database")
     app_username = os.environ.get("APP_USER")
@@ -98,7 +120,10 @@ def configure_database(conn: Connection, config: dict) -> None:
     )
 
     configure_roles(conn, [migrator_username, app_username], database_name)
-    configure_schema(conn, schema_name, migrator_username, app_username)
+
+    for s in get_all_schema_names(conn, schema_name):
+        configure_schema(conn, s, migrator_username, app_username)
+
     configure_superuser_extensions(conn, config["superuser_extensions"])
 
 
@@ -131,7 +156,7 @@ def configure_role(conn: Connection, username: str, database_name: str) -> None:
 
 
 def configure_schema(conn: Connection, schema_name: str, migrator_username: str, app_username: str) -> None:
-    print("---- Configuring schema")
+    print(f"---- Configuring schema: {schema_name}")
     print(f"------ Creating schema: {schema_name=}")
     db.execute(conn, f"CREATE SCHEMA IF NOT EXISTS {identifier(schema_name)}")
     print(f"------ Changing schema owner: new_owner={migrator_username}")
@@ -143,6 +168,60 @@ def configure_schema(conn: Connection, schema_name: str, migrator_username: str,
     db.execute(
         conn,
         f"GRANT USAGE ON SCHEMA {identifier(schema_name)} TO {identifier(app_username)}",
+    )
+    print(f"------ Revoking CREATE on schema: revokee={app_username}")
+    db.execute(
+        conn,
+        f"REVOKE CREATE ON SCHEMA {identifier(schema_name)} FROM {identifier(app_username)}",
+    )
+
+    print(f"------ Granting privileges on existing objects in schema: grantee={app_username}")
+    db.execute(
+        conn,
+        f"GRANT ALL ON ALL TABLES IN SCHEMA {identifier(schema_name)} TO {identifier(app_username)}",
+    )
+    db.execute(
+        conn,
+        f"GRANT ALL ON ALL SEQUENCES IN SCHEMA {identifier(schema_name)} TO {identifier(app_username)}",
+    )
+    db.execute(
+        conn,
+        f"GRANT ALL ON ALL ROUTINES IN SCHEMA {identifier(schema_name)} TO {identifier(app_username)}",
+    )
+
+    fix_schema_object_ownership(conn, schema_name, migrator_username)
+
+
+def fix_schema_object_ownership(conn: Connection, schema_name: str, migrator_username: str) -> None:
+    """Reassign ownership of any tables, foreign tables, sequences, and views
+    in the schema that are not already owned by the migrator user."""
+    print(f"------ Fixing object ownership in schema {schema_name}: new_owner={migrator_username}")
+    db.execute(
+        conn,
+        f"""
+        DO $$
+        DECLARE
+            r RECORD;
+        BEGIN
+            FOR r IN
+                SELECT c.relname, c.relkind
+                FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                JOIN pg_roles o ON o.oid = c.relowner
+                WHERE n.nspname = '{schema_name}'
+                AND o.rolname != '{migrator_username}'
+                AND c.relkind IN ('r', 'f', 'S', 'v')
+            LOOP
+                IF r.relkind = 'S' THEN
+                    EXECUTE format('ALTER SEQUENCE %I.%I OWNER TO %I', '{schema_name}', r.relname, '{migrator_username}');
+                ELSE
+                    EXECUTE format('ALTER TABLE %I.%I OWNER TO %I', '{schema_name}', r.relname, '{migrator_username}');
+                END IF;
+                RAISE NOTICE 'Changed owner of %.% to {migrator_username}', '{schema_name}', r.relname;
+            END LOOP;
+        END
+        $$;
+        """,
     )
 
 
@@ -157,19 +236,20 @@ def configure_default_privileges():
     schema_name = os.environ.get("DB_SCHEMA")
     app_username = os.environ.get("APP_USER")
     with db.connect_using_iam(migrator_username) as conn:
-        print(f"------ Granting privileges for future objects in schema: grantee={app_username}")
-        db.execute(
-            conn,
-            f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON TABLES TO {identifier(app_username)}",
-        )
-        db.execute(
-            conn,
-            f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON SEQUENCES TO {identifier(app_username)}",
-        )
-        db.execute(
-            conn,
-            f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(schema_name)} GRANT ALL ON ROUTINES TO {identifier(app_username)}",
-        )
+        for s in get_all_schema_names(conn, schema_name):
+            print(f"------ Granting default privileges for future objects in schema {s}: grantee={app_username}")
+            db.execute(
+                conn,
+                f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(s)} GRANT ALL ON TABLES TO {identifier(app_username)}",
+            )
+            db.execute(
+                conn,
+                f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(s)} GRANT ALL ON SEQUENCES TO {identifier(app_username)}",
+            )
+            db.execute(
+                conn,
+                f"ALTER DEFAULT PRIVILEGES IN SCHEMA {identifier(s)} GRANT ALL ON ROUTINES TO {identifier(app_username)}",
+            )
 
 
 def print_current_db_config(


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #7960  

## Changes proposed

- Updated run-setup-foreign-tables to add `DB_USER` env var override to connect as migrator instead of app
- Updated manage.py to do the following:
  - Add `get_all_schema_names()` to dynamically discover schemas by querying `pg_namespace`
  - Updated `configure_database()` to loop over all schemas instead of just the primary one
  - Updated `configure_schema()` to revoke CREATE from app, grant on existing objects, and fix object ownership
  - Add `fix_schema_object_ownership()` to reassign to reassign tables/foreign tables/sequences/views not owned by migrator
  - Updated `configure_default_privileges()` to set default privileges for all discovered schemas


## Context for reviewers

We audited DB user privileges across api-dev and api-prod and found that the legacy schema and all 31 foreign tables within it are owned by root or app instead of migrator. The app user also has CREATE privilege on the legacy schema, which it shouldn't. This happened because `setup-foreign-tables` was using the migrator IAM role but never overrode `DB_USER`, so it connected to Postgres as app. The original batch of foreign tables was created by root directly.

The role manager lambda previously only configured the primary api schema — legacy and staging were never managed. These changes make the role manager discover and configure all schemas on every deploy, and fix existing ownership. See the ticket for the full audit tables

## Validation steps

- Deploy to dev and verify the role manager lambda logs show it discovering and configuring api, legacy, staging, and EGRANTSADMIN schemas
- Re-run audit queries against api-dev to confirm fixes. Connect to the app database via RDS Query Editor:
  - Schema ownership and privileges - verify legacy is owned by migrator and app only has USAGE (no CREATE):
    ```
      SELECT nspname, nspowner::regrole::text, nspacl::text[]
      FROM pg_namespace
      WHERE nspname NOT LIKE 'pg_%'
      AND nspname NOT IN ('information_schema', 'public');
    ```
  - Foreign table ownership - verify all tables in legacy are owned by migrator:
    ```
      SELECT c.relname, c.relkind::text, pg_roles.rolname AS owner
      FROM pg_class c
      JOIN pg_namespace n ON n.oid = c.relnamespace
      JOIN pg_roles ON pg_roles.oid = c.relowner
      WHERE n.nspname = 'legacy'
      ORDER BY c.relname;
    ```
  - Default privileges - verify migrator has schema-scoped default privileges for legacy and staging:
    ```
      SELECT pg_roles.rolname, nspname, defaclobjtype::text, defaclacl::text[]
      FROM pg_default_acl
      JOIN pg_namespace ON pg_namespace.oid = defaclnamespace
      JOIN pg_roles ON pg_roles.oid = defaclrole;
    ```
- Verify the API application still functions normally (app can still read/write all tables)
- Run `setup-foreign-tables` in dev to confirm it connects as migrator
- Repeat audit queries against api-prod after prod deploy
  