### PR TITLE
[Issue #10244] Endpoint for returning multiple test user auth tokens

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -63,6 +63,12 @@ inputs:
   staging_test_user_api_key:
     description: "test user API key used in spoofing staging user logins"
     default: ""
+  staging_test_user_manager_api_key:
+    description: "manager API key used to request auth tokens for test users via POST /v1/internal/e2e-token"
+    default: ""
+  staging_test_user_id:
+    description: "UUID of the staging test user whose token will be requested for login spoofing"
+    default: ""
   staging_client_session_secret:
     description: "encode key for client side JWTs, used in spoofing staging user logins"
     default: ""
@@ -140,6 +146,8 @@ runs:
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
         STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
+        STAGING_TEST_USER_MANAGER_API_KEY: ${{ inputs.staging_test_user_manager_api_key }}
+        STAGING_TEST_USER_ID: ${{ inputs.staging_test_user_id }}
         SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
 
       run: |
@@ -159,6 +167,8 @@ runs:
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
         STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
+        STAGING_TEST_USER_MANAGER_API_KEY: ${{ inputs.staging_test_user_manager_api_key }}
+        STAGING_TEST_USER_ID: ${{ inputs.staging_test_user_id }}
         SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
 
       run: |

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -64,6 +64,8 @@ jobs:
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
           staging_test_user_api_key: ${{ secrets.STAGING_TEST_USER_API_KEY }}
+          staging_test_user_manager_api_key: ${{ secrets.STAGING_TEST_USER_MANAGER_API_KEY }}
+          staging_test_user_id: ${{ secrets.STAGING_TEST_USER_ID }}
           staging_client_session_secret: ${{ secrets.STAGING_CLIENT_SESSION_SECRET }}
           do-chrome-install: "true"
   create-report:

--- a/api/local.env
+++ b/api/local.env
@@ -57,6 +57,11 @@ API_JWT_PRIVATE_KEY=
 API_JWT_PUBLIC_KEY=
 LOGIN_GOV_CLIENT_ASSERTION_PRIVATE_KEY=
 
+# API key used by the local E2E test orchestrator to authenticate against
+# POST /v1/internal/e2e-token and request auth tokens for test users.
+# Staging uses STAGING_TEST_USER_MANAGER_API_KEY (stored in 1Password / GH Secrets).
+LOCAL_TEST_USER_MANAGER_API_KEY=local-manager-key
+
 ############################
 # Endpoints
 ############################

--- a/api/src/api/internal/internal_routes.py
+++ b/api/src/api/internal/internal_routes.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 import grants_shared.adapters.db as db
 import grants_shared.adapters.db.flask_db as flask_db
@@ -38,21 +39,26 @@ def update_internal_roles(
 
 
 @internal_blueprint.post("/e2e-token")
+@internal_blueprint.input(internal_schema.E2ETokenRequestSchema, location="json")
 @internal_blueprint.output(internal_schema.E2ETokenResponseSchema)
 @internal_blueprint.doc(hide=True)
 @internal_blueprint.auth_required(api_user_key_auth)
 @flask_db.with_db_session()
-def get_e2e_token(db_session: db.Session) -> response.ApiResponse:
+def get_e2e_token(db_session: db.Session, json_data: dict[str, uuid.UUID]) -> response.ApiResponse:
     """
     Endpoint to fetch a viable auth token for a test user account.
-    Only accessible via API key auth with the read_test_user_token privilege.
+    Only accessible via API key auth with the manage_test_user_token privilege,
+    and only in lower environments.
     """
+    target_user_id = json_data["user_id"]
+
+    add_extra_data_to_current_request_logs({"target_user_id": target_user_id})
     logger.info("POST /v1/internal/e2e-token")
 
     with db_session.begin():
-        user = api_user_key_auth.get_user()
-        db_session.add(user)
+        api_key_user = api_user_key_auth.get_user()
+        db_session.add(api_key_user)
 
-        token_data = create_e2e_token(db_session, user)
+        token_data = create_e2e_token(db_session, api_key_user, target_user_id)
 
     return response.ApiResponse(message="Success", data=token_data)

--- a/api/src/api/internal/internal_schema.py
+++ b/api/src/api/internal/internal_schema.py
@@ -23,6 +23,16 @@ class InternalRoleAssignmentResponseSchema(AbstractResponseSchema):
     pass
 
 
+class E2ETokenRequestSchema(Schema):
+    user_id = fields.UUID(
+        required=True,
+        metadata={
+            "description": "The UUID of the test user to issue an auth token for",
+            "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+        },
+    )
+
+
 class E2ETokenResponseSchema(AbstractResponseSchema):
     token = fields.String(metadata={"description": "The viable JWT auth token"})
     expires_at = fields.DateTime(

--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -324,6 +324,8 @@ class Privilege(StrEnum):
 
     INTERNAL_S3_SCAN = "internal_s3_scan"
 
+    MANAGE_TEST_USER_TOKEN = "manage_test_user_token"
+
 
 class RoleType(StrEnum):
     ORGANIZATION = "organization"

--- a/api/src/constants/static_role_values.py
+++ b/api/src/constants/static_role_values.py
@@ -281,6 +281,20 @@ INTERNAL_S3_SCANNER_ROLE = Role(
     ],
 )
 
+E2E_TEST_USER_MANAGER_ROLE_ID = uuid.UUID("b2c3d4e5-f6a7-4b5c-9d0e-1f2a3b4c5d6e")
+E2E_TEST_USER_MANAGER_ROLE = Role(
+    role_id=E2E_TEST_USER_MANAGER_ROLE_ID,
+    role_name="E2E Test User Manager",
+    is_core=True,
+    link_privileges=get_link_privileges(
+        E2E_TEST_USER_MANAGER_ROLE_ID,
+        [Privilege.MANAGE_TEST_USER_TOKEN],
+    ),
+    link_role_types=[
+        LinkRoleRoleType(role_id=E2E_TEST_USER_MANAGER_ROLE_ID, role_type=RoleType.INTERNAL),
+    ],
+)
+
 CORE_ROLES = [
     ORG_ADMIN,
     ORG_MEMBER,
@@ -297,4 +311,5 @@ CORE_ROLES = [
     GRANTOR_PROGRAM_OFFICER,
     GRANTOR_BUDGET_OFFICER,
     INTERNAL_S3_SCANNER_ROLE,
+    E2E_TEST_USER_MANAGER_ROLE,
 ]

--- a/api/src/db/models/lookup_models.py
+++ b/api/src/db/models/lookup_models.py
@@ -345,6 +345,7 @@ PRIVILEGE_CONFIG: LookupConfig[Privilege] = LookupConfig(
         LookupStr(Privilege.UPDATE_AWARD_RECOMMENDATION, 30),
         LookupStr(Privilege.SUBMIT_AWARD_RECOMMENDATION, 31),
         LookupStr(Privilege.INTERNAL_S3_SCAN, 32),
+        LookupStr(Privilege.MANAGE_TEST_USER_TOKEN, 33),
     ]
 )
 

--- a/api/src/services/internal/create_e2e_token.py
+++ b/api/src/services/internal/create_e2e_token.py
@@ -1,26 +1,47 @@
 import logging
-import os
+import uuid
 
 import grants_shared.adapters.db as db
+from pydantic import Field
+from sqlalchemy import select
 
 from src.api.route_utils import raise_flask_error
 from src.auth.api_jwt_auth import create_jwt_for_user
-from src.auth.endpoint_access_util import verify_access
+from src.auth.endpoint_access_util import can_access, verify_access
 from src.constants.lookup_constants import Privilege
 from src.db.models.user_models import User
+from src.util.env_config import PydanticBaseEnvConfig
 
 logger = logging.getLogger(__name__)
 
+LOWER_ENVIRONMENTS = {"local", "dev", "staging", "training"}
 
-def create_e2e_token(db_session: db.Session, user: User) -> dict:
-    if os.getenv("ENVIRONMENT") not in ["local", "dev", "staging", "training"]:
+
+class _EnvironmentConfig(PydanticBaseEnvConfig):
+    environment: str | None = Field(default=None, alias="ENVIRONMENT")
+
+
+def create_e2e_token(db_session: db.Session, api_key_user: User, target_user_id: uuid.UUID) -> dict:
+    env_config = _EnvironmentConfig()
+    if env_config.environment not in LOWER_ENVIRONMENTS:
         logger.warning("Attempted to access E2E token endpoint in production")
-        raise_flask_error(403, "Forbidden")
+        raise_flask_error(404, "Not Found")
 
-    verify_access(user, {Privilege.READ_TEST_USER_TOKEN}, None)
+    verify_access(api_key_user, {Privilege.MANAGE_TEST_USER_TOKEN}, None)
+
+    target_user = db_session.execute(
+        select(User).where(User.user_id == target_user_id)
+    ).scalar_one_or_none()
+
+    if target_user is None or not can_access(target_user, {Privilege.READ_TEST_USER_TOKEN}, None):
+        logger.info(
+            "E2E token requested for non-test user",
+            extra={"target_user_id": target_user_id},
+        )
+        raise_flask_error(404, "Not Found")
 
     logger.info("Generating E2E bypass token")
 
-    jwt_str, token_session = create_jwt_for_user(user, db_session)
+    jwt_str, token_session = create_jwt_for_user(target_user, db_session)
 
     return {"token": jwt_str, "expires_at": token_session.expires_at}

--- a/api/tests/lib/seed_e2e.py
+++ b/api/tests/lib/seed_e2e.py
@@ -3,8 +3,10 @@ import os
 import uuid
 
 import grants_shared.adapters.db as db
+from pydantic import Field
 
-from src.constants.static_role_values import E2E_TEST_USER_ROLE
+from src.constants.static_role_values import E2E_TEST_USER_MANAGER_ROLE, E2E_TEST_USER_ROLE
+from src.util.env_config import PydanticBaseEnvConfig
 from src.util.file_util import write_to_file
 from tests.lib.seed_data_utils import UserBuilder
 
@@ -13,9 +15,19 @@ logger = logging.getLogger(__name__)
 ###############################
 # This script will
 # * seed the local database with a user that can be used for fake or potentially real logins from automated e2e tests
-# * create an authorization token entry tied to that user, seeding the database accordingly
+# * seed a "manager" user whose API key the e2e orchestrator uses to call
+#   POST /v1/internal/e2e-token (mirrors the staging manager-key flow)
+# * create an authorization token entry tied to the test user, seeding the database accordingly
 # * write the resulting token into the e2e_token.tmp file (where it can be retrieved by CI processes for frontend / e2e use)
 ###############################
+
+# Static UUID for the local E2E manager user. Documented to QA alongside the
+# test user UUIDs.
+E2E_MANAGER_USER_ID = uuid.UUID("c3d4e5f6-a7b8-4c5d-9e0f-1a2b3c4d5e6f")
+
+
+class _SeedE2EConfig(PydanticBaseEnvConfig):
+    local_test_user_manager_api_key: str = Field(alias="LOCAL_TEST_USER_MANAGER_API_KEY")
 
 
 def _write_token_to_file(token: str) -> None:
@@ -25,9 +37,11 @@ def _write_token_to_file(token: str) -> None:
 
 
 def _build_users_and_tokens(db_session: db.Session) -> None:
+    config = _SeedE2EConfig()
+
     builder = (
         # Reuse the seeded one_org_user so the spoofed E2E session always has
-        # organization membership (Sally's Soup Emporium) in local/CI runs.
+        # organization membership in local/CI runs.
         UserBuilder(uuid.UUID("f15c7491-7ebc-4f4f-8de6-3ac0594d9c63"), db_session, "user for e2e")
         .with_jwt_auth()
         .with_api_key("e2e-test-key")
@@ -36,3 +50,12 @@ def _build_users_and_tokens(db_session: db.Session) -> None:
 
     builder.build()
     _write_token_to_file(builder.jwt_token)
+
+    # Manager user: holds the API key the e2e orchestrator uses to request
+    # tokens for any test user via POST /v1/internal/e2e-token.
+    (
+        UserBuilder(E2E_MANAGER_USER_ID, db_session, "e2e test user manager")
+        .with_api_key(config.local_test_user_manager_api_key)
+        .with_internal_role(E2E_TEST_USER_MANAGER_ROLE)
+        .build()
+    )

--- a/api/tests/src/api/internal/test_internal_e2e_token.py
+++ b/api/tests/src/api/internal/test_internal_e2e_token.py
@@ -1,62 +1,152 @@
+import uuid
+from email.utils import parsedate_to_datetime
+
+import jwt
+import pytest
+from sqlalchemy import select
+
 from src.constants.lookup_constants import Privilege, RoleType
+from src.db.models.user_models import UserTokenSession
 from tests.src.db.models import factories
 
 E2E_TOKEN_URL = "/v1/internal/e2e-token"
 
 
-def setup_e2e_privileges(db_session, api_key_value, has_privilege=True):
-    """Helper to setup a user with or without the E2E token privilege"""
+@pytest.fixture
+def manager_api_key(db_session, enable_factory_create):
+    """Create a 'test user manager' user + API key with MANAGE_TEST_USER_TOKEN privilege."""
+    manager_user = factories.UserFactory.create()
+    api_key = factories.UserApiKeyFactory.create(user=manager_user)
+
+    manager_role = factories.RoleFactory.create(
+        role_name="Test User Manager", privileges=[Privilege.MANAGE_TEST_USER_TOKEN]
+    )
+    factories.LinkRoleRoleTypeFactory.create(role=manager_role, role_type=RoleType.INTERNAL)
+    factories.InternalUserRoleFactory.create(user=manager_user, role=manager_role)
+
+    return api_key.key_id
+
+
+@pytest.fixture
+def test_user(db_session, enable_factory_create):
+    """Create a user tagged as a test user (has READ_TEST_USER_TOKEN privilege)."""
     user = factories.UserFactory.create()
-    factories.UserApiKeyFactory.create(user=user, key_id=api_key_value)
 
-    privileges = [Privilege.READ_TEST_USER_TOKEN] if has_privilege else [Privilege.VIEW_APPLICATION]
-
-    role = factories.RoleFactory.create(role_name="E2E Role", privileges=privileges)
+    role = factories.RoleFactory.create(
+        role_name="E2E Test User", privileges=[Privilege.READ_TEST_USER_TOKEN]
+    )
     factories.LinkRoleRoleTypeFactory.create(role=role, role_type=RoleType.INTERNAL)
     factories.InternalUserRoleFactory.create(user=user, role=role)
 
     return user
 
 
-def test_get_e2e_token_success(client, db_session, enable_factory_create, monkeypatch):
-    """Test successful token retrieval in a lower environment"""
-    api_key = "privileged-e2e-key"
-    setup_e2e_privileges(db_session, api_key, has_privilege=True)
-
-    resp = client.post(E2E_TOKEN_URL, headers={"X-API-Key": api_key})
+def test_get_e2e_token_success(client, db_session, manager_api_key, test_user):
+    """Test successful token retrieval for a test user in a lower environment"""
+    resp = client.post(
+        E2E_TOKEN_URL,
+        headers={"X-API-Key": manager_api_key},
+        json={"user_id": str(test_user.user_id)},
+    )
 
     assert resp.status_code == 200
     data = resp.get_json()["data"]
-    assert "token" in data
-    assert "expires_at" in data
-    assert isinstance(data["token"], str)
+
+    # The issued token must belong to the target test user, not the manager
+    # whose API key made the request
+    decoded_token = jwt.decode(data["token"], options={"verify_signature": False})
+    assert decoded_token["user_id"] == str(test_user.user_id)
+
+    token_session = db_session.execute(
+        select(UserTokenSession).where(UserTokenSession.token_id == decoded_token["sub"])
+    ).scalar_one_or_none()
+    assert token_session is not None
+    assert token_session.user_id == test_user.user_id
+    assert token_session.is_valid is True
+    # The response serializes the datetime in RFC 822 format with second precision
+    assert parsedate_to_datetime(data["expires_at"]) == token_session.expires_at.replace(
+        microsecond=0
+    )
 
 
-def test_get_e2e_token_forbidden(client, db_session, enable_factory_create, monkeypatch):
-    """Test that a valid key without the specific privilege returns 403"""
-    api_key = "unprivileged-key"
-    setup_e2e_privileges(db_session, api_key, has_privilege=False)
+def test_get_e2e_token_forbidden_wrong_privilege(
+    client, db_session, enable_factory_create, test_user
+):
+    """An API key without MANAGE_TEST_USER_TOKEN returns 403"""
+    user = factories.UserFactory.create()
+    api_key = factories.UserApiKeyFactory.create(user=user)
 
-    resp = client.post(E2E_TOKEN_URL, headers={"X-API-Key": api_key})
+    role = factories.RoleFactory.create(
+        role_name="Unprivileged", privileges=[Privilege.VIEW_APPLICATION]
+    )
+    factories.LinkRoleRoleTypeFactory.create(role=role, role_type=RoleType.INTERNAL)
+    factories.InternalUserRoleFactory.create(user=user, role=role)
+
+    resp = client.post(
+        E2E_TOKEN_URL,
+        headers={"X-API-Key": api_key.key_id},
+        json={"user_id": str(test_user.user_id)},
+    )
 
     assert resp.status_code == 403
     assert resp.get_json()["message"] == "Forbidden"
 
 
 def test_get_e2e_token_unauthorized(client, enable_factory_create):
-    """Test that a missing or invalid key returns 401"""
-    resp = client.post(E2E_TOKEN_URL, headers={"X-API-Key": "invalid-key"})
+    """A missing or invalid API key returns 401"""
+    resp = client.post(
+        E2E_TOKEN_URL,
+        headers={"X-API-Key": "invalid-key"},
+        json={"user_id": str(uuid.uuid4())},
+    )
 
     assert resp.status_code == 401
     assert resp.get_json()["message"] == "Invalid API key"
 
 
-def test_get_e2e_token_production_guard_403(client, db_session, enable_factory_create, monkeypatch):
-    """Test that the endpoint returns a 403 in production, even with valid auth"""
+def test_get_e2e_token_production_returns_404(
+    client, db_session, manager_api_key, test_user, monkeypatch
+):
+    """In production, the endpoint returns 404 even with valid auth"""
     monkeypatch.setenv("ENVIRONMENT", "production")
-    api_key = "prod-test-key"
-    setup_e2e_privileges(db_session, api_key, has_privilege=True)
 
-    resp = client.post(E2E_TOKEN_URL, headers={"X-API-Key": api_key})
+    resp = client.post(
+        E2E_TOKEN_URL,
+        headers={"X-API-Key": manager_api_key},
+        json={"user_id": str(test_user.user_id)},
+    )
 
-    assert resp.status_code == 403
+    assert resp.status_code == 404
+
+
+def test_get_e2e_token_user_not_found_returns_404(client, db_session, manager_api_key):
+    """If the user_id doesn't match any user, returns 404"""
+    resp = client.post(
+        E2E_TOKEN_URL,
+        headers={"X-API-Key": manager_api_key},
+        json={"user_id": str(uuid.uuid4())},
+    )
+
+    assert resp.status_code == 404
+
+
+def test_get_e2e_token_non_test_user_returns_404(
+    client, db_session, manager_api_key, enable_factory_create
+):
+    """If the user exists but isn't tagged as a test user, returns 404"""
+    non_test_user = factories.UserFactory.create()
+
+    resp = client.post(
+        E2E_TOKEN_URL,
+        headers={"X-API-Key": manager_api_key},
+        json={"user_id": str(non_test_user.user_id)},
+    )
+
+    assert resp.status_code == 404
+
+
+def test_get_e2e_token_missing_user_id_returns_422(client, db_session, manager_api_key):
+    """A request missing the user_id field returns 422"""
+    resp = client.post(E2E_TOKEN_URL, headers={"X-API-Key": manager_api_key}, json={})
+
+    assert resp.status_code == 422

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -77,6 +77,9 @@ const playwrightEnv = {
   testUserPassword: process.env.STAGING_TEST_USER_PASSWORD || "",
   testUserAuthKey: process.env.STAGING_TEST_USER_MFA_KEY || "",
   stagingTestUserApiKey: process.env.STAGING_TEST_USER_API_KEY || "",
+  stagingTestUserManagerApiKey:
+    process.env.STAGING_TEST_USER_MANAGER_API_KEY || "",
+  stagingTestUserId: process.env.STAGING_TEST_USER_ID || "",
 };
 
 export default playwrightEnv;

--- a/frontend/tests/e2e/utils/auth/authenticate-e2e-user-utils.ts
+++ b/frontend/tests/e2e/utils/auth/authenticate-e2e-user-utils.ts
@@ -23,19 +23,24 @@ const { baseUrl, targetEnv, testUserLabel } = playwrightEnv;
 // used to simulate a staging login without performing any login actions
 // calls dedicated API endpoint to fetch session token for a test user
 // and creates a frontend session based on the token from the response
-// requires STAGING_TEST_USER_API_KEY to be set in env vars
+// requires STAGING_TEST_USER_MANAGER_API_KEY and STAGING_TEST_USER_ID to be set in env vars
 const attemptStagingSpoof = async (
   context: BrowserContext,
 ): Promise<boolean> => {
-  if (!playwrightEnv.stagingTestUserApiKey) {
+  const { stagingTestUserManagerApiKey, stagingTestUserId } = playwrightEnv;
+  if (!stagingTestUserManagerApiKey || !stagingTestUserId) {
     return false;
   }
   // get server side staging user JWT token
   const response = await fetch(
     `${playwrightEnv.apiUrl}/v1/internal/e2e-token`,
     {
-      headers: { "X-API-Key": playwrightEnv.stagingTestUserApiKey },
+      headers: {
+        "X-API-Key": stagingTestUserManagerApiKey,
+        "Content-Type": "application/json",
+      },
       method: "POST",
+      body: JSON.stringify({ user_id: stagingTestUserId }),
     },
   );
   if (!response.ok) {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10244  

## Changes proposed

Backend:

- internal_routes.py - `POST /v1/internal/e2e-token` now accepts a request body and issues the token for the requested user rather than the API-key user
- internal_schema.py - new `E2ETokenRequestSchema` with required `user_id` field
- create_e2e_token.py - requires the new `MANAGE_TEST_USER_TOKEN` privilege on the API-key user, looks up the target user, and only issues tokens for users tagged with the E2E Test User role; returns 404 (instead of 403) outside lower environments and for missing/non-test users
- lookup_constants.py - new `MANAGE_TEST_USER_TOKEN` privilege
- lookup_models.py - lookup entry for the new privilege
- static_role_values.py - new "E2E Test User Manager" core role carrying the new privilege
- local.env - adds `LOCAL_TEST_USER_MANAGER_API_KEY` default for local development
- seed_e2e.py - seeds a local manager user holding the manager API key, alongside the existing test user
- test_internal_e2e_token.py - tests updated for the new flow: verifies the issued token belongs to the target user (JWT claims + `UserTokenSession` row), plus 401/403/404/422 cases

Frontend / CI:

- authenticate-e2e-user-utils.ts - staging login spoof now authenticates with the manager API key and passes the test user's ID in the request body
- playwright-env.ts - adds `stagingTestUserManagerApiKey` and `stagingTestUserId` env vars
- action.yml - new `staging_test_user_manager_api_key` and staging_test_user_id inputs passed to the test env
- e2e-staging.yml - passes the new `STAGING_TEST_USER_MANAGER_API_KEY` and `STAGING_TEST_USER_ID` secrets to the e2e action

## Context for reviewers

This changes auth on the e2e-token endpoint: previously the test user's own API key authorized the request (via `READ_TEST_USER_TOKEN`); now a dedicated "manager" key with the new `MANAGE_TEST_USER_TOKEN` privilege requests tokens for test users, enabling multiple test users without distributing per-user keys. Note two deliberate deviations from the ticket AC: an invalid/missing API key returns 401 (existing `api_user_key_auth` behavior) rather than 403, and the endpoint remains available in dev and training in addition to local/staging (preserving the previous environment list).

## Validation steps

1. Confirm tests pass.

2. Local: `make db-seed-local`, then `curl -X POST localhost:8080/v1/internal/e2e-token -H "X-API-Key: local-manager-key" -H "Content-Type: application/json" -d '{"user_id": "f15c7491-7ebc-4f4f-8de6-3ac0594d9c63"}'` → 200 with token; repeat with a non-test user ID → 404

3.  Staging secrets (`STAGING_TEST_USER_MANAGER_API_KEY`, `STAGING_TEST_USER_ID`, `LOCAL_TEST_USER_MANAGER_API_KEY`) are already in GitHub secrets / 1Password; the staging manager user exists with the key, and its manager-role assignment runs post-deploy (role row is created by the deploy's lookup sync)

4. Post-deploy: curl the staging endpoint with the manager key for the existing test user, then trigger the `e2e-staging` workflow and confirm the spoof path authenticates (no fallback to real login) 