### PR TITLE
Add unit tests for formatCurrencyUtil

### DIFF
--- a/frontend/src/utils/formatCurrencyUtil.test.ts
+++ b/frontend/src/utils/formatCurrencyUtil.test.ts
@@ -1,0 +1,23 @@
+import { formatCurrency } from "src/utils/formatCurrencyUtil";
+
+describe("formatCurrency", () => {
+  it("formats positive integers as USD", () => {
+    expect(formatCurrency(1000)).toBe("$1,000");
+  });
+
+  it("formats large numbers with commas", () => {
+    expect(formatCurrency(1234567)).toBe("$1,234,567");
+  });
+
+  it("returns empty string for zero (falsy input)", () => {
+    expect(formatCurrency(0)).toBe("");
+  });
+
+  it("returns empty string for null", () => {
+    expect(formatCurrency(null)).toBe("");
+  });
+
+  it("formats negative values", () => {
+    expect(formatCurrency(-500)).toBe("-$500");
+  });
+});


### PR DESCRIPTION
## Summary
Adds Jest unit tests for the pure function `formatCurrency` in `frontend/src/utils/formatCurrencyUtil.ts`.

## Changes
- Creates `frontend/src/utils/formatCurrencyUtil.test.ts`
- Tests cover: positive integers, large numbers, zero (falsy), null, and negative values
- No modifications to `formatCurrencyUtil.ts` itself

## Testing
```
cd frontend && npm run test -- formatCurrencyUtil
```
All 5 tests pass.

Fixes #9789