### PR TITLE
Port v0.17 storage service_principals_with_access support

### DIFF
--- a/infra/modules/storage/access_control.tf
+++ b/infra/modules/storage/access_control.tf
@@ -57,6 +57,7 @@ data "aws_iam_policy_document" "storage_access" {
       "arn:aws:s3:::${var.name}/*"
     ]
   }
+
   statement {
     actions   = ["kms:GenerateDataKey", "kms:Decrypt"]
     effect    = "Allow"

--- a/infra/modules/storage/encryption.tf
+++ b/infra/modules/storage/encryption.tf
@@ -1,3 +1,53 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "kms_key_policy" {
+  # checkov:skip=CKV_AWS_109:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_111:Root account requires full KMS permissions to enable IAM-based access control
+  # checkov:skip=CKV_AWS_356:In a key policy, the wildcard character in the Resource element represents the KMS key to which the key policy is attached.
+
+  # This gives the AWS account that owns the KMS key full access to the KMS key,
+  # deferring specific access rules to IAM roles.
+  #
+  # This is the default key policy for programmatically generated KMS keys in
+  # general, see: https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-root-enable-iam
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  # Optional: Allow the given AWS service principals to use the key via S3, for situations
+  # where the service can't use more explicitly configured IAM roles
+  dynamic "statement" {
+    for_each = length(var.service_principals_with_access) > 0 ? [1] : []
+    content {
+      sid    = "AllowViaS3Service"
+      effect = "Allow"
+      principals {
+        type        = "Service"
+        identifiers = var.service_principals_with_access
+      }
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:DescribeKey"
+      ]
+      resources = ["*"]
+      condition {
+        test     = "StringEquals"
+        variable = "kms:ViaService"
+        values   = ["s3.${data.aws_region.current.name}.amazonaws.com"]
+      }
+    }
+  }
+}
+
 resource "aws_kms_key" "storage" {
   description = "KMS key for bucket ${var.name}"
   # The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key.
@@ -5,7 +55,7 @@ resource "aws_kms_key" "storage" {
   # Generates new cryptographic material every 365 days, this is used to encrypt your data. The KMS key retains the old material for decryption purposes.
   enable_key_rotation = "true"
 
-  # checkov:skip=CKV2_AWS_64:We're encrpying with KMS, I don't feel the need to specify a KMS policy as well
+  policy = data.aws_iam_policy_document.kms_key_policy.json
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "storage" {

--- a/infra/modules/storage/providers.tf
+++ b/infra/modules/storage/providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/infra/modules/storage/tests/storage.tftest.hcl
+++ b/infra/modules/storage/tests/storage.tftest.hcl
@@ -1,4 +1,14 @@
-mock_provider "aws" {}
+mock_provider "aws" {
+  # aws_iam_policy_document.kms_key_policy is used as the policy for
+  # aws_kms_key.storage, which validates the value as JSON. The default
+  # mock_provider value is not valid JSON, so provide a valid stub.
+  override_data {
+    target = data.aws_iam_policy_document.kms_key_policy
+    values = {
+      json = "{}"
+    }
+  }
+}
 
 variables {
   name = "my-test-bucket-12345"

--- a/infra/modules/storage/variables.tf
+++ b/infra/modules/storage/variables.tf
@@ -8,3 +8,17 @@ variable "name" {
   type        = string
   description = "Name of the AWS S3 bucket. Needs to be globally unique across all regions."
 }
+
+variable "service_principals_with_access" {
+  description = <<-EOT
+  Storage access should generally be controlled via attaching the `access_policy_arn`
+  output to an IAM role, but there are some situations where that may not be possible.
+  Generally when an AWS service doesn't have a way to assume a particular IAM role for operations.
+
+  This list of AWS service principals (e.g., bedrock.amazonaws.com) will be used to configure
+  resources (e.g., the bucket's KMS key) such that the services will be able
+  to access the bucket's objects.
+  EOT
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Ticket
Tracks #9837 (template-infra v0.16 → v0.17 upgrade).

## Scope
One slice of the v0.17 upgrade — upstream PR [navapbc/template-infra#997](https://github.com/navapbc/template-infra/pull/997): support configuring the storage module for AWS service principal access.

The earlier #9672 already brought over the S3 state-locking part of v0.17. This PR ports the storage-module change. Other v0.17 items (new DDE / SMS modules, network vpc_endpoint restructure, bin script cleanups, doc additions, monitoring/database/service tweaks, Playwright bump) are intentionally **not** in this PR — they have different risk profiles and will land as focused follow-ups.

## What changed

### `infra/modules/storage/variables.tf`
- Add `service_principals_with_access` (list(string), default `[]`)

### `infra/modules/storage/encryption.tf`
- Add a `data.aws_iam_policy_document.kms_key_policy` and reference it as `policy` on `aws_kms_key.storage`
- The policy grants:
  - The AWS account root full `kms:*` (functionally equivalent to the implicit default AWS attaches when no policy is given)
  - For each principal in `service_principals_with_access`, conditional `Decrypt` / `GenerateDataKey` / `DescribeKey` access via the S3 service (`kms:ViaService = s3.<region>.amazonaws.com`)
- Adds `data.aws_caller_identity.current` and `data.aws_region.current`

### `infra/modules/storage/providers.tf` (new)
- Declares the `aws` provider source, matching the convention v0.17 introduced for modules

### `infra/modules/storage/access_control.tf`
- Cosmetic blank line between two statements in the storage_access policy doc

### `infra/modules/storage/tests/storage.tftest.hcl`
- `mock_provider "aws"` needs an `override_data` block for `data.aws_iam_policy_document.kms_key_policy` since the default mock value isn't valid JSON and `aws_kms_key` validates the `policy` field

## Why this is safe to land alone
- `service_principals_with_access` defaults to `[]`. Existing callers (`api`, `analytics`, `frontend`, `nofos`) pass nothing → the `dynamic` block produces zero statements → behavior is unchanged
- The new explicit KMS key policy grants the root account `kms:*`, which is what AWS attaches by default when no policy is given. **No semantic change** to existing KMS access, but `terraform apply` will show `aws_kms_key.storage` being updated in-place to set `policy` from null → the explicit doc. That's a one-time policy field rewrite; no key rotation, no data re-encryption

## Testing

- [x] `terraform fmt -recursive infra/modules/storage` clean
- [x] `terraform validate` clean
- [x] `terraform test` — 8 passed, 0 failed
- [ ] `terraform plan` against each consumer of `module.storage` to confirm the only diff is the KMS key policy field being populated
- [ ] CI checks

## Follow-up v0.17 items (not in this PR)
- Document Data Extraction module (only if backend wants it)
- SMS notifications module + phone pool (only if backend wants SMS as a channel)
- Network module vpc_endpoints restructure (needs care — sgg's network module diverges from upstream)
- Accounts outputs.tf change
- `bin/*` script cleanups (many small)
- New docs: `temporary-environments-and-out-of-band-resources.md`, `deletion-protection-and-temporary-environments.md`
- Monitoring / database role manager / service database_access small tweaks