### PR TITLE
[Unticketed] Modify the opportunity notification code to batch queries

### DIFF
--- a/api/src/task/notifications/opportunity_notifcation.py
+++ b/api/src/task/notifications/opportunity_notifcation.py
@@ -1,5 +1,6 @@
+import itertools
 import logging
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from datetime import datetime
 from typing import cast
 from uuid import UUID
@@ -87,6 +88,8 @@ NOT_SPECIFIED = "not specified"  # If None value display this string
 
 TRUNCATION_THRESHOLD = 250
 
+BATCH_QUERY_SIZE = 1000
+
 UTM_TAG = "?utm_source=notification&utm_medium=email&utm_campaign=opportunity_update"
 
 
@@ -106,6 +109,7 @@ class OpportunityNotificationTask(BaseNotificationTask):
         user_opportunity_pairs: list = []
         versionless_opportunities: set = set()
 
+        logger.info("Processing opportunity versions to determine notifications")
         for user_saved_opp, latest_opp_ver in results:
             if latest_opp_ver is None:
                 logger.error(
@@ -173,7 +177,17 @@ class OpportunityNotificationTask(BaseNotificationTask):
         ]
 
         # Get last notified versions.
-        prior_notified_versions = self._get_last_notified_versions(enabled_user_opportunity_pairs)
+        # Batch this into chunks to avoid the query
+        # being incredibly large in the worst case scenario
+        # as it can hit the 65k Postgres limit on fields in a query
+        prior_notified_versions: dict[tuple[UUID, UUID], OpportunityVersion] = {}
+        logger.info("Getting when users were last notified about an opportunity")
+        for enabled_user_opportunity_pairs_batch in itertools.batched(
+            enabled_user_opportunity_pairs, n=BATCH_QUERY_SIZE, strict=False
+        ):
+            prior_notified_versions |= self._get_last_notified_versions(
+                enabled_user_opportunity_pairs_batch
+            )
 
         users_email_notifications: list[UserEmailNotification] = []
         for user_changed_opp in changed_saved_opportunities:
@@ -245,7 +259,7 @@ class OpportunityNotificationTask(BaseNotificationTask):
 
     def _get_users_with_email_disabled(self, user_ids: list[UUID]) -> set[UUID]:
         """Return user IDs that have explicitly disabled email notifications for their own saved opportunities."""
-
+        logger.info("Getting users with email disabled for notifications")
         if not user_ids:
             return set()
         stmt = select(UserSavedOpportunityNotification.user_id).where(
@@ -260,6 +274,7 @@ class OpportunityNotificationTask(BaseNotificationTask):
         Retrieve the latest OpportunityVersion for each opportunity saved by users.
         """
         # Rank all versions per opportunity_id, by created_at descending
+        logger.info("Fetching latest opportunity versions")
         row_number = (
             func.row_number()
             .over(
@@ -302,7 +317,7 @@ class OpportunityNotificationTask(BaseNotificationTask):
         return results
 
     def _get_last_notified_versions(
-        self, user_opportunity_pairs: list
+        self, user_opportunity_pairs: Iterable
     ) -> dict[tuple[UUID, UUID], OpportunityVersion]:
         """
         Given (user_id, opportunity_id) pairs, return the most recent


### PR DESCRIPTION
## Summary

## Changes proposed
* Change the opportunity notification query that finds prior notification versions to be batched

## Context for reviewers
With an unrelated backfill of data, we created a version of every opportunity in our system, which made the query size massive. The query that happens in the `_get_last_notified_versions` function is incredibly complex and does a lot of joins that have a lot of fields in them. With that large backfill, we're hitting a limit on Postgres of 65k fields defined in the query

```
psycopg.OperationalError) sending query and params failed: number of parameters must be between 0 and 65535
```

While in the long-term, we should consider simplifying the query (pulling logic out into our python code), that's a bigger refactor than we want to do when fixing a bug. This instead just batches that query into chunks.

## Validation steps
I loaded 50k opportunities, and users with those opportunities saved into my local DB using `make console` and our factories. Without my change, I get the same error we're seeing in prod, with the change, we're able to get past that query and fetch the data as appropriate. Batch sizes of 5000 or more still hit the error, so don't think we'd want to increase it further. Also tested with a batch size of 1 and the unit tests to verify nothing breaks with the batching logic (since 1000 is way more than the tests would ever setup)