### PR TITLE
[Issue #10254] Increase Display Limit on Opportunities List Page

### DIFF
--- a/frontend/src/app/[locale]/(base)/opportunities/page.tsx
+++ b/frontend/src/app/[locale]/(base)/opportunities/page.tsx
@@ -386,7 +386,7 @@ async function OpportunitiesListPage(props: OpportunitiesListProps) {
   if (agencyUserAcccess.canView) {
     const pageRequest: PaginationRequestBody = {
       page_offset: 1,
-      page_size: 25,
+      page_size: 5000,
       sort_order: [
         {
           order_by: "opportunity_title",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10254 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
In the Opportunity List Page `page.tsx`, update `page_size` to 5000 (max allowed by `generate_pagination_schema`)

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Currently only up to 25 opportunities are being listed on the Opportunities List Page. The limit should be raised to 5000 (the maximum allowed size set by `max_page_size` of the schema) so that all of the opportunities are displayed on the list - Noting that Pagination is a future feature to potentially be implemented.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] User can see all of the 25+ opportunities on the Opportunity List page.
