### PR TITLE
[Unticketed] Remove PerformanceSite Form references from local seed and build opportunities script

### DIFF
--- a/api/src/task/opportunities/build_automatic_opportunities.py
+++ b/api/src/task/opportunities/build_automatic_opportunities.py
@@ -46,7 +46,6 @@ from src.form_schema.forms import (
     ProjectAbstract_v1_2,
     ProjectAbstractSummary_v2_0,
     ProjectNarrativeAttachment_v1_2,
-    ProjectPerformanceSiteLocation_v4_0,
     SF424_v4_0,
     SF424a_v1_0,
     SF424b_v1_1,
@@ -621,12 +620,6 @@ class BuildAutomaticOpportunitiesTask(Task):
                 "Project Narrative Attachment Form",
                 ProjectNarrativeAttachment_v1_2.form_id,
                 "6bdc2df3-6e51-4aea-89af-bade326feba1",
-            ),
-            (
-                "E2E-PPSL",
-                "Project Performance Site Location(s)",
-                ProjectPerformanceSiteLocation_v4_0.form_id,
-                "8a30cbe2-f297-49b7-b996-fc22982a3eb5",
             ),
             (
                 "E2E-SF424",

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -570,13 +570,6 @@ def _build_custom_test_competitions(forms: dict[str, Form]) -> None:
             "3219b68b-c3c5-41d8-b889-d75eafd014d5",
         ),
         (
-            "PerformanceSite",
-            "E2E-PPSL",
-            "Project Performance Site Location(s)",
-            "8a30cbe2-f297-49b7-b996-fc22982a3eb5",
-            "7fc52d4e-6efb-421d-8b0a-8c9e982f1e0f",
-        ),
-        (
             "SF424_4_0",
             "E2E-SF424",
             "Application for Federal Assistance (SF-424)",

--- a/api/tests/src/task/opportunities/test_build_automatic_opportunities.py
+++ b/api/tests/src/task/opportunities/test_build_automatic_opportunities.py
@@ -63,7 +63,7 @@ def test_build_automatic_opportunities(enable_factory_create, db_session, forms)
 
     # Grab the opportunities created from the task itself
     opportunities = task.opportunities
-    assert len(opportunities) == 38
+    assert len(opportunities) == 37
 
     # Figure out the forms we added to each opportunity
     opp_form_ids_for_opps = set()
@@ -80,7 +80,7 @@ def test_build_automatic_opportunities(enable_factory_create, db_session, forms)
     # There should also be one opportunity with every form
     assert all_form_ids in opp_form_ids_for_opps
 
-    assert task.metrics[task.Metrics.OPPORTUNITY_CREATED_COUNT] == 38
+    assert task.metrics[task.Metrics.OPPORTUNITY_CREATED_COUNT] == 37
     assert task.metrics[task.Metrics.OPPORTUNITY_ALREADY_EXIST_COUNT] == 0
 
     # If we rerun the task, all opportunities should be skipped (including ALL-forms)
@@ -90,7 +90,7 @@ def test_build_automatic_opportunities(enable_factory_create, db_session, forms)
     assert len(task.opportunities) == 0
 
     assert task.metrics[task.Metrics.OPPORTUNITY_CREATED_COUNT] == 0
-    assert task.metrics[task.Metrics.OPPORTUNITY_ALREADY_EXIST_COUNT] == 38
+    assert task.metrics[task.Metrics.OPPORTUNITY_ALREADY_EXIST_COUNT] == 37
 
 
 def test_opportunity_ids_are_consistent_across_runs(enable_factory_create, db_session, forms):
@@ -143,7 +143,6 @@ def test_opportunity_ids_are_consistent_across_runs(enable_factory_create, db_se
         "E2E-PABS-ORG-IND-01": uuid.UUID("d3081452-2cf8-4817-9abf-812e5d794485"),
         "E2E-PABSS-ORG-IND-01": uuid.UUID("e3bfbd7b-2205-46a8-9aa3-714f7e130958"),
         "E2E-PNA-ORG-IND-01": uuid.UUID("6bdc2df3-6e51-4aea-89af-bade326feba1"),
-        "E2E-PPSL-ORG-IND-01": uuid.UUID("8a30cbe2-f297-49b7-b996-fc22982a3eb5"),
         "E2E-SF424-ORG-IND-01": uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
         "E2E-SF424A-ORG-IND-01": uuid.UUID("6c25cd41-660e-473f-abff-654083b7795d"),
         "E2E-SF424B-ORG-IND-01": uuid.UUID("dbd8b2c4-0d6b-48b6-9427-32ee7795f4d6"),


### PR DESCRIPTION
## Summary
Alerts-infra-lower-envs reported a failure for the `build-automatic-opportunities` task in staging for the form `ProjectPerformanceSiteLocation_v4_0` (form ID: `6ebd786f-cccf-4ee1-a100-61436975025b`), as it is not available in staging yet. This PR resolves that issue by removing references to ProjectPerformanceSiteLocation form from the local seed and build opportunities script. 

## Changes proposed
Remove references to ProjectPerformanceSiteLocation form from /build_automatic_opportunities.py and seed_local_db.py
Update test_build_automatic_opportunities.py to reflect the changes above.

