### PR TITLE
[unticketed]: fix uv issue in analytics docker image

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -112,6 +112,7 @@ COPY src /analytics/src
 ENV PATH="/analytics/.venv/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin" \
     HOST=0.0.0.0 \
     TMPDIR="/tmp" \
+    UV_CACHE_DIR="/tmp/.cache/uv" \
     SSL_CERT_FILE="/etc/pki/tls/certs/ca-bundle.crt" \
     SSL_CERT_DIR="/etc/pki/tls/certs" \
     PYTHONOPTIMIZE=0

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:f44d0bf@sha256:81b0aecb1ba33a4822f87bada8b220192db94ecd9fbad19d18d8976f3f2a1b16 AS base
+FROM ghcr.io/hhs/python-base-image:8ae2ecf@sha256:33d915d6da8c2c4049537fb5a5a209fb6af0a2b7009c524c3474631b57510864 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -113,6 +113,7 @@ ENV PATH="/analytics/.venv/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin" \
     HOST=0.0.0.0 \
     TMPDIR="/tmp" \
     UV_CACHE_DIR="/tmp/.cache/uv" \
+    UV_NO_SYNC=1 \
     SSL_CERT_FILE="/etc/pki/tls/certs/ca-bundle.crt" \
     SSL_CERT_DIR="/etc/pki/tls/certs" \
     PYTHONOPTIMIZE=0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:f44d0bf@sha256:81b0aecb1ba33a4822f87bada8b220192db94ecd9fbad19d18d8976f3f2a1b16 AS base
+FROM ghcr.io/hhs/python-base-image:8ae2ecf@sha256:33d915d6da8c2c4049537fb5a5a209fb6af0a2b7009c524c3474631b57510864 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -144,7 +144,7 @@ RUN dnf install -y \
       glib2-2.82.2-767.amzn2023 \
       curl-minimal-8.11.1-4.amzn2023.0.3 \
       libcurl-minimal-8.11.1-4.amzn2023.0.3 \
-      kernel6.18-headers-6.18.20-41.237.amzn2023 \
+      kernel6.18-headers-6.18.25-55.108.amzn2023 \
       glibc-2.34-231.amzn2023.0.4 \
       glibc-common-2.34-231.amzn2023.0.4 \
       glibc-devel-2.34-231.amzn2023.0.4 \


### PR DESCRIPTION
## Summary

Updated the analytics docker image with: `UV_CACHE_DIR="/tmp/.cache/uv"` and  `UV_NO_SYNC=1 `

## Validation steps

Deployed to dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/25680112754)

Ran the [analytics-dev-sprint-reports](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/statemachines/view/arn:aws:states:us-east-1:315341936575:stateMachine:analytics-dev-sprint-reports) successfully. 

<img width="651" height="303" alt="Screenshot 2026-05-11 at 11 46 36 AM" src="https://github.com/user-attachments/assets/b5630201-0118-4166-8505-9f1e5325275c" />


