### PR TITLE
[Issue #10038] Add an ECS task job lock to our load-transform job in dev/staging

### DIFF
--- a/api/src/data_migration/command/load_transform.py
+++ b/api/src/data_migration/command/load_transform.py
@@ -13,6 +13,7 @@ import src.db.models.staging
 from src.constants.lookup_constants import JobType
 from src.task.ecs_background_task import ecs_background_task
 from src.task.opportunities.set_current_opportunities_task import SetCurrentOpportunitiesTask
+from src.task.task_job_lock import TaskJobLock
 
 from ...task.opportunities.store_opportunity_version_task import StoreOpportunityVersionTask
 from ..data_migration_blueprint import data_migration_blueprint
@@ -53,15 +54,16 @@ def load_transform(
     foreign_tables = {t.name: t for t in src.db.models.foreign.metadata.tables.values()}
     staging_tables = {t.name: t for t in src.db.models.staging.metadata.tables.values()}
 
-    if load:
-        LoadOracleDataTask(
-            db_session, foreign_tables, staging_tables, tables_to_load, insert_chunk_size
-        ).run()
-    if transform:
-        TransformOracleDataTask(db_session).run()
-    if set_current:
-        SetCurrentOpportunitiesTask(db_session).run()
-    if store_version:
-        StoreOpportunityVersionTask(db_session).run()
+    with TaskJobLock(db_session, job_type=JobType.LOAD_TRANSFORM, lock_duration_minutes=90):
+        if load:
+            LoadOracleDataTask(
+                db_session, foreign_tables, staging_tables, tables_to_load, insert_chunk_size
+            ).run()
+        if transform:
+            TransformOracleDataTask(db_session).run()
+        if set_current:
+            SetCurrentOpportunitiesTask(db_session).run()
+        if store_version:
+            StoreOpportunityVersionTask(db_session).run()
 
     logger.info("load and transform complete")

--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -62,6 +62,9 @@ module "dev_config" {
 
     # Workflow
     WORKFLOW_SERVICE_INTERNAL_USER_ID = "5711f79c-2445-47c7-bbcb-c8caa293ffad"
+
+    # Job lock — only enabled in dev/staging while we validate it
+    ENABLE_JOB_LOCK = "true"
   }
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html

--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -117,6 +117,26 @@ locals {
     grantee2 = "ENABLED"
     prod     = "ENABLED"
   }
+  # Only enable the job lock in dev/staging so we can validate it before
+  # turning it on in training/prod.
+  load-transform-environment-vars = {
+    dev = [
+      {
+        Name  = "ENABLE_JOB_LOCK"
+        Value = "true"
+      }
+    ]
+    staging = [
+      {
+        Name  = "ENABLE_JOB_LOCK"
+        Value = "true"
+      }
+    ]
+    training = null
+    grantee1 = null
+    grantee2 = null
+    prod     = null
+  }
   sam-extracts-state = {
     dev      = "ENABLED"
     staging  = "ENABLED"
@@ -149,7 +169,7 @@ locals {
       state               = local.load-transform-state[var.environment]
       cpu                 = try(local.scheduled_jobs_config[var.environment].cpu, null)
       mem                 = try(local.scheduled_jobs_config[var.environment].mem, null)
-      environment_vars    = try(local.scheduled_jobs_config[var.environment].environment_vars, null)
+      environment_vars    = local.load-transform-environment-vars[var.environment]
     }
     load-search-opportunity-data = {
       task_command = ["flask", "load-search-data", "load-opportunity-data"]

--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -117,26 +117,6 @@ locals {
     grantee2 = "ENABLED"
     prod     = "ENABLED"
   }
-  # Only enable the job lock in dev/staging so we can validate it before
-  # turning it on in training/prod.
-  load-transform-environment-vars = {
-    dev = [
-      {
-        Name  = "ENABLE_JOB_LOCK"
-        Value = "true"
-      }
-    ]
-    staging = [
-      {
-        Name  = "ENABLE_JOB_LOCK"
-        Value = "true"
-      }
-    ]
-    training = null
-    grantee1 = null
-    grantee2 = null
-    prod     = null
-  }
   sam-extracts-state = {
     dev      = "ENABLED"
     staging  = "ENABLED"
@@ -169,7 +149,7 @@ locals {
       state               = local.load-transform-state[var.environment]
       cpu                 = try(local.scheduled_jobs_config[var.environment].cpu, null)
       mem                 = try(local.scheduled_jobs_config[var.environment].mem, null)
-      environment_vars    = local.load-transform-environment-vars[var.environment]
+      environment_vars    = try(local.scheduled_jobs_config[var.environment].environment_vars, null)
     }
     load-search-opportunity-data = {
       task_command = ["flask", "load-search-data", "load-opportunity-data"]

--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -63,6 +63,9 @@ module "staging_config" {
 
     # Workflow
     WORKFLOW_SERVICE_INTERNAL_USER_ID = "903bf2e6-b213-4744-9f95-66ccfd98a819"
+
+    # Job lock — only enabled in dev/staging while we validate it
+    ENABLE_JOB_LOCK = "true"
   }
   # Enables ECS Exec access for debugging or jump access.
   # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10038  

## Changes proposed

- Updated load_transform.py to wrap load, transform, set-current, and store-version in a single `TaskJobLock` context manager
- Updated dev.tf to set `ENABLE_JOB_LOCK = "true"`
- Updated staging.tf to set `ENABLE_JOB_LOCK = "true"`

## Context for reviewers

This is the first usage of the `TaskJobLock` context manager. It wraps the full load-transform job (load → transform → set-current → store-version) with a 90-minute hold. `ENABLE_JOB_LOCK` is set at the environment level for dev/staging only.

## Validation steps

After dev/staging deployment:
- Terraform plan shows `ENABLE_JOB_LOCK=true` on the load-transform task in dev/staging, and no env var diff in training/grantee1/grantee2/prod
- In dev, trigger the job and confirm a row appears in `api.job_lock` for `job_type = "load-transform"` and the `"Job lock released"` log line fires with `job_lock_enabled: true`
- Trigger a second run while the first is in flight and confirm it fails with `TaskJobLockIsLockedError`