### PR TITLE
[unticketed]: update metabase network name

### DIFF
--- a/infra/metabase/app-config/grantee1.tf
+++ b/infra/metabase/app-config/grantee1.tf
@@ -4,7 +4,7 @@ module "grantee1_config" {
   app_name       = local.app_name
   default_region = module.project_config.default_region
   environment    = "grantee1"
-  network_name   = "prod"
+  network_name   = "grantee1"
 
   # Analytics database that Metabase connects to
   analytics_database_cluster_name = "analytics-grantee1"

--- a/infra/metabase/app-config/staging.tf
+++ b/infra/metabase/app-config/staging.tf
@@ -4,7 +4,7 @@ module "staging_config" {
   app_name       = local.app_name
   default_region = module.project_config.default_region
   environment    = "staging"
-  network_name   = "prod"
+  network_name   = "staging"
 
   # Analytics database that Metabase connects to
   analytics_database_cluster_name = "analytics-staging"

--- a/infra/metabase/app-config/training.tf
+++ b/infra/metabase/app-config/training.tf
@@ -4,7 +4,7 @@ module "training_config" {
   app_name       = local.app_name
   default_region = module.project_config.default_region
   environment    = "training"
-  network_name   = "prod"
+  network_name   = "training"
 
   # Analytics database that Metabase connects to
   analytics_database_cluster_name = "analytics-training"


### PR DESCRIPTION
## Summary

Updated the  metabase network name to match their respective environments. 

## Validation steps

Successfully deployed the changes to staging from local: 

<img width="835" height="318" alt="Screenshot 2026-06-01 at 12 47 48 PM" src="https://github.com/user-attachments/assets/b84985b7-bb62-41f0-ab57-abf9861b1964" />

Verified staging metabase is working as is: [here](https://data.staging.simpler.grants.gov/auth/login?redirect=%2F)

