### PR TITLE
[unticketed]: update grype yml ignore file

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -32,3 +32,20 @@ ignore:
   # Not fixed in GA Python yet
   # Last checked 05/13/2026
   - vulnerability: CVE-2026-7210
+
+  # unicodedata DoS (excessive CPU consumption). Fix only in pre-release
+  # Python 3.15 (3.15.0b2); no fix in any GA 3.14.x release yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 06/08/2026
+  - vulnerability: CVE-2026-3276
+
+  # base64 altchars input-validation flaw. Marked "will not fix" in 3.14
+  # (deprecation warning only); real fix deferred to a future Python release.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 06/08/2026
+  - vulnerability: CVE-2025-12781
+
+  # Fix only in pre-release Python 3.15 (3.15.0b2); no fix in any GA 3.14.x yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 06/08/2026
+  - vulnerability: CVE-2026-7774


### PR DESCRIPTION
## Summary

Updated the anchore ignore list to skip the 3 cve's below as they are not available in the GA version of python just yet: 

```
python  3.14.5     3.15.0b2  binary  CVE-2026-3276   Medium    < 0.1% (15th)  < 0.1  
python  3.14.5     3.15.0a6  binary  CVE-2025-12781  Medium    < 0.1% (15th)  < 0.1  
python  3.14.5     3.15.0b2  binary  CVE-2026-7774   Medium    < 0.1% (8th)   < 0.1  
```


## Validation steps

The anchore scan steps should be passing in this pull request. 