### PR TITLE
[Issue #10347] Add ENABLE_SIMPLER_ROUTE key and env var

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -212,6 +212,7 @@ SOAP_PARTNER_GATEWAY_URI=http://mock-applicants-soap-api
 SOAP_PARTNER_GATEWAY_AUTH_KEY=soap_partner_gateway_auth_key
 SOAP_GRANTORS_PATH=/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort
 SOAP_APPLICANTS_PATH=/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort
+ENABLE_SIMPLER_ROUTE=true
 
 # Enable extra logging for soap proxy locally. This will not corresponding value
 # in lower environments. Only enabled locally.

--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -28,6 +28,7 @@ MTLS_CERT_HEADER_KEY = "X-Amzn-Mtls-Clientcert"
 S2S_PARTNER_CERTID_JWT_B64_HEADER_KEY = "S2S_PARTNER_CERTID_JWT_B64"
 LOG_LOCAL_RESPONSE_HEADER_KEY = "Log-Local-Response"
 USE_SIMPLER_OVERRIDE_KEY = "Use-Simpler-Override"
+ENABLE_SIMPLER_ROUTE_KEY = "Enable-Simpler-Route"
 
 
 class SOAPClientCertificateNotConfigured(Exception):

--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -33,7 +33,7 @@ class LegacySoapAPIConfig(PydanticBaseEnvConfig):
     soap_partner_gateway_auth_key: str = Field("", alias="SOAP_PARTNER_GATEWAY_AUTH_KEY")
     soap_grantors_path: str = Field("", alias="SOAP_GRANTORS_PATH")
     soap_applicants_path: str = Field("", alias="SOAP_APPLICANTS_PATH")
-    enable_simpler_route: bool = Field(False, alias="ENABLE_SIMPLER_ROUTE")
+    enable_simpler_route: bool = Field(True, alias="ENABLE_SIMPLER_ROUTE")
 
     @property
     def gg_url(self) -> str:

--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -33,6 +33,7 @@ class LegacySoapAPIConfig(PydanticBaseEnvConfig):
     soap_partner_gateway_auth_key: str = Field("", alias="SOAP_PARTNER_GATEWAY_AUTH_KEY")
     soap_grantors_path: str = Field("", alias="SOAP_GRANTORS_PATH")
     soap_applicants_path: str = Field("", alias="SOAP_APPLICANTS_PATH")
+    enable_simpler_route: bool = Field(False, alias="ENABLE_SIMPLER_ROUTE")
 
     @property
     def gg_url(self) -> str:

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -37,4 +37,4 @@ class LegacySoapApiEvent(StrEnum):
 
     RETURNING_SIMPLER_RESPONSE = "returning_simpler_response"
     RETURNING_LEGACY_SOAP_RESPONSE = "returning_legacy_soap_response"
-    SIMPLER_ROUTE_DISABLED = "simpler-route-disabled"
+    SIMPLER_ROUTE_DISABLED = "simpler_route_disabled"

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -37,3 +37,4 @@ class LegacySoapApiEvent(StrEnum):
 
     RETURNING_SIMPLER_RESPONSE = "returning_simpler_response"
     RETURNING_LEGACY_SOAP_RESPONSE = "returning_legacy_soap_response"
+    SIMPLER_ROUTE_DISABLED = "simpler-route-disabled"

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -74,6 +74,10 @@ def get_proxy_response(soap_request: SOAPRequest, timeout: int = PROXY_TIMEOUT) 
             soap_request.headers.get(config.gg_s2s_proxy_header_key, config.gg_url),
             soap_request.full_path.lstrip("/"),
         )
