### PR TITLE
[unticketed]: upgrade uv version in analytics and api containers

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:71516a8@sha256:2cfa1fb890ba880455f004c16dc08fb6b1951bd9bd1c1b1e95ade41a396214d1 AS base
+FROM ghcr.io/hhs/python-base-image:93345e2@sha256:0eeaf1627e20946cbabd515176affb31ca5f7a6f32481253ff6478ef3a657847 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:71516a8@sha256:2cfa1fb890ba880455f004c16dc08fb6b1951bd9bd1c1b1e95ade41a396214d1 AS base
+FROM ghcr.io/hhs/python-base-image:93345e2@sha256:0eeaf1627e20946cbabd515176affb31ca5f7a6f32481253ff6478ef3a657847 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -1,4 +1,10 @@
 #==============================================
+# Stage 0: UV binary source
+#==============================================
+ARG UV_VERSION=0.11.15
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
+#==============================================
 # Stage 1: Build Python base from Amazon Linux
 #==============================================
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS amazonlinux-builder
@@ -6,7 +12,6 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS amazonlinux-builder
 ARG PYTHON_VERSION=3.14.5
 ARG PY_MM=3.14
 ARG PIP_VERSION=26.0
-ARG UV_VERSION=0.11.15
 
 SHELL ["/bin/bash", "-eux", "-c"]
 
@@ -63,8 +68,8 @@ RUN python3 -m pip install --no-cache-dir --upgrade "virtualenv>=20.35.3"
 
 # Install UV
 # https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-# Version is pinned via the UV_VERSION build arg at the top of this file.
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+# Version is pinned via the UV_VERSION build arg / uv stage at the top of this file.
+COPY --from=uv /uv /uvx /bin/
 
 # Upgrade urllib3 to fix security vulnerabilities (GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53)
 RUN python3 -m pip install --no-cache-dir --upgrade "urllib3>=2.6.0"

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -6,6 +6,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS amazonlinux-builder
 ARG PYTHON_VERSION=3.14.5
 ARG PY_MM=3.14
 ARG PIP_VERSION=26.0
+ARG UV_VERSION=0.11.15
 
 SHELL ["/bin/bash", "-eux", "-c"]
 
@@ -62,9 +63,8 @@ RUN python3 -m pip install --no-cache-dir --upgrade "virtualenv>=20.35.3"
 
 # Install UV
 # https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-# Pinned to 0.11.15 to fix bundled Rust crate vulnerabilities:
-# uv (GHSA-4gg8-gxpx-9rph), astral-tokio-tar (GHSA-3cv2-h65g-fgmm), tar (GHSA-3pv8-6f4r-ffg2)
-COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
+# Version is pinned via the UV_VERSION build arg at the top of this file.
+COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
 
 # Upgrade urllib3 to fix security vulnerabilities (GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53)
 RUN python3 -m pip install --no-cache-dir --upgrade "urllib3>=2.6.0"

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -62,7 +62,9 @@ RUN python3 -m pip install --no-cache-dir --upgrade "virtualenv>=20.35.3"
 
 # Install UV
 # https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --from=ghcr.io/astral-sh/uv:0.11.9 /uv /uvx /bin/
+# Pinned to 0.11.15 to fix bundled Rust crate vulnerabilities:
+# uv (GHSA-4gg8-gxpx-9rph), astral-tokio-tar (GHSA-3cv2-h65g-fgmm), tar (GHSA-3pv8-6f4r-ffg2)
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
 
 # Upgrade urllib3 to fix security vulnerabilities (GHSA-2xpw-w6gg-jr37, GHSA-gm62-xv2j-4w53)
 RUN python3 -m pip install --no-cache-dir --upgrade "urllib3>=2.6.0"


### PR DESCRIPTION
## Summary

Upgraded uv version to resolve anchore cve findings: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/26753384558)

## Validation steps

Deployed ap toi dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/26759307880)
Deployed analytics to dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/26759544887)