### PR TITLE
[Unticketed] Misc test cleanup on the backend

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -121,7 +121,7 @@ target-version = "py314"
 
 [tool.ruff.lint]
 # See: https://docs.astral.sh/ruff/rules/ for all possible rules
-select = ["B", "C", "E", "F", "W", "B9", "UP", "RUF", "PT", "TID251"]
+select = ["B", "C", "E", "F", "W", "B9", "UP", "RUF", "PT", "TID251", "T20"]
 ignore = [
     # too many leading '#' for block comment, we can format our comments however we want
     "E266",
@@ -198,6 +198,15 @@ allowed-confusables = [
     # but the few places we do this are kept simple and help better organize complex scenarios
     "PT018"
 ]
+
+# While we generally don't want print statements anywhere in our code
+# We make exceptions for some scripts that run only locally if it helps
+# us format information better.
+"tool/console/interactive.py" = ["T201"]
+"tests/lib/seed_local_soap_certificate.py" = ["T201"]
+"src/task/forms/list_forms_task.py" = ["T201"]
+"src/form_schema/dat_to_jsonschema_cli.py" = ["T201"]
+
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 # For these libraries, we do use them, but have our own derived versions we want

--- a/api/src/task/opportunities/set_current_opportunities_task.py
+++ b/api/src/task/opportunities/set_current_opportunities_task.py
@@ -62,7 +62,7 @@ class SetCurrentOpportunitiesTask(Task):
             self._process_opportunities()
 
     def _process_opportunities(self) -> None:
-        # This selectinload significantly imrproves performance as it tells SQLAlchemy
+        # This selectinload significantly improves performance as it tells SQLAlchemy
         # to fetch all summaries+current opportunity summaries rather than lazy loading
         # them as needed.
         opportunities = self.db_session.scalars(

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -26,13 +26,12 @@ from src.constants.lookup_constants import Privilege, RoleType
 from src.constants.schema import Schemas
 from src.constants.static_role_values import NAVA_INTERNAL_ROLE
 from src.db import models
-from src.db.models.agency_models import Agency
 from src.db.models.competition_models import FormInstruction
 from src.db.models.foreign import metadata as foreign_metadata
 from src.db.models.lookup.sync_lookup_values import sync_lookup_values
 from src.db.models.opportunity_models import Opportunity
 from src.db.models.staging import metadata as staging_metadata
-from src.db.models.user_models import AgencyUser, User, UserApiKey
+from src.db.models.user_models import User, UserApiKey
 from src.form_schema.forms import get_active_forms
 from src.form_schema.jsonschema_resolver import resolve_jsonschema
 from src.util.local import load_local_env_vars
@@ -570,11 +569,6 @@ class BaseTestClass:
         class implementation.
         """
         cascade_delete_from_db_table(db_session, Opportunity)
-
-    @pytest.fixture(scope="class")
-    def truncate_agencies(self, db_session):
-        cascade_delete_from_db_table(db_session, AgencyUser)
-        cascade_delete_from_db_table(db_session, Agency)
 
     @pytest.fixture(scope="class")
     def truncate_staging_tables(self, db_session, test_staging_schema):

--- a/api/tests/src/api/agencies_v1/test_agency_auth.py
+++ b/api/tests/src/api/agencies_v1/test_agency_auth.py
@@ -95,7 +95,6 @@ def test_agency_search_unauthorized_401_no_auth(client, method, url, body):
 def test_agency_search_with_inactive_api_user_key(client, enable_factory_create, db_session):
     """Test agency search endpoint with inactive API user key"""
     inactive_api_key = UserApiKeyFactory.create(is_active=False)
-    db_session.commit()
 
     response = client.post(
         "/v1/agencies/search",

--- a/api/tests/src/api/applications/test_application_submissions_list.py
+++ b/api/tests/src/api/applications/test_application_submissions_list.py
@@ -30,8 +30,6 @@ def test_application_submissions_list_success_jwt_auth(
     submission1 = ApplicationSubmissionFactory.create(application=application)
     submission2 = ApplicationSubmissionFactory.create(application=application)
 
-    db_session.commit()
-
     request_data = {
         "pagination": {
             "page_offset": 1,
@@ -86,8 +84,6 @@ def test_application_submissions_list_success_api_key_auth(
     # Create a submission
     submission = ApplicationSubmissionFactory.create(application=application)
 
-    db_session.commit()
-
     request_data = {
         "pagination": {
             "page_offset": 1,
@@ -121,8 +117,6 @@ def test_application_submissions_list_empty(
         application_user=ApplicationUserFactory.create(user=user, application=application),
         role=RoleFactory.create(privileges=[Privilege.VIEW_APPLICATION]),
     )
-
-    db_session.commit()
 
     request_data = {
         "pagination": {
@@ -172,8 +166,6 @@ def test_application_submissions_list_forbidden(
     application = ApplicationFactory.create()
 
     # User is NOT associated with application - should get 403
-    db_session.commit()
-
     request_data = {
         "pagination": {
             "page_offset": 1,
@@ -228,10 +220,7 @@ def test_application_submissions_list_pagination(
     )
 
     # Create 5 submissions
-    for _ in range(5):
-        ApplicationSubmissionFactory.create(application=application)
-
-    db_session.commit()
+    ApplicationSubmissionFactory.create_batch(size=5, application=application)
 
     # Request page 1 with page size 2
     request_data = {
@@ -295,8 +284,6 @@ def test_application_submissions_list_default_sort(
     # Create submissions
     ApplicationSubmissionFactory.create(application=application)
 
-    db_session.commit()
-
     # Request without explicit sort order (should use default)
     request_data = {
         "pagination": {
@@ -330,10 +317,7 @@ def test_application_submissions_list_ascending_sort(
     )
 
     # Create submissions
-    ApplicationSubmissionFactory.create(application=application)
-    ApplicationSubmissionFactory.create(application=application)
-
-    db_session.commit()
+    ApplicationSubmissionFactory.create_batch(size=2, application=application)
 
     request_data = {
         "pagination": {
@@ -366,8 +350,6 @@ def test_application_submissions_list_invalid_sort_field(
         application_user=ApplicationUserFactory.create(user=user, application=application),
         role=RoleFactory.create(privileges=[Privilege.VIEW_APPLICATION]),
     )
-
-    db_session.commit()
 
     request_data = {
         "pagination": {

--- a/api/tests/src/api/competition_alpha/test_competition_update_flag.py
+++ b/api/tests/src/api/competition_alpha/test_competition_update_flag.py
@@ -23,7 +23,6 @@ def test_update_competition_flag_to_true_success(
 
     competition = factories.CompetitionFactory.create(is_simpler_grants_enabled=False)
     factories.CompetitionInstructionFactory.create(competition=competition)
-    db_session.commit()
 
     payload = {"is_simpler_grants_enabled": True}
     url = f"/alpha/competitions/{competition.competition_id}/flag"
@@ -43,7 +42,6 @@ def test_update_competition_flag_to_false_success(
 
     competition = factories.CompetitionFactory.create(is_simpler_grants_enabled=True)
     factories.CompetitionInstructionFactory.create(competition=competition)
-    db_session.commit()
 
     payload = {"is_simpler_grants_enabled": False}
     url = f"/alpha/competitions/{competition.competition_id}/flag"

--- a/api/tests/src/api/internal/test_internal_routes.py
+++ b/api/tests/src/api/internal/test_internal_routes.py
@@ -30,7 +30,7 @@ def setup_admin_privileges(db_session, api_key_value):
     factories.LinkRoleRoleTypeFactory.create(role=admin_role, role_type=RoleType.INTERNAL)
 
     factories.InternalUserRoleFactory.create(user=user, role=admin_role)
-    db_session.commit()
+
     return user
 
 
@@ -47,7 +47,6 @@ def test_update_internal_role_success(
     external_link = factories.LinkExternalUserFactory.create(
         user=target_user, email="success@test.org"
     )
-    db_session.commit()
 
     payload = {"user_email": external_link.email, "internal_role_id": str(role_to_assign.role_id)}
 
@@ -72,7 +71,6 @@ def test_update_internal_role_not_found(
 
     target_user = factories.UserFactory.create()
     external_link = factories.LinkExternalUserFactory.create(user=target_user, email="404@test.org")
-    db_session.commit()
 
     payload = {"user_email": external_link.email, "internal_role_id": str(uuid.uuid4())}
 
@@ -98,7 +96,6 @@ def test_update_internal_role_already_assigned(
     )
 
     factories.InternalUserRoleFactory.create(user=target_user, role=role)
-    db_session.commit()
 
     payload = {"user_email": external_link.email, "internal_role_id": str(role.role_id)}
 

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_attachments.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_attachments.py
@@ -30,8 +30,6 @@ def existing_opportunity(grantor_auth_data, enable_factory_create):
 @pytest.fixture
 def existing_attachment(db_session, existing_opportunity, enable_factory_create, mock_s3_bucket):
     """Create an attachment for the opportunity"""
-    print(f"Creating attachment for opportunity ID: {existing_opportunity.opportunity_id}")
-
     attachment = opportunity_models.OpportunityAttachment(
         attachment_id=uuid.uuid4(),
         legacy_attachment_id=12345,

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_list.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_list.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 
 import pytest
@@ -235,8 +234,6 @@ def test_list_opportunities_invalid_token(client, db_session, grantor_auth_data)
 
 def test_list_opportunities_agency_not_found(client, db_session, grantor_auth_data):
     user, agency, token, _ = grantor_auth_data
-
-    time.sleep(0.1)
 
     fake_agency_id = uuid.uuid4()
 

--- a/api/tests/src/api/opportunities_v1/test_opportunity_auth.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_auth.py
@@ -104,7 +104,6 @@ def test_opportunity_get_success_with_api_user_key(
 def test_opportunity_search_with_inactive_api_user_key(client, enable_factory_create, db_session):
     """Test opportunity search endpoint with inactive API user key"""
     inactive_api_key = UserApiKeyFactory.create(is_active=False)
-    db_session.commit()
 
     response = client.post(
         "/v1/opportunities/search",
@@ -121,7 +120,6 @@ def test_opportunity_search_csv_with_inactive_api_user_key(
 ):
     """Test opportunity search CSV endpoint with inactive API user key"""
     inactive_api_key = UserApiKeyFactory.create(is_active=False)
-    db_session.commit()
 
     response = client.post(
         "/v1/opportunities/search/csv",
@@ -138,7 +136,6 @@ def test_opportunity_get_with_inactive_api_user_key(client, enable_factory_creat
     inactive_api_key = UserApiKeyFactory.create(is_active=False)
     # Create an opportunity to get
     opportunity = OpportunityFactory.create()
-    db_session.commit()
 
     response = client.get(
         f"/v1/opportunities/{opportunity.opportunity_id}",
@@ -185,7 +182,6 @@ def test_opportunity_auth_precedence_jwt_first(
     """Test that JWT auth takes precedence over API key auth when both are provided"""
     # Create an opportunity to get
     opportunity = OpportunityFactory.create()
-    db_session.commit()
 
     # Send both headers - JWT should take precedence over API key
     response = client.get(

--- a/api/tests/src/api/opportunities_v1/test_opportunity_route_get.py
+++ b/api/tests/src/api/opportunities_v1/test_opportunity_route_get.py
@@ -135,7 +135,6 @@ def test_get_opportunity_with_attachment_200(
 ):
     # Create an opportunity with an attachment
     opportunity = OpportunityFactory.create(has_attachments=True)
-    db_session.commit()
 
     # Make the GET request
     resp = client.get(
@@ -540,7 +539,6 @@ def test_get_opportunity_with_competitions_200(
     # Create an opportunity with a competition
     opportunity = OpportunityFactory.create()
     competition = CompetitionFactory.create(opportunity=opportunity)
-    db_session.commit()
 
     # Make the GET request
     resp = client.get(
@@ -563,7 +561,6 @@ def test_get_opportunity_with_competitions_200_JWT(client, db_session, user_auth
     # Create an opportunity with a competition
     opportunity = OpportunityFactory.create()
     competition = CompetitionFactory.create(opportunity=opportunity)
-    db_session.commit()
 
     # Make the GET request
     resp = client.get(

--- a/api/tests/src/api/organizations_v1/test_list_legacy_users.py
+++ b/api/tests/src/api/organizations_v1/test_list_legacy_users.py
@@ -54,8 +54,6 @@ class TestListLegacyUsers:
             inviter=user,
         )
 
-        db_session.commit()
-
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/legacy-users",
             headers={"X-SGG-Token": token},
@@ -107,8 +105,6 @@ class TestListLegacyUsers:
             organization=organization,
         )
 
-        db_session.commit()
-
         # Filter for only available users
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/legacy-users",
@@ -153,8 +149,6 @@ class TestListLegacyUsers:
             organization=organization,
             inviter=user,
         )
-
-        db_session.commit()
 
         # Filter for member and pending invitation (exclude available)
         resp = client.post(
@@ -221,8 +215,6 @@ class TestListLegacyUsers:
         create_legacy_user_with_status(uei, "apple@example.com")
         create_legacy_user_with_status(uei, "banana@example.com")
 
-        db_session.commit()
-
         # Call without sort_order - should use default (email ascending)
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/legacy-users",
@@ -267,8 +259,6 @@ class TestListLegacyUsers:
             email="ignored@example.com",
         )
 
-        db_session.commit()
-
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/legacy-users",
             headers={"X-SGG-Token": token},
@@ -306,8 +296,6 @@ class TestListLegacyUsers:
             last_name="User",
             created_date=datetime(2024, 1, 1, tzinfo=UTC),
         )
-
-        db_session.commit()
 
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/legacy-users",
@@ -355,8 +343,6 @@ class TestListLegacyUsers:
             rejected_at=None,
         )
 
-        db_session.commit()
-
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/legacy-users",
             headers={"X-SGG-Token": token},
@@ -384,8 +370,6 @@ class TestListLegacyUsers:
         # Create 5 legacy users
         for i in range(5):
             create_legacy_user_with_status(uei, f"user{i}@example.com")
-
-        db_session.commit()
 
         # Request page 1 with page size 2
         resp = client.post(
@@ -415,8 +399,6 @@ class TestListLegacyUsers:
         # Create 5 legacy users with predictable emails for sorting
         for i in range(5):
             create_legacy_user_with_status(uei, f"user{i}@example.com")
-
-        db_session.commit()
 
         # Request page 2 with page size 2
         resp = client.post(
@@ -457,8 +439,6 @@ class TestListLegacyUsers:
             create_legacy_user_with_status(
                 uei, f"{name.lower()}@example.com", first_name=name, last_name="User"
             )
-
-        db_session.commit()
 
         # Sort by first_name ascending
         resp = client.post(

--- a/api/tests/src/api/organizations_v1/test_list_organization_invitations.py
+++ b/api/tests/src/api/organizations_v1/test_list_organization_invitations.py
@@ -58,8 +58,6 @@ class TestListOrganizationInvitations:
             role=role,
         )
 
-        db_session.commit()
-
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/invitations/list",
             headers={"X-SGG-Token": token},
@@ -112,8 +110,6 @@ class TestListOrganizationInvitations:
             accepted_at=datetime.now(UTC) - timedelta(days=1),
             rejected_at=None,
         )
-
-        db_session.commit()
 
         # Filter for only pending invitations
         resp = client.post(
@@ -210,7 +206,6 @@ class TestListOrganizationInvitations:
         # Create a different organization
 
         other_organization = OrganizationFactory.create()
-        db_session.commit()
 
         resp = client.post(
             f"/v1/organizations/{other_organization.organization_id}/invitations/list",
@@ -296,8 +291,6 @@ class TestListOrganizationInvitations:
             organization_invitation=invitation,
             role=role,
         )
-
-        db_session.commit()
 
         resp = client.post(
             f"/v1/organizations/{organization.organization_id}/invitations/list",
@@ -402,8 +395,6 @@ class TestListOrganizationInvitations:
             accepted_at=None,
             rejected_at=None,
         )
-
-        db_session.commit()
 
         # Filter for expired invitations
         resp = client.post(

--- a/api/tests/src/api/users/test_user_delete_saved_opportunity.py
+++ b/api/tests/src/api/users/test_user_delete_saved_opportunity.py
@@ -13,9 +13,7 @@ from tests.src.db.models.factories import (
 
 @pytest.fixture
 def user(enable_factory_create, db_session):
-    user = UserFactory.create()
-    db_session.commit()
-    return user
+    return UserFactory.create()
 
 
 @pytest.fixture

--- a/api/tests/src/api/users/test_user_delete_saved_search.py
+++ b/api/tests/src/api/users/test_user_delete_saved_search.py
@@ -3,8 +3,7 @@ import uuid
 
 import pytest
 
-from src.db.models.user_models import UserSavedSearch, UserTokenSession
-from tests.lib.db_testing import cascade_delete_from_db_table
+from src.db.models.user_models import UserSavedSearch
 from tests.src.db.models.factories import UserFactory, UserSavedSearchFactory
 
 
@@ -13,14 +12,7 @@ def saved_search(enable_factory_create, user, db_session):
     search = UserSavedSearchFactory.create(
         user=user, name="Test Search", search_query={"keywords": "python"}
     )
-    db_session.commit()
     return search
-
-
-@pytest.fixture(autouse=True)
-def clear_data(db_session):
-    cascade_delete_from_db_table(db_session, UserTokenSession)
-    return
 
 
 def test_user_delete_saved_search_unauthorized_user(

--- a/api/tests/src/api/users/test_user_get_saved_searches.py
+++ b/api/tests/src/api/users/test_user_get_saved_searches.py
@@ -47,7 +47,6 @@ def saved_searches(user, db_session):
             created_at=datetime(2024, 1, 3, tzinfo=timezone.utc),
         ),
     ]
-    db_session.commit()
     return searches
 
 
@@ -62,7 +61,6 @@ def test_user_get_saved_searches_unauthorized_user(
 ):
     # Try to get searches for a different user ID
     different_user = UserFactory.create()
-    db_session.commit()
 
     response = client.post(
         f"/v1/users/{different_user.user_id}/saved-searches/list",

--- a/api/tests/src/api/users/test_user_list_api_keys.py
+++ b/api/tests/src/api/users/test_user_list_api_keys.py
@@ -21,7 +21,6 @@ def test_list_api_keys_empty_result(
 def test_list_api_keys_single_key(enable_factory_create, db_session, client, user, user_auth_token):
     """Test listing API keys when user has one key"""
     api_key = UserApiKeyFactory.create(user=user, key_name="Test API Key")
-    db_session.commit()
 
     response = client.post(
         f"/v1/users/{user.user_id}/api-keys/list",
@@ -51,7 +50,6 @@ def test_list_api_keys_multiple_keys_ordered_by_created_at(
     api_key1 = UserApiKeyFactory.create(user=user, key_name="First Key")
     api_key2 = UserApiKeyFactory.create(user=user, key_name="Second Key")
     api_key3 = UserApiKeyFactory.create(user=user, key_name="Third Key")
-    db_session.commit()
 
     response = client.post(
         f"/v1/users/{user.user_id}/api-keys/list",
@@ -86,7 +84,6 @@ def test_list_api_keys_only_users_keys(
     other_user_key = UserApiKeyFactory.create(user=other_user, key_name="Other User Key")
 
     user_key = UserApiKeyFactory.create(user=user, key_name="User Key")
-    db_session.commit()
 
     response = client.post(
         f"/v1/users/{user.user_id}/api-keys/list",
@@ -113,7 +110,6 @@ def test_list_api_keys_includes_inactive_keys(
     """Test that both active and inactive keys are returned"""
     active_key = UserApiKeyFactory.create(user=user, key_name="Active Key", is_active=True)
     inactive_key = UserApiKeyFactory.create(user=user, key_name="Inactive Key", is_active=False)
-    db_session.commit()
 
     response = client.post(
         f"/v1/users/{user.user_id}/api-keys/list",

--- a/api/tests/src/auth/test_api_user_key_auth.py
+++ b/api/tests/src/auth/test_api_user_key_auth.py
@@ -38,7 +38,6 @@ def test_validate_api_key_in_db_success(enable_factory_create, db_session):
     """Test successful API key validation"""
     user = UserFactory.create()
     api_key = UserApiKeyFactory.create(user=user, key_id="test-key-123", is_active=True)
-    db_session.commit()
 
     result = validate_api_key_in_db("test-key-123", db_session)
 
@@ -57,7 +56,6 @@ def test_validate_api_key_in_db_key_inactive(enable_factory_create, db_session):
     """Test API key validation when key is inactive"""
     user = UserFactory.create()
     UserApiKeyFactory.create(user=user, key_id="inactive-key", is_active=False)
-    db_session.commit()
 
     with pytest.raises(ApiKeyValidationError, match="API key is inactive"):
         validate_api_key_in_db("inactive-key", db_session)
@@ -70,7 +68,6 @@ def test_api_user_key_auth_happy_path(mini_app, enable_factory_create, db_sessio
     api_key = UserApiKeyFactory.create(
         user=user, key_id="valid-gateway-key", is_active=True, last_used=None
     )
-    db_session.commit()
 
     resp = mini_app.test_client().get(
         "/dummy_auth_endpoint", headers={"X-API-Key": "valid-gateway-key"}
@@ -95,7 +92,6 @@ def test_api_user_key_auth_inactive_key(mini_app, enable_factory_create, db_sess
     """Test API Gateway key authentication with inactive key"""
     user = UserFactory.create()
     UserApiKeyFactory.create(user=user, key_id="inactive-gateway-key", is_active=False)
-    db_session.commit()
 
     resp = mini_app.test_client().get(
         "/dummy_auth_endpoint", headers={"X-API-Key": "inactive-gateway-key"}

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_agency.py
@@ -18,6 +18,8 @@ from src.data_migration.transformation.subtask.transform_agency import (
     transform_agency_notify,
 )
 from src.db.models.agency_models import Agency
+from src.db.models.user_models import AgencyUser
+from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.data_migration.transformation.conftest import (
     BaseTransformTestClass,
     setup_agency,
@@ -383,6 +385,11 @@ class TestTransformAgency(BaseTransformTestClass):
 
 
 class TestValidateAgencyData(BaseTransformTestClass):
+
+    @pytest.fixture(scope="class")
+    def truncate_agencies(self, db_session):
+        cascade_delete_from_db_table(db_session, AgencyUser)
+        cascade_delete_from_db_table(db_session, Agency)
 
     @pytest.fixture
     def validate_agency_data(self, transform_oracle_data_task, truncate_agencies):

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_competition.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_competition.py
@@ -8,10 +8,7 @@ from src.data_migration.transformation.subtask.transform_competition import (
     transform_form_family,
     transform_open_to_applicants,
 )
-from src.db.models.competition_models import Competition
-from src.db.models.opportunity_models import Opportunity, OpportunityAssistanceListing
 from src.util import file_util
-from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.data_migration.transformation.conftest import (
     BaseTransformTestClass,
     setup_competition,
@@ -20,17 +17,12 @@ from tests.src.data_migration.transformation.conftest import (
 
 
 class TestTransformCompetition(BaseTransformTestClass):
-    @pytest.fixture(autouse=True)
-    def cleanup_competitions(self, db_session, test_staging_schema):
-        """Clean up competition data before each test."""
-        # Use cascade delete to properly handle foreign key constraints
-        cascade_delete_from_db_table(db_session, Competition)
 
-        # Clean opportunity tables
-        cascade_delete_from_db_table(db_session, OpportunityAssistanceListing)
-        cascade_delete_from_db_table(db_session, Opportunity)
-
-        db_session.commit()
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self):
+        # To avoid conflicting with any assistance listings or cfdas in other tests
+        # we set the sequence (ie. the ID) to a much higher number past any that would have been created.
+        f.OpportunityAssistanceListingFactory.reset_sequence(1_000_000)
 
     @pytest.fixture
     def transform_competition(self, transform_oracle_data_task):

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
@@ -1,12 +1,14 @@
 import pytest
+from sqlalchemy import update
 
 import src.data_migration.transformation.transform_constants as transform_constants
 from src.data_migration.transformation.subtask.transform_opportunity import TransformOpportunity
+from src.db.models import staging
 from src.services.competition_alpha.competition_instruction_util import (
     get_s3_competition_instruction_path,
 )
 from src.services.opportunity_attachments import attachment_util
-from src.util import file_util
+from src.util import datetime_util, file_util
 from tests.src.data_migration.transformation.conftest import (
     BaseTransformTestClass,
     setup_opportunity,
@@ -21,6 +23,15 @@ from tests.src.db.models.factories import (
 
 
 class TestTransformOpportunity(BaseTransformTestClass):
+
+    @pytest.fixture(autouse=True)
+    def clear_opportunities(self, db_session):
+        db_session.execute(
+            update(staging.opportunity.Topportunity)
+            .where(staging.opportunity.Topportunity.transformed_at.is_(None))
+            .values(transformed_at=datetime_util.utcnow())
+        )
+
     @pytest.fixture
     def transform_opportunity(self, transform_oracle_data_task, s3_config):
         return TransformOpportunity(transform_oracle_data_task, s3_config)

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
@@ -22,7 +22,7 @@ from tests.src.db.models.factories import (
 
 class TestTransformOpportunity(BaseTransformTestClass):
     @pytest.fixture
-    def transform_opportunity(self, transform_oracle_data_task, truncate_staging_tables, s3_config):
+    def transform_opportunity(self, transform_oracle_data_task, s3_config):
         return TransformOpportunity(transform_oracle_data_task, s3_config)
 
     def test_process_opportunities(self, db_session, transform_opportunity):
@@ -120,7 +120,7 @@ class TestTransformOpportunity(BaseTransformTestClass):
         )
 
         attachments = []
-        for i in range(10):
+        for i in range(3):
             s3_path = attachment_util.get_s3_attachment_path(
                 f"my_file{i}.txt", i, target_opportunity, s3_config
             )
@@ -134,7 +134,7 @@ class TestTransformOpportunity(BaseTransformTestClass):
             attachments.append(attachment)
 
         competition_instructions = []
-        for _ in range(3):
+        for _ in range(2):
             competition = CompetitionFactory.create(opportunity=target_opportunity)
             competition_instruction = CompetitionInstructionFactory.create(competition=competition)
             competition_instructions.append(competition_instruction)
@@ -165,7 +165,7 @@ class TestTransformOpportunity(BaseTransformTestClass):
         )
 
         attachments = []
-        for i in range(10):
+        for i in range(3):
             s3_path = attachment_util.get_s3_attachment_path(
                 f"my_file{i}.txt", i, target_opportunity, s3_config
             )
@@ -180,7 +180,7 @@ class TestTransformOpportunity(BaseTransformTestClass):
             attachments.append(attachment)
 
         competition_instructions = []
-        for i in range(3):
+        for i in range(2):
             competition = CompetitionFactory.create(opportunity=target_opportunity)
 
             s3_path = get_s3_competition_instruction_path(

--- a/api/tests/src/form_schema/test_csv_to_jsonschema.py
+++ b/api/tests/src/form_schema/test_csv_to_jsonschema.py
@@ -61,7 +61,6 @@ def test_csv_to_jsonschema_contains_expected_fields(csv_file_content, expected_f
     """Test that the generated schema contains expected fields."""
     schema, _ = csv_to_jsonschema(csv_file_content)
 
-    print(schema)
     # Look for each field in the schema properties
     for field in expected_fields:
         # Fields might be in the main schema or in a section

--- a/api/tests/src/logging/test_flask_logger.py
+++ b/api/tests/src/logging/test_flask_logger.py
@@ -132,7 +132,7 @@ def test_add_extra_log_data_for_current_request(app: Flask, caplog: pytest.LogCa
 def test_log_response_time(app: Flask, caplog: pytest.LogCaptureFixture):
     @app.get("/sleep")
     def sleep():
-        time.sleep(0.1)  # 0.1 s = 100 ms
+        time.sleep(0.01)  # 0.01 s = 10 ms
         return "ok"
 
     app.test_client().get("/sleep")
@@ -140,7 +140,7 @@ def test_log_response_time(app: Flask, caplog: pytest.LogCaptureFixture):
     last_record = caplog.records[-1]
     assert "response.time_ms" in last_record.__dict__
     response_time_ms = last_record.__dict__["response.time_ms"]
-    expected_response_time_ms = 100  # ms
-    allowed_error = 25  # ms
+    expected_response_time_ms = 10  # ms
+    allowed_error = 5  # ms
 
     assert response_time_ms == pytest.approx(expected_response_time_ms, abs=allowed_error)

--- a/api/tests/src/services/opportunities_v1/test_opportunity_version.py
+++ b/api/tests/src/services/opportunities_v1/test_opportunity_version.py
@@ -1,22 +1,12 @@
-import pytest
-
 from src.constants.lookup_constants import OpportunityCategory
-from src.db.models.agency_models import Agency
-from src.db.models.opportunity_models import Opportunity, OpportunityVersion
+from src.db.models.opportunity_models import OpportunityVersion
 from src.services.opportunities_v1.opportunity_version import save_opportunity_version
-from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.db.models.factories import (
     AgencyFactory,
     OpportunityAssistanceListingFactory,
     OpportunityAttachmentFactory,
     OpportunityFactory,
 )
-
-
-@pytest.fixture(autouse=True)
-def clear_data(db_session, test_api_schema):
-    cascade_delete_from_db_table(db_session, Opportunity)
-    cascade_delete_from_db_table(db_session, Agency)
 
 
 def test_save_opportunity_version(db_session, enable_factory_create):
@@ -62,7 +52,11 @@ def test_save_opportunity_version(db_session, enable_factory_create):
     save_opportunity_version(db_session, opp)
 
     # Verify Record created
-    saved_opp_version = db_session.query(OpportunityVersion).all()
+    saved_opp_version = (
+        db_session.query(OpportunityVersion)
+        .where(OpportunityVersion.opportunity_id == opp.opportunity_id)
+        .all()
+    )
 
     assert len(saved_opp_version) == 1
     assert saved_opp_version[0].opportunity_id == opp.opportunity_id
@@ -84,7 +78,11 @@ def test_save_opportunity_version_with_attachments(db_session, enable_factory_cr
     save_opportunity_version(db_session, opp)
 
     # Verify Record created
-    saved_opp_version = db_session.query(OpportunityVersion).all()
+    saved_opp_version = (
+        db_session.query(OpportunityVersion)
+        .where(OpportunityVersion.opportunity_id == opp.opportunity_id)
+        .all()
+    )
 
     assert len(saved_opp_version) == 1
     assert saved_opp_version[0].opportunity_id == opp.opportunity_id
@@ -96,7 +94,11 @@ def test_save_opportunity_version_draft(db_session, enable_factory_create):
     save_opportunity_version(db_session, opp)
 
     # Verify record is not created
-    saved_opp_version = db_session.query(OpportunityVersion).all()
+    saved_opp_version = (
+        db_session.query(OpportunityVersion)
+        .where(OpportunityVersion.opportunity_id == opp.opportunity_id)
+        .all()
+    )
     assert len(saved_opp_version) == 0
 
 

--- a/api/tests/src/task/agencies/test_setup_lower_env_agencies.py
+++ b/api/tests/src/task/agencies/test_setup_lower_env_agencies.py
@@ -1,11 +1,21 @@
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import selectinload
 
 from src.constants.static_role_values import OPPORTUNITY_PUBLISHER
 from src.db.models.user_models import AgencyUser, User, UserType
 from src.task.agencies.setup_lower_env_agencies import SetupLowerEnvAgenciesTask
 from tests.src.db.models.factories import UserFactory
+
+
+@pytest.fixture(autouse=True)
+def cleanup_users(db_session):
+    # for performance reasons - we don't want this test to actually
+    # process every user in the DB. The code is setup to only
+    # process "standard" users, so we'll make all users non-standard
+    # that already exist.
+    db_session.execute(update(User).values(user_type=UserType.LEGACY_CERTIFICATE))
+    db_session.commit()
 
 
 def test_setup_lower_env_agencies(enable_factory_create, db_session):

--- a/api/tests/src/task/test_ecs_background_task.py
+++ b/api/tests/src/task/test_ecs_background_task.py
@@ -20,7 +20,7 @@ def test_ecs_background_task(app, caplog, monkeypatch_session):
     @ecs_background_task(task_name="my_test_task_name")
     def my_test_func(param1, param2):
         # Add a brief sleep so that we can test the duration logic
-        time.sleep(0.2)  # 0.2s
+        time.sleep(0.05)  # 0.05s
         add_extra_data_to_global_logs({"example_param": 12345})
 
         return param1 + param2
@@ -38,8 +38,8 @@ def test_ecs_background_task(app, caplog, monkeypatch_session):
 
     last_record = relevant_records[-1].__dict__
     # Make sure the ECS task duration was tracked
-    allowed_error = 0.1
-    assert last_record["ecs_task_duration_sec"] == pytest.approx(0.2, abs=allowed_error)
+    allowed_error = 0.03
+    assert last_record["ecs_task_duration_sec"] == pytest.approx(0.05, abs=allowed_error)
     # Make sure the extra we added was put in this automatically
     assert last_record["example_param"] == 12345
     assert last_record["message"] == "Completed ECS task my_test_task_name"

--- a/api/tests/src/workflow/manager/test_workflow_manager.py
+++ b/api/tests/src/workflow/manager/test_workflow_manager.py
@@ -139,7 +139,7 @@ def test_workflow_sqs_messages_process_batch_success(workflow_sqs_queue, app):
         )
 
     message_post_process = boto_client.receive_message(
-        QueueUrl=workflow_sqs_queue, MaxNumberOfMessages=10, WaitTimeSeconds=5
+        QueueUrl=workflow_sqs_queue, MaxNumberOfMessages=10, WaitTimeSeconds=0
     )
 
     # Verify: check metrics reflect 1 batch processed

--- a/api/tests/validate_legacy_soap_api/validate_soap_endpoints.py
+++ b/api/tests/validate_legacy_soap_api/validate_soap_endpoints.py
@@ -252,7 +252,7 @@ def validate_grantors_get_application_zip_request(soap_context: ValidateSoapCont
     # The xml namespaces here do not need to be cleaned because there are no
     # blank namepsaces to default to the wrong url here
     validate_response_xml(resp.content, "GetApplicationZipResponse", soap_context)
-    print("Validation: GetApplicationZip is validated")
+    logger.info("Validation: GetApplicationZip is validated")
 
 
 def validate_grantors_get_submission_list_expanded_request(
@@ -262,7 +262,7 @@ def validate_grantors_get_submission_list_expanded_request(
     assert resp.status_code == 200
     fixed_bytes = clean_xml_namespaces(resp.content)
     validate_response_xml(fixed_bytes, "GetSubmissionListExpandedResponse", soap_context)
-    print("Validation: GetSubmissionListExpanded is validated")
+    logger.info("Validation: GetSubmissionListExpanded is validated")
 
 
 def validate_confirm_application_delivery_request(
@@ -272,7 +272,7 @@ def validate_confirm_application_delivery_request(
     assert resp.status_code == 200
     fixed_bytes = clean_xml_namespaces(resp.content)
     validate_response_xml(fixed_bytes, "ConfirmApplicationDeliveryResponse", soap_context)
-    print("Validation: ConfirmApplicationDelivery is validated")
+    logger.info("Validation: ConfirmApplicationDelivery is validated")
 
 
 def validate_update_application_info_request(
@@ -282,7 +282,7 @@ def validate_update_application_info_request(
     assert resp.status_code == 200
     fixed_bytes = clean_xml_namespaces(resp.content)
     validate_response_xml(fixed_bytes, "UpdateApplicationInfoResponse", soap_context)
-    print("Validation: UpdateApplicationInfo is validated")
+    logger.info("Validation: UpdateApplicationInfo is validated")
 
 
 def get_credentials(stack: ExitStack) -> tuple:


### PR DESCRIPTION
## Summary

## Changes proposed
* Various cleanup pieces in our tests including:
  * Removing print statements + added a lint rule to catch
  * Removing `db_session.commit()` right after a call to and `create` call on our factory (which commits)
  * A few minor performance improvements to slow tests that had sleeps/other extra stuff that made them take several seconds (a lot more to do here, but got a few simple ones)

## Context for reviewers
Just routine upkeep - was looking at any performance improvements we could make as part of some of the data separation work, but there weren't many easy/obvious wins without quite a bit more refactor.

## Validation steps
Other than one comment change, this is all tests, the tests themselves say whether they still work.
