### PR TITLE
fix: add ValidationErrorDetail to saved-item delete services

### DIFF
--- a/api/src/services/users/delete_saved_opportunity.py
+++ b/api/src/services/users/delete_saved_opportunity.py
@@ -3,9 +3,11 @@ from uuid import UUID
 from grants_shared.adapters import db
 from sqlalchemy import select
 
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.opportunity_models import Opportunity
 from src.db.models.user_models import UserSavedOpportunity
+from src.validation.validation_constants import ValidationErrorType
 
 
 def delete_saved_opportunity(
@@ -31,6 +33,16 @@ def delete_saved_opportunity(
         ).scalar_one_or_none()
 
     if not saved_opp:
-        raise_flask_error(404, "Saved opportunity not found")
+        raise_flask_error(
+            404,
+            "Saved opportunity not found",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.SAVED_ITEM_NOT_FOUND,
+                    message="Saved opportunity not found",
+                    field="opportunity_id",
+                )
+            ],
+        )
 
     saved_opp.is_deleted = True

--- a/api/src/services/users/delete_saved_search.py
+++ b/api/src/services/users/delete_saved_search.py
@@ -3,8 +3,10 @@ from uuid import UUID
 from grants_shared.adapters import db
 from sqlalchemy import select
 
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.user_models import UserSavedSearch
+from src.validation.validation_constants import ValidationErrorType
 
 
 def delete_saved_search(db_session: db.Session, user_id: UUID, saved_search_id: UUID) -> None:
@@ -15,6 +17,16 @@ def delete_saved_search(db_session: db.Session, user_id: UUID, saved_search_id: 
     ).scalar_one_or_none()
 
     if not saved_search:
-        raise_flask_error(404, "Saved search not found")
+        raise_flask_error(
+            404,
+            "Saved search not found",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.SAVED_ITEM_NOT_FOUND,
+                    message="Saved search not found",
+                    field="saved_search_id",
+                )
+            ],
+        )
 
     saved_search.is_deleted = True

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -57,3 +57,5 @@ class ValidationErrorType(StrEnum):
 
     # File upload validation error types
     PENDING_FILE_UPLOAD_LIMIT_EXCEEDED = "pending_file_upload_limit_exceeded"
+
+    SAVED_ITEM_NOT_FOUND = "saved_item_not_found"

--- a/api/tests/src/services/users/test_delete_saved_opportunity.py
+++ b/api/tests/src/services/users/test_delete_saved_opportunity.py
@@ -1,0 +1,56 @@
+import uuid
+
+import apiflask.exceptions
+import pytest
+from grants_shared.adapters import db
+from sqlalchemy import select
+
+import tests.src.db.models.factories as factories
+from src.db.models.user_models import UserSavedOpportunity
+from src.services.users.delete_saved_opportunity import delete_saved_opportunity
+from src.validation.validation_constants import ValidationErrorType
+
+
+def test_delete_saved_opportunity_success(enable_factory_create, db_session: db.Session):
+    user = factories.UserFactory.create()
+    opportunity = factories.OpportunityFactory.create()
+    saved_opp = factories.UserSavedOpportunityFactory.create(
+        user=user, opportunity=opportunity, is_deleted=False
+    )
+
+    delete_saved_opportunity(db_session, user.user_id, opportunity.opportunity_id)
+
+    result = db_session.execute(
+        select(UserSavedOpportunity).where(
+            UserSavedOpportunity.user_id == user.user_id,
+            UserSavedOpportunity.opportunity_id == opportunity.opportunity_id,
+        )
+    ).scalar_one_or_none()
+    assert result is not None
+    assert result.is_deleted is True
+
+
+def test_delete_saved_opportunity_not_found(enable_factory_create, db_session: db.Session):
+    user = factories.UserFactory.create()
+    nonexistent_id = uuid.uuid4()
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_opportunity(db_session, user.user_id, nonexistent_id)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.extra_data["validation_issues"][0]["type"] == ValidationErrorType.SAVED_ITEM_NOT_FOUND
+
+
+def test_delete_saved_opportunity_wrong_user(enable_factory_create, db_session: db.Session):
+    user1 = factories.UserFactory.create()
+    user2 = factories.UserFactory.create()
+    opportunity = factories.OpportunityFactory.create()
+    factories.UserSavedOpportunityFactory.create(
+        user=user1, opportunity=opportunity, is_deleted=False
+    )
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_opportunity(db_session, user2.user_id, opportunity.opportunity_id)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.extra_data["validation_issues"][0]["type"] == ValidationErrorType.SAVED_ITEM_NOT_FOUND

--- a/api/tests/src/services/users/test_delete_saved_search.py
+++ b/api/tests/src/services/users/test_delete_saved_search.py
@@ -1,0 +1,49 @@
+import uuid
+
+import apiflask.exceptions
+import pytest
+from grants_shared.adapters import db
+from sqlalchemy import select
+
+import tests.src.db.models.factories as factories
+from src.db.models.user_models import UserSavedSearch
+from src.services.users.delete_saved_search import delete_saved_search
+from src.validation.validation_constants import ValidationErrorType
+
+
+def test_delete_saved_search_success(enable_factory_create, db_session: db.Session):
+    user = factories.UserFactory.create()
+    saved_search = factories.UserSavedSearchFactory.create(user=user, is_deleted=False)
+
+    delete_saved_search(db_session, user.user_id, saved_search.saved_search_id)
+
+    result = db_session.execute(
+        select(UserSavedSearch).where(
+            UserSavedSearch.saved_search_id == saved_search.saved_search_id
+        )
+    ).scalar_one_or_none()
+    assert result is not None
+    assert result.is_deleted is True
+
+
+def test_delete_saved_search_not_found(enable_factory_create, db_session: db.Session):
+    user = factories.UserFactory.create()
+    nonexistent_id = uuid.uuid4()
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_search(db_session, user.user_id, nonexistent_id)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.extra_data["validation_issues"][0]["type"] == ValidationErrorType.SAVED_ITEM_NOT_FOUND
+
+
+def test_delete_saved_search_wrong_user(enable_factory_create, db_session: db.Session):
+    user1 = factories.UserFactory.create()
+    user2 = factories.UserFactory.create()
+    saved_search = factories.UserSavedSearchFactory.create(user=user1, is_deleted=False)
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_search(db_session, user2.user_id, saved_search.saved_search_id)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.extra_data["validation_issues"][0]["type"] == ValidationErrorType.SAVED_ITEM_NOT_FOUND


### PR DESCRIPTION
Closes #9817

## Summary

Two delete service functions raised bare 404 errors without the structured `validation_issues` payload required by the API error-handling convention (`documentation/rules/api-error-handling.md`).

**`api/src/validation/validation_constants.py`**
- Add `SAVED_ITEM_NOT_FOUND = "saved_item_not_found"` to `ValidationErrorType`

**`api/src/services/users/delete_saved_search.py`**
- Wrap the 404 with `ValidationErrorDetail(type=SAVED_ITEM_NOT_FOUND, field="saved_search_id")`

**`api/src/services/users/delete_saved_opportunity.py`**
- Same pattern with `field="opportunity_id"`

**New test files** (`test_delete_saved_search.py`, `test_delete_saved_opportunity.py`)
- Happy path: soft-delete sets `is_deleted=True`
- 404 path: asserts status code and typed `ValidationErrorDetail` in `validation_issues`
- Wrong-user path: confirms 404 with typed error detail

## Test plan

- [ ] `cd api && uv run pytest tests/src/services/users/test_delete_saved_search.py tests/src/services/users/test_delete_saved_opportunity.py -v`