### PR TITLE
[Issue #10502] Need headless not headed Chrome

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -109,7 +109,7 @@ runs:
       shell: bash
       working-directory: ./frontend
       run: |
-        npx playwright install --with-deps chrome
+        npx playwright install --with-deps chromium-headless-shell
 
     # Conditionally install Firefox if requested (Shard 2 on the CI/CD run)
     - name: Install Firefox and dependencies

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -147,7 +147,7 @@ jobs:
           npm ci
 
       # Install Chrome only for caching; other browsers installed per-shard in test job
-      - run: npx playwright install --with-deps chrome
+      - run: npx playwright install --with-deps chromium-headless-shell
         if: steps.playwright-cache.outputs.cache-hit != 'true'
 
       # We package ourselves as tar.gz because this preserves permissions that a regular artifact upload/download does not.


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10502  

## Changes proposed

We need to cache headless chrome, not regular chrome

## Context for reviewers

This was changed in the last PR around test infra, but because it was using a cached Playwright install that had all the browsers, it didn't fail when we swapped out the all browser install to the just chrome install because we hit the cache that included headless chrome.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- Cleared existing playwright cache so that we would do a clean headless only install and test that completely.
- Checks pass
