### PR TITLE
[Issue #10531] Fix auto-summation for Section A, Row 5, Column G of SF-424A

### DIFF
--- a/api/src/form_schema/forms/sf424a/1/0/form_json.py
+++ b/api/src/form_schema/forms/sf424a/1/0/form_json.py
@@ -493,23 +493,11 @@ FORM_RULE_SCHEMA = {
             }
         },
         # Section A - Total Amount (Column G, Row 5)
-        # IMPORTANT:
-        # Previously this was described as "sum of Column G, Rows 1–4",
-        # but Column G (Rows 1–4) is now user-editable and not a reliable source of truth.
-        #
-        # Therefore, Row 5 must be derived from the underlying structured budget inputs
-        # in budget_summary rather than any precomputed or user-edited totals.
+        # is the sum of (Column G, Rows 1-4)
         "total_amount": {
             "gg_pre_population": {
                 "rule": "sum_monetary",
-                "fields": [
-                    "total_budget_summary.federal_estimated_unobligated_amount",
-                    "total_budget_summary.non_federal_estimated_unobligated_amount",
-                    "total_budget_summary.federal_new_or_revised_amount",
-                    "total_budget_summary.non_federal_new_or_revised_amount",
-                ],
-                # Run after line-item budget_summary values are finalized
-                "order": 2,
+                "fields": ["activity_line_items[*].budget_summary.total_amount"],
             }
         },
     },

--- a/api/tests/src/form_schema/forms/test_sf424a.py
+++ b/api/tests/src/form_schema/forms/test_sf424a.py
@@ -529,7 +529,7 @@ def test_sf424a_v_1_0_auto_summation_full_data(
             "non_federal_estimated_unobligated_amount": "-9.98",
             "federal_new_or_revised_amount": "51.05",
             "non_federal_new_or_revised_amount": "47.04",
-            "total_amount": "113.13",
+            "total_amount": "86.10",
         },
         "total_budget_categories": {
             "personnel_amount": "113.04",
@@ -584,7 +584,8 @@ def test_sf424a_v_1_0_auto_summation_full_data(
     }
 
 
-def test_sf424a_v_1_0_total_budget_summary_sums_cf_not_row_g(enable_factory_create, sf424a_v1_0):
+def test_sf424a_v_1_0_total_budget_summary_sums_column_g(enable_factory_create, sf424a_v1_0):
+    """Row 5 Column G should sum Column G (rows 1-4), not Row 5 Columns C-F."""
     data = {
         "activity_line_items": [
             {
@@ -593,7 +594,7 @@ def test_sf424a_v_1_0_total_budget_summary_sums_cf_not_row_g(enable_factory_crea
                     "non_federal_estimated_unobligated_amount": "2.00",
                     "federal_new_or_revised_amount": "3.00",
                     "non_federal_new_or_revised_amount": "4.00",
-                    "total_amount": "999.00",  # should NOT matter
+                    "total_amount": "10.00",
                 }
             },
             {
@@ -602,7 +603,7 @@ def test_sf424a_v_1_0_total_budget_summary_sums_cf_not_row_g(enable_factory_crea
                     "non_federal_estimated_unobligated_amount": "20.00",
                     "federal_new_or_revised_amount": "30.00",
                     "non_federal_new_or_revised_amount": "40.00",
-                    "total_amount": "888.00",  # should NOT matter
+                    "total_amount": "40.00",
                 }
             },
         ],
@@ -618,17 +619,18 @@ def test_sf424a_v_1_0_total_budget_summary_sums_cf_not_row_g(enable_factory_crea
     validate_application_form(app, ApplicationAction.MODIFY)
     app_json = app.application_response
 
-    # G ignored everywhere
-    assert app_json["activity_line_items"][0]["budget_summary"]["total_amount"] == "999.00"
-    assert app_json["activity_line_items"][1]["budget_summary"]["total_amount"] == "888.00"
+    # Individual row G values are preserved unchanged
+    assert app_json["activity_line_items"][0]["budget_summary"]["total_amount"] == "10.00"
+    assert app_json["activity_line_items"][1]["budget_summary"]["total_amount"] == "40.00"
 
-    # ONLY C–F used
-    assert app_json["total_budget_summary"]["total_amount"] == "110.00"
+    # Row 5 G = sum of Column G rows 1-4 (10 + 40 = 50), NOT sum of C-F (1+2+3+4 + 10+20+30+40 = 110)
+    assert app_json["total_budget_summary"]["total_amount"] == "50.00"
 
 
-def test_sf424a_v_1_0_row_g_is_never_used_in_total_budget_summary(
+def test_sf424a_v_1_0_total_budget_summary_column_g_differs_from_cf_sum(
     enable_factory_create, sf424a_v1_0
 ):
+    """For supplemental grants Column G per row is NOT the sum of C-F; Row 5 G must still sum Column G."""
     data = {
         "activity_line_items": [
             {
@@ -637,7 +639,7 @@ def test_sf424a_v_1_0_row_g_is_never_used_in_total_budget_summary(
                     "non_federal_estimated_unobligated_amount": "0.00",
                     "federal_new_or_revised_amount": "0.00",
                     "non_federal_new_or_revised_amount": "0.00",
-                    "total_amount": "999999.00",  # extreme value
+                    "total_amount": "999999.00",  # user-entered value unrelated to C-F
                 }
             }
         ],
@@ -653,4 +655,5 @@ def test_sf424a_v_1_0_row_g_is_never_used_in_total_budget_summary(
     validate_application_form(app, ApplicationAction.MODIFY)
     app_json = app.application_response
 
-    assert app_json["total_budget_summary"]["total_amount"] == "0.00"
+    # Row 5 G = sum of Column G rows 1-4, which is 999999.00 (not 0.00 from C-F)
+    assert app_json["total_budget_summary"]["total_amount"] == "999999.00"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10531

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Fixed the `total_budget_summary.total_amount` pre-population rule in `sf424a/1/0/form_json.py` to sum `activity_line_items[*].budget_summary.total_amount`
- Updated `test_sf424a_v_1_0_auto_summation_full_data` to expect the correct total (`86.10` instead of `113.13`)
- Updated other unit tests


## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The prior implementation was "user-editable and not a reliable source of truth." For supplemental grants the instructions explicitly state Column G should be the new total budgeted amount (not C+D+E+F), so summing the row-5 column totals produced a wrong result.


## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] All new unit tests pass
- [x] Deploy to testing environment and confirm Row 5, Column G reflects the sum of rows 1–4 Column G values
- [ ] UAT with Chris K