### PR TITLE
[Issue #10761] Modify our Task class to abstract away the DB table

### DIFF
--- a/api/src/task/base_task.py
+++ b/api/src/task/base_task.py
@@ -1,0 +1,138 @@
+import abc
+import itertools
+import logging
+import time
+from enum import StrEnum
+from typing import Any
+
+import grants_shared.adapters.db as db
+
+logger = logging.getLogger(__name__)
+
+TASK_CLASS_KEY = "task_class"
+
+
+class BaseTask(abc.ABC, metaclass=abc.ABCMeta):
+    """
+    Abstract base class representing an arbitrary
+    task that works with the database.
+
+    This approach handles a few basic patterns including:
+    - Simple metric aggregation & logging
+    - Timing metrics
+    - High-level error handling
+
+    The persistence of job status/metrics is delegated to the abstract
+    ``start_job`` and ``finish_job`` methods so this class has no direct
+    dependency on any particular database table.
+    """
+
+    class Metrics(StrEnum):
+        # Derived classes will implement their own
+        # Metrics class with metrics
+        pass
+
+    def __init__(self, db_session: db.Session) -> None:
+        self.db_session = db_session
+        self.metrics: dict[str, Any] = {}
+
+    def run(self) -> None:
+        job_succeeded = True
+
+        try:
+            # Record the start of the job
+            self.start_job()
+
+            # Initialize the metrics
+            self.initialize_metrics()
+
+            # Start the timer
+            logger.info("Starting %s", self.cls_name())
+            start = time.perf_counter()
+
+            # Run the actual task
+            self.run_task()
+
+            # Calculate and set a duration
+            end = time.perf_counter()
+            duration = round((end - start), 3)
+            self.set_metrics({"task_duration_sec": duration})
+
+            self._log_metrics(duration)
+        except Exception:
+            job_succeeded = False
+            raise
+        finally:
+            # Rollback if the session is not active due to error above
+            if not self.db_session.is_active:
+                self.db_session.rollback()
+
+            self.finish_job(job_succeeded)
+
+    def initialize_metrics(self) -> None:
+        zero_metrics_dict: dict[str, Any] = {metric: 0 for metric in self.Metrics}
+        zero_metrics_dict[TASK_CLASS_KEY] = self.cls_name()
+        self.set_metrics(zero_metrics_dict)
+
+    def set_metrics(self, metrics: dict[str, Any]) -> None:
+        self.metrics.update(**metrics)
+
+    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
+        if name not in self.metrics:
+            self.metrics[name] = 0
+
+        self.metrics[name] += value
+
+        if prefix is not None:
+            # Rather than re-implement the above, just re-use the function without a prefix
+            self.increment(f"{prefix}.{name}", value, prefix=None)
+
+    def _log_metrics(self, duration: float) -> None:
+        """Log metrics out, handling metrics if they exceed the maximum number of reportable metrics."""
+
+        # New Relic has a limit of 255 metrics maximum. It won't ingest the logs
+        # if there are more than that number of key-value pairs. In addition to the metrics
+        # we've added, we add various other attributes to the logs (environment, ecs info),
+        # so we should assume a chunk of that 255 is already reserved. For simplicity,
+        # if there are more than 100 metrics, we'll be careful and batch the log message.
+        if len(self.metrics) > 100:
+            # add a warning, we should probably refactor something if this is regularly
+            # happening, but we'll account for it below.
+            logger.warning(
+                "A large number of metrics are being added for this task - batching them together",
+                extra={TASK_CLASS_KEY: self.cls_name(), "metric_count": len(self.metrics)},
+            )
+
+            metric_batches: list[dict[str, Any]] = []
+
+            # Since a lot of our dashboards depend on pulling values out by the task_class
+            # make sure that's included in every batch automatically.
+            iter_metrics = {k: v for k, v in self.metrics.items() if k != TASK_CLASS_KEY}
+            for batch in itertools.batched(iter_metrics.items(), n=100, strict=False):
+                metric_batch = dict(batch)
+                metric_batch[TASK_CLASS_KEY] = self.cls_name()
+                metric_batches.append(metric_batch)
+
+        else:  # By default, batch of 1 of everything
+            metric_batches = [self.metrics]
+
+        for metric_batch in metric_batches:
+            logger.info("Completed %s in %s seconds", self.cls_name(), duration, extra=metric_batch)
+
+    def cls_name(self) -> str:
+        return self.__class__.__name__
+
+    @abc.abstractmethod
+    def start_job(self) -> None:
+        """Override to record the start of the job (e.g. persist a job record)."""
+        pass
+
+    @abc.abstractmethod
+    def finish_job(self, job_succeeded: bool) -> None:
+        """Override to record the completion of the job, including final metrics."""
+        pass
+
+    @abc.abstractmethod
+    def run_task(self) -> None:
+        """Override to define the task logic"""
+        pass

--- a/api/src/task/task.py
+++ b/api/src/task/task.py
@@ -1,129 +1,35 @@
-import abc
-import itertools
 import logging
-import time
-from enum import StrEnum
 from typing import Any
 
 import grants_shared.adapters.db as db
 
 from src.db.models.task_models import JobLog, JobStatus
+from src.task.base_task import BaseTask
 
 logger = logging.getLogger(__name__)
 
-TASK_CLASS_KEY = "task_class"
 
-
-class Task(abc.ABC, metaclass=abc.ABCMeta):
+class Task(BaseTask):
     """
-    Abstract base class representing an arbitrary
-    task that works with the database.
+    Task implementation that persists job status and metrics to the JobLog table.
 
-    This approach handles a few basic patterns including:
-    - Simple metric aggregation & logging
-    - Timing metrics
-    - High-level error handling
+    All reusable functionality (DB session management, metrics, timing, and error
+    handling) lives in BaseTask. This class only adds the JobLog persistence.
     """
-
-    class Metrics(StrEnum):
-        # Derived classes will implement their own
-        # Metrics class with metrics
-        pass
 
     def __init__(self, db_session: db.Session) -> None:
-        self.db_session = db_session
-        self.metrics: dict[str, Any] = {}
+        super().__init__(db_session)
         self.job: JobLog | None = None
 
-    def run(self) -> None:
-        job_succeeded = True
+    def start_job(self) -> None:
+        # Create initial job record
+        self.job = JobLog(job_type=self.cls_name(), job_status=JobStatus.STARTED)
+        self.db_session.add(self.job)
+        self.db_session.commit()
 
-        try:
-            # Create initial job record
-            self.job = JobLog(job_type=self.cls_name(), job_status=JobStatus.STARTED)
-            self.db_session.add(self.job)
-            self.db_session.commit()
-
-            # Initialize the metrics
-            self.initialize_metrics()
-
-            # Start the timer
-            logger.info("Starting %s", self.cls_name())
-            start = time.perf_counter()
-
-            # Run the actual task
-            self.run_task()
-
-            # Calculate and set a duration
-            end = time.perf_counter()
-            duration = round((end - start), 3)
-            self.set_metrics({"task_duration_sec": duration})
-
-            self._log_metrics(duration)
-        except Exception:
-            job_succeeded = False
-            raise
-        finally:
-            job_status = JobStatus.COMPLETED if job_succeeded else JobStatus.FAILED
-
-            # Rollback if the session is not active due to error above
-            if not self.db_session.is_active:
-                self.db_session.rollback()
-
-            self.update_job(job_status, metrics=self.metrics)
-
-    def initialize_metrics(self) -> None:
-        zero_metrics_dict: dict[str, Any] = {metric: 0 for metric in self.Metrics}
-        zero_metrics_dict[TASK_CLASS_KEY] = self.cls_name()
-        self.set_metrics(zero_metrics_dict)
-
-    def set_metrics(self, metrics: dict[str, Any]) -> None:
-        self.metrics.update(**metrics)
-
-    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
-        if name not in self.metrics:
-            self.metrics[name] = 0
-
-        self.metrics[name] += value
-
-        if prefix is not None:
-            # Rather than re-implement the above, just re-use the function without a prefix
-            self.increment(f"{prefix}.{name}", value, prefix=None)
-
-    def _log_metrics(self, duration: float) -> None:
-        """Log metrics out, handling metrics if they exceed the maximum number of reportable metrics."""
-
-        # New Relic has a limit of 255 metrics maximum. It won't ingest the logs
-        # if there are more than that number of key-value pairs. In addition to the metrics
-        # we've added, we add various other attributes to the logs (environment, ecs info),
-        # so we should assume a chunk of that 255 is already reserved. For simplicity,
-        # if there are more than 100 metrics, we'll be careful and batch the log message.
-        if len(self.metrics) > 100:
-            # add a warning, we should probably refactor something if this is regularly
-            # happening, but we'll account for it below.
-            logger.warning(
-                "A large number of metrics are being added for this task - batching them together",
-                extra={TASK_CLASS_KEY: self.cls_name(), "metric_count": len(self.metrics)},
-            )
-
-            metric_batches: list[dict[str, Any]] = []
-
-            # Since a lot of our dashboards depend on pulling values out by the task_class
-            # make sure that's included in every batch automatically.
-            iter_metrics = {k: v for k, v in self.metrics.items() if k != TASK_CLASS_KEY}
-            for batch in itertools.batched(iter_metrics.items(), n=100, strict=False):
-                metric_batch = dict(batch)
-                metric_batch[TASK_CLASS_KEY] = self.cls_name()
-                metric_batches.append(metric_batch)
-
-        else:  # By default, batch of 1 of everything
-            metric_batches = [self.metrics]
-
-        for metric_batch in metric_batches:
-            logger.info("Completed %s in %s seconds", self.cls_name(), duration, extra=metric_batch)
-
-    def cls_name(self) -> str:
-        return self.__class__.__name__
+    def finish_job(self, job_succeeded: bool) -> None:
+        job_status = JobStatus.COMPLETED if job_succeeded else JobStatus.FAILED
+        self.update_job(job_status, metrics=self.metrics)
 
     def update_job(self, job_status: JobStatus, metrics: dict[str, Any] | None = None) -> None:
         if self.job is None:
@@ -132,8 +38,3 @@ class Task(abc.ABC, metaclass=abc.ABCMeta):
         self.job.job_status = job_status
         self.job.metrics = self.metrics
         self.db_session.commit()
-
-    @abc.abstractmethod
-    def run_task(self) -> None:
-        """Override to define the task logic"""
-        pass

--- a/api/tests/src/task/test_task.py
+++ b/api/tests/src/task/test_task.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError, InvalidRequestError
 
 from src.db.models.extract_models import ExtractMetadata
 from src.db.models.task_models import JobLog, JobStatus
+from src.task.base_task import BaseTask
 from src.task.task import Task
 from tests.src.db.models.factories import ExtractMetadataFactory, ExtractType
 
@@ -52,6 +53,53 @@ class DBFailingTask(Task):
     def run_task(self) -> None:
         # Simulate DB operation failing
         raise InvalidRequestError("DB Error", None, None)
+
+
+class InMemoryTask(BaseTask):
+    """BaseTask implementation that tracks job lifecycle in memory, with no DB table."""
+
+    def __init__(self, db_session):
+        super().__init__(db_session)
+        self.started = False
+        self.finish_succeeded: bool | None = None
+
+    def start_job(self) -> None:
+        self.started = True
+
+    def finish_job(self, job_succeeded: bool) -> None:
+        self.finish_succeeded = job_succeeded
+
+    def run_task(self) -> None:
+        self.set_metrics({"records_processed": 5})
+
+
+class InMemoryFailingTask(InMemoryTask):
+    """BaseTask implementation that fails during run_task"""
+
+    def run_task(self) -> None:
+        raise ValueError("Task failed")
+
+
+def test_base_task_runs_without_db_table(db_session):
+    """BaseTask drives the run lifecycle without any direct DB table dependency"""
+    task = InMemoryTask(db_session)
+    task.run()
+
+    assert task.started is True
+    assert task.finish_succeeded is True
+    assert task.metrics["records_processed"] == 5
+    assert "task_duration_sec" in task.metrics
+
+
+def test_base_task_finish_job_reports_failure(db_session):
+    """When run_task raises, BaseTask still calls finish_job indicating failure"""
+    task = InMemoryFailingTask(db_session)
+
+    with pytest.raises(ValueError):
+        task.run()
+
+    assert task.started is True
+    assert task.finish_succeeded is False
 
 
 def test_task_handles_general_error(db_session):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10761  

## Changes proposed

- Created base_task.py to add a `BaseTask` class holding all reusable, table-agnostic functionality with new abstract `start_job()` and `finish_job` hooks for persisting job state.
- Updated task.py to derive `Task` from `BaseTask` and implement only the `JobLog`-specific logic, keeping its public interface unchanged.
- Updated test_task.py to add coverage proving `BaseTask` runs its full lifecycle without any DB table, including the failure path.

## Context for reviewers

Pure refactor (no behavior change) that splits the table-agnostic task functionality into `BaseTask` so it can be moved to `grants_shared` later, leaving the `JobLog`-coupled `Task` here in the API.

## Validation steps

Confirm full test suite passes.