### PR TITLE
[Issue #10349] Add header to "Edit Application Submission Details"

### DIFF
--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/actions.test.ts
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/actions.test.ts
@@ -2,8 +2,26 @@ import { identity } from "lodash";
 
 import {
   saveAwardRecommendation,
+  saveAwardRecommendationSubmissionDetails,
   submitAwardRecommendationForReview,
 } from "./actions";
+
+const mockUpdateAwardRecommendationSubmissionDetails = jest.fn();
+const mockRedirect = jest.fn();
+
+jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher", () => ({
+  updateAwardRecommendationSubmissionDetails: (
+    ...args: unknown[]
+  ): Promise<unknown> =>
+    mockUpdateAwardRecommendationSubmissionDetails(...args) as Promise<unknown>,
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => {
+    mockRedirect(...args);
+    throw new Error("NEXT_REDIRECT");
+  },
+}));
 
 jest.mock("next-intl/server", () => ({
   getTranslations: () => identity,
@@ -16,192 +34,109 @@ describe("Award Recommendation Actions", () => {
   });
 
   describe("saveAwardRecommendation", () => {
-    it("successfully extracts string values from FormData", async () => {
-      const formData = new FormData();
-      formData.append("additional_info", "Test additional info");
-      formData.append("award_selection_method", "merit-review-only");
-      formData.append("award_selection_details", "Test details");
-      formData.append("other_key_information", "Test other info");
-
-      const result = await saveAwardRecommendation(formData);
+    it("returns success", async () => {
+      const result = await saveAwardRecommendation(new FormData());
 
       expect(result.success).toBe(true);
       expect(result.errorMessage).toBeUndefined();
-    });
-
-    it("handles FormData with missing fields (null values)", async () => {
-      const formData = new FormData();
-      // Only add some fields, others will be null
-
-      const result = await saveAwardRecommendation(formData);
-
-      expect(result.success).toBe(true);
-      expect(result.errorMessage).toBeUndefined();
-    });
-
-    it("handles FormData with empty string values", async () => {
-      const formData = new FormData();
-      formData.append("additional_info", "");
-      formData.append("award_selection_method", "");
-      formData.append("award_selection_details", "");
-      formData.append("other_key_information", "");
-
-      const result = await saveAwardRecommendation(formData);
-
-      expect(result.success).toBe(true);
-      expect(result.errorMessage).toBeUndefined();
-    });
-
-    it("handles File type by converting to empty string", async () => {
-      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
-      const formData = new FormData();
-      const testFile = new File(["test content"], "test.txt", {
-        type: "text/plain",
-      });
-      formData.append("additional_info", testFile);
-      formData.append("award_selection_method", "merit-review-only");
-      formData.append("award_selection_details", "Test details");
-      formData.append("other_key_information", "Test other info");
-
-      const result = await saveAwardRecommendation(formData);
-
-      expect(result.success).toBe(true);
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'Unexpected File type for form field "additional_info"',
-      );
-      consoleWarnSpy.mockRestore();
-    });
-
-    it("handles special characters in form values", async () => {
-      const formData = new FormData();
-      formData.append("additional_info", "Test with <html> & special chars");
-      formData.append("award_selection_method", "merit-review-other");
-      formData.append("award_selection_details", "Details with\nnewlines");
-      formData.append("other_key_information", "Unicode: 你好 🎉");
-
-      const result = await saveAwardRecommendation(formData);
-
-      expect(result.success).toBe(true);
     });
   });
 
   describe("submitAwardRecommendationForReview", () => {
-    it("successfully extracts string values from FormData", async () => {
-      const formData = new FormData();
-      formData.append("additional_info", "Test additional info");
-      formData.append("award_selection_method", "merit-review-only");
-      formData.append("award_selection_details", "Test details");
-      formData.append("other_key_information", "Test other info");
-
-      const result = await submitAwardRecommendationForReview(formData);
+    it("returns success", async () => {
+      const result = await submitAwardRecommendationForReview(new FormData());
 
       expect(result.success).toBe(true);
       expect(result.errorMessage).toBeUndefined();
-    });
-
-    it("handles FormData with missing fields (null values)", async () => {
-      const formData = new FormData();
-      // Only add some fields, others will be null
-
-      const result = await submitAwardRecommendationForReview(formData);
-
-      expect(result.success).toBe(true);
-      expect(result.errorMessage).toBeUndefined();
-    });
-
-    it("handles FormData with empty string values", async () => {
-      const formData = new FormData();
-      formData.append("additional_info", "");
-      formData.append("award_selection_method", "");
-      formData.append("award_selection_details", "");
-      formData.append("other_key_information", "");
-
-      const result = await submitAwardRecommendationForReview(formData);
-
-      expect(result.success).toBe(true);
-      expect(result.errorMessage).toBeUndefined();
-    });
-
-    it("handles File type by converting to empty string", async () => {
-      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
-      const formData = new FormData();
-      const testFile = new File(["test content"], "test.txt", {
-        type: "text/plain",
-      });
-      formData.append("additional_info", testFile);
-      formData.append("award_selection_method", "merit-review-only");
-      formData.append("award_selection_details", "Test details");
-      formData.append("other_key_information", "Test other info");
-
-      const result = await submitAwardRecommendationForReview(formData);
-
-      expect(result.success).toBe(true);
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'Unexpected File type for form field "additional_info"',
-      );
-      consoleWarnSpy.mockRestore();
-    });
-
-    it("handles special characters in form values", async () => {
-      const formData = new FormData();
-      formData.append("additional_info", "Test with <html> & special chars");
-      formData.append("award_selection_method", "merit-review-other");
-      formData.append("award_selection_details", "Details with\nnewlines");
-      formData.append("other_key_information", "Unicode: 你好 🎉");
-
-      const result = await submitAwardRecommendationForReview(formData);
-
-      expect(result.success).toBe(true);
-    });
-
-    it("handles long text values within character limits", async () => {
-      const formData = new FormData();
-      const longText = "a".repeat(500); // Max character count
-      formData.append("additional_info", longText);
-      formData.append("award_selection_method", "merit-review-only");
-      formData.append("award_selection_details", longText);
-      formData.append("other_key_information", longText);
-
-      const result = await submitAwardRecommendationForReview(formData);
-
-      expect(result.success).toBe(true);
     });
   });
 
-  describe("getFormDataValue helper (implicit testing)", () => {
-    it("converts null to empty string", async () => {
-      const formData = new FormData();
-      // Don't add any fields - they'll be null
+  describe("saveAwardRecommendationSubmissionDetails", () => {
+    const submissionId = "63588df8-f2d1-44ed-a201-5804abba696b";
 
-      const result = await saveAwardRecommendation(formData);
-
-      expect(result.success).toBe(true);
+    beforeEach(() => {
+      mockUpdateAwardRecommendationSubmissionDetails.mockResolvedValue([]);
     });
 
-    it("converts File to empty string and logs warning", async () => {
-      const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+    it("parses form data and redirects to the award recommendation edit page", async () => {
       const formData = new FormData();
-      const testFile = new File(["content"], "file.txt");
-      formData.append("additional_info", testFile);
-
-      await saveAwardRecommendation(formData);
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'Unexpected File type for form field "additional_info"',
+      formData.append("award_recommendation_id", "ar-id-123");
+      formData.append(
+        "award_recommendation_application_submission_id",
+        submissionId,
       );
-      consoleWarnSpy.mockRestore();
+      formData.append(
+        `award_recommendation_submissions[${submissionId}][award_recommendation_type]`,
+        "recommended_for_funding",
+      );
+      formData.append(
+        `award_recommendation_submissions[${submissionId}][recommended_amount]`,
+        "$50,000",
+      );
+      formData.append(
+        `award_recommendation_submissions[${submissionId}][general_comment]`,
+        "Looks good",
+      );
+
+      await expect(
+        saveAwardRecommendationSubmissionDetails(formData),
+      ).rejects.toThrow("NEXT_REDIRECT");
+
+      expect(
+        mockUpdateAwardRecommendationSubmissionDetails,
+      ).toHaveBeenCalledWith("ar-id-123", {
+        [submissionId]: {
+          award_recommendation_type: "recommended_for_funding",
+          recommended_amount: "50000.00",
+          general_comment: "Looks good",
+          has_exception: false,
+          exception_detail: null,
+        },
+      });
+      expect(mockRedirect).toHaveBeenCalledWith(
+        "/award-recommendation/ar-id-123/edit",
+      );
     });
 
-    it("preserves string values", async () => {
+    it("includes exception details when the exception checkbox is checked", async () => {
       const formData = new FormData();
-      formData.append("additional_info", "Test value");
-      formData.append("award_selection_method", "merit-review-only");
-      formData.append("award_selection_details", "Details");
-      formData.append("other_key_information", "Info");
+      formData.append("award_recommendation_id", "ar-id-123");
+      formData.append(
+        "award_recommendation_application_submission_id",
+        submissionId,
+      );
+      formData.append(
+        `award_recommendation_submissions[${submissionId}][award_recommendation_type]`,
+        "not_recommended",
+      );
+      formData.append(
+        `award_recommendation_submissions[${submissionId}][has_exception]`,
+        "on",
+      );
+      formData.append(
+        `award_recommendation_submissions[${submissionId}][exception_detail]`,
+        "Skipped due to budget",
+      );
+      formData.append(
+        `award_recommendation_submissions[${submissionId}][recommended_amount]`,
+        "0",
+      );
 
-      const result = await saveAwardRecommendation(formData);
+      await expect(
+        saveAwardRecommendationSubmissionDetails(formData),
+      ).rejects.toThrow("NEXT_REDIRECT");
 
-      expect(result.success).toBe(true);
+      expect(
+        mockUpdateAwardRecommendationSubmissionDetails,
+      ).toHaveBeenCalledWith("ar-id-123", {
+        [submissionId]: {
+          award_recommendation_type: "not_recommended",
+          recommended_amount: "0.00",
+          general_comment: null,
+          has_exception: true,
+          exception_detail: "Skipped due to budget",
+        },
+      });
     });
   });
 });

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/actions.ts
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/actions.ts
@@ -1,55 +1,90 @@
 "use server";
 
+import { updateAwardRecommendationSubmissionDetails } from "src/services/fetch/fetchers/awardRecommendationFetcher";
+import {
+  AwardRecommendationSubmissionDetailUpdate,
+  AwardRecommendationType,
+} from "src/types/awardRecommendationTypes";
+
+import { isRedirectError } from "next/dist/client/components/redirect-error";
+import { redirect } from "next/navigation";
+
 export type AwardRecommendationActionResponse = {
   success?: boolean;
   errorMessage?: string;
   validationErrors?: Record<string, string[]>;
 };
 
-/**
- * Safely extracts a value from FormData with explicit null/File handling
- * @param formData - The FormData object
- * @param key - The key to extract
- * @returns The value as string, or empty string if null/undefined/File
- */
-function getFormDataValue(formData: FormData, key: string): string {
-  const value = formData.get(key);
+const exceptionEligibleRecommendationTypes: AwardRecommendationType[] = [
+  "recommended_without_funding",
+  "not_recommended",
+];
 
-  // Handle null or undefined
-  if (value === null || value === undefined) {
-    return "";
+function readStringValue(value: FormDataEntryValue | null): string {
+  return typeof value === "string" ? value : "";
+}
+
+function submissionFieldName(submissionId: string, field: string): string {
+  return `award_recommendation_submissions[${submissionId}][${field}]`;
+}
+
+function parseRecommendedAmountForApi(value: string): string {
+  if (!value) {
+    return "0.00";
   }
 
-  // Handle File type - reject it
-  if (value instanceof File) {
-    console.warn(`Unexpected File type for form field "${key}"`);
-    return "";
+  const numeric = value.replace(/[$,\s]/g, "");
+  const amount = Number(numeric);
+
+  if (Number.isNaN(amount)) {
+    return value;
   }
 
-  // Return the string value
-  return value;
+  return amount.toFixed(2);
+}
+
+function buildSubmissionUpdate(
+  formData: FormData,
+  submissionId: string,
+): AwardRecommendationSubmissionDetailUpdate {
+  const recommendationType = readStringValue(
+    formData.get(
+      submissionFieldName(submissionId, "award_recommendation_type"),
+    ),
+  ) as AwardRecommendationType;
+  const canHaveException =
+    exceptionEligibleRecommendationTypes.includes(recommendationType);
+  const hasException =
+    canHaveException &&
+    readStringValue(
+      formData.get(submissionFieldName(submissionId, "has_exception")),
+    ) === "on";
+  const generalComment = readStringValue(
+    formData.get(submissionFieldName(submissionId, "general_comment")),
+  );
+  const exceptionDetail = readStringValue(
+    formData.get(submissionFieldName(submissionId, "exception_detail")),
+  );
+
+  return {
+    award_recommendation_type: recommendationType,
+    general_comment: generalComment || null,
+    recommended_amount: parseRecommendedAmountForApi(
+      readStringValue(
+        formData.get(submissionFieldName(submissionId, "recommended_amount")),
+      ),
+    ),
+    has_exception: hasException,
+    exception_detail: hasException ? exceptionDetail || null : null,
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function saveAwardRecommendation(
-  formData: FormData,
+  _formData: FormData,
 ): Promise<AwardRecommendationActionResponse> {
-  // Extract form data
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const rawFormData = {
-    additionalInfo: getFormDataValue(formData, "additional_info"),
-    awardSelectionMethod: getFormDataValue(formData, "award_selection_method"),
-    awardSelectionDetails: getFormDataValue(
-      formData,
-      "award_selection_details",
-    ),
-    otherKeyInformation: getFormDataValue(formData, "other_key_information"),
-  };
-
   try {
     // TODO: Implement save functionality when endpoint is available
-    // const response = await saveAwardRecommendationAPI(rawFormData);
-
     return {
       success: true,
     };
@@ -64,45 +99,40 @@ export async function saveAwardRecommendation(
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function saveAwardRecommendationSubmissionDetails(
   formData: FormData,
 ): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const rawFormData = Object.fromEntries(formData.entries());
+  const awardRecommendationId = readStringValue(
+    formData.get("award_recommendation_id"),
+  );
+  const submissionId = readStringValue(
+    formData.get("award_recommendation_application_submission_id"),
+  );
 
   try {
-    // TODO: Implement submission detail save functionality when the frontend
-    // wiring for the batch update endpoint is ready.
-    return;
+    await updateAwardRecommendationSubmissionDetails(awardRecommendationId, {
+      [submissionId]: buildSubmissionUpdate(formData, submissionId),
+    });
+    redirect(`/award-recommendation/${awardRecommendationId}/edit`);
   } catch (e) {
+    if (isRedirectError(e)) {
+      throw e;
+    }
+
     const error = e as Error;
     console.error(
       `Error saving award recommendation submission details - ${error.message} ${error.cause?.toString() || ""}`,
     );
+    throw error;
   }
 }
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function submitAwardRecommendationForReview(
-  formData: FormData,
+  _formData: FormData,
 ): Promise<AwardRecommendationActionResponse> {
-  // Extract form data
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const rawFormData = {
-    additionalInfo: getFormDataValue(formData, "additional_info"),
-    awardSelectionMethod: getFormDataValue(formData, "award_selection_method"),
-    awardSelectionDetails: getFormDataValue(
-      formData,
-      "award_selection_details",
-    ),
-    otherKeyInformation: getFormDataValue(formData, "other_key_information"),
-  };
-
   try {
     // TODO: Implement submit for review functionality when endpoint is available
-    // const response = await submitAwardRecommendationAPI(rawFormData);
-
     return {
       success: true,
     };

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/AwardRecommendationSubmissionEditHero.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/AwardRecommendationSubmissionEditHero.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+
+import AwardRecommendationSubmissionEditHero from "./AwardRecommendationSubmissionEditHero";
+
+describe("AwardRecommendationSubmissionEditHero", () => {
+  const defaultProps = {
+    awardRecommendationId: "ar-id-123",
+    awardRecommendationBreadcrumbTitle: "Award Rec #: AR-26-0002",
+    applicationSubmissionNumber: "APP-26-00001",
+    applicationId: "app-id-456",
+    awardRecsLabel: "Award Recs",
+    editTitle: "Edit APP-26-00001",
+    viewOriginalApplicationLabel: "View original application",
+    cancelLabel: "Cancel",
+    saveLabel: "Save",
+  };
+
+  it("renders breadcrumb, title, action buttons, and application link", () => {
+    render(<AwardRecommendationSubmissionEditHero {...defaultProps} />);
+
+    expect(
+      screen.getByTestId("award-recommendation-submission-edit-hero"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("award-recommendation-submission-edit-hero"),
+    ).toHaveClass("bg-base-lightest");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Edit APP-26-00001",
+    );
+
+    const applicationLink = screen.getByRole("link", {
+      name: /View original application/i,
+    });
+    expect(applicationLink).toBeVisible();
+    expect(applicationLink).toHaveAttribute(
+      "href",
+      "/workspace/applications/app-id-456",
+    );
+    expect(applicationLink).toHaveAttribute("target", "_blank");
+    expect(applicationLink).toHaveTextContent("APP-26-00001");
+
+    expect(screen.getByRole("link", { name: "Cancel" })).toHaveAttribute(
+      "href",
+      "/award-recommendation/ar-id-123/edit",
+    );
+    expect(screen.getByRole("button", { name: "Save" })).toHaveAttribute(
+      "type",
+      "submit",
+    );
+  });
+});

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/AwardRecommendationSubmissionEditHero.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/AwardRecommendationSubmissionEditHero.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { Button, Grid, GridContainer } from "@trussworks/react-uswds";
+
+import Breadcrumbs from "src/components/core/Breadcrumbs";
+import { USWDSIcon } from "src/components/core/USWDSIcon";
+
+type AwardRecommendationSubmissionEditHeroProps = {
+  awardRecommendationId: string;
+  awardRecommendationBreadcrumbTitle: string;
+  applicationSubmissionNumber: string;
+  applicationId: string;
+  awardRecsLabel: string;
+  editTitle: string;
+  viewOriginalApplicationLabel: string;
+  cancelLabel: string;
+  saveLabel: string;
+};
+
+export default function AwardRecommendationSubmissionEditHero({
+  awardRecommendationId,
+  awardRecommendationBreadcrumbTitle,
+  applicationSubmissionNumber,
+  applicationId,
+  awardRecsLabel,
+  editTitle,
+  viewOriginalApplicationLabel,
+  cancelLabel,
+  saveLabel,
+}: AwardRecommendationSubmissionEditHeroProps) {
+  const editPageHref = `/award-recommendation/${awardRecommendationId}/edit`;
+
+  return (
+    <div
+      data-testid="award-recommendation-submission-edit-hero"
+      className="text-dark bg-base-lightest padding-bottom-4 mobile-lg:padding-y-4 tablet:padding-y-6"
+    >
+      <GridContainer>
+        <Grid>
+          <Breadcrumbs
+            className="padding-y-0 bg-transparent"
+            breadcrumbList={[
+              {
+                title: awardRecsLabel,
+                path: "/",
+              },
+              {
+                title: awardRecommendationBreadcrumbTitle,
+                path: editPageHref,
+              },
+              {
+                title: editTitle,
+              },
+            ]}
+          />
+          <Grid className="padding-bottom-4 mobile-lg:padding-y-4 tablet:padding-y-3">
+            <h1 className="font-sans-xl tablet:font-sans-2xl">{editTitle}</h1>
+          </Grid>
+          <div className="display-flex flex-column tablet:flex-row tablet:flex-justify flex-align-end gap-2">
+            <Link
+              href={`/workspace/applications/${applicationId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="usa-link display-inline-flex flex-align-center flex-wrap"
+            >
+              {viewOriginalApplicationLabel} {applicationSubmissionNumber}
+              <USWDSIcon
+                name="launch"
+                className="usa-icon--size-2 text-middle margin-left-05"
+              />
+            </Link>
+            <div className="display-flex flex-justify-start gap-1 margin-top-4 tablet:margin-top-0 flex-shrink-0">
+              <Link
+                href={editPageHref}
+                className="usa-button usa-button--outline width-auto"
+                prefetch={false}
+              >
+                {cancelLabel}
+              </Link>
+              <Button type="submit" className="width-auto">
+                {saveLabel}
+              </Button>
+            </div>
+          </div>
+        </Grid>
+      </GridContainer>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.test.tsx
@@ -55,6 +55,10 @@ const mockGetAwardRecommendationSubmission = jest
   .fn()
   .mockResolvedValue(mockAwardRecommendationSubmissions[0]);
 
+const mockGetAwardRecommendationDetails = jest.fn().mockResolvedValue({
+  award_recommendation_number: "AR-26-0002",
+});
+
 jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher", () => ({
   getAwardRecommendationSubmission: (
     awardRecommendationId: string,
@@ -64,6 +68,13 @@ jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher", () => ({
       awardRecommendationId,
       applicationSubmissionId,
     ) as Promise<AwardRecommendationSubmission | null>,
+  getAwardRecommendationDetails: (
+    awardRecommendationId: string,
+  ): Promise<{ award_recommendation_number: string }> =>
+    mockGetAwardRecommendationDetails(awardRecommendationId) as Promise<{
+      award_recommendation_number: string;
+    }>,
+  updateAwardRecommendationSubmissionDetails: jest.fn(),
 }));
 
 const pageParams = Promise.resolve({
@@ -94,6 +105,9 @@ describe("AwardRecommendationSubmissionEditPage", () => {
       mockGetAwardRecommendationSubmission.mockResolvedValue(
         mockAwardRecommendationSubmissions[0],
       );
+      mockGetAwardRecommendationDetails.mockResolvedValue({
+        award_recommendation_number: "AR-26-0002",
+      });
     });
 
     it("fetches the application submission details", async () => {
@@ -102,10 +116,35 @@ describe("AwardRecommendationSubmissionEditPage", () => {
         searchParams: Promise.resolve({}),
       });
 
+      expect(mockGetAwardRecommendationDetails).toHaveBeenCalledWith(
+        "AR-26-0001",
+      );
       expect(mockGetAwardRecommendationSubmission).toHaveBeenCalledWith(
         "AR-26-0001",
         mockAwardRecommendationSubmissions[0]
           .award_recommendation_application_submission_id,
+      );
+    });
+
+    it("renders the submission edit hero", async () => {
+      const component = await AwardRecommendationSubmissionEditPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(
+        await screen.findByTestId("award-recommendation-submission-edit-hero"),
+      ).toBeVisible();
+      expect(
+        screen.getByRole("link", {
+          name: /submissionEdit.viewOriginalApplication/i,
+        }),
+      ).toHaveAttribute(
+        "href",
+        "/workspace/applications/63588df8-f2d1-44ed-a201-5804abba696d",
+      );
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+        "submissionEdit.editTitle",
       );
     });
 
@@ -187,7 +226,7 @@ describe("AwardRecommendationSubmissionEditPage", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("renders cancel and save buttons", async () => {
+    it("renders cancel and save buttons in the hero", async () => {
       const component = await AwardRecommendationSubmissionEditPage({
         params: pageParams,
       });

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.tsx
@@ -136,7 +136,7 @@ async function AwardRecommendationSubmissionEditPageContent({
         <input
           type="hidden"
           name="award_recommendation_application_submission_id"
-          value={submission.award_recommendation_application_submission_id}
+          value={applicationSubmissionId}
         />
         <RecommendationDetailsSection submission={submission} />
       </GridContainer>

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.tsx
@@ -1,21 +1,24 @@
 import { Metadata } from "next";
 import { saveAwardRecommendationSubmissionDetails } from "src/app/[locale]/(base)/award-recommendation/[id]/actions";
+import AwardRecommendationSubmissionEditHero from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/AwardRecommendationSubmissionEditHero";
 import { RecommendationDetailsSection } from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
-import { getAwardRecommendationSubmission } from "src/services/fetch/fetchers/awardRecommendationFetcher";
+import {
+  getAwardRecommendationDetails,
+  getAwardRecommendationSubmission,
+} from "src/services/fetch/fetchers/awardRecommendationFetcher";
 import { AwardRecommendationSubmission } from "src/types/awardRecommendationTypes";
 import { WithFeatureFlagProps } from "src/types/uiTypes";
 
 import { getTranslations } from "next-intl/server";
-import Link from "next/link";
 import { redirect } from "next/navigation";
-import { Alert, Button, Grid, GridContainer } from "@trussworks/react-uswds";
+import { Alert, GridContainer } from "@trussworks/react-uswds";
 
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ locale: string; id?: string }>;
+  params: Promise<{ locale: string; id: string }>;
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale });
@@ -31,8 +34,8 @@ export const dynamic = "force-dynamic";
 export type AwardRecommendationSubmissionEditPageProps = {
   params: Promise<{
     locale: string;
-    id?: string;
-    applicationSubmissionId?: string;
+    id: string;
+    applicationSubmissionId: string;
   }>;
 } & WithFeatureFlagProps;
 
@@ -43,43 +46,50 @@ async function AwardRecommendationSubmissionEditPageContent({
   const t = await getTranslations("AwardRecommendation");
 
   let submission: AwardRecommendationSubmission | null = null;
-  if (awardRecommendationId && applicationSubmissionId) {
-    try {
-      submission = await getAwardRecommendationSubmission(
+  let awardRecommendationNumber = awardRecommendationId;
+
+  try {
+    const [awardRecommendationDetails, submissionDetails] = await Promise.all([
+      getAwardRecommendationDetails(awardRecommendationId),
+      getAwardRecommendationSubmission(
         awardRecommendationId,
         applicationSubmissionId,
-      );
-    } catch (error) {
-      console.error(
-        "Failed to fetch award recommendation submission details",
-        error,
-      );
-      const errorStatus = parseErrorStatus(error as ApiRequestError);
+      ),
+    ]);
 
-      if (errorStatus === 401 || errorStatus === 403) {
-        return (
-          <Alert
-            heading={t("errorHeadingAuthentication")}
-            headingLevel="h2"
-            type="error"
-            validation
-          >
-            {t("authenticationError")}
-          </Alert>
-        );
-      }
+    awardRecommendationNumber =
+      awardRecommendationDetails.award_recommendation_number;
+    submission = submissionDetails;
+  } catch (error) {
+    console.error(
+      "Failed to fetch award recommendation submission details",
+      error,
+    );
+    const errorStatus = parseErrorStatus(error as ApiRequestError);
 
+    if (errorStatus === 401 || errorStatus === 403) {
       return (
         <Alert
-          heading={t("errorHeadingAwardRecommendationSubmission")}
+          heading={t("errorHeadingAuthentication")}
           headingLevel="h2"
-          type="warning"
+          type="error"
           validation
         >
-          {t("awardRecommendationSubmissionFetchError")}
+          {t("authenticationError")}
         </Alert>
       );
     }
+
+    return (
+      <Alert
+        heading={t("errorHeadingAwardRecommendationSubmission")}
+        headingLevel="h2"
+        type="warning"
+        validation
+      >
+        {t("awardRecommendationSubmissionFetchError")}
+      </Alert>
+    );
   }
 
   if (!submission) {
@@ -95,30 +105,40 @@ async function AwardRecommendationSubmissionEditPageContent({
     );
   }
 
+  const applicationSubmission = submission.application_submission;
+  const applicationSubmissionNumber =
+    applicationSubmission.application_submission_number || "";
+  const applicationId = applicationSubmission.application?.application_id ?? "";
+
   return (
-    <form>
+    <form action={saveAwardRecommendationSubmissionDetails}>
+      <AwardRecommendationSubmissionEditHero
+        awardRecommendationId={awardRecommendationId}
+        awardRecommendationBreadcrumbTitle={`${t("heroTitle")}: ${awardRecommendationNumber}`}
+        applicationSubmissionNumber={applicationSubmissionNumber}
+        applicationId={applicationId}
+        awardRecsLabel={t("awardRecs")}
+        editTitle={t("submissionEdit.editTitle", {
+          applicationSubmissionNumber,
+        })}
+        viewOriginalApplicationLabel={t(
+          "submissionEdit.viewOriginalApplication",
+        )}
+        cancelLabel={t("heroButtons.cancel")}
+        saveLabel={t("heroButtons.save")}
+      />
       <GridContainer>
+        <input
+          type="hidden"
+          name="award_recommendation_id"
+          value={awardRecommendationId}
+        />
+        <input
+          type="hidden"
+          name="award_recommendation_application_submission_id"
+          value={submission.award_recommendation_application_submission_id}
+        />
         <RecommendationDetailsSection submission={submission} />
-        <Grid row className="grid-gap">
-          <Grid col={9} tablet={{ col: 9 }}>
-            <Grid className="display-flex flex-justify-start gap-1 margin-top-2 margin-bottom-5">
-              <Link
-                href={`/award-recommendation/${awardRecommendationId}/edit`}
-                className="usa-button usa-button--outline width-auto"
-                prefetch={false}
-              >
-                {t("heroButtons.cancel")}
-              </Link>
-              <Button
-                type="submit"
-                formAction={saveAwardRecommendationSubmissionDetails}
-                className="width-auto"
-              >
-                {t("heroButtons.save")}
-              </Button>
-            </Grid>
-          </Grid>
-        </Grid>
       </GridContainer>
     </form>
   );

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2081,6 +2081,10 @@ export const messages = {
       submitForReview: "Submit for review",
       backToEdit: "Back to Edit",
     },
+    submissionEdit: {
+      editTitle: "Edit {applicationSubmissionNumber}",
+      viewOriginalApplication: "View original application",
+    },
     pageTitle: "Review your Recommendation",
     pageTitleEdit: "Edit your recommendation",
     description: "Award Recommendation flow coming soon.",

--- a/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.test.ts
+++ b/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.test.ts
@@ -5,6 +5,7 @@ import {
   getAwardRecommendationSubmission,
   listAwardRecommendationSubmissions,
   listAwardRecommendationSubmissionsPaginated,
+  updateAwardRecommendationSubmissionDetails,
 } from "src/services/fetch/fetchers/awardRecommendationFetcher";
 import { APIResponse } from "src/types/apiResponseTypes";
 import {
@@ -146,6 +147,39 @@ describe("getAwardRecommendationSubmission", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe("updateAwardRecommendationSubmissionDetails", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls fetchAwardRecommendationWithMethod with the correct arguments", async () => {
+    const submissionId =
+      mockAwardRecommendationSubmissions[0]
+        .award_recommendation_application_submission_id;
+
+    await updateAwardRecommendationSubmissionDetails("an id", {
+      [submissionId]: {
+        award_recommendation_type: "recommended_for_funding",
+        recommended_amount: "50000.00",
+        has_exception: false,
+      },
+    });
+
+    expect(mockInnerFetch).toHaveBeenCalledWith({
+      subPath: "an id/submission-details",
+      body: {
+        award_recommendation_submissions: {
+          [submissionId]: {
+            award_recommendation_type: "recommended_for_funding",
+            recommended_amount: "50000.00",
+            has_exception: false,
+          },
+        },
+      },
+    });
   });
 });
 

--- a/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.ts
@@ -3,6 +3,7 @@ import {
   AwardRecommendationDetails,
   AwardRecommendationRisk,
   AwardRecommendationSubmission,
+  AwardRecommendationSubmissionDetailUpdate,
   AwardRecommendationSubmissionListFilters,
 } from "src/types/awardRecommendationTypes";
 import { PaginationRequestBody } from "src/types/search/searchRequestTypes";
@@ -108,4 +109,28 @@ export const deleteAwardRecommendationRisk = async (
     success: response.ok,
     message: responseBody.message,
   };
+};
+
+export const updateAwardRecommendationSubmissionDetails = async (
+  awardRecommendationId: string,
+  awardRecommendationSubmissions: Record<
+    string,
+    AwardRecommendationSubmissionDetailUpdate
+  >,
+): Promise<AwardRecommendationSubmission[]> => {
+  const response = await fetchAwardRecommendationWithMethod("PUT")({
+    subPath: `${awardRecommendationId}/submission-details`,
+    body: {
+      award_recommendation_submissions: awardRecommendationSubmissions,
+    },
+  });
+  const responseBody = (await response.json()) as APIResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      responseBody.message || "Failed to save submission details",
+    );
+  }
+
+  return (responseBody.data as AwardRecommendationSubmission[]) || [];
 };

--- a/frontend/src/types/awardRecommendationTypes.ts
+++ b/frontend/src/types/awardRecommendationTypes.ts
@@ -123,6 +123,14 @@ export type AwardRecommendationSubmissionDetail = {
   exception_detail?: string;
 };
 
+export type AwardRecommendationSubmissionDetailUpdate = {
+  recommended_amount?: string;
+  general_comment?: string | null;
+  award_recommendation_type?: AwardRecommendationType;
+  has_exception?: boolean;
+  exception_detail?: string | null;
+};
+
 export type AwardRecommendationSubmission = {
   award_recommendation_application_submission_id: string;
   application_submission: AwardRecommendationApplicationSubmission;


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10349 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Added `AwardRecommendationSubmissionEditHero` to the Edit Application Submission Details page, including breadcrumbs, page title, Cancel/Save actions, and a “View original application” link to `/workspace/applications/{applicationId}`.
- Wrapped the edit page in a form wired to `saveAwardRecommendationSubmissionDetails`, which calls the existing `PUT .../submission-details` API via a new `updateAwardRecommendationSubmissionDetails` fetcher.
- Simplified FormData parsing in `actions.ts` to match project conventions (`readStringValue` + direct field reads with a hidden submission ID).

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
- The hero lives in page-local _components/ per our component organization guidelines.
   - Note that Chai is working on a standard Hero component to be used across Award Recommendation pages, so this will likely need to be refactored to use that component instead.
- Save redirects back to the award recommendation edit page on success.
- The “View original application” link opens the grantee workspace application view in a new tab

## Validation steps

- [ ] Disable the `awardRecommendationOff` feature flag.
- [ ] Navigate to an award recommendation edit page and open a submission’s edit details page by clicking the link in the table (or go directly to http://localhost:3000/award-recommendation/{id}/application-submissions/{applicationSubmissionId}/edit).
- [ ] Confirm the header shows breadcrumbs, the submission number in the title, Cancel/Save buttons, and the “View original application” link.
- [ ] Update recommendation fields and click Save; confirm you are redirected to the AR edit page and changes persist after reload (Can see these changes in the Recommended/Exceptions tables, depending on the changes you make)
