### PR TITLE
[unticketed]: pin db engine versions across all environments api database

### DIFF
--- a/infra/api/app-config/dev.tf
+++ b/infra/api/app-config/dev.tf
@@ -12,6 +12,7 @@ module "dev_config" {
   enable_https                      = true
   has_database                      = local.has_database
   database_enable_http_endpoint     = true
+  database_engine_version           = "17.7"
   database_newrelic_entity_guid     = "NTI0OTgwOXxJTkZSQXxOQXw3NDM0NDY4MDExNzAwMjY1NzM1"
   has_incident_management_service   = local.has_incident_management_service
   enable_notifications              = local.enable_notifications

--- a/infra/api/app-config/grantee1.tf
+++ b/infra/api/app-config/grantee1.tf
@@ -12,6 +12,7 @@ module "grantee1_config" {
   enable_https                      = true
   has_database                      = local.has_database
   database_enable_http_endpoint     = true
+  database_engine_version           = "17.7"
   database_newrelic_entity_guid     = "NTI0OTgwOXxJTkZSQXxOQXwyNjY5ODkxMDczODI5NDA4MTg"
   database_deletion_protection      = false
   has_incident_management_service   = local.has_incident_management_service

--- a/infra/api/app-config/grantee2.tf
+++ b/infra/api/app-config/grantee2.tf
@@ -12,6 +12,7 @@ module "grantee2_config" {
   enable_https                      = true
   has_database                      = local.has_database
   database_enable_http_endpoint     = true
+  database_engine_version           = "17.7"
   database_newrelic_entity_guid     = ""
   database_deletion_protection      = false
   has_incident_management_service   = local.has_incident_management_service

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -12,6 +12,7 @@ module "prod_config" {
   mtls_domain_name                  = "soap.simpler.grants.gov"
   has_database                      = local.has_database
   database_enable_http_endpoint     = true
+  database_engine_version           = "17.7"
   database_newrelic_entity_guid     = "NTI0OTgwOXxJTkZSQXxOQXw3NTg3MzYwMjg2Njg1MjU2ODYy"
   has_incident_management_service   = local.has_incident_management_service
   enable_identity_provider          = local.enable_identity_provider

--- a/infra/api/app-config/training.tf
+++ b/infra/api/app-config/training.tf
@@ -10,7 +10,7 @@ module "training_config" {
   secondary_domain_names            = ["alb.training.simpler.grants.gov"]
   mtls_domain_name                  = "soap.training.simpler.grants.gov"
   enable_https                      = true
-  database_engine_version           = "17.5"
+  database_engine_version           = "17.7"
   has_database                      = true
   database_enable_http_endpoint     = true
   database_newrelic_entity_guid     = "NTI0OTgwOXxJTkZSQXxOQXwtMjEwNzYwNjQ1MjUwNjc2ODE4OQ"


### PR DESCRIPTION
## Summary

Pinned the db engine verion for the api database - for each environment. So we don't default to the engine version that is set at the module level. 

## Validation steps

Deployed the api database module across dev, staging, grantee1 and 2 locally. 