### PR TITLE
GET Endpoint to Fetch All SGG Forms

### DIFF
--- a/api/src/api/forms_v1/__init__.py
+++ b/api/src/api/forms_v1/__init__.py
@@ -1,0 +1,6 @@
+from src.api.forms_v1.forms_blueprint import forms_blueprint
+
+# Import forms_routes module to register the API routes on the blueprint
+import src.api.forms_v1.forms_routes  # noqa: F401 isort:skip
+
+__all__ = ["forms_blueprint"]

--- a/api/src/api/forms_v1/forms_blueprint.py
+++ b/api/src/api/forms_v1/forms_blueprint.py
@@ -1,0 +1,9 @@
+from apiflask import APIBlueprint
+
+forms_blueprint = APIBlueprint(
+    "forms_v1",
+    __name__,
+    tag="Forms v1",
+    cli_group="forms_v1",
+    url_prefix="/v1",
+)

--- a/api/src/api/forms_v1/forms_routes.py
+++ b/api/src/api/forms_v1/forms_routes.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 @forms_blueprint.get("/forms/")
 @forms_blueprint.output(forms_schemas.FormsListResponseSchema())
 @forms_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
-@forms_blueprint.doc(responses=[200, 403, 500])
 @flask_db.with_db_session()
 def forms_get_all(db_session: db.Session) -> response.ApiResponse:
     """Get all forms associated with the SGG agency code"""

--- a/api/src/api/forms_v1/forms_routes.py
+++ b/api/src/api/forms_v1/forms_routes.py
@@ -1,0 +1,29 @@
+import logging
+
+import src.adapters.db as db
+import src.adapters.db.flask_db as flask_db
+import src.api.forms_v1.forms_schemas as forms_schemas
+import src.api.response as response
+from src.api.forms_v1.forms_blueprint import forms_blueprint
+from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
+from src.services.forms_v1.get_forms import get_all_forms
+
+logger = logging.getLogger(__name__)
+
+
+@forms_blueprint.get("/forms/")
+@forms_blueprint.output(forms_schemas.FormsListResponseSchema())
+@forms_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@forms_blueprint.doc(responses=[200, 403, 500])
+@flask_db.with_db_session()
+def forms_get_all(db_session: db.Session) -> response.ApiResponse:
+    """Get all forms associated with the SGG agency code"""
+    logger.info("GET /v1/forms/")
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        forms = get_all_forms(db_session, user)
+
+    return response.ApiResponse(message="Success", data=forms)

