### PR TITLE
[Issue #9456] standardize handling of unauthenticated frontend situations

### DIFF
--- a/frontend/src/app/[locale]/(base)/developers/api-dashboard/page.tsx
+++ b/frontend/src/app/[locale]/(base)/developers/api-dashboard/page.tsx
@@ -1,3 +1,4 @@
+import Unauthenticated from "src/app/[locale]/(base)/unauthenticated/page";
 import { getSession } from "src/services/auth/session";
 import { handleListApiKeys } from "src/services/fetch/fetchers/apiKeyFetcher";
 import { LocalizedPageProps } from "src/types/intl";
@@ -7,7 +8,6 @@ import { getTranslations } from "next-intl/server";
 import GeneralErrorAlert from "src/components/core/GeneralErrorAlert";
 import ApiKeyTable from "src/components/developers/apiDashboard/ApiKeyTable";
 import { CreateApiKeyButton } from "src/components/developers/apiDashboard/CreateApiKeyButton";
-import Unauthenticated from "../../unauthenticated/page";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -15,7 +15,7 @@ export const revalidate = 0;
 export default async function ApiDashboardPage({ params }: LocalizedPageProps) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "ApiDashboard" });
-  let apiKeys;
+  let apiKeyResponse;
 
   const session = await getSession();
   if (!session?.token) {
@@ -23,7 +23,7 @@ export default async function ApiDashboardPage({ params }: LocalizedPageProps) {
   }
 
   try {
-    apiKeys = await handleListApiKeys(session.user_id);
+    apiKeyResponse = await handleListApiKeys(session.user_id);
   } catch (e) {
     console.error("Failed to fetch API keys:", e);
     return (
@@ -43,7 +43,7 @@ export default async function ApiDashboardPage({ params }: LocalizedPageProps) {
         <CreateApiKeyButton />
       </div>
 
-      <ApiKeyTable apiKeys={apiKeys} />
+      <ApiKeyTable apiKeys={apiKeyResponse.data} />
     </div>
   );
 }

--- a/frontend/src/app/[locale]/(base)/developers/api-dashboard/page.tsx
+++ b/frontend/src/app/[locale]/(base)/developers/api-dashboard/page.tsx
@@ -1,4 +1,5 @@
-import { fetchApiKeys } from "src/services/fetch/fetchers/apiKeyFetcher";
+import { getSession } from "src/services/auth/session";
+import { handleListApiKeys } from "src/services/fetch/fetchers/apiKeyFetcher";
 import { LocalizedPageProps } from "src/types/intl";
 
 import { getTranslations } from "next-intl/server";
@@ -6,6 +7,7 @@ import { getTranslations } from "next-intl/server";
 import GeneralErrorAlert from "src/components/core/GeneralErrorAlert";
 import ApiKeyTable from "src/components/developers/apiDashboard/ApiKeyTable";
 import { CreateApiKeyButton } from "src/components/developers/apiDashboard/CreateApiKeyButton";
+import Unauthenticated from "../../unauthenticated/page";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -15,8 +17,13 @@ export default async function ApiDashboardPage({ params }: LocalizedPageProps) {
   const t = await getTranslations({ locale, namespace: "ApiDashboard" });
   let apiKeys;
 
+  const session = await getSession();
+  if (!session?.token) {
+    return <Unauthenticated />;
+  }
+
   try {
-    apiKeys = await fetchApiKeys();
+    apiKeys = await handleListApiKeys(session.user_id);
   } catch (e) {
     console.error("Failed to fetch API keys:", e);
     return (

--- a/frontend/src/app/[locale]/(base)/grantor/opportunities/create/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunities/create/page.tsx
@@ -1,6 +1,4 @@
-import TopLevelError from "src/app/[locale]/(base)/error/page";
 import { UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import { fetchUserAgencies } from "src/services/fetch/fetchers/agenciesFetcher";
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";

--- a/frontend/src/app/[locale]/(base)/grantor/opportunities/create/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunities/create/page.tsx
@@ -1,4 +1,5 @@
-import { UnauthorizedError } from "src/errors";
+import TopLevelError from "src/app/[locale]/(base)/error/page";
+import { MissingAuthError, UnauthorizedError } from "src/errors";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import { fetchUserAgencies } from "src/services/fetch/fetchers/agenciesFetcher";
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
@@ -71,18 +72,14 @@ async function CreateOpportunityPage({ searchParams }: CreateOpportunityProps) {
     ? selectedAgencyParam[0]
     : selectedAgencyParam;
 
-  const userSession = await getSession();
-
-  // Check the user's session
-  if (!userSession || !userSession.token) {
-    return <TopLevelError />;
-  }
-
   // Get agencies
   let userAgencies: RelevantAgencyRecord[];
   try {
     userAgencies = await fetchUserAgencies();
   } catch (error) {
+    if (error instanceof MissingAuthError) {
+      return <TopLevelError />;
+    }
     if (error instanceof UnauthorizedError) {
       throw error;
     }

--- a/frontend/src/app/[locale]/(base)/grantor/opportunities/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunities/page.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { axe } from "jest-axe";
+import { identity } from "lodash";
 import OpportunitiesListPage from "src/app/[locale]/(base)/grantor/opportunities/page";
 import { UnauthorizedError } from "src/errors";
 import { UserAgency } from "src/services/fetch/fetchers/userAgenciesFetcher";
@@ -24,6 +25,10 @@ jest.mock("react", () => ({
 
 jest.mock("next-intl", () => ({
   useTranslations: () => useTranslationsMock(),
+}));
+
+jest.mock("next-intl/server", () => ({
+  getTranslations: identity,
 }));
 
 const withFeatureFlagMock = jest
@@ -149,8 +154,8 @@ jest.mock("src/services/fetch/fetchers/grantorOpportunitiesFetcher", () => ({
     mockSearchForOpportunities(arg) as Promise<BaseOpportunity[]>,
 }));
 
-jest.mock("src/services/fetch/fetchers/userAgenciesFetcher", () => ({
-  fetchUserAgencies: () => mockFetchUserAgencies() as Promise<UserAgency[]>,
+jest.mock("src/services/fetch/fetchers/agenciesFetcher", () => ({
+  getUserAgencies: () => mockFetchUserAgencies() as Promise<UserAgency[]>,
 }));
 
 jest.mock("src/utils/userPrivileges", () => ({
@@ -406,15 +411,6 @@ describe("Opportunities", () => {
       render(component);
 
       expect(await screen.findByTestId("alert")).toBeVisible();
-    });
-
-    it("unauthorized errors propagate up the stack", async () => {
-      mockFetchUserAgencies.mockRejectedValue(
-        new UnauthorizedError("No active session"),
-      );
-      await expect(
-        OpportunitiesListPage({ params: localeParams }),
-      ).rejects.toThrow();
     });
   });
 

--- a/frontend/src/app/[locale]/(base)/grantor/opportunities/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunities/page.tsx
@@ -1,14 +1,13 @@
 import TopLevelError from "src/app/[locale]/(base)/error/page";
-import { UnauthorizedError } from "src/errors";
+import Unauthenticated from "src/app/[locale]/(base)/unauthenticated/page";
+import { MissingAuthError, UnauthorizedError } from "src/errors";
 import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
+import { getUserAgencies } from "src/services/fetch/fetchers/agenciesFetcher";
 import { searchOpportunitiesByAgency } from "src/services/fetch/fetchers/grantorOpportunitiesFetcher";
-import {
-  fetchUserAgencies,
-  UserAgency,
-} from "src/services/fetch/fetchers/userAgenciesFetcher";
 import { LocalizedPageProps, TFn } from "src/types/intl";
 import { BaseOpportunity } from "src/types/opportunity/opportunityResponseTypes";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import { PaginationRequestBody } from "src/types/search/searchRequestTypes";
 import { WithFeatureFlagProps } from "src/types/uiTypes";
 import {
@@ -69,7 +68,11 @@ const OpportunitiesErrorPage = () => {
   );
 };
 
-const AgencyNotAuthorizedPage = ({ agencies }: { agencies: UserAgency[] }) => {
+const AgencyNotAuthorizedPage = ({
+  agencies,
+}: {
+  agencies: RelevantAgencyRecord[];
+}) => {
   const t = useTranslations("Opportunities");
   return (
     <OpportunitiesPageWrapper>
@@ -187,7 +190,7 @@ const OpportunitiesHeader = ({
 }: {
   userOpportunitiesCount: number;
   agencyName: string;
-  agencies: UserAgency[];
+  agencies: RelevantAgencyRecord[];
   currentAgencyId: string;
   isSingleAgency: boolean;
   canCreate: boolean;
@@ -335,13 +338,12 @@ async function OpportunitiesListPage(props: OpportunitiesListProps) {
   }
 
   // B. Get all Agencies this user belongs to
-  let userAgencies: UserAgency[];
+  let userAgencies: RelevantAgencyRecord[];
   try {
-    userAgencies = await fetchUserAgencies();
+    userAgencies = await getUserAgencies(userSession.user_id);
   } catch (error) {
-    console.error("Bad agencies", error);
-    if (error instanceof UnauthorizedError) {
-      throw error;
+    if (error instanceof MissingAuthError) {
+      return <Unauthenticated />;
     }
     return <OpportunitiesErrorPage />;
   }
@@ -357,7 +359,7 @@ async function OpportunitiesListPage(props: OpportunitiesListProps) {
     redirect(`?agency=${sortedUserAgencies[0].agency_id}`);
   }
   const selectedAgency = sortedUserAgencies.find(
-    (a) => a.agency_id === selectedAgencyId,
+    (a) => a.agency_id.toString() === selectedAgencyId,
   );
   if (!selectedAgency) {
     return <AgencyNotAuthorizedPage agencies={sortedUserAgencies} />;
@@ -366,7 +368,7 @@ async function OpportunitiesListPage(props: OpportunitiesListProps) {
   // D. Check the user's privileges for the selected Agency
   let userPrivilegeResult: UserPrivilegeResult[];
   const userPrivilegeDef: UserPrivilegeRequest[] = getUserPrivilegeDefinition(
-    selectedAgency.agency_id,
+    selectedAgency.agency_id.toString(),
   );
   try {
     userPrivilegeResult = await checkRequiredPrivileges(
@@ -399,7 +401,7 @@ async function OpportunitiesListPage(props: OpportunitiesListProps) {
     };
     try {
       userOpportunities = await searchOpportunitiesByAgency(
-        selectedAgency.agency_id,
+        selectedAgency.agency_id.toString(),
         pageRequest,
       );
     } catch (error) {

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/page.tsx
@@ -1,6 +1,9 @@
 import { Metadata } from "next";
-import { ApiRequestError, parseErrorStatus } from "src/errors";
-import { getSession } from "src/services/auth/session";
+import {
+  ApiRequestError,
+  MissingAuthError,
+  parseErrorStatus,
+} from "src/errors";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import { getOpportunityForGrantor } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
 import { GrantorOpportunityDetail } from "src/types/opportunity/opportunityResponseTypes";
@@ -32,11 +35,8 @@ export async function generateMetadata({
   const t = await getTranslations({ locale });
   let title = t("OpportunityEdit.pageTitle");
   try {
-    const session = await getSession();
-    if (session?.token) {
-      const { data } = await getOpportunityForGrantor(id);
-      title = `${t("OpportunityEdit.pageTitle")} - ${data.opportunity_title || ""}`;
-    }
+    const { data } = await getOpportunityForGrantor(id);
+    title = `${t("OpportunityEdit.pageTitle")} - ${data.opportunity_title || ""}`;
   } catch {
     // fall back to static title
   }
@@ -53,11 +53,6 @@ async function OpportunityEditPage({ params, searchParams }: PageProps) {
   const t = await getTranslations({ locale, namespace: "Errors" });
   const tEdit = await getTranslations({ locale, namespace: "OpportunityEdit" });
 
-  const session = await getSession();
-  if (!session || !session.token) {
-    return <UnauthorizedMessage />;
-  }
-
   // TODO(#8601): Replace this fail-closed placeholder with a real grantor authorization
   // check once the frontend has a way to verify whether the current session can edit
   // this opportunity for its agency.
@@ -73,6 +68,10 @@ async function OpportunityEditPage({ params, searchParams }: PageProps) {
       response.data.non_forecast_summary?.opportunity_summary_id ??
       "";
   } catch (error) {
+    if (error instanceof MissingAuthError) {
+      // TODO: should be an anauthenticated message
+      return <UnauthorizedMessage />;
+    }
     const status = parseErrorStatus(error as ApiRequestError);
     if (status === 404) {
       notFound();

--- a/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/form/[appFormId]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import TopLevelError from "src/app/[locale]/(base)/error/page";
+import { ApiRequestError } from "src/errors";
 import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import { getApplicationDetails } from "src/services/fetch/fetchers/applicationFetcher";
@@ -47,23 +48,18 @@ interface formPageProps {
 async function FormPage({ params }: formPageProps) {
   const { applicationId, appFormId } = await params;
   const { data, error } = await getFormData({ applicationId, appFormId });
-  const userSession = await getSession();
   const t = await getTranslations("Application");
-
-  if (!userSession || !userSession.token) {
-    return <TopLevelError />;
-  }
 
   let response;
   try {
     response = await getApplicationDetails(applicationId);
 
     if (response.status_code !== 200) {
-      console.error(
-        `Error retrieving application details for (${applicationId})`,
-        response,
+      throw new ApiRequestError(
+        "API request error",
+        "APIRequestError",
+        response.status_code,
       );
-      return <TopLevelError />;
     }
   } catch (e) {
     console.error(

--- a/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/form/[appFormId]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/form/[appFormId]/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from "next";
 import TopLevelError from "src/app/[locale]/(base)/error/page";
 import { ApiRequestError } from "src/errors";
-import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import { getApplicationDetails } from "src/services/fetch/fetchers/applicationFetcher";
 import getFormData from "src/utils/getFormData";

--- a/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/page.tsx
@@ -1,6 +1,10 @@
 import { Metadata } from "next";
 import TopLevelError from "src/app/[locale]/(base)/error/page";
-import { ApiRequestError, parseErrorStatus } from "src/errors";
+import {
+  ApiRequestError,
+  MissingAuthError,
+  parseErrorStatus,
+} from "src/errors";
 import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import {
@@ -34,12 +38,8 @@ interface ApplicationLandingPageProps {
 }
 
 async function ApplicationLandingPage({ params }: ApplicationLandingPageProps) {
-  const userSession = await getSession();
   const t = await getTranslations("Application");
 
-  if (!userSession || !userSession.token) {
-    return <TopLevelError />;
-  }
   const { applicationId } = await params;
   let details = {} as ApplicationDetailsCardProps;
   let historyDetails = [] as ApplicationHistoryCardProps;
@@ -73,6 +73,9 @@ async function ApplicationLandingPage({ params }: ApplicationLandingPageProps) {
     }
     opportunity = opportunityResponse.data;
   } catch (e) {
+    if (e instanceof MissingAuthError) {
+      return <TopLevelError />;
+    }
     if (parseErrorStatus(e as ApiRequestError) === 404) {
       console.error(
         `Error retrieving application details for application (${applicationId})`,

--- a/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/applications/[applicationId]/page.tsx
@@ -5,7 +5,6 @@ import {
   MissingAuthError,
   parseErrorStatus,
 } from "src/errors";
-import { getSession } from "src/services/auth/session";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import {
   getApplicationDetails,

--- a/frontend/src/app/[locale]/(base)/workspace/organizations/[id]/page.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/organizations/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from "next";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
-import { getSession } from "src/services/auth/session";
 import { getOrganizationDetails } from "src/services/fetch/fetchers/organizationsFetcher";
 
 import { getTranslations } from "next-intl/server";
@@ -23,10 +22,6 @@ export async function generateMetadata({
   const t = await getTranslations({ locale });
   let title = `${t("OrganizationDetail.pageTitle")} | Simpler.Grants.gov`;
   try {
-    const session = await getSession();
-    if (!session?.token) {
-      throw new Error("not logged in");
-    }
     const organizationDetails = await getOrganizationDetails(id);
     title = `${t("OrganizationDetail.pageTitle")}: ${organizationDetails.sam_gov_entity.legal_business_name || ""} | Simpler.Grants.gov`;
   } catch (error) {

--- a/frontend/src/app/api/applications/[applicationId]/attachments/[applicationAttachmentId]/handler.ts
+++ b/frontend/src/app/api/applications/[applicationId]/attachments/[applicationAttachmentId]/handler.ts
@@ -1,5 +1,4 @@
-import { ApiRequestError, readError, UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
+import { ApiRequestError, readError } from "src/errors";
 import { deleteAttachment } from "src/services/fetch/fetchers/applicationFetcher";
 
 import { revalidateTag } from "next/cache";
@@ -13,10 +12,6 @@ export const deleteAttachmentHandler = async (
   },
 ) => {
   try {
-    const session = await getSession();
-    if (!session || !session.token) {
-      throw new UnauthorizedError("No active session");
-    }
     const applicationId = (await params).applicationId;
     const applicationAttachmentId = (await params).applicationAttachmentId;
 

--- a/frontend/src/app/api/applications/[applicationId]/attachments/handler.ts
+++ b/frontend/src/app/api/applications/[applicationId]/attachments/handler.ts
@@ -13,7 +13,7 @@ export const postAttachmentHandler = async (
   const session = await getSession();
 
   if (!session || !session.token) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
   }
 
   const { applicationId } = await params;

--- a/frontend/src/app/api/applications/[applicationId]/forms/[formId]/handler.ts
+++ b/frontend/src/app/api/applications/[applicationId]/forms/[formId]/handler.ts
@@ -1,5 +1,4 @@
-import { ApiRequestError, readError, UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
+import { ApiRequestError, readError } from "src/errors";
 import { handleUpdateApplicationFormIncludeInSubmission } from "src/services/fetch/fetchers/applicationFetcher";
 
 export const updateApplicationIncludeFormInSubmissionHandler = async (
@@ -7,12 +6,6 @@ export const updateApplicationIncludeFormInSubmissionHandler = async (
   { params }: { params: Promise<{ applicationId: string; formId: string }> },
 ) => {
   try {
-    const session = await getSession();
-    if (!session || !session.token) {
-      throw new UnauthorizedError(
-        "No active session to update including form in application submission",
-      );
-    }
     const applicationId = (await params).applicationId;
     const formId = (await params).formId;
     const { is_included_in_submission } = (await request.json()) as {

--- a/frontend/src/app/api/applications/[applicationId]/forms/[formId]/route.test.ts
+++ b/frontend/src/app/api/applications/[applicationId]/forms/[formId]/route.test.ts
@@ -3,7 +3,6 @@
  */
 import { updateApplicationIncludeFormInSubmissionHandler } from "src/app/api/applications/[applicationId]/forms/[formId]/handler";
 
-const getSessionMock = jest.fn();
 const mockUpdateApplicationFormIncludeInSubmission = jest.fn();
 
 jest.mock("src/services/fetch/fetchers/applicationFetcher", () => ({
@@ -17,10 +16,6 @@ jest.mock("src/services/fetch/fetchers/applicationFetcher", () => ({
       formId,
       is_included_in_submission,
     ) as unknown,
-}));
-
-jest.mock("src/services/auth/session", () => ({
-  getSession: (): unknown => getSessionMock(),
 }));
 
 describe("PUT request", () => {
@@ -39,7 +34,6 @@ describe("PUT request", () => {
   });
 
   it("returns success response when update is successful", async () => {
-    getSessionMock.mockResolvedValue({ token: "token123" });
     mockUpdateApplicationFormIncludeInSubmission.mockResolvedValue({
       status_code: 200,
       data: {
@@ -54,7 +48,6 @@ describe("PUT request", () => {
     );
     const json = (await response.json()) as unknown;
 
-    expect(getSessionMock).toHaveBeenCalled();
     expect(mockUpdateApplicationFormIncludeInSubmission).toHaveBeenCalledWith(
       "app123",
       "form456",
@@ -68,25 +61,7 @@ describe("PUT request", () => {
     });
   });
 
-  it("throws UnauthorizedError if no session token", async () => {
-    getSessionMock.mockResolvedValue(null);
-
-    const req = mockRequest({ is_included_in_submission: false });
-    const response = await updateApplicationIncludeFormInSubmissionHandler(
-      req,
-      { params: mockParams },
-    );
-    const json = (await response.json()) as { message: string };
-
-    expect(response.status).toBe(401);
-    expect(json.message).toMatch(
-      /No active session to update including form in application submission/,
-    );
-    expect(getSessionMock).toHaveBeenCalled();
-  });
-
   it("returns error if API response is not 200", async () => {
-    getSessionMock.mockResolvedValue({ token: "token123" });
     mockUpdateApplicationFormIncludeInSubmission.mockResolvedValue({
       status_code: 400,
       message: "Invalid update",

--- a/frontend/src/app/api/applications/[applicationId]/submit/handler.ts
+++ b/frontend/src/app/api/applications/[applicationId]/submit/handler.ts
@@ -1,5 +1,4 @@
-import { ApiRequestError, readError, UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
+import { ApiRequestError, readError } from "src/errors";
 import { handleSubmitApplication } from "src/services/fetch/fetchers/applicationFetcher";
 
 export const submitApplicationHandler = async (
@@ -7,10 +6,6 @@ export const submitApplicationHandler = async (
   { params }: { params: Promise<{ applicationId: string }> },
 ) => {
   try {
-    const session = await getSession();
-    if (!session || !session.token) {
-      throw new UnauthorizedError("No active session submit application");
-    }
     const applicationId = (await params).applicationId;
 
     const response = await handleSubmitApplication(applicationId);

--- a/frontend/src/app/api/applications/[applicationId]/transfer-ownership/handler.test.ts
+++ b/frontend/src/app/api/applications/[applicationId]/transfer-ownership/handler.test.ts
@@ -8,7 +8,6 @@ type MinimalResponse = {
   json: () => Promise<unknown>;
 };
 
-const getSessionMock = jest.fn<Promise<{ token: string } | null>, []>();
 const addOrganizationToApplicationMock = jest.fn<
   Promise<{ message: string; data: { application_id: string } }>,
   [{ applicationId: string; organizationId: string }]
@@ -48,10 +47,6 @@ jest.mock(
   }),
 );
 
-jest.mock("src/services/auth/session", () => ({
-  getSession: (): Promise<{ token: string } | null> => getSessionMock(),
-}));
-
 jest.mock("src/services/fetch/fetchers/addOrganizationToApplication", () => ({
   addOrganizationToApplication: (args: {
     applicationId: string;
@@ -89,20 +84,7 @@ describe("transferOwnershipHandler", () => {
     );
   });
 
-  it("returns 401 when session is missing", async () => {
-    getSessionMock.mockResolvedValueOnce(null);
-
-    const response = (await transferOwnershipHandler(
-      createFakeRequest({ organization_id: "org-123" }),
-      { params: Promise.resolve({ applicationId: "app-123" }) },
-    )) as unknown as MinimalResponse;
-
-    expect(response.status).toBe(401);
-  });
-
   it("returns 400 when organization_id is missing", async () => {
-    getSessionMock.mockResolvedValueOnce({ token: "fakeToken" });
-
     const response = (await transferOwnershipHandler(createFakeRequest({}), {
       params: Promise.resolve({ applicationId: "app-123" }),
     })) as unknown as MinimalResponse;
@@ -111,8 +93,6 @@ describe("transferOwnershipHandler", () => {
   });
 
   it("returns 200 and calls addOrganizationToApplication on success", async () => {
-    getSessionMock.mockResolvedValueOnce({ token: "fakeToken" });
-
     addOrganizationToApplicationMock.mockResolvedValueOnce({
       message: "Success",
       data: { application_id: "app-123" },
@@ -140,8 +120,6 @@ describe("transferOwnershipHandler", () => {
   });
 
   it("returns 500 when addOrganizationToApplication throws", async () => {
-    getSessionMock.mockResolvedValueOnce({ token: "fakeToken" });
-
     addOrganizationToApplicationMock.mockRejectedValueOnce(new Error("Boom"));
 
     const response = (await transferOwnershipHandler(

--- a/frontend/src/app/api/applications/[applicationId]/transfer-ownership/handler.ts
+++ b/frontend/src/app/api/applications/[applicationId]/transfer-ownership/handler.ts
@@ -13,11 +13,6 @@ export const transferOwnershipHandler = async (
   options: { params: Promise<{ applicationId: string }> },
 ): Promise<Response> => {
   try {
-    const session = await getSession();
-    if (!session?.token) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
     const { applicationId } = await options.params;
 
     let parsedBody: TransferOwnershipRequestBody;

--- a/frontend/src/app/api/applications/[applicationId]/transfer-ownership/handler.ts
+++ b/frontend/src/app/api/applications/[applicationId]/transfer-ownership/handler.ts
@@ -1,5 +1,4 @@
 import { readError } from "src/errors";
-import { getSession } from "src/services/auth/session";
 import { addOrganizationToApplication } from "src/services/fetch/fetchers/addOrganizationToApplication";
 
 import { NextResponse } from "next/server";

--- a/frontend/src/app/api/applications/start/handler.ts
+++ b/frontend/src/app/api/applications/start/handler.ts
@@ -1,13 +1,8 @@
-import { ApiRequestError, readError, UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
+import { ApiRequestError, readError } from "src/errors";
 import { handleStartApplication } from "src/services/fetch/fetchers/applicationFetcher";
 
 export const startApplicationHandler = async (request: Request) => {
   try {
-    const session = await getSession();
-    if (!session || !session.token) {
-      throw new UnauthorizedError("No active session start application");
-    }
     const { competitionId, applicationName, organization } =
       (await request.json()) as {
         competitionId: string;

--- a/frontend/src/app/api/auth/logout/handler.ts
+++ b/frontend/src/app/api/auth/logout/handler.ts
@@ -1,5 +1,4 @@
-import { ApiRequestError, readError, UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
+import { ApiRequestError, readError } from "src/errors";
 import { deleteSession } from "src/services/auth/sessionUtils";
 import { postUserLogout } from "src/services/fetch/fetchers/fetchers";
 
@@ -7,10 +6,6 @@ import { NextResponse } from "next/server";
 
 export async function logoutUser() {
   try {
-    const session = await getSession();
-    if (!session || !session.token) {
-      throw new UnauthorizedError("No active session to logout");
-    }
     // logout on API via /v1/users/token/logout
     const response = await postUserLogout();
     if (!response) {

--- a/frontend/src/app/api/auth/logout/route.test.ts
+++ b/frontend/src/app/api/auth/logout/route.test.ts
@@ -5,13 +5,8 @@
 import { logoutUser } from "src/app/api/auth/logout/handler";
 import { UnauthorizedError } from "src/errors";
 
-const getSessionMock = jest.fn();
 const deleteSessionMock = jest.fn();
 const postLogoutMock = jest.fn();
-
-jest.mock("src/services/auth/session", () => ({
-  getSession: (): unknown => getSessionMock(),
-}));
 
 jest.mock("src/services/auth/sessionUtils", () => ({
   deleteSession: (): unknown => deleteSessionMock(),
@@ -25,31 +20,12 @@ jest.mock("src/services/fetch/fetchers/fetchers", () => ({
 // is to throw an error
 describe("/api/auth/logout POST handler", () => {
   afterEach(() => jest.clearAllMocks());
-  it("errors if there is no current session token", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "",
-    }));
-    const response = await logoutUser();
-
-    expect(postLogoutMock).toHaveBeenCalledTimes(0);
-    expect(response.status).toEqual(401);
-    const json = (await response.json()) as { message: string };
-    expect(json.message).toEqual(
-      "Error logging out: No active session to logout",
-    );
-  });
-  it("calls postLogout with token from session", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-    }));
+  it("calls postUserLogout", async () => {
     await logoutUser();
 
     expect(postLogoutMock).toHaveBeenCalledTimes(1);
   });
   it("errors if API logout call errors", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-    }));
     postLogoutMock.mockImplementation(() => {
       throw new Error("the API threw this error");
     });
@@ -61,33 +37,23 @@ describe("/api/auth/logout POST handler", () => {
     expect(json.message).toEqual("Error logging out: the API threw this error");
   });
   it("errors if API logout call returns nothing", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-    }));
     postLogoutMock.mockImplementation(() => null);
     const response = await logoutUser();
 
     expect(postLogoutMock).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(400);
     const json = (await response.json()) as { message: string };
-    // const message = JSON.parse(json) as FrontendErrorDetails;
     expect(json.message).toEqual(
       "Error logging out: No logout response from API",
     );
   });
   it("calls deleteSession", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-    }));
     postLogoutMock.mockImplementation(() => "success");
     await logoutUser();
 
     expect(deleteSessionMock).toHaveBeenCalledTimes(1);
   });
   it("calls deleteSession if token expired", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-    }));
     postLogoutMock.mockImplementation(() => {
       throw new UnauthorizedError("Token expired");
     });
@@ -100,9 +66,6 @@ describe("/api/auth/logout POST handler", () => {
     expect(json.message).toEqual("session previously expired");
   });
   it("returns sucess message on success", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-    }));
     postLogoutMock.mockImplementation(() => "success");
     const response = await logoutUser();
 

--- a/frontend/src/app/api/award-recommendations/[id]/risks/[riskId]/handler.test.tsx
+++ b/frontend/src/app/api/award-recommendations/[id]/risks/[riskId]/handler.test.tsx
@@ -38,7 +38,11 @@ describe("deleteRiskForAwardRecommendation", () => {
     jest.clearAllMocks();
   });
 
+<<<<<<< HEAD
   it("returns success response when delete is successful", async () => {
+=======
+  it("deletes risk successfully", async () => {
+>>>>>>> 98cb39983 (fix typing, tests and lint)
     (
       fetcherModule.deleteAwardRecommendationRisk as jest.Mock
     ).mockResolvedValue({ success: true, message: "Risk deleted" });

--- a/frontend/src/app/api/award-recommendations/[id]/risks/[riskId]/handler.test.tsx
+++ b/frontend/src/app/api/award-recommendations/[id]/risks/[riskId]/handler.test.tsx
@@ -38,11 +38,7 @@ describe("deleteRiskForAwardRecommendation", () => {
     jest.clearAllMocks();
   });
 
-<<<<<<< HEAD
   it("returns success response when delete is successful", async () => {
-=======
-  it("deletes risk successfully", async () => {
->>>>>>> 98cb39983 (fix typing, tests and lint)
     (
       fetcherModule.deleteAwardRecommendationRisk as jest.Mock
     ).mockResolvedValue({ success: true, message: "Risk deleted" });

--- a/frontend/src/app/api/award-recommendations/[id]/risks/handler.test.tsx
+++ b/frontend/src/app/api/award-recommendations/[id]/risks/handler.test.tsx
@@ -40,3 +40,4 @@ describe("getRisksForAwardRecommendation", () => {
     expect(json.pagination_info).toEqual(mockPaginationInfo);
   });
 });
+g;

--- a/frontend/src/app/api/award-recommendations/[id]/risks/handler.test.tsx
+++ b/frontend/src/app/api/award-recommendations/[id]/risks/handler.test.tsx
@@ -1,37 +1,17 @@
-import * as fetcherModule from "src/services/fetch/fetchers/awardRecommendationFetcher";
+/**
+ * @jest-environment node
+ */
 
 import { NextRequest } from "next/server";
 
 import { getRisksForAwardRecommendation } from "./handler";
 
-jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher");
+const mockGetAwardRecommendationRisks = jest.fn();
 
-jest.mock("src/services/auth/sessionUtils", () => ({
-  decrypt: jest.fn(),
-  encrypt: jest.fn(),
-  CLIENT_JWT_ENCRYPTION_ALGORITHM: "HS256",
-  API_JWT_ENCRYPTION_ALGORITHM: "RS256",
-  newExpirationDate: () => new Date(0),
+jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher", () => ({
+  getAwardRecommendationRisks: () =>
+    mockGetAwardRecommendationRisks() as unknown,
 }));
-
-interface MockResponse {
-  json: () => Promise<unknown>;
-  status: number;
-}
-
-global.Response = class Response {
-  constructor(
-    public body: unknown,
-    public init?: ResponseInit,
-  ) {}
-  static json(data: unknown, init?: ResponseInit): MockResponse {
-    return {
-      json: jest.fn().mockResolvedValue(data),
-      status: init?.status || 200,
-      ...init,
-    } as MockResponse;
-  }
-} as unknown as typeof globalThis.Response;
 
 const mockPagination = { page_offset: 1, page_size: 10, sort_order: [] };
 const mockRisks = [{ id: 1, type: "ADD_MONITORING" }];
@@ -43,7 +23,7 @@ describe("getRisksForAwardRecommendation", () => {
   });
 
   it("returns risks and pagination info on success", async () => {
-    (fetcherModule.getAwardRecommendationRisks as jest.Mock).mockResolvedValue({
+    mockGetAwardRecommendationRisks.mockResolvedValue({
       risks: mockRisks,
       paginationInfo: mockPaginationInfo,
     });

--- a/frontend/src/app/api/user/saved-searches/list/handler.ts
+++ b/frontend/src/app/api/user/saved-searches/list/handler.ts
@@ -1,16 +1,8 @@
-import { readError, UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
+import { readError } from "src/errors";
 import { fetchSavedSearches } from "src/services/fetch/fetchers/savedSearchFetcher";
 
 export const listSavedSearches = async (_request: Request) => {
   try {
-    const session = await getSession();
-    if (!session || !session.token) {
-      throw new UnauthorizedError(
-        "No active session to fetch saved opportunities",
-      );
-    }
-
     const savedSearches = await fetchSavedSearches();
 
     return new Response(JSON.stringify(savedSearches), {

--- a/frontend/src/app/api/user/saved-searches/list/route.test.ts
+++ b/frontend/src/app/api/user/saved-searches/list/route.test.ts
@@ -6,12 +6,7 @@ import { listSavedSearches } from "src/app/api/user/saved-searches/list/handler"
 import { SavedSearchRecord } from "src/types/search/searchRequestTypes";
 import { fakeSavedSearch } from "src/utils/testing/fixtures";
 
-const getSessionMock = jest.fn();
 const mockFetchSavedSearches = jest.fn();
-
-jest.mock("src/services/auth/session", () => ({
-  getSession: (): unknown => getSessionMock(),
-}));
 
 jest.mock("src/services/fetch/fetchers/savedSearchFetcher", () => ({
   fetchSavedSearches: (...args: unknown[]) =>
@@ -26,11 +21,6 @@ const fakeSavedSearches = [
 describe("POST request", () => {
   afterEach(() => jest.clearAllMocks());
   it("sends back the result of fetchSavedSearches", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-      user_id: "1",
-    }));
-
     mockFetchSavedSearches.mockResolvedValue(fakeSavedSearches);
 
     const response = await listSavedSearches(new Request("http://anywhere"));
@@ -39,24 +29,9 @@ describe("POST request", () => {
     expect(response.status).toBe(200);
     expect(mockFetchSavedSearches).toHaveBeenCalledTimes(1);
     expect(json).toEqual(fakeSavedSearches);
-    expect(getSessionMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("sends unauthorized error if session is not available", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "",
-    }));
-
-    const response = await listSavedSearches(new Request("http://anywhere"));
-    expect(response.status).toBe(401);
-    expect(mockFetchSavedSearches).toHaveBeenCalledTimes(0);
   });
 
   it("sends error if fetch call fails", async () => {
-    getSessionMock.mockImplementation(() => ({
-      token: "fakeToken",
-    }));
-
     mockFetchSavedSearches.mockImplementation(() => {
       throw new Error("oops");
     });

--- a/frontend/src/components/manageUsers/UserOrganizationInvite.tsx
+++ b/frontend/src/components/manageUsers/UserOrganizationInvite.tsx
@@ -1,4 +1,4 @@
-import { getSession } from "src/services/auth/session";
+import { MissingAuthError } from "src/errors";
 import { getOrganizationRoles } from "src/services/fetch/fetchers/organizationsFetcher";
 import { UserRole } from "src/types/userTypes";
 
@@ -13,15 +13,14 @@ export async function UserOrganizationInvite({
 }) {
   // fetch roles for organization (this will happen in page gate eventually)
   const t = await getTranslations("ManageUsers.inviteUser");
-  const session = await getSession();
-  if (!session?.token) {
-    console.error("unable to display user invites, not logged in");
-    return;
-  }
   let organizationRoles: UserRole[] = [];
   try {
     organizationRoles = await getOrganizationRoles(organizationId);
   } catch (e) {
+    if (e instanceof MissingAuthError) {
+      console.error("unable to display user invites, not logged in");
+      return;
+    }
     console.error("unable to fetch organization roles", e);
   }
   return (

--- a/frontend/src/components/organization/OrganizationRoster.tsx
+++ b/frontend/src/components/organization/OrganizationRoster.tsx
@@ -1,4 +1,4 @@
-import { getSession } from "src/services/auth/session";
+import { MissingAuthError } from "src/errors";
 import { getOrganizationUsers } from "src/services/fetch/fetchers/organizationsFetcher";
 import { UserDetail } from "src/types/userTypes";
 
@@ -73,19 +73,18 @@ export const OrganizationRoster = async ({
   organizationId: string;
 }) => {
   const t = await getTranslations("OrganizationDetail.rosterTable");
-  const session = await getSession();
-  if (!session?.token) {
-    return (
-      <Alert headingLevel="h3" type="error">
-        not logged in
-      </Alert>
-    );
-  }
 
   let organizationUsers;
   try {
     organizationUsers = await getOrganizationUsers(organizationId);
   } catch (e) {
+    if (e instanceof MissingAuthError) {
+      return (
+        <Alert headingLevel="h3" type="error">
+          not logged in
+        </Alert>
+      );
+    }
     console.error(e);
     return <GeneralErrorAlert />;
   }

--- a/frontend/src/components/workspace/AgencySelector.tsx
+++ b/frontend/src/components/workspace/AgencySelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { UserAgency } from "src/services/fetch/fetchers/userAgenciesFetcher";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
@@ -11,7 +11,7 @@ export const AgencySelector = ({
   currentAgencyId,
   className,
 }: {
-  agencies: UserAgency[];
+  agencies: RelevantAgencyRecord[];
   currentAgencyId: string;
   className?: string;
 }) => {

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -3,8 +3,6 @@
  * Note that the errors defined here rely on stringifying JSON data into the Error's message parameter
  * That data will need to be parsed back out into JSON when reading the error
  */
-import { error } from "console";
-import errorMap from "node_modules/zod/v3/locales/en.cjs";
 import { FrontendErrorDetails } from "src/types/apiResponseTypes";
 import { QueryParamData } from "src/types/search/searchRequestTypes";
 
@@ -27,7 +25,7 @@ export const parseErrorStatus = (error: ApiRequestError): number => {
 };
 
 export class MissingAuthError extends Error {
-  constructor(message: string) {
+  constructor(message?: string) {
     const erroMessage =
       message || "Request requires authentication and is missing user token";
     const cause = {

--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -3,8 +3,12 @@
  * Note that the errors defined here rely on stringifying JSON data into the Error's message parameter
  * That data will need to be parsed back out into JSON when reading the error
  */
+import { error } from "console";
+import errorMap from "node_modules/zod/v3/locales/en.cjs";
 import { FrontendErrorDetails } from "src/types/apiResponseTypes";
 import { QueryParamData } from "src/types/search/searchRequestTypes";
+
+import { ErrorMessage } from "@trussworks/react-uswds";
 
 export const parseErrorStatus = (error: ApiRequestError): number => {
   const { message } = error;
@@ -21,6 +25,18 @@ export const parseErrorStatus = (error: ApiRequestError): number => {
     return 500;
   }
 };
+
+export class MissingAuthError extends Error {
+  constructor(message: string) {
+    const erroMessage =
+      message || "Request requires authentication and is missing user token";
+    const cause = {
+      type: "MissingAuthError",
+      message: ErrorMessage,
+    };
+    super(erroMessage, { cause });
+  }
+}
 
 /**
  * A fetch request failed due to a network error. The error wasn't the fault of the user,

--- a/frontend/src/services/fetch/FetcherHelpers.test.ts
+++ b/frontend/src/services/fetch/FetcherHelpers.test.ts
@@ -152,15 +152,20 @@ describe("getDefaultHeaders", () => {
     const headers = await getDefaultHeaders({});
     expect(headers["X-SGG-Token"]).toEqual(undefined);
   });
-  it("does not include user auth token header if required but not available", async () => {
+  it("throws if auth token is required but not available", async () => {
     getSessionMock.mockResolvedValue(null);
-    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
     const { getDefaultHeaders } = await import(
       "src/services/fetch/fetcherHelpers"
     );
-    const headers = await getDefaultHeaders({ requiresUserAuthToken: true });
-    expect(headers["X-SGG-Token"]).toEqual(undefined);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    const err = await wrapForExpectedError(() =>
+      getDefaultHeaders({
+        requiresUserAuthToken: true,
+        url: "http://something.net",
+      }),
+    );
+    expect(err.message).toEqual(
+      "No user token present for call to authorized endpoint at http://something.net",
+    );
   });
   it("includes user auth token from session when present and required", async () => {
     getSessionMock.mockResolvedValue({ token: "a token" });

--- a/frontend/src/services/fetch/fetcherHelpers.ts
+++ b/frontend/src/services/fetch/fetcherHelpers.ts
@@ -25,9 +25,11 @@ import { printAwsHeaders, printResponseInfo } from "src/utils/generalUtils";
 export async function getDefaultHeaders({
   addContentType = true,
   requiresUserAuthToken = false,
+  url,
 }: {
   addContentType?: boolean;
   requiresUserAuthToken?: boolean;
+  url?: string;
 }): Promise<Record<string, string>> {
   const headers: Record<string, string> = {};
 
@@ -43,10 +45,11 @@ export async function getDefaultHeaders({
     const session = await getSession();
     if (!session?.token) {
       // May want to throw here
-      console.warn("no user token present for authorized endpoint call");
-    } else {
-      headers["X-SGG-Token"] = session.token;
+      throw new Error(
+        `No user token present for call to authorized endpoint at ${url || "unknown url"}`,
+      );
     }
+    headers["X-SGG-Token"] = session.token;
   }
 
   return headers;

--- a/frontend/src/services/fetch/fetcherHelpers.ts
+++ b/frontend/src/services/fetch/fetcherHelpers.ts
@@ -7,6 +7,7 @@ import {
   BadRequestError,
   ForbiddenError,
   InternalServerError,
+  MissingAuthError,
   NetworkError,
   NotFoundError,
   RequestTimeoutError,
@@ -44,8 +45,7 @@ export async function getDefaultHeaders({
   if (requiresUserAuthToken) {
     const session = await getSession();
     if (!session?.token) {
-      // May want to throw here
-      throw new Error(
+      throw new MissingAuthError(
         `No user token present for call to authorized endpoint at ${url || "unknown url"}`,
       );
     }

--- a/frontend/src/services/fetch/fetchers/Fetchers.test.ts
+++ b/frontend/src/services/fetch/fetchers/Fetchers.test.ts
@@ -103,6 +103,7 @@ describe("requesterForEndpoint", () => {
     expect(getDefaultHeadersMock).toHaveBeenCalledWith({
       addContentType: true,
       requiresUserAuthToken: true,
+      url: "fakeurl/1",
     });
     expect(fetchMock).toHaveBeenCalledWith("fakeurl/1", {
       body: JSON.stringify({ key: "value" }),

--- a/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
@@ -1,10 +1,6 @@
 "server only";
 
-import {
-  ApiRequestError,
-  MissingAuthError,
-  UnauthorizedError,
-} from "src/errors";
+import { ApiRequestError, MissingAuthError } from "src/errors";
 import { getSession } from "src/services/auth/session";
 import {
   fetchUserWithMethod,

--- a/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/agenciesFetcher.ts
@@ -1,6 +1,10 @@
 "server only";
 
-import { ApiRequestError, UnauthorizedError } from "src/errors";
+import {
+  ApiRequestError,
+  MissingAuthError,
+  UnauthorizedError,
+} from "src/errors";
 import { getSession } from "src/services/auth/session";
 import {
   fetchUserWithMethod,
@@ -97,7 +101,9 @@ export const fetchUserAgencies = async (): Promise<RelevantAgencyRecord[]> => {
     const session = await getSession();
     if (!session || !session.token) {
       // we shouldn't get there because the page should be checking authentication
-      throw new UnauthorizedError("No active session");
+      throw new MissingAuthError(
+        "Error fetching user agencies - not logged in",
+      );
     }
     const agencies = await getUserAgencies(session.user_id);
     return agencies;

--- a/frontend/src/services/fetch/fetchers/apiKeyFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/apiKeyFetcher.ts
@@ -1,11 +1,11 @@
 import "server-only";
 
 import { fetchUserWithMethod } from "src/services/fetch/fetchers/fetchers";
-import { APIResponse } from "src/types/apiResponseTypes";
+import { ApiKeyResponse } from "src/types/apiKeyTypes";
 
 export const handleListApiKeys = async (
   userId: string,
-): Promise<APIResponse> => {
+): Promise<ApiKeyResponse> => {
   const body = {
     pagination: {
       page_offset: 1,
@@ -25,13 +25,13 @@ export const handleListApiKeys = async (
     body,
   });
 
-  return (await resp.json()) as APIResponse;
+  return (await resp.json()) as ApiKeyResponse;
 };
 
 export const handleCreateApiKey = async (
   userId: string,
   keyName: string,
-): Promise<APIResponse> => {
+): Promise<ApiKeyResponse> => {
   const body = {
     key_name: keyName,
   };
@@ -42,14 +42,14 @@ export const handleCreateApiKey = async (
     body,
   });
 
-  return (await resp.json()) as APIResponse;
+  return (await resp.json()) as ApiKeyResponse;
 };
 
 export const handleRenameApiKey = async (
   userId: string,
   apiKeyId: string,
   keyName: string,
-): Promise<APIResponse> => {
+): Promise<ApiKeyResponse> => {
   const body = {
     key_name: keyName,
   };
@@ -60,17 +60,17 @@ export const handleRenameApiKey = async (
     body,
   });
 
-  return (await resp.json()) as APIResponse;
+  return (await resp.json()) as ApiKeyResponse;
 };
 
 export const handleDeleteApiKey = async (
   userId: string,
   apiKeyId: string,
-): Promise<APIResponse> => {
+): Promise<ApiKeyResponse> => {
   const subPath = `${userId}/api-keys/${apiKeyId}`;
   const resp = await fetchUserWithMethod("DELETE")({
     subPath,
   });
 
-  return (await resp.json()) as APIResponse;
+  return (await resp.json()) as ApiKeyResponse;
 };

--- a/frontend/src/services/fetch/fetchers/apiKeyFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/apiKeyFetcher.ts
@@ -1,39 +1,7 @@
 import "server-only";
 
-import { getSession } from "src/services/auth/session";
 import { fetchUserWithMethod } from "src/services/fetch/fetchers/fetchers";
-import { ApiKey } from "src/types/apiKeyTypes";
 import { APIResponse } from "src/types/apiResponseTypes";
-
-// this is a duplicate - resolve with handleListApiKeys
-export const fetchApiKeys = async (): Promise<ApiKey[]> => {
-  const session = await getSession();
-  if (!session || !session.token) {
-    return [];
-  }
-
-  const body = {
-    pagination: {
-      page_offset: 1,
-      page_size: 25,
-      sort_order: [
-        {
-          order_by: "created_at",
-          sort_direction: "descending",
-        },
-      ],
-    },
-  };
-
-  const subPath = `${session.user_id}/api-keys/list`;
-  const resp = await fetchUserWithMethod("POST")({
-    subPath,
-    body,
-  });
-
-  const json = (await resp.json()) as { data: ApiKey[] };
-  return json.data;
-};
 
 export const handleListApiKeys = async (
   userId: string,

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -69,6 +69,7 @@ export function requesterForEndpoint({
     const defaultHeaders = await getDefaultHeaders({
       addContentType,
       requiresUserAuthToken: requiresAuth,
+      url,
     });
     const headers = {
       ...defaultHeaders,

--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.test.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.test.ts
@@ -80,14 +80,6 @@ describe("getOrganizationDetails", () => {
       subPath: "org-123",
     });
   });
-
-  it("throws UnauthorizedError when session is missing or has no token", async () => {
-    mockGetSession.mockResolvedValue(null);
-
-    await expect(getOrganizationDetails("org-123")).rejects.toBeInstanceOf(
-      UnauthorizedError,
-    );
-  });
 });
 
 describe("getUserOrganizations", () => {
@@ -143,14 +135,6 @@ describe("getOrganizationUsers", () => {
       },
     });
   });
-
-  it("throws UnauthorizedError when session is missing or has no token", async () => {
-    mockGetSession.mockResolvedValue(null);
-
-    await expect(getOrganizationUsers("org-123")).rejects.toBeInstanceOf(
-      UnauthorizedError,
-    );
-  });
 });
 
 describe("getOrganizationRoles", () => {
@@ -173,14 +157,6 @@ describe("getOrganizationRoles", () => {
     expect(fetchOrganizationMock).toHaveBeenCalledWith({
       subPath: "org-123/roles/list",
     });
-  });
-
-  it("throws UnauthorizedError when session is missing or has no token", async () => {
-    mockGetSession.mockResolvedValue(null);
-
-    await expect(getOrganizationRoles("org-123")).rejects.toBeInstanceOf(
-      UnauthorizedError,
-    );
   });
 });
 
@@ -264,14 +240,6 @@ describe("getOrganizationPendingInvitations", () => {
       { invitee_email: "zeta@example.com" },
     ]);
   });
-
-  it("throws UnauthorizedError when session is missing or has no token", async () => {
-    mockGetSession.mockResolvedValue(null);
-
-    await expect(
-      getOrganizationPendingInvitations("org-123"),
-    ).rejects.toBeInstanceOf(UnauthorizedError);
-  });
 });
 
 describe("updateOrganizationUserRoles", () => {
@@ -300,14 +268,6 @@ describe("updateOrganizationUserRoles", () => {
         role_ids: ["role-1", "role-2"],
       },
     });
-  });
-
-  it("throws UnauthorizedError when session is missing or has no token", async () => {
-    mockGetSession.mockResolvedValue(null);
-
-    await expect(
-      updateOrganizationUserRoles("org-123", "user-1", ["role-1"]),
-    ).rejects.toBeInstanceOf(UnauthorizedError);
   });
 });
 
@@ -419,13 +379,5 @@ describe("getOrganizationLegacyUsers", () => {
         },
       },
     });
-  });
-
-  it("throws UnauthorizedError when session is missing or has no token", async () => {
-    mockGetSession.mockResolvedValue(null);
-
-    await expect(getOrganizationLegacyUsers("org-123")).rejects.toBeInstanceOf(
-      UnauthorizedError,
-    );
   });
 });

--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
@@ -17,10 +17,6 @@ import { fetchOrganizationWithMethod, fetchUserWithMethod } from "./fetchers";
 export const getOrganizationDetails = async (
   organizationId: string,
 ): Promise<Organization> => {
-  const session = await getSession();
-  if (!session || !session.token) {
-    throw new UnauthorizedError("No active session");
-  }
   const resp = await fetchOrganizationWithMethod("GET")({
     subPath: organizationId,
   });
@@ -41,12 +37,6 @@ export const getUserOrganizations = async (
 export const getOrganizationUsers = async (
   organizationId: string,
 ): Promise<UserDetail[]> => {
-  const session = await getSession();
-
-  if (!session || !session.token) {
-    throw new UnauthorizedError("No active session");
-  }
-
   const resp = await fetchOrganizationWithMethod("POST")({
     subPath: `${organizationId}/users`,
     body: {
@@ -71,12 +61,6 @@ export const getOrganizationUsers = async (
 export const getOrganizationRoles = async (
   organizationId: string,
 ): Promise<UserRole[]> => {
-  const session = await getSession();
-
-  if (!session || !session.token) {
-    throw new UnauthorizedError("No active session");
-  }
-
   const resp = await fetchOrganizationWithMethod("POST")({
     subPath: `${organizationId}/roles/list`,
   });
@@ -104,12 +88,6 @@ export const inviteUserToOrganization = async (requestData: {
 export const getOrganizationPendingInvitations = async (
   organizationId: string,
 ): Promise<OrganizationPendingInvitation[]> => {
-  const session = await getSession();
-
-  if (!session || !session.token) {
-    throw new UnauthorizedError("No active session");
-  }
-
   const response = await fetchOrganizationWithMethod("POST")({
     subPath: `${organizationId}/invitations/list`,
     body: {
@@ -142,12 +120,6 @@ export const updateOrganizationUserRoles = async (
   userId: string,
   roleIds: string[],
 ): Promise<UserDetail> => {
-  const session = await getSession();
-
-  if (!session || !session.token) {
-    throw new UnauthorizedError("No active session");
-  }
-
   const resp = await fetchOrganizationWithMethod("PUT")({
     subPath: `${organizationId}/users/${userId}`,
     body: { role_ids: roleIds },
@@ -168,12 +140,6 @@ export const removeOrganizationUser = async (
   organizationId: string,
   userId: string,
 ): Promise<UserDetail> => {
-  const session = await getSession();
-
-  if (!session || !session.token) {
-    throw new UnauthorizedError("No active session");
-  }
-
   const resp = await fetchOrganizationWithMethod("DELETE")({
     subPath: `${organizationId}/users/${userId}`,
   });
@@ -192,12 +158,6 @@ export const removeOrganizationUser = async (
 export const getOrganizationLegacyUsers = async (
   organizationId: string,
 ): Promise<OrganizationLegacyUser[]> => {
-  const session = await getSession();
-
-  if (!session || !session.token) {
-    throw new UnauthorizedError("No active session");
-  }
-
   const resp = await fetchOrganizationWithMethod("POST")({
     subPath: `${organizationId}/legacy-users`,
     body: {

--- a/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/organizationsFetcher.ts
@@ -1,5 +1,3 @@
-import { UnauthorizedError } from "src/errors";
-import { getSession } from "src/services/auth/session";
 import { Organization } from "src/types/applicationResponseTypes";
 import { OrganizationInviteRecord } from "src/types/organizationTypes";
 import {

--- a/frontend/src/types/apiKeyTypes.ts
+++ b/frontend/src/types/apiKeyTypes.ts
@@ -1,3 +1,5 @@
+import { APIResponse } from "./apiResponseTypes";
+
 export interface ApiKey {
   api_key_id: string;
   key_name: string;
@@ -5,4 +7,8 @@ export interface ApiKey {
   created_at: string;
   last_used: string | null;
   is_active: boolean;
+}
+
+export interface ApiKeyResponse extends APIResponse {
+  data: ApiKey[];
 }


### PR DESCRIPTION
## TODO

- Figure out if / how this should be split up after https://github.com/HHS/simpler-grants-gov/pull/10578 and https://github.com/HHS/simpler-grants-gov/pull/10557 are merged


## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->

Work for #9456 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Following up on work from , this change 
* standardizes handling of missing tokens for authenticated routes by throwing an error rather than making an API request that is doomed to fail
* removes unnecessary checking for session tokens in cases where fetch functionality will naturally handle the case downstream
* standardizes handling of errors thrown from requests missing tokens
* cleans up some fetch handler functions

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. `npm run local` on this branch
2. For each page on the site that requires authentication, visit the page as a logged in user, then log out
3. _VERIFY_: an `Unauthenticated` message is displayed

#### Bonus Points

For each action on the site that requires authentication:

1. visit the page where the action takes place
2. log in
3. manually remove the "session" cookie from your browser session
4. perform the action
5. _VERIFY_: the correct handling of the unauthenticated action is shown
