### PR TITLE
[Issue #10758] Update numeric validation messages to include "or equal to"

### DIFF
--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -417,11 +417,11 @@ export const messages = {
       additionalInfoUrlText: "Enter additional information URL text.",
       grantorContactDetails: "Enter grantor contact details.",
       awardMinCurrencyInput:
-        "Award minimum must be greater than zero and less than $1,000,000,000,000,000.",
+        "Award minimum must be greater than or equal to zero and less than $1,000,000,000,000,000.",
       awardMaxCurrencyInput:
-        "Award maximum must be greater than zero and less than $1,000,000,000,000,000.",
+        "Award maximum must be greater than or equal to zero and less than $1,000,000,000,000,000.",
       totalFundingCurrencyInput:
-        "Estimated total program funding must be greater than zero and less than $1,000,000,000,000,000.",
+        "Estimated total program funding must be greater than or equal to zero and less than $1,000,000,000,000,000.",
       awardMinLessThanTotal:
         "Award minimum cannot exceed the Estimated Total Program Funding.",
       awardMaxLessThanTotal:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10758 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Simply update three validation message to include "or equal to. I.e. from "[field_name] must be greater than zero and less than $1,000,000,000,000,000." to "[field_name] must be greater than **or equal to** zero and less than $1,000,000,000,000,000."

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- Code review
- Open the Edit Opportunity page and for each of the three fields, enter a number greater than 1,000,000,000,000,000 or less than zero (a negative number). Tab or click off the field to see the field validation message. 