### PR TITLE
[Issue #9715] Create an endpoint for getting a presigned url for uploading a file by a user

### DIFF
--- a/api/src/api/files_v1/file_routes.py
+++ b/api/src/api/files_v1/file_routes.py
@@ -46,7 +46,6 @@ def create_presigned_upload_route(db_session: db.Session, json_data: dict) -> re
             db_session=db_session,
             user=user,
             request_data=json_data,
-            dynamodb_client=DynamoDBClient(),
         )
 
     add_extra_data_to_current_request_logs({"pending_file_id": result.pending_file_id})

--- a/api/src/api/files_v1/file_routes.py
+++ b/api/src/api/files_v1/file_routes.py
@@ -13,10 +13,52 @@ from src.adapters.aws.dynamodb_adapter import DynamoDBClient
 from src.api.files_v1.file_blueprint import file_blueprint
 from src.auth.api_user_key_auth import api_user_key_auth
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
+from src.services.files.create_presigned_upload import create_presigned_upload
 from src.services.files.stream_file_scan_results import stream_file_scan_results
 from src.services.files.update_pending_file_scan_status import update_pending_file_scan_status
 
 logger = logging.getLogger(__name__)
+
+
+@file_blueprint.post("")
+@file_blueprint.input(file_schemas.CreatePresignedUploadRequestSchema, location="json")
+@file_blueprint.output(file_schemas.CreatePresignedUploadResponseSchema)
+@file_blueprint.doc(
+    summary="Create a presigned upload URL",
+    description=(
+        "Generate a presigned s3 URL the caller can POST a file to. Creates a "
+        "pending file record and a DynamoDB row tracking the scan status. The "
+        "caller is responsible for performing the multipart POST to the "
+        "returned URL with the returned body fields and the file attached."
+    ),
+    responses=[200, 401, 429],
+)
+@file_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def create_presigned_upload_route(db_session: db.Session, json_data: dict) -> response.ApiResponse:
+    user = jwt_or_api_user_key_multi_auth.get_user()
+    add_extra_data_to_current_request_logs({"user_id": user.user_id})
+    logger.info("POST /v1/files")
+
+    with db_session.begin():
+        db_session.add(user)
+        result = create_presigned_upload(
+            db_session=db_session,
+            user=user,
+            request_data=json_data,
+            dynamodb_client=DynamoDBClient(),
+        )
+
+    add_extra_data_to_current_request_logs({"pending_file_id": result.pending_file_id})
+
+    return response.ApiResponse(
+        message="Success",
+        data={
+            "url": result.url,
+            "body": result.body,
+            "pending_file_id": result.pending_file_id,
+        },
+    )
 
 
 @file_blueprint.post("/<uuid:pending_file_id>")

--- a/api/src/api/files_v1/file_schemas.py
+++ b/api/src/api/files_v1/file_schemas.py
@@ -1,4 +1,4 @@
-from src.api.schemas.extension import Schema, fields
+from src.api.schemas.extension import Schema, fields, validators
 from src.api.schemas.response_schema import AbstractResponseSchema
 from src.constants.lookup_constants import FileScanStatus
 
@@ -16,6 +16,51 @@ class FileScanStatusUpdateRequestSchema(Schema):
 
 class FileScanStatusUpdateResponseSchema(AbstractResponseSchema):
     pass
+
+
+class CreatePresignedUploadRequestSchema(Schema):
+    file_name = fields.String(
+        required=True,
+        validate=validators.Length(min=1, max=100),
+        metadata={
+            "description": "The name of the file to upload",
+            "example": "example.txt",
+        },
+    )
+    mime_type = fields.String(
+        required=True,
+        metadata={
+            "description": "The mime/content type of the file to upload",
+            "example": "text/plain",
+        },
+    )
+
+
+class PresignedUploadDataSchema(Schema):
+    url = fields.String(
+        metadata={
+            "description": "The presigned URL the caller should POST the file to",
+            "example": "https://example-bucket.s3.amazonaws.com/",
+        },
+    )
+    body = fields.Dict(
+        metadata={
+            "description": (
+                "The form fields the caller must include in the multipart POST "
+                "alongside the file. Send these as form data, with the file "
+                "attached under the 'file' field."
+            ),
+        },
+    )
+    pending_file_id = fields.UUID(
+        metadata={
+            "description": "The ID of the pending file record",
+        },
+    )
+
+
+class CreatePresignedUploadResponseSchema(AbstractResponseSchema):
+    data = fields.Nested(PresignedUploadDataSchema)
 
 
 class FileScanResultsDataSchema(Schema):

