### PR TITLE
[Issue 9561] Document the /health endpoint for developers and operators

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -295,6 +295,45 @@ export NEW_RELIC_REGION="US" # Always "US".
 
 You will then be able to interact with New Relic via Terraform. There's some New Relic Terraform configuration inside of the `infra/accounts/` folder for example. From this point you can use normal Terraform CLI commands to interact with New Relic, `terraform init` `terraform apply` etc.
 
+## Health Check Endpoint
+
+The API exposes a `GET /health` endpoint that operators can use to verify both the application layer and its database connection are functioning. The endpoint is suitable for load-balancer target group health checks, container orchestrator liveness/readiness probes, and ad-hoc incident diagnosis.
+
+**Path:** `/health` (same path in all environments)
+
+### Local development
+
+```bash
+curl http://localhost:8080/health
+```
+
+### Response codes
+
+| Code | Condition | Meaning |
+|---|---|---|
+| `200 OK` | Application is up **and** `SELECT 1` succeeds against the database | Service is healthy |
+| `503 Service Unavailable` | Application is up but the database query fails | Database connectivity issue |
+
+### Response body (200)
+
+```json
+{
+  "message": "Service healthy",
+  "data": {
+    "commit_sha": "ffaca647223e0b6e54344122eefa73401f5ec131",
+    "commit_link": "https://github.com/HHS/simpler-grants-gov/commit/ffaca647223e0b6e54344122eefa73401f5ec131",
+    "release_notes_link": "https://github.com/HHS/simpler-grants-gov/releases",
+    "last_deploy_time": "2025-06-01T10:00:00",
+    "deploy_whoami": "runner"
+  },
+  "status_code": 200
+}
+```
+
+### Using for readiness/liveness checks
+
+When configuring a load balancer target group or a Kubernetes liveness probe, use `GET /health` and expect HTTP 200. A 503 response indicates the database is unreachable and the instance should be considered unhealthy.
+
 ### Metabase Version Upgrade steps are below: 
 
 #### To Note: We do not push any new image into ecr for the metabase upgrade as the images are pulled directly from Metabase's docker hub repository. 

--- a/api/README.md
+++ b/api/README.md
@@ -83,6 +83,48 @@ CLI commands are of the form `<task group> <task name> <any other params>`. So i
    bin/run-command api <env> '["flask", "task", "generate-notifications"]'
    ```
 
+## Endpoints
+
+### Health Check
+
+`GET /health`
+
+Verifies that the application and its database connection are functioning. Useful for confirming your local stack is running:
+
+```bash
+curl http://localhost:8080/health
+```
+
+#### Success response — `200 OK`
+
+```json
+{
+  "message": "Service healthy",
+  "data": {
+    "commit_sha": "ffaca647223e0b6e54344122eefa73401f5ec131",
+    "commit_link": "https://github.com/HHS/simpler-grants-gov/commit/ffaca647223e0b6e54344122eefa73401f5ec131",
+    "release_notes_link": "https://github.com/HHS/simpler-grants-gov/releases",
+    "last_deploy_time": "2025-06-01T10:00:00",
+    "deploy_whoami": "runner"
+  },
+  "status_code": 200
+}
+```
+
+#### Failure response — `503 Service Unavailable`
+
+Returned when the database connectivity check (`SELECT 1`) fails. The response body contains a generic error message.
+
+#### Response fields
+
+| Field | Description |
+|---|---|
+| `commit_sha` | GitHub commit SHA for the latest deployed commit |
+| `commit_link` | GitHub link to the latest deployed commit |
+| `release_notes_link` | Link to the release notes |
+| `last_deploy_time` | Latest deploy time (US/Eastern) |
+| `deploy_whoami` | The user or identity that performed the deploy |
+
 ## Technical Information
 
 * [API Technical Overview](../documentation/api/technical-overview.md)


### PR DESCRIPTION
## Summary
Fixes #9561

Documents the existing `GET /health` endpoint in two locations to serve different audiences.

## Changes

### `api/README.md`
- Added an **Endpoints > Health Check** section for developers
- Documents the HTTP method and path, success (200) and failure (503) response codes
- Includes an example `curl` command for local development
- Provides an example JSON response body and a response-field reference table
- All field names match `HealthcheckMetadataSchema` in `healthcheck.py`

### `OPERATIONS.md`
- Added a **Health Check Endpoint** section for operators and platform engineers
- Documents the endpoint path, response codes and their meanings, with a conditions table
- Includes guidance on using the endpoint for load-balancer target group health checks and Kubernetes liveness/readiness probes
- Provides an example JSON response body for quick reference

## Acceptance Criteria
- [x] `api/README.md` includes an "Endpoints" section documenting `GET /health`
- [x] The `api/README.md` entry includes HTTP method/path, description, success (200) and failure (503) codes with conditions, and example response body
- [x] `OPERATIONS.md` includes a "Health Check Endpoint" section
- [x] The `OPERATIONS.md` entry includes the full local URL, response codes and meanings, and readiness/liveness check guidance
- [x] All response field names match `HealthcheckMetadataSchema`
- [x] No code changes — documentation only

@btabaska @mdragon @KevinJBoyer — requesting review.