### PR TITLE
#9817 Add ValidationErrorDetail to two saved-search/saved-opportunity delete service functions

### DIFF
--- a/api/src/services/users/delete_saved_opportunity.py
+++ b/api/src/services/users/delete_saved_opportunity.py
@@ -3,9 +3,11 @@ from uuid import UUID
 from sqlalchemy import select
 
 from src.adapters import db
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.opportunity_models import Opportunity
 from src.db.models.user_models import UserSavedOpportunity
+from src.validation.validation_constants import ValidationErrorType
 
 
 def delete_saved_opportunity(
@@ -31,6 +33,15 @@ def delete_saved_opportunity(
         ).scalar_one_or_none()
 
     if not saved_opp:
-        raise_flask_error(404, "Saved opportunity not found")
+        raise_flask_error(
+            404,
+            "Saved opportunity not found",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.SAVED_ITEM_NOT_FOUND,
+                    message="Saved opportunity not found",
+                )
+            ],
+        )
 
     saved_opp.is_deleted = True

--- a/api/src/services/users/delete_saved_search.py
+++ b/api/src/services/users/delete_saved_search.py
@@ -3,8 +3,10 @@ from uuid import UUID
 from sqlalchemy import select
 
 from src.adapters import db
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.user_models import UserSavedSearch
+from src.validation.validation_constants import ValidationErrorType
 
 
 def delete_saved_search(db_session: db.Session, user_id: UUID, saved_search_id: UUID) -> None:
@@ -15,6 +17,14 @@ def delete_saved_search(db_session: db.Session, user_id: UUID, saved_search_id: 
     ).scalar_one_or_none()
 
     if not saved_search:
-        raise_flask_error(404, "Saved search not found")
+        raise_flask_error(
+            404,
+            "Saved search not found",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.SAVED_ITEM_NOT_FOUND, message="Saved search not found"
+                )
+            ],
+        )
 
     saved_search.is_deleted = True

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -41,6 +41,7 @@ class ValidationErrorType(StrEnum):
     MISSING_REQUIRED_FORM = "missing_required_form"
     APPLICATION_FORM_VALIDATION = "application_form_validation"
     MISSING_APPLICATION_FORM = "missing_application_form"
+    SAVED_ITEM_NOT_FOUND = "saved_item_not_found"
 
     UNKNOWN_APPLICATION_ATTACHMENT = "unknown_application_attachment"
 

--- a/api/tests/src/services/users/test_delete_saved_opportunity.py
+++ b/api/tests/src/services/users/test_delete_saved_opportunity.py
@@ -1,0 +1,61 @@
+from uuid import uuid4
+
+import pytest
+from apiflask.exceptions import HTTPError
+
+from src.services.users.delete_saved_opportunity import delete_saved_opportunity
+from src.validation.validation_constants import ValidationErrorType
+from tests.src.db.models.factories import (
+    OpportunityFactory,
+    UserFactory,
+    UserSavedOpportunityFactory,
+)
+
+
+def test_delete_saved_opportunity_sets_is_deleted(
+    db_session,
+    enable_factory_create,
+):
+    """Test that deleting a saved opportunity soft deletes it"""
+
+    user = UserFactory.create()
+    opportunity = OpportunityFactory.create()
+
+    saved_opp = UserSavedOpportunityFactory.create(
+        user=user,
+        opportunity=opportunity,
+        is_deleted=False,
+    )
+    
+    # Should properly erase saved opportunity data
+    delete_saved_opportunity(
+        db_session,
+        user.user_id,
+        opportunity.opportunity_id,
+    )
+
+    assert saved_opp.is_deleted is True
+
+
+def test_delete_saved_opportunity_not_found_raises_typed_404(
+    db_session,
+    enable_factory_create,
+):
+    """Test that deleting a nonexistent saved opportunity raises typed validation errors"""
+
+    user = UserFactory.create()
+
+    # Should raise error associated with raise_flask_error
+    with pytest.raises(HTTPError) as exc:
+        delete_saved_opportunity(
+            db_session,
+            user.user_id,
+            uuid4(),
+        )
+
+    assert exc.value.status_code == 404
+
+    validation_issue = exc.value.extra_data["validation_issues"][0]
+
+    assert validation_issue.type == ValidationErrorType.SAVED_ITEM_NOT_FOUND
+    assert validation_issue.message == "Saved opportunity not found"

