### PR TITLE
[unticketed] remove token headers from award rec calls

### DIFF
--- a/frontend/src/app/api/award-recommendations/[id]/risks/[riskId]/handler.ts
+++ b/frontend/src/app/api/award-recommendations/[id]/risks/[riskId]/handler.ts
@@ -25,11 +25,7 @@ export async function deleteRiskForAwardRecommendation(
       throw new Error("Risk ID is required");
     }
 
-    const result = await deleteAwardRecommendationRisk(
-      id,
-      riskId,
-      session.token,
-    );
+    const result = await deleteAwardRecommendationRisk(id, riskId);
 
     return Response.json({
       message: result.message || "Risk deleted successfully",

--- a/frontend/src/app/api/award-recommendations/[id]/risks/handler.ts
+++ b/frontend/src/app/api/award-recommendations/[id]/risks/handler.ts
@@ -32,7 +32,6 @@ export async function getRisksForAwardRecommendation(
     const { risks, paginationInfo } = await getAwardRecommendationRisks(
       id,
       pagination,
-      session.token,
     );
 
     return Response.json({

--- a/frontend/src/services/fetch/fetchers/awardRecommendationFetcherClient.test.tsx
+++ b/frontend/src/services/fetch/fetchers/awardRecommendationFetcherClient.test.tsx
@@ -17,21 +17,17 @@ describe("getAwardRecommendationRisks", () => {
         pagination_info: { total_pages: 1 },
       }),
     });
-    const result = await getAwardRecommendationRisks(
-      "award-id",
-      { page_offset: 1, page_size: 10, sort_order: [] },
-      "token",
-    );
+    const result = await getAwardRecommendationRisks("award-id", {
+      page_offset: 1,
+      page_size: 10,
+      sort_order: [],
+    });
     expect(result.risks).toEqual([{ id: 1 }]);
     expect(result.paginationInfo).toEqual({ total_pages: 1 });
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining("award-id"),
       expect.objectContaining({
         method: "POST",
-        headers: expect.objectContaining({ "X-SGG-Token": "token" }) as Record<
-          string,
-          string
-        >,
       }) as RequestInit,
     );
   });
@@ -39,11 +35,11 @@ describe("getAwardRecommendationRisks", () => {
   it("handles fetch error", async () => {
     (global.fetch as jest.Mock).mockRejectedValue(new Error("fail"));
     await expect(
-      getAwardRecommendationRisks(
-        "award-id",
-        { page_offset: 1, page_size: 10, sort_order: [] },
-        "token",
-      ),
+      getAwardRecommendationRisks("award-id", {
+        page_offset: 1,
+        page_size: 10,
+        sort_order: [],
+      }),
     ).rejects.toThrow("fail");
   });
 });
@@ -60,21 +56,13 @@ describe("deleteAwardRecommendationRisk", () => {
         .fn()
         .mockResolvedValue({ message: "Risk deleted successfully" }),
     });
-    const result = await deleteAwardRecommendationRisk(
-      "award-id",
-      "risk-id",
-      "token",
-    );
+    const result = await deleteAwardRecommendationRisk("award-id", "risk-id");
     expect(result.success).toBe(true);
     expect(result.message).toBe("Risk deleted successfully");
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining("award-id/risks/risk-id"),
       expect.objectContaining({
         method: "DELETE",
-        headers: expect.objectContaining({ "X-SGG-Token": "token" }) as Record<
-          string,
-          string
-        >,
       }) as RequestInit,
     );
   });
@@ -84,11 +72,7 @@ describe("deleteAwardRecommendationRisk", () => {
       ok: false,
       json: jest.fn().mockResolvedValue({ message: "Delete failed" }),
     });
-    const result = await deleteAwardRecommendationRisk(
-      "award-id",
-      "risk-id",
-      "token",
-    );
+    const result = await deleteAwardRecommendationRisk("award-id", "risk-id");
     expect(result.success).toBe(false);
     expect(result.message).toBe("Delete failed");
   });
@@ -96,7 +80,7 @@ describe("deleteAwardRecommendationRisk", () => {
   it("handles fetch error", async () => {
     (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
     await expect(
-      deleteAwardRecommendationRisk("award-id", "risk-id", "token"),
+      deleteAwardRecommendationRisk("award-id", "risk-id"),
     ).rejects.toThrow("Network error");
   });
 });

--- a/frontend/src/services/fetch/fetchers/awardRecommendationFetcherClient.ts
+++ b/frontend/src/services/fetch/fetchers/awardRecommendationFetcherClient.ts
@@ -14,7 +14,6 @@ type ApiResponse<T> = {
 export const getAwardRecommendationRisks = async (
   id: string,
   pagination: PaginationRequestBody,
-  token: string,
 ): Promise<{
   risks: AwardRecommendationRisk[];
   paginationInfo: PaginationInfo | undefined;
@@ -26,7 +25,6 @@ export const getAwardRecommendationRisks = async (
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-SGG-Token": token,
       },
       body: JSON.stringify({ pagination }),
     },
@@ -43,7 +41,6 @@ export const getAwardRecommendationRisks = async (
 export const deleteAwardRecommendationRisk = async (
   awardRecommendationId: string,
   riskId: string,
-  token: string,
 ): Promise<{ success: boolean; message?: string }> => {
   const apiBase = environment.API_URL || "";
   const response = await fetch(
@@ -52,7 +49,6 @@ export const deleteAwardRecommendationRisk = async (
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        "X-SGG-Token": token,
       },
     },
   );


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed
Brings award rec API fetch related code up to date in terms of fetcher / endpoint definition patterns and token usage

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. run general regression test of award rec functionality