### PR TITLE
[Issue #10540] Add shared schema types for non-negative monetary and integer percentage

### DIFF
--- a/api/src/form_schema/shared/common_shared.py
+++ b/api/src/form_schema/shared/common_shared.py
@@ -62,6 +62,33 @@ COMMON_SHARED_JSON_SCHEMA_V1 = {
         "minLength": 1,
         "maxLength": 14,
     },
+    "budget_monetary_amount_non_negative": {
+        # Represents a non-negative monetary amount for user-input cells (e.g. SF424C budget rows).
+        # We use a string instead of number to avoid any floating point rounding issues.
+        # Negative values are not allowed; use budget_monetary_amount if negatives are needed.
+        "type": "string",
+        # Pattern: any number of digits with an optional decimal point and exactly 2 decimal digits.
+        "pattern": r"^\d*([.]\d{2})?$",
+        "minLength": 1,
+        "maxLength": 14,
+    },
+    "budget_monetary_total_non_negative": {
+        # Represents a non-negative monetary amount for computed subtotal/total cells (e.g. SF424C).
+        # Identical constraints to budget_monetary_amount_non_negative but named separately so
+        # form schemas can distinguish user-input cells from computed output cells.
+        "type": "string",
+        "pattern": r"^\d*([.]\d{2})?$",
+        "minLength": 1,
+        "maxLength": 14,
+    },
+    "percentage": {
+        # Represents a whole-number percentage. A value of 5 means 5%, not 0.05.
+        # Valid range is 0–100 inclusive. Used as the right-hand operand in
+        # multiply_by_percentage rules; always pass the integer display value, never a decimal.
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 100,
+    },
     "phone_number": {
         "type": "string",
         "minLength": 1,

--- a/api/tests/src/form_schema/shared/test_common_shared.py
+++ b/api/tests/src/form_schema/shared/test_common_shared.py
@@ -352,3 +352,131 @@ def test_shared_common_v1_sam_uei_max_length():
     assert len(validation_issues) == 1
     assert validation_issues[0].type == "maxLength"
     assert validation_issues[0].field == "$.my_field"
+
+
+###################################
+# Budget Monetary Amount Non-Negative
+###################################
+
+
+@pytest.mark.parametrize("value", ["10", "123.45", "100000000.00", "0.00", "0", "99999999999.99"])
+def test_shared_common_v1_budget_monetary_amount_non_negative_valid(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_amount_non_negative")
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 0
+
+
+@pytest.mark.parametrize("value", ["-1.01", "-100000000.00", "-0.01"])
+def test_shared_common_v1_budget_monetary_amount_non_negative_rejects_negative(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_amount_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "pattern"
+    assert validation_issues[0].field == "$.my_field"
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["not-money", "1.1", "10000.000", "+12", "1e12", "3.", "4.x0"],
+)
+def test_shared_common_v1_budget_monetary_amount_non_negative_invalid_pattern(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_amount_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "pattern"
+    assert validation_issues[0].field == "$.my_field"
+
+
+def test_shared_common_v1_budget_monetary_amount_non_negative_min_length():
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_amount_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": ""}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
+@pytest.mark.parametrize("value", ["100000000000000", "123456789000.00"])
+def test_shared_common_v1_budget_monetary_amount_non_negative_max_length(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_amount_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
+###################################
+# Budget Monetary Total Non-Negative
+###################################
+
+
+@pytest.mark.parametrize("value", ["10", "0.00", "99999999999.99"])
+def test_shared_common_v1_budget_monetary_total_non_negative_valid(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_total_non_negative")
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 0
+
+
+@pytest.mark.parametrize("value", ["-1.01", "-0.01"])
+def test_shared_common_v1_budget_monetary_total_non_negative_rejects_negative(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_total_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "pattern"
+    assert validation_issues[0].field == "$.my_field"
+
+
+@pytest.mark.parametrize("value", ["100000000000000", "123456789000.00"])
+def test_shared_common_v1_budget_monetary_total_non_negative_max_length(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_total_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
+###################################
+# Percentage
+###################################
+
+
+@pytest.mark.parametrize("value", [0, 1, 50, 99, 100])
+def test_shared_common_v1_percentage_valid(value):
+    schema = build_schema(COMMON_SHARED_V1, "percentage")
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 0
+
+
+@pytest.mark.parametrize("value", [-1, -100])
+def test_shared_common_v1_percentage_below_minimum(value):
+    schema = build_schema(COMMON_SHARED_V1, "percentage")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minimum"
+    assert validation_issues[0].field == "$.my_field"
+
+
+@pytest.mark.parametrize("value", [101, 200])
+def test_shared_common_v1_percentage_above_maximum(value):
+    schema = build_schema(COMMON_SHARED_V1, "percentage")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maximum"
+    assert validation_issues[0].field == "$.my_field"
+
+
+@pytest.mark.parametrize("value", [50.5, 0.5, 99.9])
+def test_shared_common_v1_percentage_rejects_decimal(value):
+    schema = build_schema(COMMON_SHARED_V1, "percentage")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "type"
+    assert validation_issues[0].field == "$.my_field"

--- a/api/tests/src/form_schema/shared/test_common_shared.py
+++ b/api/tests/src/form_schema/shared/test_common_shared.py
@@ -430,6 +430,28 @@ def test_shared_common_v1_budget_monetary_total_non_negative_rejects_negative(va
     assert validation_issues[0].field == "$.my_field"
 
 
+@pytest.mark.parametrize(
+    "value",
+    ["not-money", "1.1", "10000.000", "+12", "1e12", "3.", "4.x0"],
+)
+def test_shared_common_v1_budget_monetary_total_non_negative_invalid_pattern(value):
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_total_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": value}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "pattern"
+    assert validation_issues[0].field == "$.my_field"
+
+
+def test_shared_common_v1_budget_monetary_total_non_negative_min_length():
+    schema = build_schema(COMMON_SHARED_V1, "budget_monetary_total_non_negative")
+
+    validation_issues = validate_json_schema({"my_field": ""}, schema)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minLength"
+    assert validation_issues[0].field == "$.my_field"
+
+
 @pytest.mark.parametrize("value", ["100000000000000", "123456789000.00"])
 def test_shared_common_v1_budget_monetary_total_non_negative_max_length(value):
     schema = build_schema(COMMON_SHARED_V1, "budget_monetary_total_non_negative")


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10540

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
`budget_monetary_amount_non_negative` - string type with same regex as budget_monetary_amount but leading minus sign disallowed
`budget_monetary_total_non_negative` - separate name to distinguish computed subtotal/total cells from user-input cells
`percentage` - intended as the right-hand operand for multiply_by_percentage (added in a separate ticket)

Add unit tests for all three types covering valid inputs, negative rejection, invalid patterns, min/max length (monetary), and out-of-range/decimal rejection (percentage)

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The existing `budget_monetary_amount` allows negatives, so the non-negative types can't be expressed by tweaking it — they need separate entries.

No existing form schemas were modified.

SF424C requires three new shared JSON schema types: non negative monetary inputs (no leading minus), non negative monetary totals, and a whole number percentage (integer 0-100). These can't be expressed by tweaking existing types because budget_monetary_amount allows negatives, and we have no percentage type at all. Staging these as a standalone ticket (separate from the form build) so the percentage contract gets reviewed alongside the arithmetic rule that depends on it.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See new unit tests added.