### PR TITLE
[Issue #10541] Add subtract_monetary rule to form rule engine

### DIFF
--- a/api/src/form_schema/rule_processing/README.md
+++ b/api/src/form_schema/rule_processing/README.md
@@ -95,6 +95,7 @@ rules currently implemented:
 * `public_competition_id` - from the competition
 * `competition_title` - from the competition
 * `sum_monetary` - calculated based on other fields in the JSON, see Monetary Summation section below for further details
+* `subtract_monetary` - calculated based on other fields in the JSON, see Monetary Subtraction section below for further details
 
 For post-population, this rule group is `gg_post_population` with the following
 rules currently implemented:
@@ -147,6 +148,25 @@ A few important details about our summation logic:
 NOTE: Only monetary summation is supported right now. All math done by this summing
 logic assumes the input values are strings of the format "0.00". If we need to support
 summing integers or other numeric types, we'll need to add a separate rule for those.
+
+## Monetary Subtraction
+We support the ability to subtract monetary amounts from each other. This rule
+requires that you specify which fields to subtract like so:
+```json
+{
+  "my_field": {
+    "gg_pre_population": {
+      "rule": "subtract_monetary",
+      "fields": ["@THIS.a", "@THIS.b"]
+    }
+  }
+}
+```
+
+This mirrors `sum_monetary`, but and every subsequent field is subtracted from the first. 
+The example above produces `a - b`, and fields of `["a", "b", "c"]` would produce `a - b - c`.
+
+For details on how the fields parameter works, see the Fields section below.
 
 ## Fields
 Some rules like our `sum_monetary` rule allow you to specify fields that

--- a/api/src/form_schema/rule_processing/README.md
+++ b/api/src/form_schema/rule_processing/README.md
@@ -163,7 +163,7 @@ requires that you specify which fields to subtract like so:
 }
 ```
 
-This mirrors `sum_monetary`, but and every subsequent field is subtracted from the first. 
+This mirrors `sum_monetary`, but every subsequent field is subtracted from the first. 
 The example above produces `a - b`, and fields of `["a", "b", "c"]` would produce `a - b - c`.
 
 For details on how the fields parameter works, see the Fields section below.

--- a/api/src/form_schema/rule_processing/json_rule_field_population.py
+++ b/api/src/form_schema/rule_processing/json_rule_field_population.py
@@ -183,6 +183,47 @@ def sum_monetary_values(context: JsonRuleContext, json_rule: JsonRule) -> str:
     return str(quantize_decimal(result))
 
 
+def subtract_monetary_values(context: JsonRuleContext, json_rule: JsonRule) -> str:
+    """Subtract monetary amounts based on configuration
+
+    Mirrors sum_monetary, but the first field is the minuend and every
+    subsequent field is subtracted from it (fields ["a", "b", "c"] produces
+    a - b - c). Each field is resolved the same way as sum_monetary.
+
+    Value returned is a string of format "0.00" with two decimal points.
+    """
+    fields = json_rule.rule.get("fields", [])
+
+    result = ZERO_DECIMAL
+    for index, field in enumerate(fields):
+        # Resolve each field on its own so a missing field keeps its position
+        # (treated as 0.00) rather than collapsing the operands of the subtraction.
+        field_total = ZERO_DECIMAL
+        for value in get_field_values(context.json_data, [field], json_rule.path):
+            if value is None:
+                continue
+
+            # If a field cannot be converted to a monetary amount, we just
+            # won't include it in the amount. These fields should have validation
+            # on them that would flag it to a user.
+            try:
+                field_total += convert_monetary_field(value)
+            except ValueError:
+                logger.info(
+                    "Cannot convert monetary amount entered", extra=json_rule.get_log_context()
+                )
+                continue
+
+        # Every subsequent field is subtracted from the first field.
+        if index == 0:
+            result += field_total
+        else:
+            result -= field_total
+
+    # Make the value always contain 2 values after the decimal.
+    return str(quantize_decimal(result))
+
+
 population_func = Callable[[JsonRuleContext, JsonRule], Any]
 
 PRE_POPULATION_MAPPER: dict[str, population_func] = {
@@ -195,6 +236,7 @@ PRE_POPULATION_MAPPER: dict[str, population_func] = {
     "public_competition_id": get_public_competition_id,
     "competition_title": get_competition_title,
     "sum_monetary": sum_monetary_values,
+    "subtract_monetary": subtract_monetary_values,
 }
 
 POST_POPULATION_MAPPER: dict[str, population_func] = {

--- a/api/tests/src/form_schema/rule_processing/test_json_rule_field_population.py
+++ b/api/tests/src/form_schema/rule_processing/test_json_rule_field_population.py
@@ -169,6 +169,109 @@ def test_handle_field_population_pre_population_sum_monetary_not_a_monetary_amou
 
 
 @pytest.mark.parametrize(
+    "rule,json_data,expected_value",
+    [
+        # Specifying no fields will get the default of 0
+        ({"rule": "subtract_monetary", "fields": []}, {}, "0.00"),
+        # Specifying fields that aren't set will get the default of 0
+        ({"rule": "subtract_monetary", "fields": ["x", "y", "z"]}, {}, "0.00"),
+        # Can subtract the second field from the first
+        ({"rule": "subtract_monetary", "fields": ["x", "y"]}, {"x": "5.43", "y": "2.61"}, "2.82"),
+        # Every subsequent field is subtracted from the first
+        (
+            {"rule": "subtract_monetary", "fields": ["x", "y", "z"]},
+            {"x": "10.00", "y": "2.50", "z": "1.25"},
+            "6.25",
+        ),
+        # A missing first field (minuend) is treated as 0.00
+        ({"rule": "subtract_monetary", "fields": ["x", "y"]}, {"y": "5.00"}, "-5.00"),
+        # A missing subsequent field (subtrahend) is treated as 0.00
+        ({"rule": "subtract_monetary", "fields": ["x", "y"]}, {"x": "5.00"}, "5.00"),
+        # Can fetch and subtract nested fields
+        (
+            {"rule": "subtract_monetary", "fields": ["x.nested_field", "y.other_field.z"]},
+            {"x": {"nested_field": "10.23"}, "y": {"other_field": {"z": "4"}}},
+            "6.23",
+        ),
+        # Can fetch from arrays, array values for a single field are summed first
+        (
+            {"rule": "subtract_monetary", "fields": ["x[*].z", "y"]},
+            {"x": [{"z": "10000.11"}, {"z": "200.33"}], "y": "56.70"},
+            "10143.74",
+        ),
+        # Can fetch from relative paths
+        (
+            {"rule": "subtract_monetary", "fields": ["@THIS.x", "@THIS.y"]},
+            {"x": "101.01", "y": "0.23"},
+            "100.78",
+        ),
+        # Result can be negative
+        (
+            {"rule": "subtract_monetary", "fields": ["x", "y"]},
+            {"x": "10.01", "y": "21.50"},
+            "-11.49",
+        ),
+        # Can handle negative inputs (subtracting a negative adds)
+        (
+            {"rule": "subtract_monetary", "fields": ["x", "y"]},
+            {"x": "10.01", "y": "-21.50"},
+            "31.51",
+        ),
+        # Subtracting equal values results in zero
+        (
+            {"rule": "subtract_monetary", "fields": ["x", "y"]},
+            {"x": "250.00", "y": "250.00"},
+            "0.00",
+        ),
+        # Values will be quantized
+        (
+            {"rule": "subtract_monetary", "fields": ["x", "y"]},
+            {"x": "456.560000", "y": "123.010000"},
+            "333.55",
+        ),
+        # Handles the max range of a monetary field
+        (
+            {"rule": "subtract_monetary", "fields": ["x", "y"]},
+            {"x": "999999999999.99", "y": "0.01"},
+            "999999999999.98",
+        ),
+    ],
+)
+def test_handle_field_population_pre_population_subtract_monetary(
+    rule, json_data, expected_value, enable_factory_create
+):
+    context = setup_context(json_data, {"my_field": rule})
+    handle_field_population(
+        context,
+        JsonRule(handler="gg_pre_population", rule=rule, path=["my_field"]),
+        PRE_POPULATION_MAPPER,
+    )
+    assert context.json_data["my_field"] == expected_value
+
+
+@pytest.mark.parametrize(
+    "rule,json_data",
+    [
+        ({"rule": "subtract_monetary", "fields": ["x"]}, {"x": 100}),
+        ({"rule": "subtract_monetary", "fields": ["x"]}, {"x": {"y": "200.00"}}),
+        ({"rule": "subtract_monetary", "fields": ["x"]}, {"x": True}),
+        ({"rule": "subtract_monetary", "fields": ["x"]}, {"x": "hello"}),
+    ],
+)
+def test_handle_field_population_pre_population_subtract_monetary_not_a_monetary_amount(
+    rule, json_data, enable_factory_create
+):
+    # Non-monetary amounts will be skipped resulting in 0.00 for all of these scenarios.
+    context = setup_context(json_data, {"my_field": rule})
+    handle_field_population(
+        context,
+        JsonRule(handler="gg_pre_population", rule=rule, path=["my_field"]),
+        PRE_POPULATION_MAPPER,
+    )
+    assert context.json_data["my_field"] == "0.00"
+
+
+@pytest.mark.parametrize(
     "rule,setup_params,expected_value",
     [
         ({"rule": "current_date"}, {}, get_now_us_eastern_date().isoformat()),


### PR DESCRIPTION
## Summary

Fixes #10541

## Changes proposed

- Add `subtract_monetary_values` and register it in `PRE_POPULATION_MAPPER` so it's invocable via `gg_pre_population`.
- Document the new rule in the rule_processing README under "Monetary Subtraction".
- Add parametrized tests covering happy path, missing values, non-monetary inputs, zero values, and max range.

## Context for reviewers

SF424C auto calculates column c (a minus b) on every row, and row 16 (row 14 minus row 15). The rule engine has sum_monetary but no subtraction primitive. Adding subtract_monetary as a narrow rule that mirrors sum_monetary's shape: takes a list of paths, returns a quantized monetary string.


## Validation steps

See updated unit tests and run:
`make test args="tests/src/form_schema/rule_processing/test_json_rule_field_population.py"`
