### PR TITLE
[Issue #10574] Update renovate config to include grants_shared

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -217,8 +217,7 @@
       "description": "Leave Postgres Docker version alone - we want it to match our AWS version",
       "enabled": false,
       "matchFileNames": [
-        "analytics/docker-compose.yml",
-        "api/docker-compose.yml"
+        "backend/docker-compose.db.yml"
       ],
       "matchPackagePatterns": ["postgres"]
     },
@@ -237,8 +236,8 @@
       "matchFileNames": [
         "analytics/pyproject.toml",
         "api/pyproject.toml",
-        "api/Dockerfile",
-        "analytics/Dockerfile"
+        "backend/grants_shared/pyproject.toml",
+        "api/docker-python-base"
       ],
       "matchPackagePatterns": ["python"]
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,6 +41,23 @@
       ]
     },
     {
+      "description": "Group all dependencies from the grants_shared directory",
+      "matchFileNames": [
+        "backend/grants_shared/**"
+      ],
+      "groupName": "Grants Shared",
+      "reviewers": [
+        "chouinar",
+        "mdragon",
+        "joshtonava",
+        "jakobpederson",
+        "chay-REIsys",
+        "hao10282025-sudo",
+        "kkrug",
+        "dghazvini"
+      ]
+    },
+    {
       "description": "Group all dependencies from the frontend directory",
       "matchFileNames": [
         "frontend/**"


### PR DESCRIPTION
## Summary
Fixes #10574

## Changes proposed
* Add grants_shared folder to renovate
* Adjusted the DB config to not update our DB in the place I recently moved the DB definition
* Adjust where we tell it not to update python to include grants_shared + define the shared python dockerfile we now use

## Context for reviewers
Renovate automatically sends us PRs to update various things in our repo. We want to see that for the new grants_shared code. Also cleaned up a few out-of-date configs pointing to the wrong place after recent code moves.

## Validation steps
I'm not sure if we have a way to make renovate run since it's an app that's just attached to our repo.