### PR TITLE
[Issue #10403] Only install webkit dependencies in the Webkit Shard, Shard 3

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -91,6 +91,7 @@ runs:
         npm install @playwright/test
         npx playwright install --with-deps
 
+    # this should only be needed on shard 3, the WebKit shard
     - name: Install Webkit dependencies
       if: ${{ inputs.force-webkit-install == 'true' }}
       shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -429,7 +429,8 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
-          force-webkit-install: "true"
+          # shard 3 is the webkit shard
+          force-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
 
   create-report:
     name: Create Merged Test Report


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10403  

## Changes proposed

Vary the require webkit install input when calling the E2E action based on whether we're running shard 3, the WebKit shard

## Context for reviewers

Webkit doesn't cleanly contain itself and it's dependencies when installing through Playwright like the other browsers do. As a result we have to re-install the playwright deps every time we run E2E. This change limits that install cost to just shard 3, as that's the only one running Webkit.

## Validation steps

- Checks pass
