### PR TITLE
[Issue #9843] Add unit test coverage for Edit Opportunity form and config

### DIFF
--- a/frontend/src/components/opportunity/OpportunityEditForm.test.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.test.tsx
@@ -256,10 +256,10 @@ describe("OpportunityEditForm — alert banners", () => {
       screen.getByText("content.alerts.validationWarningHeading"),
     ).toBeInTheDocument();
     // Each error appears both in the summary alert and as an inline field error
-    expect(screen.getAllByText("Funding type is required")).not.toHaveLength(0);
+    expect(screen.getAllByText("Funding type is required")).toHaveLength(2);
     expect(
       screen.getAllByText("Close date must be a valid date"),
-    ).not.toHaveLength(0);
+    ).toHaveLength(2);
   });
 
   it("does not show validation errors alert when validationErrors is empty", () => {
@@ -753,14 +753,14 @@ describe("OpportunityEditForm — inline validation errors", () => {
       },
     });
 
-    expect(screen.getAllByText("Funding type required")).not.toHaveLength(0);
+    expect(screen.getAllByText("Funding type required")).toHaveLength(2);
     expect(
       screen.getAllByText("Eligible applicants required"),
-    ).not.toHaveLength(0);
-    expect(screen.getAllByText("Invalid email")).not.toHaveLength(0);
+    ).toHaveLength(2);
+    expect(screen.getAllByText("Invalid email")).toHaveLength(2);
     expect(
       screen.getAllByText("Additional eligibility info required"),
-    ).not.toHaveLength(0);
+    ).toHaveLength(2);
   });
 });
 

