### PR TITLE
[Issue #9063] Allow regex schema validator to set an error message

### DIFF
--- a/api/src/api/schemas/extension/field_validators.py
+++ b/api/src/api/schemas/extension/field_validators.py
@@ -12,9 +12,22 @@ Validator = validators.Validator  # re-export
 
 
 class Regexp(validators.Regexp):
-    REGEX_ERROR = MarshmallowErrorContainer(
-        ValidationErrorType.FORMAT, "String does not match expected pattern."
-    )
+    """
+    Validator which can run a regex against a string.
+    """
+
+    def __init__(
+        self,
+        regex: str | bytes | typing.Pattern,
+        flags: int = 0,
+        error_message: str = "String does not match expected pattern.",
+    ):
+        """
+        :param regex: The regular expression to run the text against.
+        :param flags: The regular expression flags to use.
+        :param error_message: Error message to raise in case of validation error.
+        """
+        super().__init__(regex, flags, error=error_message)
 
     @typing.overload
     def __call__(self, value: str) -> str: ...
@@ -24,7 +37,9 @@ class Regexp(validators.Regexp):
 
     def __call__(self, value: str | bytes) -> str | bytes:
         if self.regex.match(value) is None:  # type: ignore
-            raise ValidationError([self.REGEX_ERROR])
+            raise ValidationError(
+                [MarshmallowErrorContainer(ValidationErrorType.FORMAT, self.error)]
+            )
 
         return value
 

--- a/api/tests/src/schemas/schema_validation_utils.py
+++ b/api/tests/src/schemas/schema_validation_utils.py
@@ -144,6 +144,9 @@ class FieldTestSchema(Schema):
     field_str_min_and_max = fields.String(validate=[validators.Length(min=2, max=3)])
     field_str_equal = fields.String(validate=[validators.Length(equal=3)])
     field_str_regex = fields.String(validate=[validators.Regexp("^\\d{3}$")])
+    field_str_regex_msg = fields.String(
+        validate=[validators.Regexp("^\\d{3}$", error_message="This is the override error")]
+    )
     field_str_email = fields.String(validate=[validators.Email()])
 
     field_url = fields.URL()
@@ -220,6 +223,7 @@ def get_valid_field_test_schema_req():
         "field_str_min_and_max": "ab",
         "field_str_equal": "abc",
         "field_str_regex": "123",
+        "field_str_regex_msg": "123",
         "field_str_email": "person@example.com",
         "field_url": "https://example.com",
         "field_int": 1,
@@ -283,6 +287,7 @@ def get_invalid_field_test_schema_req():
         "field_str_min_and_max": "a",
         "field_str_equal": "a",
         "field_str_regex": "abc",
+        "field_str_regex_msg": "abc",
         "field_str_email": "not an email",
         "field_url": "not a url",
         "field_int": {},
@@ -344,6 +349,9 @@ def get_expected_validation_errors():
         "field_str_min_and_max": [get_length_range_error_msg(2, 3)],
         "field_str_equal": [get_length_equal_error_msg(3)],
         "field_str_regex": [INVALID_STRING_PATTERN],
+        "field_str_regex_msg": [
+            MarshmallowErrorContainer(ValidationErrorType.FORMAT, "This is the override error")
+        ],
         "field_str_email": [INVALID_EMAIL],
         "field_url": [INVALID_URL],
         "field_int": [INVALID_INTEGER],


### PR DESCRIPTION
## Summary
Fixes #9063 

## Changes proposed
* Allow the regex error validator in our schemas

## Context for reviewers
I was technically just looking at how we'd solve it to write into the ticket, but it was less effort to finish implementing it rather than write up the ticket fully.

This'll make it so we can return a better error message like putting "Only these characters are allowed abc" or whatever you want.

## Validation steps
Updated the tests which thoroughly test all the schema functionality
