### PR TITLE
[Issue #10729] Upload SOAP data to s3

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -245,6 +245,7 @@ SOAP_PARTNER_GATEWAY_AUTH_KEY=soap_partner_gateway_auth_key
 SOAP_GRANTORS_PATH=/grantsws-agency-partner/services/v2/AgencyWebServicesSoapPort
 SOAP_APPLICANTS_PATH=/grantsws-applicant/services/v2/ApplicantWebServicesSoapPort
 ENABLE_SIMPLER_ROUTE=true
+SAVE_SOAP_MESSAGES_TO_S3=false
 
 # Enable extra logging for soap proxy locally. This will not corresponding value
 # in lower environments. Only enabled locally.

--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -35,6 +35,7 @@ class LegacySoapAPIConfig(PydanticBaseEnvConfig):
     soap_applicants_path: str = Field("", alias="SOAP_APPLICANTS_PATH")
     enable_simpler_route: bool = Field(True, alias="ENABLE_SIMPLER_ROUTE")
     save_soap_messages_to_s3: bool = Field(False, alias="SAVE_SOAP_MESSAGES_TO_S3")
+    environment: str = Field(alias="ENVIRONMENT")
 
     @property
     def gg_url(self) -> str:

--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -34,6 +34,7 @@ class LegacySoapAPIConfig(PydanticBaseEnvConfig):
     soap_grantors_path: str = Field("", alias="SOAP_GRANTORS_PATH")
     soap_applicants_path: str = Field("", alias="SOAP_APPLICANTS_PATH")
     enable_simpler_route: bool = Field(True, alias="ENABLE_SIMPLER_ROUTE")
+    save_soap_messages_to_s3: bool = Field(False, alias="SAVE_SOAP_MESSAGES_TO_S3")
 
     @property
     def gg_url(self) -> str:

--- a/api/src/legacy_soap_api/legacy_soap_api_config.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_config.py
@@ -35,7 +35,6 @@ class LegacySoapAPIConfig(PydanticBaseEnvConfig):
     soap_applicants_path: str = Field("", alias="SOAP_APPLICANTS_PATH")
     enable_simpler_route: bool = Field(True, alias="ENABLE_SIMPLER_ROUTE")
     save_soap_messages_to_s3: bool = Field(False, alias="SAVE_SOAP_MESSAGES_TO_S3")
-    environment: str = Field(alias="ENVIRONMENT")
 
     @property
     def gg_url(self) -> str:

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -38,6 +38,7 @@ class LegacySoapApiEvent(StrEnum):
     RETURNING_SIMPLER_RESPONSE = "returning_simpler_response"
     RETURNING_LEGACY_SOAP_RESPONSE = "returning_legacy_soap_response"
     SIMPLER_ROUTE_DISABLED = "simpler_route_disabled"
+    ERROR_UPLOADING_DEBUG_DATA = "error_uploading_debug_data"
 
 
 class SimplerRequests(StrEnum):

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -38,3 +38,11 @@ class LegacySoapApiEvent(StrEnum):
     RETURNING_SIMPLER_RESPONSE = "returning_simpler_response"
     RETURNING_LEGACY_SOAP_RESPONSE = "returning_legacy_soap_response"
     SIMPLER_ROUTE_DISABLED = "simpler_route_disabled"
+
+
+class SimplerRequests(StrEnum):
+    GET_SUBMISSION_LIST_REQUEST = "GetSubmissionListRequest"
+    GET_SUBMISSION_LIST_EXPANDED_REQUEST = "GetSubmissionListExpandedRequest"
+    CONFIRM_APPLICATION_DELIVERY_REQUESET = "ConfirmApplicationDeliveryRequest"
+    UPDATE_APPLICATION_INFO_REQUEST = "UpdateApplicationInfoRequest"
+    GET_APPLICATION_ZIP_REQUEST = "GetApplicationZipRequest"

--- a/api/src/legacy_soap_api/legacy_soap_api_constants.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_constants.py
@@ -43,6 +43,6 @@ class LegacySoapApiEvent(StrEnum):
 class SimplerRequests(StrEnum):
     GET_SUBMISSION_LIST_REQUEST = "GetSubmissionListRequest"
     GET_SUBMISSION_LIST_EXPANDED_REQUEST = "GetSubmissionListExpandedRequest"
-    CONFIRM_APPLICATION_DELIVERY_REQUESET = "ConfirmApplicationDeliveryRequest"
+    CONFIRM_APPLICATION_DELIVERY_REQUEST = "ConfirmApplicationDeliveryRequest"
     UPDATE_APPLICATION_INFO_REQUEST = "UpdateApplicationInfoRequest"
     GET_APPLICATION_ZIP_REQUEST = "GetApplicationZipRequest"

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -1,7 +1,6 @@
 import io
 import json
 import logging
-import os
 import re
 import uuid
 from collections.abc import Callable, Iterator
@@ -532,16 +531,13 @@ def write_debug_data_to_s3(
     operation_name: str, soap_request: SOAPRequest, soap_legacy_response: SOAPResponse
 ) -> None:
     if get_soap_config().save_soap_messages_to_s3 and operation_name in SimplerRequests:
+        config = get_soap_config()
         s3_config = S3Config()
         debug_identifier = uuid.uuid4()
-        logger.info(
-            "soap_client: debug info uploaded to s3",
-            extra={"debug_identifier": debug_identifier},
-        )
         base_path = file_util.join(
             s3_config.draft_files_bucket_path,
             "soap",
-            os.getenv("ENVIRONMENT") or "local",
+            config.environment,
             f"{debug_identifier}",
         )
         request_s3_path = file_util.join(
@@ -554,3 +550,7 @@ def write_debug_data_to_s3(
             "response.txt",
         )
         file_util.write_to_file(response_s3_path, soap_legacy_response.to_bytes().decode("utf-8"))
+        logger.info(
+            "soap_client: debug info uploaded to s3",
+            extra={"debug_identifier": debug_identifier},
+        )

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -1,6 +1,7 @@
 import io
 import json
 import logging
+import os
 import re
 import uuid
 from collections.abc import Callable, Iterator
@@ -13,15 +14,18 @@ from defusedxml import minidom
 from lxml import etree
 from sqlalchemy import exists, select
 
+from src.adapters.aws import S3Config
 from src.db.models.competition_models import (
     ApplicationSubmission,
     ApplicationSubmissionRetrieved,
     ApplicationSubmissionTrackingNumber,
 )
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
+from src.legacy_soap_api.legacy_soap_api_constants import SimplerRequests
 from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage, SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.soap_payload_handler import extract_soap_xml
+from src.util import file_util
 
 logger = logging.getLogger(__name__)
 
@@ -522,3 +526,31 @@ def to_snake_case(name: str) -> str:
     """
     sub = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", sub).lower()
+
+
+def write_debug_data_to_s3(
+    operation_name: str, soap_request: SOAPRequest, soap_legacy_response: SOAPResponse
+) -> None:
+    if get_soap_config().save_soap_messages_to_s3 and operation_name in SimplerRequests:
+        s3_config = S3Config()
+        debug_identifier = uuid.uuid4()
+        logger.info(
+            "soap_client: debug info uploaded to s3",
+            extra={"debug_identifier": debug_identifier},
+        )
+        base_path = file_util.join(
+            s3_config.draft_files_bucket_path,
+            "soap",
+            os.getenv("ENVIRONMENT") or "local",
+            f"{debug_identifier}",
+        )
+        request_s3_path = file_util.join(
+            base_path,
+            "request.txt",
+        )
+        file_util.write_to_file(request_s3_path, b"".join(soap_request.data).decode("utf-8"))
+        response_s3_path = file_util.join(
+            base_path,
+            "response.txt",
+        )
+        file_util.write_to_file(response_s3_path, soap_legacy_response.to_bytes().decode("utf-8"))

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -531,14 +531,12 @@ def write_debug_data_to_s3(
     operation_name: str, soap_request: SOAPRequest, soap_legacy_response: SOAPResponse
 ) -> None:
     if get_soap_config().save_soap_messages_to_s3 and operation_name in SimplerRequests:
-        config = get_soap_config()
         s3_config = S3Config()
         debug_identifier = uuid.uuid4()
         base_path = file_util.join(
             s3_config.draft_files_bucket_path,
             "soap",
-            config.environment,
-            f"{debug_identifier}",
+            str(debug_identifier),
         )
         request_s3_path = file_util.join(
             base_path,

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -264,6 +264,6 @@ def process_simpler_request(
             except Exception:
                 logger.exception(
                     "soap_client: failed to upload debug info to s3",
-                    extra={"soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER},
+                    extra={"soap_api_event": LegacySoapApiEvent.ERROR_UPLOADING_DEBUG_DATA},
                 )
     return soap_legacy_response.to_flask_response()

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -19,7 +19,7 @@ from src.legacy_soap_api.legacy_soap_api_client import (
     SimplerGrantorsS2SClient,
 )
 from src.legacy_soap_api.legacy_soap_api_config import SimplerSoapAPI, get_soap_config
-from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
+from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent, SimplerRequests
 from src.legacy_soap_api.legacy_soap_api_proxy import get_proxy_response as get_legacy_response
 from src.legacy_soap_api.legacy_soap_api_schemas import (
     SOAPInvalidEnvelope,
@@ -35,13 +35,12 @@ from src.legacy_soap_api.legacy_soap_api_utils import (
     get_invalid_path_response,
     get_soap_error_response,
     get_soap_fault_error_response,
+    write_debug_data_to_s3,
 )
 from src.legacy_soap_api.soap_payload_handler import get_soap_operation_name
 
 logger = logging.getLogger(__name__)
 
-GET_SUBMISSION_LIST_REQUEST = "GetSubmissionListRequest"
-GET_SUBMISSION_LIST_EXPANDED_REQUEST = "GetSubmissionListExpandedRequest"
 GET_OPPORTUNITY_LIST_REQUEST = "GetOpportunityListRequest"
 
 
@@ -163,7 +162,6 @@ def process_simpler_request(
             return get_soap_error_response(
                 faultstring="Certificate is expired. (Authorization Failure)"
             ).to_flask_response()
-
     try:
         soap_request = SOAPRequest(
             api_name=api_name,
@@ -205,7 +203,11 @@ def process_simpler_request(
         # GetSubmissionListExpanded will call both if use_simpler is true
         # handled in the get_simpler_response
         elif (
-            operation_name in [GET_SUBMISSION_LIST_EXPANDED_REQUEST, GET_SUBMISSION_LIST_REQUEST]
+            operation_name
+            in [
+                SimplerRequests.GET_SUBMISSION_LIST_EXPANDED_REQUEST,
+                SimplerRequests.GET_SUBMISSION_LIST_REQUEST,
+            ]
             and api_name == SimplerSoapAPI.GRANTORS
         ):
             soap_legacy_response = get_legacy_response(soap_request)
@@ -222,7 +224,6 @@ def process_simpler_request(
             },
         )
         return get_soap_error_response().to_flask_response()
-
     if auth and auth.certificate.legacy_certificate:
         try:
             return get_simpler_soap_response(
@@ -258,4 +259,5 @@ def process_simpler_request(
                     "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
                 },
             )
+            write_debug_data_to_s3(operation_name, soap_request, soap_legacy_response)
     return soap_legacy_response.to_flask_response()

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -259,5 +259,11 @@ def process_simpler_request(
                     "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
                 },
             )
-            write_debug_data_to_s3(operation_name, soap_request, soap_legacy_response)
+            try:
+                write_debug_data_to_s3(operation_name, soap_request, soap_legacy_response)
+            except Exception:
+                logger.exception(
+                    "soap_client: failed to upload debug info to s3",
+                    extra={"soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER},
+                )
     return soap_legacy_response.to_flask_response()

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1,7 +1,10 @@
 import logging
+import os
 from datetime import datetime
 from unittest import mock
 
+import boto3
+import moto
 from lxml import etree
 
 from src.constants.lookup_constants import ApplicationStatus, Privilege
@@ -123,6 +126,97 @@ def test_successful_confirm_application_delivery_request(
         .all()
     )
     assert len(retrieved) == 1
+
+
+@mock.patch("uuid.uuid4")
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response")
+def test_request_and_response_data_uploaded_to_s3_if_save_soap_messages_flag_is_true_and_operation_name_is_one_of_the_valid_operations(
+    mock_get_simpler_soap_response,
+    mock_uuid,
+    monkeypatch,
+    mock_s3_bucket,
+    db_session,
+    client,
+    enable_factory_create,
+    caplog,
+) -> None:
+    mock_uuid.return_value = TEST_UUID
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    mock_get_simpler_soap_response.side_effect = Exception()
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.ACCEPTED
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+        cert_id=soap_client_certificate.legacy_certificate.cert_id,
+    )
+    with moto.mock_aws():
+        with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+            mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={
+                    "Use-Simpler-Override": "1",
+                    MTLS_CERT_HEADER_KEY: mtls_cert,
+                },
+            )
+            assert response.status_code == 500
+            expected_response = (
+                "--uuid:00000000-aaaa-0000-bbbb-000000000000\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\n'
+                "Content-ID: <root.message@cxf.apache.org>\r\n"
+                '\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+                "<soap:Body><soap:Fault><faultcode>soap:Server</faultcode><faultstring>Failed to confirm application delivery.(Authorization Failure)</faultstring></soap:Fault>"
+                "</soap:Body>"
+                "</soap:Envelope>\r\n"
+                "--uuid:00000000-aaaa-0000-bbbb-000000000000--"
+            ).encode()
+            assert response.data == expected_response
+        record = next(
+            r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
+        )
+        assert record
+        get_request = s3_client.get_object(
+            Bucket=mock_s3_bucket,
+            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/request.txt",
+        )
+        request_contents = get_request["Body"].read()
+        get_response = s3_client.get_object(
+            Bucket=mock_s3_bucket,
+            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/response.txt",
+        )
+        response_contents = get_response["Body"].read()
+        assert request_contents == mock_data
+        assert response_contents == expected_response
 
 
 @mock.patch("uuid.uuid4")

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -213,6 +213,79 @@ def test_request_and_response_data_uploaded_to_s3_if_save_soap_messages_flag_is_
 
 
 @mock.patch("uuid.uuid4")
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response")
+def test_if_write_debug_data_to_s3_fails_the_exception_is_logged(
+    mock_get_simpler_soap_response,
+    mock_uuid,
+    monkeypatch,
+    mock_s3_bucket,
+    db_session,
+    client,
+    enable_factory_create,
+    caplog,
+    s3_config,
+    mock_s3,
+) -> None:
+    mock_uuid.return_value = TEST_UUID
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    mock_get_simpler_soap_response.side_effect = Exception()
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.ACCEPTED
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+        cert_id=soap_client_certificate.legacy_certificate.cert_id,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        with mock.patch(
+            "src.legacy_soap_api.simpler_soap_api.write_debug_data_to_s3"
+        ) as mock_write_debug:
+            mock_write_debug.side_effect = Exception()
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={
+                    "Use-Simpler-Override": "1",
+                    MTLS_CERT_HEADER_KEY: mtls_cert,
+                },
+            )
+            assert response.status_code == 500
+        record = next(
+            r
+            for r in caplog.records
+            if r.message == "soap_client: failed to upload debug info to s3"
+        )
+        assert record
+
+
+@mock.patch("uuid.uuid4")
 def test_successful_confirm_application_delivery_request_when_in_received_by_agency_status(
     mock_uuid, db_session, client, enable_factory_create, caplog
 ) -> None:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1,10 +1,7 @@
 import logging
-import os
 from datetime import datetime
 from unittest import mock
 
-import boto3
-import moto
 from lxml import etree
 
 from src.constants.lookup_constants import ApplicationStatus, Privilege
@@ -18,6 +15,7 @@ from src.legacy_soap_api.legacy_soap_api_auth import (
 )
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_utils import get_invalid_path_response
+from src.util import file_util
 from tests.lib.data_factories import get_mtls_urlencoded_str_and_serial_number, setup_cert_user
 from tests.src.db.models.factories import (
     AgencyFactory,
@@ -139,12 +137,12 @@ def test_request_and_response_data_uploaded_to_s3_if_save_soap_messages_flag_is_
     client,
     enable_factory_create,
     caplog,
+    s3_config,
+    mock_s3,
 ) -> None:
     mock_uuid.return_value = TEST_UUID
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
-    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
-    s3_client = boto3.client("s3", region_name="us-east-1")
     mock_get_simpler_soap_response.side_effect = Exception()
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
@@ -178,45 +176,40 @@ def test_request_and_response_data_uploaded_to_s3_if_save_soap_messages_flag_is_
         legacy_certificate=soap_client_certificate.legacy_certificate,
         cert_id=soap_client_certificate.legacy_certificate.cert_id,
     )
-    with moto.mock_aws():
-        with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
-            mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
-            response = client.post(
-                full_path,
-                data=mock_data,
-                headers={
-                    "Use-Simpler-Override": "1",
-                    MTLS_CERT_HEADER_KEY: mtls_cert,
-                },
-            )
-            assert response.status_code == 500
-            expected_response = (
-                "--uuid:00000000-aaaa-0000-bbbb-000000000000\r\n"
-                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\n'
-                "Content-ID: <root.message@cxf.apache.org>\r\n"
-                '\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
-                "<soap:Body><soap:Fault><faultcode>soap:Server</faultcode><faultstring>Failed to confirm application delivery.(Authorization Failure)</faultstring></soap:Fault>"
-                "</soap:Body>"
-                "</soap:Envelope>\r\n"
-                "--uuid:00000000-aaaa-0000-bbbb-000000000000--"
-            ).encode()
-            assert response.data == expected_response
-        record = next(
-            r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        response = client.post(
+            full_path,
+            data=mock_data,
+            headers={
+                "Use-Simpler-Override": "1",
+                MTLS_CERT_HEADER_KEY: mtls_cert,
+            },
         )
-        assert record
-        get_request = s3_client.get_object(
-            Bucket=mock_s3_bucket,
-            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/request.txt",
-        )
-        request_contents = get_request["Body"].read()
-        get_response = s3_client.get_object(
-            Bucket=mock_s3_bucket,
-            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/response.txt",
-        )
-        response_contents = get_response["Body"].read()
-        assert request_contents == mock_data
-        assert response_contents == expected_response
+        assert response.status_code == 500
+        expected_response = (
+            "--uuid:00000000-aaaa-0000-bbbb-000000000000\r\n"
+            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\n'
+            "Content-ID: <root.message@cxf.apache.org>\r\n"
+            '\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+            "<soap:Body><soap:Fault><faultcode>soap:Server</faultcode><faultstring>Failed to confirm application delivery.(Authorization Failure)</faultstring></soap:Fault>"
+            "</soap:Body>"
+            "</soap:Envelope>\r\n"
+            "--uuid:00000000-aaaa-0000-bbbb-000000000000--"
+        ).encode()
+        assert response.data == expected_response
+    record = next(
+        r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
+    )
+    assert record
+    request_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap/{record.debug_identifier}/request.txt"
+    )
+    response_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap/{record.debug_identifier}/response.txt"
+    )
+    assert request_contents.replace("\n", "") == mock_data.decode().replace("\n", "")
+    assert response_contents.replace("\r", "") == expected_response.decode().replace("\r", "")
 
 
 @mock.patch("uuid.uuid4")

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -1,0 +1,136 @@
+import logging
+import os
+
+import boto3
+import moto
+
+from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
+from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
+from src.legacy_soap_api.legacy_soap_api_utils import write_debug_data_to_s3
+from tests.lib.data_factories import create_soap_request
+
+NSMAP = {
+    "envelope": "http://schemas.xmlsoap.org/soap/envelope/",
+    "application_request": "http://apply.grants.gov/services/AgencyWebServices-V2.0",
+    "tracking_number": "http://apply.grants.gov/system/GrantsCommonElements-V1.0",
+}
+GET_APPLICATION_ZIP_PATH = f"{{{NSMAP['envelope']}}}Body/{{{NSMAP['application_request']}}}GetApplicationZipRequest/{{{NSMAP['tracking_number']}}}GrantsGovTrackingNumber"
+LEGACY_TRACKING_NUMBER = "GRANT00000008"
+SOAP_PAYLOAD = (
+    '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+    'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+    'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+    "<soapenv:Header/>"
+    "<soapenv:Body>"
+    "<agen:GetApplicationZipRequest>"
+    "<gran:GrantsGovTrackingNumber>GRANT9000000</gran:GrantsGovTrackingNumber>"
+    "</agen:GetApplicationZipRequest>"
+    "</soapenv:Body>"
+    "</soapenv:Envelope>"
+).encode("utf-8")
+SOAP_LEGACY_RESPONSE_PAYLOAD = (
+    "--uuid:def0358e-9646-4696-a879-59956dedfabc"
+    'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
+    "Content-Transfer-Encoding: binary"
+    "Content-ID: <root.message@cxf.apache.org>"
+    '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+    "<soap:Body><ns2:GetSubmissionListExpandedResponse"
+    'xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" '
+    'xmlns:ns11="http://schemas.xmlsoap.org/wsdl/" '
+    'xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" '
+    'xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" '
+    'xmlns:ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" '
+    'xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" '
+    'xmlns:ns6="http://apply.grants.gov/system/GrantsPackage-V1.0" '
+    'xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" '
+    'xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" '
+    'xmlns:ns3="http://apply.grants.gov/system/GrantsTemplate-V1.0" '
+    'xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+    'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+    "<ns2:Success>true</ns2:Success>"
+    "<ns2:AvailableApplicationNumber>0</ns2:AvailableApplicationNumber>"
+    "</ns2:GetSubmissionListExpandedResponse>"
+    "</soap:Body>"
+    "</soap:Envelope>"
+    "--uuid:def0358e-9646-4696-a879-59956dedfabc--"
+).encode("utf-8")
+
+
+def test_write_debug_data_to_s3(
+    caplog, db_session, enable_factory_create, monkeypatch, mock_s3_bucket
+) -> None:
+    caplog.set_level(logging.INFO)
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    with moto.mock_aws():
+        soap_legacy_response = SOAPResponse(
+            data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+        )
+        soap_request = create_soap_request(SOAP_PAYLOAD)
+        write_debug_data_to_s3(
+            "GetSubmissionListExpandedRequest", soap_request, soap_legacy_response
+        )
+        record = next(
+            r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
+        )
+        get_request = s3_client.get_object(
+            Bucket=mock_s3_bucket,
+            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/request.txt",
+        )
+        request_contents = get_request["Body"].read()
+        get_response = s3_client.get_object(
+            Bucket=mock_s3_bucket,
+            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/response.txt",
+        )
+        response_contents = get_response["Body"].read()
+        assert request_contents == SOAP_PAYLOAD
+        assert response_contents == SOAP_LEGACY_RESPONSE_PAYLOAD
+
+
+def test_write_debug_data_to_s3_does_not_run_if_flag_is_set_to_false(
+    db_session, enable_factory_create, monkeypatch, mock_s3_bucket
+) -> None:
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "false")
+    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    with moto.mock_aws():
+        soap_legacy_response = SOAPResponse(
+            data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+        )
+        soap_request = create_soap_request(SOAP_PAYLOAD)
+        write_debug_data_to_s3(
+            "GetSubmissionListExpandedRequest", soap_request, soap_legacy_response
+        )
+        objects = s3_client.list_objects_v2(Bucket=mock_s3_bucket)
+        assert objects.get("Contents", None) is None
+
+
+def test_write_debug_data_to_s3_does_not_run_if_not_in_specified_operations(
+    db_session, enable_factory_create, monkeypatch, mock_s3_bucket
+) -> None:
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    with moto.mock_aws():
+        soap_legacy_response = SOAPResponse(
+            data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+        )
+        soap_request = create_soap_request(SOAP_PAYLOAD)
+        write_debug_data_to_s3(
+            "GetSubmissionListExpandedRequest", soap_request, soap_legacy_response
+        )
+        write_debug_data_to_s3("GetSubmissionListRequest", soap_request, soap_legacy_response)
+        write_debug_data_to_s3("GetApplicationZipRequest", soap_request, soap_legacy_response)
+        write_debug_data_to_s3(
+            "ConfirmApplicationDeliveryRequest", soap_request, soap_legacy_response
+        )
+        write_debug_data_to_s3("UpdateApplicationInfoRequest", soap_request, soap_legacy_response)
+        write_debug_data_to_s3("X", soap_request, soap_legacy_response)
+        write_debug_data_to_s3("Y", soap_request, soap_legacy_response)
+        objects = s3_client.list_objects_v2(Bucket=mock_s3_bucket)
+        # If it triggered on everything it should be 14
+        assert len(objects.get("Contents")) == 10

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -1,12 +1,11 @@
 import logging
-import os
 
 import boto3
-import moto
 
 from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_utils import write_debug_data_to_s3
+from src.util import file_util
 from tests.lib.data_factories import create_soap_request
 
 NSMAP = {
@@ -57,80 +56,63 @@ SOAP_LEGACY_RESPONSE_PAYLOAD = (
 
 
 def test_write_debug_data_to_s3(
-    caplog, db_session, enable_factory_create, monkeypatch, mock_s3_bucket
+    caplog, db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
 ) -> None:
     caplog.set_level(logging.INFO)
     soap_api_config.get_soap_config.cache_clear()
-    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
-    s3_client = boto3.client("s3", region_name="us-east-1")
-    with moto.mock_aws():
-        soap_legacy_response = SOAPResponse(
-            data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
-        )
-        soap_request = create_soap_request(SOAP_PAYLOAD)
-        write_debug_data_to_s3(
-            "GetSubmissionListExpandedRequest", soap_request, soap_legacy_response
-        )
-        record = next(
-            r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
-        )
-        get_request = s3_client.get_object(
-            Bucket=mock_s3_bucket,
-            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/request.txt",
-        )
-        request_contents = get_request["Body"].read()
-        get_response = s3_client.get_object(
-            Bucket=mock_s3_bucket,
-            Key=f"soap/{os.getenv('ENVIRONMENT')}/{record.debug_identifier}/response.txt",
-        )
-        response_contents = get_response["Body"].read()
-        assert request_contents == SOAP_PAYLOAD
-        assert response_contents == SOAP_LEGACY_RESPONSE_PAYLOAD
+    soap_legacy_response = SOAPResponse(
+        data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+    )
+    soap_request = create_soap_request(SOAP_PAYLOAD)
+    write_debug_data_to_s3("GetSubmissionListExpandedRequest", soap_request, soap_legacy_response)
+    record = next(
+        r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
+    )
+    request_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap/{record.debug_identifier}/request.txt"
+    )
+    response_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap/{record.debug_identifier}/response.txt"
+    )
+    assert request_contents.replace("\n", "") == SOAP_PAYLOAD.decode().replace("\n", "")
+    assert response_contents.replace("\r", "") == SOAP_LEGACY_RESPONSE_PAYLOAD.decode().replace(
+        "\r", ""
+    )
 
 
 def test_write_debug_data_to_s3_does_not_run_if_flag_is_set_to_false(
-    db_session, enable_factory_create, monkeypatch, mock_s3_bucket
+    db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
 ) -> None:
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "false")
-    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
     s3_client = boto3.client("s3", region_name="us-east-1")
-    with moto.mock_aws():
-        soap_legacy_response = SOAPResponse(
-            data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
-        )
-        soap_request = create_soap_request(SOAP_PAYLOAD)
-        write_debug_data_to_s3(
-            "GetSubmissionListExpandedRequest", soap_request, soap_legacy_response
-        )
-        objects = s3_client.list_objects_v2(Bucket=mock_s3_bucket)
-        assert objects.get("Contents", None) is None
+    soap_legacy_response = SOAPResponse(
+        data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+    )
+    soap_request = create_soap_request(SOAP_PAYLOAD)
+    write_debug_data_to_s3("GetSubmissionListExpandedRequest", soap_request, soap_legacy_response)
+    objects = s3_client.list_objects_v2(Bucket="local-mock-draft-bucket")
+    assert objects.get("Contents", None) is None
 
 
 def test_write_debug_data_to_s3_does_not_run_if_not_in_specified_operations(
-    db_session, enable_factory_create, monkeypatch, mock_s3_bucket
+    db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
 ) -> None:
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
-    monkeypatch.setenv("DRAFT_FILES_BUCKET", f"s3://{mock_s3_bucket}")
     s3_client = boto3.client("s3", region_name="us-east-1")
-    with moto.mock_aws():
-        soap_legacy_response = SOAPResponse(
-            data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
-        )
-        soap_request = create_soap_request(SOAP_PAYLOAD)
-        write_debug_data_to_s3(
-            "GetSubmissionListExpandedRequest", soap_request, soap_legacy_response
-        )
-        write_debug_data_to_s3("GetSubmissionListRequest", soap_request, soap_legacy_response)
-        write_debug_data_to_s3("GetApplicationZipRequest", soap_request, soap_legacy_response)
-        write_debug_data_to_s3(
-            "ConfirmApplicationDeliveryRequest", soap_request, soap_legacy_response
-        )
-        write_debug_data_to_s3("UpdateApplicationInfoRequest", soap_request, soap_legacy_response)
-        write_debug_data_to_s3("X", soap_request, soap_legacy_response)
-        write_debug_data_to_s3("Y", soap_request, soap_legacy_response)
-        objects = s3_client.list_objects_v2(Bucket=mock_s3_bucket)
-        # If it triggered on everything it should be 14
-        assert len(objects.get("Contents")) == 10
+    soap_legacy_response = SOAPResponse(
+        data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+    )
+    soap_request = create_soap_request(SOAP_PAYLOAD)
+    write_debug_data_to_s3("GetSubmissionListExpandedRequest", soap_request, soap_legacy_response)
+    write_debug_data_to_s3("GetSubmissionListRequest", soap_request, soap_legacy_response)
+    write_debug_data_to_s3("GetApplicationZipRequest", soap_request, soap_legacy_response)
+    write_debug_data_to_s3("ConfirmApplicationDeliveryRequest", soap_request, soap_legacy_response)
+    write_debug_data_to_s3("UpdateApplicationInfoRequest", soap_request, soap_legacy_response)
+    write_debug_data_to_s3("X", soap_request, soap_legacy_response)
+    write_debug_data_to_s3("Y", soap_request, soap_legacy_response)
+    objects = s3_client.list_objects_v2(Bucket="local-mock-draft-bucket")
+    # If it triggered on everything it should be 14
+    assert len(objects.get("Contents")) == 10

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -126,6 +126,11 @@ locals {
       secret_store_name = "/api/${var.environment}/enable-simpler-route"
     }
 
+    SAVE_SOAP_MESSAGES_TO_S3 = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/save-soap-messages-to-s3"
+    }
+
     SAM_GOV_API_KEY = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/sam-gov-api-key"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10729  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- added method `write_debug_data_to_s3`
- added tests for method
- added test to actually post the endpoint and see if it works
- added new env variable `SAVE_SOAP_MESSAGES_TO_S3`
- added support for parameter store for new env variable
- set new env variable in local.env

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
For troubleshooting SOAP/Proxy issues it would be helpful to get a copy of the exact request and response data. We want to be able to control that per environments and only wanted it for certain operations.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] can get data from s3 when run in env where the flag is flipped