--- a/frontend/src/components/opportunity/OpportunityEditForm.test.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.test.tsx
@@ -257,9 +257,9 @@ describe("OpportunityEditForm — alert banners", () => {
     ).toBeInTheDocument();
     // Each error appears both in the summary alert and as an inline field error
     expect(screen.getAllByText("Funding type is required")).toHaveLength(2);
-    expect(
-      screen.getAllByText("Close date must be a valid date"),
-    ).toHaveLength(2);
+    expect(screen.getAllByText("Close date must be a valid date")).toHaveLength(
+      2,
+    );
   });
 
   it("does not show validation errors alert when validationErrors is empty", () => {
@@ -754,9 +754,7 @@ describe("OpportunityEditForm — inline validation errors", () => {
     });
 
     expect(screen.getAllByText("Funding type required")).toHaveLength(2);
-    expect(
-      screen.getAllByText("Eligible applicants required"),
-    ).toHaveLength(2);
+    expect(screen.getAllByText("Eligible applicants required")).toHaveLength(2);
     expect(screen.getAllByText("Invalid email")).toHaveLength(2);
     expect(
       screen.getAllByText("Additional eligibility info required"),

--- a/frontend/src/components/opportunity/OpportunityEditForm.test.tsx
+++ b/frontend/src/components/opportunity/OpportunityEditForm.test.tsx
@@ -1,7 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 import OpportunityEditForm from "./OpportunityEditForm";
 import { OpportunityEditFormValues } from "./opportunityEditFormConfig";
+
+const mockUseActionState = jest.fn();
+
+jest.mock("react", () => ({
+  ...jest.requireActual<typeof import("react")>("react"),
+  useActionState: () => mockUseActionState() as unknown,
+}));
+
+jest.mock("src/app/[locale]/(base)/opportunity/[id]/edit/actions", () => ({
+  saveOpportunityEditAction: jest.fn(),
+}));
 
 jest.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
@@ -71,15 +82,20 @@ const renderOpportunityEditForm = (
     />,
   );
 
-describe("OpportunityEditForm", () => {
-  it("does not render the old scaffold information alert", () => {
-    renderOpportunityEditForm();
+// ─── Rendering ───────────────────────────────────────────────────────────────
+// Verifies static structure: enum-backed controls, hidden fields, and
+// the edit-lock warning when isDraft=false.
+describe("OpportunityEditForm — rendering", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
 
-    expect(
-      screen.queryByText(
-        "This page is a frontend scaffold for editing draft opportunity details. Save wiring will be added when the grantor update API contract is ready.",
-      ),
-    ).not.toBeInTheDocument();
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   it("renders enum-backed controls for the edit form", () => {
@@ -92,7 +108,7 @@ describe("OpportunityEditForm", () => {
       screen.getByRole("combobox", { name: /labels\.category/i }),
     ).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: /yes/i })).toBeInTheDocument();
-    // Verify checkbox value attribute so the correct enum string is submitted with the form
+    // Verify checkbox value attribute so the correct enum string is submitted with the form.
     // (checkboxes without a value= prop default to "on" and fail API validation)
     // .toHaveValue() cannot be used here: for unchecked checkboxes it always returns null
     // regardless of the value attribute, so .toHaveAttribute() is required instead.
@@ -129,9 +145,710 @@ describe("OpportunityEditForm", () => {
     );
   });
 
-  it("shows the non-draft warning", () => {
+  it("shows the non-draft warning when isDraft is false", () => {
     renderOpportunityEditForm({ isDraft: false });
 
     expect(screen.getByText("content.draftOnlyWarning")).toBeInTheDocument();
+  });
+});
+
+// ─── Alert banners ────────────────────────────────────────────────────────────
+// Covers the four banner states: newly-created success, save success, save error,
+// and field-level validation summary.
+describe("OpportunityEditForm — alert banners", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shows the newly created success alert when isNewlyCreated=true and no action messages", () => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm({ isNewlyCreated: true });
+
+    expect(
+      screen.getByText("content.alerts.newOpportunityHeading"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("content.alerts.newOpportunityBody"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the newly created alert when formState.successMessage is present", () => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {}, successMessage: "Saved!" },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm({ isNewlyCreated: true });
+
+    expect(
+      screen.queryByText("content.alerts.newOpportunityHeading"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the newly created alert when formState.errorMessage is present", () => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {}, errorMessage: "Something failed" },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm({ isNewlyCreated: true });
+
+    expect(
+      screen.queryByText("content.alerts.newOpportunityHeading"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the error alert when formState.errorMessage is set", () => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {}, errorMessage: "Save failed" },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm();
+
+    expect(screen.getByText("Save failed")).toBeInTheDocument();
+  });
+
+  it("shows the success alert when formState.successMessage is set", () => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {}, successMessage: "Changes saved" },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm();
+
+    expect(screen.getByText("Changes saved")).toBeInTheDocument();
+    expect(screen.getByText("content.alerts.successBody")).toBeInTheDocument();
+  });
+
+  it("shows the validation errors alert when validationErrors has entries", () => {
+    mockUseActionState.mockReturnValue([
+      {
+        validationErrors: {
+          fundingType: ["Funding type is required"],
+          closeDate: ["Close date must be a valid date"],
+        },
+      },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm();
+
+    expect(
+      screen.getByText("content.alerts.validationWarningHeading"),
+    ).toBeInTheDocument();
+    // Each error appears both in the summary alert and as an inline field error
+    expect(screen.getAllByText("Funding type is required")).not.toHaveLength(0);
+    expect(
+      screen.getAllByText("Close date must be a valid date"),
+    ).not.toHaveLength(0);
+  });
+
+  it("does not show validation errors alert when validationErrors is empty", () => {
+    renderOpportunityEditForm();
+
+    expect(
+      screen.queryByText("content.alerts.validationWarningHeading"),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── Conditional fields ───────────────────────────────────────────────────────
+// Three sections are conditionally rendered based on form state:
+// fundingCategoryExplanation, closeDateExplanation, additionalEligibilityInfo.
+describe("OpportunityEditForm — conditional fields", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shows the funding category explanation textarea when fundingCategories is 'other'", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, fundingCategories: "other" },
+    });
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /labels\.fundingCategoryExplanation/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the funding category explanation textarea when fundingCategories is not 'other'", () => {
+    renderOpportunityEditForm();
+
+    expect(
+      screen.queryByRole("textbox", {
+        name: /labels\.fundingCategoryExplanation/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the close date explanation textarea when closeDate is empty", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, closeDate: "" },
+    });
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /labels\.closeDateExplanation/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the close date explanation textarea when closeDate has a value", () => {
+    renderOpportunityEditForm();
+
+    expect(
+      screen.queryByRole("textbox", {
+        name: /labels\.closeDateExplanation/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows additional eligibility info textarea when 'other' is in eligibleApplicants", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, eligibleApplicants: ["other"] },
+    });
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /labels\.additionalEligibilityInfo/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows additional eligibility info textarea when 'unrestricted' is in eligibleApplicants", () => {
+    renderOpportunityEditForm({
+      initialValues: {
+        ...initialValues,
+        eligibleApplicants: ["unrestricted"],
+      },
+    });
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /labels\.additionalEligibilityInfo/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides additional eligibility info textarea when neither 'other' nor 'unrestricted' is selected", () => {
+    renderOpportunityEditForm();
+
+    expect(
+      screen.queryByRole("textbox", {
+        name: /labels\.additionalEligibilityInfo/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ─── Eligibility checkboxes ───────────────────────────────────────────────────
+// Confirms initial checked state and that toggling a checkbox updates state correctly.
+describe("OpportunityEditForm — eligibility checkboxes", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders eligibility checkboxes as checked when the value is in eligibleApplicants", () => {
+    renderOpportunityEditForm({
+      initialValues: {
+        ...initialValues,
+        eligibleApplicants: [
+          "for_profit_organizations_other_than_small_businesses",
+        ],
+      },
+    });
+
+    expect(
+      screen.getByRole("checkbox", {
+        name: /for-profit organizations other than small businesses/i,
+      }),
+    ).toBeChecked();
+  });
+
+  it("toggles an eligibility checkbox on then off", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, eligibleApplicants: [] },
+    });
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /for-profit organizations other than small businesses/i,
+    });
+
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("clicking one checkbox from each eligibility group updates state independently", () => {
+    // Exercises the onToggle lambda in all five EligibilityCheckboxGroup instances
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, eligibleApplicants: [] },
+    });
+
+    // education group
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /independent school districts/i }),
+    );
+    // government group
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /state governments/i }),
+    );
+    // nonprofit group
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /other native american tribal organizations/i,
+      }),
+    );
+    // misc group
+    fireEvent.click(screen.getByRole("checkbox", { name: /^individuals$/i }));
+
+    expect(
+      screen.getByRole("checkbox", { name: /independent school districts/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /state governments/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", {
+        name: /other native american tribal organizations/i,
+      }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /^individuals$/i }),
+    ).toBeChecked();
+  });
+});
+
+// ─── Save state ───────────────────────────────────────────────────────────────
+// When a save creates a new summary record, the returned ID is synced into
+// the hidden opportunitySummaryId input so subsequent saves target the correct record.
+describe("OpportunityEditForm — save state", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("updates the opportunitySummaryId hidden field when formState.newOpportunitySummaryId is set", () => {
+    mockUseActionState.mockReturnValue([
+      {
+        validationErrors: {},
+        newOpportunitySummaryId: "new-summary-789",
+      },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm();
+
+    expect(screen.getByDisplayValue("new-summary-789")).toHaveAttribute(
+      "name",
+      "opportunitySummaryId",
+    );
+  });
+});
+
+// ─── Funding details — field interactions ─────────────────────────────────────
+// All funding-section inputs are controlled; onChange updates state and re-renders.
+// Number inputs pass through formatNumber, formatting valid numbers with commas.
+describe("OpportunityEditForm — funding details interactions", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("updates fundingType when the Select value changes", () => {
+    renderOpportunityEditForm();
+
+    const select = screen.getByRole("combobox", {
+      name: /labels\.fundingType/i,
+    });
+    fireEvent.change(select, { target: { value: "cooperative_agreement" } });
+
+    expect(select).toHaveValue("cooperative_agreement");
+  });
+
+  it("updates costSharing to true when the Yes radio is clicked", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, costSharing: false },
+    });
+
+    const radio = screen.getByRole("radio", { name: /labels\.yes/i });
+    fireEvent.click(radio);
+
+    expect(radio).toBeChecked();
+  });
+
+  it("updates costSharing to false when the No radio is clicked", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, costSharing: true },
+    });
+
+    const radio = screen.getByRole("radio", { name: /labels\.no/i });
+    fireEvent.click(radio);
+
+    expect(radio).toBeChecked();
+  });
+
+  it("updates fundingCategories when the category Select changes", () => {
+    renderOpportunityEditForm();
+
+    const select = screen.getByRole("combobox", { name: /labels\.category/i });
+    fireEvent.change(select, { target: { value: "health" } });
+
+    expect(select).toHaveValue("health");
+  });
+
+  it("updates expectedNumberOfAwards when the input changes", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: /labels\.expectedNumberOfAwards/i,
+    });
+    fireEvent.change(input, { target: { value: "10" } });
+
+    expect(input).toHaveValue("10");
+  });
+
+  it("formats estimatedTotalProgramFunding with commas on re-render", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: /labels\.estimatedTotalProgramFunding/i,
+    });
+    fireEvent.change(input, { target: { value: "750000" } });
+
+    expect(input).toHaveValue("750,000");
+  });
+
+  it("updates awardMinimum when the input changes", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: /labels\.awardMinimum/i,
+    });
+    fireEvent.change(input, { target: { value: "500" } });
+
+    expect(input).toHaveValue("500");
+  });
+
+  it("formats awardMaximum with commas on re-render", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: /labels\.awardMaximum/i,
+    });
+    fireEvent.change(input, { target: { value: "5000" } });
+
+    expect(input).toHaveValue("5,000");
+  });
+
+  it("updates fundingCategoryExplanation when the textarea changes", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, fundingCategories: "other" },
+    });
+
+    const textarea = screen.getByRole("textbox", {
+      name: /labels\.fundingCategoryExplanation/i,
+    });
+    fireEvent.change(textarea, { target: { value: "Explanation text" } });
+
+    expect(textarea).toHaveValue("Explanation text");
+  });
+
+  it("updates closeDateExplanation when the textarea changes", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, closeDate: "" },
+    });
+
+    const textarea = screen.getByRole("textbox", {
+      name: /labels\.closeDateExplanation/i,
+    });
+    fireEvent.change(textarea, { target: { value: "No close date set" } });
+
+    expect(textarea).toHaveValue("No close date set");
+  });
+});
+
+// ─── Eligibility and additional info — field interactions ─────────────────────
+// Controlled inputs in the eligibility and additional information sections;
+// onChange updates are reflected in the displayed value.
+describe("OpportunityEditForm — eligibility and additional info interactions", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("updates additionalEligibilityInfo when the textarea changes", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, eligibleApplicants: ["other"] },
+    });
+
+    const textarea = screen.getByRole("textbox", {
+      name: /labels\.additionalEligibilityInfo/i,
+    });
+    fireEvent.change(textarea, { target: { value: "Any eligibility info" } });
+
+    expect(textarea).toHaveValue("Any eligibility info");
+  });
+
+  it("updates description when the textarea changes", () => {
+    renderOpportunityEditForm();
+
+    const textarea = screen.getByRole("textbox", {
+      name: /labels\.description/i,
+    });
+    fireEvent.change(textarea, { target: { value: "Updated description" } });
+
+    expect(textarea).toHaveValue("Updated description");
+  });
+
+  it("updates additionalInfoUrl when the input changes", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: "labels.additionalInfoUrl",
+    });
+    fireEvent.change(input, { target: { value: "https://new.example.com" } });
+
+    expect(input).toHaveValue("https://new.example.com");
+  });
+
+  it("updates additionalInfoUrlText when the input changes", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: "labels.additionalInfoUrlText",
+    });
+    fireEvent.change(input, { target: { value: "New link text" } });
+
+    expect(input).toHaveValue("New link text");
+  });
+
+  it("updates grantorContactDetails when the textarea changes", () => {
+    renderOpportunityEditForm();
+
+    const textarea = screen.getByRole("textbox", {
+      name: /labels\.grantorContactDetails/i,
+    });
+    fireEvent.change(textarea, { target: { value: "Updated contact info" } });
+
+    expect(textarea).toHaveValue("Updated contact info");
+  });
+
+  it("updates contactEmail when the input changes", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: "labels.contactEmail",
+    });
+    fireEvent.change(input, { target: { value: "new@example.com" } });
+
+    expect(input).toHaveValue("new@example.com");
+  });
+
+  it("updates contactEmailText when the input changes", () => {
+    renderOpportunityEditForm();
+
+    const input = screen.getByRole("textbox", {
+      name: "labels.contactEmailText",
+    });
+    fireEvent.change(input, { target: { value: "Email us here" } });
+
+    expect(input).toHaveValue("Email us here");
+  });
+});
+
+// ─── Inline validation errors ─────────────────────────────────────────────────
+// When the save action returns field-level errors, each affected input renders
+// an ErrorMessage. All fields are exercised in a single scenario.
+describe("OpportunityEditForm — inline validation errors", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("shows inline validation errors for all fields simultaneously", () => {
+    mockUseActionState.mockReturnValue([
+      {
+        validationErrors: {
+          fundingType: ["Funding type required"],
+          fundingCategory: ["Funding category required"],
+          expectedNumberOfAwards: ["Must be a number"],
+          estimatedTotalProgramFunding: ["Must be a number"],
+          awardMinimum: ["Award minimum invalid"],
+          awardMaximum: ["Award maximum invalid"],
+          publishDate: ["Publish date required"],
+          closeDate: ["Close date required"],
+          eligibleApplicants: ["Eligible applicants required"],
+          description: ["Description required"],
+          additionalInfoUrl: ["Invalid URL"],
+          additionalInfoUrlText: ["URL text required"],
+          grantorContactDetails: ["Contact details required"],
+          contactEmail: ["Invalid email"],
+          contactEmailText: ["Contact email text required"],
+          additionalEligibilityInfo: ["Additional eligibility info required"],
+        },
+      },
+      jest.fn(),
+      false,
+    ]);
+
+    renderOpportunityEditForm({
+      initialValues: {
+        ...initialValues,
+        // show the additionalEligibilityInfo field so its inline error renders
+        eligibleApplicants: ["other"],
+      },
+    });
+
+    expect(screen.getAllByText("Funding type required")).not.toHaveLength(0);
+    expect(
+      screen.getAllByText("Eligible applicants required"),
+    ).not.toHaveLength(0);
+    expect(screen.getAllByText("Invalid email")).not.toHaveLength(0);
+    expect(
+      screen.getAllByText("Additional eligibility info required"),
+    ).not.toHaveLength(0);
+  });
+});
+
+// ─── Key information display ──────────────────────────────────────────────────
+// The read-only panel resolves values through fallbacks: empty fields show the
+// "not available" placeholder; unknown enum values render as-is.
+describe("OpportunityEditForm — key information display", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders 'not available' fallback when all key information fields are empty", () => {
+    renderOpportunityEditForm({
+      opportunityKeyInformation: {
+        title: "",
+        agency: "",
+        assistanceListings: "",
+        opportunityNumber: "",
+        opportunityStage: "",
+        awardSelectionMethod: "",
+        awardSelectionMethodExplanation: "",
+      },
+    });
+
+    // The || fallback fires for each field — all should show the not-available key
+    const notAvailableEls = screen.getAllByText("content.notAvailable");
+    expect(notAvailableEls.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to the raw value when awardSelectionMethod is not a known enum", () => {
+    renderOpportunityEditForm({
+      initialValues: {
+        ...initialValues,
+        awardSelectionMethod: "unknown_method",
+      },
+    });
+
+    // find() returns undefined → ?.label is undefined → falls back to awardSelectionMethod value
+    expect(screen.getByText("unknown_method")).toBeInTheDocument();
+  });
+});
+
+// ─── Number formatting edge cases ────────────────────────────────────────────
+// Non-numeric and empty strings must pass through unchanged rather than being zeroed out.
+describe("OpportunityEditForm — number formatting edge cases", () => {
+  beforeEach(() => {
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      jest.fn(),
+      false,
+    ]);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("displays a non-numeric awardMinimum value as-is without formatting", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, awardMinimum: "abc" },
+    });
+
+    const input = screen.getByRole("textbox", {
+      name: /labels\.awardMinimum/i,
+    });
+
+    // formatNumber("abc") → isNaN branch → returns "abc" as-is
+    expect(input).toHaveValue("abc");
+  });
+
+  it("displays an empty awardMaximum as an empty string without formatting", () => {
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, awardMaximum: "" },
+    });
+
+    const input = screen.getByRole("textbox", {
+      name: /labels\.awardMaximum/i,
+    });
+
+    // formatNumber("") → !raw branch → returns ""
+    expect(input).toHaveValue("");
   });
 });

