### PR TITLE
[Unticketed] Upgrade package dependencies for vuln scan

### DIFF
--- a/analytics/pyproject.toml
+++ b/analytics/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic>=2.0.3,<3",
     "slack-sdk>=3.23.0,<4",
     "sqlparse>=0.5.0",
-    "typer[all]>=0.25.0,<0.26",
+    "typer>=0.25.0,<0.26",
     "sqlalchemy>=2.0.30,<3",
     "pydantic-settings>=2.3.4,<3",
     "boto3>=1.35.56,<2",
@@ -25,7 +25,7 @@ dependencies = [
     "smart-open>=7.0.5,<8",
     "newrelic>=11.5.0,<12",
     "requests>=2.33.0,<3",
-    "urllib3>=2.6.3,<3",
+    "urllib3>=2.7.0,<3",
 ]
 
 [project.scripts]

--- a/analytics/uv.lock
+++ b/analytics/uv.lock
@@ -923,8 +923,8 @@ requires-dist = [
     { name = "smart-open", specifier = ">=7.0.5,<8" },
     { name = "sqlalchemy", specifier = ">=2.0.30,<3" },
     { name = "sqlparse", specifier = ">=0.5.0" },
-    { name = "typer", extras = ["all"], specifier = ">=0.25.0,<0.26" },
-    { name = "urllib3", specifier = ">=2.6.3,<3" },
+    { name = "typer", specifier = ">=0.25.0,<0.26" },
+    { name = "urllib3", specifier = ">=2.7.0,<3" },
 ]
 
 [package.metadata.requires-dev]
@@ -1112,11 +1112,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "common-grants-sdk~=0.6.0",
     "PyYAML>=6.0.3,<7",
     "jsonref>=1.1.0,<2",
-    "urllib3>=2.6.3,<3",
+    "urllib3>=2.7.0,<3",
     "python-statemachine>=3.0.0,<4",
     "beautifulsoup4>=4.14.3,<5",
 ]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1721,7 +1721,7 @@ requires-dist = [
     { name = "smart-open", specifier = ">=7.0.0,<8" },
     { name = "sqlalchemy", extras = ["mypy"], specifier = ">=2.0.21,<3" },
     { name = "tenacity", specifier = ">=8.0,<9" },
-    { name = "urllib3", specifier = ">=2.6.3,<3" },
+    { name = "urllib3", specifier = ">=2.7.0,<3" },
     { name = "xlrd", specifier = ">=2.0.1,<3" },
     { name = "xmlschema", specifier = ">=3.4.0,<4" },
     { name = "xmltodict", specifier = ">=1.0.0,<2" },
@@ -1927,11 +1927,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

## Changes proposed
Upgrade urllib3 to 2.7.0

## Context for reviewers
https://github.com/HHS/simpler-grants-gov/actions/runs/25734893831/job/75569289648


