### PR TITLE
BULK UPDATE POC endpoint for upcoming award recommendation submission details

### DIFF
--- a/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
@@ -30,6 +30,8 @@ from src.api.award_recommendations_alpha.award_recommendation_schemas import (
     AwardRecommendationSubmissionListRequestSchema,
     AwardRecommendationSubmissionListResponseSchema,
     AwardRecommendationUpdateRequestSchema,
+    AwardRecommendationSubmissionDetailBulkUpdateRequestSchema,
+    AwardRecommendationSubmissionDetailBulkUpdateResponseSchema,
 )
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.services.award_recommendations.create_award_recommendation import (
@@ -71,6 +73,9 @@ from src.services.award_recommendations.update_award_recommendation_risk import 
 )
 from src.services.award_recommendations.update_award_recommendation_submissions import (
     update_award_recommendation_submissions,
+)
+from src.services.award_recommendations.bulk_update_award_recommendation_submission_details import (
+    bulk_update_award_recommendation_submission_details,
 )
 
 logger = logging.getLogger(__name__)
@@ -547,3 +552,67 @@ def award_recommendation_delete(
         delete_award_recommendation(db_session, user, award_recommendation_id)
 
     return response.ApiResponse(message="Success", data=None)
+
+@award_recommendation_blueprint.put(
+    "/award-recommendations/submission-details/bulk"
+)
+@award_recommendation_blueprint.input(
+    AwardRecommendationSubmissionDetailBulkUpdateRequestSchema,
+    location="json",
+)
+@award_recommendation_blueprint.output(
+    AwardRecommendationSubmissionDetailBulkUpdateResponseSchema
+)
+@award_recommendation_blueprint.doc(
+    summary="Bulk Update Award Recommendation Submission Details",
+    description=(
+        "Update award recommendation submission detail fields for multiple "
+        "award recommendations. Bulk fields are applied to every record, and "
+        "individual fields are applied per record."
+    ),
+    responses=[200, 401, 403, 404, 422],
+)
+@award_recommendation_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def award_recommendation_submission_detail_bulk_update(
+    db_session: db.Session,
+    json_data: dict,
+) -> response.ApiResponse:
+    record_ids = json_data["record_ids"]
+    bulk_field_updates = json_data["bulk_field_updates"]
+    individual_updates = json_data["individual_updates"]
+
+    logger.info("PUT /alpha/award-recommendations/submission-details/bulk")
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        updated_award_recommendations = (
+            bulk_update_award_recommendation_submission_details(
+                db_session=db_session,
+                user=user,
+                award_recommendation_submission_detail_ids=record_ids,
+                bulk_field_updates=bulk_field_updates,
+                individual_updates=individual_updates,
+            )
+        )
+
+    response_data = [
+        {
+            "award_recommendation_submission_detail_id": (
+                submission_detail.award_recommendation_submission_detail_id
+            ),
+            "award_recommendation_type": submission_detail.award_recommendation_type,
+            "has_exception": submission_detail.has_exception,
+            "general_comment": submission_detail.general_comment,
+            "exception_detail": submission_detail.exception_detail,
+            "recommended_amount": submission_detail.recommended_amount,
+        }
+        for submission_detail in updated_award_recommendations
+    ]
+
+    return response.ApiResponse(
+        message="Success",
+        data=response_data,
+    )

--- a/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
@@ -1,6 +1,7 @@
 from grants_shared.api.schemas.extension import Schema, fields
 from grants_shared.api.schemas.extension.field_validators import Length
 from grants_shared.api.schemas.response_schema import AbstractResponseSchema
+from marshmallow import ValidationError, validates_schema
 from grants_shared.api.schemas.search_schema import (
     BoolSearchSchemaBuilder,
     StrSearchSchemaBuilder,
@@ -870,3 +871,137 @@ class AwardRecommendationAuditResponseSchema(AbstractResponseSchema, PaginationM
     """Schema for POST /alpha/award-recommendations/:award_recommendation_id/audit_history response"""
 
     data = fields.List(fields.Nested(AwardRecommendationAuditDataSchema()))
+
+class AwardRecommendationSubmissionDetailBulkUpdateFieldsSchema(Schema):
+    """Fields applied to every selected award recommendation submission detail."""
+
+    award_recommendation_type = fields.Enum(
+        AwardRecommendationType,
+        allow_none=True,
+        metadata={"description": "The recommendation type for this submission"},
+    )
+
+    has_exception = fields.Boolean(
+        required=True,
+        metadata={"description": "Whether the recommendation has an exception."},
+    )
+
+    general_comment = fields.String(
+        allow_none=True,
+        required=True,
+        metadata={"description": "General comment for the recommendation."},
+    )
+
+    exception_detail = fields.String(
+        allow_none=True,
+        required=True,
+        metadata={"description": "Exception detail for the recommendation."},
+    )
+
+
+class AwardRecommendationSubmissionDetailIndividualUpdateFieldsSchema(Schema):
+    """Fields applied individually by award recommendation ID."""
+
+    recommended_amount = fields.Decimal(
+        required=True,
+        as_string=True,
+        metadata={"description": "Recommended amount for this award recommendation."},
+    )
+
+class AwardRecommendationSubmissionDetailBulkUpdateRequestSchema(Schema):
+    """Schema for PUT /alpha/award-recommendations/submission-details/bulk request."""
+
+    record_ids = fields.List(
+        fields.UUID(),
+        required=True,
+        metadata={
+            "description": "Award recommendation IDs to update.",
+        },
+    )
+
+    bulk_field_updates = fields.Nested(
+        AwardRecommendationSubmissionDetailBulkUpdateFieldsSchema,
+        required=True,
+        metadata={
+            "description": "Fields applied to every selected award recommendation.",
+        },
+    )
+
+    individual_updates = fields.Dict(
+        keys=fields.UUID(),
+        values=fields.Nested(
+            AwardRecommendationSubmissionDetailIndividualUpdateFieldsSchema
+        ),
+        required=True,
+        metadata={
+            "description": (
+                "Per-record updates keyed by award recommendation ID. "
+                "Each record ID must also be present in record_ids."
+            ),
+        },
+    )
+
+    @validates_schema
+    def validate_record_ids_match_individual_updates(self, data, **kwargs):
+        record_ids = set(data.get("record_ids", []))
+        individual_update_ids = set(data.get("individual_updates", {}).keys())
+
+        missing_ids = record_ids - individual_update_ids
+        unexpected_ids = individual_update_ids - record_ids
+
+        errors = {}
+
+        if missing_ids:
+            errors["individual_updates"] = [
+                "Missing individual updates for record IDs: "
+                f"{sorted(str(id_) for id_ in missing_ids)}"
+            ]
+
+        if unexpected_ids:
+            errors["individual_updates"] = [
+                *errors.get("individual_updates", []),
+                "Individual updates provided for IDs not present in record_ids: "
+                f"{sorted(str(id_) for id_ in unexpected_ids)}",
+            ]
+
+        if errors:
+            raise ValidationError(errors)
+        
+class AwardRecommendationSubmissionDetailBulkUpdateResultSchema(Schema):
+    award_recommendation_submission_detail_id = fields.UUID(
+        required=True,
+        metadata={"description": "The updated award recommendation submission detail ID."},
+    )
+
+    award_recommendation_type = fields.Enum(
+        AwardRecommendationType,
+        allow_none=True,
+        metadata={"description": "The recommendation type for this submission"},
+    )
+
+    has_exception = fields.Boolean(required=True)
+
+    general_comment = fields.String(
+        allow_none=True,
+        required=True,
+    )
+
+    exception_detail = fields.String(
+        allow_none=True,
+        required=True,
+    )
+
+    recommended_amount = fields.Decimal(
+        required=True,
+        as_string=True,
+    )
+
+
+class AwardRecommendationSubmissionDetailBulkUpdateResponseSchema(AbstractResponseSchema):
+    data = fields.List(
+        fields.Nested(AwardRecommendationSubmissionDetailBulkUpdateResultSchema),
+        required=True,
+        metadata={
+            "description": "Updated award recommendation submission detail records.",
+        },
+    )

--- a/api/src/services/award_recommendations/bulk_update_award_recommendation_submission_details.py
+++ b/api/src/services/award_recommendations/bulk_update_award_recommendation_submission_details.py
@@ -1,0 +1,92 @@
+import logging
+import uuid
+
+import grants_shared.adapters.db as db
+from sqlalchemy import select
+
+from src.auth.endpoint_access_util import verify_access
+from src.constants.lookup_constants import Privilege
+from src.db.models.award_recommendation_models import (
+    AwardRecommendationApplicationSubmission,
+    AwardRecommendationSubmissionDetail,
+)
+from src.db.models.user_models import User
+
+logger = logging.getLogger(__name__)
+
+
+def bulk_update_award_recommendation_submission_details(
+    db_session: db.Session,
+    user: User,
+    award_recommendation_submission_detail_ids: list[uuid.UUID],
+    bulk_field_updates: dict,
+    individual_updates: dict[uuid.UUID, dict],
+) -> list[AwardRecommendationSubmissionDetail]:
+    """
+    Bulk update award recommendation submission details.
+
+    All bulk fields are required and applied to every submission detail record.
+    All individual fields are required per submission detail record.
+    """
+
+    requested_ids = set(award_recommendation_submission_detail_ids)
+    individual_update_ids = set(individual_updates.keys())
+
+    missing_individual_ids = requested_ids - individual_update_ids
+    if missing_individual_ids:
+        raise ValueError(
+            "Missing individual updates for award recommendation submission detail IDs: "
+            f"{sorted(str(id_) for id_ in missing_individual_ids)}"
+        )
+
+    unexpected_individual_ids = individual_update_ids - requested_ids
+    if unexpected_individual_ids:
+        raise ValueError(
+            "Individual updates provided for records not included in "
+            "award_recommendation_submission_detail_ids: "
+            f"{sorted(str(id_) for id_ in unexpected_individual_ids)}"
+        )
+
+    updated_submission_details: list[AwardRecommendationSubmissionDetail] = []
+
+    for submission_detail_id in award_recommendation_submission_detail_ids:
+        xref = db_session.execute(
+            select(AwardRecommendationApplicationSubmission).where(
+                AwardRecommendationApplicationSubmission.award_recommendation_submission_detail_id
+                == submission_detail_id
+            )
+        ).scalar_one_or_none()
+
+        if xref is None:
+            raise ValueError(
+                f"Award recommendation submission detail {submission_detail_id} "
+                "is not linked to an award recommendation application submission"
+            )
+
+        award_recommendation = xref.award_recommendation
+        agency = award_recommendation.opportunity.agency_record
+
+        verify_access(
+            user,
+            {Privilege.UPDATE_AWARD_RECOMMENDATION},
+            agency,
+        )
+
+        submission_detail = xref.award_recommendation_submission_detail
+
+        submission_detail.award_recommendation_type = (
+            bulk_field_updates["award_recommendation_type"]
+        )
+        submission_detail.has_exception = bulk_field_updates["has_exception"]
+        submission_detail.general_comment = bulk_field_updates["general_comment"]
+        submission_detail.exception_detail = bulk_field_updates["exception_detail"]
+        submission_detail.recommended_amount = individual_updates[
+            submission_detail_id
+        ]["recommended_amount"]
+
+        db_session.add(submission_detail)
+        updated_submission_details.append(submission_detail)
+
+    db_session.flush()
+
+    return updated_submission_details

--- a/api/tests/src/api/award_recommendations/test_bulk_update_award_recommendation_submission_details.py
+++ b/api/tests/src/api/award_recommendations/test_bulk_update_award_recommendation_submission_details.py
@@ -1,0 +1,202 @@
+import pytest
+from decimal import Decimal
+from src.constants.lookup_constants import (
+    AwardRecommendationAuditEvent,
+    AwardRecommendationStatus,
+    AwardRecommendationType,
+    Privilege,
+)
+from src.db.models.opportunity_models import Opportunity
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    ApplicationFactory,
+    ApplicationSubmissionFactory,
+    AwardRecommendationApplicationSubmissionFactory,
+    AwardRecommendationFactory,
+    AwardRecommendationSubmissionDetailFactory,
+    CompetitionFactory,
+    OpportunityFactory,
+)
+
+API_URL = "/alpha/award-recommendations"
+
+
+####################################
+# Fixtures
+####################################
+
+
+@pytest.fixture
+def agency(enable_factory_create):
+    return AgencyFactory.create()
+
+
+@pytest.fixture
+def opportunity(agency) -> Opportunity:
+    return OpportunityFactory.create(agency_code=agency.agency_code)
+
+
+####################################
+# Happy Path Test
+####################################
+
+
+class TestBulkUpdateAwardRecommendationSubmissionDetails200:
+
+    def test_bulk_update_award_recommendation_submission_details_by_detail_id_200(
+        self,
+        client,
+        db_session,
+        agency,
+        opportunity,
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[
+                Privilege.UPDATE_AWARD_RECOMMENDATION,
+                Privilege.VIEW_AWARD_RECOMMENDATION,
+            ],
+        )
+
+        competition_1 = CompetitionFactory.create(opportunity=opportunity)
+        competition_2 = CompetitionFactory.create(opportunity=opportunity)
+
+        application_1 = ApplicationFactory.create(competition=competition_1)
+        application_2 = ApplicationFactory.create(competition=competition_2)
+
+        application_submission_1 = ApplicationSubmissionFactory.create(
+            application=application_1,
+            total_requested_amount=Decimal("1000.00"),
+        )
+
+        application_submission_2 = ApplicationSubmissionFactory.create(
+            application=application_2,
+            total_requested_amount=Decimal("2000.00"),
+        )
+
+        award_recommendation_1 = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_status=AwardRecommendationStatus.IN_REVIEW,
+            is_deleted=False,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+
+        award_recommendation_2 = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_status=AwardRecommendationStatus.IN_REVIEW,
+            is_deleted=False,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+
+        submission_detail_1 = AwardRecommendationSubmissionDetailFactory.create(
+            award_recommendation_type=AwardRecommendationType.NOT_RECOMMENDED,
+            has_exception=False,
+            general_comment="Original general comment 1",
+            exception_detail="Original exception detail 1",
+            recommended_amount=Decimal("100.00"),
+        )
+
+        submission_detail_2 = AwardRecommendationSubmissionDetailFactory.create(
+            award_recommendation_type=AwardRecommendationType.NOT_RECOMMENDED,
+            has_exception=False,
+            general_comment="Original general comment 2",
+            exception_detail="Original exception detail 2",
+            recommended_amount=Decimal("200.00"),
+        )
+
+        AwardRecommendationApplicationSubmissionFactory.create(
+            award_recommendation=award_recommendation_1,
+            application_submission=application_submission_1,
+            award_recommendation_submission_detail=submission_detail_1,
+        )
+
+        AwardRecommendationApplicationSubmissionFactory.create(
+            award_recommendation=award_recommendation_2,
+            application_submission=application_submission_2,
+            award_recommendation_submission_detail=submission_detail_2,
+        )
+
+        update_data = {
+            "record_ids": [
+                str(submission_detail_1.award_recommendation_submission_detail_id),
+                str(submission_detail_2.award_recommendation_submission_detail_id),
+            ],
+            "bulk_field_updates": {
+                "award_recommendation_type": AwardRecommendationType.RECOMMENDED_FOR_FUNDING,
+                "has_exception": True,
+                "general_comment": "Updated general comment",
+                "exception_detail": "Updated exception detail",
+            },
+            "individual_updates": {
+                str(submission_detail_1.award_recommendation_submission_detail_id): {
+                    "recommended_amount": 500000,
+                },
+                str(submission_detail_2.award_recommendation_submission_detail_id): {
+                    "recommended_amount": 1000000,
+                },
+            },
+        }
+
+        resp = client.put(
+            f"{API_URL}/submission-details/bulk",
+            json=update_data,
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 200
+
+        data = resp.json["data"]
+        assert len(data) == 2
+
+        response_by_id = {
+            item["award_recommendation_submission_detail_id"]: item
+            for item in data
+        }
+
+        detail_1_data = response_by_id[
+            str(submission_detail_1.award_recommendation_submission_detail_id)
+        ]
+        detail_2_data = response_by_id[
+            str(submission_detail_2.award_recommendation_submission_detail_id)
+        ]
+
+        assert detail_1_data["award_recommendation_type"] == AwardRecommendationType.RECOMMENDED_FOR_FUNDING
+        assert detail_1_data["has_exception"] is True
+        assert detail_1_data["general_comment"] == "Updated general comment"
+        assert detail_1_data["exception_detail"] == "Updated exception detail"
+        assert detail_1_data["recommended_amount"] in [
+            500000,
+            "500000",
+            "500000.00",
+        ]
+
+        assert detail_2_data["award_recommendation_type"] == AwardRecommendationType.RECOMMENDED_FOR_FUNDING
+        assert detail_2_data["has_exception"] is True
+        assert detail_2_data["general_comment"] == "Updated general comment"
+        assert detail_2_data["exception_detail"] == "Updated exception detail"
+        assert detail_2_data["recommended_amount"] in [
+            1000000,
+            "1000000",
+            "1000000.00",
+        ]
+
+        db_session.refresh(submission_detail_1)
+        db_session.refresh(submission_detail_2)
+        db_session.refresh(award_recommendation_1)
+        db_session.refresh(award_recommendation_2)
+
+        assert submission_detail_1.award_recommendation_type == AwardRecommendationType.RECOMMENDED_FOR_FUNDING
+        assert submission_detail_1.has_exception is True
+        assert submission_detail_1.general_comment == "Updated general comment"
+        assert submission_detail_1.exception_detail == "Updated exception detail"
+        assert submission_detail_1.recommended_amount == 500000
+
+        assert submission_detail_2.award_recommendation_type == AwardRecommendationType.RECOMMENDED_FOR_FUNDING
+        assert submission_detail_2.has_exception is True
+        assert submission_detail_2.general_comment == "Updated general comment"
+        assert submission_detail_2.exception_detail == "Updated exception detail"
+        assert submission_detail_2.recommended_amount == 1000000


### PR DESCRIPTION
# Add Bulk Update Endpoint for Award Recommendation Submission Details

## Summary

This PR introduces an initial bulk update endpoint for `AwardRecommendationSubmissionDetail` records. It is only meant to explore how bulk updates can work and be referenced by an upcoming tech spec doc. No authorization or other safety checks are implemented at this point.

The endpoint supports applying a common set of fields across multiple submission detail records while allowing `recommended_amount` to be specified individually per record.

### New Endpoint

`PUT /alpha/award-recommendations/submission-details/bulk`

Example request:

```json
{
  "record_ids": [
    "11d313ee-cbcf-4dd3-8777-5fcf788422a0",
    "c36824d7-81df-44f3-b312-8623f2c458bb"
  ],
  "bulk_field_updates": {
    "award_recommendation_type": "recommended_for_funding",
    "has_exception": true,
    "general_comment": "Recommended for funding based on panel review.",
    "exception_detail": "Funding exceeds standard threshold."
  },
  "individual_updates": {
    "11d313ee-cbcf-4dd3-8777-5fcf788422a0": {
      "recommended_amount": "500000.00"
    },
    "c36824d7-81df-44f3-b312-8623f2c458bb": {
      "recommended_amount": "1000000.00"
    }
  }
}
```

## Changes Included

* Added bulk update endpoint for `AwardRecommendationSubmissionDetail`
* Added request and response schemas
* Added service logic to update:

  * `award_recommendation_type`
  * `has_exception`
  * `general_comment`
  * `exception_detail`
  * `recommended_amount`
* Added happy-path integration test coverage
* Supports updating multiple submission detail records in a single request

## Current Limitations / Follow-Up Work

This implementation is intended as an initial proof of concept and does not yet include all expected validation and authorization checks.

### Authorization

The endpoint currently does not perform record-level authorization checks.

Future work should verify that the requesting user has appropriate access to all records being updated.

### Record Relationship Validation

The endpoint currently updates the provided submission detail IDs independently.

Future work should validate assumptions about record relationships, including:

* Whether all submission detail records belong to the same award recommendation submission
* Whether all records belong to the same opportunity
* Whether mixed-agency updates should be prohibited
* Whether additional business rules should be enforced before allowing bulk updates

### Audit History

The endpoint currently does not create audit records for submission detail updates.

Future work should determine the appropriate audit model/event and add audit history tracking.

### Additional Validation

The endpoint currently validates request structure through the API schema but does not yet enforce all business-level validation rules.

Additional validation requirements should be identified as business workflows are finalized.

## Testing

Added happy-path integration coverage verifying:

* Multiple submission detail records can be updated in a single request
* Bulk fields are applied to all selected records
* Individual recommended amounts are applied correctly
* Database state reflects the requested updates
