### PR TITLE
[Issue #10142] Modify transform opportunity to set agency_id

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_opportunity.py
+++ b/api/src/data_migration/transformation/subtask/transform_opportunity.py
@@ -121,16 +121,16 @@ class TransformOpportunity(AbstractTransformSubTask):
                         "agency_id": agency.agency_id,
                     },
                 )
-                transformed_opportunity.agency_id = agency.agency_id
                 self.increment(self.Metrics.OPPORTUNITY_TRANSFORMED_HAS_AGENCY)
+                transformed_opportunity.agency_id = agency.agency_id
             else:
-                transformed_opportunity.agency_id = None
                 logger.info(
-                    "Attaching agency to opportunity",
+                    "No agency found to attach to opportunity",
                     extra=extra
                     | {"agency_code": transformed_opportunity.agency_code, "agency_id": None},
                 )
                 self.increment(self.Metrics.OPPORTUNITY_TRANSFORMED_NULL_AGENCY)
+                transformed_opportunity.agency_id = None
 
             if is_insert:
                 self.increment(

--- a/api/src/data_migration/transformation/subtask/transform_opportunity.py
+++ b/api/src/data_migration/transformation/subtask/transform_opportunity.py
@@ -1,5 +1,8 @@
 import logging
+from enum import StrEnum
 from typing import cast
+
+from sqlalchemy import select
 
 import src.data_migration.transformation.transform_constants as transform_constants
 import src.data_migration.transformation.transform_util as transform_util
@@ -7,6 +10,7 @@ from src.adapters.aws import S3Config
 from src.data_migration.transformation.subtask.abstract_transform_subtask import (
     AbstractTransformSubTask,
 )
+from src.db.models.agency_models import Agency
 from src.db.models.competition_models import Competition
 from src.db.models.opportunity_models import Opportunity, OpportunityAttachment
 from src.db.models.staging.opportunity import Topportunity
@@ -21,6 +25,12 @@ logger = logging.getLogger(__name__)
 
 
 class TransformOpportunity(AbstractTransformSubTask):
+
+    class Metrics(StrEnum):
+        # Note - most metrics we use are in the reused metrics
+        # class across each of the transform tasks, these are additional ones
+        OPPORTUNITY_TRANSFORMED_HAS_AGENCY = "opportunity_transformed_has_agency"
+        OPPORTUNITY_TRANSFORMED_NULL_AGENCY = "opportunity_transformed_null_agency"
 
     def __init__(self, task: Task, s3_config: S3Config | None = None):
         super().__init__(task)
@@ -100,6 +110,28 @@ class TransformOpportunity(AbstractTransformSubTask):
                 source_opportunity, target_opportunity
             )
 
+            agency = self._get_agency_for_opportunity(transformed_opportunity.agency_code)
+
+            if agency is not None:
+                logger.info(
+                    "Attaching agency to opportunity",
+                    extra=extra
+                    | {
+                        "agency_code": transformed_opportunity.agency_code,
+                        "agency_id": agency.agency_id,
+                    },
+                )
+                transformed_opportunity.agency_id = agency.agency_id
+                self.increment(self.Metrics.OPPORTUNITY_TRANSFORMED_HAS_AGENCY)
+            else:
+                transformed_opportunity.agency_id = None
+                logger.info(
+                    "Attaching agency to opportunity",
+                    extra=extra
+                    | {"agency_code": transformed_opportunity.agency_code, "agency_id": None},
+                )
+                self.increment(self.Metrics.OPPORTUNITY_TRANSFORMED_NULL_AGENCY)
+
             if is_insert:
                 self.increment(
                     transform_constants.Metrics.TOTAL_RECORDS_INSERTED,
@@ -172,3 +204,57 @@ class TransformOpportunity(AbstractTransformSubTask):
             )
             file_util.move_file(competition_instruction.file_location, s3_path)
             competition_instruction.file_location = s3_path
