### PR TITLE
[Issue #10486] Create client for calling SES

### DIFF
--- a/backend/grants_shared/local.env
+++ b/backend/grants_shared/local.env
@@ -33,3 +33,16 @@ DB_SSL_MODE=allow
 HIDE_SQL_PARAMETER_LOGS=TRUE
 
 ALL_DB_SCHEMAS=grants_shared,other
+
+############################
+# AWS
+############################
+
+# This env var is used to set local AWS credentials
+IS_LOCAL_AWS=1
+
+############################
+# AWS SES
+############################
+
+AWS_SES_FROM_EMAIL=noreply@local.test

--- a/backend/grants_shared/pyproject.toml
+++ b/backend/grants_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grants-shared"
-version = "0.2.3"
+version = "0.2.4"
 description = "Shared code used by the Simpler Grants.gov repo"
 readme = "README.md"
 license = "CC0-1.0"

--- a/backend/grants_shared/src/grants_shared/aws/__init__.py
+++ b/backend/grants_shared/src/grants_shared/aws/__init__.py
@@ -1,0 +1,11 @@
+from .aws_session import get_aws_config, get_boto_session, is_local_aws
+from .ses_adapter import SESConfig, get_ses_client, send_email
+
+__all__ = [
+    "get_aws_config",
+    "get_boto_session",
+    "is_local_aws",
+    "get_ses_client",
+    "send_email",
+    "SESConfig",
+]

--- a/backend/grants_shared/src/grants_shared/aws/aws_session.py
+++ b/backend/grants_shared/src/grants_shared/aws/aws_session.py
@@ -1,0 +1,38 @@
+import boto3
+from pydantic import Field
+
+from grants_shared.util.env_config import PydanticBaseEnvConfig
+
+
+class AwsConfig(PydanticBaseEnvConfig):
+    is_local_aws: bool = False
+    aws_region: str = Field(alias="AWS_REGION", default="us-east-1")
+
+
+_aws_config: AwsConfig | None = None
+
+
+def get_aws_config() -> AwsConfig:
+    global _aws_config
+    if _aws_config is None:
+        _aws_config = AwsConfig()
+
+    return _aws_config
+
+
+def is_local_aws() -> bool:
+    """Whether we are running against local AWS which affects the credentials we use (forces them to be not real)"""
+    return get_aws_config().is_local_aws
+
+
+def get_boto_session() -> boto3.Session:
+    config = get_aws_config()
+    if is_local_aws():
+        # Locally, set fake creds so we can't hit actual AWS resources
+        return boto3.Session(
+            aws_access_key_id="NO_CREDS",
+            aws_secret_access_key="NO_CREDS",
+            region_name=config.aws_region,
+        )
+
+    return boto3.Session(region_name=config.aws_region)

--- a/backend/grants_shared/src/grants_shared/aws/ses_adapter.py
+++ b/backend/grants_shared/src/grants_shared/aws/ses_adapter.py
@@ -23,7 +23,7 @@ def get_ses_client(session: boto3.Session | None = None) -> botocore.client.Base
     if session is None:
         session = get_boto_session()
 
-    return session.client("ses")
+    return session.client("sesv2")
 
 
 def send_email(
@@ -33,16 +33,16 @@ def send_email(
     ses_client: botocore.client.BaseClient | None = None,
 ) -> str:
     """
-    Send an email using AWS SES.
+    Send an email using AWS SESv2.
 
     Args:
         to_address: Email address to send to
         subject: Email subject line
         message: Email body (supports both HTML and plain text)
-        ses_client: Optional SES client (for testing)
+        ses_client: Optional SESv2 client (for testing)
 
     Returns:
-        Message ID from SES
+        Message ID from SESv2
 
     Raises:
         Exception: If email fails to send
@@ -65,7 +65,7 @@ def send_email(
 
     try:
         logger.info(
-            "Sending email via SES",
+            "Sending email via SESv2",
             extra={
                 "to_address": to_address,
                 "subject": subject,
@@ -74,14 +74,16 @@ def send_email(
         )
 
         response = ses_client.send_email(
-            Source=config.aws_ses_from_email,
+            FromEmailAddress=config.aws_ses_from_email,
             Destination={"ToAddresses": [to_address]},
-            Message={
-                "Subject": {"Data": subject, "Charset": "UTF-8"},
-                "Body": {
-                    "Text": {"Data": message, "Charset": "UTF-8"},
-                    "Html": {"Data": message, "Charset": "UTF-8"},
-                },
+            Content={
+                "Simple": {
+                    "Subject": {"Data": subject, "Charset": "UTF-8"},
+                    "Body": {
+                        "Text": {"Data": message, "Charset": "UTF-8"},
+                        "Html": {"Data": message, "Charset": "UTF-8"},
+                    },
+                }
             },
         )
 
@@ -89,7 +91,7 @@ def send_email(
         message_id = response_object.message_id
 
         logger.info(
-            "Successfully sent email via SES",
+            "Successfully sent email via SESv2",
             extra={
                 "message_id": message_id,
                 "to_address": to_address,
@@ -98,20 +100,18 @@ def send_email(
 
         return message_id
 
-    except ClientError as e:
+    except ClientError:
         logger.exception(
-            "Failed to send email via SES",
+            "Failed to send email via SESv2",
             extra={
                 "to_address": to_address,
                 "subject": subject,
-                "error_code": e.response.get("Error", {}).get("Code"),
-                "error_message": e.response.get("Error", {}).get("Message"),
             },
         )
-        raise Exception("Failed to send email via SES") from e
+        raise
     except Exception:
         logger.exception(
-            "Unexpected error sending email via SES",
+            "Unexpected error sending email via SESv2",
             extra={
                 "to_address": to_address,
                 "subject": subject,

--- a/backend/grants_shared/src/grants_shared/aws/ses_adapter.py
+++ b/backend/grants_shared/src/grants_shared/aws/ses_adapter.py
@@ -1,0 +1,120 @@
+import logging
+
+import boto3
+import botocore.client
+from botocore.exceptions import ClientError
+from pydantic import BaseModel, Field
+
+from grants_shared.aws.aws_session import get_boto_session, is_local_aws
+from grants_shared.util.env_config import PydanticBaseEnvConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SESConfig(PydanticBaseEnvConfig):
+    aws_ses_from_email: str = Field(alias="AWS_SES_FROM_EMAIL")
+
+
+class SESResponse(BaseModel):
+    message_id: str = Field(alias="MessageId")
+
+
+def get_ses_client(session: boto3.Session | None = None) -> botocore.client.BaseClient:
+    if session is None:
+        session = get_boto_session()
+
+    return session.client("ses")
+
+
+def send_email(
+    to_address: str,
+    subject: str,
+    message: str,
+    ses_client: botocore.client.BaseClient | None = None,
+) -> str:
+    """
+    Send an email using AWS SES.
+
+    Args:
+        to_address: Email address to send to
+        subject: Email subject line
+        message: Email body (supports both HTML and plain text)
+        ses_client: Optional SES client (for testing)
+
+    Returns:
+        Message ID from SES
+
+    Raises:
+        Exception: If email fails to send
+    """
+    config = SESConfig()
+
+    if is_local_aws():
+        logger.info(
+            "Local environment detected - not sending actual email",
+            extra={
+                "to_address": to_address,
+                "subject": subject,
+                "from_address": config.aws_ses_from_email,
+            },
+        )
+        return "local-mock-message-id"
+
+    if ses_client is None:
+        ses_client = get_ses_client()
+
+    try:
+        logger.info(
+            "Sending email via SES",
+            extra={
+                "to_address": to_address,
+                "subject": subject,
+                "from_address": config.aws_ses_from_email,
+            },
+        )
+
+        response = ses_client.send_email(
+            Source=config.aws_ses_from_email,
+            Destination={"ToAddresses": [to_address]},
+            Message={
+                "Subject": {"Data": subject, "Charset": "UTF-8"},
+                "Body": {
+                    "Text": {"Data": message, "Charset": "UTF-8"},
+                    "Html": {"Data": message, "Charset": "UTF-8"},
+                },
+            },
+        )
+
+        response_object = SESResponse.model_validate(response)
+        message_id = response_object.message_id
+
+        logger.info(
+            "Successfully sent email via SES",
+            extra={
+                "message_id": message_id,
+                "to_address": to_address,
+            },
+        )
+
+        return message_id
+
+    except ClientError as e:
+        logger.exception(
+            "Failed to send email via SES",
+            extra={
+                "to_address": to_address,
+                "subject": subject,
+                "error_code": e.response.get("Error", {}).get("Code"),
+                "error_message": e.response.get("Error", {}).get("Message"),
+            },
+        )
+        raise Exception("Failed to send email via SES") from e
+    except Exception:
+        logger.exception(
+            "Unexpected error sending email via SES",
+            extra={
+                "to_address": to_address,
+                "subject": subject,
+            },
+        )
+        raise

--- a/backend/grants_shared/src/grants_shared/aws/ses_adapter.py
+++ b/backend/grants_shared/src/grants_shared/aws/ses_adapter.py
@@ -50,6 +50,7 @@ def send_email(
     config = SESConfig()
 
     if is_local_aws():
+        # the local logger has the email details for debugging
         logger.info(
             "Local environment detected - not sending actual email",
             extra={
@@ -64,14 +65,7 @@ def send_email(
         ses_client = get_ses_client()
 
     try:
-        logger.info(
-            "Sending email via SESv2",
-            extra={
-                "to_address": to_address,
-                "subject": subject,
-                "from_address": config.aws_ses_from_email,
-            },
-        )
+        logger.info("Sending email via SESv2")
 
         response = ses_client.send_email(
             FromEmailAddress=config.aws_ses_from_email,
@@ -94,27 +88,11 @@ def send_email(
             "Successfully sent email via SESv2",
             extra={
                 "message_id": message_id,
-                "to_address": to_address,
             },
         )
 
         return message_id
 
     except ClientError:
-        logger.exception(
-            "Failed to send email via SESv2",
-            extra={
-                "to_address": to_address,
-                "subject": subject,
-            },
-        )
-        raise
-    except Exception:
-        logger.exception(
-            "Unexpected error sending email via SESv2",
-            extra={
-                "to_address": to_address,
-                "subject": subject,
-            },
-        )
+        logger.exception("Failed to send email via SESv2")
         raise

--- a/backend/grants_shared/tests/grants_shared/aws/test_ses_adapter.py
+++ b/backend/grants_shared/tests/grants_shared/aws/test_ses_adapter.py
@@ -8,14 +8,11 @@ import grants_shared.aws.aws_session as aws_session_module
 from grants_shared.aws import send_email
 
 
-def test_send_email_success(ses_client, monkeypatch):
+def test_send_email_success(ses_client):
     """Test successfully sending an email via SES"""
-    from_email = os.getenv("AWS_SES_FROM_EMAIL")
     to_email = "recipient@example.com"
     message_subject = "Test Subject"
     message_body = "This is a test email message"
-
-    ses_client.verify_email_identity(EmailAddress=from_email)
 
     message_id = send_email(
         to_address=to_email,
@@ -30,19 +27,15 @@ def test_send_email_success(ses_client, monkeypatch):
     assert len(ses_backend.sent_messages) == 1
 
     sent_email = ses_backend.sent_messages[0]
-    assert sent_email.source == from_email
+    assert sent_email.source == os.getenv("AWS_SES_FROM_EMAIL")
     assert to_email in sent_email.destinations["ToAddresses"]
     assert sent_email.subject == message_subject
     assert sent_email.body == message_body
 
 
-def test_send_email_html_special_characters(ses_client, monkeypatch):
+def test_send_email_html_special_characters(ses_client):
     """Test sending emails with HTML content and special characters in subject and body"""
-    from_email = os.getenv("AWS_SES_FROM_EMAIL")
     to_email = "recipient@example.com"
-
-    ses_client.verify_email_identity(EmailAddress=from_email)
-
     subject = "Test with émojis 🎉 and spëcial çharacters"
     message = """<html>
                     <body>
@@ -87,11 +80,14 @@ def test_send_email_html_special_characters(ses_client, monkeypatch):
     assert "©" in sent_email.body
 
 
-def test_send_email_unverified_sender(ses_client, monkeypatch):
+def test_send_email_unverified_sender(ses_client):
     """Test that sending from an unverified email address fails"""
     to_email = "recipient@example.com"
     message_subject = "Test Subject"
     message_body = "This is a test email message"
+
+    # Delete the verified email identity to simulate unverified sender
+    ses_client.delete_email_identity(EmailIdentity=os.getenv("AWS_SES_FROM_EMAIL"))
 
     with pytest.raises(Exception) as exc_info:
         send_email(
@@ -101,17 +97,18 @@ def test_send_email_unverified_sender(ses_client, monkeypatch):
             ses_client=ses_client,
         )
 
-    assert "Failed to send email" in str(exc_info.value)
+    # "Email address not verified" is partial of the error message
+    assert "Email address not verified" in str(exc_info.value)
 
 
-def test_send_email_multiple_recipients(ses_client, monkeypatch):
+def test_send_email_multiple_recipients(ses_client):
     """Test sending emails to multiple recipients sequentially"""
     from_email = os.getenv("AWS_SES_FROM_EMAIL")
     recipients = ["recipient1@example.com", "recipient2@example.com", "recipient3@example.com"]
     message_subject = "Test Subject"
     message_body = "This is a test email message"
 
-    ses_client.verify_email_identity(EmailAddress=from_email)
+    ses_client.create_email_identity(EmailIdentity=from_email)
 
     message_ids = []
     for recipient in recipients:

--- a/backend/grants_shared/tests/grants_shared/aws/test_ses_adapter.py
+++ b/backend/grants_shared/tests/grants_shared/aws/test_ses_adapter.py
@@ -103,12 +103,9 @@ def test_send_email_unverified_sender(ses_client):
 
 def test_send_email_multiple_recipients(ses_client):
     """Test sending emails to multiple recipients sequentially"""
-    from_email = os.getenv("AWS_SES_FROM_EMAIL")
     recipients = ["recipient1@example.com", "recipient2@example.com", "recipient3@example.com"]
     message_subject = "Test Subject"
     message_body = "This is a test email message"
-
-    ses_client.create_email_identity(EmailIdentity=from_email)
 
     message_ids = []
     for recipient in recipients:
@@ -127,7 +124,6 @@ def test_send_email_multiple_recipients(ses_client):
 
 def test_send_email_local_environment(monkeypatch):
     """Test that in local environment, emails are not actually sent"""
-
     monkeypatch.setenv("IS_LOCAL_AWS", "1")
 
     # Clear the cached config so it picks up the new environment variable

--- a/backend/grants_shared/tests/grants_shared/aws/test_ses_adapter.py
+++ b/backend/grants_shared/tests/grants_shared/aws/test_ses_adapter.py
@@ -1,0 +1,145 @@
+import os
+
+import pytest
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.ses.models import ses_backends
+
+import grants_shared.aws.aws_session as aws_session_module
+from grants_shared.aws import send_email
+
+
+def test_send_email_success(ses_client, monkeypatch):
+    """Test successfully sending an email via SES"""
+    from_email = os.getenv("AWS_SES_FROM_EMAIL")
+    to_email = "recipient@example.com"
+    message_subject = "Test Subject"
+    message_body = "This is a test email message"
+
+    ses_client.verify_email_identity(EmailAddress=from_email)
+
+    message_id = send_email(
+        to_address=to_email,
+        subject=message_subject,
+        message=message_body,
+        ses_client=ses_client,
+    )
+
+    assert message_id is not None
+
+    ses_backend = ses_backends[DEFAULT_ACCOUNT_ID][ses_client.meta.region_name]
+    assert len(ses_backend.sent_messages) == 1
+
+    sent_email = ses_backend.sent_messages[0]
+    assert sent_email.source == from_email
+    assert to_email in sent_email.destinations["ToAddresses"]
+    assert sent_email.subject == message_subject
+    assert sent_email.body == message_body
+
+
+def test_send_email_html_special_characters(ses_client, monkeypatch):
+    """Test sending emails with HTML content and special characters in subject and body"""
+    from_email = os.getenv("AWS_SES_FROM_EMAIL")
+    to_email = "recipient@example.com"
+
+    ses_client.verify_email_identity(EmailAddress=from_email)
+
+    subject = "Test with émojis 🎉 and spëcial çharacters"
+    message = """<html>
+                    <body>
+                        <h1>Test Email with Special Characters</h1>
+                        <p>Message with special characters: €, £, ¥, ñ, ü</p>
+                        <p>Emojis: 🚀 📧 ✅ 🎉</p>
+                        <ul>
+                            <li>Currency: € £ ¥</li>
+                            <li>Accents: é ñ ü ç</li>
+                            <li>Symbols: © ® ™</li>
+                        </ul>
+                    </body>
+                </html>"""
+
+    message_id = send_email(
+        to_address=to_email,
+        subject=subject,
+        message=message,
+        ses_client=ses_client,
+    )
+
+    assert message_id is not None
+
+    # Verify special characters and HTML content are preserved correctly
+    ses_backend = ses_backends[DEFAULT_ACCOUNT_ID][ses_client.meta.region_name]
+    sent_email = ses_backend.sent_messages[0]
+
+    # Verify subject with special characters
+    assert sent_email.subject == subject
+    assert "🎉" in sent_email.subject
+    assert "émojis" in sent_email.subject
+
+    # Verify HTML content is preserved
+    assert sent_email.body == message
+    assert "<html>" in sent_email.body
+    assert "<h1>Test Email with Special Characters</h1>" in sent_email.body
+
+    # Verify special characters in HTML body
+    assert "€" in sent_email.body
+    assert "🚀" in sent_email.body
+    assert "ñ" in sent_email.body
+    assert "©" in sent_email.body
+
+
+def test_send_email_unverified_sender(ses_client, monkeypatch):
+    """Test that sending from an unverified email address fails"""
+    to_email = "recipient@example.com"
+    message_subject = "Test Subject"
+    message_body = "This is a test email message"
+
+    with pytest.raises(Exception) as exc_info:
+        send_email(
+            to_address=to_email,
+            subject=message_subject,
+            message=message_body,
+            ses_client=ses_client,
+        )
+
+    assert "Failed to send email" in str(exc_info.value)
+
+
+def test_send_email_multiple_recipients(ses_client, monkeypatch):
+    """Test sending emails to multiple recipients sequentially"""
+    from_email = os.getenv("AWS_SES_FROM_EMAIL")
+    recipients = ["recipient1@example.com", "recipient2@example.com", "recipient3@example.com"]
+    message_subject = "Test Subject"
+    message_body = "This is a test email message"
+
+    ses_client.verify_email_identity(EmailAddress=from_email)
+
+    message_ids = []
+    for recipient in recipients:
+        message_id = send_email(
+            to_address=recipient,
+            subject=message_subject,
+            message=message_body,
+            ses_client=ses_client,
+        )
+        message_ids.append(message_id)
+
+    ses_backend = ses_backends[DEFAULT_ACCOUNT_ID][ses_client.meta.region_name]
+    assert len(ses_backend.sent_messages) == len(recipients)
+    assert all(isinstance(msg.id, str) and len(msg.id) > 0 for msg in ses_backend.sent_messages)
+
+
+def test_send_email_local_environment(monkeypatch):
+    """Test that in local environment, emails are not actually sent"""
+
+    monkeypatch.setenv("IS_LOCAL_AWS", "1")
+
+    # Clear the cached config so it picks up the new environment variable
+    aws_session_module._aws_config = None
+
+    message_id = send_email(
+        to_address="test@example.com",
+        subject="Local Test",
+        message="This should not actually send",
+    )
+
+    assert message_id == "local-mock-message-id"

--- a/backend/grants_shared/tests/grants_shared/conftest.py
+++ b/backend/grants_shared/tests/grants_shared/conftest.py
@@ -1,7 +1,9 @@
 import uuid
 
 import _pytest.monkeypatch
+import boto3
 import pytest
+from moto import mock_aws
 
 from grants_shared.adapters import db
 from grants_shared.db.models.base import metadata
@@ -111,3 +113,19 @@ def db_session(db_client: db.DBClient) -> db.Session:
     """
     with db_client.get_session() as session:
         yield session
+
+
+#################
+# AWS Mocking
+#################
+
+
+@pytest.fixture
+def ses_client(monkeypatch):
+    """
+    Create a mocked SES client using moto. The mock is automatically cleaned up after the test.
+    """
+    monkeypatch.setenv("IS_LOCAL_AWS", "0")
+
+    with mock_aws():
+        yield boto3.client("ses", region_name="us-east-1")

--- a/backend/grants_shared/tests/grants_shared/conftest.py
+++ b/backend/grants_shared/tests/grants_shared/conftest.py
@@ -1,6 +1,5 @@
-import uuid
-
 import os
+import uuid
 
 import _pytest.monkeypatch
 import boto3

--- a/backend/grants_shared/tests/grants_shared/conftest.py
+++ b/backend/grants_shared/tests/grants_shared/conftest.py
@@ -1,5 +1,7 @@
 import uuid
 
+import os
+
 import _pytest.monkeypatch
 import boto3
 import pytest
@@ -123,9 +125,11 @@ def db_session(db_client: db.DBClient) -> db.Session:
 @pytest.fixture
 def ses_client(monkeypatch):
     """
-    Create a mocked SES client using moto. The mock is automatically cleaned up after the test.
+    Create a mocked SESv2 client using moto. The mock is automatically cleaned up after the test.
     """
     monkeypatch.setenv("IS_LOCAL_AWS", "0")
 
     with mock_aws():
-        yield boto3.client("ses", region_name="us-east-1")
+        ses_client = boto3.client("sesv2", region_name="us-east-1")
+        ses_client.create_email_identity(EmailIdentity=os.getenv("AWS_SES_FROM_EMAIL"))
+        yield ses_client

--- a/backend/grants_shared/uv.lock
+++ b/backend/grants_shared/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.3"
+version = "0.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "apiflask" },


### PR DESCRIPTION
## Summary

Fixes #10486 

## Changes proposed

We want to add an adapter for calling SES, similar to the one we have for calling Pinpoint. We just need the client to wrap the [send_email](https://docs.aws.amazon.com/boto3/latest/reference/services/ses/client/send_email.html) function of the SES client.

## Context for reviewers

Related to https://github.com/HHS/simpler-grants-gov/issues/9836. Infra is handling infra portion setup and add SES. Backend engineers need to build and test backend and remove pinpoint

Create this client in our grants_shared package - do not create it under api

The client should have a configuration with AWS_SES_FROM_EMAIL - the email we'll send from. This'll be configured by infra, set something in local.env.

Our function should take in:

Who to send the email to
Subject
Message
We should send an email, handling any errors gracefully.

The response from SES looks to just be a message ID, log and return that.

Unlike pinpoint, SES has its functionality mocked out by moto3 (the mock boto3 we use for unit tests) so we can set that up instead of creating the hacky mock for pinpoint: https://docs.getmoto.org/en/latest/docs/services/ses.html

This ticket won't yet swap existing functionality to use this client, we'll have follow-up tickets to switchover.

## Validation steps

- Create a client for interacting with SES in our grants_shared code
- Setup any test utils in conftest for SES - use them to write unit tests for sending the emails
- When running locally, we shouldn't actually send anything, we're not going to have a service to call for real - should just do a log
