### PR TITLE
[Issue #10242] Update CONTRIBUTING.md with Fork GitHub Action info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ This project follows [trunk-based development](./DEVELOPMENT.md#branching-model)
 1.  Work with repo maintainers to get your change reviewed
 1.  Wait for your change to be pulled into `hhs/simpler-grants-gov/main`
 
+You don't have to enable GitHub Actions on your fork. But if you do for some reason, running the [Fork - Disable Unneeded Actions](.github/workflows/fork-disable-unneeded-actions.yml) action will disabled the scheduled jobs that will regularly run, and fail, on your fork: 
+
 ### Testing, Coding Style and Linters
 
 Each application has its own testing and linters. Every commit is tested to adhere to tests and the linting guidelines. It is recommended to run tests and linters locally before committing.


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10242 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add a link to the new Action to disable scheduled Actions on forks.

## Context for reviewers

My fork was spamming me with failed job notifications. I don't know when I set my Actions to run in the fork, but I guess I had and there's not an easy way to turn them off once you've done that.  But by default actions don't run so this is a bit of a corner case.