+    logger.info(
+        "soap_client_certificate: sending request to proxy_url",
+        extra={"proxy_url": proxy_url},
+    )
     _request = Request(method="POST", url=proxy_url, headers=proxy_headers, data=soap_request.data)
 
     response = _get_soap_response(_request, timeout=timeout)

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -4,6 +4,7 @@ from flask import request
 
 import src.adapters.db as db
 from src.legacy_soap_api.legacy_soap_api_auth import (
+    ENABLE_SIMPLER_ROUTE_KEY,
     MTLS_CERT_HEADER_KEY,
     USE_SIMPLER_OVERRIDE_KEY,
     SOAPClientCertificateIsExpired,
@@ -179,6 +180,12 @@ def process_simpler_request(
         is_legacy_only_certificate = (
             auth and auth.certificate and not auth.certificate.legacy_certificate
         )
+
+        if (
+            not get_soap_config().enable_simpler_route
+            and request.headers.get(ENABLE_SIMPLER_ROUTE_KEY, None) != "1"
+        ):
+            return get_legacy_response(soap_request).to_flask_response()
 
         # If it is GetOpportunityList or is valid legacy certificate but not configured in Simpler
         # call legacy and don't call simpler

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -185,6 +185,10 @@ def process_simpler_request(
             not get_soap_config().enable_simpler_route
             and request.headers.get(ENABLE_SIMPLER_ROUTE_KEY, None) != "1"
         ):
+            logger.info(
+                "soap_client_certificate: simpler route is disabled, returning legacy response",
+                extra={"soap_api_event": LegacySoapApiEvent.SIMPLER_ROUTE_DISABLED},
+            )
             return get_legacy_response(soap_request).to_flask_response()
 
         # If it is GetOpportunityList or is valid legacy certificate but not configured in Simpler

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -8,6 +8,7 @@ from src.constants.lookup_constants import ApplicationStatus, Privilege
 from src.db.models.competition_models import ApplicationSubmissionRetrieved
 from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
 from src.legacy_soap_api.legacy_soap_api_auth import (
+    ENABLE_SIMPLER_ROUTE_KEY,
     MTLS_CERT_HEADER_KEY,
     SOAPAuth,
     SOAPClientCertificate,
@@ -1120,3 +1121,124 @@ def test_calls_simpler_if_using_simpler_tracking_number(
     assert response.status_code == 200
     mock_get_soap_response.assert_not_called()
     mock_get_simpler_soap_response.assert_called_once()
+
+
+def test_enable_simpler_routes_set_to_false_stops_simpler_calls(
+    db_session, client, enable_factory_create, monkeypatch
+) -> None:
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("ENABLE_SIMPLER_ROUTE", "false")
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
+    LegacyAgencyCertificateFactory.create(
+        serial_number=serial_number,
+        cert_id=tcertificate.currentcertid,
+        expiration_date=datetime(2070, 1, 1).date(),
+    )
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:GetSubmissionListExpandedRequest>"
+        "</agen:GetSubmissionListExpandedRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    with mock.patch(
+        "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
+    ) as mock_legacy_response:
+        mock_legacy_response.return_value = SOAPResponse(
+            data=b"test response", status_code=200, headers={}
+        )
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
+        ) as mock_simpler_response:
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={MTLS_CERT_HEADER_KEY: mtls_cert},
+            )
+    assert response.status_code == 200
+    mock_legacy_response.assert_called_once()
+    mock_simpler_response.assert_not_called()
+
+
+def test_enable_simpler_routes_set_to_true_allows_simpler_calls(
+    db_session, client, enable_factory_create, monkeypatch
+) -> None:
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("ENABLE_SIMPLER_ROUTE", "true")
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
+    LegacyAgencyCertificateFactory.create(
+        serial_number=serial_number,
+        cert_id=tcertificate.currentcertid,
+        expiration_date=datetime(2070, 1, 1).date(),
+    )
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:GetSubmissionListExpandedRequest>"
+        "</agen:GetSubmissionListExpandedRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    with mock.patch(
+        "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
+    ) as mock_legacy_response:
+        mock_legacy_response.return_value = SOAPResponse(
+            data=b"test response", status_code=200, headers={}
+        )
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
+        ) as mock_simpler_response:
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={MTLS_CERT_HEADER_KEY: mtls_cert},
+            )
+    assert response.status_code == 200
+    mock_legacy_response.assert_called_once()
+    mock_simpler_response.assert_called_once()
+
+
+def test_x(db_session, client, enable_factory_create, monkeypatch) -> None:
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("ENABLE_SIMPLER_ROUTE", "false")
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
+    LegacyAgencyCertificateFactory.create(
+        serial_number=serial_number,
+        cert_id=tcertificate.currentcertid,
+        expiration_date=datetime(2070, 1, 1).date(),
+    )
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:GetSubmissionListExpandedRequest>"
+        "</agen:GetSubmissionListExpandedRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    with mock.patch(
+        "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
+    ) as mock_legacy_response:
+        mock_legacy_response.return_value = SOAPResponse(
+            data=b"test response", status_code=200, headers={}
+        )
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
+        ) as mock_simpler_response:
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={MTLS_CERT_HEADER_KEY: mtls_cert, ENABLE_SIMPLER_ROUTE_KEY: "1"},
+            )
+    assert response.status_code == 200
+    mock_legacy_response.assert_called_once()
+    mock_simpler_response.assert_called_once()

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1123,11 +1123,7 @@ def test_calls_simpler_if_using_simpler_tracking_number(
     mock_get_simpler_soap_response.assert_called_once()
 
 
-def test_enable_simpler_routes_set_to_false_stops_simpler_calls(
-    db_session, client, enable_factory_create, monkeypatch
-) -> None:
-    soap_api_config.get_soap_config.cache_clear()
-    monkeypatch.setenv("ENABLE_SIMPLER_ROUTE", "false")
+def post_get_submission_list_expanded(client, add_to_headers=None):
     mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
     tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
     LegacyAgencyCertificateFactory.create(
@@ -1145,6 +1141,21 @@ def test_enable_simpler_routes_set_to_false_stops_simpler_calls(
         "</soapenv:Body>"
         "</soapenv:Envelope>"
     ).encode()
+    headers = {MTLS_CERT_HEADER_KEY: mtls_cert}
+    if add_to_headers is not None:
+        headers.update(add_to_headers)
+    return client.post(
+        full_path,
+        data=mock_data,
+        headers=headers,
+    )
+
+
+def test_enable_simpler_routes_set_to_false_stops_simpler_calls(
+    db_session, client, enable_factory_create, monkeypatch, caplog
+) -> None:
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("ENABLE_SIMPLER_ROUTE", "false")
     with mock.patch(
         "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
     ) as mock_legacy_response:
@@ -1154,14 +1165,14 @@ def test_enable_simpler_routes_set_to_false_stops_simpler_calls(
         with mock.patch(
             "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
         ) as mock_simpler_response:
-            response = client.post(
-                full_path,
-                data=mock_data,
-                headers={MTLS_CERT_HEADER_KEY: mtls_cert},
-            )
+            response = post_get_submission_list_expanded(client)
     assert response.status_code == 200
     mock_legacy_response.assert_called_once()
     mock_simpler_response.assert_not_called()
+    assert (
+        "soap_client_certificate: simpler route is disabled, returning legacy response"
+        in caplog.messages
+    )
 
 
 def test_enable_simpler_routes_set_to_true_allows_simpler_calls(
@@ -1169,23 +1180,6 @@ def test_enable_simpler_routes_set_to_true_allows_simpler_calls(
 ) -> None:
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("ENABLE_SIMPLER_ROUTE", "true")
-    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
-    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
-    LegacyAgencyCertificateFactory.create(
-        serial_number=serial_number,
-        cert_id=tcertificate.currentcertid,
-        expiration_date=datetime(2070, 1, 1).date(),
-    )
-    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
-    mock_data = (
-        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
-        "<soapenv:Header/>"
-        "<soapenv:Body>"
-        "<agen:GetSubmissionListExpandedRequest>"
-        "</agen:GetSubmissionListExpandedRequest>"
-        "</soapenv:Body>"
-        "</soapenv:Envelope>"
-    ).encode()
     with mock.patch(
         "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
     ) as mock_legacy_response:
@@ -1195,36 +1189,17 @@ def test_enable_simpler_routes_set_to_true_allows_simpler_calls(
         with mock.patch(
             "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
         ) as mock_simpler_response:
-            response = client.post(
-                full_path,
-                data=mock_data,
-                headers={MTLS_CERT_HEADER_KEY: mtls_cert},
-            )
+            response = post_get_submission_list_expanded(client)
     assert response.status_code == 200
     mock_legacy_response.assert_called_once()
     mock_simpler_response.assert_called_once()
 
 
-def test_x(db_session, client, enable_factory_create, monkeypatch) -> None:
+def test_enable_simpler_route_header_overrides_disabled_config(
+    db_session, client, enable_factory_create, monkeypatch, caplog
+) -> None:
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("ENABLE_SIMPLER_ROUTE", "false")
-    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
-    tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)
-    LegacyAgencyCertificateFactory.create(
-        serial_number=serial_number,
-        cert_id=tcertificate.currentcertid,
-        expiration_date=datetime(2070, 1, 1).date(),
-    )
-    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
-    mock_data = (
-        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
-        "<soapenv:Header/>"
-        "<soapenv:Body>"
-        "<agen:GetSubmissionListExpandedRequest>"
-        "</agen:GetSubmissionListExpandedRequest>"
-        "</soapenv:Body>"
-        "</soapenv:Envelope>"
-    ).encode()
     with mock.patch(
         "src.legacy_soap_api.simpler_soap_api.get_legacy_response"
     ) as mock_legacy_response:
@@ -1234,10 +1209,8 @@ def test_x(db_session, client, enable_factory_create, monkeypatch) -> None:
         with mock.patch(
             "src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response"
         ) as mock_simpler_response:
-            response = client.post(
-                full_path,
-                data=mock_data,
-                headers={MTLS_CERT_HEADER_KEY: mtls_cert, ENABLE_SIMPLER_ROUTE_KEY: "1"},
+            response = post_get_submission_list_expanded(
+                client, add_to_headers={ENABLE_SIMPLER_ROUTE_KEY: "1"}
             )
     assert response.status_code == 200
     mock_legacy_response.assert_called_once()

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -119,6 +119,11 @@ locals {
       secret_store_name = "/api/${var.environment}/use-simpler"
     }
 
+    ENABLE_SIMPLER_ROUTE = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/enable-simpler-route"
+    }
+
     SAM_GOV_API_KEY = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/sam-gov-api-key"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10347  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
-`ENABLE_SIMPLER_ROUTE` env var 
- '"Enable-Simpler-Override"' header in order to override `ENABLE_SIMPLER_ROUTE`
- tests

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We want the ability to deactive Simpler route and force just the Legacy response (`ENABLE_SIMPLER_ROUTE`) and a header var that will override that when we want to do testing on individual requests ('"Enable-Simpler-Override"' ).

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
-  [ ]  Can deactivate the Simpler route
- [ ] Can use the header to enable Simpler route on a request
