### PR TITLE
[Issue #10772] Add a way to strip zeros from foreign table DDL

### DIFF
--- a/api/src/db/extension/sqlalchemy_column.py
+++ b/api/src/db/extension/sqlalchemy_column.py
@@ -1,0 +1,18 @@
+import sqlalchemy
+
+
+class StripZerosText(sqlalchemy.Text):
+    """SQLAlchemy column type for a TEXT column that
+    if used in the foreign data wrapper SQL generation script
+    will render with "OPTIONS (strip_zeros 'true')" included.
+
+    Stripping the zeros avoids a character encoding issue for
+    converting Oracle columns that contain 0x00 bytes.
+
+    If used in any other context, identical to sqlalchemy.Text.
+
+    See: https://github.com/laurenz/oracle_fdw#column-options for
+    further information about strip_zeros.
+    """
+
+    pass

--- a/api/src/db/models/foreign/dialect.py
+++ b/api/src/db/models/foreign/dialect.py
@@ -8,6 +8,8 @@ import re
 import sqlalchemy
 import sqlalchemy.dialects.postgresql
 
+from src.db.extension.sqlalchemy_column import StripZerosText
+
 
 class ForeignTableDDLCompiler(sqlalchemy.sql.compiler.DDLCompiler):
     """SQLAlchemy compiler for creating foreign tables."""
@@ -32,9 +34,23 @@ class ForeignTableDDLCompiler(sqlalchemy.sql.compiler.DDLCompiler):
     def visit_create_column(self, create, first_pk=False, **kw):
         column = create.element
         sql = super().visit_create_column(create, first_pk, **kw)
-        if sql and column.primary_key:
+
+        if not sql:
+            return sql
+
+        options = []
+        if column.primary_key:
+            options.append("key 'true'")
+
+        if isinstance(column.type, StripZerosText):
+            options.append("strip_zeros 'true'")
+
+        if len(options) > 0:
             # Add "OPTIONS ..." to primary key column.
-            sql = re.sub(r"^(.*?)( NOT NULL)?$", r"\1 OPTIONS (key 'true')\2", sql)
+            option_str = f" OPTIONS ({(", ".join(options))})"
+
+            sql = re.sub(r"^(.*?)( NOT NULL)?$", rf"\1{option_str}\2", sql)
+
         return sql
 
 

--- a/api/src/db/models/legacy_mixin/user_mixin.py
+++ b/api/src/db/models/legacy_mixin/user_mixin.py
@@ -2,13 +2,17 @@ from datetime import date, datetime
 
 from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
 
+from src.db.extension.sqlalchemy_column import StripZerosText
+
 
 @declarative_mixin
 class VuserAccountMixin:
     user_account_id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[str]
     full_name: Mapped[str | None]
-    email: Mapped[str | None]
+    # We've encountered issues where the emails sometimes include 0x00
+    # Set the type as StripZerosText to strip those out when generating the create table command.
+    email: Mapped[str | None] = mapped_column(StripZerosText)
     phone_number: Mapped[str | None]
     first_name: Mapped[str | None]
     middle_name: Mapped[str | None]

--- a/api/tests/src/data_migration/test_setup_foreign_tables.py
+++ b/api/tests/src/data_migration/test_setup_foreign_tables.py
@@ -5,6 +5,7 @@ import sqlalchemy
 
 import src.db.models.foreign
 from src.data_migration.setup_foreign_tables import build_sql
+from src.db.models.foreign.dialect import StripZerosText
 
 EXPECTED_LOCAL_OPPORTUNITY_SQL = [
     "CREATE TABLE IF NOT EXISTS __[SCHEMA_legacy].topportunity (",
@@ -60,20 +61,45 @@ TEST_TABLE = sqlalchemy.Table(
     TEST_METADATA,
     sqlalchemy.Column("id", sqlalchemy.Integer, nullable=False, primary_key=True),
     sqlalchemy.Column("description", sqlalchemy.Text),
+    sqlalchemy.Column("zero_str", StripZerosText),
     schema="schema1",
 )
 EXPECTED_LOCAL_TEST_SQL = [
     "CREATE TABLE IF NOT EXISTS __[SCHEMA_schema1].test_table (",
     "id SERIAL NOT NULL,",
     "description TEXT,",
+    "zero_str TEXT,",
     "PRIMARY KEY (id)",
     ")",
 ]
 EXPECTED_NONLOCAL_TEST_SQL = [
     "CREATE FOREIGN TABLE IF NOT EXISTS __[SCHEMA_schema1].test_table (",
     "id INTEGER OPTIONS (key 'true') NOT NULL,",
-    "description TEXT",
+    "description TEXT,",
+    "zero_str TEXT OPTIONS (strip_zeros 'true')",
     ") SERVER grants OPTIONS (schema 'EGRANTSADMIN', table 'TEST_TABLE', readonly 'true', prefetch '1000')",
+]
+
+
+TEST_TABLE_DUAL_PRIMARY_TABLE = sqlalchemy.Table(
+    "test_table_dual_primary",
+    TEST_METADATA,
+    sqlalchemy.Column("id", StripZerosText, nullable=False, primary_key=True),
+    sqlalchemy.Column("description", sqlalchemy.Text),
+    schema="schema1",
+)
+EXPECTED_LOCAL_DUAL_PRIMARY_SQL = [
+    "CREATE TABLE IF NOT EXISTS __[SCHEMA_schema1].test_table_dual_primary (",
+    "id TEXT NOT NULL,",
+    "description TEXT,",
+    "PRIMARY KEY (id)",
+    ")",
+]
+EXPECTED_NONLOCAL_DUAL_PRIMARY_SQL = [
+    "CREATE FOREIGN TABLE IF NOT EXISTS __[SCHEMA_schema1].test_table_dual_primary (",
+    "id TEXT OPTIONS (key 'true', strip_zeros 'true') NOT NULL,",
+    "description TEXT",
+    ") SERVER grants OPTIONS (schema 'EGRANTSADMIN', table 'TEST_TABLE_DUAL_PRIMARY', readonly 'true', prefetch '1000')",
 ]
 
 
@@ -82,6 +108,8 @@ EXPECTED_NONLOCAL_TEST_SQL = [
     [
         (TEST_TABLE, True, EXPECTED_LOCAL_TEST_SQL),
         (TEST_TABLE, False, EXPECTED_NONLOCAL_TEST_SQL),
+        (TEST_TABLE_DUAL_PRIMARY_TABLE, True, EXPECTED_LOCAL_DUAL_PRIMARY_SQL),
+        (TEST_TABLE_DUAL_PRIMARY_TABLE, False, EXPECTED_NONLOCAL_DUAL_PRIMARY_SQL),
         (
             src.db.models.foreign.metadata.tables["legacy.topportunity"],
             True,
@@ -96,5 +124,4 @@ EXPECTED_NONLOCAL_TEST_SQL = [
 )
 def test_build_sql(table, is_local, expected_sql, test_foreign_schema):
     sql = build_sql(table, is_local, test_foreign_schema)
-
     assert re.split(r"\s*\n\s*", sql) == expected_sql


### PR DESCRIPTION
## Summary
Fixes #10772

## Changes proposed
* Make it so we can set `strip_zeros` on columns when generating the foreign table schemas

## Context for reviewers
Two parts to this change of note. The simpler part, we already have a custom approach for generating/overriding the create table command for specific columns, so simply adjusted the logic when we have a column marked as appropriate to include the strip zero option.

The more complex part was finding a way to mark a column to have this. While you can pass in dialect options (that is, extra keywords it assumes correspond to a specific DB tech), that gets a whole bunch of warning complaints from within SQLAlchemy's code. Was easier to just make a new column type that is just `Text` but we can do an `isinstance` check on to see if it's that type. This approach also makes it so when these columns get used outside the context of the foreign tables (we reuse these table defs for actual Postgres tables in the staging schema) it just does nothing - which is exactly what we want.

## Validation steps
Tests validate the SQL we output.

Verified nothing gets generated different when creating DB migrations / no warnings output with this approach.

Will test this works in dev/staging after I merge it.

