### PR TITLE
[unticketed]: update github actions versions to use latest node version

### DIFF
--- a/.github/workflows/vulnerability-scans.yml
+++ b/.github/workflows/vulnerability-scans.yml
@@ -48,7 +48,7 @@ jobs:
     outputs:
       commit_hash: ${{ steps.get-commit-hash.outputs.commit_hash }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1000
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Scans Dockerfile for any bad practices or issues
       - name: Scan Dockerfile by hadolint
@@ -90,14 +90,14 @@ jobs:
       image: ${{ steps.shared-output.outputs.image }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.sha }}
           fetch-depth: 1000
 
       - name: Check Docker image cached
         id: check-docker-image-cached
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
           lookup-only: true
@@ -110,7 +110,7 @@ jobs:
       - name: Restore Docker layers
         if: steps.check-docker-image-cached.outputs.cache-hit != 'true'
         id: restore-buildx
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ inputs.app_name }}-buildx-${{ needs.get-commit-hash.outputs.commit_hash }}
@@ -153,7 +153,7 @@ jobs:
       - name: Cache Docker layers
         if: steps.check-docker-image-cached.outputs.cache-hit != 'true'
         id: cache-buildx
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ inputs.app_name }}-buildx-${{ needs.get-commit-hash.outputs.commit_hash }}
@@ -178,7 +178,7 @@ jobs:
 
       - name: Cache Docker image
         if: steps.check-docker-image-cached.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: /tmp/docker-image.tar
           key: ${{ inputs.app_name }}-docker-img-${{ needs.get-commit-hash.outputs.commit_hash }}
@@ -283,7 +283,7 @@ jobs:
     needs: [build-and-cache, get-commit-hash]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Clear ignore files
         # If there's an exact match in cache, skip build entirely
@@ -294,7 +294,7 @@ jobs:
           mv new.grype.yml .grype.yml
 
       - name: Restore cached Docker image
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
           key: ${{ inputs.app_name }}-docker-img-${{ needs.get-commit-hash.outputs.commit_hash }}
@@ -305,7 +305,7 @@ jobs:
 
       - name: Run Anchore vulnerability scan (json)
         if: always() # Runs even if there is a failure
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@v7
         id: anchore-scan-json
         with:
           image: ${{ needs.build-and-cache.outputs.image }}
@@ -315,7 +315,7 @@ jobs:
 
       - name: Run Anchore vulnerability scan (table)
         if: always() # Runs even if there is a failure
-        uses: anchore/scan-action@v6
+        uses: anchore/scan-action@v7
         with:
           image: ${{ needs.build-and-cache.outputs.image }}
           output-format: table
@@ -405,10 +405,10 @@ jobs:
     needs: [build-and-cache, get-commit-hash]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Restore cached Docker image
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: /tmp/docker-image.tar
           key: ${{ inputs.app_name }}-docker-img-${{ needs.get-commit-hash.outputs.commit_hash }}


### PR DESCRIPTION
## Summary

Updated the github actions versions to use an updated node version.  Node 20 is depreciated. 

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Run anchore/scan-action@v6
```

## Validation steps

All scans should be passing below. 