### PR TITLE
[Issue #10874] Add character length validation to Edit Opportunity page fields

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
@@ -167,6 +167,29 @@ describe("OpportunityEditForm — rendering", () => {
     expect(screen.getByText("content.draftOnlyWarning")).toBeInTheDocument();
   });
 
+  it("disables character-count fields when isDraft is false", () => {
+    renderOpportunityEditForm({ isDraft: false });
+
+    expect(
+      screen.getByRole("textbox", { name: /labels\.description/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: /labels\.grantorContactDetails/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: "labels.additionalInfoUrl" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: "labels.additionalInfoUrlText" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: "labels.contactEmail" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("textbox", { name: "labels.contactEmailText" }),
+    ).toBeDisabled();
+  });
+
   it("pre-checks eligibility checkboxes from initialValues", () => {
     renderOpportunityEditForm();
 

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
@@ -190,6 +190,32 @@ describe("OpportunityEditForm — rendering", () => {
     ).toBeDisabled();
   });
 
+  it("disables fundingCategoryExplanation when isDraft is false and fundingCategories is 'other'", () => {
+    renderOpportunityEditForm({
+      isDraft: false,
+      initialValues: { ...initialValues, fundingCategories: "other" },
+    });
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /labels\.fundingCategoryExplanation/i,
+      }),
+    ).toBeDisabled();
+  });
+
+  it("disables additionalEligibilityInfo when isDraft is false and eligibleApplicants includes 'other'", () => {
+    renderOpportunityEditForm({
+      isDraft: false,
+      initialValues: { ...initialValues, eligibleApplicants: ["other"] },
+    });
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /labels\.additionalEligibilityInfo/i,
+      }),
+    ).toBeDisabled();
+  });
+
   it("pre-checks eligibility checkboxes from initialValues", () => {
     renderOpportunityEditForm();
 

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
@@ -38,6 +38,7 @@ import {
   TextInput,
 } from "@trussworks/react-uswds";
 
+import { CommonCharacterCount } from "src/components/core/forms/CommonFormFields";
 import { DynamicFieldLabel } from "src/components/core/forms/DynamicFieldLabel";
 
 function formatNumber(value: string): string {
@@ -578,21 +579,17 @@ export default function OpportunityEditForm({
 
           {fundingCategory === "other" && (
             <div className="width-full">
-              <FormGroup>
-                <DynamicFieldLabel
-                  idFor="funding-category-explanation"
-                  title={t("labels.fundingCategoryExplanation")}
-                  description={t("content.fundingCategoryExplanationHint")}
-                />
-                <Textarea
-                  id="funding-category-explanation"
-                  name="fundingCategoryExplanation"
-                  defaultValue={initialValues.fundingCategoryExplanation}
-                  rows={5}
-                  className="width-full"
-                  disabled={!isDraft}
-                />
-              </FormGroup>
+              <CommonCharacterCount
+                isTextArea={true}
+                labelText={t("labels.fundingCategoryExplanation")}
+                description={t("content.fundingCategoryExplanationHint")}
+                fieldId="fundingCategoryExplanation"
+                fieldMaxLength={2500}
+                isRequired={false}
+                defaultValue={initialValues.fundingCategoryExplanation}
+                onTextChange={() => {}}
+                disabled={!isDraft}
+              />
             </div>
           )}
 
@@ -843,26 +840,22 @@ export default function OpportunityEditForm({
           {(selectedEligibility.includes("other") ||
             selectedEligibility.includes("unrestricted")) && (
             <div className="width-full">
-              <FormGroup error={!!getFieldError("additionalEligibilityInfo")}>
-                <DynamicFieldLabel
-                  idFor="additional-eligibility-info"
-                  title={t("labels.additionalEligibilityInfo")}
-                  description={t("content.additionalEligibilityInfoHint")}
-                />
-                {getFieldError("additionalEligibilityInfo") ? (
-                  <ErrorMessage>
-                    {getFieldError("additionalEligibilityInfo")}
-                  </ErrorMessage>
-                ) : null}
-                <Textarea
-                  id="additional-eligibility-info"
-                  name="additionalEligibilityInfo"
-                  defaultValue={initialValues.additionalEligibilityInfo}
-                  rows={5}
-                  className="width-full"
-                  disabled={!isDraft}
-                />
-              </FormGroup>
+              <CommonCharacterCount
+                isTextArea={true}
+                labelText={t("labels.additionalEligibilityInfo")}
+                description={t("content.additionalEligibilityInfoHint")}
+                fieldId="additionalEligibilityInfo"
+                fieldMaxLength={4000}
+                isRequired={false}
+                defaultValue={initialValues.additionalEligibilityInfo}
+                onTextChange={() => {}}
+                rawErrors={
+                  getFieldError("additionalEligibilityInfo")
+                    ? [getFieldError("additionalEligibilityInfo") as string]
+                    : []
+                }
+                disabled={!isDraft}
+              />
             </div>
           )}
         </div>
@@ -883,138 +876,116 @@ export default function OpportunityEditForm({
 
         <div className="display-flex flex-column gap-2">
           <div className="width-full">
-            <FormGroup error={!!getFieldError("description")}>
-              <DynamicFieldLabel
-                idFor="description"
-                title={t("labels.description")}
-                description={t("content.descriptionHint")}
-              />
-              {getFieldError("description") ? (
-                <ErrorMessage>{getFieldError("description")}</ErrorMessage>
-              ) : null}
-              <Textarea
-                id="description"
-                name="description"
-                defaultValue={initialValues.description}
-                rows={5}
-                className="width-full"
-                disabled={!isDraft}
-              />
-            </FormGroup>
+            <CommonCharacterCount
+              isTextArea={true}
+              labelText={t("labels.description")}
+              description={t("content.descriptionHint")}
+              fieldId="description"
+              fieldMaxLength={1800}
+              isRequired={false}
+              defaultValue={initialValues.description}
+              onTextChange={() => {}}
+              rawErrors={
+                getFieldError("description")
+                  ? [getFieldError("description") as string]
+                  : []
+              }
+              disabled={!isDraft}
+            />
           </div>
 
           <div className="grid-row grid-gap-lg">
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("additionalInfoUrl")}>
-                <DynamicFieldLabel
-                  idFor="additional-info-url"
-                  title={t("labels.additionalInfoUrl")}
-                  description={t("content.additionalInfoUrlHint")}
-                />
-                {getFieldError("additionalInfoUrl") ? (
-                  <ErrorMessage>
-                    {getFieldError("additionalInfoUrl")}
-                  </ErrorMessage>
-                ) : null}
-                <TextInput
-                  id="additional-info-url"
-                  name="additionalInfoUrl"
-                  type="url"
-                  defaultValue={initialValues.additionalInfoUrl}
-                  className="width-full"
-                  disabled={!isDraft}
-                />
-              </FormGroup>
+              <CommonCharacterCount
+                inputType="url"
+                labelText={t("labels.additionalInfoUrl")}
+                description={t("content.additionalInfoUrlHint")}
+                fieldId="additionalInfoUrl"
+                fieldMaxLength={250}
+                isRequired={false}
+                defaultValue={initialValues.additionalInfoUrl}
+                onTextChange={() => {}}
+                rawErrors={
+                  getFieldError("additionalInfoUrl")
+                    ? [getFieldError("additionalInfoUrl") as string]
+                    : []
+                }
+                disabled={!isDraft}
+              />
             </div>
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("additionalInfoUrlText")}>
-                <DynamicFieldLabel
-                  idFor="additional-info-url-text"
-                  title={t("labels.additionalInfoUrlText")}
-                  description={t("content.additionalInfoUrlTextHint")}
-                />
-                {getFieldError("additionalInfoUrlText") ? (
-                  <ErrorMessage>
-                    {getFieldError("additionalInfoUrlText")}
-                  </ErrorMessage>
-                ) : null}
-                <TextInput
-                  id="additional-info-url-text"
-                  name="additionalInfoUrlText"
-                  type="text"
-                  defaultValue={initialValues.additionalInfoUrlText}
-                  className="width-full"
-                  disabled={!isDraft}
-                />
-              </FormGroup>
+              <CommonCharacterCount
+                labelText={t("labels.additionalInfoUrlText")}
+                description={t("content.additionalInfoUrlTextHint")}
+                fieldId="additionalInfoUrlText"
+                fieldMaxLength={250}
+                isRequired={false}
+                defaultValue={initialValues.additionalInfoUrlText}
+                onTextChange={() => {}}
+                rawErrors={
+                  getFieldError("additionalInfoUrlText")
+                    ? [getFieldError("additionalInfoUrlText") as string]
+                    : []
+                }
+                disabled={!isDraft}
+              />
             </div>
           </div>
 
           <div className="width-full">
-            <FormGroup error={!!getFieldError("grantorContactDetails")}>
-              <DynamicFieldLabel
-                idFor="grantor-contact-details"
-                title={t("labels.grantorContactDetails")}
-                description={t("content.grantorContactDetailsHint")}
-              />
-              {getFieldError("grantorContactDetails") ? (
-                <ErrorMessage>
-                  {getFieldError("grantorContactDetails")}
-                </ErrorMessage>
-              ) : null}
-              <Textarea
-                id="grantor-contact-details"
-                name="grantorContactDetails"
-                defaultValue={initialValues.grantorContactDetails}
-                rows={5}
-                className="width-full"
-                disabled={!isDraft}
-              />
-            </FormGroup>
+            <CommonCharacterCount
+              isTextArea={true}
+              labelText={t("labels.grantorContactDetails")}
+              description={t("content.grantorContactDetailsHint")}
+              fieldId="grantorContactDetails"
+              fieldMaxLength={1000}
+              isRequired={false}
+              defaultValue={initialValues.grantorContactDetails}
+              onTextChange={() => {}}
+              rawErrors={
+                getFieldError("grantorContactDetails")
+                  ? [getFieldError("grantorContactDetails") as string]
+                  : []
+              }
+              disabled={!isDraft}
+            />
           </div>
 
           <div className="grid-row grid-gap-lg">
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("contactEmail")}>
-                <DynamicFieldLabel
-                  idFor="contact-email"
-                  title={t("labels.contactEmail")}
-                  description={t("content.contactEmailHint")}
-                />
-                {getFieldError("contactEmail") ? (
-                  <ErrorMessage>{getFieldError("contactEmail")}</ErrorMessage>
-                ) : null}
-                <TextInput
-                  id="contact-email"
-                  name="contactEmail"
-                  type="email"
-                  defaultValue={initialValues.contactEmail}
-                  className="width-full"
-                  disabled={!isDraft}
-                />
-              </FormGroup>
+              <CommonCharacterCount
+                inputType="email"
+                labelText={t("labels.contactEmail")}
+                description={t("content.contactEmailHint")}
+                fieldId="contactEmail"
+                fieldMaxLength={130}
+                isRequired={false}
+                defaultValue={initialValues.contactEmail}
+                onTextChange={() => {}}
+                rawErrors={
+                  getFieldError("contactEmail")
+                    ? [getFieldError("contactEmail") as string]
+                    : []
+                }
+                disabled={!isDraft}
+              />
             </div>
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("contactEmailText")}>
-                <DynamicFieldLabel
-                  idFor="contact-email-text"
-                  title={t("labels.contactEmailText")}
-                  description={t("content.contactEmailTextHint")}
-                />
-                {getFieldError("contactEmailText") ? (
-                  <ErrorMessage>
-                    {getFieldError("contactEmailText")}
-                  </ErrorMessage>
-                ) : null}
-                <TextInput
-                  id="contact-email-text"
-                  name="contactEmailText"
-                  type="text"
-                  defaultValue={initialValues.contactEmailText}
-                  className="width-full"
-                  disabled={!isDraft}
-                />
-              </FormGroup>
+              <CommonCharacterCount
+                labelText={t("labels.contactEmailText")}
+                description={t("content.contactEmailTextHint")}
+                fieldId="contactEmailText"
+                fieldMaxLength={108}
+                isRequired={false}
+                defaultValue={initialValues.contactEmailText}
+                onTextChange={() => {}}
+                rawErrors={
+                  getFieldError("contactEmailText")
+                    ? [getFieldError("contactEmailText") as string]
+                    : []
+                }
+                disabled={!isDraft}
+              />
             </div>
           </div>
         </div>

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
@@ -298,6 +298,8 @@ export default function OpportunityEditForm({
     {} as Record<string, { label: string; value: string }[]>,
   );
 
+  // CommonCharacterCount fields use onTextChange={() => {}} because they are uncontrolled:
+  // values are read from FormData on submit, not tracked in React state.
   return (
     <form
       ref={formRef}

--- a/frontend/src/components/core/forms/CommonFormFields.test.tsx
+++ b/frontend/src/components/core/forms/CommonFormFields.test.tsx
@@ -161,6 +161,48 @@ describe("CommonCharacterCount", () => {
     const charCountText = screen.getByText("10 characters over limit");
     expect(charCountText).toBeInTheDocument();
   });
+  it("renders the input as disabled when disabled=true", () => {
+    render(
+      <CommonCharacterCount
+        {...commonCharacterCountProps}
+        isTextArea={false}
+        defaultValue=""
+        disabled={true}
+      />,
+    );
+    const element = screen.getByRole("textbox", {
+      name: "Label for Something",
+    });
+    expect(element).toBeDisabled();
+  });
+  it("renders the input with type=email when inputType='email'", () => {
+    render(
+      <CommonCharacterCount
+        {...commonCharacterCountProps}
+        isTextArea={false}
+        defaultValue=""
+        inputType="email"
+      />,
+    );
+    const element = screen.getByRole("textbox", {
+      name: "Label for Something",
+    });
+    expect(element).toHaveAttribute("type", "email");
+  });
+  it("renders the input with type=url when inputType='url'", () => {
+    render(
+      <CommonCharacterCount
+        {...commonCharacterCountProps}
+        isTextArea={false}
+        defaultValue=""
+        inputType="url"
+      />,
+    );
+    const element = screen.getByRole("textbox", {
+      name: "Label for Something",
+    });
+    expect(element).toHaveAttribute("type", "url");
+  });
 });
 
 // --- Test Common Select ---

--- a/frontend/src/components/core/forms/CommonFormFields.test.tsx
+++ b/frontend/src/components/core/forms/CommonFormFields.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
 
 import {
   CommonCharacterCount,
@@ -112,6 +113,14 @@ const commonCharacterCountProps = {
   isTextArea: false,
 };
 describe("CommonCharacterCount", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <CommonCharacterCount {...commonCharacterCountProps} isTextArea={false} defaultValue="" />,
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("Renders the element with maxLength", () => {
     render(<CommonCharacterCount {...commonCharacterCountProps} />);
     const element = screen.getByRole("textbox", {
@@ -175,6 +184,23 @@ describe("CommonCharacterCount", () => {
     });
     expect(element).toBeDisabled();
   });
+
+  it("renders the textarea as disabled when disabled=true and isTextArea=true", () => {
+    render(
+      <CommonCharacterCount
+        {...commonCharacterCountProps}
+        isTextArea={true}
+        defaultValue=""
+        disabled={true}
+      />,
+    );
+    const element = screen.getByRole("textbox", {
+      name: "Label for Something",
+    });
+    expect(element).toBeDisabled();
+    expect(element instanceof HTMLTextAreaElement).toBe(true);
+  });
+
   it("renders the input with type=email when inputType='email'", () => {
     render(
       <CommonCharacterCount
@@ -189,6 +215,7 @@ describe("CommonCharacterCount", () => {
     });
     expect(element).toHaveAttribute("type", "email");
   });
+
   it("renders the input with type=url when inputType='url'", () => {
     render(
       <CommonCharacterCount

--- a/frontend/src/components/core/forms/CommonFormFields.test.tsx
+++ b/frontend/src/components/core/forms/CommonFormFields.test.tsx
@@ -115,7 +115,11 @@ const commonCharacterCountProps = {
 describe("CommonCharacterCount", () => {
   it("has no accessibility violations", async () => {
     const { container } = render(
-      <CommonCharacterCount {...commonCharacterCountProps} isTextArea={false} defaultValue="" />,
+      <CommonCharacterCount
+        {...commonCharacterCountProps}
+        isTextArea={false}
+        defaultValue=""
+      />,
     );
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/frontend/src/components/core/forms/CommonFormFields.tsx
+++ b/frontend/src/components/core/forms/CommonFormFields.tsx
@@ -111,6 +111,7 @@ export const CommonTextArea = ({
 // ----------------------------------------------------------
 export const CommonCharacterCount = ({
   isTextArea = false,
+  inputType = "text",
   labelText,
   description, // or instructions
   fieldId,
@@ -119,8 +120,10 @@ export const CommonCharacterCount = ({
   defaultValue = "",
   onTextChange,
   rawErrors = [],
+  disabled = false,
 }: {
   isTextArea?: boolean;
+  inputType?: "text" | "email" | "url";
   labelText: string;
   description: string;
   fieldId: string;
@@ -129,6 +132,7 @@ export const CommonCharacterCount = ({
   defaultValue?: string;
   onTextChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   rawErrors?: string[];
+  disabled?: boolean;
 }) => {
   const error = rawErrors.length ? true : undefined;
   return (
@@ -149,6 +153,8 @@ export const CommonCharacterCount = ({
           onChange={onTextChange}
           isTextArea={isTextArea}
           aria-describedby={`label-for-${fieldId}`}
+          disabled={disabled}
+          {...(!isTextArea && { type: inputType })}
         />
       </FormGroup>
     </>


### PR DESCRIPTION
## Summary

Work for #10874

## Changes proposed

- Replace raw `TextInput`/`Textarea` fields in `OpportunityEditForm` with `CommonCharacterCount` for 8 long-text fields: `description`, `fundingCategoryExplanation`, `additionalEligibilityInfo`, `grantorContactDetails`, `additionalInfoUrl`, `additionalInfoUrlText`, `contactEmail`, `contactEmailText`
- Add `inputType?: "text" | "email" | "url"` prop to `CommonCharacterCount` (in `CommonFormFields.tsx`) so URL and email fields preserve their input type through the USWDS `CharacterCount` component
- Add `disabled` prop tests and `inputType` prop tests to `CommonFormFields.test.tsx`
- Add a test to `OpportunityEditForm.test.tsx` verifying all 6 character-count text fields are disabled when `isDraft=false`

## Context for reviewers

`CommonCharacterCount` wraps USWDS `CharacterCount` which automatically shows "X characters allowed / left / over limit" based on `maxLength` - no custom error messages needed.

Added `inputType` prop to `CommonCharacterCount` (`"text" | "email" | "url"`, defaults to `"text"`), passed as `type` to the underlying `<input>` when `isTextArea=false`. Used for `additionalInfoUrl` (`type="url"`) and `contactEmail` (`type="email"`).

The `disabled={!isDraft}` prop on each field ensures published opportunities remain read-only.

## Validation steps

1. Run `npm run all-checks` in `frontend/` - all checks should pass
2. Seed local DB: `make db-seed-local-with-agencies` (from `api/`)
3. Log in as `one_agency_opp_edit` via the TestUserSelect dropdown
4. Open the Edit Opportunity page for a **draft** opportunity
   - Verify `description`, `grantorContactDetails`, `additionalInfoUrl`, `additionalInfoUrlText`, `contactEmail`, `contactEmailText` all show a character count below the field (e.g. "1800 characters allowed")
   - Type into any field and verify the count updates (e.g. "1798 characters left")
   - Type past the limit and verify "X characters over limit" appears in red
5. Open the Edit Opportunity page for a **published** opportunity
   - Verify the same fields are greyed out / unclickable
   - Verify the draft-only warning banner appears at the top