### PR TITLE
[Issue #11084] Improve newsletter subscription error handling

### DIFF
--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.test.tsx
@@ -113,4 +113,54 @@ describe("SubscriptionForm", () => {
       expect(errorAlerts.length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  it("shows a field-level email error when the API returns invalidEmail", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({ success: false, errorCode: "invalidEmail" }),
+      } as unknown as Response),
+    ) as unknown as typeof global.fetch;
+
+    render(<SubscriptionForm />);
+
+    const inputs = screen.getAllByTestId("textInput");
+    const nameInput = inputs.find((i) => i.id === "name")!;
+    const emailInput = inputs.find((i) => i.id === "email")!;
+    const button = screen.getByRole("button", { name: "form.button" });
+
+    fireEvent.change(nameInput, { target: { value: "Test User" } });
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("errors.invalidEmail")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a try-again message when the API returns tooManyRequests", async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({ success: false, errorCode: "tooManyRequests" }),
+      } as unknown as Response),
+    ) as unknown as typeof global.fetch;
+
+    render(<SubscriptionForm />);
+
+    const inputs = screen.getAllByTestId("textInput");
+    const nameInput = inputs.find((i) => i.id === "name")!;
+    const emailInput = inputs.find((i) => i.id === "email")!;
+    const button = screen.getByRole("button", { name: "form.button" });
+
+    fireEvent.change(nameInput, { target: { value: "Test User" } });
+    fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText("errors.tooManyRequests")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.tsx
+++ b/frontend/src/app/[locale]/(base)/newsletter/_components/SubscriptionForm.tsx
@@ -97,6 +97,16 @@ export default function SubscriptionForm() {
           errorMessage: t("errors.alreadySubscribed"),
           validationErrors: {},
         });
