### PR TITLE
[unticketed]: upgrade python version to 3.14.6 to resolve anchore cve

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:70d1802@sha256:0e2fa02c865b2c836e616174a02d50c2a19da9d6e1ac44cfa0dd66cdfb881b71 AS base
+FROM ghcr.io/hhs/python-base-image:b6b5679@sha256:988d748c408a3af9a485c73998a68e60121e1708620ca1473a67e733f89fbd37 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:70d1802@sha256:0e2fa02c865b2c836e616174a02d50c2a19da9d6e1ac44cfa0dd66cdfb881b71 AS base
+FROM ghcr.io/hhs/python-base-image:b6b5679@sha256:988d748c408a3af9a485c73998a68e60121e1708620ca1473a67e733f89fbd37 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -9,7 +9,7 @@ FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 #==============================================
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS amazonlinux-builder
 
-ARG PYTHON_VERSION=3.14.5
+ARG PYTHON_VERSION=3.14.6
 ARG PY_MM=3.14
 ARG PIP_VERSION=26.0
 


### PR DESCRIPTION
## Summary

Resolved the python version cve. Upgraded python from version 3.14.5 to 3.14.6. 

Failing anchore scan: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/27755926594)

## Validation steps

All scans should be passing below. 