### PR TITLE
[Issue #10766] Modify our load opportunities / load agencies to search index jobs to not fail if the cluster is snapshotting when we delete

### DIFF
--- a/api/src/adapters/search/opensearch_client.py
+++ b/api/src/adapters/search/opensearch_client.py
@@ -5,11 +5,25 @@ from typing import Any
 import boto3
 import opensearchpy
 from grants_shared.logs.flask_logger import add_extra_data_to_current_request_logs
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_fixed
 
 from src.adapters.search.opensearch_config import OpensearchConfig, get_opensearch_config
 from src.adapters.search.opensearch_response import SearchResponse
 
 logger = logging.getLogger(__name__)
+
+# OpenSearch automatically snapshots our indexes hourly. An index that is
+# actively being snapshotted cannot be deleted and OpenSearch returns a 400
+# RequestError with this error type.
+SNAPSHOT_IN_PROGRESS_ERROR = "snapshot_in_progress_exception"
+
+
+def _is_snapshot_in_progress_error(exception: BaseException) -> bool:
+    return (
+        isinstance(exception, opensearchpy.exceptions.RequestError)
+        and exception.error == SNAPSHOT_IN_PROGRESS_ERROR
+    )
+
 
 # By default, we'll override the default analyzer+tokenization
 # for a search index. You can provide your own when calling create_index
@@ -77,8 +91,30 @@ class SearchClient:
     def delete_index(self, index_name: str) -> None:
         """
         Delete an index. Can also delete all indexes via a prefix.
+
+        If the index is being snapshotted, OpenSearch refuses the delete. We retry
+        a few times to wait out a short snapshot, and if it is still in progress we
+        skip the delete rather than fail the job -- the next run of the load job
+        deletes all stale indexes, so the leftover index gets cleaned up then.
         """
         logger.info("Deleting search index %s", index_name, extra={"index_name": index_name})
+        try:
+            self._delete_index_with_retry(index_name)
+        except opensearchpy.exceptions.RequestError as e:
+            if not _is_snapshot_in_progress_error(e):
+                raise
+            logger.info(
+                "Skipping search index delete, snapshot in progress",
+                extra={"index_name": index_name},
+            )
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(2),
+        retry=retry_if_exception(_is_snapshot_in_progress_error),
+        reraise=True,
+    )
+    def _delete_index_with_retry(self, index_name: str) -> None:
         self._client.indices.delete(index=index_name)
 
     def bulk_upsert(

--- a/api/tests/src/adapters/search/test_opensearch_client.py
+++ b/api/tests/src/adapters/search/test_opensearch_client.py
@@ -1,10 +1,12 @@
+import logging
 import uuid
+from unittest import mock
 
 import opensearchpy
 import pytest
 
 from src.adapters.search import get_opensearch_config
-from src.adapters.search.opensearch_client import _get_connection_parameters
+from src.adapters.search.opensearch_client import SearchClient, _get_connection_parameters
 from tests.src.adapters.search.test_opensearch_query_builder import (
     CALL_OF_WINTER,
     WINTER,
@@ -46,6 +48,87 @@ def test_create_and_delete_index_duplicate(search_client):
     search_client.delete_index(index_name)
     with pytest.raises(Exception, match="no such index"):
         search_client.delete_index(index_name)
+
+
+def _snapshot_in_progress_error() -> opensearchpy.exceptions.RequestError:
+    return opensearchpy.exceptions.RequestError(
+        400,
+        "snapshot_in_progress_exception",
+        {"error": {"reason": "Cannot delete indices that are being snapshotted: [[some-index]]."}},
+    )
+
+
+@pytest.fixture
+def instant_delete_retries(monkeypatch):
+    # Avoid real waits between retries in delete_index
+    monkeypatch.setattr(
+        SearchClient._delete_index_with_retry.retry, "sleep", lambda *args, **kwargs: None
+    )
+
+
+def test_delete_index_snapshot_in_progress_is_skipped(
+    search_client, monkeypatch, instant_delete_retries, caplog
+):
+    caplog.set_level(logging.INFO)
+    index_name = f"test-index-{uuid.uuid4().int}"
+    search_client.create_index(index_name)
+
+    delete_mock = mock.MagicMock(side_effect=_snapshot_in_progress_error())
+    monkeypatch.setattr(search_client._client.indices, "delete", delete_mock)
+
+    # A snapshot in progress should not fail the call
+    search_client.delete_index(index_name)
+
+    # Retried up to the max attempts before giving up
+    assert delete_mock.call_count == 3
+
+    skip_logs = [
+        r
+        for r in caplog.records
+        if r.message == "Skipping search index delete, snapshot in progress"
+    ]
+    assert len(skip_logs) == 1
+    assert skip_logs[0].index_name == index_name
+
+
+def test_delete_index_succeeds_after_snapshot_clears(
+    search_client, monkeypatch, instant_delete_retries
+):
+    index_name = f"test-index-{uuid.uuid4().int}"
+    search_client.create_index(index_name)
+
+    real_delete = search_client._client.indices.delete
+    call_count = 0
+
+    def flaky_delete(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise _snapshot_in_progress_error()
+        return real_delete(*args, **kwargs)
+
+    monkeypatch.setattr(search_client._client.indices, "delete", flaky_delete)
+
+    search_client.delete_index(index_name)
+
+    assert call_count == 3
+    assert search_client.index_exists(index_name) is False
+
+
+def test_delete_index_other_request_error_is_raised(
+    search_client, monkeypatch, instant_delete_retries
+):
+    index_name = f"test-index-{uuid.uuid4().int}"
+
+    other_error = opensearchpy.exceptions.RequestError(400, "some_other_exception", {})
+    delete_mock = mock.MagicMock(side_effect=other_error)
+    monkeypatch.setattr(search_client._client.indices, "delete", delete_mock)
+
+    with pytest.raises(opensearchpy.exceptions.RequestError, match="some_other_exception"):
+        search_client.delete_index(index_name)
+
+    # Non-snapshot errors are not retried
+    assert delete_mock.call_count == 1
 
 
 def test_bulk_upsert(search_client, generic_index):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10766 

## Changes proposed

- Updated opensearch_client.py to retry `delete_index` on OpenSearch's `snapshot_in_progress_exception` (3 attempts, 2s apart), and if the index is still snapshotting after retries, log at info and skip the delete instead of failing. Added the `SNAPSHOT_IN_PROGRESS_ERROR` constant and `_is_snapshot_in_progress_error` to scope the handling to only that error.
- Updated test_opensearch_client.py to cover the new delete behavior: skip-after-retries-exhausted, success-when-the-snapshot-clears-mid-retry, and other `RequestErrors` still raising without retry.

## Context for reviewers

Both hourly search-index jobs (opportunities and agencies) delete the old index via `cleanup_old_indices` → `delete_index`, so fixing it in `delete_index` covers both. This intentionally changes delete behavior - a snapshotting index is now skipped rather than failing the job, which is safe because `cleanup_old_indices` deletes all stale indexes on the next run.

## Validation steps

Confirm tests pass.

We can't truly test this locally since a snapshot-in-progress cannot be reproduced locally. We will need to monitor alerts once this is merged. 