### PR TITLE
[Issue #10872] Remove soap error logging to s3 restrictions

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -20,7 +20,7 @@ from src.db.models.competition_models import (
     ApplicationSubmissionTrackingNumber,
 )
 from src.legacy_soap_api.legacy_soap_api_config import get_soap_config
-from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent, SimplerRequests
+from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
 from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage, SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.soap_payload_handler import extract_soap_xml
@@ -528,11 +528,8 @@ def to_snake_case(name: str) -> str:
 
 
 def write_debug_data_to_s3(soap_request: SOAPRequest, soap_legacy_response: SOAPResponse) -> None:
-    try:
-        if (
-            get_soap_config().save_soap_messages_to_s3
-            and soap_request.operation_name in SimplerRequests
-        ):
+    if get_soap_config().save_soap_messages_to_s3:
+        try:
             s3_config = S3Config()
             debug_identifier = uuid.uuid4()
             base_path = file_util.join(
@@ -556,8 +553,8 @@ def write_debug_data_to_s3(soap_request: SOAPRequest, soap_legacy_response: SOAP
                 "soap_client: debug info uploaded to s3",
                 extra={"debug_identifier": debug_identifier},
             )
-    except Exception:
-        logger.exception(
-            "soap_client: failed to upload debug info to s3",
-            extra={"soap_api_event": LegacySoapApiEvent.ERROR_UPLOADING_DEBUG_DATA},
-        )
+        except Exception:
+            logger.exception(
+                "soap_client: failed to upload debug info to s3",
+                extra={"soap_api_event": LegacySoapApiEvent.ERROR_UPLOADING_DEBUG_DATA},
+            )

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -100,7 +100,7 @@ def test_write_debug_data_to_s3_does_not_run_if_flag_is_set_to_false(
     assert objects.get("Contents", None) is None
 
 
-def test_write_debug_data_to_s3_does_not_run_if_not_in_specified_operations(
+def test_write_debug_data_to_s3_runs_on_any_endpoint(
     db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
 ) -> None:
     soap_api_config.get_soap_config.cache_clear()
@@ -136,5 +136,4 @@ def test_write_debug_data_to_s3_does_not_run_if_not_in_specified_operations(
         create_soap_request(SOAP_PAYLOAD, operation_name="Y"), soap_legacy_response
     )
     objects = s3_client.list_objects_v2(Bucket="local-mock-draft-bucket")
-    # If it triggered on everything it should be 14
-    assert len(objects.get("Contents")) == 10
+    assert len(objects.get("Contents")) == 14


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10872  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- removed check for endpoints 

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We want to log all error responses and requests no matter the endpoint.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] run invalid request and check s3 bucket
