### PR TITLE
[Unticketed] Hardcode "migrator" as the user in setup-foreign-tables and move ownership fixing to before GRANT statements

### DIFF
--- a/bin/run-setup-foreign-tables
+++ b/bin/run-setup-foreign-tables
@@ -20,8 +20,7 @@ echo "  app_name=${app_name}"
 echo "  environment=${environment}"
 echo
 
-./bin/terraform-init "infra/${app_name}/app-config" "${environment}"
-db_migrator_user=$(terraform -chdir="infra/${app_name}/app-config" output -json environment_configs | jq -r ".${environment}.database_config.migrator_username")
+db_migrator_user="migrator"
 
 ./bin/terraform-init "infra/${app_name}/service" "${environment}"
 migrator_role_arn=$(terraform -chdir="infra/${app_name}/service" output -raw migrator_role_arn)

--- a/infra/modules/database/role_manager/manage.py
+++ b/infra/modules/database/role_manager/manage.py
@@ -154,6 +154,8 @@ def configure_schema(conn: Connection, schema_name: str, migrator_username: str,
         f"REVOKE CREATE ON SCHEMA {identifier(schema_name)} FROM {identifier(app_username)}",
     )
 
+    fix_schema_object_ownership(conn, schema_name, migrator_username)
+
     print(f"------ Granting privileges on existing objects in schema: grantee={app_username}")
     db.execute(
         conn,
@@ -167,8 +169,6 @@ def configure_schema(conn: Connection, schema_name: str, migrator_username: str,
         conn,
         f"GRANT ALL ON ALL ROUTINES IN SCHEMA {identifier(schema_name)} TO {identifier(app_username)}",
     )
-
-    fix_schema_object_ownership(conn, schema_name, migrator_username)
 
 
 def fix_schema_object_ownership(conn: Connection, schema_name: str, migrator_username: str) -> None:


### PR DESCRIPTION
## Summary

## Changes proposed

- Updated setup-foreign-tables to hardcode "migrator as the db user
- Updated manage.py to move `fix_schema_object_ownership` to be before GRANT statements

## Context for reviewers

`app-config` has no terraform backend block, so `./bin/terraform-init` doesn't work for it. Since `migrator_username` is hardcoded to "migrator" in every environment's config, we hardcode it in the script instead of looking it up via terraform.

## Validation steps

The hardcoded value matches migrator_username in database.tf across all environments.