### PR TITLE
[unticketed]: update staging db engine version

### DIFF
--- a/infra/api/app-config/staging.tf
+++ b/infra/api/app-config/staging.tf
@@ -12,6 +12,7 @@ module "staging_config" {
   enable_https                      = true
   has_database                      = local.has_database
   database_enable_http_endpoint     = true
+  database_engine_version           = "17.7"
   database_newrelic_entity_guid     = "NTI0OTgwOXxJTkZSQXxOQXwtMjA3MTAxMDcwODY2NTUyNTU"
   has_incident_management_service   = local.has_incident_management_service
   enable_identity_provider          = local.enable_identity_provider

--- a/infra/api/database/main.tf
+++ b/infra/api/database/main.tf
@@ -94,6 +94,7 @@ module "database" {
   max_capacity                   = local.database_config.max_capacity
   min_capacity                   = local.database_config.min_capacity
   enable_http_endpoint           = local.database_config.enable_http_endpoint
+  engine_version                 = local.database_config.database_engine_version
   vpc_id                         = data.aws_vpc.network.id
   private_subnet_ids             = data.aws_subnets.database.ids
   aws_services_security_group_id = data.aws_security_groups.aws_services.ids[0]


### PR DESCRIPTION
## Summary

The current db engine version in staging is 17.7. Our terraform is default to 17.5 for the staging environment. 

## Validation steps

Deployed from local against staging.