### PR TITLE
[Issue #10937] Surface legacy response when legacy response errors out

### DIFF
--- a/api/src/legacy_soap_api/simpler_soap_api.py
+++ b/api/src/legacy_soap_api/simpler_soap_api.py
@@ -195,12 +195,14 @@ def process_simpler_request(
 
         # If it is GetOpportunityList or is valid legacy certificate but not configured in Simpler
         # call legacy and don't call simpler
+        is_alternate_response: bool = False
         if is_get_opportunity_list or is_legacy_only_certificate:
             soap_legacy_response = get_legacy_response(soap_request)
             write_debug_data_to_s3(soap_request, soap_legacy_response)
             return soap_legacy_response.to_flask_response()
         # If it has a Simpler GrantsGovTrackingNumber then don't call legacy
         elif alternate_legacy_response := get_alternate_legacy_response(soap_request):
+            is_alternate_response = True
             logger.info(
                 "simpler_soap_api: skipping legacy call",
             )
@@ -238,8 +240,26 @@ def process_simpler_request(
             simpler_soap_response = get_simpler_soap_response(
                 soap_request, soap_legacy_response, db_session
             )
-            write_debug_data_to_s3(soap_request, simpler_soap_response)
-            return simpler_soap_response.to_flask_response()
+            # In the event where there's a successful simpler response
+            # but the legacy response failed (and not just skipped
+            # with the alternate response) then surface the legacy response
+            if (
+                simpler_soap_response.status_code == 200
+                and soap_legacy_response.status_code != 200
+                and not is_alternate_response
+            ):
+                logger.info(
+                    msg="simpler_soap_api: override simpler response with legacy response",
+                    extra={
+                        "simpler_status_code": simpler_soap_response.status_code,
+                        "legacy_status_code": soap_legacy_response.status_code,
+                    },
+                )
+                write_debug_data_to_s3(soap_request, soap_legacy_response)
+                return soap_legacy_response.to_flask_response()
+            else:
+                write_debug_data_to_s3(soap_request, simpler_soap_response)
+                return simpler_soap_response.to_flask_response()
         except SOAPClientUserDoesNotHavePermission:
             msg = "soap_client_certificate: User did not have permission to access this application"
             logger.info(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime
 from unittest import mock
 
@@ -49,6 +50,10 @@ MOCK_FINGERPRINT = "123"
 MOCK_CERT = "456"
 MOCK_CERT_STR = "certstr"
 TEST_UUID = "00000000-aaaa-0000-bbbb-000000000000"
+
+
+def strip_response(s):
+    return re.sub(r">\s+<", "><", s.strip())
 
 
 def test_successful_request(client, enable_factory_create, fixture_from_file, caplog) -> None:
@@ -969,24 +974,14 @@ def test_confirm_application_delivery_returns_not_found_response_if_simpler_id_i
         full_path, data=etree.tostring(envelope), headers={MTLS_CERT_HEADER_KEY: mtls_cert}
     )
     expected = (
-        b"--uuid:00000000-aaaa-0000-bbbb-000000000000\r\n"
-        b'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\n'
-        b"Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
-        b'<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n        '
-        b"<soap:Body>\n            "
-        b"<soap:Fault>\n                "
-        b"<faultcode>soap:Server</faultcode>\n                "
-        b"<faultstring>Failed to confirm application delivery.(Authorization Failure)"
-        b"</faultstring>\n            "
-        b"</soap:Fault>\n        "
-        b"</soap:Body>\n    "
-        b"</soap:Envelope>\r\n"
-        b"--uuid:00000000-aaaa-0000-bbbb-000000000000--\r\n"
+        "--uuid:00000000-aaaa-0000-bbbb-000000000000\r\nContent-Type: application/xop+xml; charset=UTF-8; "
+        'type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org>'
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body>'
+        "<soap:Fault><faultcode>soap:Server</faultcode><faultstring>Failed to confirm application delivery.(Authorization Failure)</faultstring></soap:Fault>"
+        "</soap:Body></soap:Envelope>\r\n--uuid:00000000-aaaa-0000-bbbb-000000000000--"
     )
     mock_get_soap_response.assert_not_called()
-    assert response.status_code == 500
-    assert response.headers["Content-Length"] == "581"
-    assert expected == response.data
+    assert strip_response(response.data.decode()) == expected
     assert (
         response.headers["Content-Type"]
         == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
@@ -1342,6 +1337,112 @@ def test_get_submission_list_expanded_always_calls_legacy_and_simpler(
     assert response.status_code == 200
     mock_get_soap_response.assert_called_once()
     mock_get_simpler_soap_response.assert_called_once()
+
+
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_legacy_response")
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response")
+def test_if_actual_legacy_response_is_500_and_simpler_response_is_200_the_legacy_response_will_be_returned(
+    mock_get_simpler_soap_response, mock_get_legacy_response, client, enable_factory_create
+) -> None:
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = """
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">
+        <soapenv:Header/>
+        <soapenv:Body>
+        <agen:GetSubmissionListExpandedRequest>
+        </agen:GetSubmissionListExpandedRequest>
+        </soapenv:Body>
+        </soapenv:Envelope>
+    """
+    envelope = etree.fromstring(mock_data)
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    mock_get_simpler_soap_response.return_value = SOAPResponse(
+        data=b"simpler", status_code=200, headers={}
+    )
+    mock_get_legacy_response.return_value = SOAPResponse(
+        data=b"legacy", status_code=500, headers={}
+    )
+    response = client.post(
+        full_path,
+        data=etree.tostring(envelope),
+        headers={MTLS_CERT_HEADER_KEY: mtls_cert},
+    )
+    assert response.status_code == 500
+    assert response.data == b"legacy"
+
+
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_legacy_response")
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response")
+def test_if_actual_legacy_response_is_200_and_simpler_response_is_500_the_simpler_response_will_be_returned(
+    mock_get_simpler_soap_response, mock_get_legacy_response, client, enable_factory_create
+) -> None:
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = """
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">
+        <soapenv:Header/>
+        <soapenv:Body>
+        <agen:GetSubmissionListExpandedRequest>
+        </agen:GetSubmissionListExpandedRequest>
+        </soapenv:Body>
+        </soapenv:Envelope>
+    """
+    envelope = etree.fromstring(mock_data)
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    mock_get_simpler_soap_response.return_value = SOAPResponse(
+        data=b"simpler", status_code=500, headers={}
+    )
+    mock_get_legacy_response.return_value = SOAPResponse(
+        data=b"legacy", status_code=200, headers={}
+    )
+    response = client.post(
+        full_path,
+        data=etree.tostring(envelope),
+        headers={MTLS_CERT_HEADER_KEY: mtls_cert},
+    )
+    assert response.status_code == 500
+    assert response.data == b"simpler"
+
+
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_legacy_response")
+@mock.patch("src.legacy_soap_api.simpler_soap_api.get_simpler_soap_response")
+def test_if_generated_legacy_response_is_500_and_simpler_response_is_200_the_simpler_response_will_be_returned(
+    mock_get_simpler_soap_response, mock_get_legacy_response, client, enable_factory_create
+) -> None:
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
+        f"<gran:GrantsGovTrackingNumber>{SIMPLER_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>"
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    envelope = etree.fromstring(mock_data)
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    _, _, _, mtls_cert = setup_cert_user(agency, privileges)
+    mock_get_simpler_soap_response.return_value = SOAPResponse(
+        data=b"simpler", status_code=200, headers={}
+    )
+    mock_get_legacy_response.return_value = SOAPResponse(
+        data=b"legacy", status_code=500, headers={}
+    )
+    response = client.post(
+        full_path,
+        data=etree.tostring(envelope),
+        headers={MTLS_CERT_HEADER_KEY: mtls_cert},
+    )
+    assert response.status_code == 200
+    assert response.data == b"simpler"
 
 
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10937  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Add check: IF simpler response is 200 AND legacy response is not 200 AND the legacy response is not a default response we generated THEN return the legacy response and log the legacy response to s3
- Added tests

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
If the simpler response is successful it swallowed a potential failed response from the legacy system. We would prefer to surface the failed legacy response.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests pass
Post-deploy
- [ ] Hit staging endpoint with current SIMP cert and see a failure (not a success)
