### PR TITLE
[Issue #10502] Install only the playwright browsers needed for the run

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -5,7 +5,7 @@ description: Composite action to run Playwright against specified environment
 # This action conditionally installs Playwright browsers (Chrome, Firefox, WebKit)
 # based on the do-chrome-install, do-firefox-install, and do-webkit-install inputs.
 # Only the browsers needed for the current test shard are installed, improving CI efficiency.
-# At least one browser input must be set to 'true' for a valid test run.
+# Chrome is cached outside this job, and will be available even if not instructed to install.
 # ---
 
 inputs:

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -1,6 +1,14 @@
 name: Run Playwright
 description: Composite action to run Playwright against specified environment
 
+# ---
+# This action conditionally installs Playwright browsers (Chrome, Firefox, WebKit)
+# based on the do-chrome-install, do-firefox-install, and do-webkit-install inputs.
+# Only the browsers needed for the current test shard are installed, improving CI efficiency.
+# At least one browser input must be set to 'true' for a valid test run.
+# ---
+
+
 inputs:
   version:
     description: "ref / sha / branch to run tests against"

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -44,8 +44,14 @@ inputs:
   workers:
     description: "number of workers to use for test run"
     default: ""
-  force-webkit-install:
-    description: "webkit dependencies aren't all cached, so we need to force it to install"
+  do-chrome-install:
+    description: "install chrome for playwright"
+    default: "false"
+  do-firefox-install:
+    description: "install firefox for playwright"
+    default: "false"
+  do-webkit-install:
+    description: "install webkit for playwright"
     default: "false"
   staging_test_user_api_key:
     description: "test user API key used in spoofing staging user logins"
@@ -83,17 +89,30 @@ runs:
         cache: ${{ inputs.package_manager }}
         cache-dependency-path: ${{ inputs.lockfile_path }}
 
-    - name: Install Node dependencies & Playwright
+    - name: Install Playwright
       if: ${{ inputs.needs_node_setup == 'true' }}
       shell: bash
       working-directory: ./frontend
       run: |
         npm install @playwright/test
-        npx playwright install --with-deps
+
+    - name: Install Firefox and dependencies
+      if: ${{ inputs.do-firefox-install == 'true' }}
+      shell: bash
+      working-directory: ./frontend
+      run: |
+        npx playwright install --with-deps firefox
+
+    - name: Install Chrome and dependencies
+      if: ${{ inputs.do-chrome-install == 'true' }}
+      shell: bash
+      working-directory: ./frontend
+      run: |
+        npx playwright install --with-deps chrome
 
     # this should only be needed on shard 3, the WebKit shard
-    - name: Install Webkit dependencies
-      if: ${{ inputs.force-webkit-install == 'true' }}
+    - name: Install Webkit and dependencies
+      if: ${{ inputs.do-webkit-install == 'true' }}
       shell: bash
       working-directory: ./frontend
       run: |

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -8,7 +8,6 @@ description: Composite action to run Playwright against specified environment
 # At least one browser input must be set to 'true' for a valid test run.
 # ---
 
-
 inputs:
   version:
     description: "ref / sha / branch to run tests against"
@@ -97,13 +96,14 @@ runs:
         cache: ${{ inputs.package_manager }}
         cache-dependency-path: ${{ inputs.lockfile_path }}
 
-    - name: Install Playwright
+    - name: Install Playwright core package
       if: ${{ inputs.needs_node_setup == 'true' }}
       shell: bash
       working-directory: ./frontend
       run: |
         npm install @playwright/test
 
+    # Conditionally install Chrome if requested
     - name: Install Chrome and dependencies
       if: ${{ inputs.do-chrome-install == 'true' }}
       shell: bash
@@ -111,6 +111,7 @@ runs:
       run: |
         npx playwright install --with-deps chrome
 
+    # Conditionally install Firefox if requested (Shard 2 on the CI/CD run)
     - name: Install Firefox and dependencies
       if: ${{ inputs.do-firefox-install == 'true' }}
       shell: bash
@@ -118,7 +119,7 @@ runs:
       run: |
         npx playwright install --with-deps firefox
 
-    # this should only be needed on shard 3, the WebKit shard
+    # Conditionally install Webkit if requested (Shard 3 on the CI/CD run)
     - name: Install Webkit and dependencies
       if: ${{ inputs.do-webkit-install == 'true' }}
       shell: bash

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -96,13 +96,6 @@ runs:
       run: |
         npm install @playwright/test
 
-    - name: Install Firefox and dependencies
-      if: ${{ inputs.do-firefox-install == 'true' }}
-      shell: bash
-      working-directory: ./frontend
-      run: |
-        npx playwright install --with-deps firefox
-
     - name: Install Chrome and dependencies
       if: ${{ inputs.do-chrome-install == 'true' }}
       shell: bash
@@ -110,13 +103,20 @@ runs:
       run: |
         npx playwright install --with-deps chrome
 
+    - name: Install Firefox and dependencies
+      if: ${{ inputs.do-firefox-install == 'true' }}
+      shell: bash
+      working-directory: ./frontend
+      run: |
+        npx playwright install --with-deps firefox
+
     # this should only be needed on shard 3, the WebKit shard
     - name: Install Webkit and dependencies
       if: ${{ inputs.do-webkit-install == 'true' }}
       shell: bash
       working-directory: ./frontend
       run: |
-        npx playwright install-deps webkit
+        npx playwright install --with-deps webkit
 
     - name: Run all e2e tests (Shard ${{ inputs.current_shard }}/${{ inputs.total_shards }})
       if: ${{ inputs.playwright_tags == '' }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -146,10 +146,11 @@ jobs:
         run: |
           npm ci
 
-      - run: npx playwright install --with-deps
+      # 2 of the 4 shards need chrome, so cache that, install the others as needed
+      - run: npx playwright install --with-deps chrome
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - run: npx playwright install-deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      #- run: npx playwright install-deps
+      #  if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
       - name: Package node_modules
@@ -429,8 +430,10 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
+          # shard 2 is the webkit shard
+          do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
           # shard 3 is the webkit shard
-          force-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
+          do-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
 
   create-report:
     name: Create Merged Test Report

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -149,8 +149,6 @@ jobs:
       # Install Chrome only for caching; other browsers installed per-shard in test job
       - run: npx playwright install --with-deps chrome
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      #- run: npx playwright install-deps
-      #  if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.
       - name: Package node_modules

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -430,7 +430,7 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
-          # shard 2 is the webkit shard
+          # shard 2 is the firefox shard
           do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
           # shard 3 is the webkit shard
           do-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -146,7 +146,7 @@ jobs:
         run: |
           npm ci
 
-      # 2 of the 4 shards need chrome, so cache that, install the others as needed
+      # Install Chrome only for caching; other browsers installed per-shard in test job
       - run: npx playwright install --with-deps chrome
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       #- run: npx playwright install-deps

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -65,6 +65,7 @@ jobs:
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
           staging_test_user_api_key: ${{ secrets.STAGING_TEST_USER_API_KEY }}
           staging_client_session_secret: ${{ secrets.STAGING_CLIENT_SESSION_SECRET }}
+          do-chrome-install: "true"
   create-report:
     name: Create Merged Test Report
     if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10502

## Changes proposed

Expose each playwright browser and dependency install as a input on the job. Set those based on the shard in the Local (CI/CD) runs (pre-install chrome since it's used in Shards 1 and 4). 

## Context for reviewers

We were installing all browsers and dependencies for all tests. For CI/CD we've re-worked that to cache chrome and firefox, but we always were having to install Webkit as it installs all over and isn't easily cachable. For Staging though we were installing all browsers and then only testing with chrome. So with this change we'll only cache chrome, and install Firefox and Webkit when needed.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- Tests pass