--- a/api/src/api/forms_v1/forms_schemas.py
+++ b/api/src/api/forms_v1/forms_schemas.py
@@ -1,0 +1,144 @@
+from src.api.schemas.extension import Schema, fields
+from src.api.schemas.response_schema import AbstractResponseSchema
+from src.constants.lookup_constants import FormType
+
+
+class FormInstructionV1Schema(Schema):
+    form_instruction_id = fields.UUID(metadata={"description": "The UUID of the form instruction"})
+    file_name = fields.String(
+        metadata={
+            "description": "The name of the form instruction file",
+            "example": "instructions.pdf",
+        }
+    )
+    download_path = fields.String(
+        metadata={"description": "The download URL for the form instruction file"}
+    )
+    created_at = fields.DateTime(
+        metadata={"description": "The timestamp when the form instruction was created"}
+    )
+    updated_at = fields.DateTime(
+        metadata={"description": "The timestamp when the form instruction was last updated"}
+    )
+
+
+class FormV1Schema(Schema):
+    form_id = fields.UUID(metadata={"description": "The primary key ID of the form"})
+
+    form_name = fields.String(
+        metadata={"description": "The name of the form", "example": "ABC Project Form"}
+    )
+
+    short_form_name = fields.String(
+        metadata={
+            "description": "The short name of the form used for making files",
+            "example": "abc_project",
+        }
+    )
+
+    form_version = fields.String(
+        metadata={"description": "The version of the form", "example": "1.0"}
+    )
+
+    agency_code = fields.String(
+        metadata={"description": "The agency code for the form", "example": "SGG"}
+    )
+
+    omb_number = fields.String(
+        allow_none=True,
+        metadata={"description": "The OMB number for the form", "example": "4040-0001"},
+    )
+
+    legacy_form_id = fields.Integer(
+        allow_none=True,
+        metadata={"description": "The legacy form ID", "example": 123},
+    )
+
+    form_json_schema = fields.Dict(
+        metadata={
+            "description": "The JSON Schema representation of the form",
+            "example": {
+                "type": "object",
+                "title": "Test form for testing",
+                "properties": {
+                    "Title": {"title": "Title", "type": "string", "minLength": 1, "maxLength": 60},
+                    "Description": {
+                        "title": "Description for application",
+                        "type": "string",
+                        "minLength": 0,
+                        "maxLength": 15,
+                    },
+                    "ApplicationNumber": {
+                        "title": "Application number",
+                        "type": "number",
+                        "minLength": 1,
+                        "maxLength": 120,
+                    },
+                    "Date": {"title": "Date of application ", "type": "string", "format": "date"},
+                },
+            },
+        }
+    )
+
+    form_ui_schema = fields.Raw(
+        metadata={
+            "description": "The UI Schema of the form for front-end rendering",
+            "example": [
+                {"type": "field", "definition": "/properties/Title"},
+                {"type": "field", "definition": "/properties/Description"},
+                {"type": "field", "definition": "/properties/ApplicationNumber"},
+                {"type": "field", "definition": "/properties/Date"},
+            ],
+        }
+    )
+
+    form_instruction = fields.Nested(
+        FormInstructionV1Schema,
+        allow_none=True,
+        metadata={"description": "The instruction file for the form, if available"},
+    )
+
+    form_rule_schema = fields.Dict(
+        allow_none=True, metadata={"description": "The rule schema for the form"}
+    )
+
+    json_to_xml_schema = fields.Dict(
+        allow_none=True,
+        metadata={"description": "The JSON to XML schema mapping configuration for the form"},
+    )
+
+    form_type = fields.Enum(
+        FormType,
+        allow_none=True,
+        metadata={
+            "description": "The type of the form",
+            "example": FormType.SF424,
+        },
+    )
+
+    sgg_version = fields.String(
+        allow_none=True,
+        metadata={
+            "description": "The SGG version of the form",
+            "example": "1.0",
+        },
+    )
+
+    is_deprecated = fields.Boolean(
+        allow_none=True,
+        metadata={
+            "description": "Whether the form is deprecated",
+            "example": False,
+        },
+    )
+
+    created_at = fields.DateTime(
+        metadata={"description": "The timestamp when the form was created"}
+    )
+    updated_at = fields.DateTime(
+        metadata={"description": "The timestamp when the form was last updated"}
+    )
+
+
+class FormsListResponseSchema(AbstractResponseSchema):
+    data = fields.List(fields.Nested(FormV1Schema))

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -23,6 +23,7 @@ from src.api.common_grants import common_grants_blueprint
 from src.api.competition_alpha import competition_blueprint
 from src.api.extracts_v1 import extract_blueprint as extracts_v1_blueprint
 from src.api.form_alpha import form_blueprint
+from src.api.forms_v1 import forms_blueprint as forms_v1_blueprint
 from src.api.healthcheck import healthcheck_blueprint
 from src.api.internal import internal_blueprint
 from src.api.local import local_blueprint
@@ -178,9 +179,11 @@ def register_blueprints(app: APIFlask) -> None:
     app.register_blueprint(healthcheck_blueprint)
     app.register_blueprint(opportunities_v1_blueprint)
 
-    # Endpoint for Create Opportunity
+    # Endpoints for Opportunity Publishing
     if endpoint_config.enable_grantor_opportunity_endpoints:
         app.register_blueprint(opportunities_grantor_v1_blueprint)
+
+    app.register_blueprint(forms_v1_blueprint)
 
     app.register_blueprint(extracts_v1_blueprint)
     app.register_blueprint(agencies_v1_blueprint)

