### PR TITLE
[Issue #10488] Switch to SES in workflow service

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -174,6 +174,12 @@ API_GATEWAY_DEFAULT_USAGE_PLAN_ID=local-dev-usage-plan
 AWS_PINPOINT_APP_ID=dummy-local-id
 
 ############################
+# Email Configuration
+############################
+
+AWS_SES_FROM_EMAIL=noreply@grants.gov
+
+############################
 # Feature Flags
 ############################
 ENABLE_OPPORTUNITY_LOG_MSG=false

--- a/api/src/workflow/util/workflow_util.py
+++ b/api/src/workflow/util/workflow_util.py
@@ -6,9 +6,9 @@ workflow logic.
 import logging
 import uuid
 
-from src.adapters.aws.pinpoint_adapter import send_pinpoint_email_raw
+from grants_shared.aws.ses_adapter import send_email
+
 from src.db.models.user_models import User
-from src.task.notifications.config import get_email_config
 from src.workflow.event.state_machine_event import StateMachineEvent
 from src.workflow.event.workflow_metric_context import WorkflowMetricContext
 
@@ -41,16 +41,12 @@ def send_workflow_email(
         )
         return
 
-    config = get_email_config()
-
     try:
         logger.info("Sending email for workflow", extra=log_extra)
-        send_pinpoint_email_raw(
+        send_email(
             to_address=user.email,
             subject=subject,
             message=message,
-            app_id=config.app_id,
-            trace_id=trace_id,
         )
 
     except Exception:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -13,6 +13,8 @@ from apiflask import APIFlask
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from grants_shared.util.local import load_local_env_vars
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.ses.models import ses_backends
 from sqlalchemy import select, text
 
 import src.app as app_entry
@@ -554,7 +556,7 @@ def file_scan_dynamodb_table(mock_dynamodb, monkeypatch):
 
 
 @pytest.fixture
-def ses_client(reset_aws_env_vars, monkeypatch):
+def ses_client(monkeypatch):
     """Create a mocked SESv2 client using moto3."""
     monkeypatch.setenv("IS_LOCAL_AWS", "0")
 
@@ -563,6 +565,15 @@ def ses_client(reset_aws_env_vars, monkeypatch):
         ses_client = boto3.client("sesv2", region_name="us-east-1")
         ses_client.create_email_identity(EmailIdentity=os.getenv("AWS_SES_FROM_EMAIL"))
         yield ses_client
+
+
+@pytest.fixture
+def get_sent_emails():
+    def func():
+        ses_backend = ses_backends[DEFAULT_ACCOUNT_ID]["us-east-1"]
+        return ses_backend.sent_messages
+
+    return func
 
 
 ####################

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,6 +1,6 @@
 import logging
-import uuid
 import os
+import uuid
 from os import path
 
 import _pytest.monkeypatch

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+import os
 from os import path
 
 import _pytest.monkeypatch
@@ -550,6 +551,18 @@ def file_scan_dynamodb_table(mock_dynamodb, monkeypatch):
     )
     monkeypatch.setenv("FILE_SCAN_CACHE_TABLE_NAME", table_name)
     return table_name
+
+
+@pytest.fixture
+def ses_client(reset_aws_env_vars, monkeypatch):
+    """Create a mocked SESv2 client using moto3."""
+    monkeypatch.setenv("IS_LOCAL_AWS", "0")
+
+    # to access ses_backends, need to add ses to the whitelist
+    with moto.mock_aws(config={"core": {"service_whitelist": ["ses", "sesv2"]}}):
+        ses_client = boto3.client("sesv2", region_name="us-east-1")
+        ses_client.create_email_identity(EmailIdentity=os.getenv("AWS_SES_FROM_EMAIL"))
+        yield ses_client
 
 
 ####################

--- a/api/tests/src/workflow/listener/test_workflow_approval_email_listener.py
+++ b/api/tests/src/workflow/listener/test_workflow_approval_email_listener.py
@@ -1,8 +1,9 @@
 import logging
 
 import pytest
+from moto.core import DEFAULT_ACCOUNT_ID
+from moto.ses.models import ses_backends
 
-from src.adapters.aws.pinpoint_adapter import _clear_mock_responses, _get_mock_responses
 from src.constants.lookup_constants import ApprovalResponseType, Privilege, WorkflowType
 from src.db.models.agency_models import Agency
 from src.db.models.user_models import User
@@ -18,26 +19,27 @@ from tests.src.workflow.state_machine.test_state_machines import BasicState
 from tests.src.workflow.workflow_test_util import send_process_event
 
 
-@pytest.fixture(autouse=True)
-def clear_emails() -> None:
-    _clear_mock_responses()
+def get_sent_emails():
+    """Get all sent emails from the moto3 SES backend."""
+    ses_backend = ses_backends[DEFAULT_ACCOUNT_ID]["us-east-1"]
+    return ses_backend.sent_messages
 
 
 def verify_email(
-    raw_email: dict,
+    sent_message,
     user: User,
     workflow: Workflow,
     agency: Agency,
     expected_state: BasicState,
     expected_privilege: Privilege,
 ) -> None:
-    assert user.email in raw_email["MessageRequest"]["Addresses"]
-    email = raw_email["MessageRequest"]["MessageConfiguration"]["EmailMessage"]["SimpleEmail"]
+    """Verify a sent email message from moto SES backend."""
+    assert user.email in sent_message.destinations["ToAddresses"]
 
-    subject = email["Subject"]["Data"]
+    subject = sent_message.subject
     assert subject == "Approval required for 'Basic Test Workflow'"
 
-    body = email["TextPart"]["Data"]
+    body = sent_message.body
 
     assert (
         f"An approval is required for a Basic Test Workflow that is currently in state '{expected_state}' from a user with the following privilege(s): {expected_privilege}"
@@ -69,10 +71,10 @@ def test_workflow_approval_email_listener_moving_into_budget_officer_state(
         expected_state=BasicState.PENDING_BUDGET_OFFICER_APPROVAL,
     )
 
-    emails = _get_mock_responses()
+    emails = get_sent_emails()
     assert len(emails) == 1
     verify_email(
-        emails[0][0],
+        emails[0],
         user=budget_officer,
         workflow=workflow,
         agency=agency,
@@ -103,10 +105,10 @@ def test_workflow_approval_email_listener_moving_into_program_officer_state(
         expected_state=BasicState.PENDING_PROGRAM_OFFICER_APPROVAL,
     )
 
-    emails = _get_mock_responses()
+    emails = get_sent_emails()
     assert len(emails) == 1
     verify_email(
-        emails[0][0],
+        emails[0],
         user=program_officer,
         workflow=workflow,
         agency=agency,
@@ -156,13 +158,13 @@ def test_workflow_approval_email_listener_multiple_users_can_approve(
         expected_state=BasicState.PENDING_BUDGET_OFFICER_APPROVAL,
     )
 
-    emails = _get_mock_responses()
+    emails = get_sent_emails()
 
     # We can know the order the emails were sent because
     # we order by when the user was created.
     assert len(emails) == 3
     verify_email(
-        emails[0][0],
+        emails[0],
         user=budget_officer,
         workflow=workflow,
         agency=agency,
@@ -170,7 +172,7 @@ def test_workflow_approval_email_listener_multiple_users_can_approve(
         expected_privilege=Privilege.BUDGET_OFFICER_APPROVAL,
     )
     verify_email(
-        emails[1][0],
+        emails[1],
         user=budget_officer2,
         workflow=workflow,
         agency=agency,
@@ -178,7 +180,7 @@ def test_workflow_approval_email_listener_multiple_users_can_approve(
         expected_privilege=Privilege.BUDGET_OFFICER_APPROVAL,
     )
     verify_email(
-        emails[2][0],
+        emails[2],
         user=budget_officer3,
         workflow=workflow,
         agency=agency,
@@ -224,7 +226,7 @@ def test_workflow_approval_email_listener_staying_in_budget_officer_state_no_ema
         approval_response_type=ApprovalResponseType.APPROVED,
     )
 
-    emails = _get_mock_responses()
+    emails = get_sent_emails()
     assert len(emails) == 0
 
     # Verify using the logs that this was the path it went down
@@ -265,7 +267,7 @@ def test_workflow_approval_email_listener_non_approval_states(
         expected_is_active=False,
     )
 
-    emails = _get_mock_responses()
+    emails = get_sent_emails()
     assert len(emails) == 0
 
     # Verify using the logs that this was the path it went down
@@ -294,7 +296,7 @@ def test_workflow_approval_email_listener_no_users(db_session, agency, opportuni
         expected_state=BasicState.PENDING_BUDGET_OFFICER_APPROVAL,
     )
 
-    emails = _get_mock_responses()
+    emails = get_sent_emails()
     assert len(emails) == 0
 
     assert caplog.messages.count("No users can do approval - cannot send email") == 1
@@ -324,7 +326,7 @@ def test_workflow_approval_email_listener_no_agency_on_opportunity(db_session, c
         expected_state=BasicState.PENDING_BUDGET_OFFICER_APPROVAL,
     )
 
-    emails = _get_mock_responses()
+    emails = get_sent_emails()
     assert len(emails) == 0
 
     caplog.messages.count(

--- a/api/tests/src/workflow/listener/test_workflow_approval_email_listener.py
+++ b/api/tests/src/workflow/listener/test_workflow_approval_email_listener.py
@@ -1,8 +1,5 @@
 import logging
 
-from moto.core import DEFAULT_ACCOUNT_ID
-from moto.ses.models import ses_backends
-
 from src.constants.lookup_constants import ApprovalResponseType, Privilege, WorkflowType
 from src.db.models.agency_models import Agency
 from src.db.models.user_models import User
@@ -16,12 +13,6 @@ from tests.src.db.models.factories import (
 )
 from tests.src.workflow.state_machine.test_state_machines import BasicState
 from tests.src.workflow.workflow_test_util import send_process_event
-
-
-def get_sent_emails():
-    """Get all sent emails from the moto3 SES backend."""
-    ses_backend = ses_backends[DEFAULT_ACCOUNT_ID]["us-east-1"]
-    return ses_backend.sent_messages
 
 
 def verify_email(
@@ -49,7 +40,7 @@ def verify_email(
 
 
 def test_workflow_approval_email_listener_moving_into_budget_officer_state(
-    db_session, agency, budget_officer, opportunity, ses_client
+    db_session, agency, budget_officer, opportunity, ses_client, get_sent_emails
 ):
     """Verify that when we first enter the pending budget officer approval state, an email is sent"""
 
@@ -83,7 +74,7 @@ def test_workflow_approval_email_listener_moving_into_budget_officer_state(
 
 
 def test_workflow_approval_email_listener_moving_into_program_officer_state(
-    db_session, agency, program_officer, opportunity, ses_client
+    db_session, agency, program_officer, opportunity, ses_client, get_sent_emails
 ):
     """Verify that when we first enter the pending program officer approval state, an email is sent"""
 
@@ -117,7 +108,7 @@ def test_workflow_approval_email_listener_moving_into_program_officer_state(
 
 
 def test_workflow_approval_email_listener_multiple_users_can_approve(
-    db_session, agency, budget_officer, opportunity, ses_client
+    db_session, agency, budget_officer, opportunity, ses_client, get_sent_emails
 ):
     # Create a few additional budget officers
     budget_officer2, _ = create_user_in_agency(
@@ -189,7 +180,7 @@ def test_workflow_approval_email_listener_multiple_users_can_approve(
 
 
 def test_workflow_approval_email_listener_staying_in_budget_officer_state_no_email(
-    db_session, agency, program_officer, opportunity, caplog, ses_client
+    db_session, agency, program_officer, opportunity, caplog, ses_client, get_sent_emails
 ):
     """Verify that if a workflow re-enters an approval state that it's already in, no email is sent"""
 
@@ -234,7 +225,7 @@ def test_workflow_approval_email_listener_staying_in_budget_officer_state_no_ema
 
 
 def test_workflow_approval_email_listener_non_approval_states(
-    db_session, agency, opportunity, caplog, ses_client
+    db_session, agency, opportunity, caplog, ses_client, get_sent_emails
 ):
     """Test that if a state isn't an approval state, no emails are sent"""
 
@@ -276,7 +267,7 @@ def test_workflow_approval_email_listener_non_approval_states(
 
 
 def test_workflow_approval_email_listener_no_users(
-    db_session, agency, opportunity, caplog, ses_client
+    db_session, agency, opportunity, caplog, ses_client, get_sent_emails
 ):
     """Verify behavior if no users have the privilege"""
 
@@ -303,7 +294,9 @@ def test_workflow_approval_email_listener_no_users(
     assert caplog.messages.count("No users can do approval - cannot send email") == 1
 
 
-def test_workflow_approval_email_listener_no_agency_on_opportunity(db_session, caplog, ses_client):
+def test_workflow_approval_email_listener_no_agency_on_opportunity(
+    db_session, caplog, ses_client, get_sent_emails
+):
     """Verify behavior if opportunity has no agency"""
     # Note that there's half a dozen checks upstream that would prevent this
     # but test it just to be safe.

--- a/api/tests/src/workflow/listener/test_workflow_approval_email_listener.py
+++ b/api/tests/src/workflow/listener/test_workflow_approval_email_listener.py
@@ -1,6 +1,5 @@
 import logging
 
-import pytest
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.ses.models import ses_backends
 
@@ -50,7 +49,7 @@ def verify_email(
 
 
 def test_workflow_approval_email_listener_moving_into_budget_officer_state(
-    db_session, agency, budget_officer, opportunity
+    db_session, agency, budget_officer, opportunity, ses_client
 ):
     """Verify that when we first enter the pending budget officer approval state, an email is sent"""
 
@@ -84,7 +83,7 @@ def test_workflow_approval_email_listener_moving_into_budget_officer_state(
 
 
 def test_workflow_approval_email_listener_moving_into_program_officer_state(
-    db_session, agency, program_officer, opportunity
+    db_session, agency, program_officer, opportunity, ses_client
 ):
     """Verify that when we first enter the pending program officer approval state, an email is sent"""
 
@@ -118,7 +117,7 @@ def test_workflow_approval_email_listener_moving_into_program_officer_state(
 
 
 def test_workflow_approval_email_listener_multiple_users_can_approve(
-    db_session, agency, budget_officer, opportunity
+    db_session, agency, budget_officer, opportunity, ses_client
 ):
     # Create a few additional budget officers
     budget_officer2, _ = create_user_in_agency(
@@ -190,7 +189,7 @@ def test_workflow_approval_email_listener_multiple_users_can_approve(
 
 
 def test_workflow_approval_email_listener_staying_in_budget_officer_state_no_email(
-    db_session, agency, program_officer, opportunity, caplog
+    db_session, agency, program_officer, opportunity, caplog, ses_client
 ):
     """Verify that if a workflow re-enters an approval state that it's already in, no email is sent"""
 
@@ -235,7 +234,7 @@ def test_workflow_approval_email_listener_staying_in_budget_officer_state_no_ema
 
 
 def test_workflow_approval_email_listener_non_approval_states(
-    db_session, agency, opportunity, caplog
+    db_session, agency, opportunity, caplog, ses_client
 ):
     """Test that if a state isn't an approval state, no emails are sent"""
 
@@ -276,7 +275,9 @@ def test_workflow_approval_email_listener_non_approval_states(
     )
 
 
-def test_workflow_approval_email_listener_no_users(db_session, agency, opportunity, caplog):
+def test_workflow_approval_email_listener_no_users(
+    db_session, agency, opportunity, caplog, ses_client
+):
     """Verify behavior if no users have the privilege"""
 
     # A random user that caused the prior event
@@ -302,7 +303,7 @@ def test_workflow_approval_email_listener_no_users(db_session, agency, opportuni
     assert caplog.messages.count("No users can do approval - cannot send email") == 1
 
 
-def test_workflow_approval_email_listener_no_agency_on_opportunity(db_session, caplog):
+def test_workflow_approval_email_listener_no_agency_on_opportunity(db_session, caplog, ses_client):
     """Verify behavior if opportunity has no agency"""
     # Note that there's half a dozen checks upstream that would prevent this
     # but test it just to be safe.


### PR DESCRIPTION
## Summary

Fixes  #10488  

## Changes proposed

Switch to SES in workflow service

## Context for reviewers

In https://github.com/HHS/simpler-grants-gov/issues/10486 we created a new client for calling SES. We want to change our workflow service code to use SES for sending emails instead of pinpoint.

Making this change should be pretty small, and mostly be changing unit tests to see the sent emails from the moto3 mock instead of the hacky approach we were doing before.

## Validation steps

- Modify the workflow code to use the SES client
- Fixed any tests
- Verified in staging that the workflow service can send emails
