### PR TITLE
[Issue #9705] Setup DynamoDB client in backend code

### DIFF
--- a/api/src/adapters/aws/__init__.py
+++ b/api/src/adapters/aws/__init__.py
@@ -1,5 +1,5 @@
 from .aws_session import get_aws_config, get_boto_session
-from .dynamodb_adapter import DynamoDBConfig
+from .dynamodb_adapter import DynamoDBConfig, get_boto_dynamodb_client
 from .s3_adapter import S3Config, get_s3_client
 from .sqs_adapter import SQSConfig, get_boto_sqs_client
 
@@ -10,5 +10,6 @@ __all__ = [
     "S3Config",
     "get_boto_sqs_client",
     "SQSConfig",
+    "get_boto_dynamodb_client",
     "DynamoDBConfig",
 ]

--- a/api/src/adapters/aws/dynamodb_adapter.py
+++ b/api/src/adapters/aws/dynamodb_adapter.py
@@ -1,8 +1,94 @@
-from pydantic import Field
+import logging
+from typing import Any
 
+import boto3
+import botocore.client
+from pydantic import BaseModel, Field
+
+from src.adapters.aws import get_aws_config, get_boto_session
 from src.util.env_config import PydanticBaseEnvConfig
+
+logger = logging.getLogger(__name__)
 
 
 class DynamoDBConfig(PydanticBaseEnvConfig):
     aws_dynamodb_endpoint_url: str | None = Field(alias="AWS_DYNAMODB_ENDPOINT_URL", default=None)
     file_scan_cache_table_name: str = Field(alias="FILE_SCAN_CACHE_TABLE_NAME")
+
+
+class DynamoDBGetItemResponse(BaseModel):
+    """Represents the response from getting an item from DynamoDB."""
+
+    item: dict[str, Any] | None = Field(default=None)
+
+
+def get_boto_dynamodb_client(
+    dynamodb_config: DynamoDBConfig | None = None, session: boto3.Session | None = None
+) -> botocore.client.BaseClient:
+    if dynamodb_config is None:
+        dynamodb_config = DynamoDBConfig()
+
+    params = {}
+    if dynamodb_config.aws_dynamodb_endpoint_url is not None:
+        params["endpoint_url"] = dynamodb_config.aws_dynamodb_endpoint_url
+
+    if session is None:
+        session = get_boto_session()
+
+    return session.client("dynamodb", region_name=get_aws_config().aws_region, **params)
+
+
+class DynamoDBClient:
+    def __init__(self, dynamodb_client: botocore.client.BaseClient | None = None):
+        self.client = dynamodb_client or get_boto_dynamodb_client()
+
+    def get_item(
+        self,
+        table_name: str,
+        key: dict[str, Any],
+        consistent_read: bool = True,
+    ) -> DynamoDBGetItemResponse:
+        """
+        Get an item from DynamoDB by its key.
+
+        Args:
+            table_name: The name of the DynamoDB table
+            key: The key of the item to retrieve (in DynamoDB format)
+            consistent_read: Whether to use consistent read (default: True)
+
+        Returns:
+            DynamoDBGetItemResponse containing the item if found, None otherwise
+        """
+        try:
+            logger.info(
+                "Getting item from DynamoDB",
+                extra={"table_name": table_name, "key": str(key)},
+            )
+
+            response = self.client.get_item(
+                TableName=table_name,
+                Key=key,
+                ConsistentRead=consistent_read,
+            )
+
+            item = response.get("Item")
+
+            if item:
+                logger.info(
+                    "Successfully retrieved item from DynamoDB",
+                    extra={"table_name": table_name, "key": str(key)},
+                )
+            else:
+                logger.info(
+                    "Item not found in DynamoDB",
+                    extra={"table_name": table_name, "key": str(key)},
+                )
+
+            return DynamoDBGetItemResponse(item=item)
+
+        except Exception:
+            logger.exception(
+                "Failed to get item from DynamoDB",
+                extra={"table_name": table_name, "key": str(key)},
+            )
+            raise

--- a/api/src/adapters/aws/dynamodb_adapter.py
+++ b/api/src/adapters/aws/dynamodb_adapter.py
@@ -92,7 +92,13 @@ class DynamoDBClient:
         try:
             logger.info(
                 "Getting item from DynamoDB",
-                extra={"table_name": table_name, "key": key},
+                extra={
+                    "table_name": table_name,
+                    "key_name": key_name,
+                    "key_type": key_type,
+                    "value": value,
+                    "consistent_read": consistent_read,
+                },
             )
 
             response = self.client.get_item(
@@ -106,12 +112,24 @@ class DynamoDBClient:
             if item:
                 logger.info(
                     "Successfully retrieved item from DynamoDB",
-                    extra={"table_name": table_name, "key": key},
+                    extra={
+                        "table_name": table_name,
+                        "key_name": key_name,
+                        "key_type": key_type,
+                        "value": value,
+                        "consistent_read": consistent_read,
+                    },
                 )
             else:
                 logger.info(
                     "Item not found in DynamoDB",
-                    extra={"table_name": table_name, "key": key},
+                    extra={
+                        "table_name": table_name,
+                        "key_name": key_name,
+                        "key_type": key_type,
+                        "value": value,
+                        "consistent_read": consistent_read,
+                    },
                 )
 
             return DynamoDBGetItemResponse(item=item)
@@ -119,6 +137,12 @@ class DynamoDBClient:
         except Exception:
             logger.exception(
                 "Failed to get item from DynamoDB",
-                extra={"table_name": table_name, "key": key},
+                extra={
+                    "table_name": table_name,
+                    "key_name": key_name,
+                    "key_type": key_type,
+                    "value": value,
+                    "consistent_read": consistent_read,
+                },
             )
             raise

--- a/api/src/adapters/aws/dynamodb_adapter.py
+++ b/api/src/adapters/aws/dynamodb_adapter.py
@@ -88,7 +88,7 @@ class DynamoDBClient:
             )
         """
         key = {key_name: {key_type: value}}
-        
+
         try:
             logger.info(
                 "Getting item from DynamoDB",

--- a/api/src/adapters/aws/dynamodb_adapter.py
+++ b/api/src/adapters/aws/dynamodb_adapter.py
@@ -45,7 +45,9 @@ class DynamoDBClient:
     def get_item(
         self,
         table_name: str,
-        key: dict[str, Any],
+        key_name: str,
+        value: Any,
+        key_type: str = "S",
         consistent_read: bool = True,
     ) -> DynamoDBGetItemResponse:
         """
@@ -53,16 +55,44 @@ class DynamoDBClient:
 
         Args:
             table_name: The name of the DynamoDB table
-            key: The key of the item to retrieve (in DynamoDB format)
+            key_name: The name of the key attribute
+            value: The value of the key
+            key_type: DynamoDB type - "S" (string), "N" (number), "B" (binary). Default: "S"
             consistent_read: Whether to use consistent read (default: True)
 
         Returns:
             DynamoDBGetItemResponse containing the item if found, None otherwise
+
+        Examples:
+            # String key (most common)
+            response = client.get_item(
+                table_name="virus-scan-cache",
+                key_name="file_id",
+                value="abc-123"
+            )
+
+            # Number key
+            response = client.get_item(
+                table_name="user-table",
+                key_name="user_id",
+                value="12345",
+                key_type="N"
+            )
+
+            # Eventually consistent read
+            response = client.get_item(
+                table_name="my-table",
+                key_name="id",
+                value="test-id",
+                consistent_read=False
+            )
         """
+        key = {key_name: {key_type: value}}
+        
         try:
             logger.info(
                 "Getting item from DynamoDB",
-                extra={"table_name": table_name, "key": str(key)},
+                extra={"table_name": table_name, "key": key},
             )
 
             response = self.client.get_item(
@@ -76,12 +106,12 @@ class DynamoDBClient:
             if item:
                 logger.info(
                     "Successfully retrieved item from DynamoDB",
-                    extra={"table_name": table_name, "key": str(key)},
+                    extra={"table_name": table_name, "key": key},
                 )
             else:
                 logger.info(
                     "Item not found in DynamoDB",
-                    extra={"table_name": table_name, "key": str(key)},
+                    extra={"table_name": table_name, "key": key},
                 )
 
             return DynamoDBGetItemResponse(item=item)
@@ -89,6 +119,6 @@ class DynamoDBClient:
         except Exception:
             logger.exception(
                 "Failed to get item from DynamoDB",
-                extra={"table_name": table_name, "key": str(key)},
+                extra={"table_name": table_name, "key": key},
             )
             raise

--- a/api/src/adapters/aws/dynamodb_adapter.py
+++ b/api/src/adapters/aws/dynamodb_adapter.py
@@ -88,17 +88,18 @@ class DynamoDBClient:
             )
         """
         key = {key_name: {key_type: value}}
+        log_extra = {
+            "table_name": table_name,
+            "key_name": key_name,
+            "key_type": key_type,
+            "value": value,
+            "consistent_read": consistent_read,
+        }
 
         try:
             logger.info(
                 "Getting item from DynamoDB",
-                extra={
-                    "table_name": table_name,
-                    "key_name": key_name,
-                    "key_type": key_type,
-                    "value": value,
-                    "consistent_read": consistent_read,
-                },
+                extra=log_extra,
             )
 
             response = self.client.get_item(
@@ -112,24 +113,12 @@ class DynamoDBClient:
             if item:
                 logger.info(
                     "Successfully retrieved item from DynamoDB",
-                    extra={
-                        "table_name": table_name,
-                        "key_name": key_name,
-                        "key_type": key_type,
-                        "value": value,
-                        "consistent_read": consistent_read,
-                    },
+                    extra=log_extra,
                 )
             else:
                 logger.info(
                     "Item not found in DynamoDB",
-                    extra={
-                        "table_name": table_name,
-                        "key_name": key_name,
-                        "key_type": key_type,
-                        "value": value,
-                        "consistent_read": consistent_read,
-                    },
+                    extra=log_extra,
                 )
 
             return DynamoDBGetItemResponse(item=item)
@@ -137,12 +126,6 @@ class DynamoDBClient:
         except Exception:
             logger.exception(
                 "Failed to get item from DynamoDB",
-                extra={
-                    "table_name": table_name,
-                    "key_name": key_name,
-                    "key_type": key_type,
-                    "value": value,
-                    "consistent_read": consistent_read,
-                },
+                extra=log_extra,
             )
             raise

--- a/api/src/db/setup_local_dynamodb.py
+++ b/api/src/db/setup_local_dynamodb.py
@@ -40,10 +40,10 @@ def _create_virus_scan_table(
         table = dynamodb.create_table(
             TableName=file_scan_cache_table_name,
             KeySchema=[
-                {"AttributeName": "attachment_id", "KeyType": "HASH"},  # Partition key
+                {"AttributeName": "file_id", "KeyType": "HASH"},  # Partition key
             ],
             AttributeDefinitions=[
-                {"AttributeName": "attachment_id", "AttributeType": "S"},  # String type
+                {"AttributeName": "file_id", "AttributeType": "S"},  # String type
             ],
             BillingMode="PAY_PER_REQUEST",  # On-demand billing for local development
         )

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -452,6 +452,7 @@ def reset_aws_env_vars(monkeypatch):
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
     monkeypatch.delenv("AWS_S3_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("AWS_SQS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_DYNAMODB_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("CDN_URL", raising=False)
     monkeypatch.setattr("src.adapters.aws.aws_session._aws_config", None)
 
@@ -511,6 +512,30 @@ def workflow_sqs_queue(mock_sqs, monkeypatch):
     # Set the env var of this queue so the SQSConfig picks it up
     monkeypatch.setenv("WORKFLOW_QUEUE_URL", queue["QueueUrl"])
     return queue["QueueUrl"]
+
+
+@pytest.fixture
+def mock_dynamodb(reset_aws_env_vars):
+    with moto.mock_aws(config={"core": {"service_whitelist": ["dynamodb"]}}):
+        yield
+
+
+@pytest.fixture
+def mock_dynamodb_table(mock_dynamodb, monkeypatch):
+    dynamodb = boto3.client("dynamodb", region_name="us-east-1")
+    table_name = "test-local-virus-scan"
+    dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "attachment_id", "KeyType": "HASH"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "attachment_id", "AttributeType": "S"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    monkeypatch.setenv("FILE_SCAN_CACHE_TABLE_NAME", table_name)
+    return table_name
 
 
 ####################

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -521,16 +521,16 @@ def mock_dynamodb(reset_aws_env_vars):
 
 
 @pytest.fixture
-def mock_dynamodb_table(mock_dynamodb, monkeypatch):
+def file_scan_dynamodb_table(mock_dynamodb, monkeypatch):
     dynamodb = boto3.client("dynamodb", region_name="us-east-1")
     table_name = "test-local-virus-scan"
     dynamodb.create_table(
         TableName=table_name,
         KeySchema=[
-            {"AttributeName": "attachment_id", "KeyType": "HASH"},
+            {"AttributeName": "file_id", "KeyType": "HASH"},
         ],
         AttributeDefinitions=[
-            {"AttributeName": "attachment_id", "AttributeType": "S"},
+            {"AttributeName": "file_id", "AttributeType": "S"},
         ],
         BillingMode="PAY_PER_REQUEST",
     )

--- a/api/tests/src/adapters/aws/test_dynamodb_adapter.py
+++ b/api/tests/src/adapters/aws/test_dynamodb_adapter.py
@@ -1,0 +1,195 @@
+import logging
+from unittest.mock import Mock, patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from pydantic import ValidationError
+
+from src.adapters.aws.dynamodb_adapter import (
+    DynamoDBClient,
+    DynamoDBConfig,
+    DynamoDBGetItemResponse,
+    get_boto_dynamodb_client,
+)
+
+
+class TestDynamoDBConfig:
+
+    def test_config_defaults(self, monkeypatch):
+        monkeypatch.delenv("FILE_SCAN_CACHE_TABLE_NAME", raising=False)
+        with pytest.raises(ValidationError):
+            DynamoDBConfig()
+
+    def test_config_from_environment(self, monkeypatch):
+        monkeypatch.setenv("FILE_SCAN_CACHE_TABLE_NAME", "test-table")
+        config = DynamoDBConfig()
+        assert config.file_scan_cache_table_name == "test-table"
+
+
+class TestGetBotoDynamoDBClient:
+
+    @patch("src.adapters.aws.dynamodb_adapter.get_boto_session")
+    def test_uses_default_session(self, mock_get_session):
+        mock_session = Mock()
+        mock_get_session.return_value = mock_session
+        get_boto_dynamodb_client()
+        mock_get_session.assert_called_once()
+        mock_session.client.assert_called_once_with(
+            "dynamodb",
+            region_name="us-east-1",
+            endpoint_url=DynamoDBConfig().aws_dynamodb_endpoint_url,
+        )
+
+    def test_uses_provided_session(self):
+        mock_session = Mock()
+        get_boto_dynamodb_client(session=mock_session)
+        mock_session.client.assert_called_once_with(
+            "dynamodb",
+            region_name="us-east-1",
+            endpoint_url=DynamoDBConfig().aws_dynamodb_endpoint_url,
+        )
+
+
+class TestDynamoDBClient:
+
+    def test_get_item_success(self, mock_dynamodb_table):
+        boto_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
+
+        boto_client.put_item(
+            TableName=mock_dynamodb_table,
+            Item={
+                "attachment_id": {"S": "test-id-123"},
+                "user_id": {"S": "user-abc-123"},
+                "status": {"S": "complete"},
+            },
+        )
+
+        response = dynamodb_client.get_item(
+            table_name=mock_dynamodb_table,
+            key={"attachment_id": {"S": "test-id-123"}},
+        )
+
+        assert isinstance(response, DynamoDBGetItemResponse)
+        assert response.item is not None
+        assert response.item["attachment_id"]["S"] == "test-id-123"
+        assert response.item["user_id"]["S"] == "user-abc-123"
+        assert response.item["status"]["S"] == "complete"
+
+    def test_get_item_not_found(self, mock_dynamodb_table):
+        boto_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
+
+        response = dynamodb_client.get_item(
+            table_name=mock_dynamodb_table,
+            key={"attachment_id": {"S": "non-existent-id"}},
+        )
+
+        assert isinstance(response, DynamoDBGetItemResponse)
+        assert response.item is None
+
+    def test_get_item_consistent_read_true(self, mock_dynamodb_table):
+        boto_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
+
+        boto_client.put_item(
+            TableName=mock_dynamodb_table,
+            Item={
+                "attachment_id": {"S": "test-id-456"},
+                "user_id": {"S": "user-456"},
+                "status": {"S": "pending"},
+            },
+        )
+
+        response = dynamodb_client.get_item(
+            table_name=mock_dynamodb_table,
+            key={"attachment_id": {"S": "test-id-456"}},
+            consistent_read=True,
+        )
+
+        assert response.item is not None
+        assert response.item["attachment_id"]["S"] == "test-id-456"
+        assert response.item["status"]["S"] == "pending"
+
+    def test_get_item_consistent_read_false(self, mock_dynamodb_table):
+        boto_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
+
+        boto_client.put_item(
+            TableName=mock_dynamodb_table,
+            Item={
+                "attachment_id": {"S": "test-id-789"},
+                "user_id": {"S": "user-789"},
+                "status": {"S": "in_progress"},
+            },
+        )
+
+        response = dynamodb_client.get_item(
+            table_name=mock_dynamodb_table,
+            key={"attachment_id": {"S": "test-id-789"}},
+            consistent_read=False,
+        )
+
+        assert response.item is not None
+        assert response.item["attachment_id"]["S"] == "test-id-789"
+        assert response.item["status"]["S"] == "in_progress"
+
+    def test_get_item_logs_on_error(self, mock_dynamodb, caplog):
+        invalid_table = "non-existent-table"
+        boto_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
+
+        with pytest.raises(ClientError):
+            with caplog.at_level(logging.ERROR):
+                dynamodb_client.get_item(
+                    table_name=invalid_table,
+                    key={"attachment_id": {"S": "test-id"}},
+                )
+
+        assert "Failed to get item from DynamoDB" in caplog.text
+        error_record = next(
+            r for r in caplog.records if r.message == "Failed to get item from DynamoDB"
+        )
+        assert error_record.table_name == invalid_table
+
+    def test_get_item_logs_success(self, mock_dynamodb_table, caplog):
+        boto_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
+
+        boto_client.put_item(
+            TableName=mock_dynamodb_table,
+            Item={
+                "attachment_id": {"S": "test-id-999"},
+                "user_id": {"S": "user-999"},
+                "status": {"S": "infected"},
+            },
+        )
+
+        with caplog.at_level(logging.INFO):
+            dynamodb_client.get_item(
+                table_name=mock_dynamodb_table,
+                key={"attachment_id": {"S": "test-id-999"}},
+            )
+
+        assert "Successfully retrieved item from DynamoDB" in caplog.text
+        success_record = next(
+            r for r in caplog.records if r.message == "Successfully retrieved item from DynamoDB"
+        )
+        assert success_record.table_name == mock_dynamodb_table
+
+    def test_get_item_logs_not_found(self, mock_dynamodb_table, caplog):
+        boto_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
+
+        with caplog.at_level(logging.INFO):
+            dynamodb_client.get_item(
+                table_name=mock_dynamodb_table,
+                key={"attachment_id": {"S": "missing-id"}},
+            )
+
+        assert "Item not found in DynamoDB" in caplog.text
+        not_found_record = next(
+            r for r in caplog.records if r.message == "Item not found in DynamoDB"
+        )
+        assert not_found_record.table_name == mock_dynamodb_table

--- a/api/tests/src/adapters/aws/test_dynamodb_adapter.py
+++ b/api/tests/src/adapters/aws/test_dynamodb_adapter.py
@@ -31,6 +31,7 @@ class TestGetBotoDynamoDBClient:
 
     @patch("src.adapters.aws.dynamodb_adapter.get_boto_session")
     def test_uses_default_session(self, mock_get_session):
+        """Verify the case when no session is provided, use the default AWS session"""
         mock_session = Mock()
         mock_get_session.return_value = mock_session
         get_boto_dynamodb_client()
@@ -42,6 +43,7 @@ class TestGetBotoDynamoDBClient:
         )
 
     def test_uses_provided_session(self):
+        """Verify the case when a specific AWS session is provided."""
         mock_session = Mock()
         get_boto_dynamodb_client(session=mock_session)
         mock_session.client.assert_called_once_with(
@@ -53,86 +55,90 @@ class TestGetBotoDynamoDBClient:
 
 class TestDynamoDBClient:
 
-    def test_get_item_success(self, mock_dynamodb_table):
+    def test_get_item_success(self, file_scan_dynamodb_table):
         boto_client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
 
         boto_client.put_item(
-            TableName=mock_dynamodb_table,
+            TableName=file_scan_dynamodb_table,
             Item={
-                "attachment_id": {"S": "test-id-123"},
+                "file_id": {"S": "test-id-123"},
                 "user_id": {"S": "user-abc-123"},
                 "status": {"S": "complete"},
             },
         )
 
         response = dynamodb_client.get_item(
-            table_name=mock_dynamodb_table,
-            key={"attachment_id": {"S": "test-id-123"}},
+            table_name=file_scan_dynamodb_table,
+            key_name="file_id",
+            value="test-id-123",
         )
 
         assert isinstance(response, DynamoDBGetItemResponse)
         assert response.item is not None
-        assert response.item["attachment_id"]["S"] == "test-id-123"
+        assert response.item["file_id"]["S"] == "test-id-123"
         assert response.item["user_id"]["S"] == "user-abc-123"
         assert response.item["status"]["S"] == "complete"
 
-    def test_get_item_not_found(self, mock_dynamodb_table):
+    def test_get_item_not_found(self, file_scan_dynamodb_table):
         boto_client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
 
         response = dynamodb_client.get_item(
-            table_name=mock_dynamodb_table,
-            key={"attachment_id": {"S": "non-existent-id"}},
+            table_name=file_scan_dynamodb_table,
+            key_name="file_id",
+            value="non-existent-id",
         )
 
         assert isinstance(response, DynamoDBGetItemResponse)
         assert response.item is None
 
-    def test_get_item_consistent_read_true(self, mock_dynamodb_table):
+    def test_get_item_consistent_read_true(self, file_scan_dynamodb_table):
         boto_client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
 
         boto_client.put_item(
-            TableName=mock_dynamodb_table,
+            TableName=file_scan_dynamodb_table,
             Item={
-                "attachment_id": {"S": "test-id-456"},
+                "file_id": {"S": "test-id-456"},
                 "user_id": {"S": "user-456"},
                 "status": {"S": "pending"},
             },
         )
 
         response = dynamodb_client.get_item(
-            table_name=mock_dynamodb_table,
-            key={"attachment_id": {"S": "test-id-456"}},
+            table_name=file_scan_dynamodb_table,
+            key_name="file_id",
+            value="test-id-456",
             consistent_read=True,
         )
 
         assert response.item is not None
-        assert response.item["attachment_id"]["S"] == "test-id-456"
+        assert response.item["file_id"]["S"] == "test-id-456"
         assert response.item["status"]["S"] == "pending"
 
-    def test_get_item_consistent_read_false(self, mock_dynamodb_table):
+    def test_get_item_consistent_read_false(self, file_scan_dynamodb_table):
         boto_client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
 
         boto_client.put_item(
-            TableName=mock_dynamodb_table,
+            TableName=file_scan_dynamodb_table,
             Item={
-                "attachment_id": {"S": "test-id-789"},
+                "file_id": {"S": "test-id-789"},
                 "user_id": {"S": "user-789"},
                 "status": {"S": "in_progress"},
             },
         )
 
         response = dynamodb_client.get_item(
-            table_name=mock_dynamodb_table,
-            key={"attachment_id": {"S": "test-id-789"}},
+            table_name=file_scan_dynamodb_table,
+            key_name="file_id",
+            value="test-id-789",
             consistent_read=False,
         )
 
         assert response.item is not None
-        assert response.item["attachment_id"]["S"] == "test-id-789"
+        assert response.item["file_id"]["S"] == "test-id-789"
         assert response.item["status"]["S"] == "in_progress"
 
     def test_get_item_logs_on_error(self, mock_dynamodb, caplog):
@@ -144,23 +150,23 @@ class TestDynamoDBClient:
             with caplog.at_level(logging.ERROR):
                 dynamodb_client.get_item(
                     table_name=invalid_table,
-                    key={"attachment_id": {"S": "test-id"}},
+                    key_name="file_id",
+                    value="test-id",
                 )
 
-        assert "Failed to get item from DynamoDB" in caplog.text
         error_record = next(
             r for r in caplog.records if r.message == "Failed to get item from DynamoDB"
         )
         assert error_record.table_name == invalid_table
 
-    def test_get_item_logs_success(self, mock_dynamodb_table, caplog):
+    def test_get_item_logs_success(self, file_scan_dynamodb_table, caplog):
         boto_client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
 
         boto_client.put_item(
-            TableName=mock_dynamodb_table,
+            TableName=file_scan_dynamodb_table,
             Item={
-                "attachment_id": {"S": "test-id-999"},
+                "file_id": {"S": "test-id-999"},
                 "user_id": {"S": "user-999"},
                 "status": {"S": "infected"},
             },
@@ -168,28 +174,28 @@ class TestDynamoDBClient:
 
         with caplog.at_level(logging.INFO):
             dynamodb_client.get_item(
-                table_name=mock_dynamodb_table,
-                key={"attachment_id": {"S": "test-id-999"}},
+                table_name=file_scan_dynamodb_table,
+                key_name="file_id",
+                value="test-id-999",
             )
 
-        assert "Successfully retrieved item from DynamoDB" in caplog.text
         success_record = next(
             r for r in caplog.records if r.message == "Successfully retrieved item from DynamoDB"
         )
-        assert success_record.table_name == mock_dynamodb_table
+        assert success_record.table_name == file_scan_dynamodb_table
 
-    def test_get_item_logs_not_found(self, mock_dynamodb_table, caplog):
+    def test_get_item_logs_not_found(self, file_scan_dynamodb_table, caplog):
         boto_client = boto3.client("dynamodb", region_name="us-east-1")
         dynamodb_client = DynamoDBClient(dynamodb_client=boto_client)
 
         with caplog.at_level(logging.INFO):
             dynamodb_client.get_item(
-                table_name=mock_dynamodb_table,
-                key={"attachment_id": {"S": "missing-id"}},
+                table_name=file_scan_dynamodb_table,
+                key_name="file_id",
+                value="missing-id",
             )
 
-        assert "Item not found in DynamoDB" in caplog.text
         not_found_record = next(
             r for r in caplog.records if r.message == "Item not found in DynamoDB"
         )
-        assert not_found_record.table_name == mock_dynamodb_table
+        assert not_found_record.table_name == file_scan_dynamodb_table


### PR DESCRIPTION
## Summary

Fixes #9705  

## Changes proposed

We want to setup logic to wrap the DynamoDB boto3 client
https://docs.aws.amazon.com/boto3/latest/reference/services/dynamodb.html

## Context for reviewers

This is similar to the other clients we've created for interacting with other AWS services like SQS to make the interface a bit easier to work with.

We want to wrap the following functions:

get_item - With the ability to pass in a table name, key, whether to use consistent read (default to true)
We only need to handle get_item as our API will only query for a record, updates are handled elsewhere.

Other considerations:

Like our SQS/s3 clients, we likely need to handle local development for connecting to the local instance (like how we have the S3_ENDPOINT_URL and SQS_ENDPOINT_URL variables)
Tests should work using the moto3 library like we do elsewhere - will need to setup a dynamoDB table https://docs.getmoto.org/en/latest/docs/services/dynamodb.html

## Validation steps

- DynamoDB adapter client created that can get_item
- Adapter client can talk to local dynamoDB (outside unit tests)
- Adapter client works with moto3 setup table (in unit tests)