--- a/api/src/services/forms_v1/get_forms.py
+++ b/api/src/services/forms_v1/get_forms.py
@@ -1,0 +1,33 @@
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+import src.adapters.db as db
+from src.db.models.competition_models import Form
+from src.db.models.user_models import User
+
+logger = logging.getLogger(__name__)
+
+
+def get_all_forms(db_session: db.Session, user: User) -> list[Form]:
+    """
+    Get all forms associated with the SGG agency code.
+    """
+
+    agency_code = "SGG"
+    stmt = (
+        select(Form)
+        .where(Form.agency_code == agency_code)
+        .options(selectinload(Form.form_instruction))
+        .order_by(Form.created_at.desc())
+    )
+
+    forms = db_session.execute(stmt).scalars().all()
+
+    logger.info(
+        "Retrieved forms for agency",
+        extra={"agency_code": agency_code, "form_count": len(forms), "user_id": user.user_id},
+    )
+
+    return list(forms)

--- a/api/tests/src/api/forms_v1/test_forms_route_get.py
+++ b/api/tests/src/api/forms_v1/test_forms_route_get.py
@@ -1,5 +1,3 @@
-
-
 from tests.src.db.models.factories import FormFactory
 
 

--- a/api/tests/src/api/forms_v1/test_forms_route_get.py
+++ b/api/tests/src/api/forms_v1/test_forms_route_get.py
@@ -23,14 +23,13 @@ def test_get_all_forms_success(client, user_auth_token, enable_factory_create):
 
     # Verify response structure for each form
     for form in our_forms:
-        assert "form_id" in form
-        assert "form_name" in form
-        assert "agency_code" in form
+        assert form["form_id"] is not None
+        assert form["form_name"] is not None
         assert form["agency_code"] == "SGG"
-        assert "form_json_schema" in form
-        assert "form_ui_schema" in form
-        assert "created_at" in form
-        assert "updated_at" in form
+        assert isinstance(form["form_json_schema"], dict)
+        assert form["form_ui_schema"] is not None
+        assert form["created_at"] is not None
+        assert form["updated_at"] is not None
 
 
 def test_get_all_forms_includes_all_fields(client, user_auth_token, enable_factory_create):
