### PR TITLE
[unticketed]: resolve anchore cve's finding in docker python base image

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:8ae2ecf@sha256:33d915d6da8c2c4049537fb5a5a209fb6af0a2b7009c524c3474631b57510864 AS base
+FROM ghcr.io/hhs/python-base-image:01d94f1@sha256:bedfbb4e63881e430c16c171ce993f477fd668833dc0cf21d1afeb0cd2bc89e7 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:8ae2ecf@sha256:33d915d6da8c2c4049537fb5a5a209fb6af0a2b7009c524c3474631b57510864 AS base
+FROM ghcr.io/hhs/python-base-image:01d94f1@sha256:bedfbb4e63881e430c16c171ce993f477fd668833dc0cf21d1afeb0cd2bc89e7 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -142,16 +142,19 @@ RUN dnf install -y \
       lz4-libs-1.9.4-1.amzn2023.0.3 \
       binutils-2.41-50.amzn2023.0.5 \
       glib2-2.82.2-767.amzn2023 \
-      curl-minimal-8.11.1-4.amzn2023.0.3 \
-      libcurl-minimal-8.11.1-4.amzn2023.0.3 \
-      kernel6.18-headers-6.18.25-55.108.amzn2023 \
+      curl-minimal-8.17.0-1.amzn2023.0.3 \
+      libcurl-minimal-8.17.0-1.amzn2023.0.3 \
+      kernel6.18-headers-6.18.25-57.109.amzn2023 \
       glibc-2.34-231.amzn2023.0.4 \
       glibc-common-2.34-231.amzn2023.0.4 \
       glibc-devel-2.34-231.amzn2023.0.4 \
       glibc-gconv-extra-2.34-231.amzn2023.0.4 \
       glibc-headers-x86-2.34-231.amzn2023.0.4 \
       glibc-minimal-langpack-2.34-231.amzn2023.0.4 \
-      python3-pip-wheel-21.3.1-2.amzn2023.0.17 && \
+      python3-pip-wheel-21.3.1-2.amzn2023.0.19 \
+      krb5-libs-1.21.3-7.amzn2023.0.1 \
+      rust-toolset-srpm-macros-1.95.0-1.amzn2023.0.2 \
+      libgcrypt-1.10.2-1.amzn2023.0.3 && \
     # CVE-2026-1757: libxml2 memory leak in xmllint (ALAS2023-2026-1446)
     dnf update -y --releasever=2023.10.20260302 \
       libxml2-2.10.4-1.amzn2023.0.18 \


### PR DESCRIPTION
## Summary

Resolve api and analytics anchore cve's from this failed scan: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/25990627798/job/76396001664)

## Validation steps

Deployed api to staging: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/26037359590)

Deployed analytics to dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/26037389188)
