### PR TITLE
[Issue #10630] Add tcertificate id logging

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_auth.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_auth.py
@@ -143,10 +143,17 @@ def get_soap_auth(mtls_cert: str | None, db_session: db.Session) -> SOAPAuth:
     if tcertificate.expirationdate and tcertificate.expirationdate <= get_now_us_eastern_date():
         logger.info(
             "soap_client_certificate: tcertificate is expired",
-            extra={"soap_api_event": LegacySoapApiEvent.CERT_EXPIRED},
+            extra={
+                "soap_api_event": LegacySoapApiEvent.CERT_EXPIRED,
+                "tcertificates_id": tcertificate.tcertificates_id,
+            },
         )
         raise SOAPClientCertificateIsExpired("tcertificate is expired")
 
+    logger.info(
+        "soap_client_certificate: valid tcertificate located",
+        extra={"tcertificates_id": tcertificate.tcertificates_id},
+    )
     legacy_certificate = get_legacy_certificate_by_serial_number(db_session, serial_number_hex)
 
     if not legacy_certificate:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_auth.py
@@ -291,13 +291,34 @@ def test_get_soap_auth_when_tcertificate_is_expired(
 ) -> None:
     caplog.set_level(logging.INFO)
     mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
-    StagingTcertificatesFactory(serial_num=serial_number, expirationdate=date(2000, 1, 1))
+    tcert = StagingTcertificatesFactory(serial_num=serial_number, expirationdate=date(2000, 1, 1))
     with pytest.raises(SOAPClientCertificateIsExpired):
         get_soap_auth(mtls_cert, db_session)
-    records = [
+    record = next(
         r for r in caplog.records if "soap_client_certificate: tcertificate is expired" in r.message
-    ]
-    assert len(records) == 1
+    )
+    assert record is not None
+    assert record.tcertificates_id == tcert.tcertificates_id
+
+
+def test_get_soap_auth_logs_tcertificate(enable_factory_create, db_session, caplog) -> None:
+    caplog.set_level(logging.INFO)
+    mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
+    tcert = StagingTcertificatesFactory.create(
+        serial_num=serial_number, expirationdate=(UTC_NOW + timedelta(days=100)).date()
+    )
+    LegacyAgencyCertificateFactory.create(
+        serial_number=tcert.serial_num, expiration_date=date(2000, 1, 1)
+    )
+    with pytest.raises(SOAPClientCertificateIsExpired):
+        get_soap_auth(mtls_cert, db_session)
+    record = next(
+        r
+        for r in caplog.records
+        if "soap_client_certificate: valid tcertificate located" in r.message
+    )
+    assert record is not None
+    assert record.tcertificates_id == tcert.tcertificates_id
 
 
 def test_get_soap_auth_when_legacy_certificate_is_expired(


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10630  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Logging for `tcertificates_id`

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
It's helpful to know that if a tcertificate is found, we can know exactly which one it is. 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] hit endpoint, check tcertificates id in log
