### PR TITLE
[Unticketed] Fix LoadOracleData filter logic timezone issue

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -69,7 +69,10 @@ class LoadOracleDataTask(src.task.task.Task):
         self.foreign_tables = foreign_tables
         self.staging_tables = staging_tables
         self.insert_chunk_size = insert_chunk_size
-        self.batch_cutoff = datetime_util.get_now_us_eastern_datetime()
+        # Strip tzinfo so the cutoff is a naive datetime with EST wall-clock values.
+        # The Oracle foreign data stores EST timestamps but Postgres treats them as UTC, so a
+        # tz-aware cutoff is converted to UTC for comparison and ends up 4-5h ahead of the source.
+        self.batch_cutoff = datetime_util.get_now_us_eastern_datetime().replace(tzinfo=None)
 
     def run_task(self) -> None:
         """Main task process, called by run()."""

--- a/api/tests/src/data_migration/load/test_load_oracle_data_task.py
+++ b/api/tests/src/data_migration/load/test_load_oracle_data_task.py
@@ -304,7 +304,7 @@ class TestLoadOracleData(BaseTestClass):
         assert updated_record.oppcategory is None
 
     @freezegun.freeze_time("2024-06-15 14:30:00")
-    def test_cutoff_is_timezone_aware_eastern(
+    def test_cutoff_is_naive_eastern_wall_clock(
         self, db_session, foreign_tables, staging_tables, enable_factory_create, caplog
     ):
         caplog.set_level(logging.INFO)
@@ -319,8 +319,13 @@ class TestLoadOracleData(BaseTestClass):
         )
         task.run()
 
-        assert task.batch_cutoff.tzinfo is not None
-        assert str(task.batch_cutoff.tzinfo) in ("EST", "EDT", "US/Eastern", "America/New_York")
+        # The cutoff must be naive: the Oracle foreign data stores EST timestamps as UTC, so a
+        # tz-aware cutoff would get converted to UTC for comparison and end up 4-5h ahead of the
+        # source data, letting post-cutoff records sneak through the filter.
+        assert task.batch_cutoff.tzinfo is None
+        # Frozen UTC time is 14:30; Eastern wall-clock (EDT in June) is 10:30.
+        assert task.batch_cutoff.hour == 10
+        assert task.batch_cutoff.minute == 30
 
         cutoff_log = next(
             record
@@ -365,7 +370,9 @@ class TestLoadOracleData(BaseTestClass):
             last_upd_date=cutoff_time + datetime.timedelta(seconds=1),
         )
 
-        with freezegun.freeze_time("2024-06-15 10:00:00"):
+        # Freeze UTC at 14:00 so the Eastern wall-clock cutoff lands at 10:00, matching
+        # cutoff_time above. (June = EDT = UTC-4.)
+        with freezegun.freeze_time("2024-06-15 14:00:00"):
             task = load_oracle_data_task.LoadOracleDataTask(
                 db_session, foreign_tables, staging_tables, ["topportunity"]
             )
@@ -400,8 +407,9 @@ class TestLoadOracleData(BaseTestClass):
             last_upd_date=cutoff_time + datetime.timedelta(minutes=5),
         )
 
-        # Run 1: cutoff is at 10:00, record is at 10:05 -- should be excluded
-        with freezegun.freeze_time("2024-06-15 10:00:00"):
+        # Freeze UTC at 14:00 so the Eastern wall-clock cutoff is 10:00 (June = EDT = UTC-4).
+        # Record is at 10:05 -- should be excluded.
+        with freezegun.freeze_time("2024-06-15 14:00:00"):
             task1 = load_oracle_data_task.LoadOracleDataTask(
                 db_session, foreign_tables, staging_tables, ["topportunity"]
             )
@@ -416,8 +424,8 @@ class TestLoadOracleData(BaseTestClass):
         )
         assert task1.metrics["count.insert.total"] == 0
 
-        # Run 2: cutoff is at 10:10, record is at 10:05 -- should be included
-        with freezegun.freeze_time("2024-06-15 10:10:00"):
+        # Run 2: cutoff is at 10:10 Eastern, record is at 10:05 -- should be included.
+        with freezegun.freeze_time("2024-06-15 14:10:00"):
             task2 = load_oracle_data_task.LoadOracleDataTask(
                 db_session, foreign_tables, staging_tables, ["topportunity"]
             )


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for Unticketed

## Changes proposed

- Updated load_oracle_data_task.py to strip the timezone from the `batch_cutoff`
- Updated test_load_oracle_data_task.py to account for change in tests 

## Context for reviewers

The Oracle source data is EST/EDT wall-clock time stored as UTC in Postgres. Our cutoff was a timezone-aware EDT value. When Postgres compared them, it normalized both to UTC, which made the source data appear to be 4 hours earlier than it really was, letting post-cutoff records sneak through.

## Validation steps

Confirm tests pass. Confirm no New Relic errors occur in lower environments before the next prod release.