+
+    def _get_agency_for_opportunity(self, agency_code: str | None) -> Agency | None:
+        # shortcut if the agency code is null/blank rather than query the DB
+        if not agency_code:
+            return None
+        return self.db_session.scalar(select(Agency).where(Agency.agency_code == agency_code))
+
+
+class TransformOpportunityAgencyConnection(AbstractTransformSubTask):
+    """
+    Handle connecting opportunities to their agency. This exists
+    to account for any edge cases in processing when we connect the opportunity
+    to its agency during the transform opportunity logic, and as a backfill.
+
+    Note, this ONLY will attach an opportunity to an agency when opportunity
+    does not have the agency_id set - it will not even fetch opportunities
+    with that set (ie. it can't correct mistakes).
+    """
+
+    class Metrics(StrEnum):
+        OPPORTUNITY_AGENCY_CONNECTION_COUNT = "opportunity_agency_connection_count"
+
+    def transform_records(self) -> None:
+        # Fetch all opportunities that need to be connected to their agency
+        opportunity_agencies: list[tuple[Opportunity, Agency]] = (
+            self.fetch_opportunities_and_agencies()
+        )
+
+        # Connect them
+        for opportunity, agency in opportunity_agencies:
+            logger.info(
+                "Adding agency to opportunity",
+                extra={
+                    "opportunity_id": opportunity.opportunity_id,
+                    "agency_id": agency.agency_id,
+                    "agency_code": opportunity.agency_code,
+                },
+            )
+            self.increment(self.Metrics.OPPORTUNITY_AGENCY_CONNECTION_COUNT)
+            opportunity.agency_id = agency.agency_id
+
+    def fetch_opportunities_and_agencies(self) -> list[tuple[Opportunity, Agency]]:
+        """Fetch all opportunities without an agency_id set that could have it set"""
+        return cast(
+            list[tuple[Opportunity, Agency]],
+            self.db_session.execute(
+                select(Opportunity, Agency)
+                # This join means we'll only fetch records where
+                # the agency exists for the opportunity that we'll be updating.
+                .join(Agency, Opportunity.agency_code == Agency.agency_code)
+                .where(Opportunity.agency_id.is_(None))
+                .execution_options(yield_per=5000)
+            ),
+        )

--- a/api/src/data_migration/transformation/transform_oracle_data_task.py
+++ b/api/src/data_migration/transformation/transform_oracle_data_task.py
@@ -26,7 +26,10 @@ from src.data_migration.transformation.subtask.transform_funding_category import
 from src.data_migration.transformation.subtask.transform_funding_instrument import (
     TransformFundingInstrument,
 )
-from src.data_migration.transformation.subtask.transform_opportunity import TransformOpportunity
+from src.data_migration.transformation.subtask.transform_opportunity import (
+    TransformOpportunity,
+    TransformOpportunityAgencyConnection,
+)
 from src.data_migration.transformation.subtask.transform_opportunity_attachment import (
     TransformOpportunityAttachment,
 )
@@ -79,8 +82,15 @@ class TransformOracleDataTask(Task):
         self.transform_config = transform_config
 
     def run_task(self) -> None:
+
+        if self.transform_config.enable_agency:
+            TransformAgency(self).run()
+            TransformAgencyHierarchy(self).run()
+            ValidateAgencyData(self).run()
+
         if self.transform_config.enable_opportunity:
             TransformOpportunity(self).run()
+            TransformOpportunityAgencyConnection(self).run()
 
         if self.transform_config.enable_assistance_listing:
             TransformAssistanceListing(self).run()
@@ -96,11 +106,6 @@ class TransformOracleDataTask(Task):
 
         if self.transform_config.enable_funding_instrument:
             TransformFundingInstrument(self).run()
-
-        if self.transform_config.enable_agency:
-            TransformAgency(self).run()
-            TransformAgencyHierarchy(self).run()
-            ValidateAgencyData(self).run()
 
         if self.transform_config.enable_opportunity_attachment:
             TransformOpportunityAttachment(self).run()

