### PR TITLE
[Issue #10277] Project/Performance Site Locations form XML matching

### DIFF
--- a/api/src/form_schema/forms/project_performance_site_location/1/0/form_json.py
+++ b/api/src/form_schema/forms/project_performance_site_location/1/0/form_json.py
@@ -206,23 +206,23 @@ FORM_RULE_SCHEMA = {
 # Helper to build site location field mappings for XML (shared between primary and additional sites)
 def _site_location_xml_fields() -> dict:
     return {
+        # Individual, OrganizationName, SAMUEI, Address, CongressionalDistrictProgramProject
+        # are defined locally in SiteLocationDataType (PerformanceSite_4_0 namespace).
+        # Their content types come from globLib, but the element names belong to the form namespace.
         "submitting_as_individual": {
             "xml_transform": {
                 "target": "Individual",
-                "namespace": "globLib",
                 "value_transform": {"type": "boolean_to_yes_no"},
             }
         },
         "organization_name": {
             "xml_transform": {
                 "target": "OrganizationName",
-                "namespace": "globLib",
             }
         },
         "uei": {
             "xml_transform": {
                 "target": "SAMUEI",
-                "namespace": "globLib",
             }
         },
         "address": {
@@ -230,6 +230,8 @@ def _site_location_xml_fields() -> dict:
                 "target": "Address",
                 "type": "nested_object",
             },
+            # Order matches AddressDataTypeV3 XSD sequence: Street1, Street2, City, County,
+            # State|Province (choice), ZipPostalCode, Country
             "street1": {
                 "xml_transform": {
                     "target": "Street1",
@@ -266,15 +268,15 @@ def _site_location_xml_fields() -> dict:
                     "namespace": "globLib",
                 }
             },
-            "country": {
-                "xml_transform": {
-                    "target": "Country",
-                    "namespace": "globLib",
-                }
-            },
             "zip_code": {
                 "xml_transform": {
                     "target": "ZipPostalCode",
+                    "namespace": "globLib",
+                }
+            },
+            "country": {
+                "xml_transform": {
+                    "target": "Country",
                     "namespace": "globLib",
                 }
             },
@@ -282,7 +284,6 @@ def _site_location_xml_fields() -> dict:
         "congressional_district": {
             "xml_transform": {
                 "target": "CongressionalDistrictProgramProject",
-                "namespace": "globLib",
             }
         },
     }
@@ -314,6 +315,7 @@ FORM_XML_TRANSFORM_RULES = {
             "additional_locations_attachment": {
                 "xml_element": "AttachedFile",
                 "type": "single_with_wrapper",
+                "file_element": "",  # content directly in <AttachedFile>, no inner wrapper
             },
         },
     },

--- a/api/src/services/xml_generation/README.md
+++ b/api/src/services/xml_generation/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This is the implementation of the JSON to XML conversion service. This service provides field mapping capabilities for various Grants.gov forms including SF-424, SF-424A, SF-424B, SF-424D, SF-LLL, CD-511, GG_LobbyingForm, Project Abstract Summary, EPA Key Contacts, Project Narrative Attachments, Budget Narrative Attachments, Other Narrative Attachments, and Project Abstract.
+This is the implementation of the JSON to XML conversion service. This service provides field mapping capabilities for various Grants.gov forms including SF-424, SF-424A, SF-424B, SF-424D, SF-LLL, CD-511, GG_LobbyingForm, Project Abstract Summary, EPA Key Contacts, Project Narrative Attachments, Budget Narrative Attachments, Other Narrative Attachments, Project Abstract, and Project/Performance Site Location(s).
 
 ## Architecture
 
@@ -541,6 +541,56 @@ The following forms currently have XML generation support:
 - **Other Narrative Attachments (v1.2)**: Other narrative file attachments
 - **Project Abstract (v1.2)**: Project abstract file attachment
 - **Supplementary Cover Sheet for NEH Grant Programs (v3.0)**: NEH-specific supplementary cover sheet
+- **Project/Performance Site Location(s) (v4.0)**: Primary and additional project performance site locations with optional attachment
+
+### Example: Project/Performance Site Location(s) (v4.0)
+
+The Performance Site form maps site location data for both the primary site and up to 299 additional sites, plus an optional attachment for overflow locations:
+
+```python
+FORM_XML_TRANSFORM_RULES = {
+    "_xml_config": {
+        "description": "XML transformation rules for Project/Performance Site Location(s) v4.0",
+        "form_name": "PerformanceSite_4_0",
+        "namespaces": {
+            "default": "http://apply.grants.gov/forms/PerformanceSite_4_0-V4.0",
+            "PerformanceSite_4_0": "http://apply.grants.gov/forms/PerformanceSite_4_0-V4.0",
+            "globLib": "http://apply.grants.gov/system/GlobalLibrary-V2.0",
+            "att": "http://apply.grants.gov/system/Attachments-V1.0",
+        },
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_0-V4.0.xsd",
+        "xml_structure": {
+            "root_element": "PerformanceSite_4_0",
+            "root_namespace_prefix": "PerformanceSite_4_0",
+            "root_attributes": {"FormVersion": "4.0"},
+        },
+        "attachment_fields": {
+            "additional_locations_attachment": {
+                "xml_element": "AttachedFile",
+                "type": "single_with_wrapper",
+                "file_element": "",  # content directly in <AttachedFile>, no inner wrapper
+            },
+        },
+    },
+    "primary_site": {
+        "xml_transform": {"target": "PrimarySite", "type": "nested_object"},
+        **_site_location_xml_fields(),
+    },
+    "additional_sites": {
+        "xml_transform": {"target": "OtherSite", "type": "array"},
+        "items": _site_location_xml_fields(),
+    },
+}
+```
+
+**Performance Site Location Field Mapping Notes:**
+
+- **Namespace split**: `Individual`, `OrganizationName`, `SAMUEI`, `Address`, and `CongressionalDistrictProgramProject` are declared in the form's own `SiteLocationDataType` — they use the default `PerformanceSite_4_0` namespace. The address *sub*-elements (`Street1`, `City`, etc.) are typed via `globLib:AddressDataTypeV3` and use the `globLib` namespace.
+- **Address element order**: The XSD sequence requires `ZipPostalCode` before `Country`. The transform rules must declare `zip_code` before `country` to match this ordering.
+- **Attachment**: The optional `additional_locations_attachment` field maps to a single `<AttachedFile>` element (type `att:AttachedFileDataType`) as a direct child of the root. Using `single_with_wrapper` with `file_element: ""` creates the outer `<AttachedFile>` wrapper and places `att:FileName`, `att:MimeType`, `att:FileLocation`, and `glob:HashValue` directly inside it — no spurious inner wrapper element.
+- `submitting_as_individual` uses the `boolean_to_yes_no` value transform (outputs `Y: Yes` / `N: No`).
+- `additional_sites` uses `type: "array"` to emit one `<OtherSite>` element per entry (max 299).
+- XSD reference: https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_0-V4.0.xsd
 
 ## Adding New Forms
 

--- a/api/src/services/xml_generation/transformers/attachment_transformer.py
+++ b/api/src/services/xml_generation/transformers/attachment_transformer.py
@@ -171,7 +171,8 @@ class AttachmentTransformer:
         uses_wrapper = field_config and field_config.get("type") == "single_with_wrapper"
 
         if uses_wrapper:
-            # Determine inner element name: config override or default to '{element_name}File'
+            # Determine inner element name: config override or default to '{element_name}File'.
+            # Empty string means no inner wrapper — content goes directly in the outer element.
             file_element_name = (
                 field_config.get("file_element", f"{element_name}File")
                 if field_config
@@ -180,18 +181,24 @@ class AttachmentTransformer:
 
             default_ns = next(iter(nsmap.values()), None) if nsmap else None
 
-            # Create the wrapper element (e.g., <ATT1>) in the default namespace
+            # Create the outer wrapper element (e.g., <ATT1>) in the default namespace
             if default_ns:
                 attachment_elem = lxml_etree.SubElement(parent, f"{{{default_ns}}}{element_name}")
-                file_elem = lxml_etree.SubElement(
-                    attachment_elem, f"{{{default_ns}}}{file_element_name}"
-                )
             else:
                 attachment_elem = lxml_etree.SubElement(parent, element_name)
-                file_elem = lxml_etree.SubElement(attachment_elem, file_element_name)
 
-            # Populate the File element with attachment content
-            self._populate_attachment_content(file_elem, attachment_data, nsmap)
+            if file_element_name:
+                # Create inner file element (e.g., <ATT1File>) and populate it
+                if default_ns:
+                    file_elem = lxml_etree.SubElement(
+                        attachment_elem, f"{{{default_ns}}}{file_element_name}"
+                    )
+                else:
+                    file_elem = lxml_etree.SubElement(attachment_elem, file_element_name)
+                self._populate_attachment_content(file_elem, attachment_data, nsmap)
+            else:
+                # No inner wrapper — populate content directly in the outer element
+                self._populate_attachment_content(attachment_elem, attachment_data, nsmap)
         else:
             # No wrapper needed - populate content directly on parent
             self._populate_attachment_content(parent, attachment_data, nsmap)

--- a/api/src/services/xml_generation/validation/test_cases.py
+++ b/api/src/services/xml_generation/validation/test_cases.py
@@ -1830,6 +1830,142 @@ OTHER_NARRATIVE_ATTACHMENTS_TEST_CASES = [
 ]
 
 
+# Sample test cases for Project/Performance Site Location v4.0 validation
+PERFORMANCE_SITE_TEST_CASES = [
+    {
+        "name": "performance_site_us_primary_only",
+        "json_input": {
+            "primary_site": {
+                "submitting_as_individual": False,
+                "organization_name": "Example University",
+                "uei": "ABCDEFGHIJ12",
+                "address": {
+                    "street1": "123 Research Blvd",
+                    "street2": "Suite 400",
+                    "city": "Science City",
+                    "county": "Grant County",
+                    "state": "CA: California",
+                    "country": "USA: UNITED STATES",
+                    "zip_code": "90210-1234",
+                },
+                "congressional_district": "CA-033",
+            }
+        },
+        "form_name": "PerformanceSite",
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_0-V4.0.xsd",
+        "pretty_print": True,
+    },
+    {
+        "name": "performance_site_international_primary",
+        "json_input": {
+            "primary_site": {
+                "submitting_as_individual": False,
+                "organization_name": "International Research Institute",
+                "address": {
+                    "street1": "10 Rue de la Paix",
+                    "city": "Paris",
+                    "country": "FRA: FRANCE",
+                },
+            }
+        },
+        "form_name": "PerformanceSite",
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_0-V4.0.xsd",
+        "pretty_print": True,
+    },
+    {
+        "name": "performance_site_individual_submitter",
+        "json_input": {
+            "primary_site": {
+                "submitting_as_individual": True,
+                "address": {
+                    "street1": "456 Main St",
+                    "city": "Springfield",
+                    "country": "USA: UNITED STATES",
+                    "zip_code": "12345-6789",
+                    "state": "IL: Illinois",
+                },
+                "congressional_district": "IL-013",
+            }
+        },
+        "form_name": "PerformanceSite",
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_0-V4.0.xsd",
+        "pretty_print": True,
+    },
+    {
+        "name": "performance_site_with_additional_sites",
+        "json_input": {
+            "primary_site": {
+                "submitting_as_individual": False,
+                "organization_name": "Example University",
+                "uei": "ABCDEFGHIJ12",
+                "address": {
+                    "street1": "123 Research Blvd",
+                    "city": "Science City",
+                    "state": "CA: California",
+                    "country": "USA: UNITED STATES",
+                    "zip_code": "90210-1234",
+                },
+                "congressional_district": "CA-033",
+            },
+            "additional_sites": [
+                {
+                    "organization_name": "Partner Lab",
+                    "address": {
+                        "street1": "789 Partner Ave",
+                        "city": "Austin",
+                        "state": "TX: Texas",
+                        "country": "USA: UNITED STATES",
+                        "zip_code": "78701",
+                    },
+                    "congressional_district": "TX-025",
+                },
+                {
+                    "organization_name": "International Research Institute",
+                    "address": {
+                        "street1": "10 Rue de la Paix",
+                        "city": "Paris",
+                        "country": "FRA: FRANCE",
+                    },
+                },
+            ],
+        },
+        "form_name": "PerformanceSite",
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_0-V4.0.xsd",
+        "pretty_print": True,
+    },
+    {
+        "name": "performance_site_with_attachment",
+        "json_input": {
+            "primary_site": {
+                "submitting_as_individual": False,
+                "organization_name": "Example University",
+                "address": {
+                    "street1": "123 Research Blvd",
+                    "city": "Science City",
+                    "state": "CA: California",
+                    "country": "USA: UNITED STATES",
+                    "zip_code": "90210-1234",
+                },
+                "congressional_district": "CA-033",
+            },
+            "additional_locations_attachment": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        },
+        "form_name": "PerformanceSite",
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_0-V4.0.xsd",
+        "pretty_print": True,
+        "attachment_mapping": {
+            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": {
+                "FileName": "additional_locations.pdf",
+                "MimeType": "application/pdf",
+                "FileLocation": "additional_locations.pdf",
+                "HashValue": "aeB1+6gdFwih51ijIRn3b8QYn24=",
+                "HashAlgorithm": "SHA-1",
+            }
+        },
+    },
+]
+
+
 def get_all_test_cases() -> list[dict[str, Any]]:
     """Get all available test cases.
 
@@ -1849,6 +1985,7 @@ def get_all_test_cases() -> list[dict[str, Any]]:
         + EPA_KEY_CONTACTS_TEST_CASES
         + ATTACHMENTFORM_TEST_CASES
         + OTHER_NARRATIVE_ATTACHMENTS_TEST_CASES
+        + PERFORMANCE_SITE_TEST_CASES
     )
 
 

--- a/api/src/services/xml_generation/validation/xsd_fetcher.py
+++ b/api/src/services/xml_generation/validation/xsd_fetcher.py
@@ -83,6 +83,12 @@ KNOWN_XSD_DEPENDENCIES = {
         "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
         "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
     ],
+    "PerformanceSite_4_0-V4.0.xsd": [
+        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
+        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
+        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
+        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
+    ],
 }
 
 

--- a/api/src/services/xml_generation/validation/xsd_validator.py
+++ b/api/src/services/xml_generation/validation/xsd_validator.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+import defusedxml.ElementTree as ET
 import xmlschema
 from lxml import etree
 
@@ -52,8 +53,6 @@ class XSDValidator:
         locations: dict[str, str] = {}
         for xsd_file in self.xsd_dir.glob("*.xsd"):
             try:
-                import xml.etree.ElementTree as ET
-
                 tree = ET.parse(str(xsd_file))
                 root = tree.getroot()
                 ns = root.get("targetNamespace")

--- a/api/src/services/xml_generation/validation/xsd_validator.py
+++ b/api/src/services/xml_generation/validation/xsd_validator.py
@@ -58,8 +58,8 @@ class XSDValidator:
                 ns = root.get("targetNamespace")
                 if ns:
                     locations[ns] = str(xsd_file)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("Failed to parse XSD file for locations map: %s (%s)", xsd_file, e)
         return locations
 
     def get_xsd_path(self, form_name: str) -> Path:

--- a/api/src/services/xml_generation/validation/xsd_validator.py
+++ b/api/src/services/xml_generation/validation/xsd_validator.py
@@ -43,6 +43,26 @@ class XSDValidator:
 
         self._schemas: dict[str, xmlschema.XMLSchema] = {}
 
+    def _build_local_locations(self) -> dict[str, str]:
+        """Build a namespace-to-local-path map from XSD files in xsd_dir.
+
+        This lets xmlschema resolve imports from local files instead of fetching
+        remote URLs, making validation faster and offline-capable.
+        """
+        locations: dict[str, str] = {}
+        for xsd_file in self.xsd_dir.glob("*.xsd"):
+            try:
+                import xml.etree.ElementTree as ET
+
+                tree = ET.parse(str(xsd_file))
+                root = tree.getroot()
+                ns = root.get("targetNamespace")
+                if ns:
+                    locations[ns] = str(xsd_file)
+            except Exception:
+                pass
+        return locations
+
     def get_xsd_path(self, form_name: str) -> Path:
         """Get the path to a stored XSD file.
 
@@ -90,7 +110,8 @@ class XSDValidator:
 
         try:
             logger.info(f"Loading XSD schema from: {xsd_path}")
-            schema = xmlschema.XMLSchema(str(xsd_path))
+            locations = self._build_local_locations()
+            schema = xmlschema.XMLSchema(str(xsd_path), locations=locations)
             self._schemas[cache_key] = schema
             return schema
 

--- a/api/src/services/xml_generation/xsds/PerformanceSite_4_0-V4.0.xsd
+++ b/api/src/services/xml_generation/xsds/PerformanceSite_4_0-V4.0.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:PerformanceSite_4_0="http://apply.grants.gov/forms/PerformanceSite_4_0-V4.0" xmlns:codes="http://apply.grants.gov/system/UniversalCodes-V2.0" xmlns:att="http://apply.grants.gov/system/Attachments-V1.0" xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0" xmlns:glob="http://apply.grants.gov/system/Global-V1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://apply.grants.gov/forms/PerformanceSite_4_0-V4.0" elementFormDefault="qualified" attributeFormDefault="qualified" version="4.0">
+	<xs:import namespace="http://apply.grants.gov/system/Attachments-V1.0" schemaLocation="https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd"/>
+	<xs:import namespace="http://apply.grants.gov/system/UniversalCodes-V2.0" schemaLocation="https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd"/>
+	<xs:import namespace="http://apply.grants.gov/system/Global-V1.0" schemaLocation="https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd"/>
+	<xs:import namespace="http://apply.grants.gov/system/GlobalLibrary-V2.0" schemaLocation="https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd"/>
+	<xs:element name="PerformanceSite_4_0">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="PrimarySite" type="PerformanceSite_4_0:SiteLocationDataType"/>
+				<xs:element name="OtherSite" type="PerformanceSite_4_0:SiteLocationDataType" minOccurs="0" maxOccurs="299"/>
+				<xs:element name="AttachedFile" type="att:AttachedFileDataType" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="FormVersion" type="globLib:FormVersionDataType" use="required" fixed="4.0"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="SiteLocationDataType">
+		<xs:sequence>
+			<xs:element name="Individual" type="globLib:YesNoDataType" minOccurs="0"/>
+			<xs:element name="OrganizationName" type="globLib:OrganizationNameDataType" minOccurs="0"/>
+			<xs:element name="SAMUEI" type="globLib:SAMUEIDataType" minOccurs="0"/>
+			<xs:element name="Address" type="globLib:AddressDataTypeV3"/>
+			<xs:element name="CongressionalDistrictProgramProject" minOccurs="0">
+				<xs:simpleType>
+					<xs:restriction base="globLib:CongressionalDistrictDataType">
+						<xs:minLength value="6"/>
+						<xs:maxLength value="6"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/api/tests/src/services/xml_generation/snapshots/performance_site_4_0.xml
+++ b/api/tests/src/services/xml_generation/snapshots/performance_site_4_0.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='utf-8'?>
+<PerformanceSite_4_0:PerformanceSite_4_0 xmlns:PerformanceSite_4_0="http://apply.grants.gov/forms/PerformanceSite_4_0-V4.0" xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0" xmlns:att="http://apply.grants.gov/system/Attachments-V1.0" PerformanceSite_4_0:FormVersion="4.0">
+  <PerformanceSite_4_0:PrimarySite>
+    <PerformanceSite_4_0:Individual>N: No</PerformanceSite_4_0:Individual>
+    <PerformanceSite_4_0:OrganizationName>Example University</PerformanceSite_4_0:OrganizationName>
+    <PerformanceSite_4_0:SAMUEI>ABCDEFGHIJ12</PerformanceSite_4_0:SAMUEI>
+    <PerformanceSite_4_0:Address>
+      <globLib:Street1>123 Research Blvd</globLib:Street1>
+      <globLib:Street2>Suite 400</globLib:Street2>
+      <globLib:City>Science City</globLib:City>
+      <globLib:County>Grant County</globLib:County>
+      <globLib:State>CA: California</globLib:State>
+      <globLib:ZipPostalCode>90210-1234</globLib:ZipPostalCode>
+      <globLib:Country>USA: UNITED STATES</globLib:Country>
+    </PerformanceSite_4_0:Address>
+    <PerformanceSite_4_0:CongressionalDistrictProgramProject>CA-033</PerformanceSite_4_0:CongressionalDistrictProgramProject>
+  </PerformanceSite_4_0:PrimarySite>
+  <PerformanceSite_4_0:OtherSite>
+    <PerformanceSite_4_0:Individual>N: No</PerformanceSite_4_0:Individual>
+    <PerformanceSite_4_0:OrganizationName>International Research Institute</PerformanceSite_4_0:OrganizationName>
+    <PerformanceSite_4_0:Address>
+      <globLib:Street1>10 Rue de la Paix</globLib:Street1>
+      <globLib:City>Paris</globLib:City>
+      <globLib:Country>FRA: FRANCE</globLib:Country>
+    </PerformanceSite_4_0:Address>
+  </PerformanceSite_4_0:OtherSite>
+  <PerformanceSite_4_0:OtherSite>
+    <PerformanceSite_4_0:Individual>Y: Yes</PerformanceSite_4_0:Individual>
+    <PerformanceSite_4_0:Address>
+      <globLib:Street1>456 Main St</globLib:Street1>
+      <globLib:City>Springfield</globLib:City>
+      <globLib:State>IL: Illinois</globLib:State>
+      <globLib:ZipPostalCode>12345-6789</globLib:ZipPostalCode>
+      <globLib:Country>USA: UNITED STATES</globLib:Country>
+    </PerformanceSite_4_0:Address>
+    <PerformanceSite_4_0:CongressionalDistrictProgramProject>IL-013</PerformanceSite_4_0:CongressionalDistrictProgramProject>
+  </PerformanceSite_4_0:OtherSite>
+  <PerformanceSite_4_0:AttachedFile>
+    <att:FileName>additional_locations.pdf</att:FileName>
+    <att:MimeType>application/pdf</att:MimeType>
+    <att:FileLocation att:href="additional_locations.pdf"/>
+    <ns0:HashValue xmlns:ns0="http://apply.grants.gov/system/Global-V1.0" ns0:hashAlgorithm="SHA-1">aeB1+6gdFwih51ijIRn3b8QYn24=</ns0:HashValue>
+  </PerformanceSite_4_0:AttachedFile>
+</PerformanceSite_4_0:PerformanceSite_4_0>

--- a/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
@@ -316,6 +316,36 @@ class TestPerformanceSiteLegacyParity:
         ), "AttachedFile must not contain a spurious AttachedFileFile inner wrapper"
 
 
