### PR TITLE
[Issue #8254] Remove deprecated feature flags from update-frontend-feature-flag.yml

### DIFF
--- a/.github/workflows/update-frontend-feature-flag.yml
+++ b/.github/workflows/update-frontend-feature-flag.yml
@@ -9,17 +9,8 @@ on:
         required: true
         type: choice
         options:
-          - feature-search-off
-          - feature-opportunity-off
-          - feature-auth-on
-          - feature-saved-opportunities-on
-          - feature-saved-searches-on
           - feature-apply-form-prototype-off
-          - feature-search-drawer-on
-          - feature-search-table-on
           - feature-developer-page-off
-          - feature-user-admin-off
-          - feature-manage-users-off
       environment:
         description: Target environment
         required: true


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #8254  

## Changes proposed

Removed the following feature flags from update-frontend-feature-flag.yml:
- feature-user-admin-off
- feature-saved-opportunities-on
- feature-saved-searches-on
- feature-auth-on
- feature-search-off
- feature-opportunity-off
- feature-manage-users-off
- feature-search-drawer-on
- feature-search-table-on

## Context for reviewers

These feature flags have been removed from the codebase and SSM parameters in AWS, but were still referenced in this yml file. It wouldn't break anything, this is just clean up.

## Validation steps

All feature flags removed from SSM parameters and all references to the feature flags removed from codebase.