--- a/frontend/src/components/opportunity/opportunityEditFormConfig.test.ts
+++ b/frontend/src/components/opportunity/opportunityEditFormConfig.test.ts
@@ -1,4 +1,9 @@
-import { buildOpportunitySummaryUpdateRequest } from "./opportunityEditFormConfig";
+import { OpportunityDetail } from "src/types/opportunity/opportunityResponseTypes";
+
+import {
+  buildOpportunityEditInitialValues,
+  buildOpportunitySummaryUpdateRequest,
+} from "./opportunityEditFormConfig";
 
 function makeFormData(fields: Record<string, string | string[]>): FormData {
   const formData = new FormData();
@@ -11,6 +16,144 @@ function makeFormData(fields: Record<string, string | string[]>): FormData {
   }
   return formData;
 }
+
+function makeOpportunity(
+  summaryOverrides: Partial<OpportunityDetail["summary"]> = {},
+  opportunityOverrides: Partial<OpportunityDetail> = {},
+): OpportunityDetail {
+  return {
+    opportunity_id: "opp-1",
+    legacy_opportunity_id: 1,
+    opportunity_status: "posted",
+    opportunity_title: "Test Opportunity",
+    opportunity_number: "OPP-001",
+    category: "discretionary",
+    category_explanation: null,
+    agency_code: "TEST",
+    agency_name: "Test Agency",
+    top_level_agency_name: null,
+    created_at: "2026-01-01",
+    updated_at: "2026-01-01",
+    is_draft: true,
+    opportunity_assistance_listings: [],
+    attachments: [],
+    competitions: null,
+    saved_to_organizations: [],
+    summary: {
+      close_date: "2026-06-01",
+      is_forecast: false,
+      post_date: "2026-05-01",
+      additional_info_url: "https://example.com",
+      additional_info_url_description: "More info",
+      agency_code: "TEST",
+      agency_contact_description: "Contact us",
+      agency_email_address: "test@example.com",
+      agency_email_address_description: "Email us",
+      agency_name: "Test Agency",
+      agency_phone_number: null,
+      applicant_eligibility_description: "Open to all",
+      applicant_types: ["individuals"],
+      archive_date: null,
+      award_ceiling: 100000,
+      award_floor: 1000,
+      close_date_description: null,
+      estimated_total_program_funding: 500000,
+      expected_number_of_awards: 5,
+      fiscal_year: null,
+      forecasted_award_date: null,
+      forecasted_close_date: null,
+      forecasted_close_date_description: null,
+      forecasted_post_date: null,
+      forecasted_project_start_date: null,
+      funding_categories: ["education"],
+      funding_category_description: null,
+      funding_instruments: ["grant"],
+      is_cost_sharing: true,
+      summary_description: "A test description",
+      updated_at: "2026-01-01",
+      version_number: 1,
+      ...summaryOverrides,
+    },
+    ...opportunityOverrides,
+  };
+}
+
+describe("buildOpportunityEditInitialValues", () => {
+  it("maps opportunity and summary fields to form values", () => {
+    const result = buildOpportunityEditInitialValues(makeOpportunity());
+
+    expect(result.title).toBe("Test Opportunity");
+    expect(result.awardSelectionMethod).toBe("discretionary");
+    expect(result.description).toBe("A test description");
+    expect(result.fundingType).toBe("grant");
+    expect(result.fundingCategories).toBe("education");
+    expect(result.awardMinimum).toBe("1000");
+    expect(result.awardMaximum).toBe("100000");
+    expect(result.estimatedTotalProgramFunding).toBe("500000");
+    expect(result.expectedNumberOfAwards).toBe("5");
+    expect(result.eligibleApplicants).toEqual(["individuals"]);
+    expect(result.costSharing).toBe(true);
+    expect(result.publishDate).toBe("2026-05-01");
+    expect(result.closeDate).toBe("2026-06-01");
+    expect(result.contactEmail).toBe("test@example.com");
+  });
+
+  it("returns empty string for null numeric summary fields (numberToString null branch)", () => {
+    const result = buildOpportunityEditInitialValues(
+      makeOpportunity({
+        award_floor: null,
+        award_ceiling: null,
+        estimated_total_program_funding: null,
+        expected_number_of_awards: null,
+      }),
+    );
+
+    expect(result.awardMinimum).toBe("");
+    expect(result.awardMaximum).toBe("");
+    expect(result.estimatedTotalProgramFunding).toBe("");
+    expect(result.expectedNumberOfAwards).toBe("");
+  });
+
+  it("falls back to empty string when opportunity_title is null", () => {
+    const result = buildOpportunityEditInitialValues(
+      makeOpportunity({}, { opportunity_title: null }),
+    );
+
+    expect(result.title).toBe("");
+  });
+
+  it("returns empty string when funding_instruments array is empty", () => {
+    const result = buildOpportunityEditInitialValues(
+      makeOpportunity({ funding_instruments: [] }),
+    );
+
+    expect(result.fundingType).toBe("");
+  });
+
+  it("returns empty string when funding_instruments is null", () => {
+    const result = buildOpportunityEditInitialValues(
+      makeOpportunity({ funding_instruments: null }),
+    );
+
+    expect(result.fundingType).toBe("");
+  });
+
+  it("returns empty array when applicant_types is null", () => {
+    const result = buildOpportunityEditInitialValues(
+      makeOpportunity({ applicant_types: null }),
+    );
+
+    expect(result.eligibleApplicants).toEqual([]);
+  });
+
+  it("returns empty string when funding_categories is empty", () => {
+    const result = buildOpportunityEditInitialValues(
+      makeOpportunity({ funding_categories: [] }),
+    );
+
+    expect(result.fundingCategories).toBe("");
+  });
+});
 
 describe("buildOpportunitySummaryUpdateRequest", () => {
   describe("stringToNullableNumber fields", () => {
@@ -102,6 +245,15 @@ describe("buildOpportunitySummaryUpdateRequest", () => {
         "individuals",
         "state_governments",
       ]);
+    });
+
+    it("falls back to eligible-applicants-values when eligibleApplicants is empty", () => {
+      const result = buildOpportunitySummaryUpdateRequest(
+        makeFormData({
+          "eligible-applicants-values": ["state_governments"],
+        }),
+      );
+      expect(result.applicant_types).toEqual(["state_governments"]);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #9843

## Changes proposed

- Added unit tests for `OpportunityEditForm` covering rendering, alert banners, conditional fields, eligibility checkboxes, save state, field interactions, inline validation errors, key information display, and number formatting edge cases
- Added unit tests for `opportunityEditFormConfig` covering `buildOpportunityEditInitialValues` and `buildOpportunitySummaryUpdateRequest` including all null/empty branch paths

## Context for reviewers

Coverage targets per the acceptance criteria:

| File | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| `OpportunityEditForm.tsx` | 93.9% | 90.9% | 96.0% | 93.9% |
| `opportunityEditFormConfig.ts` | 100% | 91.6% | 100% | 100% |

Backend responses are simulated in tests without making any network calls. This follows the same pattern used in `CreateOpportunityForm`, `UserInviteForm`, and `UserProfileForm` tests.

## Validation steps

```
bash
cd frontend
npx jest --testPathPattern="src/components/opportunity/OpportunityEditForm|opportunityEditFormConfig" --no-coverage
```
### Expected: all tests passing
`npm run all-checks`

### Expected: all checks pass