+_SNAPSHOT_PATH = Path(__file__).parent / "snapshots" / "performance_site_4_0.xml"
+
+
+class TestPerformanceSiteSnapshot:
+    """Regression snapshot test pinning the full generated XML output.
+
+    To regenerate after an intentional change, run the generation with the same
+    input below and write the result to the snapshot file.
+    """
+
+    def test_full_xml_matches_snapshot(self):
+        """Generated XML for a comprehensive case must match the stored snapshot."""
+        data = {
+            "primary_site": _US_SITE,
+            "additional_sites": [_INTL_SITE, _INDIVIDUAL_US_SITE],
+            "additional_locations_attachment": _ATTACHMENT_UUID,
+        }
+        service = XMLGenerationService()
+        request = XMLGenerationRequest(
+            application_data=data,
+            transform_config=PERFORMANCE_SITE_TRANSFORM_RULES,
+            attachment_mapping={_ATTACHMENT_UUID: _ATTACHMENT_INFO},
+        )
+        response = service.generate_xml(request)
+        assert response.success, response.error_message
+
+        expected = _SNAPSHOT_PATH.read_text()
+        assert response.xml_data == expected
+
+
 class TestPerformanceSiteXSDValidation:
     """XSD validation tests for Performance Site Location form XML."""
 

