### PR TITLE
[Issue #9734] Add additional fields in SF-424A frontend

### DIFF
--- a/frontend/src/components/apply-form/widgets/budget/Budget424aSectionC.tsx
+++ b/frontend/src/components/apply-form/widgets/budget/Budget424aSectionC.tsx
@@ -8,13 +8,16 @@ import {
 import React, { JSX } from "react";
 import { Table } from "@trussworks/react-uswds";
 
+import TextWidget from "src/components/apply-form/widgets/TextWidget";
 import { ACTIVITY_ITEMS } from "./budgetConstants";
 import { getBudgetErrors } from "./budgetErrorLabels";
+import { activityTitleSchema } from "./budgetSchemas";
 import { BaseActivityItem, MoneyString } from "./budgetTypes";
 import { CurrencyInput, HelperText } from "./budgetUiComponents";
 import { asMoney, getStringOrUndefined, isRecord } from "./budgetValueGuards";
 
 interface NonFederalResources {
+  grant_program?: string;
   applicant_amount?: MoneyString;
   state_amount?: MoneyString;
   other_amount?: MoneyString;
@@ -38,6 +41,8 @@ type NormalizedC = {
 function pickNonFederalResources(value: unknown): NonFederalResources {
   if (!isRecord(value)) return {};
   return {
+    grant_program:
+      typeof value.grant_program === "string" ? value.grant_program : undefined,
     applicant_amount: asMoney(value.applicant_amount),
     state_amount: asMoney(value.state_amount),
     other_amount: asMoney(value.other_amount),
@@ -146,26 +151,37 @@ function Budget424aSectionC<
   ];
 
   const titleCell = (rowIndex: number): JSX.Element => {
-    const title =
-      getStringOrUndefined(activityItems, `[${rowIndex}].activity_title`) ?? "";
-    const cfda =
-      getStringOrUndefined(
+    const title = getStringOrUndefined(
+      activityItems,
+      `[${rowIndex}].non_federal_resources.grant_program`,
+    );
+
+    const hasAmounts =
+      get(
         activityItems,
-        `[${rowIndex}].assistance_listing_number`,
-      ) ?? "";
+        `[${rowIndex}].non_federal_resources.applicant_amount`,
+      ) 
+      ||
+      get(activityItems, `[${rowIndex}].non_federal_resources.state_amount`
+
+      )
+       ||
+      get(activityItems, `[${rowIndex}].non_federal_resources.other_amount`);
+
+    const displayTitle = title?.trim() ? title : hasAmounts ? "N/A" : "";
 
     return (
-      <div className="display-flex flex-column">
-        {/* Display text only (no input). Fallback to dash. */}
-        <div className="minw-15 font-sans-sm text-italic">
-          {title.trim() ? title : "—"}
-        </div>
-        {cfda.trim() ? (
-          <div className="font-sans-3xs text-base-dark text-italic">
-            CFDA: {cfda}
-          </div>
-        ) : null}
-      </div>
+      <TextWidget
+        schema={activityTitleSchema}
+        id={`activity_line_items[${rowIndex}]--non_federal_resources--grant_program`}
+        rawErrors={getErrorMessagesForField(
+          `activity_line_items[${rowIndex}]--non_federal_resources--grant_program`,
+        )}
+        formClassName="margin-left-2"
+        inputClassName="minw-10 sf424a-section-a__activity-input"
+        value={displayTitle}
+        disabled={disabled}
+      />
     );
   };
 

--- a/frontend/src/components/apply-form/widgets/budget/Budget424aSectionC.tsx
+++ b/frontend/src/components/apply-form/widgets/budget/Budget424aSectionC.tsx
@@ -160,12 +160,8 @@ function Budget424aSectionC<
       get(
         activityItems,
         `[${rowIndex}].non_federal_resources.applicant_amount`,
-      ) 
-      ||
-      get(activityItems, `[${rowIndex}].non_federal_resources.state_amount`
-
-      )
-       ||
+      ) ||
+      get(activityItems, `[${rowIndex}].non_federal_resources.state_amount`) ||
       get(activityItems, `[${rowIndex}].non_federal_resources.other_amount`);
 
     const displayTitle = title?.trim() ? title : hasAmounts ? "N/A" : "";

--- a/frontend/src/components/apply-form/widgets/budget/Budget424aSectionE.tsx
+++ b/frontend/src/components/apply-form/widgets/budget/Budget424aSectionE.tsx
@@ -8,13 +8,16 @@ import {
 import React, { JSX } from "react";
 import { Table } from "@trussworks/react-uswds";
 
+import TextWidget from "src/components/apply-form/widgets/TextWidget";
 import { ACTIVITY_ITEMS, BUDGET_ACTIVITY_COLUMNS } from "./budgetConstants";
 import { getBudgetErrors } from "./budgetErrorLabels";
+import { activityTitleSchema } from "./budgetSchemas";
 import { BaseActivityItem, MoneyString } from "./budgetTypes";
 import { CurrencyInput, HelperText } from "./budgetUiComponents";
 import { asMoney, getStringOrUndefined, isRecord } from "./budgetValueGuards";
 
 interface FederalFundEstimates {
+  grant_program?: string;
   first_year_amount?: MoneyString;
   second_year_amount?: MoneyString;
   third_year_amount?: MoneyString;
@@ -34,6 +37,8 @@ type NormalizedE = {
 function pickFederalFundEstimates(value: unknown): FederalFundEstimates {
   if (!isRecord(value)) return {};
   return {
+    grant_program:
+      typeof value.grant_program === "string" ? value.grant_program : undefined,
     first_year_amount: asMoney(value.first_year_amount),
     second_year_amount: asMoney(value.second_year_amount),
     third_year_amount: asMoney(value.third_year_amount),
@@ -130,25 +135,42 @@ function Budget424aSectionE<
   type YearKey = (typeof YEARS)[number]["key"];
 
   const titleCell = (rowIndex: number): JSX.Element => {
-    const title =
-      getStringOrUndefined(activityItems, `[${rowIndex}].activity_title`) ?? "";
-    const assistanceListingNumber =
-      getStringOrUndefined(
-        activityItems,
-        `[${rowIndex}].assistance_listing_number`,
-      ) ?? "";
+    const title = getStringOrUndefined(
+      activityItems,
+      `[${rowIndex}].federal_fund_estimates.grant_program`,
+    );
 
+    const hasAmounts =
+      get(
+        activityItems,
+        `[${rowIndex}].federal_fund_estimates.first_year_amount`,
+      ) ||
+      get(
+        activityItems,
+        `[${rowIndex}].federal_fund_estimates.second_year_amount`,
+      ) ||
+      get(
+        activityItems,
+        `[${rowIndex}].federal_fund_estimates.third_year_amount`,
+      ) ||
+      get(
+        activityItems,
+        `[${rowIndex}].federal_fund_estimates.fourth_year_amount`,
+      );
+
+    const displayTitle = title?.trim() ? title : hasAmounts ? "N/A" : "";
     return (
-      <div className="display-flex flex-column">
-        <div className="minw-15 font-sans-sm text-italic">
-          {title.trim() ? title : "—"}
-        </div>
-        {assistanceListingNumber.trim() ? (
-          <div className="font-sans-3xs text-base-dark text-italic">
-            CFDA: {assistanceListingNumber}
-          </div>
-        ) : null}
-      </div>
+      <TextWidget
+        schema={activityTitleSchema}
+        id={`activity_line_items[${rowIndex}]--federal_fund_estimates--grant_program`}
+        rawErrors={getErrorMessagesForField(
+          `activity_line_items[${rowIndex}]--federal_fund_estimates--grant_program`,
+        )}
+        formClassName="margin-left-2"
+        inputClassName="minw-10 sf424a-section-a__activity-input"
+        value={displayTitle}
+        disabled={disabled}
+      />
     );
   };
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9734 

## Changes proposed

- Added editable UI fields for SF-424A Section C Column A and Section E Column A.

- Updated Section C and Section E to use the schema-backed fields instead of read-only/pre-populated display values.

- Kept the new fields optional and editable.

- Preserved existing amount fields, calculations, and totals behavior.

- Ensured the new Column A values are available for save/reopen and print view behavior.

## Context for reviewers

As Per DAT business rules, Section C Column A and Section E Column A should be user-editable. If the user leaves Column A blank but enters corresponding values in the related amount columns, the field should populate as “N/A” upon save/submission. 

## Validation steps

- Open SF-424A and verify Section C Column A and Section E Column A are editable.

- Enter values, save, refresh/reopen, and confirm values persist.

- Leave Column A blank while entering corresponding amount values, save, and confirm it populates as N/A.
