### PR TITLE
[Unticketed] Fix path of presigned urls locally

### DIFF
--- a/api/src/util/file_util.py
+++ b/api/src/util/file_util.py
@@ -154,7 +154,7 @@ def pre_sign_upload(
 
     metadata_fields = {f"x-amz-meta-{k}": v for k, v in metadata.items()}
 
-    return s3_client.generate_presigned_post(
+    presigned_post_result = s3_client.generate_presigned_post(
         Bucket=bucket,
         Key=key,
         Fields={"Content-Type": content_type, **metadata_fields},
@@ -166,6 +166,16 @@ def pre_sign_upload(
         ],
         ExpiresIn=s3_config.presigned_s3_duration,
     )
+
+    # When running locally, swap out the presigned url to replace s3mock with localhost
+    # We never set the endpoint url non-locally, this is local-only.
+    if s3_config.aws_s3_endpoint_url:
+        # Only relevant when local, due to docker path issues
+        presigned_post_result["url"] = presigned_post_result.get("url", "").replace(
+            s3_config.aws_s3_endpoint_url, "http://localhost:9090"
+        )
+
+    return presigned_post_result
 
 
 def get_file_length_bytes(path: str) -> int:

--- a/api/tests/src/util/test_file_util.py
+++ b/api/tests/src/util/test_file_util.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from urllib.parse import parse_qs, urlparse
 
 import boto3
@@ -283,3 +284,22 @@ def test_pre_sign_file_location_uses_configured_duration(mock_s3_bucket):
 
     query = parse_qs(urlparse(url).query)
     assert int(query["X-Amz-Expires"][0]) == 900
+
+
+def test_presigned_post_local_override_with_s3_endpoint_url(mock_s3_bucket, s3_config):
+    file_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    s3_config.aws_s3_endpoint_url = "http://mocks3:9090"
+
+    result = file_util.pre_sign_upload(
+        file_path=f"s3://{mock_s3_bucket}/some/file.txt",
+        content_type="text/plain",
+        metadata={
+            "file-id": str(file_id),
+            "user-id": str(user_id),
+        },
+        s3_config=s3_config,
+    )
+
+    assert result["url"].startswith("http://localhost:9090")


### PR DESCRIPTION
## Summary

## Changes proposed
* Fix the s3 path for presigned uploads for

## Context for reviewers
We do this for presigned downloads already. This works around a problem where when our API interacts with s3 locally, it interacts with `http://s3mock:9090/...` but outside of Docker, it should be interacting with `http://localhost:9090/...`. This is purely for local dev, and won't be used anywhere else.

## Validation steps
Locally, instead of getting the s3mock url back from the POST files endpoint, I get localhost as expected:
<img width="1351" height="408" alt="Screenshot 2026-06-16 at 12 20 25 PM" src="https://github.com/user-attachments/assets/83596f18-5294-4eaf-884b-471f76a350c6" />
