### PR TITLE
[Issue #10760] Modify LoadOracleData to capture timing metrics for all parts of its run

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -156,6 +156,13 @@ class LoadOracleDataTask(src.task.task.Task):
 
         self.log_row_count("after", staging_table)
 
+    def add_timing_metric(self, name: str, value: float) -> None:
+        """Accumulate a float timing metric into the task metrics.
+
+        increment() only handles integer counts, so timing totals are summed here instead.
+        """
+        self.metrics[name] = round(self.metrics.get(name, 0) + value, 3)
+
     def do_insert(
         self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table
     ) -> LoadResult:
@@ -202,8 +209,8 @@ class LoadOracleDataTask(src.task.task.Task):
         copy_time = round(t1 - t0, 3)
         total_insert_count = sum(insert_chunk_count)
         self.increment("count.insert.total", total_insert_count)
-        self.increment("time.insert.total", copy_time)
-        self.increment("time.insert_fetch.total", fetch_time)
+        self.add_timing_metric("time.insert.total", copy_time)
+        self.add_timing_metric("time.insert_fetch.total", fetch_time)
 
         log_extra |= {
             f"count.insert.{staging_table.name}": total_insert_count,
@@ -267,8 +274,8 @@ class LoadOracleDataTask(src.task.task.Task):
         copy_time = round(t1 - t0, 3)
         total_update_count = sum(update_chunk_count)
         self.increment("count.update.total", total_update_count)
-        self.increment("time.update.total", copy_time)
-        self.increment("time.update_fetch.total", fetch_time)
+        self.add_timing_metric("time.update.total", copy_time)
+        self.add_timing_metric("time.update_fetch.total", fetch_time)
 
         log_extra |= {
             f"count.update.{staging_table.name}": total_update_count,
@@ -301,7 +308,7 @@ class LoadOracleDataTask(src.task.task.Task):
         delete_count = result.rowcount  # type: ignore[attr-defined]
 
         self.increment("count.delete.total", delete_count)
-        self.increment("time.delete.total", delete_time)
+        self.add_timing_metric("time.delete.total", delete_time)
 
         log_extra |= {
             f"count.delete.{staging_table.name}": delete_count,

--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -4,6 +4,7 @@
 import itertools
 import logging
 import time
+from dataclasses import dataclass
 
 import sqlalchemy
 from grants_shared.adapters import db
@@ -14,6 +15,22 @@ import src.task.task
 from . import sql
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LoadResult:
+    """Row count and timing breakdown for a single load operation (insert/update/delete) on one table."""
+
+    count: int = 0
+    # Time spent executing the SELECT that determines which rows to act on.
+    fetch_time: float = 0.0
+    # Time spent copying the rows (inserts/updates) or marking them deleted.
+    copy_time: float = 0.0
+
+    @property
+    def total_time(self) -> float:
+        return round(self.fetch_time + self.copy_time, 3)
+
 
 TABLES_TO_LOAD = [
     "topportunity",
@@ -122,13 +139,26 @@ class LoadOracleDataTask(src.task.task.Task):
 
         self.log_row_count("before", foreign_table, staging_table)
 
-        self.do_update(foreign_table, staging_table)
-        self.do_insert(foreign_table, staging_table)
-        self.do_mark_deleted(foreign_table, staging_table)
+        update_result = self.do_update(foreign_table, staging_table)
+        insert_result = self.do_insert(foreign_table, staging_table)
+        delete_result = self.do_mark_deleted(foreign_table, staging_table)
+
+        processing_time = round(
+            update_result.total_time + insert_result.total_time + delete_result.total_time, 3
+        )
+        logger.info(
+            "Processed table",
+            extra={
+                "table": table_name,
+                f"time.processing.{staging_table.name}": processing_time,
+            },
+        )
 
         self.log_row_count("after", staging_table)
 
-    def do_insert(self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table) -> int:
+    def do_insert(
+        self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table
+    ) -> LoadResult:
         """Determine new rows by primary key, and copy them into the staging table."""
         log_extra: dict = {"table": foreign_table.name}
 
@@ -141,8 +171,10 @@ class LoadOracleDataTask(src.task.task.Task):
 
         logger.info("Fetching records to be inserted", extra=log_extra)
         select_sql = sql.build_select_new_rows_sql(foreign_table, staging_table, self.batch_cutoff)
+        fetch_t0 = time.monotonic()
         with self.db_session.begin():
             new_ids = self.db_session.execute(select_sql).all()
+        fetch_time = round(time.monotonic() - fetch_t0, 3)
 
         t0 = time.monotonic()
         insert_chunk_count = []
@@ -167,19 +199,25 @@ class LoadOracleDataTask(src.task.task.Task):
             )
 
         t1 = time.monotonic()
+        copy_time = round(t1 - t0, 3)
         total_insert_count = sum(insert_chunk_count)
         self.increment("count.insert.total", total_insert_count)
+        self.increment("time.insert.total", copy_time)
+        self.increment("time.insert_fetch.total", fetch_time)
 
         log_extra |= {
             f"count.insert.{staging_table.name}": total_insert_count,
             f"count.insert.chunk.{staging_table.name}": ",".join(map(str, insert_chunk_count)),
-            f"time.insert.{staging_table.name}": round(t1 - t0, 3),
+            f"time.insert.{staging_table.name}": copy_time,
+            f"time.insert_fetch.{staging_table.name}": fetch_time,
         }
         logger.info("Processed records to be inserted", extra=log_extra)
 
-        return total_insert_count
+        return LoadResult(count=total_insert_count, fetch_time=fetch_time, copy_time=copy_time)
 
-    def do_update(self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table) -> int:
+    def do_update(
+        self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table
+    ) -> LoadResult:
         """Find updated rows using last_upd_date, copy them, and reset transformed_at to NULL."""
         log_extra: dict = {"table": foreign_table.name}
 
@@ -194,8 +232,10 @@ class LoadOracleDataTask(src.task.task.Task):
         select_sql = sql.build_select_updated_rows_sql(
             foreign_table, staging_table, self.batch_cutoff
         )
+        fetch_t0 = time.monotonic()
         with self.db_session.begin():
             update_ids = self.db_session.execute(select_sql).all()
+        fetch_time = round(time.monotonic() - fetch_t0, 3)
 
         t0 = time.monotonic()
         update_chunk_count = []
@@ -224,21 +264,25 @@ class LoadOracleDataTask(src.task.task.Task):
             )
 
         t1 = time.monotonic()
+        copy_time = round(t1 - t0, 3)
         total_update_count = sum(update_chunk_count)
         self.increment("count.update.total", total_update_count)
+        self.increment("time.update.total", copy_time)
+        self.increment("time.update_fetch.total", fetch_time)
 
         log_extra |= {
             f"count.update.{staging_table.name}": total_update_count,
             f"count.update.chunk.{staging_table.name}": ",".join(map(str, update_chunk_count)),
-            f"time.update.{staging_table.name}": round(t1 - t0, 3),
+            f"time.update.{staging_table.name}": copy_time,
+            f"time.update_fetch.{staging_table.name}": fetch_time,
         }
         logger.info("Processed records to be updated", extra=log_extra)
 
-        return total_update_count
+        return LoadResult(count=total_update_count, fetch_time=fetch_time, copy_time=copy_time)
 
     def do_mark_deleted(
         self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table
-    ) -> int:
+    ) -> LoadResult:
         """Find deleted rows, set is_deleted=TRUE, and reset transformed_at to NULL."""
         log_extra: dict = {"table": foreign_table.name}
 
@@ -253,18 +297,20 @@ class LoadOracleDataTask(src.task.task.Task):
         with self.db_session.begin():
             result = self.db_session.execute(update_sql)
         t1 = time.monotonic()
+        delete_time = round(t1 - t0, 3)
         delete_count = result.rowcount  # type: ignore[attr-defined]
 
         self.increment("count.delete.total", delete_count)
+        self.increment("time.delete.total", delete_time)
 
         log_extra |= {
             f"count.delete.{staging_table.name}": delete_count,
-            f"time.delete.{staging_table.name}": round(t1 - t0, 3),
+            f"time.delete.{staging_table.name}": delete_time,
         }
 
         logger.info("Processed records to be deleted", extra=log_extra)
 
-        return delete_count
+        return LoadResult(count=delete_count, copy_time=delete_time)
 
     def log_row_count(self, message: str, *tables: sqlalchemy.Table) -> None:
         """Log the number of rows in each of the tables using SQL COUNT()."""

--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -156,13 +156,6 @@ class LoadOracleDataTask(src.task.task.Task):
 
         self.log_row_count("after", staging_table)
 
-    def add_timing_metric(self, name: str, value: float) -> None:
-        """Accumulate a float timing metric into the task metrics.
-
-        increment() only handles integer counts, so timing totals are summed here instead.
-        """
-        self.metrics[name] = round(self.metrics.get(name, 0) + value, 3)
-
     def do_insert(
         self, foreign_table: sqlalchemy.Table, staging_table: sqlalchemy.Table
     ) -> LoadResult:
@@ -209,8 +202,8 @@ class LoadOracleDataTask(src.task.task.Task):
         copy_time = round(t1 - t0, 3)
         total_insert_count = sum(insert_chunk_count)
         self.increment("count.insert.total", total_insert_count)
-        self.add_timing_metric("time.insert.total", copy_time)
-        self.add_timing_metric("time.insert_fetch.total", fetch_time)
+        self.increment("time.insert.total", copy_time)
+        self.increment("time.insert_fetch.total", fetch_time)
 
         log_extra |= {
             f"count.insert.{staging_table.name}": total_insert_count,
@@ -274,8 +267,8 @@ class LoadOracleDataTask(src.task.task.Task):
         copy_time = round(t1 - t0, 3)
         total_update_count = sum(update_chunk_count)
         self.increment("count.update.total", total_update_count)
-        self.add_timing_metric("time.update.total", copy_time)
-        self.add_timing_metric("time.update_fetch.total", fetch_time)
+        self.increment("time.update.total", copy_time)
+        self.increment("time.update_fetch.total", fetch_time)
 
         log_extra |= {
             f"count.update.{staging_table.name}": total_update_count,
@@ -308,7 +301,7 @@ class LoadOracleDataTask(src.task.task.Task):
         delete_count = result.rowcount  # type: ignore[attr-defined]
 
         self.increment("count.delete.total", delete_count)
-        self.add_timing_metric("time.delete.total", delete_time)
+        self.increment("time.delete.total", delete_time)
 
         log_extra |= {
             f"count.delete.{staging_table.name}": delete_count,

--- a/api/src/task/base_task.py
+++ b/api/src/task/base_task.py
@@ -77,7 +77,7 @@ class BaseTask(abc.ABC, metaclass=abc.ABCMeta):
     def set_metrics(self, metrics: dict[str, Any]) -> None:
         self.metrics.update(**metrics)
 
-    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
+    def increment(self, name: str, value: float = 1, prefix: str | None = None) -> None:
         if name not in self.metrics:
             self.metrics[name] = 0
 

--- a/api/src/task/base_task.py
+++ b/api/src/task/base_task.py
@@ -77,7 +77,7 @@ class BaseTask(abc.ABC, metaclass=abc.ABCMeta):
     def set_metrics(self, metrics: dict[str, Any]) -> None:
         self.metrics.update(**metrics)
 
-    def increment(self, name: str, value: float = 1, prefix: str | None = None) -> None:
+    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
         if name not in self.metrics:
             self.metrics[name] = 0
 

--- a/api/src/task/base_task.py
+++ b/api/src/task/base_task.py
@@ -77,7 +77,7 @@ class BaseTask(abc.ABC, metaclass=abc.ABCMeta):
     def set_metrics(self, metrics: dict[str, Any]) -> None:
         self.metrics.update(**metrics)
 
-    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
+    def increment(self, name: str, value: int | float = 1, prefix: str | None = None) -> None:
         if name not in self.metrics:
             self.metrics[name] = 0
 

--- a/api/src/task/subtask.py
+++ b/api/src/task/subtask.py
@@ -47,7 +47,7 @@ class SubTask(abc.ABC, metaclass=abc.ABCMeta):
         # Passthrough method to the task set_metrics function
         self.task.set_metrics(metrics)
 
-    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
+    def increment(self, name: str, value: int | float = 1, prefix: str | None = None) -> None:
         # Passthrough method to the task increment function
         self.task.increment(name, value, prefix)
 

--- a/api/src/task/subtask.py
+++ b/api/src/task/subtask.py
@@ -47,7 +47,7 @@ class SubTask(abc.ABC, metaclass=abc.ABCMeta):
         # Passthrough method to the task set_metrics function
         self.task.set_metrics(metrics)
 
-    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
+    def increment(self, name: str, value: float = 1, prefix: str | None = None) -> None:
         # Passthrough method to the task increment function
         self.task.increment(name, value, prefix)
 

--- a/api/src/task/subtask.py
+++ b/api/src/task/subtask.py
@@ -47,7 +47,7 @@ class SubTask(abc.ABC, metaclass=abc.ABCMeta):
         # Passthrough method to the task set_metrics function
         self.task.set_metrics(metrics)
 
-    def increment(self, name: str, value: float = 1, prefix: str | None = None) -> None:
+    def increment(self, name: str, value: int = 1, prefix: str | None = None) -> None:
         # Passthrough method to the task increment function
         self.task.increment(name, value, prefix)
 

--- a/api/tests/src/data_migration/load/test_load_oracle_data_task.py
+++ b/api/tests/src/data_migration/load/test_load_oracle_data_task.py
@@ -156,6 +156,56 @@ class TestLoadOracleData(BaseTestClass):
         assert task.metrics["count.insert.total"] == 2
         assert task.metrics["count.update.total"] == 2
 
+        # Timing total metrics are recorded for each part of the run. Timing is
+        # non-deterministic, so just assert the keys exist and hold sane values.
+        for timing_metric in (
+            "time.insert.total",
+            "time.insert_fetch.total",
+            "time.update.total",
+            "time.update_fetch.total",
+            "time.delete.total",
+        ):
+            assert timing_metric in task.metrics
+            assert task.metrics[timing_metric] >= 0
+
+    def test_per_table_timing_metrics_logged(
+        self, db_session, foreign_tables, staging_tables, enable_factory_create, caplog
+    ):
+        caplog.set_level(logging.INFO)
+
+        source_table = foreign_tables["topportunity"]
+        destination_table = staging_tables["topportunity"]
+
+        db_session.execute(sqlalchemy.delete(source_table))
+        db_session.execute(sqlalchemy.delete(destination_table))
+
+        ForeignTopportunityFactory.create(opportunity_id=101, oppnumber="B-1", cfdas=[])
+
+        task = load_oracle_data_task.LoadOracleDataTask(
+            db_session, foreign_tables, staging_tables, ["topportunity"]
+        )
+        task.run()
+
+        # The fetch timing for the SELECT that determines records appears alongside
+        # the existing copy timing in the per-operation "Processed records" log lines.
+        insert_log = next(
+            r for r in caplog.records if r.message == "Processed records to be inserted"
+        )
+        assert hasattr(insert_log, "time.insert.topportunity")
+        assert hasattr(insert_log, "time.insert_fetch.topportunity")
+        assert getattr(insert_log, "time.insert_fetch.topportunity") >= 0
+
+        update_log = next(
+            r for r in caplog.records if r.message == "Processed records to be updated"
+        )
+        assert hasattr(update_log, "time.update.topportunity")
+        assert hasattr(update_log, "time.update_fetch.topportunity")
+
+        # The per-table processing time (sum of the five parts) is logged once per table.
+        processing_log = next(r for r in caplog.records if r.message == "Processed table")
+        assert hasattr(processing_log, "time.processing.topportunity")
+        assert getattr(processing_log, "time.processing.topportunity") >= 0
+
     def test_raises_if_table_dicts_different(self, db_session, foreign_tables, staging_tables):
         with pytest.raises(
             ValueError, match="keys of foreign_tables and staging_tables must be equal"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10760

## Changes proposed

- Updated load_oracle_data_task.py to add a `LoadResult` dataclass and have `do_insert`/`do_update`/`do_mark_deleted` return it (count + fetch/copy timing) instead of a bare count. Added separate timing of the record-determination `SELECT` so we now log `time.insert_fetch.{table}` / `time.update_fetch.{table}` alongside the existing `time.insert.{table}` / `time.update.{table}`, increment `time.{insert,update,delete}.total` and `time.{insert,update}_fetch.total` into metrics, and log a per-table `time.processing.{table}` (sum of all five parts).
- Updated base_task.py to widen the `increment` typing to `int | float` so it reads clearly when used for timing totals as well as integer counts.
- Updated subtask.py to widen the `increment` passthrough typing to match.
- Updated test_load_oracle_data_task.py to assert the new timing total metrics in `test_load_data` and added `test_per_table_timing_metrics_logged` covering the per-table fetch/processing log fields.

## Context for reviewers

The fetch step (determining which records need to be inserted/updated) is typically longer than the copies themselves but was previously untimed. This change captures it so we can see the full picture per table. New Relic dashboard updates are intentionally deferred until this runs in staging at least once, so there's real data to build the panels against.

## Validation steps

Confirm tests pass.