### PR TITLE
[Issue #5152] Move newsletter subscription to API route for improved test stability

### DIFF
--- a/backend/grants_shared/tests/grants_shared/util/test_local.py
+++ b/backend/grants_shared/tests/grants_shared/util/test_local.py
@@ -1,0 +1,77 @@
+import os
+
+import pytest
+
+from grants_shared.util.local import error_if_not_local, load_local_env_vars
+
+
+class TestLoadLocalEnvVars:
+    def test_loads_dotenv_when_environment_is_local(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("TEST_VAR=hello\n")
+        monkeypatch.setenv("ENVIRONMENT", "local")
+        monkeypatch.delenv("TEST_VAR", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        assert os.getenv("TEST_VAR") == "hello"
+
+    def test_loads_dotenv_when_environment_is_unset(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("TEST_VAR2=world\n")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("TEST_VAR2", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        assert os.getenv("TEST_VAR2") == "world"
+
+    def test_skips_dotenv_when_environment_is_not_local(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("TEST_VAR3=should_not_load\n")
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        monkeypatch.delenv("TEST_VAR3", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        assert os.getenv("TEST_VAR3") is None
+
+    @pytest.mark.parametrize("env", ["staging", "prod", "production", "test"])
+    def test_skips_dotenv_for_non_local_environments(self, monkeypatch, tmp_path, env):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("SKIP_VAR=skip\n")
+        monkeypatch.setenv("ENVIRONMENT", env)
+        monkeypatch.delenv("SKIP_VAR", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        assert os.getenv("SKIP_VAR") is None
+
+
+class TestErrorIfNotLocal:
+    def test_passes_when_environment_is_local(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "local")
+        # Should not raise
+        error_if_not_local()
+
+    def test_raises_when_environment_is_not_local(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        with pytest.raises(
+            Exception, match="Local-only process called when environment was set to non-local"
+        ):
+            error_if_not_local()
+
+    def test_raises_when_environment_is_unset(self, monkeypatch):
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        with pytest.raises(
+            Exception, match="Local-only process called when environment was set to non-local"
+        ):
+            error_if_not_local()
+
+    @pytest.mark.parametrize("env", ["staging", "prod", "production", "test"])
+    def test_raises_for_non_local_environments(self, monkeypatch, env):
+        monkeypatch.setenv("ENVIRONMENT", env)
+        with pytest.raises(
+            Exception, match="Local-only process called when environment was set to non-local"
+        ):
+            error_if_not_local()

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
@@ -41,10 +41,12 @@ describe("SubscriptionForm", () => {
 
   it("calls /api/newsletter/subscribe on submit", async () => {
     global.fetch = jest.fn(() =>
-      Promise.resolve({
-        json: () => Promise.resolve({ success: true }),
-      }),
-    );
+      Promise.resolve(
+        ({
+          json: () => Promise.resolve({ success: true }),
+        } as unknown) as Response,
+      ),
+    ) as unknown as typeof global.fetch;
 
     render(<SubscriptionForm />);
 
@@ -68,10 +70,12 @@ describe("SubscriptionForm", () => {
 
   it("redirects to confirmation page on success", async () => {
     global.fetch = jest.fn(() =>
-      Promise.resolve({
-        json: () => Promise.resolve({ success: true }),
-      }),
-    );
+      Promise.resolve(
+        ({
+          json: () => Promise.resolve({ success: true }),
+        } as unknown) as Response,
+      ),
+    ) as unknown as typeof global.fetch;
 
     render(<SubscriptionForm />);
 
@@ -92,10 +96,12 @@ describe("SubscriptionForm", () => {
 
   it("shows server error message on failure", async () => {
     global.fetch = jest.fn(() =>
-      Promise.resolve({
-        json: () => Promise.resolve({ success: false, errorCode: "server" }),
-      }),
-    );
+      Promise.resolve(
+        ({
+          json: () => Promise.resolve({ success: false, errorCode: "server" }),
+        } as unknown) as Response,
+      ),
+    ) as unknown as typeof global.fetch;
 
     render(<SubscriptionForm />);
 

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
@@ -1,4 +1,16 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor, fireEvent } from "@testing-library/react";
+
+// Ensure the client fetch used by the component delegates to `global.fetch`,
+// which the tests mock below. Must mock before importing the component.
+jest.mock("src/hooks/useClientFetch", () => ({
+  useClientFetch: () => ({
+    clientFetch: async (url: string, options?: RequestInit) => {
+      const res = await (global.fetch as unknown as jest.Mock)(url, options);
+      return res.json();
+    },
+  }),
+}));
+
 import SubscriptionForm from "src/app/[locale]/(base)/newsletter/_components/SubscriptionForm";
 
 const mockRouterPush = jest.fn();
@@ -32,9 +44,17 @@ describe("SubscriptionForm", () => {
       }),
     ) as jest.Mock;
 
-    render(<SubscriptionForm />);
+    const { container } = render(<SubscriptionForm />);
 
+    const nameInput = container.querySelector('#name') as HTMLInputElement;
+    const emailInput = container.querySelector('#email') as HTMLInputElement;
     const button = screen.getByRole("button", { name: "form.button" });
+
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: "Test User" } });
+      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    });
+
     act(() => {
       button.click();
     });
@@ -54,9 +74,17 @@ describe("SubscriptionForm", () => {
       }),
     ) as jest.Mock;
 
-    render(<SubscriptionForm />);
+    const { container } = render(<SubscriptionForm />);
 
+    const nameInput = container.querySelector('#name') as HTMLInputElement;
+    const emailInput = container.querySelector('#email') as HTMLInputElement;
     const button = screen.getByRole("button", { name: "form.button" });
+
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: "Test User" } });
+      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    });
+
     act(() => {
       button.click();
     });
@@ -73,9 +101,17 @@ describe("SubscriptionForm", () => {
       }),
     ) as jest.Mock;
 
-    render(<SubscriptionForm />);
+    const { container } = render(<SubscriptionForm />);
 
+    const nameInput = container.querySelector('#name') as HTMLInputElement;
+    const emailInput = container.querySelector('#email') as HTMLInputElement;
     const button = screen.getByRole("button", { name: "form.button" });
+
+    act(() => {
+      fireEvent.change(nameInput, { target: { value: "Test User" } });
+      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+    });
+
     act(() => {
       button.click();
     });

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
@@ -1,13 +1,22 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import SubscriptionForm from "src/app/[locale]/(base)/newsletter/_components/SubscriptionForm";
 
-const mockSubscribeEmail = jest.fn();
-
-jest.mock("src/app/[locale]/(base)/newsletter/actions", () => ({
-  subscribeEmail: (...args: unknown[]): unknown => mockSubscribeEmail(...args),
+const mockRouterPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
 }));
 
 describe("SubscriptionForm", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
   it("renders", () => {
     render(<SubscriptionForm />);
 
@@ -16,8 +25,13 @@ describe("SubscriptionForm", () => {
     expect(button).toBeInTheDocument();
   });
 
-  it("calls subscribeEmail action on submit", () => {
-    mockSubscribeEmail.mockImplementation(() => Promise.resolve());
+  it("calls /api/newsletter/subscribe on submit", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ success: true }),
+      }),
+    ) as jest.Mock;
+
     render(<SubscriptionForm />);
 
     const button = screen.getByRole("button", { name: "form.button" });
@@ -25,42 +39,50 @@ describe("SubscriptionForm", () => {
       button.click();
     });
 
-    expect(mockSubscribeEmail).toHaveBeenCalledWith(
-      { errorMessage: "", validationErrors: {} },
-      expect.any(FormData),
-    );
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/newsletter/subscribe",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
   });
 
-  // unclear why, but React server actions are still not working with Jest here
-  // action function is replaced with `javascript:throw new Error('A React form was unexpectedly submitted')`
-  // See also https://github.com/facebook/react/blob/f83903bfcc5a61811bd1b69b14f0ebbac4754462/packages/react-dom-bindings/src/client/ReactDOMComponent.js#L468
-  // - DWS 2-12-25
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("shows relevant errors returned by action", () => {
-    mockSubscribeEmail.mockImplementation(() =>
+  it("redirects to confirmation page on success", async () => {
+    global.fetch = jest.fn(() =>
       Promise.resolve({
-        errorMessage: "an error message",
-        validationErrors: {
-          name: "bad name, sorry",
-          email: "this really was not a valid email",
-        },
+         json: () => Promise.resolve({ success: true }),
       }),
-    );
-    const { rerender } = render(<SubscriptionForm />);
+     ) as jest.Mock;
+
+    render(<SubscriptionForm />);
 
     const button = screen.getByRole("button", { name: "form.button" });
     act(() => {
       button.click();
     });
 
-    rerender(<SubscriptionForm />);
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith("/newsletter/confirmation");
+    });
+  });
 
-    const errorAlerts = screen.getAllByRole("alert");
+  it("shows server error message on failure", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ success: false, errorCode: "server" }),
+      }),
+    ) as jest.Mock;
 
