### PR TITLE
[Issue 10886] Distinguish scan failed from scan error in file input

### DIFF
--- a/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
+++ b/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
@@ -13,15 +13,40 @@ const errorStatuses = new Map([
   ["uploading", "upload-error"],
   ["scanning", "scan-error"],
   ["post-upload", "post-upload-error"],
-  // need to figure out how to disintguish between scan failure and scan error.
-  // this will likely depend on the implementation of handling scan failures on the backend
-  // Next API will return a specific error and we can return that error status before dealing with this map
 ]);
+
+const scanFailureErrorPatterns = [
+  /scan[\s-]?fail(ed)?/i,
+  /infected/i,
+  /malware/i,
+  /virus/i,
+];
+
+const getErrorStatus = ({
+  status,
+  errorMessage,
+}: {
+  status: FileUploadProcessStatus;
+  errorMessage?: string;
+}): FileUploadStatus => {
+  const scanFailed =
+    status === "scanning" &&
+    scanFailureErrorPatterns.some((pattern) =>
+      pattern.test((errorMessage || "").toLowerCase()),
+    );
+
+  if (scanFailed) {
+    return "scan-fail";
+  }
+
+  return (errorStatuses.get(status) as FileUploadStatus) || "error";
+};
 
 export const FileInputStatusDisplay = ({
   fileName,
   status,
   error,
+  errorMessage,
   postUploadActionProgressMessage,
   postUploadActionSuccessMessage,
   postUploadActionErrorMessage,
@@ -33,6 +58,7 @@ export const FileInputStatusDisplay = ({
   onDismiss: () => void;
   status?: FileUploadProcessStatus;
   error: boolean;
+  errorMessage?: string;
   postUploadActionProgressMessage: string;
   postUploadActionSuccessMessage?: string;
   postUploadActionErrorMessage?: string;
@@ -57,7 +83,7 @@ export const FileInputStatusDisplay = ({
   };
 
   const adjustedStatus = error
-    ? (errorStatuses.get(status) as FileUploadStatus) || "error"
+    ? getErrorStatus({ status, errorMessage })
     : status;
   const statusMessageForDisplay = messagesMap[adjustedStatus];
 

--- a/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
@@ -358,6 +358,53 @@ describe("SimplerFileInput", () => {
       );
     });
 
+    it("displays a scan failed message when scan failure error occurs", async () => {
+      const trigger = createAdvanceStreamTrigger();
+      clientFetchMock.mockResolvedValue(
+        new Response(
+          makeAdvanceableTestStreamForTrigger(
+            [
+              JSON.stringify({ status: "uploading" }),
+              JSON.stringify({ status: "scanning" }),
+              JSON.stringify({
+                status: "error",
+                error: "scan failed: file infected",
+              }),
+            ],
+            trigger,
+          ),
+        ),
+      );
+      render(
+        <SimplerFileInput
+          onDelete={() => Promise.resolve()}
+          postUploadAction={() => Promise.resolve(undefined)}
+          postUploadActionProgressMessage="post upload action in progress"
+          postUploadActionSuccessMessage="post upload action success"
+          postUploadActionErrorMessage="post upload action error"
+          id="file-input-test"
+          labelId="file-input-label"
+        />,
+      );
+      const input = await screen.findByTestId("file-input-input");
+      await userEvent.upload(
+        input,
+        new File(["test content"], "test.txt", {
+          type: "text/plain",
+        }),
+      );
+      trigger.advance();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      trigger.advance();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      trigger.advance();
+      await waitFor(async () =>
+        expect(
+          await screen.findByTestId("file-upload-status-display"),
+        ).toHaveTextContent("scanFail"),
+      );
+    });
+
     it("displays a post-upload error if error occurs during post-upload process", async () => {
       const trigger = createAdvanceStreamTrigger();
       // we're not concerned with the upload process here, so no need to mess with stream states

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -267,6 +267,7 @@ export const SimplerFileInput = ({
           onCancel={() => void handleCancel()}
           onDismiss={handleDismiss}
           error={!!uploadError}
+          errorMessage={uploadError?.message}
           status={currentStatus}
           postUploadActionProgressMessage={postUploadActionProgressMessage}
           postUploadActionSuccessMessage={postUploadActionSuccessMessage}


### PR DESCRIPTION
Fixes #10886

This updates the file-upload status display so scan-time errors that indicate a failed scan now render the existing "scanFail" message, while other scan-time errors still render "scanError".

It passes the upload error message through to FileInputStatusDisplay and adds a focused test for the scan-failed path.