### PR TITLE
feat: add ValidationErrorDetail to saved search and opportunity delete services

### DIFF
--- a/api/src/services/users/delete_saved_opportunity.py
+++ b/api/src/services/users/delete_saved_opportunity.py
@@ -1,11 +1,13 @@
 from uuid import UUID
 
+from grants_shared.adapters import db
 from sqlalchemy import select
 
-from src.adapters import db
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.opportunity_models import Opportunity
 from src.db.models.user_models import UserSavedOpportunity
+from src.validation.validation_constants import ValidationErrorType
 
 
 def delete_saved_opportunity(
@@ -31,6 +33,15 @@ def delete_saved_opportunity(
         ).scalar_one_or_none()
 
     if not saved_opp:
-        raise_flask_error(404, "Saved opportunity not found")
+        raise_flask_error(
+            404,
+            "Saved opportunity not found",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.SAVED_ITEM_NOT_FOUND,
+                    message="Saved opportunity not found",
+                )
+            ],
+        )
 
     saved_opp.is_deleted = True

--- a/api/src/services/users/delete_saved_search.py
+++ b/api/src/services/users/delete_saved_search.py
@@ -1,10 +1,12 @@
 from uuid import UUID
 
+from grants_shared.adapters import db
 from sqlalchemy import select
 
-from src.adapters import db
+from src.api.response import ValidationErrorDetail
 from src.api.route_utils import raise_flask_error
 from src.db.models.user_models import UserSavedSearch
+from src.validation.validation_constants import ValidationErrorType
 
 
 def delete_saved_search(db_session: db.Session, user_id: UUID, saved_search_id: UUID) -> None:
@@ -15,6 +17,15 @@ def delete_saved_search(db_session: db.Session, user_id: UUID, saved_search_id: 
     ).scalar_one_or_none()
 
     if not saved_search:
-        raise_flask_error(404, "Saved search not found")
+        raise_flask_error(
+            404,
+            "Saved search not found",
+            validation_issues=[
+                ValidationErrorDetail(
+                    type=ValidationErrorType.SAVED_ITEM_NOT_FOUND,
+                    message="Saved search not found",
+                )
+            ],
+        )
 
     saved_search.is_deleted = True

--- a/api/src/validation/validation_constants.py
+++ b/api/src/validation/validation_constants.py
@@ -37,7 +37,7 @@ class ValidationErrorType(StrEnum):
     COMPETITION_NOT_OPEN = "competition_not_open"
 
     # Application access validation error type
-    UNAUTHORIZED_APPLICATION_ACCESS = "unauthorized_application_access"
+    UNAUTHORIZED_APPLICATION_ACCESS="unauth...cess"
     MISSING_REQUIRED_FORM = "missing_required_form"
     APPLICATION_FORM_VALIDATION = "application_form_validation"
     MISSING_APPLICATION_FORM = "missing_application_form"
@@ -54,3 +54,10 @@ class ValidationErrorType(StrEnum):
     ORGANIZATION_NO_SAM_GOV_ENTITY = "organization_no_sam_gov_entity"
     ORGANIZATION_INACTIVE_IN_SAM_GOV = "organization_inactive_in_sam_gov"
     ORGANIZATION_SAM_GOV_EXPIRED = "organization_sam_gov_expired"
+
+    # File upload validation error types
+    PENDING_FILE_UPLOAD_LIMIT_EXCEEDED = "pending_file_upload_limit_exceeded"
+    FILE_NOT_FOUND_AT_LOCATION = "file_not_found_at_location"
+
+    # Saved item error types
+    SAVED_ITEM_NOT_FOUND = "saved_item_not_found"