-    expect(errorAlerts).toHaveLength(2);
-    expect(errorAlerts[0]).toHaveTextContent("bad name, sorry");
-    expect(errorAlerts[1]).toHaveTextContent(
-      "this really was not a valid email",
-    );
+    render(<SubscriptionForm />);
+
+    const button = screen.getByRole("button", { name: "form.button" });
+    act(() => {
+      button.click();
+    });
+
+    await waitFor(() => {
+      const errorAlerts = screen.getAllByRole("alert");
+      expect(errorAlerts.length).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
@@ -1,11 +1,13 @@
-import { act, render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
-// Ensure the client fetch used by the component delegates to `global.fetch`,
-// which the tests mock below. Must mock before importing the component.
+// Mock useClientFetch to delegate to the already-mocked `global.fetch` in tests.
 jest.mock("src/hooks/useClientFetch", () => ({
   useClientFetch: () => ({
     clientFetch: async (url: string, options?: RequestInit) => {
-      const res = await (global.fetch as unknown as jest.Mock)(url, options);
+      const fn = global.fetch as unknown as jest.MockedFunction<typeof fetch>;
+      const res = await fn(url, options);
+      // `Response.json()` returns `any`; allow this in the test mock
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return res.json();
     },
   }),
@@ -42,22 +44,19 @@ describe("SubscriptionForm", () => {
       Promise.resolve({
         json: () => Promise.resolve({ success: true }),
       }),
-    ) as jest.Mock;
+    );
 
-    const { container } = render(<SubscriptionForm />);
+    render(<SubscriptionForm />);
 
-    const nameInput = container.querySelector('#name') as HTMLInputElement;
-    const emailInput = container.querySelector('#email') as HTMLInputElement;
+    const inputs = screen.getAllByTestId("textInput");
+    const nameInput = inputs.find((i) => i.id === "name")!;
+    const emailInput = inputs.find((i) => i.id === "email")!;
     const button = screen.getByRole("button", { name: "form.button" });
 
-    act(() => {
-      fireEvent.change(nameInput, { target: { value: "Test User" } });
-      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
-    });
+    fireEvent.change(nameInput, { target: { value: "Test User" } });
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
 
-    act(() => {
-      button.click();
-    });
+    fireEvent.click(button);
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
@@ -72,22 +71,19 @@ describe("SubscriptionForm", () => {
       Promise.resolve({
         json: () => Promise.resolve({ success: true }),
       }),
-    ) as jest.Mock;
+    );
 
-    const { container } = render(<SubscriptionForm />);
+    render(<SubscriptionForm />);
 
-    const nameInput = container.querySelector('#name') as HTMLInputElement;
-    const emailInput = container.querySelector('#email') as HTMLInputElement;
+    const inputs = screen.getAllByTestId("textInput");
+    const nameInput = inputs.find((i) => i.id === "name")!;
+    const emailInput = inputs.find((i) => i.id === "email")!;
     const button = screen.getByRole("button", { name: "form.button" });
 
-    act(() => {
-      fireEvent.change(nameInput, { target: { value: "Test User" } });
-      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
-    });
+    fireEvent.change(nameInput, { target: { value: "Test User" } });
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
 
-    act(() => {
-      button.click();
-    });
+    fireEvent.click(button);
 
     await waitFor(() => {
       expect(mockRouterPush).toHaveBeenCalledWith("/newsletter/confirmation");
@@ -99,22 +95,19 @@ describe("SubscriptionForm", () => {
       Promise.resolve({
         json: () => Promise.resolve({ success: false, errorCode: "server" }),
       }),
-    ) as jest.Mock;
+    );
 
-    const { container } = render(<SubscriptionForm />);
+    render(<SubscriptionForm />);
 
-    const nameInput = container.querySelector('#name') as HTMLInputElement;
-    const emailInput = container.querySelector('#email') as HTMLInputElement;
+    const inputs = screen.getAllByTestId("textInput");
+    const nameInput = inputs.find((i) => i.id === "name")!;
+    const emailInput = inputs.find((i) => i.id === "email")!;
     const button = screen.getByRole("button", { name: "form.button" });
 
-    act(() => {
-      fireEvent.change(nameInput, { target: { value: "Test User" } });
-      fireEvent.change(emailInput, { target: { value: "test@example.com" } });
-    });
+    fireEvent.change(nameInput, { target: { value: "Test User" } });
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
 
-    act(() => {
-      button.click();
-    });
+    fireEvent.click(button);
 
     await waitFor(() => {
       const errorAlerts = screen.getAllByRole("alert");

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
@@ -50,9 +50,9 @@ describe("SubscriptionForm", () => {
   it("redirects to confirmation page on success", async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
-         json: () => Promise.resolve({ success: true }),
+        json: () => Promise.resolve({ success: true }),
       }),
-     ) as jest.Mock;
+    ) as jest.Mock;
 
     render(<SubscriptionForm />);
 

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import SubscriptionForm from "src/app/[locale]/(base)/newsletter/_components/SubscriptionForm";
 
 // Mock useClientFetch to delegate to the already-mocked `global.fetch` in tests.
 jest.mock("src/hooks/useClientFetch", () => ({
@@ -12,8 +13,6 @@ jest.mock("src/hooks/useClientFetch", () => ({
     },
   }),
 }));
-
-import SubscriptionForm from "src/app/[locale]/(base)/newsletter/_components/SubscriptionForm";
 
 const mockRouterPush = jest.fn();
 jest.mock("next/navigation", () => ({
@@ -41,11 +40,9 @@ describe("SubscriptionForm", () => {
 
   it("calls /api/newsletter/subscribe on submit", async () => {
     global.fetch = jest.fn(() =>
-      Promise.resolve(
-        ({
-          json: () => Promise.resolve({ success: true }),
-        } as unknown) as Response,
-      ),
+      Promise.resolve({
+        json: () => Promise.resolve({ success: true }),
+      } as unknown as Response),
     ) as unknown as typeof global.fetch;
 
     render(<SubscriptionForm />);
@@ -70,11 +67,9 @@ describe("SubscriptionForm", () => {
 
   it("redirects to confirmation page on success", async () => {
     global.fetch = jest.fn(() =>
-      Promise.resolve(
-        ({
-          json: () => Promise.resolve({ success: true }),
-        } as unknown) as Response,
-      ),
+      Promise.resolve({
+        json: () => Promise.resolve({ success: true }),
+      } as unknown as Response),
     ) as unknown as typeof global.fetch;
 
     render(<SubscriptionForm />);
@@ -96,11 +91,9 @@ describe("SubscriptionForm", () => {
 
   it("shows server error message on failure", async () => {
     global.fetch = jest.fn(() =>
-      Promise.resolve(
-        ({
-          json: () => Promise.resolve({ success: false, errorCode: "server" }),
-        } as unknown) as Response,
-      ),
+      Promise.resolve({
+        json: () => Promise.resolve({ success: false, errorCode: "server" }),
+      } as unknown as Response),
     ) as unknown as typeof global.fetch;
 
     render(<SubscriptionForm />);

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { subscribeEmail } from "src/app/[locale]/(base)/newsletter/actions";
-
 import { useTranslations } from "next-intl";
-import React, { useActionState } from "react";
+import { useRouter } from "next/navigation";
+import { useState, type ReactNode } from "react";
 import {
   ErrorMessage,
   FormGroup,
@@ -18,10 +17,16 @@ export type ValidationErrors = {
   email?: string[];
 };
 
+type FormState = {
+  errorMessage: ReactNode;
+  validationErrors: ValidationErrors;
+};
+
 export default function SubscriptionForm() {
   const t = useTranslations("Subscribe");
+  const router = useRouter();
 
-  const [state, formAction] = useActionState(subscribeEmail, {
+  const [state, setState] = useState<FormState>({
     errorMessage: "",
     validationErrors: {},
   });
@@ -34,8 +39,57 @@ export default function SubscriptionForm() {
     );
   };
 
+  const handleSubmit = async (event: {
+    preventDefault(): void;
+    currentTarget: HTMLFormElement;
+  }) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    const response = await fetch("/api/newsletter/subscribe", {
+      method: "POST",
+      body: formData,
+    });
+
+    const data = (await response.json()) as {
+      success: boolean;
+      errorCode?: string;
+      validationErrors?: ValidationErrors;
+    };
+
+    if (data.success) {
+      router.push("/newsletter/confirmation");
+      return;
+    }
+
+    if (data.validationErrors) {
+      setState({ errorMessage: "", validationErrors: data.validationErrors });
+      return;
+    }
+
+    if (data.errorCode === "alreadySubscribed") {
+      setState({
+        errorMessage: t("errors.alreadySubscribed"),
+        validationErrors: {},
+      });
+    } else {
+      setState({
+        errorMessage: t.rich("errors.server", {
+          "email-link": (content) => (
+            <a href="mailto:simpler@grants.gov">{content}</a>
+          ),
+        }),
+        validationErrors: {},
+      });
+    }
+  };
+
   return (
-    <form action={formAction}>
+    <form
+      onSubmit={(e) => {
+        void handleSubmit(e);
+      }}
+    >
       <FormGroup error={showError("name")}>
         <Label htmlFor="name" className="maxw-full">
           {t("form.name") + " "}

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useClientFetch } from "src/hooks/useClientFetch";
+
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState, type ReactNode } from "react";
@@ -22,22 +24,39 @@ type FormState = {
   validationErrors: ValidationErrors;
 };
 
+type SubscribeResponse = {
+  success: boolean;
+  errorCode?: string;
+  validationErrors?: ValidationErrors;
+};
+
 export default function SubscriptionForm() {
   const t = useTranslations("Subscribe");
   const router = useRouter();
+  const { clientFetch } = useClientFetch<SubscribeResponse>(
+    "Newsletter subscription failed",
+  );
 
-  const [state, setState] = useState<FormState>({
+  const [subscribeErrorState, setSubscribeErrorState] = useState<FormState>({
     errorMessage: "",
     validationErrors: {},
   });
 
   const showError = (fieldName: string): boolean => {
-    if (!state?.validationErrors) return false;
+    if (!subscribeErrorState?.validationErrors) return false;
 
     return (
-      state?.validationErrors[fieldName as keyof ValidationErrors] !== undefined
+      subscribeErrorState?.validationErrors[
+        fieldName as keyof ValidationErrors
+      ] !== undefined
     );
   };
+
+  const serverError = t.rich("errors.server", {
+    "email-link": (content) => (
+      <a href="mailto:simpler@grants.gov">{content}</a>
+    ),
+  });
 
   const handleSubmit = async (event: {
     preventDefault(): void;
@@ -46,39 +65,47 @@ export default function SubscriptionForm() {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
 
-    const response = await fetch("/api/newsletter/subscribe", {
-      method: "POST",
-      body: formData,
-    });
-
-    const data = (await response.json()) as {
-      success: boolean;
-      errorCode?: string;
-      validationErrors?: ValidationErrors;
-    };
-
-    if (data.success) {
-      router.push("/newsletter/confirmation");
-      return;
-    }
-
-    if (data.validationErrors) {
-      setState({ errorMessage: "", validationErrors: data.validationErrors });
-      return;
-    }
-
-    if (data.errorCode === "alreadySubscribed") {
-      setState({
-        errorMessage: t("errors.alreadySubscribed"),
-        validationErrors: {},
+    // Client-side validation — mirrors the API's Zod schema so the API never
+    // receives an invalid payload during normal usage.
+    const name = (formData.get("name") as string) ?? "";
+    const email = (formData.get("email") as string) ?? "";
+    const clientValidationErrors: ValidationErrors = {};
+    if (!name.trim()) clientValidationErrors.name = ["Please enter a name."];
+    if (!email.trim())
+      clientValidationErrors.email = ["Please enter an email address."];
+    if (Object.keys(clientValidationErrors).length > 0) {
+      setSubscribeErrorState({
+        errorMessage: "",
+        validationErrors: clientValidationErrors,
       });
-    } else {
-      setState({
-        errorMessage: t.rich("errors.server", {
-          "email-link": (content) => (
-            <a href="mailto:simpler@grants.gov">{content}</a>
-          ),
-        }),
+      return;
+    }
+
+    try {
+      const data = await clientFetch("/api/newsletter/subscribe", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (data.success) {
+        router.push("/newsletter/confirmation");
+        return;
+      }
+
+      if (data.errorCode === "alreadySubscribed") {
+        setSubscribeErrorState({
+          errorMessage: t("errors.alreadySubscribed"),
+          validationErrors: {},
+        });
+      } else {
+        setSubscribeErrorState({
+          errorMessage: serverError,
+          validationErrors: {},
+        });
+      }
+    } catch {
+      setSubscribeErrorState({
+        errorMessage: serverError,
         validationErrors: {},
       });
     }
@@ -99,7 +126,7 @@ export default function SubscriptionForm() {
         </Label>
         {showError("name") ? (
           <ErrorMessage className="maxw-mobile-lg">
-            {state?.validationErrors.name?.[0]}
+            {subscribeErrorState?.validationErrors.name?.[0]}
           </ErrorMessage>
         ) : (
           <></>
@@ -133,7 +160,7 @@ export default function SubscriptionForm() {
         </Label>
         {showError("email") ? (
           <ErrorMessage className="maxw-mobile-lg">
-            {state?.validationErrors.email?.[0]}
+            {subscribeErrorState?.validationErrors.email?.[0]}
           </ErrorMessage>
         ) : (
           <></>
@@ -151,9 +178,9 @@ export default function SubscriptionForm() {
         <TextInput type="text" name="hp" id="hp" />
       </div>
       <SubscriptionSubmitButton />
-      {state?.errorMessage ? (
+      {subscribeErrorState?.errorMessage ? (
         <ErrorMessage className="maxw-mobile-lg">
-          {state?.errorMessage}
+          {subscribeErrorState?.errorMessage}
         </ErrorMessage>
       ) : (
         <></>

--- a/frontend/src/app/[locale]/(base)/newsletter/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/page.test.tsx
@@ -31,6 +31,7 @@ jest.mock("next-intl/server", () => ({
 
 jest.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: jest.fn() }),
 }));
 
 jest.mock("src/services/sessionStorage/sessionStorage", () => {

--- a/frontend/src/app/api/newsletter/subscribe/route.ts
+++ b/frontend/src/app/api/newsletter/subscribe/route.ts
@@ -1,0 +1,84 @@
+import { environment } from "src/constants/environments";
+import { z } from "zod";
+
+import { NextRequest, NextResponse } from "next/server";
+
+const subscribeSchema = z.object({
+  name: z.string().min(1, "Please enter a name."),
+  email: z
+    .string()
+    .min(1, "Please enter an email address.")
+    .email("Please enter a valid email address."),
+});
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+
+  const name = formData.get("name") as string;
+  const LastName = formData.get("LastName") as string;
+  const email = formData.get("email") as string;
+  const hp = formData.get("hp") as string;
+
+  const validated = subscribeSchema.safeParse({ name, email });
+  if (!validated.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        validationErrors: validated.error.flatten().fieldErrors,
+      },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const requestData = {
+      list: environment.SENDY_LIST_ID,
+      subform: "yes",
+      boolean: "true",
+      api_key: environment.SENDY_API_KEY,
+      hp,
+      name,
+      LastName,
+      email,
+    };
+
+    const sendyResponse = await fetch(
+      `${environment.SENDY_API_URL}/subscribe`,
+      {
+        method: "POST",
+        headers: { "Content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams(requestData),
+      },
+    );
+
+    const responseText = await sendyResponse.text();
+
+    if (responseText.includes("Already subscribed")) {
+      return NextResponse.json(
+        { success: false, errorCode: "alreadySubscribed" },
+        { status: 200 },
+      );
+    }
+
+    if (!sendyResponse.ok || !["1", "true"].includes(responseText)) {
+      console.error(
+        `Error subscribing user: Sendy returned an error response: ${responseText}, Status: ${sendyResponse.status}`,
+      );
+      return NextResponse.json(
+        { success: false, errorCode: "server" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    const error = e as Error;
+    console.error(
+      `Error subscribing user: Exception: ${error.message} ${error.cause?.toString() ?? ""}`,
+    );
+    return NextResponse.json(
+      { success: false, errorCode: "server" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/tests/e2e/subscribe/specs/subscribe.spec.ts
+++ b/frontend/tests/e2e/subscribe/specs/subscribe.spec.ts
@@ -20,7 +20,6 @@ test.beforeEach(async ({ page }) => {
 
   // Background: Given I open "/newsletter"
   await page.goto("/newsletter", { waitUntil: "domcontentloaded", timeout });
-
 });
 
 /**

--- a/frontend/tests/e2e/subscribe/specs/subscribe.spec.ts
+++ b/frontend/tests/e2e/subscribe/specs/subscribe.spec.ts
@@ -7,49 +7,20 @@
  * @scenario Show error when subscription fails
  */
 
+import { expect, test } from "@playwright/test";
 import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
-
-import {
-  expect,
-  // NextFixture,
-  test,
-} from "next/experimental/testmode/playwright";
 
 const { FULL_REGRESSION } = VALID_TAGS;
 
 const { targetEnv } = playwrightEnv;
-
-// function mockAPIEndpoints(next: NextFixture, responseText = "1") {
-//   next.onFetch((request: Request) => {
-//     if (request.url.endsWith("/subscribe") && request.method === "POST") {
-//       return new Response(responseText, {
-//         status: 200,
-//         headers: {
-//           "Content-Type": "text/plain",
-//         },
-//       });
-//     }
-
-//     return "abort";
-//   });
-// }
 
 test.beforeEach(async ({ page }) => {
   const timeout = targetEnv === "staging" ? 180000 : 60000;
 
   // Background: Given I open "/newsletter"
   await page.goto("/newsletter", { waitUntil: "domcontentloaded", timeout });
-  await page.route("**/newsletter", async (route) => {
-    if (route.request().method() === "POST") {
-      await route.fulfill({
-        status: 200,
-        headers: {
-          "Content-Type": "text/plain",
-        },
-      });
-    }
-  });
+
 });
 
 /**
@@ -60,20 +31,10 @@ test("has title", { tag: [FULL_REGRESSION] }, async ({ page }) => {
   await expect(page).toHaveTitle(/Subscribe | Simpler.Grants.gov/);
 });
 
-/*
-  note that most of these tests are currently skipped, and will be revisited in
-
-  https://github.com/HHS/simpler-grants-gov/issues/5152
-
-  we will need to figure out a way to mock out the calls to sendy, which may likely
-  mean mocking out the server action call. Unclear how to do that, may need to proxy it
-  through a normal API call or something.
-*/
-
 /**
  * @scenario Show errors when submitting empty form
  */
-test.skip("client side errors", async ({ page }) => {
+test("client side errors", async ({ page }) => {
   // When I click "Subscribe" button
   await page.getByRole("button", { name: /subscribe/i }).click();
 
@@ -91,8 +52,15 @@ test.skip("client side errors", async ({ page }) => {
 /**
  * @scenario Subscribe with valid name and email
  */
-test.skip("successful signup", async ({ /* next */ page }) => {
-  // mockAPIEndpoints(next);
+test("successful signup", async ({ page }) => {
+  // Mock the newsletter subscribe API so the test doesn't call Sendy
+  await page.route("**/api/newsletter/subscribe", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true }),
+    });
+  });
 
   // When I fill "First Name (required)" with "Apple"
   await page.getByLabel("First Name (required)").fill("Apple");
@@ -116,10 +84,15 @@ test.skip("successful signup", async ({ /* next */ page }) => {
 /**
  * @scenario Show error when subscription fails
  */
-test.skip("error during signup", async ({ /* next */ page }) => {
-  // TODO: Determine network error simulation strategy
-  // Given the subscription service is unavailable
-  // mockAPIEndpoints(next, "Error with subscribing");
+test("error during signup", async ({ page }) => {
+  // Mock the newsletter subscribe API to return a server error
+  await page.route("**/api/newsletter/subscribe", async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: "application/json",
+      body: JSON.stringify({ success: false, errorCode: "server" }),
+    });
+  });
 
   // When I fill "First Name (required)" with "Apple"
   await page.getByLabel("First Name (required)").fill("Apple");


### PR DESCRIPTION
## Summary
Work for : Task #5152 

## Changes proposed
- Newsletter subscription currently uses a Server Action, but E2E tests are unreliable because Next.js experimental test mode cannot consistently mock the server-side Sendy request in CI. This PR introduces an API route so the browser makes a real HTTP request that Playwright can reliably intercept in all environments.

## Context for reviewers
- To improve test stability, we are introducing a standard API route (/api/newsletter/subscribe)
- This change does not affect user behavior or Sendy integration, but improves test reliability and removes dependency on experimental Next.js testing features.


## Validation steps
- All tests pass locally and in CI after these changes
