### PR TITLE
[unticketed]: resolve trivy and anchore cves

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:b6b5679@sha256:988d748c408a3af9a485c73998a68e60121e1708620ca1473a67e733f89fbd37 AS base
+FROM ghcr.io/hhs/python-base-image:8dc0b48@sha256:4875ffafd9b316c757354255e810e9b4a37771c2131070ec48839b3ce1c32652 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:b6b5679@sha256:988d748c408a3af9a485c73998a68e60121e1708620ca1473a67e733f89fbd37 AS base
+FROM ghcr.io/hhs/python-base-image:8dc0b48@sha256:4875ffafd9b316c757354255e810e9b4a37771c2131070ec48839b3ce1c32652 AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -154,16 +154,13 @@ RUN dnf install -y \
       glib2-2.82.2-767.amzn2023 \
       curl-minimal-8.17.0-1.amzn2023.0.3 \
       libcurl-minimal-8.17.0-1.amzn2023.0.3 \
-      kernel6.18-headers-6.18.30-61.116.amzn2023 \
       glibc-2.34-231.amzn2023.0.4 \
       glibc-common-2.34-231.amzn2023.0.4 \
       glibc-devel-2.34-231.amzn2023.0.4 \
       glibc-gconv-extra-2.34-231.amzn2023.0.4 \
       glibc-headers-x86-2.34-231.amzn2023.0.4 \
       glibc-minimal-langpack-2.34-231.amzn2023.0.4 \
-      python3-pip-wheel-21.3.1-2.amzn2023.0.19 \
       krb5-libs-1.21.3-7.amzn2023.0.1 \
-      rust-toolset-srpm-macros-1.95.0-1.amzn2023.0.2 \
       libgcrypt-1.10.2-1.amzn2023.0.3 \
       libsolv-0.7.22-1.amzn2023.0.4 \
       gnutls-3.8.10-4.amzn2023.0.2 && \
@@ -171,6 +168,14 @@ RUN dnf install -y \
     dnf update -y --releasever=2023.10.20260302 \
       libxml2-2.10.4-1.amzn2023.0.18 \
       libxml2-devel-2.10.4-1.amzn2023.0.18 && \
+    dnf update -y --releasever=2023.12.20260622 \
+      openssl-3.5.5-1.amzn2023.0.5 \
+      openssl-libs-3.5.5-1.amzn2023.0.5 \
+      openssl-devel-3.5.5-1.amzn2023.0.5 \
+      openssl-fips-provider-latest-3.5.5-1.amzn2023.0.5 \
+      kernel6.18-headers-6.18.35-68.127.amzn2023 \
+      python3-pip-wheel-21.3.1-2.amzn2023.0.20 \
+      rust-toolset-srpm-macros-1.96.0-1.amzn2023.0.2 && \
     dnf clean all && \
     # Remove the system Python RPMs
     (dnf remove -y python3 python3-libs || rpm -e --nodeps python3 python3-libs || true) && \


### PR DESCRIPTION
## Summary

Resolve anchore and trivy cve findings in the python base image. 

Link to failing anchore and trivy scan: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28027717024)

## Validation steps

All scans should be passing below. 

Deployed to api dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28030805456)

Deployed to analytics dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28030830697)

