### PR TITLE
[Issue #10974] File input delete modal

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityAttachmentUploadInput.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityAttachmentUploadInput.tsx
@@ -15,7 +15,7 @@ import {
   ModalToggleButton,
 } from "@trussworks/react-uswds";
 
-import { DeleteAttachmentModal } from "src/components/core/fileInput/DeleteAttachmentModal";
+import { DeleteFileModal } from "src/components/core/fileInput/DeleteFileModal";
 import { USWDSIcon } from "src/components/core/USWDSIcon";
 
 const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024; // 2GB
@@ -178,9 +178,9 @@ export function OpportunityAttachmentUploadInput({
         </ul>
       )}
 
-      <DeleteAttachmentModal
+      <DeleteFileModal
         deletePending={deletePending}
-        handleDeleteAttachment={() => {
+        handleDeleteFile={() => {
           confirmDelete().catch(() =>
             setErrorMessage(
               t("errorDeleteFailed", { fileName: fileToDelete?.name ?? "" }),

--- a/frontend/src/components/apply-form/widgets/AttachmentUploadWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/AttachmentUploadWidget.tsx
@@ -178,7 +178,7 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
       )}
 
       <DeleteFileModal
-        Filending={deletePending}
+        deletePending={deletePending}
         handleDeleteFile={handleDeleteConfirmed}
         modalId="delete-attachment-modal"
         modalRef={deleteModalRef}

--- a/frontend/src/components/apply-form/widgets/AttachmentUploadWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/AttachmentUploadWidget.tsx
@@ -15,7 +15,7 @@ import {
   ModalRef,
 } from "@trussworks/react-uswds";
 
-import { DeleteAttachmentModal } from "src/components/core/fileInput/DeleteAttachmentModal";
+import { DeleteFileModal } from "src/components/core/fileInput/DeleteFileModal";
 import { DynamicFieldLabel } from "src/components/core/forms/DynamicFieldLabel";
 import { FieldErrors } from "src/components/core/forms/FieldErrors";
 import { getLabelTypeFromOptions } from "./getLabelTypeFromOptions";
@@ -177,9 +177,9 @@ const AttachmentUploadWidget = (props: UswdsWidgetProps) => {
         </div>
       )}
 
-      <DeleteAttachmentModal
-        deletePending={deletePending}
-        handleDeleteAttachment={handleDeleteConfirmed}
+      <DeleteFileModal
+        Filending={deletePending}
+        handleDeleteFile={handleDeleteConfirmed}
         modalId="delete-attachment-modal"
         modalRef={deleteModalRef}
         pendingDeleteName={deletePendingName ?? ""}

--- a/frontend/src/components/apply-form/widgets/MultipleAttachmentUploadWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/MultipleAttachmentUploadWidget.tsx
@@ -18,7 +18,7 @@ import {
   ModalRef,
 } from "@trussworks/react-uswds";
 
-import { DeleteAttachmentModal } from "src/components/core/fileInput/DeleteAttachmentModal";
+import { DeleteFileModal } from "src/components/core/fileInput/DeleteFileModal";
 import { DynamicFieldLabel } from "src/components/core/forms/DynamicFieldLabel";
 import { FieldErrors } from "src/components/core/forms/FieldErrors";
 import { getLabelTypeFromOptions } from "./getLabelTypeFromOptions";
@@ -224,9 +224,9 @@ const MultipleAttachmentUploadWidget = ({
         />
       )}
 
-      <DeleteAttachmentModal
+      <DeleteFileModal
         deletePending={deletePending}
-        handleDeleteAttachment={confirmDelete}
+        handleDeleteFile={confirmDelete}
         modalId="multi-attachment-delete-modal"
         modalRef={deleteModalRef}
         pendingDeleteName={deletePendingName ?? ""}

--- a/frontend/src/components/core/fileInput/DeleteFileModal.test.tsx
+++ b/frontend/src/components/core/fileInput/DeleteFileModal.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { DeleteFileModal } from "./DeleteFileModal";
+
+const defaultProps = {
+  deletePending: false,
+  handleDeleteFile: jest.fn(),
+  modalId: "delete-file-modal",
+  modalRef: { current: null },
+  pendingDeleteName: undefined,
+};
+
+describe("DeleteFileModal", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("calls handleDeleteFile when clicking the delete button", async () => {
+    const handleDeleteFile = jest.fn();
+    render(
+      <DeleteFileModal {...defaultProps} handleDeleteFile={handleDeleteFile} />,
+    );
+
+    const deleteButton = screen.getByRole("button", { name: "deleteFileCta" });
+    expect(deleteButton).toBeInTheDocument();
+
+    await userEvent.click(deleteButton);
+    expect(handleDeleteFile).toHaveBeenCalledTimes(1);
+  });
+  it("disables the delete button when delete is pending", () => {
+    render(<DeleteFileModal {...defaultProps} deletePending={true} />);
+
+    const deleteButton = screen.getByRole("button", { name: "deleting" });
+    expect(deleteButton).toBeDisabled();
+  });
+  it("displays the pendingDeleteName when provided", () => {
+    render(
+      <DeleteFileModal {...defaultProps} pendingDeleteName="my-file.pdf" />,
+    );
+
+    expect(screen.getByText("titleText my-file.pdf?")).toBeInTheDocument();
+  });
+  it("displays a generic caution title when no pendingDeleteName is provided", () => {
+    render(<DeleteFileModal {...defaultProps} pendingDeleteName={undefined} />);
+
+    expect(screen.getByText("cautionDeletingAttachment")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/core/fileInput/DeleteFileModal.tsx
+++ b/frontend/src/components/core/fileInput/DeleteFileModal.tsx
@@ -14,11 +14,8 @@ import { SimplerModal } from "src/components/core/SimplerModal";
 import Spinner from "src/components/core/Spinner";
 
 interface Props {
-  // for now, allowing the ID to be optional. As the SimplerFileInput is rolled out, this component
-  // will only be used there, where it is required, so we can adjust at that time
-  // or can we do this without the id, and rely on the parent to know about the id, yeah probably
-  handleDeleteFile: () => void;
   deletePending: boolean;
+  handleDeleteFile: () => void;
   modalId: string;
   modalRef: RefObject<ModalRef | null>;
   pendingDeleteName: string | undefined;

--- a/frontend/src/components/core/fileInput/DeleteFileModal.tsx
+++ b/frontend/src/components/core/fileInput/DeleteFileModal.tsx
@@ -14,21 +14,24 @@ import { SimplerModal } from "src/components/core/SimplerModal";
 import Spinner from "src/components/core/Spinner";
 
 interface Props {
+  // for now, allowing the ID to be optional. As the SimplerFileInput is rolled out, this component
+  // will only be used there, where it is required, so we can adjust at that time
+  // or can we do this without the id, and rely on the parent to know about the id, yeah probably
+  handleDeleteFile: () => void;
   deletePending: boolean;
-  handleDeleteAttachment: () => void;
   modalId: string;
   modalRef: RefObject<ModalRef | null>;
   pendingDeleteName: string | undefined;
 }
 
-export const DeleteAttachmentModal = ({
+export const DeleteFileModal = ({
   deletePending,
-  handleDeleteAttachment,
+  handleDeleteFile,
   modalId,
   modalRef,
   pendingDeleteName,
 }: Props) => {
-  const t = useTranslations("Application.attachments.deleteModal");
+  const t = useTranslations("FileInput.deleteModal");
   return (
     <SimplerModal
       modalId={modalId}
@@ -46,7 +49,7 @@ export const DeleteAttachmentModal = ({
           <Button
             disabled={deletePending}
             type="button"
-            onClick={handleDeleteAttachment}
+            onClick={handleDeleteFile}
           >
             {deletePending ? (
               <>

--- a/frontend/src/components/core/fileInput/FileInputExistingFiles.test.tsx
+++ b/frontend/src/components/core/fileInput/FileInputExistingFiles.test.tsx
@@ -22,6 +22,9 @@ const generateFile = (date: Date, index: number) => ({
   updatedAt: date.getTime(),
 });
 
+const testDateOne = new Date("04 Dec 1995");
+const testDateTwo = new Date("04 Dec 1996");
+
 describe("FileInputExistingFiles", () => {
   afterEach(() => {
     jest.resetAllMocks();
@@ -33,8 +36,8 @@ describe("FileInputExistingFiles", () => {
     ).not.toBeInTheDocument();
   });
   it("displays file name for each file present", () => {
-    const fileOne = generateFile(new Date("04 Dec 1995"), 1);
-    const fileTwo = generateFile(new Date("04 Dec 1996"), 2);
+    const fileOne = generateFile(testDateOne, 1);
+    const fileTwo = generateFile(testDateTwo, 2);
     render(
       <FileInputExistingFiles
         existingFiles={[fileOne, fileTwo]}
@@ -45,8 +48,8 @@ describe("FileInputExistingFiles", () => {
     expect(screen.getByText("file name 2")).toBeInTheDocument();
   });
   it("displays file size and timestamp for each file present", () => {
-    const fileOne = generateFile(new Date("04 Dec 1995"), 1);
-    const fileTwo = generateFile(new Date("04 Dec 1996"), 2);
+    const fileOne = generateFile(testDateOne, 1);
+    const fileTwo = generateFile(testDateTwo, 2);
     render(
       <FileInputExistingFiles
         existingFiles={[fileOne, fileTwo]}
@@ -57,8 +60,8 @@ describe("FileInputExistingFiles", () => {
     expect(screen.getByText("2 | savedOn 1996")).toBeInTheDocument();
   });
   it("displays a delete button for each provided file", async () => {
-    const fileOne = generateFile(new Date("04 Dec 1995"), 1);
-    const fileTwo = generateFile(new Date("04 Dec 1996"), 2);
+    const fileOne = generateFile(testDateOne, 1);
+    const fileTwo = generateFile(testDateTwo, 2);
     render(
       <FileInputExistingFiles
         existingFiles={[fileOne, fileTwo]}
@@ -70,10 +73,10 @@ describe("FileInputExistingFiles", () => {
     });
     expect(deleteButtons).toHaveLength(2);
   });
-  it("calls onDelete with the id for each file on delete button click", async () => {
+  it("calls onDelete with file metadata for each file on delete button click", async () => {
     const onDeleteMock = jest.fn();
-    const fileOne = generateFile(new Date("04 Dec 1995"), 1);
-    const fileTwo = generateFile(new Date("04 Dec 1996"), 2);
+    const fileOne = generateFile(testDateOne, 1);
+    const fileTwo = generateFile(testDateTwo, 2);
     render(
       <FileInputExistingFiles
         existingFiles={[fileOne, fileTwo]}
@@ -91,10 +94,22 @@ describe("FileInputExistingFiles", () => {
 
     await userEvent.click(firstButton);
     expect(onDeleteMock).toHaveBeenCalledTimes(1);
-    expect(onDeleteMock).toHaveBeenCalledWith("1");
+    expect(onDeleteMock).toHaveBeenCalledWith({
+      fileName: "file name 1",
+      fileSize: 1,
+      id: "1",
+      mimeType: "file",
+      updatedAt: testDateOne.getTime(),
+    });
 
     await userEvent.click(secondButton);
     expect(onDeleteMock).toHaveBeenCalledTimes(2);
-    expect(onDeleteMock).toHaveBeenCalledWith("2");
+    expect(onDeleteMock).toHaveBeenCalledWith({
+      fileName: "file name 2",
+      fileSize: 2,
+      id: "2",
+      mimeType: "file",
+      updatedAt: testDateTwo.getTime(),
+    });
   });
 });

--- a/frontend/src/components/core/fileInput/FileInputExistingFiles.test.tsx
+++ b/frontend/src/components/core/fileInput/FileInputExistingFiles.test.tsx
@@ -9,8 +9,8 @@ jest.mock("src/utils/fileUtils/formatFileSizeUtil", () => ({
 
 jest.mock("src/utils/dateUtil", () => ({
   // for ease of testing, this will take the epoch ms, and return the year
-  formatDate: (dateMs: number | string) => {
-    return new Date(Number(dateMs)).getFullYear();
+  formatDate: (dateMs: string) => {
+    return new Date(dateMs).getFullYear();
   },
 }));
 
@@ -19,7 +19,7 @@ const generateFile = (date: Date, index: number) => ({
   fileName: `file name ${index}`,
   fileSize: index,
   mimeType: "file",
-  updatedAt: date.getTime(),
+  updatedAt: date.toString(),
 });
 
 const testDateOne = new Date("04 Dec 1995");
@@ -99,7 +99,7 @@ describe("FileInputExistingFiles", () => {
       fileSize: 1,
       id: "1",
       mimeType: "file",
-      updatedAt: testDateOne.getTime(),
+      updatedAt: testDateOne.toString(),
     });
 
     await userEvent.click(secondButton);
@@ -109,7 +109,7 @@ describe("FileInputExistingFiles", () => {
       fileSize: 2,
       id: "2",
       mimeType: "file",
-      updatedAt: testDateTwo.getTime(),
+      updatedAt: testDateTwo.toString(),
     });
   });
 });

--- a/frontend/src/components/core/fileInput/FileInputExistingFiles.tsx
+++ b/frontend/src/components/core/fileInput/FileInputExistingFiles.tsx
@@ -12,7 +12,7 @@ export const FileInputExistingFiles = ({
   onDelete,
 }: {
   existingFiles?: UploadFileMetadata[];
-  onDelete: (fileId: string) => Promise<unknown>;
+  onDelete: (fileToDelete: UploadFileMetadata) => void;
 }) => {
   const t = useTranslations("FileInput.existingFiles");
   if (existingFiles && existingFiles.length) {
@@ -38,7 +38,7 @@ export const FileInputExistingFiles = ({
               type="button"
               unstyled
               onClick={() => {
-                void onDelete(existingFile.id);
+                void onDelete(existingFile);
               }}
             >
               <USWDSIcon

--- a/frontend/src/components/core/fileInput/FileInputExistingFiles.tsx
+++ b/frontend/src/components/core/fileInput/FileInputExistingFiles.tsx
@@ -10,9 +10,11 @@ import { USWDSIcon } from "src/components/core/USWDSIcon";
 export const FileInputExistingFiles = ({
   existingFiles,
   onDelete,
+  filesWithDeleteError = [] as string[],
 }: {
   existingFiles?: UploadFileMetadata[];
   onDelete: (fileToDelete: UploadFileMetadata) => void;
+  filesWithDeleteError?: string[];
 }) => {
   const t = useTranslations("FileInput.existingFiles");
   if (existingFiles && existingFiles.length) {
@@ -21,34 +23,40 @@ export const FileInputExistingFiles = ({
         ? `${formatFileSize(existingFile.fileSize)} | `
         : "";
       const timestampDisplay = `${t("savedOn")} ${formatDate(existingFile.updatedAt.toString())}`;
+      const hasError = filesWithDeleteError.findIndex(
+        (fileWithDeleteError) => fileWithDeleteError === existingFile.id,
+      );
       return (
-        <GridContainer key={existingFile.id}>
-          <Grid col={2}>
-            <USWDSIcon name="file_present" />
-          </Grid>
-          <Grid>
-            <div className="text-bold">{existingFile.fileName}</div>
-            <div>
-              {fileSizeDisplay}
-              {timestampDisplay}
-            </div>
-          </Grid>
-          <Grid col={3}>
-            <Button
-              type="button"
-              unstyled
-              onClick={() => {
-                void onDelete(existingFile);
-              }}
-            >
-              <USWDSIcon
-                className="usa-icon margin-right-05 margin-left-neg-05"
-                name="delete"
-              />
-              {t("delete")}
-            </Button>
-          </Grid>
-        </GridContainer>
+        <>
+          <GridContainer key={existingFile.id}>
+            <Grid col={2}>
+              <USWDSIcon name="file_present" />
+            </Grid>
+            <Grid>
+              <div className="text-bold">{existingFile.fileName}</div>
+              <div>
+                {fileSizeDisplay}
+                {timestampDisplay}
+              </div>
+            </Grid>
+            <Grid col={3}>
+              <Button
+                type="button"
+                unstyled
+                onClick={() => {
+                  void onDelete(existingFile);
+                }}
+              >
+                <USWDSIcon
+                  className="usa-icon margin-right-05 margin-left-neg-05"
+                  name="delete"
+                />
+                {t("delete")}
+              </Button>
+            </Grid>
+          </GridContainer>
+          {hasError > -1 ? <div>{t("deleteError")}</div> : null}
+        </>
       );
     });
     return (

--- a/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
@@ -25,6 +25,12 @@ jest.mock("src/hooks/useClientFetch", () => ({
   }),
 }));
 
+const fakeExistingFile = {
+  id: "1",
+  fileName: "test.txt",
+  updatedAt: new Date().toDateString(),
+};
+
 let originalAbortController: typeof AbortController;
 
 describe("SimplerFileInput", () => {
@@ -530,6 +536,36 @@ describe("SimplerFileInput", () => {
         }),
       );
       await waitFor(() => expect(mockOnError).toHaveBeenCalledWith(fakeError));
+    });
+    it("calls onDelete callback with file id on delete file confirmation", async () => {
+      const mockOnDelete = jest.fn().mockResolvedValue(true);
+      render(
+        <SimplerFileInput
+          onDelete={mockOnDelete}
+          postUploadAction={() => Promise.resolve(undefined)}
+          postUploadActionProgressMessage="post upload action in progress"
+          postUploadActionSuccessMessage="post upload action success"
+          postUploadActionErrorMessage="post upload action error"
+          id="file-input-test"
+          labelId="file-input-label"
+          existingFiles={[fakeExistingFile]}
+        />,
+      );
+      const deleteButton = screen.getByRole("button", {
+        name: "delete",
+      });
+      expect(deleteButton).toBeInTheDocument();
+      // open the modal
+      await userEvent.click(deleteButton);
+
+      const deleteConfirmButton = screen.getByRole("button", {
+        name: "deleteFileCta",
+      });
+      expect(deleteConfirmButton).toBeInTheDocument();
+
+      // confirm deletion
+      await userEvent.click(deleteConfirmButton);
+      expect(mockOnDelete).toHaveBeenCalledWith(fakeExistingFile.id);
     });
   });
   it("cancels upload in progress on cancel button click", async () => {

--- a/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
@@ -672,6 +672,38 @@ describe("SimplerFileInput", () => {
 
     expect(controllerAbortMock).toHaveBeenCalledTimes(1);
   });
+  it("displays error message if error occurs during delete", async () => {
+    const mockOnDelete = jest.fn().mockRejectedValue(new Error());
+    render(
+      <SimplerFileInput
+        onDelete={mockOnDelete}
+        postUploadAction={() => Promise.resolve(undefined)}
+        postUploadActionProgressMessage="post upload action in progress"
+        postUploadActionSuccessMessage="post upload action success"
+        postUploadActionErrorMessage="post upload action error"
+        id="file-input-test"
+        labelId="file-input-label"
+        existingFiles={[fakeExistingFile]}
+      />,
+    );
+    const deleteButton = screen.getByRole("button", {
+      name: "delete",
+    });
+    expect(deleteButton).toBeInTheDocument();
+    // open the modal
+    await userEvent.click(deleteButton);
+
+    const deleteConfirmButton = screen.getByRole("button", {
+      name: "deleteFileCta",
+    });
+    expect(deleteConfirmButton).toBeInTheDocument();
+
+    // confirm deletion
+    await userEvent.click(deleteConfirmButton);
+    expect(mockOnDelete).toHaveBeenCalledWith(fakeExistingFile.id);
+    const errorMessage = screen.getByText("deleteError");
+    expect(errorMessage).toBeInTheDocument();
+  });
   // not able to test this since the only way to really hide this for now is with CSS, which is not
   // testable using testing-library tools.
   // aria-hidden seems to be the way to do this for testing, but is that possible?

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -88,6 +88,7 @@ export const SimplerFileInput = ({
   const [filePendingDeletion, setFilePendingDeletion] =
     useState<UploadFileMetadata>();
   const [deletePending, setDeletePending] = useState(false);
+  const [deleteErrors, setDeleteErrors] = useState<string[]>([]);
 
   const handleCancel = async () => {
     setCurrentStatus(undefined);
@@ -109,6 +110,20 @@ export const SimplerFileInput = ({
     [currentStatus, setUploadError, onError],
   );
 
+  const clearDeleteErrorsForId = useCallback(
+    (id: string) => {
+      setDeleteErrors(
+        deleteErrors.reduce((acc, currentDeleteErrorId) => {
+          if (currentDeleteErrorId !== id) {
+            return acc.concat([currentDeleteErrorId]);
+          }
+          return acc;
+        }, [] as string[]),
+      );
+    },
+    [deleteErrors],
+  );
+
   // this does not update the list of existing / previously uploaded files internally,
   // and relies on the parent to update that list upon successful deletion
   const handleDeleteFile = useCallback(() => {
@@ -122,6 +137,7 @@ export const SimplerFileInput = ({
         setDeletePending(false);
         setFilePendingDeletion(undefined);
         deleteModalRef.current?.toggleModal();
+        clearDeleteErrorsForId(filePendingDeletion.id);
         return;
       })
       .catch((e) => {
@@ -130,8 +146,9 @@ export const SimplerFileInput = ({
         setDeletePending(false);
         setFilePendingDeletion(undefined);
         deleteModalRef.current?.toggleModal();
+        setDeleteErrors(deleteErrors.concat([filePendingDeletion.id]));
       });
-  }, [filePendingDeletion, onDelete]);
+  }, [filePendingDeletion, onDelete, deleteErrors, clearDeleteErrorsForId]);
 
   const readResponseStream = useCallback(
     (reader: ReadableStreamDefaultReader<string>) => {
@@ -271,6 +288,7 @@ export const SimplerFileInput = ({
           setFilePendingDeletion(fileToDelete);
           deleteModalRef.current?.toggleModal();
         }}
+        filesWithDeleteError={}
       />
       <DeleteFileModal
         // this only supports deleting one file at a time.

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -88,7 +88,9 @@ export const SimplerFileInput = ({
   const [filePendingDeletion, setFilePendingDeletion] =
     useState<UploadFileMetadata>();
   const [deletePending, setDeletePending] = useState(false);
-  const [deleteErrors, setDeleteErrors] = useState<string[]>([]);
+  const [filesWithDeleteError, setFilesWithDeleteError] = useState<string[]>(
+    [],
+  );
 
   const handleCancel = async () => {
     setCurrentStatus(undefined);
@@ -110,20 +112,6 @@ export const SimplerFileInput = ({
     [currentStatus, setUploadError, onError],
   );
 
-  const clearDeleteErrorsForId = useCallback(
-    (id: string) => {
-      setDeleteErrors(
-        deleteErrors.reduce((acc, currentDeleteErrorId) => {
-          if (currentDeleteErrorId !== id) {
-            return acc.concat([currentDeleteErrorId]);
-          }
-          return acc;
-        }, [] as string[]),
-      );
-    },
-    [deleteErrors],
-  );
-
   // this does not update the list of existing / previously uploaded files internally,
   // and relies on the parent to update that list upon successful deletion
   const handleDeleteFile = useCallback(() => {
@@ -137,7 +125,8 @@ export const SimplerFileInput = ({
         setDeletePending(false);
         setFilePendingDeletion(undefined);
         deleteModalRef.current?.toggleModal();
-        clearDeleteErrorsForId(filePendingDeletion.id);
+        // figured we may need to clear delete errors for the file here, but it should
+        // be removed from the dom on successful delete so I don't think it's necessary
         return;
       })
       .catch((e) => {
@@ -146,9 +135,11 @@ export const SimplerFileInput = ({
         setDeletePending(false);
         setFilePendingDeletion(undefined);
         deleteModalRef.current?.toggleModal();
-        setDeleteErrors(deleteErrors.concat([filePendingDeletion.id]));
+        setFilesWithDeleteError(
+          filesWithDeleteError.concat([filePendingDeletion.id]),
+        );
       });
-  }, [filePendingDeletion, onDelete, deleteErrors, clearDeleteErrorsForId]);
+  }, [filePendingDeletion, onDelete, filesWithDeleteError]);
 
   const readResponseStream = useCallback(
     (reader: ReadableStreamDefaultReader<string>) => {
@@ -288,7 +279,7 @@ export const SimplerFileInput = ({
           setFilePendingDeletion(fileToDelete);
           deleteModalRef.current?.toggleModal();
         }}
-        filesWithDeleteError={}
+        filesWithDeleteError={filesWithDeleteError}
       />
       <DeleteFileModal
         // this only supports deleting one file at a time.

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -8,8 +8,9 @@ import {
 } from "src/types/fileUploadTypes";
 
 import { ChangeEvent, useCallback, useRef, useState } from "react";
-import { FileInput, FileInputRef } from "@trussworks/react-uswds";
+import { FileInput, FileInputRef, ModalRef } from "@trussworks/react-uswds";
 
+import { DeleteFileModal } from "./DeleteFileModal";
 import { FileInputExistingFiles } from "./FileInputExistingFiles";
 import { FileInputStatusDisplay } from "./FileInputStatusDisplay";
 
@@ -67,6 +68,7 @@ export const SimplerFileInput = ({
   required = false,
 }: SimplerFileInputProps) => {
   const fileInputRef = useRef<FileInputRef | null>(null);
+  const deleteModalRef = useRef<ModalRef | null>(null);
 
   const { clientFetch } = useClientFetch<Response>("unable to upload file", {
     jsonResponse: true,
@@ -83,6 +85,9 @@ export const SimplerFileInput = ({
     useState<AbortController>();
   const [responseReader, setResponseReader] =
     useState<ReadableStreamDefaultReader>();
+  const [filePendingDeletion, setFilePendingDeletion] =
+    useState<UploadFileMetadata>();
+  const [deletePending, setDeletePending] = useState(false);
 
   const handleCancel = async () => {
     setCurrentStatus(undefined);
@@ -103,6 +108,30 @@ export const SimplerFileInput = ({
     },
     [currentStatus, setUploadError, onError],
   );
+
+  // this does not update the list of existing / previously uploaded files internally,
+  // and relies on the parent to update that list upon successful deletion
+  const handleDeleteFile = useCallback(() => {
+    if (!filePendingDeletion) {
+      console.error("Attempting to delete, but no file selected");
+      return;
+    }
+    setDeletePending(true);
+    onDelete(filePendingDeletion?.id)
+      .then(() => {
+        setDeletePending(false);
+        setFilePendingDeletion(undefined);
+        deleteModalRef.current?.toggleModal();
+        return;
+      })
+      .catch((e) => {
+        // do we want to do anything else here to surface the error?
+        console.error("Error deleting file", e);
+        setDeletePending(false);
+        setFilePendingDeletion(undefined);
+        deleteModalRef.current?.toggleModal();
+      });
+  }, [filePendingDeletion, onDelete]);
 
   const readResponseStream = useCallback(
     (reader: ReadableStreamDefaultReader<string>) => {
@@ -238,7 +267,20 @@ export const SimplerFileInput = ({
       ) : null}
       <FileInputExistingFiles
         existingFiles={existingFiles}
-        onDelete={onDelete}
+        onDelete={(fileToDelete: UploadFileMetadata) => {
+          setFilePendingDeletion(fileToDelete);
+          deleteModalRef.current?.toggleModal();
+        }}
+      />
+      <DeleteFileModal
+        // this only supports deleting one file at a time.
+        // in order to support deleting more than one file at a time we'd
+        // need to switch things up a bit, and I don't know if that's a requirement
+        deletePending={deletePending}
+        handleDeleteFile={handleDeleteFile}
+        modalId={`${id}-delete-file-modal`}
+        modalRef={deleteModalRef}
+        pendingDeleteName={filePendingDeletion?.fileName}
       />
     </>
   );

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -557,16 +557,6 @@ export const messages = {
       fileSize: "File Size",
       uploadBy: "Upload by",
       uploadDate: "Upload date",
-      deleteModal: {
-        titleText: "Delete",
-        cancelDeleteCta: "Cancel",
-        cautionDeletingAttachment: "Caution, deleting attachment",
-        descriptionText:
-          "You may have uploaded this attachment in response to a form question. Check to ensure you no longer need it.",
-        deleteFileCta: "Delete file",
-        deleteFilesCta: "Delete files",
-        deleting: "Deleting...",
-      },
     },
     historyTable: {
       applicationHistory: "Application History",
@@ -2477,6 +2467,16 @@ export const messages = {
       uploadError: "Upload error",
       scanError: "Scan error",
       postUploadError: "Post upload error",
+    },
+    deleteModal: {
+      titleText: "Delete",
+      cancelDeleteCta: "Cancel",
+      cautionDeletingAttachment: "Caution, deleting attachment",
+      descriptionText:
+        "You may have uploaded this attachment in response to a form question. Check to ensure you no longer need it.",
+      deleteFileCta: "Delete file",
+      deleteFilesCta: "Delete files",
+      deleting: "Deleting...",
     },
   },
 };

--- a/frontend/src/types/fileUploadTypes.ts
+++ b/frontend/src/types/fileUploadTypes.ts
@@ -24,7 +24,7 @@ export type UploadFileMetadata = {
   fileSize?: number;
   mimeType?: string;
   downloadUrl?: string;
-  updatedAt: number; // ?? may come back as a string
+  updatedAt: string;
 };
 
 export type FileUploadStatusUpdate = {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->


This adds support for the file deletion modal to the file input component. This should have been done as part of https://github.com/HHS/simpler-grants-gov/pull/10808 but I forgot about it.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Integrates the existing DeleteAttachmentModal (renamed DeleteFileModal) into the SimplerFileInput. That file was previously untested so added some basic tests there as well

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. _VERIFY_: unit tests cover necessary functionality
2. _VERIFY_: unit tests pass