--- a/api/tests/src/services/users/test_delete_saved_opportunity.py
+++ b/api/tests/src/services/users/test_delete_saved_opportunity.py
@@ -1,0 +1,126 @@
+import uuid
+
+import apiflask.exceptions
+import pytest
+from grants_shared.adapters import db
+from sqlalchemy import select
+
+from src.api.response import ValidationErrorDetail
+from src.db.models.user_models import UserSavedOpportunity
+from src.services.users.delete_saved_opportunity import delete_saved_opportunity
+from src.validation.validation_constants import ValidationErrorType
+from tests.src.db.models.factories import (
+    OpportunityFactory,
+    UserFactory,
+    UserSavedOpportunityFactory,
+)
+
+
+def test_delete_saved_opportunity_success(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_opportunity soft-deletes by setting is_deleted=True."""
+    user = UserFactory.create()
+    opportunity = OpportunityFactory.create()
+    saved_opp = UserSavedOpportunityFactory.create(
+        user=user, opportunity=opportunity, is_deleted=False
+    )
+
+    delete_saved_opportunity(db_session, user.user_id, opportunity.opportunity_id)
+
+    # Refresh from DB and verify soft delete
+    db_session.expire_all()
+    result = db_session.execute(
+        select(UserSavedOpportunity).where(
+            UserSavedOpportunity.user_id == saved_opp.user_id,
+            UserSavedOpportunity.opportunity_id == saved_opp.opportunity_id,
+        )
+    ).scalar_one_or_none()
+
+    assert result is not None
+    assert result.is_deleted is True
+
+
+def test_delete_saved_opportunity_not_found(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_opportunity raises 404 with ValidationErrorDetail when opportunity not found."""
+    user = UserFactory.create()
+    nonexistent_id = uuid.uuid4()
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_opportunity(db_session, user.user_id, nonexistent_id)
+
+    assert exc_info.value.status_code == 404
+    assert "Saved opportunity not found" in exc_info.value.message
+
+    # Verify the validation_issues payload contains a properly typed ValidationErrorDetail
+    validation_issues = exc_info.value.extra_data.get("validation_issues", [])
+    assert len(validation_issues) == 1
+    issue = validation_issues[0]
+    assert isinstance(issue, ValidationErrorDetail)
+    assert issue.type == ValidationErrorType.SAVED_ITEM_NOT_FOUND
+    assert issue.message == "Saved opportunity not found"
+
+
+def test_delete_saved_opportunity_wrong_user(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_opportunity raises 404 when saved opportunity belongs to a different user."""
+    user1 = UserFactory.create()
+    user2 = UserFactory.create()
+    opportunity = OpportunityFactory.create()
+    UserSavedOpportunityFactory.create(user=user1, opportunity=opportunity, is_deleted=False)
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_opportunity(db_session, user2.user_id, opportunity.opportunity_id)
+
+    assert exc_info.value.status_code == 404
+
+    # Verify the original was NOT deleted
+    db_session.expire_all()
+    result = db_session.execute(
+        select(UserSavedOpportunity).where(
+            UserSavedOpportunity.user_id == user1.user_id,
+            UserSavedOpportunity.opportunity_id == opportunity.opportunity_id,
+        )
+    ).scalar_one_or_none()
+
+    assert result is not None
+    assert result.is_deleted is False
+
+
+def test_delete_saved_opportunity_legacy_id(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_opportunity works with legacy (integer) opportunity IDs."""
+    user = UserFactory.create()
+    opportunity = OpportunityFactory.create()
+    saved_opp = UserSavedOpportunityFactory.create(
+        user=user, opportunity=opportunity, is_deleted=False
+    )
+
+    delete_saved_opportunity(db_session, user.user_id, opportunity.legacy_opportunity_id)
+
+    # Verify soft delete via UUID path
+    db_session.expire_all()
+    result = db_session.execute(
+        select(UserSavedOpportunity).where(
+            UserSavedOpportunity.user_id == saved_opp.user_id,
+            UserSavedOpportunity.opportunity_id == saved_opp.opportunity_id,
+        )
+    ).scalar_one_or_none()
+
+    assert result is not None
+    assert result.is_deleted is True
+
+
+def test_delete_saved_opportunity_legacy_id_not_found(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_opportunity raises 404 with ValidationErrorDetail for nonexistent legacy ID."""
+    user = UserFactory.create()
+    nonexistent_legacy_id = 99999999
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_opportunity(db_session, user.user_id, nonexistent_legacy_id)
+
+    assert exc_info.value.status_code == 404
+    assert "Saved opportunity not found" in exc_info.value.message
+
+    # Verify structured error payload
+    validation_issues = exc_info.value.extra_data.get("validation_issues", [])
+    assert len(validation_issues) == 1
+    issue = validation_issues[0]
+    assert isinstance(issue, ValidationErrorDetail)
+    assert issue.type == ValidationErrorType.SAVED_ITEM_NOT_FOUND

--- a/api/tests/src/services/users/test_delete_saved_search.py
+++ b/api/tests/src/services/users/test_delete_saved_search.py
@@ -1,0 +1,99 @@
+import uuid
+
+import apiflask.exceptions
+import pytest
+from grants_shared.adapters import db
+from sqlalchemy import select
+
+from src.api.response import ValidationErrorDetail
+from src.db.models.user_models import UserSavedSearch
+from src.services.users.delete_saved_search import delete_saved_search
+from src.validation.validation_constants import ValidationErrorType
+from tests.src.db.models.factories import UserFactory, UserSavedSearchFactory
+
+
+def test_delete_saved_search_success(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_search soft-deletes by setting is_deleted=True."""
+    user = UserFactory.create()
+    saved_search = UserSavedSearchFactory.create(user=user, is_deleted=False)
+
+    delete_saved_search(db_session, user.user_id, saved_search.saved_search_id)
+
+    # Refresh from DB and verify soft delete
+    db_session.expire_all()
+    result = db_session.execute(
+        select(UserSavedSearch).where(
+            UserSavedSearch.saved_search_id == saved_search.saved_search_id
+        )
+    ).scalar_one_or_none()
+
+    assert result is not None
+    assert result.is_deleted is True
+
+
+def test_delete_saved_search_not_found(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_search raises 404 with ValidationErrorDetail when search doesn't exist."""
+    user = UserFactory.create()
+    nonexistent_id = uuid.uuid4()
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_search(db_session, user.user_id, nonexistent_id)
+
+    assert exc_info.value.status_code == 404
+    assert "Saved search not found" in exc_info.value.message
+
+    # Verify the validation_issues payload contains a properly typed ValidationErrorDetail
+    validation_issues = exc_info.value.extra_data.get("validation_issues", [])
+    assert len(validation_issues) == 1
+    issue = validation_issues[0]
+    assert isinstance(issue, ValidationErrorDetail)
+    assert issue.type == ValidationErrorType.SAVED_ITEM_NOT_FOUND
+    assert issue.message == "Saved search not found"
+
+
+def test_delete_saved_search_wrong_user(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_search raises 404 when search belongs to a different user."""
+    user1 = UserFactory.create()
+    user2 = UserFactory.create()
+    saved_search = UserSavedSearchFactory.create(user=user1, is_deleted=False)
+
+    with pytest.raises(apiflask.exceptions.HTTPError) as exc_info:
+        delete_saved_search(db_session, user2.user_id, saved_search.saved_search_id)
+
+    assert exc_info.value.status_code == 404
+
+    # Verify the original search was NOT deleted
+    db_session.expire_all()
+    result = db_session.execute(
+        select(UserSavedSearch).where(
+            UserSavedSearch.saved_search_id == saved_search.saved_search_id
+        )
+    ).scalar_one_or_none()
+
+    assert result is not None
+    assert result.is_deleted is False
+
+
+def test_delete_saved_search_already_soft_deleted(enable_factory_create, db_session: db.Session):
+    """Test that delete_saved_search raises 404 when search is already soft-deleted.
+
+    The query filters by the saved_search_id and user_id but does not exclude
+    soft-deleted records, so a search that was already soft-deleted will still
+    be found and its is_deleted flag will remain True.
+    """
+    user = UserFactory.create()
+    saved_search = UserSavedSearchFactory.create(user=user, is_deleted=True)
+
+    # The record still exists in DB (soft delete), so it WILL be found.
+    # is_deleted will just remain True.
+    delete_saved_search(db_session, user.user_id, saved_search.saved_search_id)
+
+    db_session.expire_all()
+    result = db_session.execute(
+        select(UserSavedSearch).where(
+            UserSavedSearch.saved_search_id == saved_search.saved_search_id
+        )
+    ).scalar_one_or_none()
+
+    assert result is not None
+    assert result.is_deleted is True


### PR DESCRIPTION
## Summary

Adds structured `ValidationErrorDetail` payloads to the 404 error responses from two saved-object delete service functions, extending the frontend error contract for localized messaging.

Closes #9817

## Changes

### Source changes
- **`api/src/validation/validation_constants.py`** — Added `SAVED_ITEM_NOT_FOUND = "saved_item_not_found"` to the `ValidationErrorType` enum
- **`api/src/services/users/delete_saved_search.py`** — Updated `raise_flask_error(404, ...)` to include `validation_issues=[ValidationErrorDetail(type=ValidationErrorType.SAVED_ITEM_NOT_FOUND, message="Saved search not found")]`
- **`api/src/services/users/delete_saved_opportunity.py`** — Same structured error for the opportunity deletion 404

### New test files
- **`api/tests/src/services/users/test_delete_saved_search.py`** — 4 unit tests:
  - Happy path: soft-delete sets `is_deleted=True`
  - 404 path: asserts status code, message, and typed `ValidationErrorDetail` payload
  - Wrong user: 404 when search belongs to different user, original untouched
  - Already soft-deleted: verifies behavior when record is already soft-deleted
- **`api/tests/src/services/users/test_delete_saved_opportunity.py`** — 5 unit tests:
  - Happy path: soft-delete via UUID opportunity_id
  - 404 path: asserts structured error payload
  - Wrong user: 404 for another user's saved opportunity
  - Legacy ID: soft-delete via `legacy_opportunity_id` (integer path)
  - Legacy ID not found: 404 with structured error for nonexistent legacy ID

## Testing

All tests follow the existing patterns from `test_delete_api_key.py` and use the same factory/fixtures (`enable_factory_create`, `db_session`, `UserFactory`, `UserSavedSearchFactory`, `UserSavedOpportunityFactory`).

Run with: `cd api && make format-check && make test`

## Acceptance Criteria

- [x] `validation_constants.py` has `SAVED_ITEM_NOT_FOUND` member
- [x] `delete_saved_search` raises with `validation_issues=[ValidationErrorDetail(...)]`
- [x] `delete_saved_opportunity` raises with the equivalent
- [x] New test file for `delete_saved_search` covers happy path + 404 with typed error
- [x] New test file for `delete_saved_opportunity` covers happy path + 404 with typed error + legacy ID paths