### PR TITLE
[unticketed]: update api docker image to fix uv related changes

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -30,6 +30,8 @@ COPY newrelic.ini /api/newrelic.ini
 ENV UV_NO_DEV=1
 # Compile python to *.pyc files for performance
 ENV UV_COMPILE_BYTECODE=1
+ENV UV_CACHE_DIR="/tmp/.cache/uv"
+ENV UV_NO_SYNC=1
 
 # Build the application wheel and install it into the venv without stripping docstrings (avoid -OO)
 # Clean up build artifacts and caches in a single layer to reduce image size


### PR DESCRIPTION
## Summary

Updated the api image with these env variables: 

```
ENV UV_CACHE_DIR="/tmp/.cache/uv"
ENV UV_NO_SYNC=1
```

## Validation steps

Deployed to staging: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/25759218284/job/75656718628)

Tested this command below: 

`bin/run-command --environment-variables "$(jq -c . ../env_vars/authomatic_opp.json)" api staging '["uv", "run", "flask", "task", "build-automatic-opportunities"]'`


<img width="942" height="258" alt="Screenshot 2026-05-12 at 4 17 08 PM" src="https://github.com/user-attachments/assets/2749abe5-634a-4b9b-ab92-750f25d37f30" />


Link to successful cloud watch run logs: [here](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/service%2Fapi-staging-fluentbit/log-events/api-staging%2Fapi-staging-fluentbit%2F61e70ad148ed4fdaa25783d2f36ecffa)