--- a/api/src/services/files/create_presigned_upload.py
+++ b/api/src/services/files/create_presigned_upload.py
@@ -10,7 +10,7 @@ from sqlalchemy import func, select
 
 import src.adapters.db as db
 import src.util.file_util as file_util
-from src.adapters.aws import S3Config, get_boto_session, get_s3_client
+from src.adapters.aws import S3Config
 from src.adapters.aws.dynamodb_adapter import DynamoDBClient, DynamoDBConfig
 from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
@@ -21,12 +21,6 @@ from src.util.env_config import PydanticBaseEnvConfig
 from src.validation.validation_constants import ValidationErrorType
 
 logger = logging.getLogger(__name__)
-
-
-# 2 GB - max file size we allow for uploads. The presigned POST policy enforces
-# this at the s3 layer so the user can't bypass it by sending a larger file.
-_MAX_FILE_UPLOAD_SIZE_BYTES = 2 * 1024 * 1024 * 1024
-_MIN_FILE_UPLOAD_SIZE_BYTES = 1
 
 
 class PresignedUploadConfig(PydanticBaseEnvConfig):
@@ -64,41 +58,6 @@ def _build_s3_file_location(s3_config: S3Config, pending_file_id: uuid.UUID, fil
     )
 
 
-def _generate_presigned_post(
-    s3_config: S3Config,
-    s3_file_location: str,
-    pending_file_id: uuid.UUID,
-    user_id: uuid.UUID,
-    mime_type: str,
-) -> dict[str, Any]:
-    """Generate a presigned POST URL + body for uploading a single file to s3.
-
-    The returned dict has ``url`` and ``fields`` keys per boto3's
-    ``generate_presigned_post``. We pass ``IfNoneMatch=*`` to ensure callers
-    can't reuse a presigned URL to overwrite an existing s3 object.
-    """
-    s3_client = get_s3_client(s3_config, get_boto_session())
-    bucket, key = file_util.split_s3_url(s3_file_location)
-
-    return s3_client.generate_presigned_post(
-        Bucket=bucket,
-        Key=key,
-        Fields={
-            "Content-Type": mime_type,
-            "x-amz-meta-file-id": str(pending_file_id),
-            "x-amz-meta-user-id": str(user_id),
-        },
-        Conditions=[
-            ["content-length-range", _MIN_FILE_UPLOAD_SIZE_BYTES, _MAX_FILE_UPLOAD_SIZE_BYTES],
-            {"Content-Type": mime_type},
-            {"x-amz-meta-file-id": str(pending_file_id)},
-            {"x-amz-meta-user-id": str(user_id)},
-            {"IfNoneMatch": "*"},
-        ],
-        ExpiresIn=s3_config.presigned_s3_duration,
-    )
-
-
 def _write_scan_record(
     dynamodb_client: DynamoDBClient,
     dynamodb_config: DynamoDBConfig,
@@ -119,13 +78,15 @@ def create_presigned_upload(
     db_session: db.Session,
     user: User,
     request_data: dict,
-    dynamodb_client: DynamoDBClient,
     s3_config: S3Config | None = None,
+    dynamodb_client: DynamoDBClient | None = None,
     dynamodb_config: DynamoDBConfig | None = None,
     config: PresignedUploadConfig | None = None,
 ) -> PresignedUploadResult:
     if s3_config is None:
         s3_config = S3Config()
+    if dynamodb_client is None:
+        dynamodb_client = DynamoDBClient()
     if dynamodb_config is None:
         dynamodb_config = DynamoDBConfig()
     if config is None:
@@ -180,15 +141,15 @@ def create_presigned_upload(
         file_scan_status=FileScanStatus.PENDING,
     )
     db_session.add(pending_file)
-    # Flush so the row is in place before we write to DynamoDB.
-    db_session.flush()
 
-    presigned = _generate_presigned_post(
+    presigned = file_util.pre_sign_upload(
+        file_path=s3_file_location,
+        content_type=mime_type,
+        metadata={
+            "file-id": str(pending_file_id),
+            "user-id": str(user.user_id),
+        },
         s3_config=s3_config,
-        s3_file_location=s3_file_location,
-        pending_file_id=pending_file_id,
-        user_id=user.user_id,
-        mime_type=mime_type,
     )
 
     _write_scan_record(

--- a/api/src/services/files/create_presigned_upload.py
+++ b/api/src/services/files/create_presigned_upload.py
@@ -1,0 +1,214 @@
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from grants_shared.util import datetime_util
+from pydantic import Field
+from sqlalchemy import func, select
+
+import src.adapters.db as db
+import src.util.file_util as file_util
+from src.adapters.aws import S3Config, get_boto_session, get_s3_client
+from src.adapters.aws.dynamodb_adapter import DynamoDBClient, DynamoDBConfig
+from src.api.response import ValidationErrorDetail
+from src.api.route_utils import raise_flask_error
+from src.constants.lookup_constants import FileScanStatus
+from src.db.models.file_upload_models import PendingFile
+from src.db.models.user_models import User
+from src.util.env_config import PydanticBaseEnvConfig
+from src.validation.validation_constants import ValidationErrorType
+
+logger = logging.getLogger(__name__)
+
+
+# 2 GB - max file size we allow for uploads. The presigned POST policy enforces
+# this at the s3 layer so the user can't bypass it by sending a larger file.
+_MAX_FILE_UPLOAD_SIZE_BYTES = 2 * 1024 * 1024 * 1024
+_MIN_FILE_UPLOAD_SIZE_BYTES = 1
+
+
+class PresignedUploadConfig(PydanticBaseEnvConfig):
+    pending_file_upload_rate_window_hours: int = Field(
+        default=1, alias="PENDING_FILE_UPLOAD_RATE_WINDOW_HOURS"
+    )
+    pending_file_upload_rate_limit: int = Field(default=100, alias="PENDING_FILE_UPLOAD_RATE_LIMIT")
+
+
+@dataclass(frozen=True)
+class PresignedUploadResult:
+    pending_file_id: uuid.UUID
+    url: str
+    body: dict[str, Any]
+
+
+def _count_recent_pending_files(
+    db_session: db.Session, user_id: uuid.UUID, window_hours: int
+) -> int:
+    cutoff = datetime_util.utcnow() - timedelta(hours=window_hours)
+    stmt = (
+        select(func.count())
+        .select_from(PendingFile)
+        .where(PendingFile.user_id == user_id, PendingFile.created_at >= cutoff)
+    )
+    return db_session.execute(stmt).scalar_one()
+
+
+def _build_s3_file_location(s3_config: S3Config, pending_file_id: uuid.UUID, file_name: str) -> str:
+    return file_util.join(
+        s3_config.file_scan_bucket_path,
+        "unscanned",
+        str(pending_file_id),
+        file_name,
+    )
+
+
+def _generate_presigned_post(
+    s3_config: S3Config,
+    s3_file_location: str,
+    pending_file_id: uuid.UUID,
+    user_id: uuid.UUID,
+    mime_type: str,
+) -> dict[str, Any]:
+    """Generate a presigned POST URL + body for uploading a single file to s3.
+
+    The returned dict has ``url`` and ``fields`` keys per boto3's
+    ``generate_presigned_post``. We pass ``IfNoneMatch=*`` to ensure callers
+    can't reuse a presigned URL to overwrite an existing s3 object.
+    """
+    s3_client = get_s3_client(s3_config, get_boto_session())
+    bucket, key = file_util.split_s3_url(s3_file_location)
+
+    return s3_client.generate_presigned_post(
+        Bucket=bucket,
+        Key=key,
+        Fields={
+            "Content-Type": mime_type,
+            "x-amz-meta-file-id": str(pending_file_id),
+            "x-amz-meta-user-id": str(user_id),
+        },
+        Conditions=[
+            ["content-length-range", _MIN_FILE_UPLOAD_SIZE_BYTES, _MAX_FILE_UPLOAD_SIZE_BYTES],
+            {"Content-Type": mime_type},
+            {"x-amz-meta-file-id": str(pending_file_id)},
+            {"x-amz-meta-user-id": str(user_id)},
+            {"IfNoneMatch": "*"},
+        ],
+        ExpiresIn=s3_config.presigned_s3_duration,
+    )
+
+
+def _write_scan_record(
+    dynamodb_client: DynamoDBClient,
+    dynamodb_config: DynamoDBConfig,
+    pending_file_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    dynamodb_client.put_item(
+        table_name=dynamodb_config.file_scan_cache_table_name,
+        item={
+            "file_id": {"S": str(pending_file_id)},
+            "user_id": {"S": str(user_id)},
+            "status": {"S": FileScanStatus.PENDING.value},
+        },
+    )
+
+
+def create_presigned_upload(
+    db_session: db.Session,
+    user: User,
+    request_data: dict,
+    dynamodb_client: DynamoDBClient,
+    s3_config: S3Config | None = None,
+    dynamodb_config: DynamoDBConfig | None = None,
+    config: PresignedUploadConfig | None = None,
+) -> PresignedUploadResult:
+    if s3_config is None:
+        s3_config = S3Config()
+    if dynamodb_config is None:
+        dynamodb_config = DynamoDBConfig()
+    if config is None:
+        config = PresignedUploadConfig()
+
+    file_name = request_data["file_name"]
+    mime_type = request_data["mime_type"]
+
+    recent_count = _count_recent_pending_files(
+        db_session, user.user_id, config.pending_file_upload_rate_window_hours
+    )
+    if recent_count >= config.pending_file_upload_rate_limit:
+        logger.info(
+            "User exceeded pending file upload rate limit",
+            extra={
+                "user_id": user.user_id,
+                "recent_pending_file_count": recent_count,
+                "pending_file_upload_rate_limit": config.pending_file_upload_rate_limit,
+                "pending_file_upload_rate_window_hours": (
+                    config.pending_file_upload_rate_window_hours
+                ),
+            },
+        )
+        raise_flask_error(
+            429,
+            message="Too many pending file uploads",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.PENDING_FILE_UPLOAD_LIMIT_EXCEEDED,
+                    message=(
+                        f"User has uploaded more than "
+                        f"{config.pending_file_upload_rate_limit} files in the past "
+                        f"{config.pending_file_upload_rate_window_hours} hour(s)"
+                    ),
+                )
+            ],
+        )
+
+    # secure_filename makes the file safe for path operations and strips
+    # non-ascii characters before we hand it to s3.
+    secure_file_name = file_util.get_secure_file_name(file_name)
+
+    pending_file_id = uuid.uuid4()
+    s3_file_location = _build_s3_file_location(s3_config, pending_file_id, secure_file_name)
+
+    pending_file = PendingFile(
+        pending_file_id=pending_file_id,
+        user=user,
+        file_name=file_name,
+        file_location=s3_file_location,
+        mime_type=mime_type,
+        file_scan_status=FileScanStatus.PENDING,
+    )
+    db_session.add(pending_file)
+    # Flush so the row is in place before we write to DynamoDB.
+    db_session.flush()
+
+    presigned = _generate_presigned_post(
+        s3_config=s3_config,
+        s3_file_location=s3_file_location,
+        pending_file_id=pending_file_id,
+        user_id=user.user_id,
+        mime_type=mime_type,
+    )
+
+    _write_scan_record(
+        dynamodb_client=dynamodb_client,
+        dynamodb_config=dynamodb_config,
+        pending_file_id=pending_file_id,
+        user_id=user.user_id,
+    )
+
+    logger.info(
+        "Created presigned upload for pending file",
+        extra={
+            "pending_file_id": pending_file_id,
+            "user_id": user.user_id,
+            "file_scan_status": FileScanStatus.PENDING,
+        },
+    )
+
+    return PresignedUploadResult(
+        pending_file_id=pending_file_id,
+        url=presigned["url"],
+        body=presigned["fields"],
+    )

--- a/api/src/util/file_util.py
+++ b/api/src/util/file_util.py
@@ -10,6 +10,7 @@ from botocore.config import Config
 from werkzeug.utils import secure_filename
 
 from src.adapters.aws import S3Config, get_boto_session, get_s3_client
+from src.app_config import AppConfig
 
 ##################################
 # Path parsing utils
@@ -114,6 +115,57 @@ def pre_sign_file_location(file_path: str, s3_config: S3Config | None = None) ->
         )
 
     return pre_sign_file_loc
+
+
+def pre_sign_upload(
+    file_path: str,
+    content_type: str,
+    metadata: dict[str, str],
+    s3_config: S3Config | None = None,
+) -> dict[str, Any]:
+    """Generate a presigned POST URL + body for uploading a file to s3.
+
+    The returned dict has a ``url`` (where the caller POSTs the file) and
+    ``fields`` (form fields the caller must include in the POST). The
+    presigned policy:
+
+    - Pins Content-Type so the caller can't override how s3 serves the file
+      back later.
+    - Sets each ``metadata`` entry as an ``x-amz-meta-<key>`` field and pins
+      it in the conditions list so the caller can't tamper with it. This is
+      how the scanning lambda picks up identifiers (file id, user id, ...)
+      off the s3 object without needing a separate lookup.
+    - Bounds the upload size between 1 byte and
+      ``AppConfig.max_file_upload_size_bytes``.
+    - Sets ``IfNoneMatch: *`` so the URL can't be replayed to overwrite an
+      already-uploaded object.
+
+    Args:
+        file_path: Full ``s3://bucket/key`` path where the upload will land.
+        content_type: MIME type of the file being uploaded.
+        metadata: Key→value pairs to attach as object metadata. Keys are
+            passed through to s3 as ``x-amz-meta-<key>``.
+    """
+    if s3_config is None:
+        s3_config = get_default_s3_config()
+
+    s3_client = get_s3_client(s3_config)
+    bucket, key = split_s3_url(file_path)
+
+    metadata_fields = {f"x-amz-meta-{k}": v for k, v in metadata.items()}
+
+    return s3_client.generate_presigned_post(
+        Bucket=bucket,
+        Key=key,
+        Fields={"Content-Type": content_type, **metadata_fields},
+        Conditions=[
+            ["content-length-range", 1, AppConfig().max_file_upload_size_bytes],
+            {"Content-Type": content_type},
+            *[{k: v} for k, v in metadata_fields.items()],
+            {"IfNoneMatch": "*"},
+        ],
+        ExpiresIn=s3_config.presigned_s3_duration,
+    )
 
 
 def get_file_length_bytes(path: str) -> int:

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -54,3 +54,6 @@ class ValidationErrorType(StrEnum):
     ORGANIZATION_NO_SAM_GOV_ENTITY = "organization_no_sam_gov_entity"
     ORGANIZATION_INACTIVE_IN_SAM_GOV = "organization_inactive_in_sam_gov"
     ORGANIZATION_SAM_GOV_EXPIRED = "organization_sam_gov_expired"
+
+    # File upload validation error types
+    PENDING_FILE_UPLOAD_LIMIT_EXCEEDED = "pending_file_upload_limit_exceeded"

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -494,10 +494,23 @@ def other_mock_s3_bucket(other_mock_s3_bucket_resource):
 
 
 @pytest.fixture
-def s3_config(mock_s3_bucket, other_mock_s3_bucket):
+def mock_file_scan_s3_bucket_resource(mock_s3):
+    bucket = mock_s3.Bucket("local-mock-file-scan-bucket")
+    bucket.create()
+    return bucket
+
+
+@pytest.fixture
+def mock_file_scan_s3_bucket(mock_file_scan_s3_bucket_resource):
+    return mock_file_scan_s3_bucket_resource.name
+
+
+@pytest.fixture
+def s3_config(mock_s3_bucket, other_mock_s3_bucket, mock_file_scan_s3_bucket):
     return S3Config(
         PUBLIC_FILES_BUCKET=f"s3://{mock_s3_bucket}",
         DRAFT_FILES_BUCKET=f"s3://{other_mock_s3_bucket}",
+        FILE_SCAN_BUCKET=f"s3://{mock_file_scan_s3_bucket}",
     )
 
 

--- a/api/tests/src/api/files_v1/test_create_presigned_upload.py
+++ b/api/tests/src/api/files_v1/test_create_presigned_upload.py
@@ -227,8 +227,7 @@ class TestCreatePresignedUpload429:
     ):
         # Use a smaller limit so the test stays fast
         monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_LIMIT", "3")
