### PR TITLE
[Issue #10877] Adjust Award Recommendation summary "Total funding recommended" to only include submissions with recommended status

### DIFF
--- a/api/src/services/award_recommendations/get_award_recommendation_summary.py
+++ b/api/src/services/award_recommendations/get_award_recommendation_summary.py
@@ -55,7 +55,16 @@ def get_award_recommendation_summary(
                 "not_recommended_count",
             ),
             func.coalesce(
-                func.sum(AwardRecommendationSubmissionDetail.recommended_amount),
+                func.sum(
+                    case(
+                        (
+                            AwardRecommendationSubmissionDetail.award_recommendation_type
+                            == AwardRecommendationType.RECOMMENDED_FOR_FUNDING,
+                            AwardRecommendationSubmissionDetail.recommended_amount,
+                        ),
+                        else_=0,
+                    )
+                ),
                 0,
             ).label("total_recommended_amount"),
         )

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_get.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_get.py
@@ -119,6 +119,7 @@ class TestGetAwardRecommendation200:
         AwardRecommendationApplicationSubmissionFactory.create(
             award_recommendation=award_recommendation,
             recommended_without_funding=True,
+            award_recommendation_submission_detail__recommended_amount=25000,
         )
         AwardRecommendationApplicationSubmissionFactory.create(
             award_recommendation=award_recommendation,

--- a/api/tests/src/services/award_recommendations/test_get_award_recommendation_summary.py
+++ b/api/tests/src/services/award_recommendations/test_get_award_recommendation_summary.py
@@ -40,6 +40,26 @@ class TestGetAwardRecommendationSummary:
         assert result.recommended_for_funding_count == 1
         assert result.not_recommended_count == 1
 
+    def test_total_recommended_amount_excludes_recommended_without_funding(
+        self, db_session, award_recommendation
+    ):
+        AwardRecommendationApplicationSubmissionFactory.create(
+            award_recommendation=award_recommendation,
+            recommended_for_funding=True,
+            award_recommendation_submission_detail__recommended_amount=50000,
+        )
+        AwardRecommendationApplicationSubmissionFactory.create(
+            award_recommendation=award_recommendation,
+            recommended_without_funding=True,
+            award_recommendation_submission_detail__recommended_amount=25000,
+        )
+
+        result = get_award_recommendation_summary(
+            db_session, award_recommendation.award_recommendation_id
+        )
+
+        assert result.total_recommended_amount == Decimal("50000")
+
     def test_returns_zeros_when_no_submissions(self, db_session, award_recommendation):
         result = get_award_recommendation_summary(
             db_session, award_recommendation.award_recommendation_id


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes for #10877 

## Changes proposed

- Excluded non-recommended submissions from being included in `total_recommended_amount` in AR summary

## Context for reviewers

Found as a bug today, needs to be merged before tomorrow so that Summary functionality can be demoed in ToT.

## Validation steps

- [ ] Go to http://localhost:3000/award-recommendation/{award_rec_id} for an award rec with recommended submissions
- [ ] Validate that the "Total funding recommended" in the summary table is actually the sum of the values in the "Recommended" column of the Recommended Awards table