### PR TITLE
[Issue #10592] Make the update pending file scan endpoint take in an s3 path

### DIFF
--- a/api/src/api/files_v1/file_routes.py
+++ b/api/src/api/files_v1/file_routes.py
@@ -77,7 +77,11 @@ def update_file_scan_status(
         db_session.add(user)
 
         update_pending_file_scan_status(
-            db_session, pending_file_id, json_data["file_scan_status"], user
+            db_session,
+            pending_file_id,
+            json_data["file_scan_status"],
+            json_data["file_location"],
+            user,
         )
 
     return response.ApiResponse(message="Success")

--- a/api/src/api/files_v1/file_schemas.py
+++ b/api/src/api/files_v1/file_schemas.py
@@ -12,6 +12,17 @@ class FileScanStatusUpdateRequestSchema(Schema):
             "example": FileScanStatus.COMPLETE,
         },
     )
+    file_location = fields.String(
+        required=True,
+        validate=validators.Regexp(
+            r"^s3://[^/]+/.+",
+            error_message="file_location must be an s3:// path",
+        ),
+        metadata={
+            "description": "The s3 path where the scanned file now lives",
+            "example": "s3://example-bucket/scanned/abc/example.txt",
+        },
+    )
 
 
 class FileScanStatusUpdateResponseSchema(AbstractResponseSchema):

--- a/api/src/services/files/local_file_scanner.py
+++ b/api/src/services/files/local_file_scanner.py
@@ -181,12 +181,17 @@ def process_metadata_change(metadata_file_path: str, db_client: db.DBClient) -> 
         extra={**log_extra, "scenario": scenario},
     )
 
+    bucket_path = S3Config().file_scan_bucket_path
+    unscanned_location = f"{bucket_path}/{s3_key}"
+
     if scenario == SCENARIO_WAIT_10S:
-        _apply_status(db_client, pending_file_id, FileScanStatus.IN_PROGRESS, log_extra)
+        _apply_status(
+            db_client, pending_file_id, FileScanStatus.IN_PROGRESS, unscanned_location, log_extra
+        )
         time.sleep(LocalFileScannerConfig().wait_scenario_delay_seconds)
 
