### PR TITLE
[unticketed]: update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,8 @@ infra-update-app-database: ## Create or update $APP_NAME's database module for $
 
 infra-module-database-role-manager-archive: ## Build/rebuild role manager code package for Lambda deploys
 	pip3 install -r infra/modules/database/role_manager/requirements.txt -t infra/modules/database/role_manager/vendor --upgrade
-	zip -r infra/modules/database/role_manager.zip infra/modules/database/role_manager
+	rm -f infra/modules/database/role_manager.zip
+	cd infra/modules/database/role_manager && zip -r ../role_manager.zip . -x '*.DS_Store' -x '*__pycache__*'
 
 infra-update-app-database-roles: ## Create or update database roles and schemas for $APP_NAME's database in $ENVIRONMENT
 	@:$(call check_defined, APP_NAME, the name of subdirectory of /infra that holds the application's infrastructure code)


### PR DESCRIPTION
## Summary

Fix the Makefile command: 

```
make infra-module-database-role-manager-archive
```

Before it was updating all the files in the role_manager directory. It was just updating the single file: role_manage.py

## Validation steps

Deployed from local against staging.