### PR TITLE
[Issue #9138] - Create an endpoint to delete an attachment for an award recommendation

### DIFF
--- a/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
@@ -8,6 +8,7 @@ from src.api.award_recommendations_alpha.award_recommendation_blueprint import (
     award_recommendation_blueprint,
 )
 from src.api.award_recommendations_alpha.award_recommendation_schemas import (
+    AwardRecommendationAttachmentDeleteResponseSchema,
     AwardRecommendationAuditRequestSchema,
     AwardRecommendationAuditResponseSchema,
     AwardRecommendationCreateRequestSchema,
@@ -34,6 +35,9 @@ from src.services.award_recommendations.create_award_recommendation import (
 )
 from src.services.award_recommendations.create_award_recommendation_risk import (
     create_award_recommendation_risk,
+)
+from src.services.award_recommendations.delete_award_recommendation_attachment import (
+    delete_award_recommendation_attachment,
 )
 from src.services.award_recommendations.delete_award_recommendation_risk import (
     delete_award_recommendation_risk,
@@ -471,6 +475,46 @@ def award_recommendation_risk_delete(
 
         delete_award_recommendation_risk(
             db_session, user, award_recommendation_id, award_recommendation_risk_id
+        )
+
+    return response.ApiResponse(message="Success", data=None)
+
+
+@award_recommendation_blueprint.delete(
+    "/award-recommendations/<uuid:award_recommendation_id>/attachments/<uuid:award_recommendation_attachment_id>"
+)
+@award_recommendation_blueprint.output(AwardRecommendationAttachmentDeleteResponseSchema)
+@award_recommendation_blueprint.doc(
+    summary="Delete Award Recommendation Attachment",
+    description="Soft delete an attachment for an award recommendation.",
+    responses=[200, 401, 403, 404],
+)
+@award_recommendation_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def award_recommendation_attachment_delete(
+    db_session: db.Session,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_attachment_id: uuid.UUID,
+) -> response.ApiResponse:
+    add_extra_data_to_current_request_logs(
+        {
+            "award_recommendation_id": award_recommendation_id,
+            "award_recommendation_attachment_id": award_recommendation_attachment_id,
+        }
+    )
+    logger.info(
+        "DELETE /alpha/award-recommendations/:award_recommendation_id/attachments/:award_recommendation_attachment_id"
+    )
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        delete_award_recommendation_attachment(
+            db_session,
+            user,
+            award_recommendation_id,
+            award_recommendation_attachment_id,
         )
 
     return response.ApiResponse(message="Success", data=None)

--- a/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
@@ -492,6 +492,10 @@ class AwardRecommendationRiskDeleteResponseSchema(AbstractResponseSchema):
     data = fields.MixinField(metadata={"example": None})
 
 
+class AwardRecommendationAttachmentDeleteResponseSchema(AbstractResponseSchema):
+    data = fields.MixinField(metadata={"example": None})
+
+
 class AwardRecommendationRiskResponseSchema(AbstractResponseSchema):
     """Schema for risk response (used by create and update)"""
 

--- a/api/src/services/award_recommendations/create_award_recommendation_risk.py
+++ b/api/src/services/award_recommendations/create_award_recommendation_risk.py
@@ -3,51 +3,18 @@ import string
 import uuid
 
 from sqlalchemy import exists, select
-from sqlalchemy.orm import selectinload
 
 import src.adapters.db as db
-from src.api.route_utils import raise_flask_error
-from src.auth.endpoint_access_util import verify_access
-from src.constants.lookup_constants import Privilege
 from src.db.models.award_recommendation_models import (
-    AwardRecommendation,
     AwardRecommendationApplicationSubmission,
     AwardRecommendationRisk,
     AwardRecommendationRiskSubmission,
 )
-from src.db.models.opportunity_models import Opportunity
 from src.db.models.user_models import User
+from src.services.award_recommendations.get_award_recommendation import (
+    get_award_recommendation_for_update,
+)
 from src.services.award_recommendations.utils import validate_all_submissions_exist
-
-
-def get_award_recommendation_for_update(
-    db_session: db.Session, user: User, award_recommendation_id: uuid.UUID
-) -> AwardRecommendation:
-    stmt = (
-        select(AwardRecommendation)
-        .where(
-            AwardRecommendation.award_recommendation_id == award_recommendation_id,
-            AwardRecommendation.is_deleted.isnot(True),
-        )
-        .options(
-            selectinload(AwardRecommendation.opportunity).selectinload(Opportunity.agency_record),
-        )
-    )
-
-    award_recommendation = db_session.execute(stmt).scalar_one_or_none()
-    if award_recommendation is None:
-        raise_flask_error(
-            404,
-            message=f"Could not find Award Recommendation with ID {award_recommendation_id}",
-        )
-
-    agency = award_recommendation.opportunity.agency_record
-    if agency is None:
-        raise_flask_error(403, message="Forbidden")
-
-    verify_access(user, {Privilege.UPDATE_AWARD_RECOMMENDATION}, agency)
-
-    return award_recommendation
 
 
 def _generate_risk_number(db_session: db.Session, agency_code: str) -> str:

--- a/api/src/services/award_recommendations/delete_award_recommendation_attachment.py
+++ b/api/src/services/award_recommendations/delete_award_recommendation_attachment.py
@@ -1,0 +1,81 @@
+import logging
+import uuid
+
+from sqlalchemy import select
+
+import src.adapters.db as db
+from src.api.route_utils import raise_flask_error
+from src.constants.lookup_constants import AwardRecommendationAuditEvent
+from src.db.models.award_recommendation_models import (
+    AwardRecommendationAttachment,
+    AwardRecommendationAudit,
+)
+from src.db.models.user_models import User
+from src.services.award_recommendations.get_award_recommendation import (
+    get_award_recommendation_for_update,
+)
+from src.util import file_util
+
+logger = logging.getLogger(__name__)
+
+
+def get_attachment_for_update(
+    db_session: db.Session,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_attachment_id: uuid.UUID,
+) -> AwardRecommendationAttachment:
+    stmt = select(AwardRecommendationAttachment).where(
+        AwardRecommendationAttachment.award_recommendation_attachment_id
+        == award_recommendation_attachment_id,
+        AwardRecommendationAttachment.award_recommendation_id == award_recommendation_id,
+        AwardRecommendationAttachment.is_deleted.isnot(True),
+    )
+
+    attachment = db_session.execute(stmt).scalar_one_or_none()
+    if attachment is None:
+        raise_flask_error(
+            404,
+            message=(
+                f"Could not find Award Recommendation Attachment with ID "
+                f"{award_recommendation_attachment_id}"
+            ),
+        )
+
+    return attachment
+
+
+def delete_award_recommendation_attachment(
+    db_session: db.Session,
+    user: User,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_attachment_id: uuid.UUID,
+) -> None:
+    award_recommendation = get_award_recommendation_for_update(
+        db_session, user, award_recommendation_id
+    )
+
+    attachment = get_attachment_for_update(
+        db_session, award_recommendation_id, award_recommendation_attachment_id
+    )
+
+    logger.info("Deleting award recommendation attachment from s3")
+    file_util.delete_file(attachment.file_location)
+
+    attachment.is_deleted = True
+    attachment.file_location = "DELETED"
+
+    award_recommendation.award_recommendation_audit_events.append(
+        AwardRecommendationAudit(
+            user=user,
+            award_recommendation_audit_event=AwardRecommendationAuditEvent.ATTACHMENT_DELETED,
+            award_recommendation_attachment=attachment,
+        )
+    )
+
+    logger.info(
+        "Successfully deleted award recommendation attachment",
+        extra={
+            "award_recommendation_id": award_recommendation_id,
+            "award_recommendation_attachment_id": award_recommendation_attachment_id,
+        },
+    )

--- a/api/src/services/award_recommendations/delete_award_recommendation_attachment.py
+++ b/api/src/services/award_recommendations/delete_award_recommendation_attachment.py
@@ -1,47 +1,19 @@
 import logging
 import uuid
 
-from sqlalchemy import select
-
 import src.adapters.db as db
-from src.api.route_utils import raise_flask_error
 from src.constants.lookup_constants import AwardRecommendationAuditEvent
-from src.db.models.award_recommendation_models import (
-    AwardRecommendationAttachment,
-    AwardRecommendationAudit,
-)
+from src.db.models.award_recommendation_models import AwardRecommendationAudit
 from src.db.models.user_models import User
 from src.services.award_recommendations.get_award_recommendation import (
     get_award_recommendation_for_update,
 )
+from src.services.award_recommendations.get_award_recommendation_attachment import (
+    get_award_recommendation_attachment,
+)
 from src.util import file_util
 
 logger = logging.getLogger(__name__)
-
-
-def get_attachment_for_update(
-    db_session: db.Session,
-    award_recommendation_id: uuid.UUID,
-    award_recommendation_attachment_id: uuid.UUID,
-) -> AwardRecommendationAttachment:
-    stmt = select(AwardRecommendationAttachment).where(
-        AwardRecommendationAttachment.award_recommendation_attachment_id
-        == award_recommendation_attachment_id,
-        AwardRecommendationAttachment.award_recommendation_id == award_recommendation_id,
-        AwardRecommendationAttachment.is_deleted.isnot(True),
-    )
-
-    attachment = db_session.execute(stmt).scalar_one_or_none()
-    if attachment is None:
-        raise_flask_error(
-            404,
-            message=(
-                f"Could not find Award Recommendation Attachment with ID "
-                f"{award_recommendation_attachment_id}"
-            ),
-        )
-
-    return attachment
 
 
 def delete_award_recommendation_attachment(
@@ -54,7 +26,7 @@ def delete_award_recommendation_attachment(
         db_session, user, award_recommendation_id
     )
 
-    attachment = get_attachment_for_update(
+    attachment = get_award_recommendation_attachment(
         db_session, award_recommendation_id, award_recommendation_attachment_id
     )
 

--- a/api/src/services/award_recommendations/delete_award_recommendation_risk.py
+++ b/api/src/services/award_recommendations/delete_award_recommendation_risk.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from src.adapters import db
 from src.db.models.user_models import User
-from src.services.award_recommendations.create_award_recommendation_risk import (
+from src.services.award_recommendations.get_award_recommendation import (
     get_award_recommendation_for_update,
 )
 from src.services.award_recommendations.update_award_recommendation_risk import get_risk_for_update

--- a/api/src/services/award_recommendations/get_award_recommendation.py
+++ b/api/src/services/award_recommendations/get_award_recommendation.py
@@ -56,3 +56,33 @@ def get_award_recommendation_and_verify_access(
     verify_access(user, {Privilege.VIEW_AWARD_RECOMMENDATION}, agency)
 
     return award_recommendation
+
+
+def get_award_recommendation_for_update(
+    db_session: db.Session, user: User, award_recommendation_id: uuid.UUID
+) -> AwardRecommendation:
+    stmt = (
+        select(AwardRecommendation)
+        .where(
+            AwardRecommendation.award_recommendation_id == award_recommendation_id,
+            AwardRecommendation.is_deleted.isnot(True),
+        )
+        .options(
+            selectinload(AwardRecommendation.opportunity).selectinload(Opportunity.agency_record),
+        )
+    )
+
+    award_recommendation = db_session.execute(stmt).scalar_one_or_none()
+    if award_recommendation is None:
+        raise_flask_error(
+            404,
+            message=f"Could not find Award Recommendation with ID {award_recommendation_id}",
+        )
+
+    agency = award_recommendation.opportunity.agency_record
+    if agency is None:
+        raise_flask_error(403, message="Forbidden")
+
+    verify_access(user, {Privilege.UPDATE_AWARD_RECOMMENDATION}, agency)
+
+    return award_recommendation

--- a/api/src/services/award_recommendations/get_award_recommendation_attachment.py
+++ b/api/src/services/award_recommendations/get_award_recommendation_attachment.py
@@ -1,0 +1,52 @@
+import uuid
+
+from sqlalchemy import select
+
+import src.adapters.db as db
+from src.api.route_utils import raise_flask_error
+from src.db.models.award_recommendation_models import AwardRecommendationAttachment
+from src.db.models.user_models import User
+from src.services.award_recommendations.get_award_recommendation import (
+    get_award_recommendation_for_update,
+)
+
+
+def get_award_recommendation_attachment(
+    db_session: db.Session,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_attachment_id: uuid.UUID,
+) -> AwardRecommendationAttachment:
+    """Fetch a non-deleted attachment belonging to the given award recommendation."""
+    attachment = db_session.execute(
+        select(AwardRecommendationAttachment).where(
+            AwardRecommendationAttachment.award_recommendation_attachment_id
+            == award_recommendation_attachment_id,
+            AwardRecommendationAttachment.award_recommendation_id == award_recommendation_id,
+            AwardRecommendationAttachment.is_deleted.isnot(True),
+        )
+    ).scalar_one_or_none()
+
+    if attachment is None:
+        raise_flask_error(
+            404,
+            message=(
+                f"Could not find Award Recommendation Attachment with ID "
+                f"{award_recommendation_attachment_id}"
+            ),
+        )
+
+    return attachment
+
+
+def get_award_recommendation_attachment_for_update(
+    db_session: db.Session,
+    user: User,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_attachment_id: uuid.UUID,
+) -> AwardRecommendationAttachment:
+    """Fetch an attachment after verifying the user can update the award recommendation."""
+    get_award_recommendation_for_update(db_session, user, award_recommendation_id)
+
+    return get_award_recommendation_attachment(
+        db_session, award_recommendation_id, award_recommendation_attachment_id
+    )

--- a/api/src/services/award_recommendations/update_award_recommendation_risk.py
+++ b/api/src/services/award_recommendations/update_award_recommendation_risk.py
@@ -11,7 +11,7 @@ from src.db.models.award_recommendation_models import (
     AwardRecommendationRiskSubmission,
 )
 from src.db.models.user_models import User
-from src.services.award_recommendations.create_award_recommendation_risk import (
+from src.services.award_recommendations.get_award_recommendation import (
     get_award_recommendation_for_update,
 )
 from src.services.award_recommendations.utils import validate_all_submissions_exist

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_attachment_delete.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_attachment_delete.py
@@ -1,0 +1,314 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import select
+
+from src.constants.lookup_constants import (
+    AwardRecommendationAuditEvent,
+    AwardRecommendationStatus,
+    Privilege,
+)
+from src.db.models.award_recommendation_models import (
+    AwardRecommendationAttachment,
+    AwardRecommendationAudit,
+)
+from src.db.models.opportunity_models import Opportunity
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    AwardRecommendationAttachmentFactory,
+    AwardRecommendationFactory,
+    OpportunityFactory,
+)
+
+API_URL = "/alpha/award-recommendations"
+
+
+####################################
+# Fixtures
+####################################
+
+
+@pytest.fixture
+def agency(enable_factory_create):
+    return AgencyFactory.create()
+
+
+@pytest.fixture
+def opportunity(agency) -> Opportunity:
+    return OpportunityFactory.create(agency_code=agency.agency_code)
+
+
+@pytest.fixture
+def award_recommendation(opportunity):
+    return AwardRecommendationFactory.create(
+        opportunity=opportunity,
+        award_recommendation_status=AwardRecommendationStatus.DRAFT,
+        is_deleted=False,
+        review_workflow=None,
+        review_workflow_id=None,
+    )
+
+
+@pytest.fixture
+def award_recommendation_attachment(award_recommendation):
+    return AwardRecommendationAttachmentFactory.create(
+        award_recommendation=award_recommendation,
+        is_deleted=False,
+    )
+
+
+####################################
+# 200 Tests
+####################################
+
+
+class TestDeleteAwardRecommendationAttachment200:
+
+    @patch(
+        "src.services.award_recommendations.delete_award_recommendation_attachment.file_util.delete_file"
+    )
+    def test_delete_attachment_200(
+        self,
+        mock_delete_file,
+        client,
+        db_session,
+        agency,
+        award_recommendation,
+        award_recommendation_attachment,
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        original_file_location = award_recommendation_attachment.file_location
+
+        resp = client.delete(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments/"
+            f"{award_recommendation_attachment.award_recommendation_attachment_id}",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json["message"] == "Success"
+        assert resp.json["data"] is None
+
+        mock_delete_file.assert_called_once_with(original_file_location)
+
+        db_session.expire_all()
+
+        deleted_attachment = db_session.execute(
+            select(AwardRecommendationAttachment).where(
+                AwardRecommendationAttachment.award_recommendation_attachment_id
+                == award_recommendation_attachment.award_recommendation_attachment_id
+            )
+        ).scalar_one()
+        assert deleted_attachment.is_deleted is True
+        assert deleted_attachment.file_location == "DELETED"
+
+        audit_event = db_session.execute(
+            select(AwardRecommendationAudit).where(
+                AwardRecommendationAudit.award_recommendation_id
+                == award_recommendation.award_recommendation_id,
+                AwardRecommendationAudit.award_recommendation_audit_event
+                == AwardRecommendationAuditEvent.ATTACHMENT_DELETED,
+            )
+        ).scalar_one()
+        assert (
+            audit_event.award_recommendation_attachment_id
+            == award_recommendation_attachment.award_recommendation_attachment_id
+        )
+
+
+####################################
+# 404 Tests
+####################################
+
+
+class TestDeleteAwardRecommendationAttachment404:
+
+    def test_delete_attachment_not_found_404(
+        self, client, db_session, agency, award_recommendation
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.delete(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments/{uuid.uuid4()}",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 404
+
+    def test_delete_attachment_wrong_award_recommendation_404(
+        self, client, db_session, agency, opportunity, award_recommendation_attachment
+    ):
+        other_award_recommendation = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_status=AwardRecommendationStatus.DRAFT,
+            is_deleted=False,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.delete(
+            f"{API_URL}/{other_award_recommendation.award_recommendation_id}/attachments/"
+            f"{award_recommendation_attachment.award_recommendation_attachment_id}",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 404
+
+    def test_delete_already_deleted_attachment_404(
+        self, client, db_session, agency, award_recommendation
+    ):
+        deleted_attachment = AwardRecommendationAttachmentFactory.create(
+            award_recommendation=award_recommendation,
+            is_deleted=True,
+        )
+
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.delete(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments/"
+            f"{deleted_attachment.award_recommendation_attachment_id}",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 404
+
+    def test_delete_attachment_deleted_award_recommendation_404(
+        self, client, db_session, agency, opportunity
+    ):
+        deleted_award_recommendation = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_status=AwardRecommendationStatus.DRAFT,
+            is_deleted=True,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        attachment = AwardRecommendationAttachmentFactory.create(
+            award_recommendation=deleted_award_recommendation,
+            is_deleted=False,
+        )
+
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.delete(
+            f"{API_URL}/{deleted_award_recommendation.award_recommendation_id}/attachments/"
+            f"{attachment.award_recommendation_attachment_id}",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 404
+
+        db_session.expire_all()
+        unchanged_attachment = db_session.execute(
+            select(AwardRecommendationAttachment).where(
+                AwardRecommendationAttachment.award_recommendation_attachment_id
+                == attachment.award_recommendation_attachment_id
+            )
+        ).scalar_one()
+        assert unchanged_attachment.is_deleted is False
+
+
+####################################
+# 401 Tests
+####################################
+
+
+class TestDeleteAwardRecommendationAttachment401:
+
+    def test_delete_attachment_no_token_401(
+        self, client, award_recommendation, award_recommendation_attachment
+    ):
+        resp = client.delete(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments/"
+            f"{award_recommendation_attachment.award_recommendation_attachment_id}",
+        )
+
+        assert resp.status_code == 401
+
+    def test_delete_attachment_invalid_token_401(
+        self, client, award_recommendation, award_recommendation_attachment
+    ):
+        resp = client.delete(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments/"
+            f"{award_recommendation_attachment.award_recommendation_attachment_id}",
+            headers={"X-SGG-Token": "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+
+####################################
+# 403 Tests
+####################################
+
+
+class TestDeleteAwardRecommendationAttachment403:
+
+    def test_delete_attachment_wrong_agency_403(
+        self, client, db_session, award_recommendation, award_recommendation_attachment
+    ):
+        other_agency = AgencyFactory.create()
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=other_agency,
+            privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION],
+        )
+
+        resp = client.delete(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments/"
+            f"{award_recommendation_attachment.award_recommendation_attachment_id}",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+        db_session.expire_all()
+        unchanged_attachment = db_session.execute(
+            select(AwardRecommendationAttachment).where(
+                AwardRecommendationAttachment.award_recommendation_attachment_id
+                == award_recommendation_attachment.award_recommendation_attachment_id
+            )
+        ).scalar_one()
+        assert unchanged_attachment.is_deleted is False
+
+    def test_delete_attachment_wrong_privilege_403(
+        self, client, db_session, agency, award_recommendation, award_recommendation_attachment
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[Privilege.VIEW_AWARD_RECOMMENDATION],
+        )
+
+        resp = client.delete(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments/"
+            f"{award_recommendation_attachment.award_recommendation_attachment_id}",
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+        db_session.expire_all()
+        unchanged_attachment = db_session.execute(
+            select(AwardRecommendationAttachment).where(
+                AwardRecommendationAttachment.award_recommendation_attachment_id
+                == award_recommendation_attachment.award_recommendation_attachment_id
+            )
+        ).scalar_one()
+        assert unchanged_attachment.is_deleted is False


### PR DESCRIPTION
## Summary

Work for #9138 

## Changes proposed

- Added `DELETE /alpha/award-recommendations/:award_recommendation_id/attachments/:award_recommendation_attachment_id` to soft-delete an award recommendation attachment
- Moved `get_award_recommendation_for_update` into `get_award_recommendation.py` and updated risk/attachment services to import it from there
- Added tests

## Context for reviewers

See [tech spec](https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/2735046679/Tech+Spec+-+Award+Recommendation+Data+Model+Initial+Endpoints#Attachment)

## Validation steps

- [ ] Confirm implementation aligns with specifications outlined in the [tech spec](https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/2735046679/Tech+Spec+-+Award+Recommendation+Data+Model+Initial+Endpoints#Attachment)
- [ ] Review created tests