### PR TITLE
[Issue #9714] Create an endpoint that streams the results of a scan back to a user

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -131,6 +131,11 @@ WORKFLOW_QUEUE_URL=http://sqsmock:9324/000000000000/local_workflow_queue
 AWS_DYNAMODB_ENDPOINT_URL=http://dynamodb-local:8000
 FILE_SCAN_CACHE_TABLE_NAME=local-virus-scan
 
+# File scan results streaming endpoint - how long to keep streaming, and how
+# long to sleep between DynamoDB polls.
+FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS=3
+FILE_SCAN_RESULTS_MAX_DURATION_SECONDS=60
+
 ############################
 # S3
 ############################

--- a/api/src/api/files_v1/file_routes.py
+++ b/api/src/api/files_v1/file_routes.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+from collections.abc import Iterator
 
 from flask import Response, stream_with_context
 
@@ -62,10 +63,15 @@ def get_file_scan_results(pending_file_id: uuid.UUID) -> Response:
     )
     logger.info("GET /v1/files/<pending_file_id>/results")
 
-    stream = stream_file_scan_results(
+    chunks = stream_file_scan_results(
         pending_file_id=pending_file_id,
         user=user,
         dynamodb_client=DynamoDBClient(),
     )
+    response_schema = file_schemas.FileScanResultsResponseSchema()
 
-    return Response(stream_with_context(stream), mimetype="application/x-ndjson")
+    def serialize() -> Iterator[str]:
+        for chunk in chunks:
+            yield response_schema.dumps(chunk) + "\n"
+
+    return Response(stream_with_context(serialize()), mimetype="application/x-ndjson")

--- a/api/src/api/files_v1/file_routes.py
+++ b/api/src/api/files_v1/file_routes.py
@@ -1,13 +1,18 @@
 import logging
 import uuid
 
+from flask import Response, stream_with_context
+
 import src.adapters.db as db
 import src.adapters.db.flask_db as flask_db
 import src.api.files_v1.file_schemas as file_schemas
 import src.api.response as response
+from src.adapters.aws.dynamodb_adapter import DynamoDBClient
 from src.api.files_v1.file_blueprint import file_blueprint
 from src.auth.api_user_key_auth import api_user_key_auth
+from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.logging.flask_logger import add_extra_data_to_current_request_logs
+from src.services.files.stream_file_scan_results import stream_file_scan_results
 from src.services.files.update_pending_file_scan_status import update_pending_file_scan_status
 
 logger = logging.getLogger(__name__)
@@ -34,3 +39,33 @@ def update_file_scan_status(
         )
 
     return response.ApiResponse(message="Success")
+
+
+@file_blueprint.get("/<uuid:pending_file_id>/results")
+@file_blueprint.output(file_schemas.FileScanResultsResponseSchema)
+@file_blueprint.doc(
+    summary="Stream file scan results",
+    description=(
+        "Stream the scan status of a pending file as newline-delimited JSON. "
+        "Each chunk matches the documented response schema. The endpoint polls "
+        "DynamoDB on a configurable interval and ends the stream when the scan "
+        "reaches a terminal status (complete/infected) or the configured max "
+        "duration elapses."
+    ),
+    responses=[200, 401, 403, 404],
+)
+@file_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+def get_file_scan_results(pending_file_id: uuid.UUID) -> Response:
+    user = jwt_or_api_user_key_multi_auth.get_user()
+    add_extra_data_to_current_request_logs(
+        {"pending_file_id": pending_file_id, "user_id": user.user_id}
+    )
+    logger.info("GET /v1/files/<pending_file_id>/results")
+
+    stream = stream_file_scan_results(
+        pending_file_id=pending_file_id,
+        user=user,
+        dynamodb_client=DynamoDBClient(),
+    )
+
+    return Response(stream_with_context(stream), mimetype="application/x-ndjson")

--- a/api/src/api/files_v1/file_schemas.py
+++ b/api/src/api/files_v1/file_schemas.py
@@ -30,4 +30,11 @@ class FileScanResultsDataSchema(Schema):
 
 
 class FileScanResultsResponseSchema(Schema):
+    """Schema for a single streamed chunk in the file-scan-results NDJSON response.
+
+    Intentionally does not inherit from ``AbstractResponseSchema`` because each
+    chunk is a partial update on the wire and does not carry ``status_code`` /
+    ``message`` envelope fields.
+    """
+
     data = fields.Nested(FileScanResultsDataSchema, required=True)

--- a/api/src/api/files_v1/file_schemas.py
+++ b/api/src/api/files_v1/file_schemas.py
@@ -16,3 +16,18 @@ class FileScanStatusUpdateRequestSchema(Schema):
 
 class FileScanStatusUpdateResponseSchema(AbstractResponseSchema):
     pass
+
+
+class FileScanResultsDataSchema(Schema):
+    status = fields.Enum(
+        FileScanStatus,
+        required=True,
+        metadata={
+            "description": "The current scan status of the file",
+            "example": FileScanStatus.PENDING,
+        },
+    )
+
+
+class FileScanResultsResponseSchema(Schema):
+    data = fields.Nested(FileScanResultsDataSchema, required=True)

--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -1,0 +1,169 @@
+import json
+import logging
+import time
+import uuid
+from collections.abc import Iterator
+
+from pydantic import Field
+
+from src.adapters.aws.dynamodb_adapter import DynamoDBClient, DynamoDBConfig
+from src.api.route_utils import raise_flask_error
+from src.constants.lookup_constants import FileScanStatus
+from src.db.models.user_models import User
+from src.util import datetime_util
+from src.util.env_config import PydanticBaseEnvConfig
+
+logger = logging.getLogger(__name__)
+
+
+# When the status reaches one of these values, the scan is finished and we
+# stop streaming further updates.
+TERMINAL_STATUSES: frozenset[FileScanStatus] = frozenset(
+    {FileScanStatus.COMPLETE, FileScanStatus.INFECTED}
+)
+
+# Attribute names on the DynamoDB scan-cache record. The partition key matches
+# what setup_local_dynamodb.py / infra define.
+SCAN_RECORD_FILE_ID_KEY = "file_id"
+SCAN_RECORD_USER_ID_ATTR = "user_id"
+SCAN_RECORD_STATUS_ATTR = "status"
+
+
+class FileScanStreamConfig(PydanticBaseEnvConfig):
+    poll_interval_seconds: float = Field(
+        default=3.0, alias="FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS"
+    )
+    max_duration_seconds: float = Field(
+        default=60.0, alias="FILE_SCAN_RESULTS_MAX_DURATION_SECONDS"
+    )
+
+
+def _get_scan_record(
+    dynamodb_client: DynamoDBClient,
+    table_name: str,
+    pending_file_id: uuid.UUID,
+) -> dict | None:
+    response = dynamodb_client.get_item(
+        table_name=table_name,
+        key_name=SCAN_RECORD_FILE_ID_KEY,
+        value=str(pending_file_id),
+        consistent_read=True,
+    )
+    return response.item
+
+
+def _get_string_attr(record: dict, attr: str) -> str | None:
+    # DynamoDB returns items in attribute-value format: {"attr": {"S": "value"}}.
+    # We only need the string-typed attributes on the scan record.
+    raw = record.get(attr)
+    if not isinstance(raw, dict):
+        return None
+    return raw.get("S")
+
+
+def stream_file_scan_results(
+    pending_file_id: uuid.UUID,
+    user: User,
+    dynamodb_client: DynamoDBClient,
+    config: FileScanStreamConfig | None = None,
+    dynamodb_config: DynamoDBConfig | None = None,
+) -> Iterator[str]:
+    """Stream file scan status updates for the given pending file.
+
+    The initial DynamoDB lookup happens before any chunks are yielded so we can
+    return a 404 or 403 with the proper HTTP status. After streaming starts, any
+    subsequent error (missing record, user mismatch) just ends the stream.
+    """
+    if config is None:
+        config = FileScanStreamConfig()
+    if dynamodb_config is None:
+        dynamodb_config = DynamoDBConfig()
+
+    table_name = dynamodb_config.file_scan_cache_table_name
+
+    # First lookup happens outside the generator so that 404/403 results in a
+    # proper HTTP status code rather than a truncated stream.
+    record = _get_scan_record(dynamodb_client, table_name, pending_file_id)
+    if record is None:
+        raise_flask_error(404, "File scan record not found")
+
+    record_user_id = _get_string_attr(record, SCAN_RECORD_USER_ID_ATTR)
+    if record_user_id != str(user.user_id):
+        logger.info(
+            "User attempted to access another user's file scan results",
+            extra={
+                "pending_file_id": pending_file_id,
+                "user_id": user.user_id,
+                "record_user_id": record_user_id,
+            },
+        )
+        raise_flask_error(403, "Forbidden")
+
+    def generate() -> Iterator[str]:
+        current_record = record
+        start_time = datetime_util.utcnow()
+
+        while True:
+            raw_status = _get_string_attr(current_record, SCAN_RECORD_STATUS_ATTR)
+            if raw_status is None:
+                logger.warning(
+                    "Scan record missing status attribute, ending stream",
+                    extra={"pending_file_id": pending_file_id},
+                )
+                return
+
+            try:
+                status = FileScanStatus(raw_status)
+            except ValueError:
+                logger.warning(
+                    "Unable to parse file scan status from record, ending stream",
+                    extra={
+                        "pending_file_id": pending_file_id,
+                        "raw_status": raw_status,
+                    },
+                )
+                return
+
+            yield json.dumps({"data": {"status": status.value}}) + "\n"
+
+            if status in TERMINAL_STATUSES:
+                logger.info(
+                    "File scan results stream reached terminal status",
+                    extra={
+                        "pending_file_id": pending_file_id,
+                        "user_id": user.user_id,
+                        "file_scan_status": status,
+                    },
+                )
+                return
+
+            elapsed = (datetime_util.utcnow() - start_time).total_seconds()
+            if elapsed >= config.max_duration_seconds:
+                logger.info(
+                    "File scan results stream reached max duration",
+                    extra={
+                        "pending_file_id": pending_file_id,
+                        "user_id": user.user_id,
+                        "last_file_scan_status": status,
+                    },
+                )
+                return
+
+            time.sleep(config.poll_interval_seconds)
+
+            next_record = _get_scan_record(dynamodb_client, table_name, pending_file_id)
+            if next_record is None or _get_string_attr(
+                next_record, SCAN_RECORD_USER_ID_ATTR
+            ) != str(user.user_id):
+                logger.info(
+                    "File scan record disappeared or user no longer authorized, ending stream",
+                    extra={
+                        "pending_file_id": pending_file_id,
+                        "user_id": user.user_id,
+                    },
+                )
+                return
+
+            current_record = next_record
+
+    return generate()

--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -1,8 +1,8 @@
-import json
 import logging
 import time
 import uuid
 from collections.abc import Iterator
+from typing import Any
 
 from pydantic import Field
 
@@ -42,7 +42,7 @@ def _get_scan_record(
     dynamodb_client: DynamoDBClient,
     table_name: str,
     pending_file_id: uuid.UUID,
-) -> dict | None:
+) -> dict[str, Any] | None:
     response = dynamodb_client.get_item(
         table_name=table_name,
         key_name=SCAN_RECORD_FILE_ID_KEY,
@@ -52,7 +52,7 @@ def _get_scan_record(
     return response.item
 
 
-def _get_string_attr(record: dict, attr: str) -> str | None:
+def _get_string_attr(record: dict[str, Any], attr: str) -> str | None:
     # DynamoDB returns items in attribute-value format: {"attr": {"S": "value"}}.
     # We only need the string-typed attributes on the scan record.
     raw = record.get(attr)
@@ -67,12 +67,15 @@ def stream_file_scan_results(
     dynamodb_client: DynamoDBClient,
     config: FileScanStreamConfig | None = None,
     dynamodb_config: DynamoDBConfig | None = None,
-) -> Iterator[str]:
+) -> Iterator[dict[str, Any]]:
     """Stream file scan status updates for the given pending file.
 
     The initial DynamoDB lookup happens before any chunks are yielded so we can
     return a 404 or 403 with the proper HTTP status. After streaming starts, any
     subsequent error (missing record, user mismatch) just ends the stream.
+
+    Yields chunks shaped like ``FileScanResultsResponseSchema``; the caller is
+    responsible for serializing each chunk through that schema.
     """
     if config is None:
         config = FileScanStreamConfig()
@@ -89,7 +92,7 @@ def stream_file_scan_results(
 
     record_user_id = _get_string_attr(record, SCAN_RECORD_USER_ID_ATTR)
     if record_user_id != str(user.user_id):
-        logger.info(
+        logger.warning(
             "User attempted to access another user's file scan results",
             extra={
                 "pending_file_id": pending_file_id,
@@ -99,7 +102,7 @@ def stream_file_scan_results(
         )
         raise_flask_error(403, "Forbidden")
 
-    def generate() -> Iterator[str]:
+    def generate() -> Iterator[dict[str, Any]]:
         current_record = record
         start_time = datetime_util.utcnow()
 
@@ -108,7 +111,10 @@ def stream_file_scan_results(
             if raw_status is None:
                 logger.warning(
                     "Scan record missing status attribute, ending stream",
-                    extra={"pending_file_id": pending_file_id},
+                    extra={
+                        "pending_file_id": pending_file_id,
+                        "user_id": user.user_id,
+                    },
                 )
                 return
 
@@ -119,12 +125,13 @@ def stream_file_scan_results(
                     "Unable to parse file scan status from record, ending stream",
                     extra={
                         "pending_file_id": pending_file_id,
+                        "user_id": user.user_id,
                         "raw_status": raw_status,
                     },
                 )
                 return
 
-            yield json.dumps({"data": {"status": status.value}}) + "\n"
+            yield {"data": {"status": status.value}}
 
             if status in TERMINAL_STATUSES:
                 logger.info(
@@ -152,11 +159,19 @@ def stream_file_scan_results(
             time.sleep(config.poll_interval_seconds)
 
             next_record = _get_scan_record(dynamodb_client, table_name, pending_file_id)
-            if next_record is None or _get_string_attr(
-                next_record, SCAN_RECORD_USER_ID_ATTR
-            ) != str(user.user_id):
+            if next_record is None:
                 logger.info(
-                    "File scan record disappeared or user no longer authorized, ending stream",
+                    "File scan record disappeared during stream, ending stream",
+                    extra={
+                        "pending_file_id": pending_file_id,
+                        "user_id": user.user_id,
+                    },
+                )
+                return
+
+            if _get_string_attr(next_record, SCAN_RECORD_USER_ID_ATTR) != str(user.user_id):
+                logger.warning(
+                    "File scan record user_id changed during stream, ending stream",
                     extra={
                         "pending_file_id": pending_file_id,
                         "user_id": user.user_id,

--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -2,6 +2,7 @@ import logging
 import time
 import uuid
 from collections.abc import Iterator
+from dataclasses import dataclass
 from typing import Any
 
 from pydantic import Field
@@ -38,27 +39,112 @@ class FileScanStreamConfig(PydanticBaseEnvConfig):
     )
 
 
+@dataclass(frozen=True)
+class FileScanRecord:
+    """Scan-cache record from DynamoDB with attributes pre-parsed.
+
+    Fields are typed as Optional because a record in DynamoDB can be partially
+    written or carry an unknown status value; callers decide what to do with
+    a missing or unparseable field.
+    """
+
+    user_id: str | None
+    status: FileScanStatus | None
+    # Kept for diagnostic logging when ``status`` couldn't be parsed.
+    raw_status: str | None
+
+
+def _get_string_attr(item: dict[str, Any], attr: str) -> str | None:
+    # DynamoDB returns items in attribute-value format: {"attr": {"S": "value"}}.
+    # We only need the string-typed attributes on the scan record.
+    raw = item.get(attr)
+    if not isinstance(raw, dict):
+        return None
+    return raw.get("S")
+
+
+def _parse_scan_record(item: dict[str, Any]) -> FileScanRecord:
+    raw_status = _get_string_attr(item, SCAN_RECORD_STATUS_ATTR)
+    status: FileScanStatus | None = None
+    if raw_status is not None:
+        try:
+            status = FileScanStatus(raw_status)
+        except ValueError:
+            status = None
+    return FileScanRecord(
+        user_id=_get_string_attr(item, SCAN_RECORD_USER_ID_ATTR),
+        status=status,
+        raw_status=raw_status,
+    )
+
+
 def _get_scan_record(
     dynamodb_client: DynamoDBClient,
     table_name: str,
     pending_file_id: uuid.UUID,
-) -> dict[str, Any] | None:
+) -> FileScanRecord | None:
     response = dynamodb_client.get_item(
         table_name=table_name,
         key_name=SCAN_RECORD_FILE_ID_KEY,
         value=str(pending_file_id),
         consistent_read=True,
     )
-    return response.item
-
-
-def _get_string_attr(record: dict[str, Any], attr: str) -> str | None:
-    # DynamoDB returns items in attribute-value format: {"attr": {"S": "value"}}.
-    # We only need the string-typed attributes on the scan record.
-    raw = record.get(attr)
-    if not isinstance(raw, dict):
+    if response.item is None:
         return None
-    return raw.get("S")
+    return _parse_scan_record(response.item)
+
+
+def _resolve_status(
+    record: FileScanRecord, pending_file_id: uuid.UUID, user_id: uuid.UUID
+) -> FileScanStatus | None:
+    """Return the record's status, or log and return None to end the stream."""
+    if record.status is not None:
+        return record.status
+
+    if record.raw_status is None:
+        logger.warning(
+            "Scan record missing status attribute, ending stream",
+            extra={"pending_file_id": pending_file_id, "user_id": user_id},
+        )
+    else:
+        logger.warning(
+            "Unable to parse file scan status from record, ending stream",
+            extra={
+                "pending_file_id": pending_file_id,
+                "user_id": user_id,
+                "raw_status": record.raw_status,
+            },
+        )
+    return None
+
+
+def _fetch_next_record(
+    dynamodb_client: DynamoDBClient,
+    table_name: str,
+    pending_file_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> FileScanRecord | None:
+    """Re-query the scan record for the next poll iteration.
+
+    Returns the record if it still exists and still belongs to ``user_id``;
+    otherwise logs and returns None to signal that the stream should end.
+    """
+    next_record = _get_scan_record(dynamodb_client, table_name, pending_file_id)
+    if next_record is None:
+        logger.info(
+            "File scan record disappeared during stream, ending stream",
+            extra={"pending_file_id": pending_file_id, "user_id": user_id},
+        )
+        return None
+
+    if next_record.user_id != str(user_id):
+        logger.warning(
+            "File scan record user_id changed during stream, ending stream",
+            extra={"pending_file_id": pending_file_id, "user_id": user_id},
+        )
+        return None
+
+    return next_record
 
 
 def stream_file_scan_results(
@@ -90,14 +176,13 @@ def stream_file_scan_results(
     if record is None:
         raise_flask_error(404, "File scan record not found")
 
-    record_user_id = _get_string_attr(record, SCAN_RECORD_USER_ID_ATTR)
-    if record_user_id != str(user.user_id):
+    if record.user_id != str(user.user_id):
         logger.warning(
             "User attempted to access another user's file scan results",
             extra={
                 "pending_file_id": pending_file_id,
                 "user_id": user.user_id,
-                "record_user_id": record_user_id,
+                "record_user_id": record.user_id,
             },
         )
         raise_flask_error(403, "Forbidden")
@@ -107,31 +192,13 @@ def stream_file_scan_results(
         start_time = datetime_util.utcnow()
 
         while True:
-            raw_status = _get_string_attr(current_record, SCAN_RECORD_STATUS_ATTR)
-            if raw_status is None:
-                logger.warning(
-                    "Scan record missing status attribute, ending stream",
-                    extra={
-                        "pending_file_id": pending_file_id,
-                        "user_id": user.user_id,
-                    },
-                )
-                return
-
-            try:
-                status = FileScanStatus(raw_status)
-            except ValueError:
-                logger.warning(
-                    "Unable to parse file scan status from record, ending stream",
-                    extra={
-                        "pending_file_id": pending_file_id,
-                        "user_id": user.user_id,
-                        "raw_status": raw_status,
-                    },
-                )
+            status = _resolve_status(current_record, pending_file_id, user.user_id)
+            if status is None:
                 return
 
             yield {"data": {"status": status.value}}
+
+            elapsed = (datetime_util.utcnow() - start_time).total_seconds()
 
             if status in TERMINAL_STATUSES:
                 logger.info(
@@ -140,11 +207,11 @@ def stream_file_scan_results(
                         "pending_file_id": pending_file_id,
                         "user_id": user.user_id,
                         "file_scan_status": status,
+                        "stream_duration_seconds": elapsed,
                     },
                 )
                 return
 
-            elapsed = (datetime_util.utcnow() - start_time).total_seconds()
             if elapsed >= config.max_duration_seconds:
                 logger.info(
                     "File scan results stream reached max duration",
@@ -152,31 +219,17 @@ def stream_file_scan_results(
                         "pending_file_id": pending_file_id,
                         "user_id": user.user_id,
                         "last_file_scan_status": status,
+                        "stream_duration_seconds": elapsed,
                     },
                 )
                 return
 
             time.sleep(config.poll_interval_seconds)
 
-            next_record = _get_scan_record(dynamodb_client, table_name, pending_file_id)
+            next_record = _fetch_next_record(
+                dynamodb_client, table_name, pending_file_id, user.user_id
+            )
             if next_record is None:
-                logger.info(
-                    "File scan record disappeared during stream, ending stream",
-                    extra={
-                        "pending_file_id": pending_file_id,
-                        "user_id": user.user_id,
-                    },
-                )
-                return
-
-            if _get_string_attr(next_record, SCAN_RECORD_USER_ID_ATTR) != str(user.user_id):
-                logger.warning(
-                    "File scan record user_id changed during stream, ending stream",
-                    extra={
-                        "pending_file_id": pending_file_id,
-                        "user_id": user.user_id,
-                    },
-                )
                 return
 
             current_record = next_record

--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -31,27 +31,21 @@ SCAN_RECORD_STATUS_ATTR = "status"
 
 
 class FileScanStreamConfig(PydanticBaseEnvConfig):
-    poll_interval_seconds: float = Field(
-        default=3.0, alias="FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS"
-    )
-    max_duration_seconds: float = Field(
-        default=60.0, alias="FILE_SCAN_RESULTS_MAX_DURATION_SECONDS"
-    )
+    poll_interval_seconds: float = Field(alias="FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS")
+    max_duration_seconds: float = Field(alias="FILE_SCAN_RESULTS_MAX_DURATION_SECONDS")
 
 
 @dataclass(frozen=True)
 class FileScanRecord:
-    """Scan-cache record from DynamoDB with attributes pre-parsed.
+    """A fully-parsed scan-cache record from DynamoDB."""
 
-    Fields are typed as Optional because a record in DynamoDB can be partially
-    written or carry an unknown status value; callers decide what to do with
-    a missing or unparseable field.
-    """
+    user_id: str
+    status: FileScanStatus
 
-    user_id: str | None
-    status: FileScanStatus | None
-    # Kept for diagnostic logging when ``status`` couldn't be parsed.
-    raw_status: str | None
+
+class InvalidFileScanRecordError(Exception):
+    """A DynamoDB scan record is missing required attributes or has an
+    unknown status value. Treated as an infrastructure error (500)."""
 
 
 def _get_string_attr(item: dict[str, Any], attr: str) -> str | None:
@@ -64,18 +58,26 @@ def _get_string_attr(item: dict[str, Any], attr: str) -> str | None:
 
 
 def _parse_scan_record(item: dict[str, Any]) -> FileScanRecord:
+    user_id = _get_string_attr(item, SCAN_RECORD_USER_ID_ATTR)
+    if user_id is None:
+        raise InvalidFileScanRecordError(
+            f"Scan record missing {SCAN_RECORD_USER_ID_ATTR!r} attribute"
+        )
+
     raw_status = _get_string_attr(item, SCAN_RECORD_STATUS_ATTR)
-    status: FileScanStatus | None = None
-    if raw_status is not None:
-        try:
-            status = FileScanStatus(raw_status)
-        except ValueError:
-            status = None
-    return FileScanRecord(
-        user_id=_get_string_attr(item, SCAN_RECORD_USER_ID_ATTR),
-        status=status,
-        raw_status=raw_status,
-    )
+    if raw_status is None:
+        raise InvalidFileScanRecordError(
+            f"Scan record missing {SCAN_RECORD_STATUS_ATTR!r} attribute"
+        )
+
+    try:
+        status = FileScanStatus(raw_status)
+    except ValueError as exc:
+        raise InvalidFileScanRecordError(
+            f"Scan record has unknown {SCAN_RECORD_STATUS_ATTR!r} value: {raw_status!r}"
+        ) from exc
+
+    return FileScanRecord(user_id=user_id, status=status)
 
 
 def _get_scan_record(
@@ -94,30 +96,6 @@ def _get_scan_record(
     return _parse_scan_record(response.item)
 
 
-def _resolve_status(
-    record: FileScanRecord, pending_file_id: uuid.UUID, user_id: uuid.UUID
-) -> FileScanStatus | None:
-    """Return the record's status, or log and return None to end the stream."""
-    if record.status is not None:
-        return record.status
-
-    if record.raw_status is None:
-        logger.warning(
-            "Scan record missing status attribute, ending stream",
-            extra={"pending_file_id": pending_file_id, "user_id": user_id},
-        )
-    else:
-        logger.warning(
-            "Unable to parse file scan status from record, ending stream",
-            extra={
-                "pending_file_id": pending_file_id,
-                "user_id": user_id,
-                "raw_status": record.raw_status,
-            },
-        )
-    return None
-
-
 def _fetch_next_record(
     dynamodb_client: DynamoDBClient,
     table_name: str,
@@ -127,11 +105,17 @@ def _fetch_next_record(
     """Re-query the scan record for the next poll iteration.
 
     Returns the record if it still exists and still belongs to ``user_id``;
-    otherwise logs and returns None to signal that the stream should end.
+    returns None (and logs) if the record was deleted between polls or now
+    belongs to a different user. Raises InvalidFileScanRecordError if the
+    record exists but is malformed -- the caller is expected to log + re-raise
+    so the stream terminates loudly.
     """
     next_record = _get_scan_record(dynamodb_client, table_name, pending_file_id)
     if next_record is None:
-        logger.info(
+        # The record existed at the start of the stream, so its disappearance
+        # mid-poll is a "should never happen" state -- TTL expiry on an active
+        # scan, an external delete, etc. Log loudly so the cause can be found.
+        logger.error(
             "File scan record disappeared during stream, ending stream",
             extra={"pending_file_id": pending_file_id, "user_id": user_id},
         )
@@ -157,8 +141,9 @@ def stream_file_scan_results(
     """Stream file scan status updates for the given pending file.
 
     The initial DynamoDB lookup happens before any chunks are yielded so we can
-    return a 404 or 403 with the proper HTTP status. After streaming starts, any
-    subsequent error (missing record, user mismatch) just ends the stream.
+    return a 404 / 403 / 500 with the proper HTTP status. After streaming
+    starts, a missing record or user mismatch just ends the stream; a malformed
+    record raises (terminating the connection) and is logged.
 
     Yields chunks shaped like ``FileScanResultsResponseSchema``; the caller is
     responsible for serializing each chunk through that schema.
@@ -170,8 +155,10 @@ def stream_file_scan_results(
 
     table_name = dynamodb_config.file_scan_cache_table_name
 
-    # First lookup happens outside the generator so that 404/403 results in a
-    # proper HTTP status code rather than a truncated stream.
+    # First lookup happens outside the generator so that 404/403/500 results in
+    # a proper HTTP status code rather than a truncated stream. A malformed
+    # record raised from _get_scan_record propagates as an unhandled exception,
+    # which the framework converts to a 500 with stack-trace logging.
     record = _get_scan_record(dynamodb_client, table_name, pending_file_id)
     if record is None:
         raise_flask_error(404, "File scan record not found")
@@ -192,10 +179,7 @@ def stream_file_scan_results(
         start_time = datetime_util.utcnow()
 
         while True:
-            status = _resolve_status(current_record, pending_file_id, user.user_id)
-            if status is None:
-                return
-
+            status = current_record.status
             yield {"data": {"status": status.value}}
 
             elapsed = (datetime_util.utcnow() - start_time).total_seconds()
@@ -226,9 +210,24 @@ def stream_file_scan_results(
 
             time.sleep(config.poll_interval_seconds)
 
-            next_record = _fetch_next_record(
-                dynamodb_client, table_name, pending_file_id, user.user_id
-            )
+            try:
+                next_record = _fetch_next_record(
+                    dynamodb_client, table_name, pending_file_id, user.user_id
+                )
+            except InvalidFileScanRecordError:
+                # Streaming has already started so we can't change the HTTP
+                # status; log explicitly (Flask's error processor only fires
+                # for HTTPError) and re-raise to abort the connection.
+                logger.exception(
+                    "Invalid file scan record encountered mid-stream, aborting",
+                    extra={
+                        "pending_file_id": pending_file_id,
+                        "user_id": user.user_id,
+                        "stream_duration_seconds": elapsed,
+                    },
+                )
+                raise
+
             if next_record is None:
                 return
 

--- a/api/tests/src/api/files_v1/test_get_file_scan_results.py
+++ b/api/tests/src/api/files_v1/test_get_file_scan_results.py
@@ -227,6 +227,7 @@ class TestGetFileScanResultsSuccess:
         assert record.pending_file_id == pending_file_id
         assert record.user_id == user.user_id
         assert record.file_scan_status == FileScanStatus.COMPLETE
+        assert record.stream_duration_seconds >= 0
 
 
 class TestGetFileScanResults401:

--- a/api/tests/src/api/files_v1/test_get_file_scan_results.py
+++ b/api/tests/src/api/files_v1/test_get_file_scan_results.py
@@ -1,0 +1,304 @@
+import json
+import uuid
+
+import boto3
+import pytest
+
+import tests.src.db.models.factories as factories
+from src.adapters.aws.dynamodb_adapter import DynamoDBClient
+from src.constants.lookup_constants import FileScanStatus
+
+
+@pytest.fixture(autouse=True)
+def fast_stream_config(monkeypatch):
+    # Keep tests well under a second - both env vars are floats so 0 is fine
+    monkeypatch.setenv("FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS", "0")
+    monkeypatch.setenv("FILE_SCAN_RESULTS_MAX_DURATION_SECONDS", "0.5")
+
+
+@pytest.fixture
+def dynamodb_boto_client(file_scan_dynamodb_table):
+    """Boto3 client used to seed records. Shares moto state with the route's client."""
+    return boto3.client("dynamodb", region_name="us-east-1")
+
+
+def _build_url(pending_file_id: uuid.UUID) -> str:
+    return f"/v1/files/{pending_file_id}/results"
+
+
+def _put_scan_record(
+    boto_client,
+    table_name: str,
+    pending_file_id: uuid.UUID,
+    user_id: uuid.UUID,
+    status: FileScanStatus,
+) -> None:
+    boto_client.put_item(
+        TableName=table_name,
+        Item={
+            "file_id": {"S": str(pending_file_id)},
+            "user_id": {"S": str(user_id)},
+            "status": {"S": status.value},
+        },
+    )
+
+
+def _parse_chunks(resp) -> list[dict]:
+    body = resp.get_data(as_text=True)
+    return [json.loads(line) for line in body.splitlines() if line.strip()]
+
+
+class TestGetFileScanResultsSuccess:
+    def test_terminal_status_complete_yields_once(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.COMPLETE,
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 200
+        assert resp.mimetype == "application/x-ndjson"
+        chunks = _parse_chunks(resp)
+        assert chunks == [{"data": {"status": FileScanStatus.COMPLETE.value}}]
+
+    def test_terminal_status_infected_yields_once(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.INFECTED,
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 200
+        chunks = _parse_chunks(resp)
+        assert chunks == [{"data": {"status": FileScanStatus.INFECTED.value}}]
+
+    def test_pending_then_terminal_yields_both(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+        monkeypatch,
+    ):
+        """When the record transitions mid-stream we yield each status."""
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.PENDING,
+        )
+
+        # Mutate the underlying record between get_item calls so we can drive
+        # the polling loop through status transitions deterministically.
+        real_get_item = DynamoDBClient.get_item
+        transitions = iter([FileScanStatus.IN_PROGRESS, FileScanStatus.COMPLETE])
+
+        def wrapped_get_item(self, *args, **kwargs):
+            result = real_get_item(self, *args, **kwargs)
+            next_status = next(transitions, None)
+            if next_status is not None:
+                _put_scan_record(
+                    dynamodb_boto_client,
+                    file_scan_dynamodb_table,
+                    pending_file_id,
+                    user.user_id,
+                    next_status,
+                )
+            return result
+
+        monkeypatch.setattr(DynamoDBClient, "get_item", wrapped_get_item)
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 200
+        chunks = _parse_chunks(resp)
+        assert chunks == [
+            {"data": {"status": FileScanStatus.PENDING.value}},
+            {"data": {"status": FileScanStatus.IN_PROGRESS.value}},
+            {"data": {"status": FileScanStatus.COMPLETE.value}},
+        ]
+
+    def test_stream_ends_when_max_duration_reached(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+        monkeypatch,
+    ):
+        """If the status never reaches terminal, the loop ends when max duration elapses."""
+        monkeypatch.setenv("FILE_SCAN_RESULTS_MAX_DURATION_SECONDS", "0")
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.PENDING,
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 200
+        chunks = _parse_chunks(resp)
+        # With max_duration=0, we yield the first status and exit on the
+        # elapsed-time check before sleeping or re-querying.
+        assert chunks == [{"data": {"status": FileScanStatus.PENDING.value}}]
+
+    def test_logs_terminal_status_reached(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+        caplog,
+    ):
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.COMPLETE,
+        )
+
+        with caplog.at_level("INFO"):
+            resp = client.get(
+                _build_url(pending_file_id),
+                headers={"X-SGG-Token": user_auth_token},
+            )
+            # Consume the stream so the generator runs to completion and the
+            # terminal-status log fires.
+            _parse_chunks(resp)
+
+        assert resp.status_code == 200
+
+        terminal_records = [
+            r
+            for r in caplog.records
+            if r.message == "File scan results stream reached terminal status"
+        ]
+        assert len(terminal_records) == 1
+        record = terminal_records[0]
+        assert record.pending_file_id == pending_file_id
+        assert record.user_id == user.user_id
+        assert record.file_scan_status == FileScanStatus.COMPLETE
+
+
+class TestGetFileScanResults401:
+    def test_no_auth(self, client, enable_factory_create):
+        resp = client.get(_build_url(uuid.uuid4()))
+        assert resp.status_code == 401
+
+
+class TestGetFileScanResults403:
+    def test_user_id_mismatch_returns_403(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        pending_file_id = uuid.uuid4()
+        other_user_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            other_user_id,
+            FileScanStatus.PENDING,
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 403
+        assert resp.get_json()["message"] == "Forbidden"
+
+    def test_other_user_with_api_key_gets_403(
+        self,
+        client,
+        user_api_key,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        # Record belongs to a totally different user
+        record_user = factories.UserFactory.create()
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            record_user.user_id,
+            FileScanStatus.PENDING,
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-API-Key": user_api_key.key_id},
+        )
+
+        assert resp.status_code == 403
+
+
+class TestGetFileScanResults404:
+    def test_record_not_in_dynamodb_returns_404(
+        self,
+        client,
+        user_auth_token,
+        file_scan_dynamodb_table,
+    ):
+        pending_file_id = uuid.uuid4()
+        # Intentionally do not put any item
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 404
+        assert "File scan record not found" in resp.get_json()["message"]

--- a/api/tests/src/api/files_v1/test_get_file_scan_results.py
+++ b/api/tests/src/api/files_v1/test_get_file_scan_results.py
@@ -121,8 +121,11 @@ class TestGetFileScanResultsSuccess:
             FileScanStatus.PENDING,
         )
 
-        # Mutate the underlying record between get_item calls so we can drive
-        # the polling loop through status transitions deterministically.
+        # We monkeypatch DynamoDBClient.get_item not to mock its behavior
+        # (the real moto-backed call still runs) but to use it as a hook for
+        # mutating the underlying record between polls. This drives the
+        # polling loop through deterministic status transitions without
+        # relying on real time / sleep.
         real_get_item = DynamoDBClient.get_item
         transitions = iter([FileScanStatus.IN_PROGRESS, FileScanStatus.COMPLETE])
 
@@ -283,6 +286,7 @@ class TestGetFileScanResults403:
         )
 
         assert resp.status_code == 403
+        assert resp.get_json()["message"] == "Forbidden"
 
 
 class TestGetFileScanResults404:
@@ -301,4 +305,4 @@ class TestGetFileScanResults404:
         )
 
         assert resp.status_code == 404
-        assert "File scan record not found" in resp.get_json()["message"]
+        assert resp.get_json()["message"] == "File scan record not found"

--- a/api/tests/src/api/files_v1/test_get_file_scan_results.py
+++ b/api/tests/src/api/files_v1/test_get_file_scan_results.py
@@ -188,6 +188,63 @@ class TestGetFileScanResultsSuccess:
         # elapsed-time check before sleeping or re-querying.
         assert chunks == [{"data": {"status": FileScanStatus.PENDING.value}}]
 
+    def test_record_disappearing_mid_stream_logs_error(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+        monkeypatch,
+        caplog,
+    ):
+        """If the record is deleted between polls, we log at ERROR and end the stream."""
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.PENDING,
+        )
+
+        real_get_item = DynamoDBClient.get_item
+        first_call = {"done": False}
+
+        def wrapped_get_item(self, *args, **kwargs):
+            result = real_get_item(self, *args, **kwargs)
+            if not first_call["done"]:
+                first_call["done"] = True
+                dynamodb_boto_client.delete_item(
+                    TableName=file_scan_dynamodb_table,
+                    Key={"file_id": {"S": str(pending_file_id)}},
+                )
+            return result
+
+        monkeypatch.setattr(DynamoDBClient, "get_item", wrapped_get_item)
+
+        with caplog.at_level("ERROR"):
+            resp = client.get(
+                _build_url(pending_file_id),
+                headers={"X-SGG-Token": user_auth_token},
+            )
+            chunks = _parse_chunks(resp)
+
+        assert resp.status_code == 200
+        # First chunk was emitted before the record vanished; nothing after.
+        assert chunks == [{"data": {"status": FileScanStatus.PENDING.value}}]
+
+        disappeared_records = [
+            r
+            for r in caplog.records
+            if r.message == "File scan record disappeared during stream, ending stream"
+        ]
+        assert len(disappeared_records) == 1
+        record = disappeared_records[0]
+        assert record.levelname == "ERROR"
+        assert record.pending_file_id == pending_file_id
+        assert record.user_id == user.user_id
+
     def test_logs_terminal_status_reached(
         self,
         client,
@@ -307,3 +364,152 @@ class TestGetFileScanResults404:
 
         assert resp.status_code == 404
         assert resp.get_json()["message"] == "File scan record not found"
+
+
+class TestGetFileScanResults500:
+    """Malformed DynamoDB records are an infrastructure error -- fail fast."""
+
+    def test_missing_user_id_returns_500(
+        self,
+        client,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        pending_file_id = uuid.uuid4()
+        dynamodb_boto_client.put_item(
+            TableName=file_scan_dynamodb_table,
+            Item={
+                "file_id": {"S": str(pending_file_id)},
+                "status": {"S": FileScanStatus.PENDING.value},
+            },
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 500
+
+    def test_missing_status_returns_500(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        pending_file_id = uuid.uuid4()
+        dynamodb_boto_client.put_item(
+            TableName=file_scan_dynamodb_table,
+            Item={
+                "file_id": {"S": str(pending_file_id)},
+                "user_id": {"S": str(user.user_id)},
+            },
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 500
+
+    def test_unknown_status_value_returns_500(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        pending_file_id = uuid.uuid4()
+        dynamodb_boto_client.put_item(
+            TableName=file_scan_dynamodb_table,
+            Item={
+                "file_id": {"S": str(pending_file_id)},
+                "user_id": {"S": str(user.user_id)},
+                "status": {"S": "not-a-real-status"},
+            },
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 500
+
+    def test_malformed_record_mid_stream_logs_and_aborts(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+        monkeypatch,
+        caplog,
+    ):
+        """A malformed record discovered mid-stream is logged and aborts the connection."""
+        pending_file_id = uuid.uuid4()
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.PENDING,
+        )
+
+        # After the first valid lookup, corrupt the record so the next poll
+        # raises InvalidFileScanRecordError.
+        real_get_item = DynamoDBClient.get_item
+        first_call = {"done": False}
+
+        def wrapped_get_item(self, *args, **kwargs):
+            result = real_get_item(self, *args, **kwargs)
+            if not first_call["done"]:
+                first_call["done"] = True
+                dynamodb_boto_client.put_item(
+                    TableName=file_scan_dynamodb_table,
+                    Item={
+                        "file_id": {"S": str(pending_file_id)},
+                        "user_id": {"S": str(user.user_id)},
+                        "status": {"S": "not-a-real-status"},
+                    },
+                )
+            return result
+
+        monkeypatch.setattr(DynamoDBClient, "get_item", wrapped_get_item)
+
+        with caplog.at_level("ERROR"):
+            try:
+                resp = client.get(
+                    _build_url(pending_file_id),
+                    headers={"X-SGG-Token": user_auth_token},
+                )
+                # Consume what was emitted before the exception aborted the stream.
+                body = resp.get_data(as_text=True)
+            except Exception:
+                # If the test client propagates the exception from inside the
+                # generator (Flask's default behavior with TESTING=True), that
+                # is equally acceptable -- the stream aborted loudly.
+                body = ""
+
+        abort_records = [
+            r
+            for r in caplog.records
+            if r.message == "Invalid file scan record encountered mid-stream, aborting"
+        ]
+        assert len(abort_records) == 1
+        record = abort_records[0]
+        assert record.pending_file_id == pending_file_id
+        assert record.user_id == user.user_id
+        assert record.exc_info is not None
+
+        # If the test client returned a response, it should only contain the
+        # first (valid) chunk -- the abort happened before any further chunks
+        # were yielded.
+        if body:
+            chunks = [json.loads(line) for line in body.splitlines() if line.strip()]
+            assert chunks == [{"data": {"status": FileScanStatus.PENDING.value}}]


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #9714 

## Changes proposed

- Updated file_routes.py to add `GET /v1/files/<pending_file_id>/results`, returning a streaming NDJSON Response
- Updated file_schemas.py to add `FileScanResultsDataSchema` and `FileScanResultsResponseSchema`
- Created stream_file_scan_results.py service to poll DynamoDB on a configurable interval, yield each status, and end on terminal status (complete/infected) or max duration
- Updated local.env to add `FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS=3` and `FILE_SCAN_RESULTS_MAX_DURATION_SECONDS=60`
- Created test_get_file_scan_results.py to house tests for the new endpoint

## Context for reviewers

Implements the file-scan-results streaming endpoint on top of the DynamoDB adapter. AuthZ deviates from our usual privilege pattern, as only the user who started the upload can read its status, This is enforced by comparing the calling user against `user_id` on the DynamoDB record.

## Validation steps

Confirm tests pass