### PR TITLE
[Issue #9984] Multithreading event handling in workflow service

### DIFF
--- a/api/src/workflow/manager/workflow_manager.py
+++ b/api/src/workflow/manager/workflow_manager.py
@@ -185,52 +185,8 @@ class WorkflowManager:
         """Fetch and process a batch of events from SQS."""
         sqs_containers = self.fetch_messages()
         logger.info("Fetched SQS messages", extra={"message_count": len(sqs_containers)})
-        messages_to_delete: list[str] = []
-        messages_to_keep: list[str] = []
 
-        if sqs_containers:
-            # Each container is processed on its own thread so that IO waits
-            # (DB calls, downstream services) overlap. The core loop stays
-            # single-threaded - we wait for every thread in this batch to
-            # finish before deleting any messages.
-            app = current_app._get_current_object()  # type: ignore[attr-defined]
-            timeout = self.config.workflow_event_processing_timeout_sec
-
-            with ThreadPoolExecutor(max_workers=len(sqs_containers)) as executor:
-                future_to_container = {
-                    executor.submit(_handle_event_in_thread, app, container): container
-                    for container in sqs_containers
-                }
-
-                for future, sqs_container in future_to_container.items():
-                    try:
-                        event_result = future.result(timeout=timeout)
-                    except FuturesTimeoutError:
-                        # Python threads can't be forcibly killed - the thread
-                        # will keep running until its DB call errors or returns,
-                        # at which point the surrounding transaction rolls back.
-                        # We stop waiting on it and treat the message as failed.
-                        logger.warning(
-                            "Workflow event handler exceeded timeout",
-                            extra=sqs_container.get_log_extra() | {"timeout_sec": timeout},
-                        )
-                        messages_to_keep.append(sqs_container.receipt_handle)
-                        continue
-                    except Exception:
-                        logger.exception(
-                            "Failed to handle current event",
-                            extra=sqs_container.get_log_extra(),
-                        )
-                        messages_to_keep.append(sqs_container.receipt_handle)
-                        continue
-
-                    if event_result in [
-                        WorkflowEventProcessingResult.SUCCESS,
-                        WorkflowEventProcessingResult.NON_RETRYABLE_ERROR,
-                    ]:
-                        messages_to_delete.append(sqs_container.receipt_handle)
-                    else:
-                        messages_to_keep.append(sqs_container.receipt_handle)
+        messages_to_delete, messages_to_keep = self._handle_containers(sqs_containers)
 
         self.delete_messages(messages_to_delete)
 
@@ -246,6 +202,61 @@ class WorkflowManager:
                 "failed_message_count": len(messages_to_keep),
             },
         )
+        return messages_to_delete, messages_to_keep
+
+    def _handle_containers(
+        self, sqs_containers: list[SqsMessageContainer]
+    ) -> tuple[list[str], list[str]]:
+        """Run each container through handle_event concurrently and classify the results.
+
+        Returns the receipt handles to delete and the receipt handles to keep on the queue.
+        Each container is processed on its own thread so IO waits (DB calls, downstream
+        services) overlap; the core loop stays single-threaded and waits for every thread
+        in this batch to finish before any messages are deleted.
+        """
+        messages_to_delete: list[str] = []
+        messages_to_keep: list[str] = []
+
+        if not sqs_containers:
+            return messages_to_delete, messages_to_keep
+
+        app = current_app._get_current_object()  # type: ignore[attr-defined]
+        timeout = self.config.workflow_event_processing_timeout_sec
+
+        with ThreadPoolExecutor(max_workers=len(sqs_containers)) as executor:
+            future_to_container = {
+                executor.submit(_handle_event_in_thread, app, container): container
+                for container in sqs_containers
+            }
+
+            for future, sqs_container in future_to_container.items():
+                try:
+                    event_result = future.result(timeout=timeout)
+                except FuturesTimeoutError:
+                    # Python threads can't be forcibly killed - the thread will
+                    # keep running until its DB call errors or returns, at which
+                    # point the surrounding transaction rolls back. We stop waiting
+                    # on it and treat the message as failed.
+                    logger.exception(
+                        "Workflow event handler exceeded timeout",
+                        extra=sqs_container.get_log_extra() | {"timeout_sec": timeout},
+                    )
+                    event_result = WorkflowEventProcessingResult.GENERAL_ERROR
+                except Exception:
+                    logger.exception(
+                        "Failed to handle current event",
+                        extra=sqs_container.get_log_extra(),
+                    )
+                    event_result = WorkflowEventProcessingResult.GENERAL_ERROR
+
+                if event_result in [
+                    WorkflowEventProcessingResult.SUCCESS,
+                    WorkflowEventProcessingResult.NON_RETRYABLE_ERROR,
+                ]:
+                    messages_to_delete.append(sqs_container.receipt_handle)
+                else:
+                    messages_to_keep.append(sqs_container.receipt_handle)
+
         return messages_to_delete, messages_to_keep
 
     def fetch_messages(self) -> list[SqsMessageContainer]:

--- a/api/src/workflow/manager/workflow_manager.py
+++ b/api/src/workflow/manager/workflow_manager.py
@@ -3,9 +3,12 @@ import logging
 import signal
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime
 from types import FrameType
 
+from flask import Flask, current_app
 from pydantic import ValidationError
 
 from src.adapters import db
@@ -38,6 +41,14 @@ class WorkflowManagerConfig(PydanticBaseEnvConfig):
     # Only used for testing, we have no limit
     # under ordinary circumstances
     workflow_maximum_batch_count: int | None = None  # WORKFLOW_MAXIMUM_BATCH_COUNT
+
+    # Per-event timeout when processing in parallel. If a thread doesn't
+    # return a result within this many seconds, we stop waiting on it,
+    # treat the event as failed (message kept on the queue), and move on.
+    # The thread itself can't be forcibly killed - the DB transaction
+    # opened inside it will roll back when the underlying operation
+    # eventually errors or completes.
+    workflow_event_processing_timeout_sec: int = 30  # WORKFLOW_EVENT_PROCESSING_TIMEOUT_SEC
 
 
 class WorkflowManager:
@@ -177,26 +188,49 @@ class WorkflowManager:
         messages_to_delete: list[str] = []
         messages_to_keep: list[str] = []
 
-        # Note that the initial approach won't be multi-threaded
-        # We'll follow-up on that later
-        for sqs_container in sqs_containers:
-            try:
-                event_result = handle_event(sqs_container)
-            except Exception:
-                logger.exception(
-                    "Failed to handle current event",
-                    extra=sqs_container.get_log_extra(),
-                )
-                messages_to_keep.append(sqs_container.receipt_handle)
-                continue
+        if sqs_containers:
+            # Each container is processed on its own thread so that IO waits
+            # (DB calls, downstream services) overlap. The core loop stays
+            # single-threaded - we wait for every thread in this batch to
+            # finish before deleting any messages.
+            app = current_app._get_current_object()  # type: ignore[attr-defined]
+            timeout = self.config.workflow_event_processing_timeout_sec
 
-            if event_result in [
-                WorkflowEventProcessingResult.SUCCESS,
-                WorkflowEventProcessingResult.NON_RETRYABLE_ERROR,
-            ]:
-                messages_to_delete.append(sqs_container.receipt_handle)
-            else:
-                messages_to_keep.append(sqs_container.receipt_handle)
+            with ThreadPoolExecutor(max_workers=len(sqs_containers)) as executor:
+                future_to_container = {
+                    executor.submit(_handle_event_in_thread, app, container): container
+                    for container in sqs_containers
+                }
+
+                for future, sqs_container in future_to_container.items():
+                    try:
+                        event_result = future.result(timeout=timeout)
+                    except FuturesTimeoutError:
+                        # Python threads can't be forcibly killed - the thread
+                        # will keep running until its DB call errors or returns,
+                        # at which point the surrounding transaction rolls back.
+                        # We stop waiting on it and treat the message as failed.
+                        logger.error(
+                            "Workflow event handler exceeded timeout",
+                            extra=sqs_container.get_log_extra() | {"timeout_sec": timeout},
+                        )
+                        messages_to_keep.append(sqs_container.receipt_handle)
+                        continue
+                    except Exception:
+                        logger.exception(
+                            "Failed to handle current event",
+                            extra=sqs_container.get_log_extra(),
+                        )
+                        messages_to_keep.append(sqs_container.receipt_handle)
+                        continue
+
+                    if event_result in [
+                        WorkflowEventProcessingResult.SUCCESS,
+                        WorkflowEventProcessingResult.NON_RETRYABLE_ERROR,
+                    ]:
+                        messages_to_delete.append(sqs_container.receipt_handle)
+                    else:
+                        messages_to_keep.append(sqs_container.receipt_handle)
 
         self.delete_messages(messages_to_delete)
 
@@ -258,6 +292,16 @@ class WorkflowManager:
                 )
         except Exception:
             logger.exception("Failed to delete messages from SQS queue")
+
+
+def _handle_event_in_thread(
+    app: Flask, sqs_container: SqsMessageContainer
+) -> WorkflowEventProcessingResult:
+    # handle_event's @with_db_session decorator pulls the DB client off
+    # current_app, which is per-thread. Push the app context here so the
+    # decorator can find it from inside the worker thread.
+    with app.app_context():
+        return handle_event(sqs_container)
 
 
 @flask_db.with_db_session()

--- a/api/src/workflow/manager/workflow_manager.py
+++ b/api/src/workflow/manager/workflow_manager.py
@@ -210,7 +210,7 @@ class WorkflowManager:
                         # will keep running until its DB call errors or returns,
                         # at which point the surrounding transaction rolls back.
                         # We stop waiting on it and treat the message as failed.
