### PR TITLE
[unticketed]: fix cd metabase image tag on main merges

### DIFF
--- a/.github/workflows/cd-metabase.yml
+++ b/.github/workflows/cd-metabase.yml
@@ -1,5 +1,5 @@
 name: Deploy Metabase
-run-name: Deploy ${{ inputs.image_tag || github.ref_name }} to Metabase ${{ inputs.environment || 'nonprod' }}
+run-name: Deploy ${{ inputs.image_tag || 'current image' }} to Metabase ${{ inputs.environment || 'nonprod' }}
 
 on:
   push:
@@ -51,7 +51,7 @@ jobs:
           environment: ${{ matrix.envs }}
 
       - name: Deploy Metabase
-        run: make release-deploy APP_NAME=metabase ENVIRONMENT=${{ matrix.envs }} IMAGE_TAG=${{ inputs.image_tag || github.ref }}
+        run: make release-deploy APP_NAME=metabase ENVIRONMENT=${{ matrix.envs }} IMAGE_TAG=${{ inputs.image_tag }}
 
   send-slack-notification:
     if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))

--- a/Makefile
+++ b/Makefile
@@ -292,8 +292,7 @@ else
 	APP_NAME_ARG := "."
 endif
 
-ifdef IMAGE_TAG
-else
+ifeq ($(origin IMAGE_TAG),undefined)
 	ifdef GIT_REPO_AVAILABLE
 		IMAGE_TAG := $(shell git log --pretty=format:'%H' -n 1 "${ROOT_REV}" -- "${APP_NAME_ARG}")
 	else

--- a/bin/deploy-release
+++ b/bin/deploy-release
@@ -16,8 +16,18 @@ echo
 
 # Update task definition and update service to use new task definition
 
-echo "::group::Starting ${app_name} deploy of ${image_tag} to ${environment}"
-TF_CLI_ARGS_apply="-input=false -auto-approve -var=image_tag=${image_tag}" make infra-update-app-service APP_NAME="${app_name}" ENVIRONMENT="${environment}"
+# When no image tag is provided, omit the image_tag variable so Terraform falls
+# back to its null default and redeploys the last image tag used
+if [ -n "${image_tag}" ]; then
+  image_tag_var="-var=image_tag=${image_tag}"
+  deploy_target="${image_tag}"
+else
+  image_tag_var=""
+  deploy_target="the last image tag used"
+fi
+
+echo "::group::Starting ${app_name} deploy of ${deploy_target} to ${environment}"
+TF_CLI_ARGS_apply="-input=false -auto-approve ${image_tag_var}" make infra-update-app-service APP_NAME="${app_name}" ENVIRONMENT="${environment}"
 echo "::endgroup::"
 
 # Wait for the service to become stable
@@ -34,7 +44,7 @@ if ! wait_for_service_stability; then
   wait_for_service_stability
 fi
 
-echo "Completed ${app_name} deploy of ${image_tag} to ${environment}"
+echo "Completed ${app_name} deploy of ${deploy_target} to ${environment}"
 
 # Invalidate CloudFront cache for frontend deployments only
 if [ "$app_name" = "frontend" ]; then


### PR DESCRIPTION
## Summary

Currently, on main merges, cd metabase is fetching the wrong image tag. It is using the branch ref instead of reusing the last image tag that was used.  

Link to failing cd-metabase: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/27365684623/job/80864445670)

```
--------------
Deploy release
--------------
Input parameters:
  app_name=metabase
  image_tag=refs/heads/main  <--- current problem
  environment=staging

```

## Validation steps

