### PR TITLE
[unticketed]: fix openapi doc gen

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -306,7 +306,7 @@ cmd: ## Run Flask app CLI command (Run `make cli args="--help"` to see list of C
 	$(FLASK_CMD) $(args)
 
 openapi-spec: ## Generate OpenAPI spec
-	docker compose run --rm openapi-tools flask --app src.app spec --format yaml --output openapi.generated.yml
+	docker compose run --rm -e DB_CHECK_CONNECTION_ON_INIT=false openapi-tools flask --app src.app spec --format yaml --output openapi.generated.yml
 
 openapi-spec-common-grants:
 	$(FLASK_CMD) common_grants spec --output ./openapi-cg.generated.yml


### PR DESCRIPTION
## Summary

Currently, the openapi erd doc gen has been failing: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28035538728/job/82987736428)

Disabled the on-init connection check so we can create the doc without requiring the db to be up. 

Fixed the doc gen and verified locally. 

## Validation steps

All scans should be passing below. 