-    _move_to_terminal_prefix(s3_key, final_status)
-    _apply_status(db_client, pending_file_id, final_status, log_extra)
+    terminal_location = _move_to_terminal_prefix(bucket_path, s3_key, final_status)
+    _apply_status(db_client, pending_file_id, final_status, terminal_location, log_extra)
 
     logger.info(
         "Local file scanner finished scanning file",
@@ -231,9 +236,12 @@ def _apply_status(
     db_client: db.DBClient,
     pending_file_id: uuid.UUID,
     status: FileScanStatus,
+    file_location: str,
     log_extra: dict[str, Any],
 ) -> None:
-    user_id = _update_pending_file_status(db_client, pending_file_id, status, log_extra)
+    user_id = _update_pending_file_status(
+        db_client, pending_file_id, status, file_location, log_extra
+    )
     if user_id is None:
         return
     _write_dynamodb_status(pending_file_id, user_id, status)
@@ -247,6 +255,7 @@ def _update_pending_file_status(
     db_client: db.DBClient,
     pending_file_id: uuid.UUID,
     status: FileScanStatus,
+    file_location: str,
     log_extra: dict[str, Any],
 ) -> uuid.UUID | None:
     """Update the pending_file row via the shared service function.
@@ -279,7 +288,9 @@ def _update_pending_file_status(
             return None
 
         uploader_user_id = pending_file.user_id
-        update_pending_file_scan_status(db_session, pending_file_id, status, scanner_user)
+        update_pending_file_scan_status(
+            db_session, pending_file_id, status, file_location, scanner_user
+        )
     return uploader_user_id
 
 
@@ -298,7 +309,8 @@ def _write_dynamodb_status(
     )
 
 
-def _move_to_terminal_prefix(s3_key: str, status: FileScanStatus) -> None:
-    bucket_path = S3Config().file_scan_bucket_path
+def _move_to_terminal_prefix(bucket_path: str, s3_key: str, status: FileScanStatus) -> str:
     destination_key = TERMINAL_STATUS_PREFIX[status] + s3_key[len(UNSCANNED_PREFIX) :]
-    file_util.move_file(f"{bucket_path}/{s3_key}", f"{bucket_path}/{destination_key}")
+    destination_path = f"{bucket_path}/{destination_key}"
+    file_util.move_file(f"{bucket_path}/{s3_key}", destination_path)
+    return destination_path

--- a/api/src/services/files/update_pending_file_scan_status.py
+++ b/api/src/services/files/update_pending_file_scan_status.py
@@ -5,11 +5,14 @@ import grants_shared.adapters.db as db
 from grants_shared.util import datetime_util
 from sqlalchemy import select
 
+import src.util.file_util as file_util
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.auth.endpoint_access_util import verify_access
 from src.constants.lookup_constants import FileScanStatus, Privilege
 from src.db.models.file_upload_models import PendingFile
 from src.db.models.user_models import User
+from src.validation.validation_constants import ValidationErrorType
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +21,7 @@ def update_pending_file_scan_status(
     db_session: db.Session,
     pending_file_id: uuid.UUID,
     file_scan_status: FileScanStatus,
+    file_location: str,
     user: User,
 ) -> None:
     verify_access(user, {Privilege.INTERNAL_S3_SCAN}, None)
@@ -28,8 +32,22 @@ def update_pending_file_scan_status(
     if pending_file is None:
         raise_flask_error(404, "Pending file not found")
 
+    if not file_util.file_exists(file_location):
+        raise_flask_error(
+            422,
+            message="File does not exist at the provided s3 path",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.FILE_NOT_FOUND_AT_LOCATION,
+                    message="File does not exist at the provided s3 path",
+                    field="file_location",
+                )
+            ],
+        )
+
     prior_file_scan_status = pending_file.file_scan_status
     pending_file.file_scan_status = file_scan_status
+    pending_file.file_location = file_location
 
     now = datetime_util.utcnow()
     scan_duration_seconds = (now - pending_file.created_at).total_seconds()
@@ -38,7 +56,8 @@ def update_pending_file_scan_status(
         "Updated pending file scan status",
         extra={
             "pending_file_id": pending_file.pending_file_id,
-            "user_id": user.user_id,
+            "scanner_user_id": user.user_id,
+            "uploader_user_id": pending_file.user_id,
             "prior_file_scan_status": prior_file_scan_status,
             "file_scan_status": file_scan_status,
             "scan_duration_seconds": scan_duration_seconds,

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -57,3 +57,4 @@ class ValidationErrorType(StrEnum):
 
     # File upload validation error types
     PENDING_FILE_UPLOAD_LIMIT_EXCEEDED = "pending_file_upload_limit_exceeded"
+    FILE_NOT_FOUND_AT_LOCATION = "file_not_found_at_location"

--- a/api/tests/src/api/files_v1/test_update_pending_file_scan_status.py
+++ b/api/tests/src/api/files_v1/test_update_pending_file_scan_status.py
@@ -1,13 +1,24 @@
 import uuid
 
+import boto3
 import pytest
 
 import tests.src.db.models.factories as factories
 from src.constants.lookup_constants import FileScanStatus, Privilege, RoleType
+from src.validation.validation_constants import ValidationErrorType
+
+# Placeholder for tests where the request fails before the s3 existence check
+# (auth, schema validation), so the path never actually gets dereferenced.
+PLACEHOLDER_S3_PATH = "s3://example-bucket/scanned/abc/example.txt"
 
 
 def _build_url(pending_file_id: uuid.UUID) -> str:
     return f"/v1/files/{pending_file_id}"
+
+
+def _put_scanned_file(bucket: str, key: str, body: bytes = b"scanned content") -> str:
+    boto3.client("s3").put_object(Bucket=bucket, Key=key, Body=body)
+    return f"s3://{bucket}/{key}"
 
 
 @pytest.fixture
@@ -23,44 +34,56 @@ def s3_scan_user_key(db_session, enable_factory_create):
 
 
 class TestUpdateFileScanStatusSuccess:
-    def test_update_scan_status_complete(self, client, db_session, s3_scan_user_key):
+    def test_update_scan_status_complete(
+        self, client, db_session, s3_scan_user_key, mock_file_scan_s3_bucket
+    ):
         pending_file = factories.PendingFileFactory.create(file_scan_status=FileScanStatus.PENDING)
+        file_location = _put_scanned_file(mock_file_scan_s3_bucket, "scanned/abc/example.txt")
 
         resp = client.post(
             _build_url(pending_file.pending_file_id),
             headers={"X-API-Key": s3_scan_user_key},
-            json={"file_scan_status": "complete"},
+            json={"file_scan_status": "complete", "file_location": file_location},
         )
 
         assert resp.status_code == 200
 
         db_session.refresh(pending_file)
         assert pending_file.file_scan_status == FileScanStatus.COMPLETE
+        assert pending_file.file_location == file_location
 
-    def test_update_scan_status_infected(self, client, db_session, s3_scan_user_key):
+    def test_update_scan_status_infected(
+        self, client, db_session, s3_scan_user_key, mock_file_scan_s3_bucket
+    ):
         pending_file = factories.PendingFileFactory.create(
             file_scan_status=FileScanStatus.IN_PROGRESS
         )
+        file_location = _put_scanned_file(mock_file_scan_s3_bucket, "infected/abc/example.txt")
 
         resp = client.post(
             _build_url(pending_file.pending_file_id),
             headers={"X-API-Key": s3_scan_user_key},
-            json={"file_scan_status": "infected"},
+            json={"file_scan_status": "infected", "file_location": file_location},
         )
 
         assert resp.status_code == 200
 
         db_session.refresh(pending_file)
         assert pending_file.file_scan_status == FileScanStatus.INFECTED
+        assert pending_file.file_location == file_location
 
-    def test_logs_scan_duration(self, client, db_session, s3_scan_user_key, caplog):
+    def test_logs_scan_duration(
+        self, client, db_session, s3_scan_user_key, mock_file_scan_s3_bucket, caplog
+    ):
         pending_file = factories.PendingFileFactory.create(file_scan_status=FileScanStatus.PENDING)
+        uploader_user_id = pending_file.user_id
+        file_location = _put_scanned_file(mock_file_scan_s3_bucket, "scanned/abc/example.txt")
 
         with caplog.at_level("INFO"):
             resp = client.post(
                 _build_url(pending_file.pending_file_id),
                 headers={"X-API-Key": s3_scan_user_key},
-                json={"file_scan_status": "complete"},
+                json={"file_scan_status": "complete", "file_location": file_location},
             )
 
         assert resp.status_code == 200
@@ -70,7 +93,8 @@ class TestUpdateFileScanStatusSuccess:
 
         record = log_records[0]
         assert record.pending_file_id == pending_file.pending_file_id
-        assert record.user_id is not None
+        assert record.scanner_user_id is not None
+        assert record.uploader_user_id == uploader_user_id
         assert record.file_scan_status == FileScanStatus.COMPLETE
         assert record.scan_duration_seconds >= 0
         assert record.prior_file_scan_status == FileScanStatus.PENDING
@@ -82,7 +106,10 @@ class TestUpdateFileScanStatus401:
 
         resp = client.post(
             _build_url(pending_file.pending_file_id),
-            json={"file_scan_status": "complete"},
+            json={
+                "file_scan_status": "complete",
+                "file_location": PLACEHOLDER_S3_PATH,
+            },
         )
 
         assert resp.status_code == 401
@@ -97,7 +124,10 @@ class TestUpdateFileScanStatus403:
         resp = client.post(
             _build_url(pending_file.pending_file_id),
             headers={"X-API-Key": user_api_key_id},
-            json={"file_scan_status": "complete"},
+            json={
+                "file_scan_status": "complete",
+                "file_location": PLACEHOLDER_S3_PATH,
+            },
         )
 
         assert resp.status_code == 403
@@ -105,11 +135,15 @@ class TestUpdateFileScanStatus403:
 
 
 class TestUpdateFileScanStatus404:
-    def test_pending_file_not_found(self, client, db_session, s3_scan_user_key):
+    def test_pending_file_not_found(
+        self, client, db_session, s3_scan_user_key, mock_file_scan_s3_bucket
+    ):
+        file_location = _put_scanned_file(mock_file_scan_s3_bucket, "scanned/abc/example.txt")
+
         resp = client.post(
             _build_url(uuid.uuid4()),
             headers={"X-API-Key": s3_scan_user_key},
-            json={"file_scan_status": "complete"},
+            json={"file_scan_status": "complete", "file_location": file_location},
         )
 
         assert resp.status_code == 404
@@ -123,7 +157,7 @@ class TestUpdateFileScanStatus422:
         resp = client.post(
             _build_url(pending_file.pending_file_id),
             headers={"X-API-Key": s3_scan_user_key},
-            json={},
+            json={"file_location": PLACEHOLDER_S3_PATH},
         )
 
         assert resp.status_code == 422
@@ -134,7 +168,59 @@ class TestUpdateFileScanStatus422:
         resp = client.post(
             _build_url(pending_file.pending_file_id),
             headers={"X-API-Key": s3_scan_user_key},
-            json={"file_scan_status": "not_a_real_status"},
+            json={
+                "file_scan_status": "not_a_real_status",
+                "file_location": PLACEHOLDER_S3_PATH,
+            },
         )
 
         assert resp.status_code == 422
+
+    def test_missing_file_location(self, client, db_session, s3_scan_user_key):
+        pending_file = factories.PendingFileFactory.create()
+
+        resp = client.post(
+            _build_url(pending_file.pending_file_id),
+            headers={"X-API-Key": s3_scan_user_key},
+            json={"file_scan_status": "complete"},
+        )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "bad_value", ["", "not-an-s3-path", "/tmp/local/path.txt", "s3:///missing-bucket.txt"]
+    )
+    def test_invalid_file_location_format(self, client, db_session, s3_scan_user_key, bad_value):
+        pending_file = factories.PendingFileFactory.create()
+
+        resp = client.post(
+            _build_url(pending_file.pending_file_id),
+            headers={"X-API-Key": s3_scan_user_key},
+            json={"file_scan_status": "complete", "file_location": bad_value},
+        )
+
+        assert resp.status_code == 422
+
+    def test_file_not_at_s3_location(
+        self, client, db_session, s3_scan_user_key, mock_file_scan_s3_bucket
+    ):
+        pending_file = factories.PendingFileFactory.create(file_scan_status=FileScanStatus.PENDING)
+        prior_file_location = pending_file.file_location
+        missing_location = f"s3://{mock_file_scan_s3_bucket}/scanned/abc/does-not-exist.txt"
+
+        resp = client.post(
+            _build_url(pending_file.pending_file_id),
+            headers={"X-API-Key": s3_scan_user_key},
+            json={"file_scan_status": "complete", "file_location": missing_location},
+        )
+
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert body["message"] == "File does not exist at the provided s3 path"
+        assert len(body["errors"]) == 1
+        assert body["errors"][0]["type"] == ValidationErrorType.FILE_NOT_FOUND_AT_LOCATION
+        assert body["errors"][0]["field"] == "file_location"
+
+        db_session.refresh(pending_file)
+        assert pending_file.file_scan_status == FileScanStatus.PENDING
+        assert pending_file.file_location == prior_file_location

--- a/api/tests/src/api/files_v1/test_update_pending_file_scan_status.py
+++ b/api/tests/src/api/files_v1/test_update_pending_file_scan_status.py
@@ -188,7 +188,8 @@ class TestUpdateFileScanStatus422:
         assert resp.status_code == 422
 
     @pytest.mark.parametrize(
-        "bad_value", ["", "not-an-s3-path", "/tmp/local/path.txt", "s3:///missing-bucket.txt"]
+        "bad_value",
+        ["", "not-an-s3-path", "http://example.com/path.txt", "s3:///missing-bucket.txt"],
     )
     def test_invalid_file_location_format(self, client, db_session, s3_scan_user_key, bad_value):
         pending_file = factories.PendingFileFactory.create()


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10592  

## Changes proposed

- Updated file_schemas.py to add required `file_location` field to `FileScanStatusUpdateRequestSchema` with `s3://` regex validation
- Updated file_routes.py to pass `file_location` from request body to the service
- Updated update_pending_file_scan_status.py to accept `file_location`, verify it exists on s3 via `file_util.file_exists`, and update the DB record
- Updated local_file_scanner.py to thread `file_location` through `_apply_status `/ `_update_pending_file_status` / `_move_to_terminal_prefix`
- Updated validation_constants.py to add `FILE_NOT_FOUND_AT_LOCATION` error type
- Updated test_update_pending_file_scan_status.py to send `file_location` in all tests, add 422 coverage for invalid-format / missing-from-s3, and assert the DB row isn't mutated on failure

## Context for reviewers

After scanning, the lambda moves the file from `unscanned/` to `scanned/` or `infected/`, and the API needs to record the new path. This change makes `file_location` required on the endpoint, validates the file actually exists at that path, and updates `pending_file.file_location` in the DB.

## Validation steps

Confirm tests pass.

To test locally:

- Seeded local DB should have user `bc7a4d76-39d4-4f4f-9c64-c11b7c2a7c0a` with API key `local_file_scanner_user_key`
- Create a pending file via the `POST /v1/files` endpoint with `X-API-Key: aws-api-gateway-key-00000000` and body `{"file_name":"manual-test.txt","mime_type":"text/plain"}`. Grab the returned `pending_file_id`
- Test new endpoint `POST /v1/files/{pending_file_id}` with `X-API-Key: local_file_scanner_user_key`
  - Pre-place a file at `s3://local-mock-file-scan-bucket/scanned/{pending_file_id}/manual-test.txt` (e.g. via `file_util.write_to_file` in the container)
  - `POST {"file_scan_status":"complete","file_location":"s3://.../scanned/{pending_file_id}/manual-test.txt"}` → 200
  - Query `pending_file: file_scan_status == complete` and `file_location` is the new path