-        for _ in range(3):
-            factories.PendingFileFactory.create(user=user)
+        factories.PendingFileFactory.create_batch(size=3, user=user)
 
         resp = client.post(
             URL,
@@ -248,16 +247,15 @@ class TestCreatePresignedUpload429:
         user,
         user_auth_token,
         aws_mocks,
-        db_session,
         monkeypatch,
     ):
         monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_LIMIT", "2")
         monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_WINDOW_HOURS", "1")
 
-        old_pending_file = factories.PendingFileFactory.create(user=user)
-        # Backdate the row past the rate-limit window so it doesn't count
-        old_pending_file.created_at = datetime_util.utcnow() - timedelta(hours=2)
-        db_session.commit()
+        # Backdate this row past the rate-limit window so it doesn't count
+        factories.PendingFileFactory.create(
+            user=user, created_at=datetime_util.utcnow() - timedelta(hours=2)
+        )
 
         # One recent pending file -- still under the limit of 2
         factories.PendingFileFactory.create(user=user)
@@ -279,8 +277,7 @@ class TestCreatePresignedUpload429:
     ):
         monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_LIMIT", "2")
         other_user = factories.UserFactory.create()
-        for _ in range(5):
-            factories.PendingFileFactory.create(user=other_user)
+        factories.PendingFileFactory.create_batch(size=5, user=other_user)
 
         resp = client.post(
             URL,

--- a/api/tests/src/api/files_v1/test_create_presigned_upload.py
+++ b/api/tests/src/api/files_v1/test_create_presigned_upload.py
@@ -1,0 +1,290 @@
+import uuid
+from datetime import timedelta
+
+import boto3
+import pytest
+from grants_shared.util import datetime_util
+from sqlalchemy import select
+
+import tests.src.db.models.factories as factories
+from src.constants.lookup_constants import FileScanStatus
+from src.db.models.file_upload_models import PendingFile
+from src.validation.validation_constants import ValidationErrorType
+
+URL = "/v1/files"
+
+
+@pytest.fixture
+def dynamodb_boto_client(file_scan_dynamodb_table):
+    """boto3 client for asserting on records the route wrote. Shares moto state."""
+    return boto3.client("dynamodb", region_name="us-east-1")
+
+
+@pytest.fixture
+def aws_mocks(
+    mock_file_scan_s3_bucket,
+    file_scan_dynamodb_table,
+):
+    """Bundle the s3 + dynamodb fixtures this endpoint needs."""
+    return {
+        "bucket": mock_file_scan_s3_bucket,
+        "table": file_scan_dynamodb_table,
+    }
+
+
+def _get_dynamodb_item(dynamodb_client, table_name, pending_file_id):
+    return dynamodb_client.get_item(
+        TableName=table_name,
+        Key={"file_id": {"S": str(pending_file_id)}},
+    ).get("Item")
+
+
+class TestCreatePresignedUploadSuccess:
+    def test_creates_pending_file_and_scan_record(
+        self,
+        client,
+        user,
+        user_auth_token,
+        db_session,
+        aws_mocks,
+        dynamodb_boto_client,
+    ):
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "example.txt", "mime_type": "text/plain"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["message"] == "Success"
+
+        data = body["data"]
+        pending_file_id = uuid.UUID(data["pending_file_id"])
+        assert data["url"].startswith("http")
+        assert data["body"]["x-amz-meta-file-id"] == str(pending_file_id)
+        assert data["body"]["x-amz-meta-user-id"] == str(user.user_id)
+        assert data["body"]["Content-Type"] == "text/plain"
+
+        pending_file = db_session.execute(
+            select(PendingFile).where(PendingFile.pending_file_id == pending_file_id)
+        ).scalar_one()
+        assert pending_file.user_id == user.user_id
+        assert pending_file.file_name == "example.txt"
+        assert pending_file.mime_type == "text/plain"
+        assert pending_file.file_scan_status == FileScanStatus.PENDING
+        assert pending_file.file_location.endswith(f"/unscanned/{pending_file_id}/example.txt")
+
+        item = _get_dynamodb_item(dynamodb_boto_client, aws_mocks["table"], pending_file_id)
+        assert item is not None
+        assert item["file_id"]["S"] == str(pending_file_id)
+        assert item["user_id"]["S"] == str(user.user_id)
+        assert item["status"]["S"] == FileScanStatus.PENDING.value
+
+    def test_secures_unsafe_file_name(
+        self,
+        client,
+        user_auth_token,
+        db_session,
+        aws_mocks,
+    ):
+        unsafe_name = "../../etc/passwd weird name.txt"
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": unsafe_name, "mime_type": "text/plain"},
+        )
+
+        assert resp.status_code == 200
+        pending_file_id = uuid.UUID(resp.get_json()["data"]["pending_file_id"])
+
+        pending_file = db_session.execute(
+            select(PendingFile).where(PendingFile.pending_file_id == pending_file_id)
+        ).scalar_one()
+        # secure_filename strips directory traversal and replaces unsafe characters
+        assert "../" not in pending_file.file_location
+        assert " " not in pending_file.file_location
+        assert pending_file.file_location.endswith("/passwd_weird_name.txt")
+        # We preserve the original file name on the DB record for display
+        assert pending_file.file_name == unsafe_name
+
+    def test_works_with_api_user_key_auth(
+        self,
+        client,
+        user_api_key,
+        db_session,
+        aws_mocks,
+    ):
+        resp = client.post(
+            URL,
+            headers={"X-API-Key": user_api_key.key_id},
+            json={"file_name": "report.pdf", "mime_type": "application/pdf"},
+        )
+
+        assert resp.status_code == 200
+        pending_file_id = uuid.UUID(resp.get_json()["data"]["pending_file_id"])
+
+        pending_file = db_session.execute(
+            select(PendingFile).where(PendingFile.pending_file_id == pending_file_id)
+        ).scalar_one()
+        assert pending_file.user_id == user_api_key.user_id
+
+    def test_presigned_url_points_to_file_scan_bucket(
+        self,
+        client,
+        user_auth_token,
+        aws_mocks,
+    ):
+        """The URL must target the file scan bucket so the lambda picks it up."""
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "hello.txt", "mime_type": "text/plain"},
+        )
+        assert resp.status_code == 200
+
+        presigned = resp.get_json()["data"]
+        # Bucket name appears either as a virtual-host subdomain or path prefix
+        # depending on signature style; both are acceptable.
+        assert aws_mocks["bucket"] in presigned["url"]
+
+    def test_logs_pending_file_id(
+        self,
+        client,
+        user,
+        user_auth_token,
+        aws_mocks,
+        caplog,
+    ):
+        with caplog.at_level("INFO"):
+            resp = client.post(
+                URL,
+                headers={"X-SGG-Token": user_auth_token},
+                json={"file_name": "example.txt", "mime_type": "text/plain"},
+            )
+
+        assert resp.status_code == 200
+        pending_file_id = uuid.UUID(resp.get_json()["data"]["pending_file_id"])
+
+        records = [
+            r for r in caplog.records if r.message == "Created presigned upload for pending file"
+        ]
+        assert len(records) == 1
+        record = records[0]
+        assert record.pending_file_id == pending_file_id
+        assert record.user_id == user.user_id
+        assert record.file_scan_status == FileScanStatus.PENDING
+
+
+class TestCreatePresignedUpload401:
+    def test_no_auth(self, client, enable_factory_create):
+        resp = client.post(URL, json={"file_name": "f.txt", "mime_type": "text/plain"})
+        assert resp.status_code == 401
+
+
+class TestCreatePresignedUpload422:
+    def test_missing_file_name(self, client, user_auth_token, aws_mocks):
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"mime_type": "text/plain"},
+        )
+        assert resp.status_code == 422
+
+    def test_missing_mime_type(self, client, user_auth_token, aws_mocks):
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "f.txt"},
+        )
+        assert resp.status_code == 422
+
+    def test_file_name_too_long(self, client, user_auth_token, aws_mocks):
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "a" * 101, "mime_type": "text/plain"},
+        )
+        assert resp.status_code == 422
+
+    def test_empty_file_name(self, client, user_auth_token, aws_mocks):
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "", "mime_type": "text/plain"},
+        )
+        assert resp.status_code == 422
+
+
+class TestCreatePresignedUpload429:
+    def test_rate_limit_exceeded_returns_429_with_validation_detail(
+        self,
+        client,
+        user,
+        user_auth_token,
+        aws_mocks,
+        monkeypatch,
+    ):
+        # Use a smaller limit so the test stays fast
+        monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_LIMIT", "3")
+        for _ in range(3):
+            factories.PendingFileFactory.create(user=user)
+
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "another.txt", "mime_type": "text/plain"},
+        )
+
+        assert resp.status_code == 429
+        body = resp.get_json()
+        assert body["message"] == "Too many pending file uploads"
+        assert len(body["errors"]) == 1
+        assert body["errors"][0]["type"] == ValidationErrorType.PENDING_FILE_UPLOAD_LIMIT_EXCEEDED
+
+    def test_only_recent_pending_files_count_toward_limit(
+        self,
+        client,
+        user,
+        user_auth_token,
+        aws_mocks,
+        db_session,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_LIMIT", "2")
+        monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_WINDOW_HOURS", "1")
+
+        old_pending_file = factories.PendingFileFactory.create(user=user)
+        # Backdate the row past the rate-limit window so it doesn't count
+        old_pending_file.created_at = datetime_util.utcnow() - timedelta(hours=2)
+        db_session.commit()
+
+        # One recent pending file -- still under the limit of 2
+        factories.PendingFileFactory.create(user=user)
+
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "ok.txt", "mime_type": "text/plain"},
+        )
+        assert resp.status_code == 200
+
+    def test_other_users_pending_files_do_not_count(
+        self,
+        client,
+        user,
+        user_auth_token,
+        aws_mocks,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("PENDING_FILE_UPLOAD_RATE_LIMIT", "2")
+        other_user = factories.UserFactory.create()
+        for _ in range(5):
+            factories.PendingFileFactory.create(user=other_user)
+
+        resp = client.post(
+            URL,
+            headers={"X-SGG-Token": user_auth_token},
+            json={"file_name": "ok.txt", "mime_type": "text/plain"},
+        )
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #9715 

## Changes proposed

- Updated file_routes.py tp add `POST /v1/files` route
- Updated file_schemas.py to add `CreatePresignedUploadRequestSchema`, `CreatePresignedUploadResponseSchema`, and `PresignedUploadDataSchema` schemas
- Created create_presigned_upload.py to house the service that rate-limits, secures the file name, generates the presigned POST URL, writes the `pending_file row`, generates the presigned POST URL via the new `file_util.pre_sign_upload` helper, and writes the DynamoDB scan record
- Updated file_util.py to add a reusable `pre_sign_upload` helper that builds the presigned POST URL + body
- Updated validation_constants.py to add `PENDING_FILE_UPLOAD_LIMIT_EXCEEDED` validation error type for the 429 response
- Updated conftest.py to add `mock_file_scan_s3_bucket` fixture and wired `FILE_SCAN_BUCKET` into the `s3_config` fixture
- Created test_create_presigned_upload.py to test the new service layer

## Context for reviewers

This is the endpoint for the file upload with virus scanning flow that generates a presigned s3 POST URL the caller uses to upload directly to the scanning bucket. Per-user limit is 100 pending files per hour, configurable via env, returning a 429.

## Validation steps

Confirm tests pass. 
To test locally:
- Hit `POST /v1/files` with a JWT or API key + `{"file_name": "x.txt", "mime_type": "text/plain"}`
- POST the returned body (with a file attached under the file field) to the returned url
- Verify the object lands in `s3://local-mock-file-scan-bucket/unscanned/<pending_file_id>/<file_name>`, a `pending_file` row exists with `file_scan_status = complete`, and a DynamoDB row exists with matching `file_id` / `user_id` / `status`