### PR TITLE
[Issue #10053] Fix WCAG AA contrast for key information text and character count hint

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
@@ -435,7 +435,7 @@ export default function OpportunityEditForm({
         <h2 className="font-heading-xl margin-top-0 margin-bottom-2">
           {t("sections.keyInformation")}
         </h2>
-        <p className="margin-top-0 margin-bottom-4 font-sans-lg text-base">
+        <p className="margin-top-0 margin-bottom-4 font-sans-lg text-base-dark">
           {t("content.keyInformationIntro")}
         </p>
 

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -1556,3 +1556,9 @@ $simpler-switch-transition-easing: ease;
   background-color: #c3e8d8;
   height: calc(100% + 1rem);
 }
+
+// Character count: react-uswds sets color via inline style, so !important is required
+// to override it. base-dark (#76766A on white = 4.6:1) meets WCAG AA.
+.usa-character-count__status {
+  color: color("base-dark") !important;
+}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -1556,10 +1556,3 @@ $simpler-switch-transition-easing: ease;
   background-color: #c3e8d8;
   height: calc(100% + 1rem);
 }
-
-// Character count: overrides low-contrast USWDS default color("base") on the status
-// message. base-dark (#76766A on white = 4.6:1) meets WCAG AA
-// (verified via WAVE accessibility tool per issue #10053).
-.usa-character-count__status {
-  color: color("base-dark");
-}

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -1563,4 +1563,3 @@ $simpler-switch-transition-easing: ease;
 .usa-character-count__status {
   color: color("base-dark");
 }
-

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -1557,8 +1557,10 @@ $simpler-switch-transition-easing: ease;
   height: calc(100% + 1rem);
 }
 
-// Character count: react-uswds sets color via inline style, so !important is required
-// to override it. base-dark (#76766A on white = 4.6:1) meets WCAG AA.
+// Character count: overrides low-contrast USWDS default color("base") on the status
+// message. base-dark (#76766A on white = 4.6:1) meets WCAG AA
+// (verified via WAVE accessibility tool per issue #10053).
 .usa-character-count__status {
-  color: color("base-dark") !important;
+  color: color("base-dark");
 }
+


### PR DESCRIPTION
## Summary

Work for #10053

## Changes proposed

- `OpportunityEditForm.tsx` - changed `text-base` --> `text-base-dark` on the \"Key information\" section intro text

## Context for reviewers

Fix uses existing USWDS theme token - no new colors introduced. `base-dark` in this project resolves to `gray-warm-50` = `#76766A`, which matches the Figma design spec (`var(--theme-color-base-dark, #76766A)`).

Note:
- AC \"Ensure sufficient color contrast for buttons\" is addressed separately in PR #10794.
- AC \"Pay special attention to red color usage\" when tested by @aoysimmons-GH was not an issue.
- Character count contrast fix removed per @andycochran feedback - a proper base color palette fix will be tracked as a separate ticket for Sprint 6.4.

## Validation steps

1. Go to `/en/grantor/opportunity/<id>/edit` - the \"Below is a summary of the key information...\" text under the Key information heading should appear darker
2. Run through https://webaim.org/resources/contrastchecker to confirm ≥4.5:1