### PR TITLE
[Issue #10276] Add version checksum

### DIFF
--- a/api/src/task/__init__.py
+++ b/api/src/task/__init__.py
@@ -12,6 +12,7 @@ import src.task.forms.update_form_task  # noqa: F401 isort:skip
 import src.task.forms.update_form_instruction_task  # noqa: F401 isort:skip
 import src.task.certificates.setup_cert_user_task  # noqa: F401 isort:skip
 import src.task.forms.list_forms_task  # noqa: F401 isort:skip
+import src.task.forms.lock_form_version_task  # noqa: F401 isort:skip
 import src.task.opportunities.build_automatic_opportunities  # noqa: F401 isort:skip
 import src.cli.xml_generation_cli  # noqa: F401 isort:skip
 import src.task.agencies.setup_lower_env_agencies  # noqa: F401 isort:skip

--- a/api/src/task/forms/lock_form_version_task.py
+++ b/api/src/task/forms/lock_form_version_task.py
@@ -1,0 +1,70 @@
+import hashlib
+import logging
+import re
+from pathlib import Path
+
+import click
+from grants_shared.util.local import error_if_not_local
+
+from src.task.task_blueprint import task_blueprint
+
+logger = logging.getLogger(__name__)
+
+FORMS_DIR = Path(__file__).parents[2] / "form_schema" / "forms"
+
+
+def compute_version_hash(form_dir: Path, version_dir: Path) -> str:
+    """Return the SHA-256 hex digest of form_json.py + config.py for a version directory.
+
+    Always hashes form_json.py first, then config.py, so the digest is stable.
+    """
+    form_json_path = version_dir / "form_json.py"
+    config_path = form_dir / "config.py"
+
+    if not form_json_path.exists():
+        raise FileNotFoundError(f"form_json.py not found: {form_json_path}")
+    if not config_path.exists():
+        raise FileNotFoundError(f"config.py not found: {config_path}")
+
+    h = hashlib.sha256()
+    h.update(form_json_path.read_bytes())
+    h.update(config_path.read_bytes())
+    return h.hexdigest()
+
+
+def get_version_dir(form_name: str, version: str) -> tuple[Path, Path]:
+    """Return (form_dir, version_dir) for the given form name and version string."""
+    if not re.fullmatch(r"\d+\.\d+", version):
+        raise ValueError(f"version must be in MAJOR.MINOR format, got {version!r}")
+
+    major, minor = version.split(".")
+    form_dir = FORMS_DIR / form_name
+    version_dir = form_dir / major / minor
+
+    if not form_dir.is_dir():
+        raise ValueError(f"no form directory found at {form_dir}")
+    if not version_dir.is_dir():
+        raise ValueError(f"no version directory found at {version_dir}")
+
+    return form_dir, version_dir
+
+
+@task_blueprint.cli.command(
+    "lock-form-version",
+    help="Hash form_json.py + config.py for a form version and write to a checksum file.",
+)
+@click.option("--form", required=True, help="Form directory name, e.g. sf424")
+@click.option("--version", required=True, help="Version in MAJOR.MINOR format, e.g. 1.0")
+def lock_form_version(form: str, version: str) -> None:
+    error_if_not_local()
+    try:
+        form_dir, version_dir = get_version_dir(form, version)
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from e
+    checksum = compute_version_hash(form_dir, version_dir)
+    checksum_path = version_dir / "checksum"
+    checksum_path.write_text(checksum + "\n")
+    click.echo(f"Wrote checksum for {form} v{version} → {checksum_path}")
+    logger.info(
+        "Locked form version", extra={"form": form, "version": version, "checksum": checksum}
+    )

--- a/api/tests/src/form_schema/forms/test_form_version_checksums.py
+++ b/api/tests/src/form_schema/forms/test_form_version_checksums.py
@@ -1,0 +1,108 @@
+import re
+from pathlib import Path
+
+import pytest
+
+from src.task.forms.lock_form_version_task import compute_version_hash, get_version_dir
+
+_FORMS_ROOT = Path(__file__).parents[4] / "src" / "form_schema" / "forms"
+
+
+def get_locked_versions() -> list[tuple[Path, Path, str, str]]:
+    """Return (form_dir, version_dir, major, minor) for every version with a checksum file."""
+    locked = []
+    for form_dir in sorted(_FORMS_ROOT.iterdir()):
+        if not form_dir.is_dir() or form_dir.name == "__pycache__":
+            continue
+        for major_dir in sorted(form_dir.iterdir()):
+            if not major_dir.is_dir() or not re.fullmatch(r"\d+", major_dir.name):
+                continue
+            for minor_dir in sorted(major_dir.iterdir()):
+                if not minor_dir.is_dir() or not re.fullmatch(r"\d+", minor_dir.name):
+                    continue
+                if (minor_dir / "checksum").exists():
+                    locked.append((form_dir, minor_dir, major_dir.name, minor_dir.name))
+    return locked
+
+
+def test_locked_form_versions_unchanged() -> None:
+    """Any version directory with a checksum file must still match its current sources.
+
+    Passes silently when no checksum files are present.
+    """
+    failures: list[str] = []
+
+    for form_dir, version_dir, major, minor in get_locked_versions():
+        expected = (version_dir / "checksum").read_text().strip()
+        actual = compute_version_hash(form_dir, version_dir)
+        if actual != expected:
+            failures.append(
+                f"{form_dir.name} v{major}.{minor}: "
+                f"expected {expected!r}, got {actual!r}. "
+                f"Run `flask task lock-form-version --form={form_dir.name} "
+                f"--version={major}.{minor}` to re-lock after an intentional change, "
+                f"or create a new version directory instead."
+            )
+
+    if failures:
+        pytest.fail("Locked form versions have been modified:\n" + "\n".join(failures))
+
+
+def test_compute_version_hash_is_stable(tmp_path: Path) -> None:
+    """compute_version_hash returns the same digest for identical file contents."""
+    form_dir = tmp_path / "my_form"
+    version_dir = form_dir / "1" / "0"
+    version_dir.mkdir(parents=True)
+    (form_dir / "config.py").write_text("FORM_ID = 'abc'\n")
+    (version_dir / "form_json.py").write_text("SCHEMA = {}\n")
+
+    first = compute_version_hash(form_dir, version_dir)
+    second = compute_version_hash(form_dir, version_dir)
+    assert first == second
+    assert len(first) == 64  # SHA-256 hex digest
+
+
+def test_compute_version_hash_changes_when_form_json_changes(tmp_path: Path) -> None:
+    """Digest differs when form_json.py content changes."""
+    form_dir = tmp_path / "my_form"
+    version_dir = form_dir / "1" / "0"
+    version_dir.mkdir(parents=True)
+    (form_dir / "config.py").write_text("FORM_ID = 'abc'\n")
+    (version_dir / "form_json.py").write_text("SCHEMA = {}\n")
+
+    original = compute_version_hash(form_dir, version_dir)
+    (version_dir / "form_json.py").write_text("SCHEMA = {'changed': True}\n")
+    assert compute_version_hash(form_dir, version_dir) != original
+
+
+def test_compute_version_hash_changes_when_config_changes(tmp_path: Path) -> None:
+    """Digest differs when config.py content changes."""
+    form_dir = tmp_path / "my_form"
+    version_dir = form_dir / "1" / "0"
+    version_dir.mkdir(parents=True)
+    (form_dir / "config.py").write_text("FORM_ID = 'abc'\n")
+    (version_dir / "form_json.py").write_text("SCHEMA = {}\n")
+
+    original = compute_version_hash(form_dir, version_dir)
+    (form_dir / "config.py").write_text("FORM_ID = 'xyz'\n")
+    assert compute_version_hash(form_dir, version_dir) != original
+
+
+def test_get_version_dir_resolves_correctly() -> None:
+    """get_version_dir returns the expected form_dir and version_dir for a known form."""
+    form_dir, version_dir = get_version_dir("sf424", "1.0")
+    assert form_dir.name == "sf424"
+    assert version_dir.name == "0"
+    assert version_dir.parent.name == "1"
+
+
+def test_get_version_dir_rejects_bad_version() -> None:
+    """get_version_dir raises ValueError for a malformed version string."""
+    with pytest.raises(ValueError, match="MAJOR.MINOR"):
+        get_version_dir("sf424", "bad")
+
+
+def test_get_version_dir_rejects_unknown_form() -> None:
+    """get_version_dir raises ValueError for a form that does not exist."""
+    with pytest.raises(ValueError, match="no form directory"):
+        get_version_dir("nonexistent_form_xyz", "1.0")

--- a/api/tests/src/form_schema/forms/test_form_version_checksums.py
+++ b/api/tests/src/form_schema/forms/test_form_version_checksums.py
@@ -2,7 +2,9 @@ import re
 from pathlib import Path
 
 import pytest
+from flask import Flask
 
+from src.task import task_blueprint
 from src.task.forms.lock_form_version_task import compute_version_hash, get_version_dir
 
 _FORMS_ROOT = Path(__file__).parents[4] / "src" / "form_schema" / "forms"
@@ -106,3 +108,17 @@ def test_get_version_dir_rejects_unknown_form() -> None:
     """get_version_dir raises ValueError for a form that does not exist."""
     with pytest.raises(ValueError, match="no form directory"):
         get_version_dir("nonexistent_form_xyz", "1.0")
+
+
+def test_lock_form_version_blocked_in_non_local_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """lock-form-version must exit non-zero when ENVIRONMENT is not 'local'."""
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    app = Flask("test_lock_form_version")
+    app.register_blueprint(task_blueprint)
+    result = app.test_cli_runner().invoke(
+        args=["task", "lock-form-version", "--form=sf424", "--version=1.0"]
+    )
+    assert result.exit_code != 0
+    assert "non-local" in str(result.exception).lower()


### PR DESCRIPTION
## Summary

Fixes #10276

## Changes proposed

- Add a task `api/src/task/forms/lock_form_version_task.py`, registered in `api/src/task/__init__.py`
- Add new tests `api/tests/src/form_schema/forms/test_form_version_checksums.py`, which verifies checksum stability, detects tampering with `form_json.py` or `config.py`, and validates form/version directory resolution

## Context for reviewers

The checksum covers two files — `form_json.py` (versioned per `MAJOR/MINOR` directory) and `config.py` (shared across versions at the form level). It's always hashed in that order for a stable digest. 

## Validation steps

- [x] See new updated unit tests pass.
- [x] Run task `lock-form-version --form=sf424 --version=1.0` in a local environment and confirm a `checksum` file is written with a 64-character hex digest
- [x] Verify `error_if_not_local()` blocks the command in non-local environments