--- a/api/tests/src/services/users/test_delete_saved_search.py
+++ b/api/tests/src/services/users/test_delete_saved_search.py
@@ -1,0 +1,55 @@
+from uuid import uuid4
+
+import pytest
+from apiflask.exceptions import HTTPError
+
+from src.services.users.delete_saved_search import delete_saved_search
+from src.validation.validation_constants import ValidationErrorType
+from tests.src.db.models.factories import UserFactory, UserSavedSearchFactory
+
+
+def test_delete_saved_search_sets_is_deleted(
+    db_session,
+    enable_factory_create,
+):
+    """To test that deleting a saved search soft deletes it"""
+
+    user = UserFactory.create()
+
+    saved_search = UserSavedSearchFactory.create(
+        user=user,
+        search_query="Sample Query",
+        is_deleted=False,
+    )
+    # Should properly erase saved search data
+    delete_saved_search(
+        db_session,
+        user.user_id,
+        saved_search.saved_search_id,
+    )
+
+    assert saved_search.is_deleted is True
+
+
+def test_delete_saved_search_not_found_raises_typed_404(
+    db_session,
+    enable_factory_create,
+):
+    """To test that deleting a nonexistent saved search raises typed validation errors"""
+
+    user = UserFactory.create()
+
+    # Should raise error associated with raise_flask_error in delete_saved_search.py
+    with pytest.raises(HTTPError) as exc:
+        delete_saved_search(
+            db_session,
+            user.user_id,
+            uuid4(),
+        )
+
+    assert exc.value.status_code == 404
+
+    validation_issue = exc.value.extra_data["validation_issues"][0]
+
+    assert validation_issue.type == ValidationErrorType.SAVED_ITEM_NOT_FOUND
+    assert validation_issue.message == "Saved search not found"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #9817 Add 'ValidationErrorDetail' to  delete_saved_search.py/delete_saved_opportunity.py to two delete service.

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Edited files: api/src/services/users/delete_saved_opportunity.py and api/src/services/users/delete_saved_search.py to incorporate `ValidationErrorType` enum as explained in the issue description, as well as importing 'ValidationErrorDetail' to handle the error message.
Added `'SAVED_ITEM_NOT_FOUND` as a constant to the file `/src/validation/validation_constants.py`


Created Two files: 
- `api/tests/src/services/users/test_delete_saved_opportunity.py`
- `api/tests/src/services/users/test_delete_saved_search.py`

to test the effects of the above changes.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

 `delete_saved_search.py` and `delete_saved_opportunity.py` now use SAVED_ITEM_NOT_FOUND constant from `ValidationErrorType` and `ValidationErrorDetail` as is expected of delete service functions.

The filepath for error handling documentation mentioned in the issue description: `documentation/rules/api-error-handling.md` doesn't seem to exist in the repo, but I found what appeared to be the correct explanation of the error-handle format under `documentation/api/error-handling.md`. The edits done to test_delete_saved_opportunity.py and test_delete_saved_opportunity.py were made to match this documentation.

Test scripts were designed to handle input from the `factory_boy` setup found in `api/tests/src/db/models/factories.py` 

A small issue occured when attempting to verify `api/tests/src/services/users/test_delete_saved_search.py`, where attempting to initialize `saved_search = UserSavedSearchFactory.create(user=user, is_deleted=False, )`,  would exit with cyclic lazy attribute `search_query`. This is probably because 'search_query' calls itself in its definition: `search_query = factory.LazyAttribute(lambda s: s.search_query`.

As such, I chose to define Search Query as just `"Sample Query"` within the file, I'm not sure if this was what is expected for testing though.

## Validation steps
<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Environment was build and activated using Docker and WSL2 as instructed from 'documentation/api/windows-setup.md'

All files were formatted using 'make format' after changes were made, and validated using 'make format-check' from within the api directory.

Both test scripts were passed using 'make test args="./tests/src/services/users/test_delete_saved_opportunity.py"', and via the full 'make test' command.

@mdragon @andycochran  @mvanhorn 

