### PR TITLE
[Issue 10556] Update closing date notification email copy from "Bookmarked" to "Saved"

### DIFF
--- a/api/src/task/notifications/closing_date_notification.py
+++ b/api/src/task/notifications/closing_date_notification.py
@@ -133,9 +133,9 @@ class ClosingDateNotificationTask(BaseNotificationTask):
                     extra={"user_id": user_id, "closing_opp_count": len(closing_opportunities)},
                 )
                 subject = (
-                    "Applications for your bookmarked funding opportunity are due soon"
+                    "Applications for your saved funding opportunity are due soon"
                     if len(closing_opportunities) == 1
-                    else "Applications for your bookmarked funding opportunities are due soon"
+                    else "Applications for your saved funding opportunities are due soon"
                 )
                 users_email_notifications.append(
                     UserEmailNotification(
@@ -168,7 +168,7 @@ class ClosingDateNotificationTask(BaseNotificationTask):
         message = (
             "Applications for the following funding opportunities are due in two weeks:\n\n"
             if has_multiple_grants
-            else "Applications for your bookmarked funding opportunity are due soon\n\n"
+            else "Applications for your saved funding opportunity are due soon\n\n"
         )
 
         for closing_opp in closing_opportunities:
@@ -180,14 +180,14 @@ class ClosingDateNotificationTask(BaseNotificationTask):
         if has_multiple_grants:
             message += (
                 "Please carefully review the opportunity listings for all requirements and deadlines.\n\n"
-                f"<a href='{self.notification_config.frontend_base_url}/saved-opportunities{UTM_TAG}' target='_blank'>To unsubscribe from email notifications for an opportunity, delete it from your bookmarked funding opportunities.</a>\n\n"
+                f"<a href='{self.notification_config.frontend_base_url}/saved-opportunities{UTM_TAG}' target='_blank'>To unsubscribe from email notifications for an opportunity, delete it from your saved funding opportunities.</a>\n\n"
                 "<b>Questions?</b>\n"
                 "If you have questions about an opportunity"
             )
         else:
             message += (
                 "Please carefully review the opportunity listing for all requirements and deadlines.\n\n"
-                f"<a href='{self.notification_config.frontend_base_url}/saved-opportunities{UTM_TAG}' target='_blank'>To unsubscribe from email notifications for this opportunity, delete it from your bookmarked funding opportunities.</a>\n\n"
+                f"<a href='{self.notification_config.frontend_base_url}/saved-opportunities{UTM_TAG}' target='_blank'>To unsubscribe from email notifications for this opportunity, delete it from your saved funding opportunities.</a>\n\n"
                 "<b>Questions?</b>\n"
                 "If you have questions about the opportunity"
             )


### PR DESCRIPTION
## Summary
Fixes #10556

Updates the closing date notification email to use "saved funding opportunity" instead of "bookmarked funding opportunity" throughout, matching the settled product language.

## Changes
- Updated 5 string references in `api/src/task/notifications/closing_date_notification.py`:
  - Email subject line (singular): "bookmarked" → "saved"
  - Email subject line (plural): "bookmarked" → "saved"
  - Single-opportunity intro line: "bookmarked" → "saved"
  - Multi-opportunity unsubscribe link text: "bookmarked" → "saved"
  - Single-opportunity unsubscribe link text: "bookmarked" → "saved"

## Testing
- No code logic changes — string replacements only
- Existing tests in `test_closing_date_notification.py` do not assert on email body content and require no changes
- Verified no remaining "bookmarked" references in the file

@btabaska @mdragon @KevinJBoyer — requesting review.