### PR TITLE
[unticketed]: resolve cve's in the python base image

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:93345e2@sha256:0eeaf1627e20946cbabd515176affb31ca5f7a6f32481253ff6478ef3a657847 AS base
+FROM ghcr.io/hhs/python-base-image:6717a8a@sha256:1e465daf806babc12710454f6738cd951f2cfefdc5a770cf737fee906e73efac AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:93345e2@sha256:0eeaf1627e20946cbabd515176affb31ca5f7a6f32481253ff6478ef3a657847 AS base
+FROM ghcr.io/hhs/python-base-image:6717a8a@sha256:1e465daf806babc12710454f6738cd951f2cfefdc5a770cf737fee906e73efac AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -165,7 +165,8 @@ RUN dnf install -y \
       krb5-libs-1.21.3-7.amzn2023.0.1 \
       rust-toolset-srpm-macros-1.95.0-1.amzn2023.0.2 \
       libgcrypt-1.10.2-1.amzn2023.0.3 \
-      gnutls-3.8.3-8.amzn2023.0.3 && \
+      libsolv-0.7.22-1.amzn2023.0.4 \
+      gnutls-3.8.10-4.amzn2023.0.2 && \
     # CVE-2026-1757: libxml2 memory leak in xmllint (ALAS2023-2026-1446)
     dnf update -y --releasever=2023.10.20260302 \
       libxml2-2.10.4-1.amzn2023.0.18 \


### PR DESCRIPTION
## Summary

Resolve the below cve's in the python base image and updated analytics & api base image tags. 

```
gnutls   3.8.3-8.amzn2023.0.3   3.8.3-8.amzn2023.0.4   rpm   ALAS2023-2026-1777  High      0.1% (27th)   < 0.1  
libsolv  0.7.22-1.amzn2023.0.3  0.7.22-1.amzn2023.0.4  rpm   ALAS2023-2026-1798  High      < 0.1% (2nd)  < 0.1  
gnutls   3.8.3-8.amzn2023.0.3   3.8.10-4.amzn2023.0.2  rpm   ALAS2023-2026-1808  Medium    < 0.1% (4th)  < 0.1  
```

Link to failing anchore scan: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/27207682926/job/80327888782)

## Validation steps

Anchore cve scans should be passing below. 