### PR TITLE
[Issue #9456] throw error in fetcher on missing token

### DIFF
--- a/frontend/src/errors.ts
+++ b/frontend/src/errors.ts
@@ -22,6 +22,18 @@ export const parseErrorStatus = (error: ApiRequestError): number => {
   }
 };
 
+export class MissingAuthError extends Error {
+  constructor(message?: string) {
+    const errorMessage =
+      message || "Request requires authentication and is missing user token";
+    const cause = {
+      type: "MissingAuthError",
+      message: errorMessage,
+    };
+    super(errorMessage, { cause });
+  }
+}
+
 /**
  * A fetch request failed due to a network error. The error wasn't the fault of the user,
  * and an issue was encountered while setting up or sending a request, or parsing the response.

--- a/frontend/src/services/fetch/FetcherHelpers.test.ts
+++ b/frontend/src/services/fetch/FetcherHelpers.test.ts
@@ -156,15 +156,20 @@ describe("getDefaultHeaders", () => {
     const headers = await getDefaultHeaders({});
     expect(headers["X-SGG-Token"]).toEqual(undefined);
   });
-  it("does not include user auth token header if required but not available", async () => {
+  it("throws if auth token is required but not available", async () => {
     getSessionMock.mockResolvedValue(null);
-    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
     const { getDefaultHeaders } = await import(
       "src/services/fetch/fetcherHelpers"
     );
-    const headers = await getDefaultHeaders({ requiresUserAuthToken: true });
-    expect(headers["X-SGG-Token"]).toEqual(undefined);
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    const err = await wrapForExpectedError(() =>
+      getDefaultHeaders({
+        requiresUserAuthToken: true,
+        url: "http://something.net",
+      }),
+    );
+    expect(err.message).toEqual(
+      "No user token present for call to authorized endpoint at http://something.net",
+    );
   });
   it("includes user auth token from session when present and required", async () => {
     getSessionMock.mockResolvedValue({ token: "a token" });

--- a/frontend/src/services/fetch/fetcherHelpers.ts
+++ b/frontend/src/services/fetch/fetcherHelpers.ts
@@ -7,6 +7,7 @@ import {
   BadRequestError,
   ForbiddenError,
   InternalServerError,
+  MissingAuthError,
   NetworkError,
   NotFoundError,
   RequestTimeoutError,
@@ -26,9 +27,11 @@ import { printAwsHeaders, printResponseInfo } from "src/utils/generalUtils";
 export async function getDefaultHeaders({
   addContentType = true,
   requiresUserAuthToken = false,
+  url,
 }: {
   addContentType?: boolean;
   requiresUserAuthToken?: boolean;
+  url?: string;
 }): Promise<Record<string, string>> {
   const headers: Record<string, string> = {};
 
@@ -48,11 +51,11 @@ export async function getDefaultHeaders({
   if (requiresUserAuthToken) {
     const session = await getSession();
     if (!session?.token) {
-      // May want to throw here
-      console.warn("no user token present for authorized endpoint call");
-    } else {
-      headers["X-SGG-Token"] = session.token;
+      throw new MissingAuthError(
+        `No user token present for call to authorized endpoint at ${url || "unknown url"}`,
+      );
     }
+    headers["X-SGG-Token"] = session.token;
   }
 
   return headers;

--- a/frontend/src/services/fetch/fetchers/Fetchers.test.ts
+++ b/frontend/src/services/fetch/fetchers/Fetchers.test.ts
@@ -103,6 +103,7 @@ describe("requesterForEndpoint", () => {
     expect(getDefaultHeadersMock).toHaveBeenCalledWith({
       addContentType: true,
       requiresUserAuthToken: true,
+      url: "fakeurl/1",
     });
     expect(fetchMock).toHaveBeenCalledWith("fakeurl/1", {
       body: JSON.stringify({ key: "value" }),

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -69,6 +69,7 @@ export function requesterForEndpoint({
     const defaultHeaders = await getDefaultHeaders({
       addContentType,
       requiresUserAuthToken: requiresAuth,
+      url,
     });
     const headers = {
       ...defaultHeaders,


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->

Work for #9456 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Following up on work from https://github.com/HHS/simpler-grants-gov/pull/9337, this change standardizes handling of missing tokens for authenticated routes by throwing an error rather than making an API request that is doomed to fail

A follow up ticket will handle some downstream consequences of this change more gracefully, but this change alone should not break any existing behavior.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. `npm run local` on this branch
2. For each page on the site that requires authentication, visit the page as a logged in user, then log out
3. _VERIFY_: an `Unauthenticated` message is displayed

#### Bonus Points

For each action on the site that requires authentication:

1. visit the page where the action takes place
2. log in
3. manually remove the "session" cookie from your browser session
4. perform the action
5. _VERIFY_: the correct handling of the unauthenticated action is shown
