### PR TITLE
[Issue#9903] Add individual applicant coverage to submission happy path

### DIFF
--- a/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
@@ -22,10 +22,7 @@ import { SFLLL_FORM_CONFIG } from "tests/e2e/apply/fixtures/sfLLL-fill-data";
 import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
-import {
-  createApplication,
-  INDIVIDUAL_APPLICANT_LABEL,
-} from "tests/e2e/utils/create-application-utils";
+import { createApplication } from "tests/e2e/utils/create-application-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { selectFormInclusionOption } from "tests/e2e/utils/forms/select-form-inclusion-utils";
 import {
@@ -44,18 +41,12 @@ const applicantScenarios = [
   {
     testName:
       "Complete the Application Submission workflow for an Organization user, with required and conditional forms",
-    createApplicationInput: {
-      applicantType: "organization" as const,
-      orgLabel: testOrgLabel,
-    },
+    orgLabel: testOrgLabel,
   },
   {
     testName:
       "Complete the Application Submission workflow for an Individual user, with required and conditional forms",
-    createApplicationInput: {
-      applicantType: "individual" as const,
-      whoIsApplyingLabel: INDIVIDUAL_APPLICANT_LABEL,
-    },
+    orgLabel: undefined,
   },
 ] as const;
 
@@ -69,7 +60,7 @@ test.beforeEach(({ page: _ }, testInfo) => {
   }
 });
 
-for (const { testName, createApplicationInput } of applicantScenarios) {
+for (const { testName, orgLabel } of applicantScenarios) {
   test(
     testName,
     { tag: [SMOKE, GRANTEE, APPLY] },
@@ -85,7 +76,7 @@ for (const { testName, createApplicationInput } of applicantScenarios) {
       await authenticateE2eUser(page, context, !!isMobile);
 
       // Covers "Starting a new application" flow for both org and individual applicants.
-      await createApplication(page, OPPORTUNITY_URL, createApplicationInput);
+      await createApplication(page, OPPORTUNITY_URL, orgLabel);
       const applicationUrl = page.url();
 
       // When the user clicks on SF424B form link

--- a/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
@@ -22,7 +22,10 @@ import { SFLLL_FORM_CONFIG } from "tests/e2e/apply/fixtures/sfLLL-fill-data";
 import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/authenticate-e2e-user-utils";
-import { createApplication } from "tests/e2e/utils/create-application-utils";
+import {
+  createApplication,
+  INDIVIDUAL_APPLICANT_LABEL,
+} from "tests/e2e/utils/create-application-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { selectFormInclusionOption } from "tests/e2e/utils/forms/select-form-inclusion-utils";
 import {
@@ -37,6 +40,25 @@ const { testOrgLabel, targetEnv } = playwrightEnv;
 const OPPORTUNITY_ID = "f7a1c2b3-4d5e-6789-8abc-1234567890ab"; // TEST-APPLY-ORG-IND-ON01
 const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
+const applicantScenarios = [
+  {
+    testName:
+      "Complete the Application Submission workflow for an Organization user, with required and conditional forms",
+    createApplicationInput: {
+      applicantType: "organization" as const,
+      orgLabel: testOrgLabel,
+    },
+  },
+  {
+    testName:
+      "Complete the Application Submission workflow for an Individual user, with required and conditional forms",
+    createApplicationInput: {
+      applicantType: "individual" as const,
+      whoIsApplyingLabel: INDIVIDUAL_APPLICANT_LABEL,
+    },
+  },
+] as const;
+
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
   if (targetEnv === "staging") {
@@ -47,79 +69,77 @@ test.beforeEach(({ page: _ }, testInfo) => {
   }
 });
 
-test(
-  "Application submission happy path - application with required SF424B and conditional SFLLL",
-  { tag: [SMOKE, GRANTEE, APPLY] },
-  async (
-    { page, context }: { page: Page; context: BrowserContext },
-    testInfo: TestInfo,
-  ) => {
-    test.setTimeout(300_000); // 5 min timeout
+for (const { testName, createApplicationInput } of applicantScenarios) {
+  test(
+    testName,
+    { tag: [SMOKE, GRANTEE, APPLY] },
+    async (
+      { page, context }: { page: Page; context: BrowserContext },
+      testInfo: TestInfo,
+    ) => {
+      test.setTimeout(300_000); // 5 min timeout
 
-    const isMobile = testInfo.project.name.match(/[Mm]obile/);
+      const isMobile = testInfo.project.name.match(/[Mm]obile/);
 
-    // Given the user is logged in
-    await authenticateE2eUser(page, context, !!isMobile);
+      // Given the user is logged in
+      await authenticateE2eUser(page, context, !!isMobile);
 
-    // Call reusable create application function from utils
-    /**
-     * Covers "Starting a new application" flow in the feature file
-     * (includes modal interaction, organization selection, and application creation)
-     */
-    await createApplication(page, OPPORTUNITY_URL, testOrgLabel);
-    const applicationUrl = page.url();
+      // Covers "Starting a new application" flow for both org and individual applicants.
+      await createApplication(page, OPPORTUNITY_URL, createApplicationInput);
+      const applicationUrl = page.url();
 
-    // When the user clicks on SF424B form link
-    // Then the form opens
-    // And the user fills out the form with valid test data
-    // And the user clicks Save
-    await fillForm(
-      testInfo,
-      page,
-      SF424B_FORM_CONFIG,
-      sf424BHappyPathTestData(testOrgLabel),
-      false,
-    );
+      // When the user clicks on SF424B form link
+      // Then the form opens
+      // And the user fills out the form with valid test data
+      // And the user clicks Save
+      await fillForm(
+        testInfo,
+        page,
+        SF424B_FORM_CONFIG,
+        sf424BHappyPathTestData(testOrgLabel),
+        false,
+      );
 
-    // Verify save success alert on form page
-    await verifyFormStatusAfterSave(page, "complete");
+      // Verify save success alert on form page
+      await verifyFormStatusAfterSave(page, "complete");
 
-    // On application page - verify form row shows "No issues detected"
-    await verifyFormStatusOnApplication(
-      page,
-      "complete",
-      "SF-424B",
-      applicationUrl,
-    );
+      // On application page - verify form row shows "No issues detected"
+      await verifyFormStatusOnApplication(
+        page,
+        "complete",
+        "SF-424B",
+        applicationUrl,
+      );
 
-    // Extra wait for page to fully render forms table after navigation
-    await page.waitForTimeout(10000);
+      // Extra wait for page to fully render forms table after navigation
+      await page.waitForTimeout(10000);
 
-    // Select 'Yes' for including SF-LLL form in submission
-    await selectFormInclusionOption(
-      page,
-      "Disclosure of Lobbying Activities (SF-LLL)",
-      "Yes",
-    );
+      // Select 'Yes' for including SF-LLL form in submission
+      await selectFormInclusionOption(
+        page,
+        "Disclosure of Lobbying Activities (SF-LLL)",
+        "Yes",
+      );
 
-    // When the user clicks on SF-LLL form link
-    // Then the form opens
-    // And the user fills out the form with valid test data
-    // And the user clicks Save
-    await fillForm(testInfo, page, SFLLL_FORM_CONFIG, SFLLL_TEST_DATA, false);
+      // When the user clicks on SF-LLL form link
+      // Then the form opens
+      // And the user fills out the form with valid test data
+      // And the user clicks Save
+      await fillForm(testInfo, page, SFLLL_FORM_CONFIG, SFLLL_TEST_DATA, false);
 
-    // Verify SF-LLL save success alert on form page
-    await verifyFormStatusAfterSave(page, "complete");
+      // Verify SF-LLL save success alert on form page
+      await verifyFormStatusAfterSave(page, "complete");
 
-    // On application page - verify SF-LLL row shows "No issues detected"
-    await verifyFormStatusOnApplication(
-      page,
-      "complete",
-      "SF-LLL",
-      applicationUrl,
-    );
+      // On application page - verify SF-LLL row shows "No issues detected"
+      await verifyFormStatusOnApplication(
+        page,
+        "complete",
+        "SF-LLL",
+        applicationUrl,
+      );
 
-    // Submit the application and verify success
-    await submitApplicationAndVerify(page, "success");
-  },
-);
+      // Submit the application and verify success
+      await submitApplicationAndVerify(page, "success");
+    },
+  );
+}

--- a/frontend/tests/e2e/utils/create-application-utils.ts
+++ b/frontend/tests/e2e/utils/create-application-utils.ts
@@ -103,7 +103,7 @@ export async function createApplication(
 
   if (!requestedLabel) {
     throw new Error(
-      "createApplication requires an organization label when applying as an organization."
+      "createApplication requires an organization label when applying as an organization.",
     );
   }
   await gotoWithRetry(page, `${baseUrl}${opportunityUrl}`, {

--- a/frontend/tests/e2e/utils/create-application-utils.ts
+++ b/frontend/tests/e2e/utils/create-application-utils.ts
@@ -9,14 +9,6 @@ const { baseUrl } = playwrightEnv;
 
 export const INDIVIDUAL_APPLICANT_LABEL = "As an individual (myself)";
 
-type CreateApplicationInput =
-  | string
-  | {
-      applicantType?: "organization" | "individual";
-      orgLabel?: string;
-      whoIsApplyingLabel?: string;
-    };
-
 async function selectOptionByLabelSubstring(
   selectLocator: Locator,
   labelSubstring: string,
@@ -97,28 +89,20 @@ async function selectOptionByLabelSubstring(
  * Creates a new application for the given opportunity.
  * @param page Playwright Page object
  * @param opportunityUrl Opportunity URL (e.g. "/opportunity/abc123")
- * @param input Organization label string (legacy) or applicant selection options
+ * @param orgLabel Optional organization label. If omitted, the application is created as an individual.
  */
 export async function createApplication(
   page: Page,
   opportunityUrl: string,
-  input: CreateApplicationInput,
+  orgLabel?: string,
 ) {
-  const isLegacyLabel = typeof input === "string";
-  const applicantType = isLegacyLabel
-    ? "organization"
-    : (input.applicantType ?? "organization");
-  const requestedLabel = isLegacyLabel
-    ? input
-    : (input.whoIsApplyingLabel ??
-      (applicantType === "individual"
-        ? INDIVIDUAL_APPLICANT_LABEL
-        : input.orgLabel));
+  const isIndividualApplicant = !orgLabel;
+  const requestedLabel = isIndividualApplicant
+    ? INDIVIDUAL_APPLICANT_LABEL
+    : orgLabel;
 
   if (!requestedLabel) {
-    throw new Error(
-      "createApplication requires orgLabel for organization applicants or whoIsApplyingLabel.",
-    );
+    throw new Error("createApplication requires an organization label.");
   }
   await gotoWithRetry(page, `${baseUrl}${opportunityUrl}`, {
     waitUntil: "domcontentloaded",
@@ -141,7 +125,7 @@ export async function createApplication(
     await selectOptionByLabelSubstring(
       orgSelect,
       requestedLabel,
-      applicantType === "organization",
+      isIndividualApplicant,
     );
   }
   const nameInput = modal.locator(

--- a/frontend/tests/e2e/utils/create-application-utils.ts
+++ b/frontend/tests/e2e/utils/create-application-utils.ts
@@ -12,7 +12,7 @@ export const INDIVIDUAL_APPLICANT_LABEL = "As an individual (myself)";
 async function selectOptionByLabelSubstring(
   selectLocator: Locator,
   labelSubstring: string,
-  fallbackToIndividual: boolean,
+  isIndividualApplicant: boolean,
 ) {
   const select = selectLocator.first();
   await select.waitFor({ state: "visible", timeout: 5000 });
@@ -32,7 +32,7 @@ async function selectOptionByLabelSubstring(
         );
 
         return (
-          hasRequestedOption || (fallbackToIndividual && hasIndividualOption)
+          hasRequestedOption || (isIndividualApplicant && hasIndividualOption)
         );
       },
       {
@@ -53,7 +53,7 @@ async function selectOptionByLabelSubstring(
 
   const resolvedLabel =
     options.find((opt: string) => opt.includes(labelSubstring)) ??
-    (fallbackToIndividual
+    (isIndividualApplicant
       ? options.find((opt: string) => opt.includes(INDIVIDUAL_APPLICANT_LABEL))
       : undefined);
 
@@ -102,7 +102,9 @@ export async function createApplication(
     : orgLabel;
 
   if (!requestedLabel) {
-    throw new Error("createApplication requires an organization label.");
+    throw new Error(
+      "createApplication requires an organization label when applying as an organization."
+    );
   }
   await gotoWithRetry(page, `${baseUrl}${opportunityUrl}`, {
     waitUntil: "domcontentloaded",

--- a/frontend/tests/e2e/utils/create-application-utils.ts
+++ b/frontend/tests/e2e/utils/create-application-utils.ts
@@ -7,28 +7,44 @@ import { gotoWithRetry } from "./lifecycle-utils";
 
 const { baseUrl } = playwrightEnv;
 
+export const INDIVIDUAL_APPLICANT_LABEL = "As an individual (myself)";
+
+type CreateApplicationInput =
+  | string
+  | {
+      applicantType?: "organization" | "individual";
+      orgLabel?: string;
+      whoIsApplyingLabel?: string;
+    };
+
 async function selectOptionByLabelSubstring(
   selectLocator: Locator,
   labelSubstring: string,
+  fallbackToIndividual: boolean,
 ) {
   const select = selectLocator.first();
   await select.waitFor({ state: "visible", timeout: 5000 });
   await expect(select).toBeEnabled({ timeout: 10000 });
 
-  // Wait for org options to load — on WebKit the dropdown may initially only
-  // show default options before the org list is fetched from the API.
-  // If the org never appears (e.g. e2e user has no orgs), fall back to individual.
+  // Wait for dropdown options to load. For organization tests, allow an
+  // individual fallback when no matching org label exists.
   await expect
     .poll(
       async () => {
         const options = await select.locator("option").allTextContents();
+        const hasRequestedOption = options.some((opt) =>
+          opt.includes(labelSubstring),
+        );
+        const hasIndividualOption = options.some((opt) =>
+          opt.includes(INDIVIDUAL_APPLICANT_LABEL),
+        );
+
         return (
-          options.some((opt) => opt.includes(labelSubstring)) ||
-          options.some((opt) => opt.includes("As an individual"))
+          hasRequestedOption || (fallbackToIndividual && hasIndividualOption)
         );
       },
       {
-        message: `Waiting for options to load in dropdown`,
+        message: "Waiting for options to load in dropdown",
         timeout: 30000,
       },
     )
@@ -45,7 +61,9 @@ async function selectOptionByLabelSubstring(
 
   const resolvedLabel =
     options.find((opt: string) => opt.includes(labelSubstring)) ??
-    options.find((opt: string) => opt.includes("As an individual (myself)"));
+    (fallbackToIndividual
+      ? options.find((opt: string) => opt.includes(INDIVIDUAL_APPLICANT_LABEL))
+      : undefined);
 
   if (!resolvedLabel) {
     throw new Error(
@@ -70,7 +88,7 @@ async function selectOptionByLabelSubstring(
   const selectedValue = await select.inputValue();
   if (!selectedValue) {
     throw new Error(
-      `Failed to select option "${resolvedLabel}" — no value was set after selection.`,
+      `Failed to select option "${resolvedLabel}" - no value was set after selection.`,
     );
   }
 }
@@ -79,13 +97,29 @@ async function selectOptionByLabelSubstring(
  * Creates a new application for the given opportunity.
  * @param page Playwright Page object
  * @param opportunityUrl Opportunity URL (e.g. "/opportunity/abc123")
- * @param orgLabel Organization label to select
+ * @param input Organization label string (legacy) or applicant selection options
  */
 export async function createApplication(
   page: Page,
   opportunityUrl: string,
-  orgLabel: string,
+  input: CreateApplicationInput,
 ) {
+  const isLegacyLabel = typeof input === "string";
+  const applicantType = isLegacyLabel
+    ? "organization"
+    : (input.applicantType ?? "organization");
+  const requestedLabel = isLegacyLabel
+    ? input
+    : (input.whoIsApplyingLabel ??
+      (applicantType === "individual"
+        ? INDIVIDUAL_APPLICANT_LABEL
+        : input.orgLabel));
+
+  if (!requestedLabel) {
+    throw new Error(
+      "createApplication requires orgLabel for organization applicants or whoIsApplyingLabel.",
+    );
+  }
   await gotoWithRetry(page, `${baseUrl}${opportunityUrl}`, {
     waitUntil: "domcontentloaded",
   });
@@ -104,7 +138,11 @@ export async function createApplication(
   );
   const orgSelectCount = await orgSelect.count();
   if (orgSelectCount > 0) {
-    await selectOptionByLabelSubstring(orgSelect, orgLabel);
+    await selectOptionByLabelSubstring(
+      orgSelect,
+      requestedLabel,
+      applicantType === "organization",
+    );
   }
   const nameInput = modal.locator(
     'input[name*="name"], input[placeholder*="application"], input[type="text"]:nth-of-type(1)',


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9903 
This PR adds explicit Individual applicant coverage to the submission happy-path flow while preserving existing behavior for Organization-based tests.

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

<h3>Summary</h3>
<p>
  This PR adds explicit Individual applicant coverage to the submission happy-path flow while preserving existing behavior for Organization-based tests.
</p>

<h3>What Changed</h3>

<h4>1) Added explicit Individual support in shared application-creation utility</h4>
<p>
  Updated <code>frontend/tests/e2e/utils/create-application-utils.ts</code> to support both input styles:
</p>
<ul>
  <li>Legacy input: organization label string</li>
  <li>Structured input:
    <ul>
      <li><code>applicantType</code></li>
      <li><code>whoIsApplyingLabel</code> or <code>orgLabel</code></li>
    </ul>
  </li>
</ul>

<p>Additional updates:</p>
<ul>
  <li>Added constant: <code>INDIVIDUAL_APPLICANT_LABEL = "As an individual (myself)"</code></li>
  <li>Preserved backward compatibility for all existing call sites that pass <code>testOrgLabel</code></li>
  <li>
    Enhanced selection logic to:
    <ul>
      <li>support explicit Individual selection</li>
      <li>keep controlled Organization fallback behavior</li>
    </ul>
  </li>
</ul>

<h4>2) Updated submission happy-path spec to run both applicant types</h4>
<p>
  Updated <code>frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts</code>:
</p>
<ul>
  <li>Added two in-spec scenarios:
    <ul>
      <li>Organization user</li>
      <li>Individual user</li>
    </ul>
  </li>
  <li>Both scenarios now call <code>createApplication(...)</code> with explicit applicant input</li>
  <li>Individual scenario explicitly uses <code>As an individual (myself)</code> via <code>INDIVIDUAL_APPLICANT_LABEL</code></li>
</ul>


## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

<ul>
  <li>Type/diagnostic check: no errors in both edited files</li>
  <li>
    Playwright test discovery (<code>--list</code>) confirms 2 tests in the submission spec:
    <ul>
      <li>Organization workflow</li>
      <li>Individual workflow</li>
    </ul>
  </li>
</ul>

<img width="1087" height="805" alt="image" src="https://github.com/user-attachments/assets/6a78bdec-90e6-40f8-8fcd-cd868e3330f7" />

Local and stg test passed: https://github.com/HHS/simpler-grants-gov/actions/runs/25697240818

