### PR TITLE
[Issue #9868] Enable API Gateway response streaming for file scan results endpoint

### DIFF
--- a/infra/modules/service/api_gateway.tf
+++ b/infra/modules/service/api_gateway.tf
@@ -53,6 +53,7 @@ locals {
         }
       }],
       "v1/users" = [],
+      "v1/files" = [],
   }][var.enable_api_gateway ? 1 : 0]
 
   second_level_endpoints = [
@@ -74,6 +75,7 @@ locals {
       "v1/users/login"                      = [{ "method" : "GET" }],
       "v1/users/logout"                     = [{ "method" : "GET" }],
       "v1/users/token"                      = [],
+      "v1/files/{file_id}"                  = [],
   }][var.enable_api_gateway ? 1 : 0]
 
   third_level_endpoints = [
@@ -115,6 +117,17 @@ locals {
       "v1/users/login/result"   = [{ "method" : "GET" }],
       "v1/users/token/logout"   = [{ "method" : "GET" }],
       "v1/users/token/refresh"  = [{ "method" : "GET" }],
+      "v1/files/{file_id}/results" = [{
+        "method" : "GET",
+        "api_key_required" : true,
+        "enable_streaming" : true,
+        "method_parameters" : {
+          "method.request.path.file_id" = true
+        },
+        "request_parameters" : {
+          "integration.request.path.file_id" : "method.request.path.file_id",
+        }
+      }],
   }][var.enable_api_gateway ? 1 : 0]
 
   fourth_level_endpoints = [
@@ -200,6 +213,7 @@ locals {
         "endpoint" : endpoint,
         "method" : config.method,
         "api_key_required" : lookup(config, "api_key_required", false),
+        "enable_streaming" : lookup(config, "enable_streaming", false),
         "method_parameters" : lookup(config, "method_parameters", {}),
         "request_parameters" : lookup(config, "request_parameters", {}),
         "request_models" : lookup(config, "request_models", {}),
@@ -448,7 +462,10 @@ resource "aws_api_gateway_integration" "third_level_endpoints" {
   type        = "HTTP_PROXY"
 
   passthrough_behavior = "WHEN_NO_MATCH"
-  timeout_milliseconds = 29000
+  # Use extended timeout for streaming endpoints (up to 15 minutes), otherwise use default 29 seconds
+  timeout_milliseconds = each.value.enable_streaming ? 900000 : 29000
+  # Enable streaming mode for endpoints that support it
+  response_transfer_mode = each.value.enable_streaming ? "STREAM" : null
 
   uri                = "https://${length(var.optional_extra_alb_domains) > 0 ? var.optional_extra_alb_domains[0] : var.domain_name}/${replace(each.value.endpoint, "+", "")}"
   request_parameters = each.value.request_parameters


### PR DESCRIPTION
## Summary

Fixes #9868

This PR enables AWS API Gateway response streaming for the `GET /v1/files/{file_id}/results` endpoint to improve performance when streaming file scan status updates to clients.

## Changes proposed

- Added `v1/files` and `v1/files/{file_id}` endpoint routes to API Gateway configuration
- Configured `v1/files/{file_id}/results` endpoint with `enable_streaming: true`
- Set `response_transfer_mode` to `"STREAM"` for streaming endpoints
- Increased timeout to 15 minutes (900000ms) for streaming endpoints vs the default 29 seconds for non-streaming endpoints
- Added `enable_streaming` flag extraction in `flattened_third_level_endpoints` transformation
- Updated `third_level_endpoints` integration to conditionally enable streaming based on the flag

## Context for reviewers

### Problem

The file scan results endpoint (`GET /v1/files/{file_id}/results`) returns streaming NDJSON responses using Flask's `stream_with_context()`. However, API Gateway was not configured with response streaming, causing it to buffer the entire response before sending it to clients. This defeated the purpose of streaming and could cause timeouts or poor UX.

### Solution

This change enables AWS API Gateway's response streaming feature (announced November 2024) specifically for the file scan results endpoint. The configuration is scoped only to this specific endpoint to avoid the previous issue where enabling streaming globally caused other routes to become non-functional.

The streaming is configured with:
- **Timeout**: Extended to 15 minutes (max allowed) for streaming vs 29 seconds default
- **Transfer Mode**: Set to `"STREAM"` to enable incremental response streaming
- **Scope**: Only applied to endpoints with `enable_streaming: true` flag

### Previous Issue

Earlier attempts to enable streaming (commits `e5ec542e6` and `32684471c` in April 2026) caused "ALL other routes were non-functional." The root cause was never fully identified but was suspected to be related to applying streaming configuration too broadly.

This implementation differs by:
1. Using a per-endpoint flag (`enable_streaming`) rather than global configuration
2. Only applying streaming settings in the integration resource for endpoints that explicitly enable it
3. Scoping the configuration to third-level endpoints only

### Testing Notes

When testing this change, please verify:

1. ✅ **Streaming endpoint works**: The `GET /v1/files/{file_id}/results` endpoint streams responses incrementally (can be tested by monitoring network activity to see chunks arriving over time)
2. ✅ **Other routes still functional**: All other API endpoints continue to work normally (this is the key acceptance criterion from the issue)
3. ✅ **Timeout handling**: The endpoint can stream for up to 15 minutes without timing out
4. ✅ **Error handling**: Errors are still properly propagated through the streaming response

## Validation steps

1. Deploy to a test environment
2. Call `GET /v1/files/{file_id}/results` and verify streaming behavior
3. Test a representative sample of other API endpoints to ensure they remain functional
4. Monitor CloudWatch logs for any errors or warnings related to API Gateway

---

**Note**: This change only affects the API Gateway configuration. The underlying Flask application streaming logic remains unchanged.