### PR TITLE
Added awardMaxGreaterThanMin validation message

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.test.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.test.ts
@@ -154,7 +154,7 @@ describe("saveOpportunityEditAction", () => {
 
     expect(result.validationErrors).toEqual({
       awardMinimum: ["awardMinLessThanMax"],
-      awardMaximum: ["awardMinLessThanMax"],
+      awardMaximum: ["awardMaxGreaterThanMin"],
     });
   });
 

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
@@ -157,7 +157,7 @@ async function validateOpportunityEditForm(formData: FormData) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ["awardMaximum"],
-            message: validationErrors("awardMinLessThanMax"),
+            message: validationErrors("awardMaxGreaterThanMin"),
           });
         }
       },

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -427,6 +427,8 @@ export const messages = {
       awardMaxLessThanTotal:
         "Award maximum cannot exceed the Estimated Total Program Funding.",
       awardMinLessThanMax: "Award minimum cannot exceed Award maximum.",
+      awardMaxGreaterThanMin:
+        "Award maximum cannot be less than Award minimum.",
     },
     attachments: {
       removeButton: "Remove",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10999 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Added an awardMaxGreaterThanMin validation message for the Award Maximum field. The validation message in the Award minimum field was being duplicated in both fields prior as per bug ticket referenced.


## Validation steps

<img width="1185" height="244" alt="image" src="https://github.com/user-attachments/assets/da8ae340-2787-4806-b8d2-6e821ce31ee4" />

