### PR TITLE
[Issue #10053] Change disabled color from gray-60 to gray-70

### DIFF
--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -72,7 +72,7 @@ h6 {
 
   &:disabled,
   &[aria-disabled="true"] {
-    color: color("gray-60");
+    color: color("gray-70");
     background-color: color("gray-20");
     border-bottom: 5px solid color("gray-10");
   }


### PR DESCRIPTION
Accessible color values need to be > 50 in number.

## Summary

Work for #10053 

## Changes proposed

Change disabled button color from `gray-60` to `gray-70`. 

## Context for reviewers

Accessible color values need to be > 50 in number. Since the background color is `gray-20`, the text needs to be at least 70. 

## Validation steps

Inspect at a disabled button and make sure its colors pass [AA contrast checker](https://webaim.org/resources/contrastchecker/)