@@ -66,17 +65,43 @@ def test_get_all_forms_includes_all_fields(client, user_auth_token, enable_facto
     assert our_form["form_type"] == FormType.SF424.value
     assert our_form["sgg_version"] == "2.0"
     assert our_form["is_deprecated"] is False
-    assert "short_form_name" in our_form
-    assert "form_version" in our_form
-    assert "agency_code" in our_form
-    assert "omb_number" in our_form
-    assert "legacy_form_id" in our_form
-    assert "form_json_schema" in our_form
-    assert "form_ui_schema" in our_form
-    assert "form_rule_schema" in our_form
-    assert "json_to_xml_schema" in our_form
-    assert "created_at" in our_form
-    assert "updated_at" in our_form
+    assert our_form["short_form_name"] == form.short_form_name
+    assert our_form["form_version"] == form.form_version
+    assert our_form["agency_code"] == "SGG"
+    assert our_form["omb_number"] == form.omb_number
+    assert our_form["legacy_form_id"] == form.legacy_form_id
+    assert isinstance(our_form["form_json_schema"], dict)
+    assert isinstance(our_form["form_ui_schema"], list)
+    assert our_form["form_rule_schema"] is None  # Factory default
+    assert our_form["json_to_xml_schema"] is None  # Factory default
+    assert our_form["form_instruction"] is None  # No instruction created
+    assert our_form["created_at"] is not None
+    assert our_form["updated_at"] is not None
+
+
+def test_get_all_forms_with_instructions(client, user_auth_token, enable_factory_create):
+    """Test getting forms with instructions includes instruction fields"""
+    form = FormFactory.create(agency_code="SGG", with_instruction=True)
+ 
+    resp = client.get("/v1/forms/", headers={"X-SGG-Token": user_auth_token})
+ 
+    assert resp.status_code == 200
+    response_data = resp.get_json()
+    forms = response_data["data"]
+ 
+    # Find the form that was just created
+    our_form = None
+    for f in forms:
+        if f["form_id"] == str(form.form_id):
+            our_form = f
+            break
+ 
+    assert our_form is not None
+    assert our_form["form_instruction"] is not None
+    assert our_form["form_instruction"]["form_instruction_id"] == str(form.form_instruction.form_instruction_id)
+    assert our_form["form_instruction"]["file_name"] == form.form_instruction.file_name
+    assert our_form["form_instruction"]["created_at"] is not None
+    assert our_form["form_instruction"]["updated_at"] is not None
 
 
 def test_get_all_forms_filters_out_non_sgg(client, user_auth_token, enable_factory_create):

--- a/api/tests/src/api/forms_v1/test_forms_route_get.py
+++ b/api/tests/src/api/forms_v1/test_forms_route_get.py
@@ -1,0 +1,156 @@
+
+
+from tests.src.db.models.factories import FormFactory
+
+
+def test_get_all_forms_success(client, user_auth_token, enable_factory_create):
+    """Test getting all SGG forms returns 200 with correct structure"""
+    form1 = FormFactory.create(agency_code="SGG", form_name="Test Form 1")
+    form2 = FormFactory.create(agency_code="SGG", form_name="Test Form 2")
+    form3 = FormFactory.create(agency_code="SGG", form_name="Test Form 3")
+
+    resp = client.get("/v1/forms/", headers={"X-SGG-Token": user_auth_token})
+
+    assert resp.status_code == 200
+    response_data = resp.get_json()
+    assert response_data["message"] == "Success"
+
+    forms = response_data["data"]
+
+    # Filter to just our created forms
+    created_form_ids = {str(form1.form_id), str(form2.form_id), str(form3.form_id)}
+    our_forms = [f for f in forms if f["form_id"] in created_form_ids]
+
+    assert len(our_forms) == 3
+
+    # Verify response structure for each form
+    for form in our_forms:
+        assert "form_id" in form
+        assert "form_name" in form
+        assert "agency_code" in form
+        assert form["agency_code"] == "SGG"
+        assert "form_json_schema" in form
+        assert "form_ui_schema" in form
+        assert "created_at" in form
+        assert "updated_at" in form
+
+
+def test_get_all_forms_includes_all_fields(client, user_auth_token, enable_factory_create):
+    """Test that all schema fields are present in response"""
+    from src.constants.lookup_constants import FormType
+
+    form = FormFactory.create(
+        agency_code="SGG",
+        form_type=FormType.SF424,
+        sgg_version="2.0",
+        is_deprecated=False,
+        form_name="Complete Fields Form",
+    )
+
+    resp = client.get("/v1/forms/", headers={"X-SGG-Token": user_auth_token})
+
+    assert resp.status_code == 200
+    response_data = resp.get_json()
+    forms = response_data["data"]
+
+    # Find the form that was just created
+    our_form = None
+    for f in forms:
+        if f["form_id"] == str(form.form_id):
+            our_form = f
+            break
+
+    assert our_form is not None
+
+    # Verify all expected fields are present
+    assert our_form["form_id"] == str(form.form_id)
+    assert our_form["form_name"] == "Complete Fields Form"
+    assert our_form["form_type"] == FormType.SF424.value
+    assert our_form["sgg_version"] == "2.0"
+    assert our_form["is_deprecated"] is False
+    assert "short_form_name" in our_form
+    assert "form_version" in our_form
+    assert "agency_code" in our_form
+    assert "omb_number" in our_form
+    assert "legacy_form_id" in our_form
+    assert "form_json_schema" in our_form
+    assert "form_ui_schema" in our_form
+    assert "form_rule_schema" in our_form
+    assert "json_to_xml_schema" in our_form
+    assert "created_at" in our_form
+    assert "updated_at" in our_form
+
+
+def test_get_all_forms_filters_out_non_sgg(client, user_auth_token, enable_factory_create):
+    """Test that non-SGG agency forms are not returned"""
+    form1 = FormFactory.create(agency_code="OTHER1")
+    form2 = FormFactory.create(agency_code="OTHER2")
+
+    resp = client.get("/v1/forms/", headers={"X-SGG-Token": user_auth_token})
+
+    assert resp.status_code == 200
+    response_data = resp.get_json()
+    assert response_data["message"] == "Success"
+    forms = response_data["data"]
+
+    # Verify all returned forms are SGG
+    for form in forms:
+        assert form["agency_code"] == "SGG"
+
+    # Verify our non-SGG forms are NOT in results
+    form_ids = [f["form_id"] for f in forms]
+    assert str(form1.form_id) not in form_ids
+    assert str(form2.form_id) not in form_ids
+
+
+def test_get_all_forms_invalid_token(client):
+    response = client.get("/v1/forms/", headers={"X-SGG-Token": "invalid-token"})
+
+    assert response.status_code == 401
+    response_data = response.get_json()
+    assert response_data["message"] == "Unable to process token"
+
+
+def test_get_all_forms_ordered_by_created_at_desc(client, user_auth_token, enable_factory_create):
+    """Test that forms are returned in descending order by created_at"""
+    form1 = FormFactory.create(agency_code="SGG", form_name="First")
+    form2 = FormFactory.create(agency_code="SGG", form_name="Second")
+    form3 = FormFactory.create(agency_code="SGG", form_name="Third")
+
+    resp = client.get("/v1/forms/", headers={"X-SGG-Token": user_auth_token})
+
+    assert resp.status_code == 200
+    response_data = resp.get_json()
+    forms = response_data["data"]
+
+    # Filter to just our created forms
+    created_form_ids = {str(form1.form_id), str(form2.form_id), str(form3.form_id)}
+    test_forms = [f for f in forms if f["form_id"] in created_form_ids]
+
+    assert len(test_forms) == 3
+
+    # Most recent should be first
+    assert test_forms[0]["form_id"] == str(form3.form_id)
+    assert test_forms[1]["form_id"] == str(form2.form_id)
+    assert test_forms[2]["form_id"] == str(form1.form_id)
+
+
+def test_get_all_forms_without_instructions(client, user_auth_token, enable_factory_create):
+    """Test getting forms without instructions returns null for form_instruction"""
+    form = FormFactory.create(agency_code="SGG", form_name="No Instructions Form")
+
+    resp = client.get("/v1/forms/", headers={"X-SGG-Token": user_auth_token})
+
+    assert resp.status_code == 200
+    response_data = resp.get_json()
+    forms = response_data["data"]
+
+    # Find the form that was just created
+    our_form = None
+    for f in forms:
+        if f["form_id"] == str(form.form_id):
+            our_form = f
+            break
+
+    assert our_form is not None
+    assert our_form["form_instruction"] is None

--- a/api/tests/src/api/forms_v1/test_forms_route_get.py
+++ b/api/tests/src/api/forms_v1/test_forms_route_get.py
@@ -82,23 +82,25 @@ def test_get_all_forms_includes_all_fields(client, user_auth_token, enable_facto
 def test_get_all_forms_with_instructions(client, user_auth_token, enable_factory_create):
     """Test getting forms with instructions includes instruction fields"""
     form = FormFactory.create(agency_code="SGG", with_instruction=True)
- 
+
     resp = client.get("/v1/forms/", headers={"X-SGG-Token": user_auth_token})
- 
+
     assert resp.status_code == 200
     response_data = resp.get_json()
     forms = response_data["data"]
- 
+
     # Find the form that was just created
     our_form = None
     for f in forms:
         if f["form_id"] == str(form.form_id):
             our_form = f
             break
- 
+
     assert our_form is not None
     assert our_form["form_instruction"] is not None
-    assert our_form["form_instruction"]["form_instruction_id"] == str(form.form_instruction.form_instruction_id)
+    assert our_form["form_instruction"]["form_instruction_id"] == str(
+        form.form_instruction.form_instruction_id
+    )
     assert our_form["form_instruction"]["file_name"] == form.form_instruction.file_name
     assert our_form["form_instruction"]["created_at"] is not None
     assert our_form["form_instruction"]["updated_at"] is not None


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10351 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
-Added a new v1/forms blueprint and endpoint for Fetching all forms with `agency_code` SGG.
-Added a new v1/forms services directory and `get_forms.py`.
-Added new v1/forms blueprint to `app.py`.
-Create a new testing directory for v1/forms and added `test_forms_route_get.py`.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Today, opportunity publication and application readiness are partially decoupled in Smarter Grants Management (SGM). Grantors can publish opportunities, but the configuration of competitions and [required forms](https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/2766897293) (collectively, Competitions) is not tightly integrated into the opportunity creation workflow. This creates ambiguity for applicants and additional operational overhead for Grantors and system administrators.

More information of how this endpoint fits into the greater workflow can be found in this [tech spec](https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/3027992702/Tech+Spec+Quad+6+Enable+Grantors+to+Post+Application+Packages+With+Opportunities#API-%2F-Integration-Details).

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] A user can fetch the list of 16 SGG forms
- [x] JSON Results match tech spec
- [x] Added passing unit tests