### PR TITLE
[Issue #10905] Log successful responses to s3

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -531,7 +531,7 @@ def to_snake_case(name: str) -> str:
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", sub).lower()
 
 
-def write_debug_data_to_s3(soap_request: SOAPRequest, soap_legacy_response: SOAPResponse) -> None:
+def write_debug_data_to_s3(soap_request: SOAPRequest, soap_response: SOAPResponse) -> None:
     if get_soap_config().save_soap_messages_to_s3:
         try:
             s3_config = S3Config()
@@ -565,7 +565,7 @@ def write_debug_data_to_s3(soap_request: SOAPRequest, soap_legacy_response: SOAP
             )
             file_util.write_to_file(
                 response_s3_path,
-                soap_legacy_response.to_bytes().decode("utf-8"),
+                soap_response.to_bytes().decode("utf-8"),
                 content_type=text_content_type,
             )
             logger.info(

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -531,7 +531,7 @@ def to_snake_case(name: str) -> str:
     return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", sub).lower()
 
 
-def write_debug_data_to_s3(soap_request: SOAPRequest, soap_response: SOAPResponse) -> None:
+def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAPResponse) -> None:
     if get_soap_config().save_soap_messages_to_s3:
         try:
             s3_config = S3Config()
@@ -547,18 +547,19 @@ def write_debug_data_to_s3(soap_request: SOAPRequest, soap_response: SOAPRespons
             # Store as plain text so the debug files preview in the browser / S3 console
             # instead of downloading as binary/octet-stream.
             text_content_type = "text/plain; charset=utf-8"
-            request_s3_path = file_util.join(
-                base_path,
-                "request.txt",
-            )
-            file_util.write_to_file(
-                request_s3_path,
-                # The request body stream is consumed when forwarding to the legacy proxy, so
-                # re-reading soap_request.data here yields nothing (the empty-request.txt bug).
-                # Use the cached head, which holds the SOAP envelope captured during parsing.
-                soap_request.data.head().decode("utf-8"),
-                content_type=text_content_type,
-            )
+            if soap_request is not None:
+                request_s3_path = file_util.join(
+                    base_path,
+                    "request.txt",
+                )
+                file_util.write_to_file(
+                    request_s3_path,
+                    # The request body stream is consumed when forwarding to the legacy proxy, so
+                    # re-reading soap_request.data here yields nothing (the empty-request.txt bug).
+                    # Use the cached head, which holds the SOAP envelope captured during parsing.
+                    soap_request.data.head().decode("utf-8"),
+                    content_type=text_content_type,
+                )
             response_s3_path = file_util.join(
                 base_path,
                 "response.txt",

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -161,6 +161,8 @@ def process_simpler_request(
             return get_soap_error_response(
                 faultstring="Certificate is expired. (Authorization Failure)"
             ).to_flask_response()
+
+    soap_request: SOAPRequest | None = None
     try:
         soap_request = SOAPRequest(
             api_name=api_name,
@@ -230,7 +232,7 @@ def process_simpler_request(
         )
         error_response = get_soap_error_response()
         write_debug_data_to_s3(soap_request, error_response)
-        return soap_legacy_response.to_flask_response()
+        return error_response.to_flask_response()
     if auth and auth.certificate.legacy_certificate:
         try:
             simpler_soap_response = get_simpler_soap_response(

--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -79,7 +79,6 @@ def get_simpler_soap_response(
                 "used_simpler_response": use_simpler,
             },
         )
-        write_debug_data_to_s3(soap_request, soap_legacy_response)
         return soap_legacy_response
     except Exception:
         err = "Unable to initialize Simpler SOAP client: Unknown error"
@@ -91,7 +90,6 @@ def get_simpler_soap_response(
                 "used_simpler_response": use_simpler,
             },
         )
-        write_debug_data_to_s3(soap_request, soap_legacy_response)
         return soap_legacy_response
 
     if use_simpler or simpler_soap_client.operation_config.always_call_simpler:
@@ -189,12 +187,16 @@ def process_simpler_request(
                 "soap_client_certificate: simpler route is disabled, returning legacy response",
                 extra={"soap_api_event": LegacySoapApiEvent.SIMPLER_ROUTE_DISABLED},
             )
-            return get_legacy_response(soap_request).to_flask_response()
+            soap_legacy_response = get_legacy_response(soap_request)
+            write_debug_data_to_s3(soap_request, soap_legacy_response)
+            return soap_legacy_response.to_flask_response()
 
         # If it is GetOpportunityList or is valid legacy certificate but not configured in Simpler
         # call legacy and don't call simpler
         if is_get_opportunity_list or is_legacy_only_certificate:
-            return get_legacy_response(soap_request).to_flask_response()
+            soap_legacy_response = get_legacy_response(soap_request)
+            write_debug_data_to_s3(soap_request, soap_legacy_response)
+            return soap_legacy_response.to_flask_response()
         # If it has a Simpler GrantsGovTrackingNumber then don't call legacy
         elif alternate_legacy_response := get_alternate_legacy_response(soap_request):
             logger.info(
@@ -214,7 +216,9 @@ def process_simpler_request(
             soap_legacy_response = get_legacy_response(soap_request)
         # Fallback: return legacy response and don't call simpler
         else:
-            return get_legacy_response(soap_request).to_flask_response()
+            soap_legacy_response = get_legacy_response(soap_request)
+            write_debug_data_to_s3(soap_request, soap_legacy_response)
+            return soap_legacy_response.to_flask_response()
 
     except Exception:
         logger.exception(
@@ -224,12 +228,16 @@ def process_simpler_request(
                 "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_LEGACY_SOAP,
             },
         )
-        return get_soap_error_response().to_flask_response()
+        error_response = get_soap_error_response()
+        write_debug_data_to_s3(soap_request, error_response)
+        return soap_legacy_response.to_flask_response()
     if auth and auth.certificate.legacy_certificate:
         try:
-            return get_simpler_soap_response(
+            simpler_soap_response = get_simpler_soap_response(
                 soap_request, soap_legacy_response, db_session
-            ).to_flask_response()
+            )
+            write_debug_data_to_s3(soap_request, simpler_soap_response)
+            return simpler_soap_response.to_flask_response()
         except SOAPClientUserDoesNotHavePermission:
             msg = "soap_client_certificate: User did not have permission to access this application"
             logger.info(
@@ -247,9 +255,11 @@ def process_simpler_request(
                     "faultstring": e.fault.faultstring,
                 },
             )
-            return get_soap_fault_error_response(
+            error_response = get_soap_fault_error_response(
                 faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
-            ).to_flask_response()
+            )
+            write_debug_data_to_s3(soap_request, error_response)
+            return error_response.to_flask_response()
         except SOAPFaultException as e:
             logger.info(
                 msg="Soap Fault Exception raised",
@@ -260,9 +270,11 @@ def process_simpler_request(
                 },
             )
             if soap_legacy_response.status_code == 500:
-                return get_soap_fault_error_response(
+                error_response = get_soap_fault_error_response(
                     faultcode=e.fault.faultcode, faultstring=e.fault.faultstring
-                ).to_flask_response()
+                )
+                write_debug_data_to_s3(soap_request, error_response)
+                return error_response.to_flask_response()
         except Exception:
             msg = "Unable to process Simpler SOAP legacy response"
             logger.exception(
@@ -272,5 +284,5 @@ def process_simpler_request(
                     "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
                 },
             )
-            write_debug_data_to_s3(soap_request, soap_legacy_response)
+    write_debug_data_to_s3(soap_request, soap_legacy_response)
     return soap_legacy_response.to_flask_response()

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -440,6 +440,77 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
     assert len(records) == 1
 
 
+def test_if_soap_request_errors_on_creation_the_s3_handling_records_just_the_response(
+    db_session,
+    client,
+    enable_factory_create,
+    caplog,
+    monkeypatch,
+    mock_s3_bucket,
+    mock_s3,
+    s3_config,
+) -> None:
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.ACCEPTED
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    ApplicationSubmissionRetrievedFactory.create(
+        application_submission=submission, created_by_user=user
+    )
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        with mock.patch("src.legacy_soap_api.simpler_soap_api.SOAPRequest") as mock_soap_request:
+            mock_soap_request.side_effect = Exception()
+            mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+            response = client.post(
+                full_path,
+                data=mock_data,
+                headers={
+                    "Use-Simpler-Override": "1",
+                    MTLS_CERT_HEADER_KEY: mtls_cert,
+                },
+            )
+        assert response.status_code == 500
+        records = [
+            r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
+        ]
+        assert len(records) == 1
+    record = records[0]
+    assert not file_util.file_exists(
+        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request.txt"
+    )
+    assert file_util.file_exists(
+        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
+    )
+
+
 @mock.patch("uuid.uuid4")
 def test_successful_confirm_application_delivery_request_when_in_tracking_number_assigned_status(
     mock_uuid, db_session, client, enable_factory_create, caplog

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -362,6 +362,7 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
     mock_s3,
     s3_config,
 ) -> None:
+    soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
     mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
@@ -450,6 +451,7 @@ def test_if_soap_request_errors_on_creation_the_s3_handling_records_just_the_res
     mock_s3,
     s3_config,
 ) -> None:
+    soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -291,7 +291,7 @@ def test_if_write_debug_data_to_s3_fails_the_exception_is_logged(
 
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.simpler_soap_api.SimplerGrantorsS2SClient")
-def test_write_debug_data_if_s2s_client_throws_specific_errors(
+def test_write_debug_data_if_flag_save_soap_messages_to_s3_is_set(
     mock_s2s_client,
     mock_uuid,
     monkeypatch,
@@ -352,8 +352,17 @@ def test_write_debug_data_if_s2s_client_throws_specific_errors(
 
 @mock.patch("uuid.uuid4")
 def test_successful_confirm_application_delivery_request_when_in_received_by_agency_status(
-    mock_uuid, db_session, client, enable_factory_create, caplog
+    mock_uuid,
+    db_session,
+    client,
+    enable_factory_create,
+    caplog,
+    monkeypatch,
+    mock_s3_bucket,
+    mock_s3,
+    s3_config,
 ) -> None:
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
     mock_uuid.return_value = TEST_UUID
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
@@ -427,6 +436,8 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
         log.faultstring
         == f"Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received by Agency' for GRANT{submission.legacy_tracking_number})"
     )
+    records = [r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"]
+    assert len(records) == 1
 
 
 @mock.patch("uuid.uuid4")

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -83,6 +83,30 @@ def test_write_debug_data_to_s3(
     )
 
 
+def test_write_debug_data_to_s3_handles_a_null_soap_request(
+    caplog, db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
+) -> None:
+    caplog.set_level(logging.INFO)
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    soap_legacy_response = SOAPResponse(
+        data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+    )
+    write_debug_data_to_s3(None, soap_legacy_response)
+    record = next(
+        r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
+    )
+    assert not file_util.file_exists(
+        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request.txt"
+    )
+    response_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
+    )
+    assert response_contents.replace("\r", "") == SOAP_LEGACY_RESPONSE_PAYLOAD.decode().replace(
+        "\r", ""
+    )
+
+
 def test_write_debug_data_to_s3_does_not_run_if_flag_is_set_to_false(
     db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
 ) -> None:


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10905  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Added s3 logging for the 200 path and a couple of the error pathes

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
In order to troubleshoot some failures we wanted to track what the successful responses look like because there seem to be some parsin gissues.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
After deploy
- [ ] hit the endpoints, check the s3 bucket for log
