### PR TITLE
[Issue #8689] Extract Correlation ID from Requests

### DIFF
--- a/backend/grants_shared/src/grants_shared/logs/flask_logger.py
+++ b/backend/grants_shared/src/grants_shared/logs/flask_logger.py
@@ -198,6 +198,10 @@ def _get_request_context_info(request: flask.Request) -> dict:
         "request.internal_id": internal_request_id,
     }
 
+    correlation_id = request.headers.get("X-Correlation-ID")
+    if correlation_id is not None:
+        data["request.correlation_id"] = correlation_id
+
     # Add query parameter data in the format request.query.<key> = <value>
     # For example, the query string ?foo=bar&baz=qux would be added as
     # request.query.foo = bar and request.query.baz = qux

--- a/backend/grants_shared/src/grants_shared/logs/flask_logger.py
+++ b/backend/grants_shared/src/grants_shared/logs/flask_logger.py
@@ -198,7 +198,7 @@ def _get_request_context_info(request: flask.Request) -> dict:
         "request.internal_id": internal_request_id,
     }
 
-    correlation_id = request.headers.get("X-Correlation-ID")
+    correlation_id = request.headers.get("X-Correlation-Id")
     if correlation_id is not None:
         data["request.correlation_id"] = correlation_id
 

--- a/backend/grants_shared/tests/grants_shared/logs/test_flask_logger.py
+++ b/backend/grants_shared/tests/grants_shared/logs/test_flask_logger.py
@@ -130,7 +130,7 @@ def test_add_extra_log_data_for_current_request(app: Flask, caplog: pytest.LogCa
 
 
 def test_correlation_id_in_logs_when_header_present(app: Flask, caplog: pytest.LogCaptureFixture):
-    app.test_client().get("/hello/jane", headers={"X-Correlation-ID": "abc-123"})
+    app.test_client().get("/hello/jane", headers={"X-Correlation-Id": "abc-123"})
 
     assert len(caplog.records) > 0
     for record in caplog.records:

--- a/backend/grants_shared/tests/grants_shared/logs/test_flask_logger.py
+++ b/backend/grants_shared/tests/grants_shared/logs/test_flask_logger.py
@@ -129,9 +129,7 @@ def test_add_extra_log_data_for_current_request(app: Flask, caplog: pytest.LogCa
     assert_dict_contains(last_record.__dict__, {"pet.name": "kitty"})
 
 
-def test_correlation_id_in_logs_when_header_present(
-    app: Flask, caplog: pytest.LogCaptureFixture
-):
+def test_correlation_id_in_logs_when_header_present(app: Flask, caplog: pytest.LogCaptureFixture):
     app.test_client().get("/hello/jane", headers={"X-Correlation-ID": "abc-123"})
 
     assert len(caplog.records) > 0

--- a/backend/grants_shared/tests/grants_shared/logs/test_flask_logger.py
+++ b/backend/grants_shared/tests/grants_shared/logs/test_flask_logger.py
@@ -129,6 +129,26 @@ def test_add_extra_log_data_for_current_request(app: Flask, caplog: pytest.LogCa
     assert_dict_contains(last_record.__dict__, {"pet.name": "kitty"})
 
 
+def test_correlation_id_in_logs_when_header_present(
+    app: Flask, caplog: pytest.LogCaptureFixture
+):
+    app.test_client().get("/hello/jane", headers={"X-Correlation-ID": "abc-123"})
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert_dict_contains(record.__dict__, {"request.correlation_id": "abc-123"})
+
+
+def test_correlation_id_absent_from_logs_when_header_missing(
+    app: Flask, caplog: pytest.LogCaptureFixture
+):
+    app.test_client().get("/hello/jane")
+
+    assert len(caplog.records) > 0
+    for record in caplog.records:
+        assert "request.correlation_id" not in record.__dict__
+
+
 def test_log_response_time(app: Flask, caplog: pytest.LogCaptureFixture):
     @app.get("/sleep")
     def sleep():


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8689

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- In `_get_request_context_info()`, reads the `X-Correlation-ID` header and adds it to the request log context as `request.correlation_id`
- Field is omitted when the header is absent (no default, no empty string)
- Add tests

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The CID is read-only and written only to the log context. It isn't related to auth or request routing.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] Run new test:`backend/grants_shared/tests/grants_shared/logs/test_flask_logger.py`
- [x] To manually verify: make a request with `-H "X-Correlation-ID: <value>"` and confirm `request.correlation_id` appears in the logs. Make the same request without the header and confirm the field is absent