--- a/api/tests/src/data_migration/transformation/conftest.py
+++ b/api/tests/src/data_migration/transformation/conftest.py
@@ -495,6 +495,8 @@ def validate_opportunity(
     source_opportunity: staging.opportunity.Topportunity,
     expect_in_db: bool = True,
     expect_values_to_match: bool = True,
+    expected_agency: Agency | None = None,
+    expect_agency_id_to_be_set: bool | None = None,
 ):
     opportunity = (
         db_session.query(Opportunity)
@@ -529,6 +531,13 @@ def validate_opportunity(
             assert opportunity.is_draft is False
         else:
             assert opportunity.is_draft is True
+
+        if expected_agency is not None:
+            assert opportunity.agency_id == expected_agency.agency_id
+
+    # Only check if the value was passed in, none won't check
+    if expect_agency_id_to_be_set is not None:
+        assert (opportunity.agency_id is not None) == expect_agency_id_to_be_set
 
 
 def validate_assistance_listing(

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_opportunity.py
@@ -1,9 +1,15 @@
+import uuid
+
 import pytest
 from sqlalchemy import update
 
 import src.data_migration.transformation.transform_constants as transform_constants
-from src.data_migration.transformation.subtask.transform_opportunity import TransformOpportunity
+from src.data_migration.transformation.subtask.transform_opportunity import (
+    TransformOpportunity,
+    TransformOpportunityAgencyConnection,
+)
 from src.db.models import staging
+from src.db.models.opportunity_models import Opportunity
 from src.services.competition_alpha.competition_instruction_util import (
     get_s3_competition_instruction_path,
 )
@@ -15,6 +21,7 @@ from tests.src.data_migration.transformation.conftest import (
     validate_opportunity,
 )
 from tests.src.db.models.factories import (
+    AgencyFactory,
     CompetitionFactory,
     CompetitionInstructionFactory,
     OpportunityAttachmentFactory,
@@ -26,6 +33,8 @@ class TestTransformOpportunity(BaseTransformTestClass):
 
     @pytest.fixture(autouse=True)
     def clear_opportunities(self, db_session):
+        # Mark any opportunity in the staging table as transformed so we'll
+        # ignore it for these tests rather than try to cleanup the data.
         db_session.execute(
             update(staging.opportunity.Topportunity)
             .where(staging.opportunity.Topportunity.transformed_at.is_(None))
@@ -255,3 +264,186 @@ class TestTransformOpportunity(BaseTransformTestClass):
         for attachment in attachments:
             assert attachment.file_location.startswith(s3_config.draft_files_bucket_path) is True
             assert file_util.file_exists(attachment.file_location) is True
+
+    def test_process_opportunity_new_opportunity_existing_agency(
+        self, db_session, transform_opportunity
+    ):
+        """Test that for a new opportunity, the proper agency gets attached if it exists"""
+        agency = AgencyFactory.create()
+
+        source_opportunity = setup_opportunity(
+            create_existing=False, source_values={"owningagency": agency.agency_code}
+        )
+
+        transform_opportunity.process_opportunity(source_opportunity, None)
+
+        validate_opportunity(db_session, source_opportunity, expected_agency=agency)
+
+        assert (
+            transform_opportunity.metrics[
+                transform_opportunity.Metrics.OPPORTUNITY_TRANSFORMED_HAS_AGENCY
+            ]
+            == 1
+        )
+
+    def test_process_opportunity_new_opportunity_no_existing_agency(
+        self, db_session, transform_opportunity
+    ):
+        """Test that for a new opportunity, no agency is attached if it doesn't exist"""
+        source_opportunity = setup_opportunity(
+            create_existing=False, source_values={"owningagency": str(uuid.uuid4())}
+        )
+
+        transform_opportunity.process_opportunity(source_opportunity, None)
+
+        validate_opportunity(db_session, source_opportunity, expect_agency_id_to_be_set=False)
+
+        assert (
+            transform_opportunity.metrics[
+                transform_opportunity.Metrics.OPPORTUNITY_TRANSFORMED_NULL_AGENCY
+            ]
+            == 1
+        )
+
+    def test_process_opportunity_update_opportunity_existing_agency(
+        self, db_session, transform_opportunity
+    ):
+        """Test that for updating an opportunity, the proper agency gets attached if it exists"""
+        agency = AgencyFactory.create()
+
+        source_opportunity = setup_opportunity(
+            create_existing=False, source_values={"owningagency": agency.agency_code}
+        )
+        target_opportunity = OpportunityFactory.create(
+            legacy_opportunity_id=source_opportunity.opportunity_id,
+            is_draft=False,
+            agency_id=None,
+            opportunity_attachments=[],
+        )
+
+        transform_opportunity.process_opportunity(source_opportunity, target_opportunity)
+
+        validate_opportunity(db_session, source_opportunity, expected_agency=agency)
+
+        assert (
+            transform_opportunity.metrics[
+                transform_opportunity.Metrics.OPPORTUNITY_TRANSFORMED_HAS_AGENCY
+            ]
+            == 1
+        )
+
+    def test_process_opportunity_update_opportunity_to_nonexistant_agency(
+        self, db_session, transform_opportunity
+    ):
+        """Test that for updating an opportunity, we can null out the agency if it doesn't exist"""
+        agency = AgencyFactory.create()
+
+        source_opportunity = setup_opportunity(
+            create_existing=False, source_values={"owningagency": str(uuid.uuid4())}
+        )
+        target_opportunity = OpportunityFactory.create(
+            legacy_opportunity_id=source_opportunity.opportunity_id,
+            is_draft=False,
+            agency_id=agency.agency_id,
+            opportunity_attachments=[],
+        )
+
+        transform_opportunity.process_opportunity(source_opportunity, target_opportunity)
+
+        validate_opportunity(db_session, source_opportunity, expect_agency_id_to_be_set=False)
+
+        assert (
+            transform_opportunity.metrics[
+                transform_opportunity.Metrics.OPPORTUNITY_TRANSFORMED_NULL_AGENCY
+            ]
+            == 1
+        )
+
+
+##############################################
+# TransformOpportunityAgencyConnection test
+##############################################
+
+
+def validate_agency_connection(db_session, opportunity, expected_agency):
+    db_session.refresh(opportunity)
+
+    if expected_agency is not None:
+        assert opportunity.agency_id == expected_agency.agency_id
+    else:
+        assert opportunity.agency_id is None
+
+
+class TestTransformOpportunityAgencyConnection(BaseTransformTestClass):
+
+    @pytest.fixture(autouse=True)
+    def cleanup_opportunities(self, db_session, enable_factory_create):
+        # We want to avoid this test fetch any other opportunities than
+        # the ones we configured. Easiest way to do that is make it so
+        # other opportunties all have their agency_id set.
+        agency = AgencyFactory.create()
+
+        # Update every agency with a null agency_id to the above agency
+        db_session.execute(
+            update(Opportunity)
+            .values(agency_id=agency.agency_id, agency_code=agency.agency_code)
+            .where(Opportunity.agency_id.is_(None))
+        )
+        db_session.commit()
+
+    @pytest.fixture
+    def transform_opportunity_agency_connection(self, transform_oracle_data_task):
+        return TransformOpportunityAgencyConnection(transform_oracle_data_task)
+
+    def test_transform_opportunity_agency_connection(
+        self, db_session, transform_opportunity_agency_connection
+    ):
+
+        agency1 = AgencyFactory.create()
+        agency2 = AgencyFactory.create()
+        agency3 = AgencyFactory.create()
+
+        opportunity1 = OpportunityFactory.create(agency_code=agency1.agency_code, agency_id=None)
+        opportunity2 = OpportunityFactory.create(agency_code=agency1.agency_code, agency_id=None)
+        opportunity3 = OpportunityFactory.create(agency_code=agency2.agency_code, agency_id=None)
+        opportunity4 = OpportunityFactory.create(agency_code=agency3.agency_code, agency_id=None)
+        opportunity5 = OpportunityFactory.create(agency_code=agency3.agency_code, agency_id=None)
+
+        # These opportunities won't get modified - even if they're currently wrong
+        opportunity6 = OpportunityFactory.create(
+            agency_code=agency1.agency_code, agency_id=agency1.agency_id
+        )
+        # this is wrong
+        opportunity7 = OpportunityFactory.create(
+            agency_code=agency2.agency_code, agency_id=agency1.agency_id
+        )
+        opportunity8 = OpportunityFactory.create(
+            agency_code=agency3.agency_code, agency_id=agency3.agency_id
+        )
+
+        # agency codes that don't match any agency, also aren't picked up (using UUIDs to be certain they're not in the DB)
+        opportunity9 = OpportunityFactory.create(agency_code=str(uuid.uuid4()), agency_id=None)
+        opportunity10 = OpportunityFactory.create(agency_code=str(uuid.uuid4()), agency_id=None)
+
+        transform_opportunity_agency_connection.run()
+
+        # All the processed opportunities
+        validate_agency_connection(db_session, opportunity1, agency1)
+        validate_agency_connection(db_session, opportunity2, agency1)
+        validate_agency_connection(db_session, opportunity3, agency2)
+        validate_agency_connection(db_session, opportunity4, agency3)
+        validate_agency_connection(db_session, opportunity5, agency3)
+
+        # None of these were touched
+        validate_agency_connection(db_session, opportunity6, agency1)
+        validate_agency_connection(db_session, opportunity7, agency1)
+        validate_agency_connection(db_session, opportunity8, agency3)
+        validate_agency_connection(db_session, opportunity9, None)
+        validate_agency_connection(db_session, opportunity10, None)
+
+        assert (
+            transform_opportunity_agency_connection.metrics[
+                transform_opportunity_agency_connection.Metrics.OPPORTUNITY_AGENCY_CONNECTION_COUNT
+            ]
+            == 5
+        )


### PR DESCRIPTION
## Summary
Fixes  #10142

## Changes proposed
* Adjust the transform_opportunity logic to set the agency ID on the opportunity when transforming
* Add a new task that handles backfilling anything that isn't already set

## Context for reviewers
We're halfway through pivoting from our current approach of managing the agency foreign key to the agency table (joining on the `agency_code` field in both tables) to a proper foreign key using `agency_id`. This'll make it so that opportunities we pull from grants.gov attempt to set the `agency_id` when we transform, as well as handle backfilling anything that might have been missed.

I'm not 100% certain, but there may be some timing edge cases where we could have the transform bit not properly link everything, so I'm erring on the side of being cautious and we'll run the backfill every hour. It only will pickup opportunities that can be connected to an agency that aren't already connected. So, if after a few weeks, the metric is always 0 processed, we can clean it up.

## Validation steps
These are mainly tested via our unit tests. I did do a quick run locally of the load-transform jobs with 10k opportunities that had no agency ID, and it took only ~1 second to run, so even though non-locally it'll be a bit slower, I think that's on the order of 1-2 minutes.
