### PR TITLE
Add unit tests for formatRoleName

### DIFF
--- a/frontend/src/utils/formatRoleName.test.ts
+++ b/frontend/src/utils/formatRoleName.test.ts
@@ -1,7 +1,7 @@
 import type { UserRole } from "src/types/userTypes";
 import { formatRoleNames } from "src/utils/formatRoleName";
 
-const role = (name: string): UserRole => ({ role_name: name } as UserRole);
+const role = (name: string): UserRole => ({ role_name: name }) as UserRole;
 
 describe("formatRoleNames", () => {
   it("returns empty string when roles is undefined", () => {

--- a/frontend/src/utils/formatRoleName.test.ts
+++ b/frontend/src/utils/formatRoleName.test.ts
@@ -1,0 +1,24 @@
+import type { UserRole } from "src/types/userTypes";
+import { formatRoleNames } from "src/utils/formatRoleName";
+
+const role = (name: string): UserRole => ({ role_name: name } as UserRole);
+
+describe("formatRoleNames", () => {
+  it("returns empty string when roles is undefined", () => {
+    expect(formatRoleNames(undefined)).toBe("");
+  });
+
+  it("returns empty string when roles is empty array", () => {
+    expect(formatRoleNames([])).toBe("");
+  });
+
+  it("returns the role_name when roles has one entry", () => {
+    expect(formatRoleNames([role("Admin")])).toBe("Admin");
+  });
+
+  it("joins role_names with a comma and space", () => {
+    expect(formatRoleNames([role("Admin"), role("Editor")])).toBe(
+      "Admin, Editor",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds Jest unit tests for the pure function `formatRoleNames` in `frontend/src/utils/formatRoleName.ts`.

## Changes
- Creates `frontend/src/utils/formatRoleName.test.ts`
- Tests cover: undefined input, empty array, single role, multiple roles joined with comma
- No modifications to `formatRoleName.ts` itself

## Testing
```
cd frontend && npm run test -- formatRoleName
```
All 4 tests pass.

Fixes #9791