--- a/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
@@ -5,6 +5,7 @@ XSD Reference: https://apply07.grants.gov/apply/forms/schemas/PerformanceSite_4_
 
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import grants_shared.adapters.db as db
 import pytest
@@ -20,6 +21,7 @@ from src.form_schema.forms.project_performance_site_location import (
 from src.services.xml_generation.models import XMLGenerationRequest
 from src.services.xml_generation.service import XMLGenerationService
 from src.services.xml_generation.submission_xml_assembler import SubmissionXMLAssembler
+from src.services.xml_generation.utils.attachment_mapping import AttachmentInfo
 from src.services.xml_generation.validation.xsd_validator import XSDValidator
 from tests.src.db.models.factories import (
     AgencyFactory,
@@ -142,14 +144,186 @@ class TestPerformanceSiteXMLGeneration:
         assert primary_pos < other_pos
 
 
+_GLOB_NS = "http://apply.grants.gov/system/Global-V1.0"
+_GLOB_LIB_NS = "http://apply.grants.gov/system/GlobalLibrary-V2.0"
+_ATT_NS = "http://apply.grants.gov/system/Attachments-V1.0"
+
+_ATTACHMENT_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+_ATTACHMENT_INFO = AttachmentInfo(
+    filename="additional_locations.pdf",
+    mime_type="application/pdf",
+    file_location="additional_locations.pdf",
+    hash_value="aeB1+6gdFwih51ijIRn3b8QYn24=",
+)
+
+
+class TestPerformanceSiteLegacyParity:
+    """Structural parity tests verifying the generated XML matches the legacy Grants.gov format.
+
+    Legacy XML (from GrantApplication.xml downloaded from Grants.gov):
+
+        <PerformanceSite_4_0:PerformanceSite_4_0
+            xmlns:PerformanceSite_4_0="http://apply.grants.gov/forms/PerformanceSite_4_0-V4.0"
+            xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0"
+            PerformanceSite_4_0:FormVersion="4.0">
+          <PerformanceSite_4_0:PrimarySite>
+            <PerformanceSite_4_0:Individual>N: No</PerformanceSite_4_0:Individual>
+            <PerformanceSite_4_0:OrganizationName>Example University</PerformanceSite_4_0:OrganizationName>
+            <PerformanceSite_4_0:SAMUEI>ABCDEFGHIJ12</PerformanceSite_4_0:SAMUEI>
+            <PerformanceSite_4_0:Address>
+              <globLib:Street1>123 Research Blvd</globLib:Street1>
+              <globLib:Street2>Suite 400</globLib:Street2>
+              <globLib:City>Science City</globLib:City>
+              <globLib:County>Grant County</globLib:County>
+              <globLib:State>CA: California</globLib:State>
+              <globLib:ZipPostalCode>90210-1234</globLib:ZipPostalCode>
+              <globLib:Country>USA: UNITED STATES</globLib:Country>
+            </PerformanceSite_4_0:Address>
+            <PerformanceSite_4_0:CongressionalDistrictProgramProject>CA-033</PerformanceSite_4_0:CongressionalDistrictProgramProject>
+          </PerformanceSite_4_0:PrimarySite>
+        </PerformanceSite_4_0:PerformanceSite_4_0>
+    """
+
+    def _generate(self, data: dict[str, Any]) -> lxml_etree._Element:
+        service = XMLGenerationService()
+        request = XMLGenerationRequest(
+            application_data=data, transform_config=PERFORMANCE_SITE_TRANSFORM_RULES
+        )
+        response = service.generate_xml(request)
+        assert response.success, f"XML generation failed: {response.error_message}"
+        return lxml_etree.fromstring(response.xml_data.encode())
+
+    def _generate_with_attachment(
+        self, data: dict[str, Any], attachment_uuid: str, attachment_info: AttachmentInfo
+    ) -> lxml_etree._Element:
+        service = XMLGenerationService()
+        request = XMLGenerationRequest(
+            application_data=data,
+            transform_config=PERFORMANCE_SITE_TRANSFORM_RULES,
+            attachment_mapping={attachment_uuid: attachment_info},
+        )
+        response = service.generate_xml(request)
+        assert response.success, f"XML generation failed: {response.error_message}"
+        return lxml_etree.fromstring(response.xml_data.encode())
+
+    def test_root_element_and_form_version(self):
+        root = self._generate({"primary_site": _US_SITE})
+
+        assert root.tag == f"{{{_FORM_NS}}}PerformanceSite_4_0"
+        assert root.get(f"{{{_FORM_NS}}}FormVersion") == "4.0"
+
+    def test_site_location_elements_use_form_namespace(self):
+        """Individual, OrganizationName, SAMUEI, Address, CongressionalDistrictProgramProject
+        are defined in SiteLocationDataType and must be in the PerformanceSite_4_0 namespace."""
+        root = self._generate({"primary_site": _US_SITE})
+
+        primary = root.find(f"{{{_FORM_NS}}}PrimarySite")
+        assert primary is not None
+
+        assert primary.find(f"{{{_FORM_NS}}}Individual") is not None
+        assert primary.find(f"{{{_FORM_NS}}}OrganizationName") is not None
+        assert primary.find(f"{{{_FORM_NS}}}SAMUEI") is not None
+        assert primary.find(f"{{{_FORM_NS}}}Address") is not None
+        assert primary.find(f"{{{_FORM_NS}}}CongressionalDistrictProgramProject") is not None
+
+    def test_address_sub_elements_use_glob_lib_namespace(self):
+        """Address child elements (Street1, City, State, etc.) must be in the globLib namespace."""
+        root = self._generate({"primary_site": _US_SITE})
+
+        address = root.find(f".//{{{_FORM_NS}}}Address")
+        assert address is not None
+
+        assert address.find(f"{{{_GLOB_LIB_NS}}}Street1") is not None
+        assert address.find(f"{{{_GLOB_LIB_NS}}}City") is not None
+        assert address.find(f"{{{_GLOB_LIB_NS}}}State") is not None
+        assert address.find(f"{{{_GLOB_LIB_NS}}}ZipPostalCode") is not None
+        assert address.find(f"{{{_GLOB_LIB_NS}}}Country") is not None
+
+    def test_address_element_order_matches_xsd(self):
+        """AddressDataTypeV3 sequence: Street1, Street2, City, County, State|Province,
+        ZipPostalCode, Country."""
+        root = self._generate({"primary_site": _US_SITE})
+        address = root.find(f".//{{{_FORM_NS}}}Address")
+
+        tags = [child.tag.split("}")[-1] for child in address]
+        zip_idx = tags.index("ZipPostalCode")
+        country_idx = tags.index("Country")
+        assert zip_idx < country_idx, "ZipPostalCode must precede Country per XSD"
+
+    def test_individual_maps_boolean_to_yes_no_code(self):
+        root = self._generate({"primary_site": _US_SITE})
+        individual = root.find(f".//{{{_FORM_NS}}}Individual")
+        assert individual is not None
+        assert individual.text == "N: No"
+
+    def test_individual_true_maps_to_yes(self):
+        root = self._generate({"primary_site": _INDIVIDUAL_US_SITE})
+        individual = root.find(f".//{{{_FORM_NS}}}Individual")
+        assert individual is not None
+        assert individual.text == "Y: Yes"
+
+    def test_additional_sites_use_other_site_element(self):
+        data = {"primary_site": _US_SITE, "additional_sites": [_INTL_SITE]}
+        root = self._generate(data)
+
+        other_sites = root.findall(f"{{{_FORM_NS}}}OtherSite")
+        assert len(other_sites) == 1
+        assert other_sites[0].find(f"{{{_FORM_NS}}}Address") is not None
+
+    def test_attachment_structure_matches_xsd(self):
+        """AttachedFile element must be a direct child of the root in the form namespace,
+        with att: content elements nested inside it (no extra inner wrapper)."""
+        data = {
+            "primary_site": _INTL_SITE,
+            "additional_locations_attachment": _ATTACHMENT_UUID,
+        }
+        root = self._generate_with_attachment(data, _ATTACHMENT_UUID, _ATTACHMENT_INFO)
+
+        attached_file = root.find(f"{{{_FORM_NS}}}AttachedFile")
+        assert attached_file is not None, "AttachedFile must be a direct child of root"
+
+        assert attached_file.find(f"{{{_ATT_NS}}}FileName") is not None
+        assert attached_file.find(f"{{{_ATT_NS}}}MimeType") is not None
+        assert attached_file.find(f"{{{_ATT_NS}}}FileLocation") is not None
+        assert attached_file.find(f"{{{_GLOB_NS}}}HashValue") is not None
+
+    def test_attachment_filename_content(self):
+        data = {
+            "primary_site": _INTL_SITE,
+            "additional_locations_attachment": _ATTACHMENT_UUID,
+        }
+        root = self._generate_with_attachment(data, _ATTACHMENT_UUID, _ATTACHMENT_INFO)
+
+        attached_file = root.find(f"{{{_FORM_NS}}}AttachedFile")
+        assert attached_file.find(f"{{{_ATT_NS}}}FileName").text == "additional_locations.pdf"
+        assert attached_file.find(f"{{{_ATT_NS}}}MimeType").text == "application/pdf"
+
+    def test_no_spurious_inner_attachment_wrapper(self):
+        """Regression: single_with_wrapper without file_element would create an extra
+        AttachedFileFile element inside AttachedFile. Verify it's absent."""
+        data = {
+            "primary_site": _INTL_SITE,
+            "additional_locations_attachment": _ATTACHMENT_UUID,
+        }
+        root = self._generate_with_attachment(data, _ATTACHMENT_UUID, _ATTACHMENT_INFO)
+
+        attached_file = root.find(f"{{{_FORM_NS}}}AttachedFile")
+        assert attached_file is not None
+
+        inner_wrapper = attached_file.find(f"{{{_FORM_NS}}}AttachedFileFile")
+        assert (
+            inner_wrapper is None
+        ), "AttachedFile must not contain a spurious AttachedFileFile inner wrapper"
+
+
 class TestPerformanceSiteXSDValidation:
     """XSD validation tests for Performance Site Location form XML."""
 
     @pytest.fixture
     def xsd_validator(self):
-        xsd_cache_dir = Path(__file__).parents[1] / "xsd_cache"
+        xsd_cache_dir = Path(__file__).parents[4] / "src/services/xml_generation/xsds"
         if not xsd_cache_dir.exists():
-            pytest.skip("XSD cache directory not found. Run 'flask task fetch-xsds'.")
+            pytest.skip("XSD directory not found. Run 'flask task fetch-xsds'.")
         xsd_path = xsd_cache_dir / "PerformanceSite_4_0-V4.0.xsd"
         if not xsd_path.exists():
             pytest.skip(
@@ -162,15 +336,16 @@ class TestPerformanceSiteXSDValidation:
         parser = lxml_etree.XMLParser(remove_blank_text=True)
         root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
 
-        ns = f"{{{_FORM_NS}}}"
-        forms_element = root.find(".//Forms")
+        grant_ns = {"grant": "http://apply.grants.gov/system/MetaGrantApplication"}
+        forms_element = root.find(".//grant:Forms", namespaces=grant_ns)
         assert forms_element is not None, "Forms element not found in submission XML"
 
-        elements = forms_element.findall(f".//{ns}PerformanceSite_4_0")
+        form_ns = f"{{{_FORM_NS}}}"
+        elements = forms_element.findall(f".//{form_ns}PerformanceSite_4_0")
         assert len(elements) == 1, f"Expected 1 PerformanceSite_4_0 element, got {len(elements)}"
 
         form_xml = lxml_etree.tostring(elements[0], encoding="unicode")
-        xsd_path = xsd_validator.xsd_cache_dir / "PerformanceSite_4_0-V4.0.xsd"
+        xsd_path = xsd_validator.xsd_dir / "PerformanceSite_4_0-V4.0.xsd"
         return xsd_validator.validate_xml(form_xml, xsd_path)
 
     def _make_application(self, enable_factory_create, db_session: db.Session, response: dict):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10227

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Fix namespace mapping in `_site_location_xml_fields()`
- Fix address element ordering
- Fix attachment generation
- Download and push `PerformanceSite_4_0-V4.0.xsd` to the `xsds/` directory
- Add `PerformanceSite_4_0-V4.0.xsd` to `KNOWN_XSD_DEPENDENCIES` in `xsd_fetcher.py` so `make fetch-xsds` keeps it in sync
- Fix `XSDValidator.load_schema` to pass a local `locations` map to `xmlschema`, resolving all schema imports from local files instead of fetching remote URLs (fixes flaky offline failures for any form, not just PerformanceSite)
- Fix `TestPerformanceSiteXSDValidation`: corrected the XSD cache path (`parents[1]` → `parents[4]`), the `Forms` element lookup (added grant namespace), and the validator attribute name (`xsd_cache_dir` → `xsd_dir`)
- Add `PERFORMANCE_SITE_TEST_CASES` to `validation/test_cases.py`
- Add `TestPerformanceSiteLegacyParity` tests
- Update `README.md`

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The transform rules in `form_json.py` were already scaffolded, but bugs needed fixing before the XML would pass XSD validation:

1. **Namespace split**: `SiteLocationDataType` is defined in the PerformanceSite XSD itself, so its child elements (`Individual`, `OrganizationName`, etc.) belong to the `PerformanceSite_4_0` namespace. The address *sub*-elements (`Street1`, `City`, etc.) come from `globLib:AddressDataTypeV3` and correctly stay in `globLib`. The original code applied `globLib` to the site-level fields (wrong)

2. **Address ordering**: `AddressDataTypeV3` declares `ZipPostalCode` before `Country` in its XSD sequence. The original field order had them reversed, which caused every test case to fail validation

3. **Attachment structure**: The `single_with_wrapper` type with no `file_element` defaulted to creating `<AttachedFile><AttachedFileFile>…</AttachedFileFile></AttachedFile>`, which doesn't match the XSD's `<AttachedFile type="att:AttachedFileDataType"/>` (direct content, no inner wrapper). Setting `file_element: ""` now skips the inner element; this is a minimal, targeted change to `attachment_transformer.py` that doesn't affect any existing form.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
`make test args="tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py"
`make test-xml-validation form=PerformanceSite`
`make test-xml-validation`
`make test args="tests/src/services/xml_generation/"`