### PR TITLE
test(frontend): add useCopyToClipboard test coverage

### DIFF
--- a/frontend/src/hooks/useCopyToClipboard.test.ts
+++ b/frontend/src/hooks/useCopyToClipboard.test.ts
@@ -97,7 +97,8 @@ describe("useCopyToClipboard", () => {
     // Saving the reference for restoration; we never invoke it through this binding.
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalExecCommand = document.execCommand;
-    document.execCommand = execCommand as unknown as typeof document.execCommand;
+    document.execCommand =
+      execCommand as unknown as typeof document.execCommand;
 
     try {
       const { result } = renderHook(() => useCopyToClipboard());

--- a/frontend/src/hooks/useCopyToClipboard.test.ts
+++ b/frontend/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from "@testing-library/react";
+import { useCopyToClipboard } from "src/hooks/useCopyToClipboard";
+
+const mockWriteText = jest.fn(() => Promise.resolve());
+
+const stubClipboard = (writeText: jest.Mock = mockWriteText) => {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    writable: true,
+    configurable: true,
+  });
+};
+
+const setSecureContext = (value: boolean) => {
+  Object.defineProperty(window, "isSecureContext", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+};
+
+describe("useCopyToClipboard", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    stubClipboard();
+    setSecureContext(true);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns idle state on initial render", () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    expect(result.current.copied).toBe(false);
+    expect(result.current.copying).toBe(false);
+    expect(typeof result.current.copyToClipboard).toBe("function");
+  });
+
+  it("writes the content to navigator.clipboard and flips copied", async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard("hello");
+    });
+
+    expect(mockWriteText).toHaveBeenCalledTimes(1);
+    expect(mockWriteText).toHaveBeenCalledWith("hello");
+    expect(result.current.copied).toBe(true);
+    expect(result.current.copying).toBe(false);
+  });
+
+  it("resets copied to false after the default reset duration elapses", async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard("hello");
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(6000);
+    });
+
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("honors a custom reset duration", async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard("hello", 1000);
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(999);
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("falls back to a temporary textarea + execCommand when clipboard is unavailable", async () => {
+    setSecureContext(false);
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    const execCommand = jest.fn().mockReturnValue(true);
+    // Saving the reference for restoration; we never invoke it through this binding.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalExecCommand = document.execCommand;
+    document.execCommand = execCommand as unknown as typeof document.execCommand;
+
+    try {
+      const { result } = renderHook(() => useCopyToClipboard());
+
+      await act(async () => {
+        await result.current.copyToClipboard("fallback-content");
+      });
+
+      expect(execCommand).toHaveBeenCalledWith("copy");
+      expect(result.current.copied).toBe(true);
+      // The temporary textarea is removed in a `finally` block.
+      expect(document.querySelector("textarea")).toBeNull();
+    } finally {
+      document.execCommand = originalExecCommand;
+    }
+  });
+
+  it("clears copying and rethrows when the underlying clipboard call fails", async () => {
+    const writeText = jest.fn(() => Promise.reject(new Error("denied")));
+    stubClipboard(writeText);
+
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await expect(result.current.copyToClipboard("nope")).rejects.toThrow(
+        /Error copying to clipboard/,
+      );
+    });
+
+    expect(result.current.copying).toBe(false);
+    expect(result.current.copied).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #9804.

## Changes proposed

Adds `frontend/src/hooks/useCopyToClipboard.test.ts` with six Jest +
React Testing Library cases for the `useCopyToClipboard` hook, which
previously had zero test coverage.

| Case | What it covers |
| --- | --- |
| idle initial state | `copied` and `copying` are `false`, `copyToClipboard` is exposed |
| happy path | `navigator.clipboard.writeText` is called with the right content and `copied` flips to `true` |
| default reset | `copied` flips back to `false` after the built-in `COPY_STATE_RESET_DURATION` (6000ms) |
| custom reset | the second positional `contentTime` argument is honored exactly (no early or late reset) |
| insecure-context fallback | when `navigator.clipboard` is missing, the hook builds a temporary `<textarea>`, calls `document.execCommand("copy")`, and removes the textarea via the existing `finally` block |
| error path | a clipboard rejection clears `copying`, leaves `copied` false, and rethrows wrapped in `Error("Error copying to clipboard: ...")` |

`jest.useFakeTimers()` is used to deterministically advance the
`setTimeout` that resets `copied`, matching the pattern in
`frontend/src/components/CopyIcon.test.tsx`. The clipboard-stubbing
helpers (`stubClipboard`, `setSecureContext`) are local to this file —
no shared test util is added.

## Context for reviewers

The technical approach in the issue ticket suggested fake timers plus
`Object.defineProperty` for `navigator.clipboard` and
`window.isSecureContext`. The skeleton in this PR follows that
verbatim; the only meaningful additions over the issue's skeleton are
the custom-duration assertion (proves the second arg actually
threads through to `setTimeout`), the textarea-cleanup assertion in
the fallback branch, and the rejection path.

The hook's `console.error` branch (line 30 in `useCopyToClipboard.ts`,
fallback `execCommand` swallowing) is not covered — that branch only
runs when `document.execCommand` itself throws synchronously, which is
several layers down from where this hook is exercised. Worth a follow-up
if a test is wanted there; flagging it because the coverage report
shows it as uncovered.

## Validation steps

```sh
cd frontend
npm install
npm run test -- useCopyToClipboard
npm run lint -- src/hooks/useCopyToClipboard.test.ts
npm run ts:check
```

Local run:

- `npm run test -- useCopyToClipboard` — 6/6 passing,
  `useCopyToClipboard.ts` coverage 96.77 % statements / 100 % branch.
- `npm run lint -- src/hooks/useCopyToClipboard.test.ts` — clean.
- `npm run ts:check` — clean.

The one `// eslint-disable-next-line @typescript-eslint/unbound-method`
covers saving `document.execCommand` for restoration after the test —
the reference is never invoked through that binding, so the cop's
warning doesn't apply here.
