### PR TITLE
[Issue #10242] One stop action to disable scheduled Actions in forks

### DIFF
--- a/.github/workflows/fork-disable-unneeded-actions.yml
+++ b/.github/workflows/fork-disable-unneeded-actions.yml
@@ -1,0 +1,38 @@
+name: Fork - Disable Unneeded Actions
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  workflow_dispatch: # for manual runs
+  schedule:
+    # Runs "at 06:00 UTC, every week on Monday" (see https://crontab.guru)
+    # Sprints are 2 weeks long, but crons don't easily support biweekly schedules
+    # and this GitHub action won't move tickets out of the current sprint
+    - cron: "0 6 * * 1"
+
+jobs:
+  disable-scheduled:
+    name: Disable scheduled jobs
+    runs-on: ubuntu-latest
+    steps:
+      - id: disable-scheduled-step
+        # only run this on forks
+        if: ${{ github.repository != 'hhs/simpler-grants-gov' }}
+        run: |
+          # NOTE: Add to this list in alphabetical order, if more jobs shouldn't run on forks
+          gh workflow disable "Check Infra deploy status"
+          gh workflow disable "CI Cron Vulnerability Scans"
+          gh workflow disable "CI Documentation Linker Checks"
+          gh workflow disable "CI Weekly Vulnerability Report"
+          gh workflow disable "Co-planning: Sync Fider to GitHub"
+          gh workflow disable "Co-planning: Sync GitHub for Fider"
+          gh workflow disable "Deliverable mapping: Issue level"
+          gh workflow disable "E2E Test Daily"
+          gh workflow disable "E2E Tests Weekly"
+          gh workflow disable "ECR Cleanup"
+          gh workflow disable "Lint - Bulk inherit parent metadata"
+          gh workflow disable "Lint - Deliverable Acceptance Criteria and Metrics"
+          gh workflow disable "Lint - Propagate milestone to sub-issues"
+          gh workflow disable "Lint - Set point and sprint on close"
+          gh workflow disable "Lint - Sprint rollover"
+          gh workflow disable "Scheduled Dev Deploy"

--- a/.github/workflows/fork-disable-unneeded-actions.yml
+++ b/.github/workflows/fork-disable-unneeded-actions.yml
@@ -9,15 +9,34 @@ on:
     # Sprints are 2 weeks long, but crons don't easily support biweekly schedules
     # and this GitHub action won't move tickets out of the current sprint
     - cron: "0 6 * * 1"
+  push:
+    branches:
+      - "mdragon/10242-disable-mainline-scheduled-job"
 
 jobs:
   disable-scheduled:
     name: Disable scheduled jobs
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version }}
+          clean: false
+
+      - id: mainline-test
+        # only run this on forks
+        if: ${{ github.repository == 'hhs/simpler-grants-gov' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow list
+
       - id: disable-scheduled-step
         # only run this on forks
         if: ${{ github.repository != 'hhs/simpler-grants-gov' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # NOTE: Add to this list in alphabetical order, if more jobs shouldn't run on forks
           gh workflow disable "Check Infra deploy status"

--- a/.github/workflows/fork-disable-unneeded-actions.yml
+++ b/.github/workflows/fork-disable-unneeded-actions.yml
@@ -9,9 +9,6 @@ on:
     # Sprints are 2 weeks long, but crons don't easily support biweekly schedules
     # and this GitHub action won't move tickets out of the current sprint
     - cron: "0 6 * * 1"
-  push:
-    branches:
-      - "mdragon/10242-disable-mainline-scheduled-job"
 
 jobs:
   disable-scheduled:
@@ -21,18 +18,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ github.ref }}
           clean: false
 
-      - id: mainline-test
-        # only run this on forks
-        if: ${{ github.repository == 'hhs/simpler-grants-gov' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh workflow list
-
       - id: disable-scheduled-step
+        name: Disable jobs not needed in the fork
         # only run this on forks
         if: ${{ github.repository != 'hhs/simpler-grants-gov' }}
         env:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10242 

## Changes proposed

Create a single Action that will disable all the scheduled jobs that don't make sense to waste cycles executing in forks.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Now that we have a lot of scheduled Actions, folks who fork our repo run those Actions and many fail because they don't have AWS connectivity or API Keys for other systems, etc. Since GH doesn't support this directly, the easiest solution seems to be a single job that will disable all the other jobs. Any new scheduled jobs can be added to the list and will be disabled automatically in any forks that update, thereby picking up the new job, and the update the disabler job.

## Validation steps

- ✅ Tested that this job doesn't run the disable commands in the mainline repo
- After merge will test that the jobs are disabled successfully in a fork