+      } else if (data.errorCode === "invalidEmail") {
+        setSubscribeErrorState({
+          errorMessage: "",
+          validationErrors: { email: [t("errors.invalidEmail")] },
+        });
+      } else if (data.errorCode === "tooManyRequests") {
+        setSubscribeErrorState({
+          errorMessage: t("errors.tooManyRequests"),
+          validationErrors: {},
+        });
       } else {
         setSubscribeErrorState({
           errorMessage: serverError,

--- a/frontend/src/app/api/newsletter/subscribe/route.test.ts
+++ b/frontend/src/app/api/newsletter/subscribe/route.test.ts
@@ -14,7 +14,9 @@ jest.mock("src/constants/environments", () => ({
   },
 }));
 
-const originalConsoleError = console.error;
+jest.mock("src/services/logger/simplerLogger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
 
 const buildRequest = (fields: Record<string, string>): NextRequest => {
   const formData = new FormData();
@@ -47,14 +49,12 @@ describe("POST /api/newsletter/subscribe", () => {
   beforeAll(() => {
     originalFetch = global.fetch;
     global.fetch = jest.fn();
-    console.error = jest.fn();
   });
 
   afterEach(() => jest.clearAllMocks());
 
   afterAll(() => {
     global.fetch = originalFetch;
-    console.error = originalConsoleError;
   });
 
   it("subscribes a valid user and calls Mailchimp with the expected request", async () => {
@@ -120,6 +120,72 @@ describe("POST /api/newsletter/subscribe", () => {
     });
   });
 
+  it("returns invalidEmail when Mailchimp rejects the email as fake or invalid", async () => {
+    mockMailchimpResponse({
+      total_created: 0,
+      total_updated: 0,
+      error_count: 1,
+      errors: [
+        {
+          email_address: "apple@example.com",
+          error:
+            "apple@example.com looks fake or invalid, please enter a real email address.",
+          error_code: "ERROR_GENERIC",
+        },
+      ],
+    });
+
+    const response = await POST(
+      buildRequest({ name: "Apple", email: "apple@example.com" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: false,
+      errorCode: "invalidEmail",
+    });
+  });
+
+  it("returns tooManyRequests when Mailchimp reports too many recent signups", async () => {
+    mockMailchimpResponse({
+      total_created: 0,
+      total_updated: 0,
+      error_count: 1,
+      errors: [
+        {
+          email_address: "apple@example.com",
+          error:
+            "apple@example.com has signed up for a lot of lists very recently; we're not allowing more signups for now.",
+          error_code: "ERROR_TOO_MANY_RECENT_SIGNUPS",
+        },
+      ],
+    });
+
+    const response = await POST(
+      buildRequest({ name: "Apple", email: "apple@example.com" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: false,
+      errorCode: "tooManyRequests",
+    });
+  });
+
+  it("returns tooManyRequests when Mailchimp responds with HTTP 429", async () => {
+    mockMailchimpResponse({}, { ok: false, status: 429 });
+
+    const response = await POST(
+      buildRequest({ name: "Apple", email: "apple@example.com" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: false,
+      errorCode: "tooManyRequests",
+    });
+  });
+
   it("returns a server error for other Mailchimp member errors", async () => {
     mockMailchimpResponse({
       total_created: 0,
@@ -145,8 +211,22 @@ describe("POST /api/newsletter/subscribe", () => {
     });
   });
 
-  it("returns a server error when Mailchimp responds with a non-ok status", async () => {
+  it("returns a server error when Mailchimp rejects our credentials (401)", async () => {
     mockMailchimpResponse({}, { ok: false, status: 401 });
+
+    const response = await POST(
+      buildRequest({ name: "Apple", email: "apple@example.com" }),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      success: false,
+      errorCode: "server",
+    });
+  });
+
+  it("returns a server error when Mailchimp has an upstream outage (5xx)", async () => {
+    mockMailchimpResponse({}, { ok: false, status: 503 });
 
     const response = await POST(
       buildRequest({ name: "Apple", email: "apple@example.com" }),

--- a/frontend/src/app/api/newsletter/subscribe/route.ts
+++ b/frontend/src/app/api/newsletter/subscribe/route.ts
@@ -1,4 +1,5 @@
 import { environment } from "src/constants/environments";
+import { logger } from "src/services/logger/simplerLogger";
 import { z } from "zod";
 
 import { NextRequest, NextResponse } from "next/server";
@@ -11,9 +12,30 @@ const subscribeSchema = z.object({
     .email("Please enter a valid email address."),
 });
 
-// Mailchimp returns this error_code in the batch-subscribe response when the
-// email address is already a member of the list.
+// Member-level error_codes returned in the batch-subscribe response body (the
+// request itself succeeds with HTTP 200). Mailchimp doesn't formally document
+// this enum, so any unrecognized code falls through to the generic server path.
 const ALREADY_SUBSCRIBED_CODE = "ERROR_CONTACT_EXISTS";
+const TOO_MANY_SIGNUPS_CODE = "ERROR_TOO_MANY_RECENT_SIGNUPS";
+
+// HTTP status Mailchimp returns when the API key's connection/rate limits are
+// exceeded.
+const RATE_LIMITED_STATUS = 429;
+
+// Mailchimp flags fake/undeliverable addresses (including test domains like
+// example.com) with the generic ERROR_GENERIC code, surfacing the detail only
+// in the human-readable message (e.g. "<email> looks fake or invalid, please
+// enter a real email address."). Matching the message is the only available
+// signal; this is intentionally fragile -- an ERROR_GENERIC whose message
+// doesn't match falls through to the generic server error rather than being
+// misclassified as an invalid email.
+const INVALID_EMAIL_MESSAGE = /looks fake or invalid|valid email address/i;
+
+// Client-correctable outcomes are returned as HTTP 200 with a distinguishing
+// errorCode (rather than a 4xx) because the shared useClientFetch hook throws on
+// any non-200 response, which would prevent the form from reading the errorCode.
+// The errorCode -- not the HTTP status -- is the signal the frontend branches on.
+const SUCCESS_STATUS = 200;
 
 type MailchimpBatchResponse = {
   total_created: number;
@@ -78,8 +100,20 @@ export async function POST(request: NextRequest) {
     );
 
     if (!mailchimpResponse.ok) {
-      console.error(
-        `Error subscribing user: Mailchimp returned an error response: Status: ${mailchimpResponse.status}`,
+      if (mailchimpResponse.status === RATE_LIMITED_STATUS) {
+        logger.warn(
+          { mailchimpStatus: mailchimpResponse.status },
+          "Newsletter subscription rate-limited by Mailchimp (HTTP status)",
+        );
+        return NextResponse.json(
+          { success: false, errorCode: "tooManyRequests" },
+          { status: SUCCESS_STATUS },
+        );
+      }
+
+      logger.error(
+        { mailchimpStatus: mailchimpResponse.status },
+        "Newsletter subscription failed: Mailchimp returned a non-ok status",
       );
       return NextResponse.json(
         { success: false, errorCode: "server" },
@@ -93,15 +127,45 @@ export async function POST(request: NextRequest) {
       (await mailchimpResponse.json()) as MailchimpBatchResponse;
 
     if (responseData.error_count > 0) {
-      if (responseData.errors[0]?.error_code === ALREADY_SUBSCRIBED_CODE) {
+      const memberError = responseData.errors[0];
+      const memberErrorCode = memberError?.error_code;
+
+      if (memberErrorCode === ALREADY_SUBSCRIBED_CODE) {
+        logger.info(
+          { mailchimpErrorCode: memberErrorCode },
+          "Newsletter subscription skipped: contact already subscribed",
+        );
         return NextResponse.json(
           { success: false, errorCode: "alreadySubscribed" },
-          { status: 200 },
+          { status: SUCCESS_STATUS },
         );
       }
 
-      console.error(
-        `Error subscribing user: Mailchimp returned a member error: ${responseData.errors[0]?.error_code}`,
+      if (memberErrorCode === TOO_MANY_SIGNUPS_CODE) {
+        logger.warn(
+          { mailchimpErrorCode: memberErrorCode },
+          "Newsletter subscription rate-limited by Mailchimp (member error)",
+        );
+        return NextResponse.json(
+          { success: false, errorCode: "tooManyRequests" },
+          { status: SUCCESS_STATUS },
+        );
+      }
+
+      if (memberError && INVALID_EMAIL_MESSAGE.test(memberError.error)) {
+        logger.info(
+          { mailchimpErrorCode: memberErrorCode },
+          "Newsletter subscription rejected: invalid email address",
+        );
+        return NextResponse.json(
+          { success: false, errorCode: "invalidEmail" },
+          { status: SUCCESS_STATUS },
+        );
+      }
+
+      logger.error(
+        { mailchimpErrorCode: memberErrorCode },
+        "Newsletter subscription failed: unrecognized Mailchimp member error",
       );
       return NextResponse.json(
         { success: false, errorCode: "server" },
@@ -112,8 +176,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true });
   } catch (e) {
     const error = e as Error;
-    console.error(
-      `Error subscribing user: Exception: ${error.message} ${error.cause?.toString() ?? ""}`,
+    logger.error(
+      { error: error.message, cause: error.cause?.toString() },
+      "Newsletter subscription failed: exception calling Mailchimp",
     );
     return NextResponse.json(
       { success: false, errorCode: "server" },

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -723,6 +723,8 @@ export const messages = {
       server:
         "An error occurred when trying to save your subscription. If this continues to happen, email <email-link>simpler@grants.gov</email-link>.",
       alreadySubscribed: "This email address has already been subscribed.",
+      tooManyRequests:
+        "Too many recent attempts. Please wait a few minutes and try again.",
     },
   },
   SubscriptionConfirmation: {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -719,7 +719,7 @@ export const messages = {
       missingName: "Please enter a name.",
       missingEmail: "Please enter an email address.",
       invalidEmail:
-        "Enter an email address in the correct format, like name@example.com.",
+        "Enter an email address in the correct format, like <name>@<domain>.",
       server:
         "An error occurred when trying to save your subscription. If this continues to happen, email <email-link>simpler@grants.gov</email-link>.",
       alreadySubscribed: "This email address has already been subscribed.",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -719,7 +719,7 @@ export const messages = {
       missingName: "Please enter a name.",
       missingEmail: "Please enter an email address.",
       invalidEmail:
-        "Enter an email address in the correct format, like <name>@<domain>.",
+        "Enter an email address in the correct format, like name@example.com.",
       server:
         "An error occurred when trying to save your subscription. If this continues to happen, email <email-link>simpler@grants.gov</email-link>.",
       alreadySubscribed: "This email address has already been subscribed.",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11084 

## Changes proposed

- Updated route.ts to map each Mailchimp outcome to a distinct `errorCode` and log level - `invalidEmail` for fake/undeliverable addresses, `tooManyRequests` for rate limiting (member error or HTTP 429), and `server` (500) only for genuine failures - replacing console.error with the shared leveled logger.
- Updated SubscriptionForm.tsx to render `invalidEmail` as a field-level error on the email input and `tooManyRequests` as a form-level "try again later" message.
- Updated index.ts to add the `errors.tooManyRequests` string.
- Updated route.test.ts to cover every outcome: invalid email, too-many-signups (member error and HTTP 429), unrecognized member error, 401/403, upstream 5xx, and thrown fetch.
- Updated SubscriptionForm.test.tsx to cover the new field-level email error and rate-limit message branches.

## Context for reviewers

Mailchimp's batch endpoint returns HTTP 200 with per-member rejections in the body, so invalid emails (e.g. example.com domains) were previously surfaced as a generic 500/server error. Client-correctable outcomes now return HTTP 200 + a distinguishing `errorCode` (matching the existing `alreadySubscribed` pattern, since the shared `useClientFetch` throws on any non-200), reserving 500 strictly for genuine server/upstream failures.

## Validation steps

1. On the newsletter page, submit with test@example.com → inline error appears under the email field.
2. Submit a fresh valid address → redirects to the confirmation page; resubmit the same address → "already subscribed" message.
3. Temporarily corrupt MAILCHIMP_API_KEY (must be done locally) and submit → generic server-error message, with an error-level log line.
4. Confirm tests pass.