-                        logger.error(
+                        logger.warning(
                             "Workflow event handler exceeded timeout",
                             extra=sqs_container.get_log_extra() | {"timeout_sec": timeout},
                         )

--- a/api/tests/src/workflow/manager/test_workflow_manager.py
+++ b/api/tests/src/workflow/manager/test_workflow_manager.py
@@ -1,5 +1,7 @@
 import json
 import logging
+import threading
+import time
 import uuid
 from unittest.mock import patch
 
@@ -456,3 +458,69 @@ def test_process_sqs_event_general_error(mock_event_handler_preprocess, app):
 
     # Verify
     assert result == WorkflowEventProcessingResult.GENERAL_ERROR
+
+
+def test_process_batch_runs_events_concurrently(workflow_sqs_queue, app, valid_message_body):
+    """Verify process_batch dispatches each event to its own thread.
+
+    A threading.Barrier with a short timeout deterministically distinguishes
+    concurrent vs. sequential execution: if the handler ran sequentially the
+    first thread would block forever (the others can't arrive at the barrier),
+    so the barrier's timeout would fire and the test would fail.
+    """
+    sqs_client = SQSClient(
+        queue_url=workflow_sqs_queue, sqs_client=boto3.client("sqs", region_name="us-east-1")
+    )
+
+    num_events = 3
+    for _ in range(num_events):
+        body = dict(valid_message_body)
+        body["event_id"] = str(uuid.uuid4())
+        sqs_client.send_message(body)
+
+    barrier = threading.Barrier(num_events, timeout=5)
+
+    def fake_handle_event(sqs_container):
+        barrier.wait()
+        return WorkflowEventProcessingResult.SUCCESS
+
+    config = WorkflowManagerConfig(workflow_cycle_duration=0, workflow_maximum_batch_count=1)
+    workflow_manager = WorkflowManager(config=config)
+
+    with app.app_context(), patch(
+        "src.workflow.manager.workflow_manager.handle_event", fake_handle_event
+    ):
+        messages_to_delete, messages_to_keep = workflow_manager.process_batch()
+
+    assert len(messages_to_delete) == num_events
+    assert len(messages_to_keep) == 0
+
+
+def test_process_batch_event_timeout_keeps_message(workflow_sqs_queue, app, valid_message_body):
+    """A handler that exceeds the per-event timeout has its message kept on the queue."""
+    sqs_client = SQSClient(
+        queue_url=workflow_sqs_queue, sqs_client=boto3.client("sqs", region_name="us-east-1")
+    )
+    sqs_client.send_message(valid_message_body)
+
+    def slow_handle_event(sqs_container):
+        # Long enough to be guaranteed past the timeout below. The
+        # ThreadPoolExecutor will wait for this to finish on shutdown,
+        # so keep it short so the test stays fast.
+        time.sleep(1)
+        return WorkflowEventProcessingResult.SUCCESS
+
+    config = WorkflowManagerConfig(
+        workflow_cycle_duration=0,
+        workflow_maximum_batch_count=1,
+        workflow_event_processing_timeout_sec=0,
+    )
+    workflow_manager = WorkflowManager(config=config)
+
+    with app.app_context(), patch(
+        "src.workflow.manager.workflow_manager.handle_event", slow_handle_event
+    ):
+        messages_to_delete, messages_to_keep = workflow_manager.process_batch()
+
+    assert messages_to_delete == []
+    assert len(messages_to_keep) == 1

--- a/api/tests/src/workflow/manager/test_workflow_manager.py
+++ b/api/tests/src/workflow/manager/test_workflow_manager.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import threading
-import time
 import uuid
 from unittest.mock import patch
 
@@ -504,10 +503,10 @@ def test_process_batch_event_timeout_keeps_message(workflow_sqs_queue, app, vali
     sqs_client.send_message(valid_message_body)
 
     def slow_handle_event(sqs_container):
-        # Long enough to be guaranteed past the timeout below. The
-        # ThreadPoolExecutor will wait for this to finish on shutdown,
-        # so keep it short so the test stays fast.
-        time.sleep(1)
+        # The handler just needs to still be running when future.result(timeout=0)
+        # is called - any brief wait suffices. ThreadPoolExecutor waits for this
+        # to finish on shutdown, so keep it short so the test stays fast.
+        threading.Event().wait(0.05)
         return WorkflowEventProcessingResult.SUCCESS
 
     config = WorkflowManagerConfig(


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9984  

## Changes proposed

- Updated workflow_manager.py to add support for multithreading. `process_batch` now submits each `SqsMessageContainer` to a `ThreadPoolExecutor` (sized to the batch, up to 10) and waits per-future with a per-event timeout
- Updated test_workflow_manager.py to add two new tests

## Context for reviewers

Our logic for processing workflow events was to fetch a batch of up to 10 and sequentially process each one. This won't scale very well, and if each event is going to be processed separately, we should process them in parallel.

## Validation steps

Confirm tests pass.
The multithreading can also be manually tested locally by starting `make cmd args="workflow workflow-main"` in one terminal, and in another terminal, firing ~10 `PUT /v1/workflows/events` requests in parallel against a fresh opportunity ID using the seeded `X-API-Key: internal_workflow_user_key`. The log should show one `Fetched SQS messages message_count=N` followed by N interleaved `Processing event` lines within milliseconds of each other and a `batch_duration_sec` close to a single event's duration. 