### PR TITLE
[Issue 9791] Add unit tests for formatRoleName

### DIFF
--- a/frontend/src/utils/formatRoleName.test.ts
+++ b/frontend/src/utils/formatRoleName.test.ts
@@ -1,0 +1,29 @@
+import type { UserRole } from "src/types/userTypes";
+import { formatRoleNames } from "src/utils/formatRoleName";
+
+const role = (name: string): UserRole =>
+  ({ role_name: name, role_id: "test-id", privileges: [] }) as UserRole;
+
+describe("formatRoleNames", () => {
+  it("returns empty string when roles is undefined", () => {
+    expect(formatRoleNames(undefined)).toBe("");
+  });
+
+  it("returns empty string when roles is an empty array", () => {
+    expect(formatRoleNames([])).toBe("");
+  });
+
+  it("formats a single role", () => {
+    expect(formatRoleNames([role("Admin")])).toBe("Admin");
+  });
+
+  it("formats multiple roles separated by comma and space", () => {
+    expect(formatRoleNames([role("Admin"), role("Editor"), role("Viewer")])).toBe(
+      "Admin, Editor, Viewer"
+    );
+  });
+
+  it("formats two roles", () => {
+    expect(formatRoleNames([role("Admin"), role("User")])).toBe("Admin, User");
+  });
+});

--- a/frontend/src/utils/formatRoleName.test.ts
+++ b/frontend/src/utils/formatRoleName.test.ts
@@ -18,9 +18,9 @@ describe("formatRoleNames", () => {
   });
 
   it("formats multiple roles separated by comma and space", () => {
-    expect(formatRoleNames([role("Admin"), role("Editor"), role("Viewer")])).toBe(
-      "Admin, Editor, Viewer"
-    );
+    expect(
+      formatRoleNames([role("Admin"), role("Editor"), role("Viewer")]),
+    ).toBe("Admin, Editor, Viewer");
   });
 
   it("formats two roles", () => {


### PR DESCRIPTION
## Summary
Adds unit tests for `formatRoleNames` in `formatRoleName.ts`:
- Returns empty string for undefined and empty arrays
- Formats single and multiple roles with comma-space separation
- Uses typed `UserRole` fixtures matching the existing interface

Resolves #9791

## Testing
- `npm run test -- formatRoleName` passes
- Follows existing test patterns from `generalUtils.test.ts`

#### Reviewers
@btabaska @mdragon @KevinJBoyer