### PR TITLE
[Issue #10936] Fix transformation issue for deleting assistance listing connected to a competition

### DIFF
--- a/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
+++ b/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
@@ -1,11 +1,15 @@
 import logging
 
+from sqlalchemy import select
+
 import src.data_migration.transformation.transform_constants as transform_constants
 import src.data_migration.transformation.transform_util as transform_util
 from src.data_migration.transformation.subtask.abstract_transform_subtask import (
     AbstractTransformSubTask,
 )
+from src.db.models.competition_models import Competition
 from src.db.models.opportunity_models import Opportunity, OpportunityAssistanceListing
+from src.db.models.staging.competition import Tcompetition
 from src.db.models.staging.opportunity import TopportunityCfda
 
 logger = logging.getLogger(__name__)
@@ -62,6 +66,10 @@ class TransformAssistanceListing(AbstractTransformSubTask):
         logger.info("Processing assistance listing", extra=extra)
 
         if source_assistance_listing.is_deleted:
+            # Before deleting, handle any competitions that reference this assistance listing
+            if target_assistance_listing is not None:
+                self._handle_competition_references(target_assistance_listing, extra)
+
             self._handle_delete(
                 source_assistance_listing,
                 target_assistance_listing,
@@ -126,3 +134,69 @@ class TransformAssistanceListing(AbstractTransformSubTask):
 
         logger.info("Processed assistance listing", extra=extra)
         source_assistance_listing.transformed_at = self.transform_time
+
+    def _handle_competition_references(
+        self, target_assistance_listing: OpportunityAssistanceListing, extra: dict
+    ) -> None:
+        """
+        Handle competitions that reference the assistance listing being deleted, for api tables.
+
+        From api side, when deleting an assistance listing, need to check if any competition(s) reference it.
+        If yes, check against to staging competition tables to see if each competition is being deleted there.
+        For each competition in staging:
+            - If it is being deleted, nullify the reference to avoid foreign key constraint violations.
+            - If it is not, same nullify the reference, but also log an error. A conflict is happening though it is not expected.
+        """
+        # Find all competitions that reference this assistance listing
+        competitions_with_reference = (
+            self.db_session.execute(
+                select(Competition).where(
+                    Competition.opportunity_assistance_listing_id
+                    == target_assistance_listing.opportunity_assistance_listing_id
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        if not competitions_with_reference:
+            return
+
+        logger.info(
+            "Found competitions referencing assistance listing being deleted",
+            extra=extra | {"competition_count": len(competitions_with_reference)},
+        )
+
+        for competition in competitions_with_reference:
+            # Check if this competition is also being deleted in the staging table
+            staging_competition = self.db_session.execute(
+                select(Tcompetition).where(
+                    Tcompetition.comp_id == competition.legacy_competition_id
+                )
+            ).scalar_one_or_none()
+
+            is_competition_being_deleted = (
+                staging_competition is not None and staging_competition.is_deleted
+            )
+
+            if is_competition_being_deleted:
+                logger.info(
+                    "Nullifying assistance listing reference on competition that is also being deleted",
+                    extra=extra
+                    | {
+                        "competition_id": competition.competition_id,
+                        "legacy_competition_id": competition.legacy_competition_id,
+                    },
+                )
+            else:
+                logger.error(
+                    "Nullifying assistance listing reference on competition that is NOT being deleted on staging - this is unexpected",
+                    extra=extra
+                    | {
+                        "competition_id": competition.competition_id,
+                        "legacy_competition_id": competition.legacy_competition_id,
+                    },
+                )
+
+            # Nullify the reference to allow the assistance listing to be deleted
+            competition.opportunity_assistance_listing_id = None

--- a/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
+++ b/api/src/data_migration/transformation/subtask/transform_assistance_listing.py
@@ -139,13 +139,9 @@ class TransformAssistanceListing(AbstractTransformSubTask):
         self, target_assistance_listing: OpportunityAssistanceListing, extra: dict
     ) -> None:
         """
-        Handle competitions that reference the assistance listing being deleted, for api tables.
+        Handle reference from competitions when deleting the assistance listing.
 
-        From api side, when deleting an assistance listing, need to check if any competition(s) reference it.
-        If yes, check against to staging competition tables to see if each competition is being deleted there.
-        For each competition in staging:
-            - If it is being deleted, nullify the reference to avoid foreign key constraint violations.
-            - If it is not, same nullify the reference, but also log an error. A conflict is happening though it is not expected.
+        We always null the reference in the api table, the check being done at the staging is purely for error handling.
         """
         # Find all competitions that reference this assistance listing
         competitions_with_reference = (

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_assistance_listing.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_assistance_listing.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy import select
 
 import src.data_migration.transformation.transform_constants as transform_constants
 import tests.src.db.models.factories as f
@@ -266,14 +267,12 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
         cfda_to_delete = setup_cfda(create_existing=True, opportunity=opportunity)
 
         # Get the created assistance listing
-        assistance_listing = (
-            db_session.query(OpportunityAssistanceListing)
-            .filter(
+        assistance_listing = db_session.execute(
+            select(OpportunityAssistanceListing).where(
                 OpportunityAssistanceListing.legacy_opportunity_assistance_listing_id
                 == cfda_to_delete.opp_cfda_id
             )
-            .one()
-        )
+        ).scalar_one()
 
         # Create a competition that references this assistance listing
         staging_competition = setup_competition(
@@ -286,11 +285,11 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
         )
 
         # Get the created competition and set the assistance listing reference
-        competition = (
-            db_session.query(Competition)
-            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
-            .one()
-        )
+        competition = db_session.execute(
+            select(Competition).where(
+                Competition.legacy_competition_id == staging_competition.comp_id
+            )
+        ).scalar_one()
         competition.opportunity_assistance_listing_id = (
             assistance_listing.opportunity_assistance_listing_id
         )
@@ -314,11 +313,11 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
         validate_assistance_listing(db_session, cfda_to_delete, expect_in_db=False)
 
         # Verify the competition's reference was nullified
-        competition_after = (
-            db_session.query(Competition)
-            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
-            .one()
-        )
+        competition_after = db_session.execute(
+            select(Competition).where(
+                Competition.legacy_competition_id == staging_competition.comp_id
+            )
+        ).scalar_one()
         assert competition_after.opportunity_assistance_listing_id is None
 
     def test_delete_assistance_listing_with_competition_reference_not_being_deleted(
@@ -331,14 +330,12 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
         cfda_to_delete = setup_cfda(create_existing=True, opportunity=opportunity)
 
         # Get the created assistance listing
-        assistance_listing = (
-            db_session.query(OpportunityAssistanceListing)
-            .filter(
+        assistance_listing = db_session.execute(
+            select(OpportunityAssistanceListing).where(
                 OpportunityAssistanceListing.legacy_opportunity_assistance_listing_id
                 == cfda_to_delete.opp_cfda_id
             )
-            .one()
-        )
+        ).scalar_one()
 
         # Create a competition that references this assistance listing
         staging_competition = setup_competition(
@@ -351,11 +348,11 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
         )
 
         # Get the created competition and set the assistance listing reference
-        competition = (
-            db_session.query(Competition)
-            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
-            .one()
-        )
+        competition = db_session.execute(
+            select(Competition).where(
+                Competition.legacy_competition_id == staging_competition.comp_id
+            )
+        ).scalar_one()
         competition.opportunity_assistance_listing_id = (
             assistance_listing.opportunity_assistance_listing_id
         )
@@ -387,11 +384,11 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
         validate_assistance_listing(db_session, cfda_to_delete, expect_in_db=False)
 
         # Verify the competition's reference was nullified despite the error
-        competition_after = (
-            db_session.query(Competition)
-            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
-            .one()
-        )
+        competition_after = db_session.execute(
+            select(Competition).where(
+                Competition.legacy_competition_id == staging_competition.comp_id
+            )
+        ).scalar_one()
         assert competition_after.opportunity_assistance_listing_id is None
 
     def test_delete_assistance_listing_without_competition_references(

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_assistance_listing.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_assistance_listing.py
@@ -5,10 +5,12 @@ import tests.src.db.models.factories as f
 from src.data_migration.transformation.subtask.transform_assistance_listing import (
     TransformAssistanceListing,
 )
+from src.db.models.competition_models import Competition
 from src.db.models.opportunity_models import Opportunity, OpportunityAssistanceListing
 from tests.src.data_migration.transformation.conftest import (
     BaseTransformTestClass,
     setup_cfda,
+    setup_competition,
     validate_assistance_listing,
 )
 
@@ -253,3 +255,153 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
         metrics = transform_assistance_listing.metrics
         assert metrics[transform_constants.Metrics.TOTAL_RECORDS_PROCESSED] == 1
         assert metrics[transform_constants.Metrics.TOTAL_RECORDS_SKIPPED] == 1
+
+    def test_delete_assistance_listing_with_competition_reference_also_being_deleted(
+        self, db_session, transform_assistance_listing
+    ):
+        """Test that when deleting an assistance listing referenced by a competition that is also being deleted,
+        the competition reference is nullified"""
+        # Create an opportunity with an assistance listing
+        opportunity = f.OpportunityFactory.create(opportunity_assistance_listings=[])
+        cfda_to_delete = setup_cfda(create_existing=True, opportunity=opportunity)
+
+        # Get the created assistance listing
+        assistance_listing = (
+            db_session.query(OpportunityAssistanceListing)
+            .filter(
+                OpportunityAssistanceListing.legacy_opportunity_assistance_listing_id
+                == cfda_to_delete.opp_cfda_id
+            )
+            .one()
+        )
+
+        # Create a competition that references this assistance listing
+        staging_competition = setup_competition(
+            db_session,
+            create_existing=True,
+            opportunity=opportunity,
+            legacy_opportunity_assistance_listing_id=cfda_to_delete.opp_cfda_id,
+            is_delete=True,  # This competition is also being deleted
+        )
+
+        # Get the created competition and set the assistance listing reference
+        competition = (
+            db_session.query(Competition)
+            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
+            .one()
+        )
+        competition.opportunity_assistance_listing_id = (
+            assistance_listing.opportunity_assistance_listing_id
+        )
+        db_session.commit()
+
+        # Verify it references the assistance listing
+        assert (
+            competition.opportunity_assistance_listing_id
+            == assistance_listing.opportunity_assistance_listing_id
+        )
+
+        # Mark the assistance listing for deletion
+        cfda_to_delete.is_deleted = True
+        cfda_to_delete.transformed_at = None
+        db_session.commit()
+
+        # Run the transformation
+        transform_assistance_listing.run_subtask()
+
+        # Verify the assistance listing was deleted
+        validate_assistance_listing(db_session, cfda_to_delete, expect_in_db=False)
+
+        # Verify the competition's reference was nullified
+        competition_after = (
+            db_session.query(Competition)
+            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
+            .one()
+        )
+        assert competition_after.opportunity_assistance_listing_id is None
+
+    def test_delete_assistance_listing_with_competition_reference_not_being_deleted(
+        self, db_session, transform_assistance_listing, caplog
+    ):
+        """Test that when deleting an assistance listing referenced by a competition that is NOT being deleted,
+        the competition reference is still nullified but an error is logged"""
+        # Create an opportunity with an assistance listing
+        opportunity = f.OpportunityFactory.create(opportunity_assistance_listings=[])
+        cfda_to_delete = setup_cfda(create_existing=True, opportunity=opportunity)
+
+        # Get the created assistance listing
+        assistance_listing = (
+            db_session.query(OpportunityAssistanceListing)
+            .filter(
+                OpportunityAssistanceListing.legacy_opportunity_assistance_listing_id
+                == cfda_to_delete.opp_cfda_id
+            )
+            .one()
+        )
+
+        # Create a competition that references this assistance listing
+        staging_competition = setup_competition(
+            db_session,
+            create_existing=True,
+            opportunity=opportunity,
+            legacy_opportunity_assistance_listing_id=cfda_to_delete.opp_cfda_id,
+            is_delete=False,  # This competition is NOT being deleted
+        )
+
+        # Get the created competition and set the assistance listing reference
+        competition = (
+            db_session.query(Competition)
+            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
+            .one()
+        )
+        competition.opportunity_assistance_listing_id = (
+            assistance_listing.opportunity_assistance_listing_id
+        )
+        db_session.commit()
+
+        # Verify it references the assistance listing
+        assert (
+            competition.opportunity_assistance_listing_id
+            == assistance_listing.opportunity_assistance_listing_id
+        )
+
+        # Mark the assistance listing for deletion
+        cfda_to_delete.is_deleted = True
+        cfda_to_delete.transformed_at = None
+        db_session.commit()
+
+        # Run the transformation
+        with caplog.at_level("ERROR"):
+            transform_assistance_listing.run_subtask()
+
+        # Verify an error was logged
+        assert any(
+            "Nullifying assistance listing reference on competition that is NOT being deleted"
+            in record.message
+            for record in caplog.records
+        )
+
+        # Verify the assistance listing was deleted
+        validate_assistance_listing(db_session, cfda_to_delete, expect_in_db=False)
+
+        # Verify the competition's reference was nullified despite the error
+        competition_after = (
+            db_session.query(Competition)
+            .filter(Competition.legacy_competition_id == staging_competition.comp_id)
+            .one()
+        )
+        assert competition_after.opportunity_assistance_listing_id is None
+
+    def test_delete_assistance_listing_without_competition_references(
+        self, db_session, transform_assistance_listing
+    ):
+        """Test that deleting an assistance listing without any competition references works normally"""
+        # Create an opportunity with an assistance listing
+        opportunity = f.OpportunityFactory.create(opportunity_assistance_listings=[])
+        cfda_to_delete = setup_cfda(create_existing=True, opportunity=opportunity, is_delete=True)
+
+        # Run the transformation
+        transform_assistance_listing.run_subtask()
+
+        # Verify the assistance listing was deleted
+        validate_assistance_listing(db_session, cfda_to_delete, expect_in_db=False)

--- a/api/tests/src/data_migration/transformation/subtask/test_transform_assistance_listing.py
+++ b/api/tests/src/data_migration/transformation/subtask/test_transform_assistance_listing.py
@@ -282,6 +282,7 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
             opportunity=opportunity,
             legacy_opportunity_assistance_listing_id=cfda_to_delete.opp_cfda_id,
             is_delete=True,  # This competition is also being deleted
+            is_already_processed=True,  # Mark as processed to avoid interfering with other tests
         )
 
         # Get the created competition and set the assistance listing reference
@@ -346,6 +347,7 @@ class TestTransformAssistanceListing(BaseTransformTestClass):
             opportunity=opportunity,
             legacy_opportunity_assistance_listing_id=cfda_to_delete.opp_cfda_id,
             is_delete=False,  # This competition is NOT being deleted
+            is_already_processed=True,  # Mark as processed to avoid interfering with other tests
         )
 
         # Get the created competition and set the assistance listing reference


### PR DESCRIPTION
## Summary

Fixes #10936  

## Changes proposed

Fix issue with transformations when deleting assistance listing that is connected to a competition

## Context for reviewers

When doing transforms from grants.gov, we process them one table at a time. For example, we have the following table transforms in this order:

- TransformOpportunity
- TransformAssistanceListing
- TransformCompetition

That order is important as we can't add a competition to an opportunity until it exists. For the reverse case where an opportunity is deleted, it cascade deletes to all of its children tables.

However, in this case, we don't have that (and adding a cascade delete is iffy). The issue we are hitting is as follows:

- An assistance listing record is marked as deleted
- A competition has that assistance listing record set on itself
- We get an error from Postgres when trying to delete the assistance listing record because the foreign key from the competition table is still referencing it.

What we want to do for this logic:

- When deleting an assistance listing, check if any competitions reference it.
- Any that do, check if those competitions are also about to be deleted (tcompetition staging tables is_deleted flag is set to true) - if so, set the opportunity_assistance_listing_id on the api competition table to null - that way we can delete the assistance listing (don't delete the competition, leave that to the later step).
- If the competition isn't about to be deleted, log an error, but still set the opportunity_assistance_listing_id to null. This shouldn't happen, but we want to be safe.

## Validation steps

- Assistance listing transform logic updated for deletes to check/fix the competition table if needed
- Tests added that verify this behavior
