### PR TITLE
test: add unit tests for grants_shared.util.local

### DIFF
--- a/backend/grants_shared/tests/grants_shared/util/test_local.py
+++ b/backend/grants_shared/tests/grants_shared/util/test_local.py
@@ -1,0 +1,77 @@
+import pytest
+
+from grants_shared.util.local import error_if_not_local, load_local_env_vars
+
+
+class TestLoadLocalEnvVars:
+    def test_loads_dotenv_when_environment_is_local(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("TEST_VAR=hello\n")
+        monkeypatch.setenv("ENVIRONMENT", "local")
+        monkeypatch.delenv("TEST_VAR", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        import os
+
+        assert os.getenv("TEST_VAR") == "hello"
+
+    def test_loads_dotenv_when_environment_is_unset(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("TEST_VAR2=world\n")
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.delenv("TEST_VAR2", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        import os
+
+        assert os.getenv("TEST_VAR2") == "world"
+
+    def test_skips_dotenv_when_environment_is_not_local(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("TEST_VAR3=should_not_load\n")
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        monkeypatch.delenv("TEST_VAR3", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        import os
+
+        assert os.getenv("TEST_VAR3") is None
+
+    @pytest.mark.parametrize("env", ["staging", "prod", "production", "test"])
+    def test_skips_dotenv_for_non_local_environments(self, monkeypatch, tmp_path, env):
+        env_file = tmp_path / "local.env"
+        env_file.write_text("SKIP_VAR=skip\n")
+        monkeypatch.setenv("ENVIRONMENT", env)
+        monkeypatch.delenv("SKIP_VAR", raising=False)
+
+        load_local_env_vars(str(env_file))
+
+        import os
+
+        assert os.getenv("SKIP_VAR") is None
+
+
+class TestErrorIfNotLocal:
+    def test_passes_when_environment_is_local(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "local")
+        # Should not raise
+        error_if_not_local()
+
+    def test_raises_when_environment_is_not_local(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "dev")
+        with pytest.raises(Exception, match="Local-only process called when environment was set to non-local"):
+            error_if_not_local()
+
+    def test_raises_when_environment_is_unset(self, monkeypatch):
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        with pytest.raises(Exception, match="Local-only process called when environment was set to non-local"):
+            error_if_not_local()
+
+    @pytest.mark.parametrize("env", ["staging", "prod", "production", "test"])
+    def test_raises_for_non_local_environments(self, monkeypatch, env):
+        monkeypatch.setenv("ENVIRONMENT", env)
+        with pytest.raises(Exception):
+            error_if_not_local()

--- a/backend/grants_shared/tests/grants_shared/util/test_local.py
+++ b/backend/grants_shared/tests/grants_shared/util/test_local.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from grants_shared.util.local import error_if_not_local, load_local_env_vars
@@ -12,8 +14,6 @@ class TestLoadLocalEnvVars:
 
         load_local_env_vars(str(env_file))
 
-        import os
-
         assert os.getenv("TEST_VAR") == "hello"
 
     def test_loads_dotenv_when_environment_is_unset(self, monkeypatch, tmp_path):
@@ -23,8 +23,6 @@ class TestLoadLocalEnvVars:
         monkeypatch.delenv("TEST_VAR2", raising=False)
 
         load_local_env_vars(str(env_file))
-
-        import os
 
         assert os.getenv("TEST_VAR2") == "world"
 
@@ -36,8 +34,6 @@ class TestLoadLocalEnvVars:
 
         load_local_env_vars(str(env_file))
 
-        import os
-
         assert os.getenv("TEST_VAR3") is None
 
     @pytest.mark.parametrize("env", ["staging", "prod", "production", "test"])
@@ -48,8 +44,6 @@ class TestLoadLocalEnvVars:
         monkeypatch.delenv("SKIP_VAR", raising=False)
 
         load_local_env_vars(str(env_file))
-
-        import os
 
         assert os.getenv("SKIP_VAR") is None
 

--- a/backend/grants_shared/tests/grants_shared/util/test_local.py
+++ b/backend/grants_shared/tests/grants_shared/util/test_local.py
@@ -56,12 +56,16 @@ class TestErrorIfNotLocal:
 
     def test_raises_when_environment_is_not_local(self, monkeypatch):
         monkeypatch.setenv("ENVIRONMENT", "dev")
-        with pytest.raises(Exception, match="Local-only process called when environment was set to non-local"):
+        with pytest.raises(
+            Exception, match="Local-only process called when environment was set to non-local"
+        ):
             error_if_not_local()
 
     def test_raises_when_environment_is_unset(self, monkeypatch):
         monkeypatch.delenv("ENVIRONMENT", raising=False)
-        with pytest.raises(Exception, match="Local-only process called when environment was set to non-local"):
+        with pytest.raises(
+            Exception, match="Local-only process called when environment was set to non-local"
+        ):
             error_if_not_local()
 
     @pytest.mark.parametrize("env", ["staging", "prod", "production", "test"])

--- a/backend/grants_shared/tests/grants_shared/util/test_local.py
+++ b/backend/grants_shared/tests/grants_shared/util/test_local.py
@@ -71,5 +71,7 @@ class TestErrorIfNotLocal:
     @pytest.mark.parametrize("env", ["staging", "prod", "production", "test"])
     def test_raises_for_non_local_environments(self, monkeypatch, env):
         monkeypatch.setenv("ENVIRONMENT", env)
-        with pytest.raises(Exception):
+        with pytest.raises(
+            Exception, match="Local-only process called when environment was set to non-local"
+        ):
             error_if_not_local()


### PR DESCRIPTION
Closes #9815

## Summary

Adds the missing test file `backend/grants_shared/tests/grants_shared/util/test_local.py` for the two functions in `grants_shared.util.local`:

- **`load_local_env_vars`**: verifies it loads the dotenv file when `ENVIRONMENT` is `"local"` or unset, and skips it for any other environment (staging, prod, production, test — parametrized)
- **`error_if_not_local`**: verifies it passes when `ENVIRONMENT=local`, raises when the env var is unset, and raises for all non-local environments

Uses `monkeypatch` for env-var control and `tmp_path` for throwaway dotenv files, consistent with the `test_deploy_metadata.py` pattern in the same directory.

## Test plan

- [ ] `cd backend/grants_shared && uv run pytest tests/grants_shared/util/test_local.py -v`