### PR TITLE
[Issue #10500] Modify the file scan stream endpoint to return file metadata when file scanning is complete

### DIFF
--- a/api/src/api/files_v1/file_schemas.py
+++ b/api/src/api/files_v1/file_schemas.py
@@ -75,6 +75,26 @@ class CreatePresignedUploadResponseSchema(AbstractResponseSchema):
     data = fields.Nested(PresignedUploadDataSchema)
 
 
+class FileMetadataSchema(Schema):
+    file_size_bytes = fields.Integer(
+        metadata={
+            "description": "The size of the scanned file in bytes",
+        },
+    )
+    file_name = fields.String(
+        metadata={
+            "description": "The name of the scanned file",
+            "example": "example.pdf",
+        },
+    )
+    download_path = fields.String(
+        metadata={
+            "description": "A presigned URL the caller can use to download the scanned file",
+            "example": "https://example-bucket.s3.amazonaws.com/scanned/abc/example.pdf",
+        },
+    )
+
+
 class FileScanResultsDataSchema(Schema):
     status = fields.Enum(
         FileScanStatus,
@@ -82,6 +102,16 @@ class FileScanResultsDataSchema(Schema):
         metadata={
             "description": "The current scan status of the file",
             "example": FileScanStatus.PENDING,
+        },
+    )
+    file_metadata = fields.Nested(
+        FileMetadataSchema,
+        allow_none=True,
+        metadata={
+            "description": (
+                "Metadata for the scanned file. Populated only once the scan "
+                "status is complete; null for any other status."
+            ),
         },
     )
 

--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -5,12 +5,17 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
+import grants_shared.adapters.db as db
+import grants_shared.adapters.db.flask_db as flask_db
+import grants_shared.util.file_util as file_util
 from grants_shared.adapters.aws.dynamodb_adapter import DynamoDBClient, DynamoDBConfig
 from grants_shared.api.route_utils import raise_flask_error
 from grants_shared.util import datetime_util
 from pydantic import Field
+from sqlalchemy import select
 
 from src.constants.lookup_constants import FileScanStatus
+from src.db.models.file_upload_models import PendingFile
 from src.db.models.user_models import User
 from src.util.env_config import PydanticBaseEnvConfig
 
@@ -41,6 +46,15 @@ class FileScanRecord:
 
     user_id: str
     status: FileScanStatus
+
+
+@dataclass(frozen=True)
+class FileMetadata:
+    """File metadata returned to the caller once a scan reaches a complete status."""
+
+    file_name: str
+    file_size_bytes: int
+    download_path: str
 
 
 class InvalidFileScanRecordError(Exception):
@@ -131,6 +145,45 @@ def _fetch_next_record(
     return next_record
 
 
+@flask_db.with_db_session()
+def get_file_metadata(db_session: db.Session, pending_file_id: uuid.UUID) -> FileMetadata:
+    """Build the file metadata returned once a scan reaches a complete status.
+
+    The DB session is only checked out when this is called -- after the scan
+    completes -- so a long-polling stream doesn't hold a connection from the
+    threadpool while it waits for the scan to finish.
+    """
+    with db_session.begin():
+        pending_file = db_session.execute(
+            select(PendingFile).where(PendingFile.pending_file_id == pending_file_id)
+        ).scalar_one_or_none()
+
+        if pending_file is None:
+            # The scan reached a complete status but the backing DB row is
+            # missing, so fail loudly with a 500.
+            raise_flask_error(500, "Pending file not found")
+
+        file_name = pending_file.file_name
+        file_location = pending_file.file_location
+
+    return FileMetadata(
+        file_name=file_name,
+        file_size_bytes=file_util.get_file_length_bytes(file_location),
+        download_path=file_util.pre_sign_file_location(file_location),
+    )
+
+
+def _metadata_for_status(status: FileScanStatus, pending_file_id: uuid.UUID) -> FileMetadata | None:
+    """Look up file metadata once the scan completes; null for any other status.
+
+    The DB session is only checked out for a complete scan, so a stream that
+    sits polling a pending scan never holds a connection.
+    """
+    if status != FileScanStatus.COMPLETE:
+        return None
+    return get_file_metadata(pending_file_id)
+
+
 def stream_file_scan_results(
     pending_file_id: uuid.UUID,
     user: User,
@@ -140,13 +193,15 @@ def stream_file_scan_results(
 ) -> Iterator[dict[str, Any]]:
     """Stream file scan status updates for the given pending file.
 
-    The initial DynamoDB lookup happens before any chunks are yielded so we can
+    The initial DynamoDB lookup -- and, if that scan is already complete, the
+    file metadata lookup -- happens before any chunks are yielded so we can
     return a 404 / 403 / 500 with the proper HTTP status. After streaming
     starts, a missing record or user mismatch just ends the stream; a malformed
     record raises (terminating the connection) and is logged.
 
     Yields chunks shaped like ``FileScanResultsResponseSchema``; the caller is
-    responsible for serializing each chunk through that schema.
+    responsible for serializing each chunk through that schema. The
+    ``file_metadata`` field is populated only once the scan completes.
     """
     if config is None:
         config = FileScanStreamConfig()
@@ -174,13 +229,21 @@ def stream_file_scan_results(
         )
         raise_flask_error(403, "Forbidden")
 
+    # Resolve metadata for the initial record outside the generator so that an
+    # already-complete scan with a missing DB row surfaces as a proper 500 (the
+    # common small-file case is complete on the very first poll) rather than a
+    # truncated stream.
+    initial_metadata = _metadata_for_status(record.status, pending_file_id)
+
     def generate() -> Iterator[dict[str, Any]]:
         current_record = record
+        file_metadata = initial_metadata
         start_time = datetime_util.utcnow()
 
         while True:
             status = current_record.status
-            yield {"data": {"status": status.value}}
+
+            yield {"data": {"status": status.value, "file_metadata": file_metadata}}
 
             elapsed = (datetime_util.utcnow() - start_time).total_seconds()
 
@@ -232,5 +295,6 @@ def stream_file_scan_results(
                 return
 
             current_record = next_record
+            file_metadata = _metadata_for_status(current_record.status, pending_file_id)
 
     return generate()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -2,6 +2,7 @@ import logging
 import os
 import uuid
 from os import path
+from types import SimpleNamespace
 
 import _pytest.monkeypatch
 import boto3
@@ -555,6 +556,36 @@ def file_scan_dynamodb_table(mock_dynamodb, monkeypatch):
     )
     monkeypatch.setenv("FILE_SCAN_CACHE_TABLE_NAME", table_name)
     return table_name
+
+
+@pytest.fixture
+def mock_dynamodb_and_s3(reset_aws_env_vars, monkeypatch):
+    """A single moto context whitelisting both dynamodb and s3.
+
+    The single-service ``mock_dynamodb`` / ``mock_s3`` fixtures each enter their
+    own ``moto.mock_aws`` context with a one-service whitelist, and the
+    innermost-entered context wins -- so they can't both be active at once.
+    Flows that touch both services (e.g. the file-scan-complete path: read the
+    dynamodb scan record, then presign/size the s3 object) need this combined
+    context instead.
+
+    Yields a namespace with ``table_name``, ``bucket``, and a ``dynamodb_client``
+    for seeding scan records.
+    """
+    table_name = "test-local-virus-scan"
+    bucket = "local-mock-public-bucket"
+    with moto.mock_aws(config={"core": {"service_whitelist": ["dynamodb", "s3"]}}):
+        dynamodb_client = boto3.client("dynamodb", region_name="us-east-1")
+        dynamodb_client.create_table(
+            TableName=table_name,
+            KeySchema=[{"AttributeName": "file_id", "KeyType": "HASH"}],
+            AttributeDefinitions=[{"AttributeName": "file_id", "AttributeType": "S"}],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        monkeypatch.setenv("FILE_SCAN_CACHE_TABLE_NAME", table_name)
+        boto3.client("s3").create_bucket(Bucket=bucket)
+
+        yield SimpleNamespace(table_name=table_name, bucket=bucket, dynamodb_client=dynamodb_client)
 
 
 @pytest.fixture

--- a/api/tests/src/api/files_v1/test_get_file_scan_results.py
+++ b/api/tests/src/api/files_v1/test_get_file_scan_results.py
@@ -8,6 +8,8 @@ from grants_shared.adapters.aws.dynamodb_adapter import DynamoDBClient
 import tests.src.db.models.factories as factories
 from src.constants.lookup_constants import FileScanStatus
 
+SCANNED_FILE_BODY = b"scanned file contents"
+
 
 @pytest.fixture(autouse=True)
 def fast_stream_config(monkeypatch):
@@ -24,6 +26,19 @@ def dynamodb_boto_client(file_scan_dynamodb_table):
 
 def _build_url(pending_file_id: uuid.UUID) -> str:
     return f"/v1/files/{pending_file_id}/results"
+
+
+def _create_complete_pending_file(bucket: str, user):
+    """Create a COMPLETE pending file record backed by a real s3 object so the
+    metadata lookup (presign + file size) has something to read."""
+    key = f"scanned/{uuid.uuid4()}/example.pdf"
+    boto3.client("s3").put_object(Bucket=bucket, Key=key, Body=SCANNED_FILE_BODY)
+    return factories.PendingFileFactory.create(
+        user=user,
+        file_name="example.pdf",
+        file_location=f"s3://{bucket}/{key}",
+        file_scan_status=FileScanStatus.COMPLETE,
+    )
 
 
 def _put_scan_record(
@@ -49,32 +64,40 @@ def _parse_chunks(resp) -> list[dict]:
 
 
 class TestGetFileScanResultsSuccess:
-    def test_terminal_status_complete_yields_once(
+    def test_terminal_status_complete_yields_metadata(
         self,
         client,
         user,
         user_auth_token,
-        dynamodb_boto_client,
-        file_scan_dynamodb_table,
+        mock_dynamodb_and_s3,
     ):
-        pending_file_id = uuid.uuid4()
+        pending_file = _create_complete_pending_file(mock_dynamodb_and_s3.bucket, user)
         _put_scan_record(
-            dynamodb_boto_client,
-            file_scan_dynamodb_table,
-            pending_file_id,
+            mock_dynamodb_and_s3.dynamodb_client,
+            mock_dynamodb_and_s3.table_name,
+            pending_file.pending_file_id,
             user.user_id,
             FileScanStatus.COMPLETE,
         )
 
         resp = client.get(
-            _build_url(pending_file_id),
+            _build_url(pending_file.pending_file_id),
             headers={"X-SGG-Token": user_auth_token},
         )
 
         assert resp.status_code == 200
         assert resp.mimetype == "application/x-ndjson"
         chunks = _parse_chunks(resp)
-        assert chunks == [{"data": {"status": FileScanStatus.COMPLETE.value}}]
+        assert len(chunks) == 1
+        data = chunks[0]["data"]
+        assert data["status"] == FileScanStatus.COMPLETE.value
+
+        metadata = data["file_metadata"]
+        assert metadata["file_name"] == "example.pdf"
+        assert metadata["file_size_bytes"] == len(SCANNED_FILE_BODY)
+        # A presigned GET URL pointing at the scanned object.
+        assert pending_file.file_location.split("/")[-1] in metadata["download_path"]
+        assert metadata["download_path"].startswith("http")
 
     def test_terminal_status_infected_yields_once(
         self,
@@ -100,22 +123,25 @@ class TestGetFileScanResultsSuccess:
 
         assert resp.status_code == 200
         chunks = _parse_chunks(resp)
-        assert chunks == [{"data": {"status": FileScanStatus.INFECTED.value}}]
+        # Metadata is only populated for a complete scan; infected stays null.
+        assert chunks == [
+            {"data": {"status": FileScanStatus.INFECTED.value, "file_metadata": None}}
+        ]
 
     def test_pending_then_terminal_yields_both(
         self,
         client,
         user,
         user_auth_token,
-        dynamodb_boto_client,
-        file_scan_dynamodb_table,
+        mock_dynamodb_and_s3,
         monkeypatch,
     ):
         """When the record transitions mid-stream we yield each status."""
-        pending_file_id = uuid.uuid4()
+        pending_file = _create_complete_pending_file(mock_dynamodb_and_s3.bucket, user)
+        pending_file_id = pending_file.pending_file_id
         _put_scan_record(
-            dynamodb_boto_client,
-            file_scan_dynamodb_table,
+            mock_dynamodb_and_s3.dynamodb_client,
+            mock_dynamodb_and_s3.table_name,
             pending_file_id,
             user.user_id,
             FileScanStatus.PENDING,
@@ -134,8 +160,8 @@ class TestGetFileScanResultsSuccess:
             next_status = next(transitions, None)
             if next_status is not None:
                 _put_scan_record(
-                    dynamodb_boto_client,
-                    file_scan_dynamodb_table,
+                    mock_dynamodb_and_s3.dynamodb_client,
+                    mock_dynamodb_and_s3.table_name,
                     pending_file_id,
                     user.user_id,
                     next_status,
@@ -151,11 +177,19 @@ class TestGetFileScanResultsSuccess:
 
         assert resp.status_code == 200
         chunks = _parse_chunks(resp)
-        assert chunks == [
-            {"data": {"status": FileScanStatus.PENDING.value}},
-            {"data": {"status": FileScanStatus.IN_PROGRESS.value}},
-            {"data": {"status": FileScanStatus.COMPLETE.value}},
+        assert [c["data"]["status"] for c in chunks] == [
+            FileScanStatus.PENDING.value,
+            FileScanStatus.IN_PROGRESS.value,
+            FileScanStatus.COMPLETE.value,
         ]
+        # Metadata is null until the scan completes, then populated on the final chunk.
+        assert chunks[0]["data"]["file_metadata"] is None
+        assert chunks[1]["data"]["file_metadata"] is None
+        final_metadata = chunks[2]["data"]["file_metadata"]
+        assert final_metadata["file_name"] == "example.pdf"
+        assert final_metadata["file_size_bytes"] == len(SCANNED_FILE_BODY)
+        assert pending_file.file_location.split("/")[-1] in final_metadata["download_path"]
+        assert final_metadata["download_path"].startswith("http")
 
     def test_stream_ends_when_max_duration_reached(
         self,
@@ -186,7 +220,7 @@ class TestGetFileScanResultsSuccess:
         chunks = _parse_chunks(resp)
         # With max_duration=0, we yield the first status and exit on the
         # elapsed-time check before sleeping or re-querying.
-        assert chunks == [{"data": {"status": FileScanStatus.PENDING.value}}]
+        assert chunks == [{"data": {"status": FileScanStatus.PENDING.value, "file_metadata": None}}]
 
     def test_record_disappearing_mid_stream_logs_error(
         self,
@@ -232,7 +266,7 @@ class TestGetFileScanResultsSuccess:
 
         assert resp.status_code == 200
         # First chunk was emitted before the record vanished; nothing after.
-        assert chunks == [{"data": {"status": FileScanStatus.PENDING.value}}]
+        assert chunks == [{"data": {"status": FileScanStatus.PENDING.value, "file_metadata": None}}]
 
         disappeared_records = [
             r
@@ -250,14 +284,14 @@ class TestGetFileScanResultsSuccess:
         client,
         user,
         user_auth_token,
-        dynamodb_boto_client,
-        file_scan_dynamodb_table,
+        mock_dynamodb_and_s3,
         caplog,
     ):
-        pending_file_id = uuid.uuid4()
+        pending_file = _create_complete_pending_file(mock_dynamodb_and_s3.bucket, user)
+        pending_file_id = pending_file.pending_file_id
         _put_scan_record(
-            dynamodb_boto_client,
-            file_scan_dynamodb_table,
+            mock_dynamodb_and_s3.dynamodb_client,
+            mock_dynamodb_and_s3.table_name,
             pending_file_id,
             user.user_id,
             FileScanStatus.COMPLETE,
@@ -368,6 +402,33 @@ class TestGetFileScanResults404:
 
 class TestGetFileScanResults500:
     """Malformed DynamoDB records are an infrastructure error -- fail fast."""
+
+    def test_complete_without_db_record_returns_500(
+        self,
+        client,
+        user,
+        user_auth_token,
+        dynamodb_boto_client,
+        file_scan_dynamodb_table,
+    ):
+        """A complete scan whose backing pending_file row is missing is a system
+        inconsistency, so we fail with a 500."""
+        pending_file_id = uuid.uuid4()
+        # No PendingFile row is created for this id.
+        _put_scan_record(
+            dynamodb_boto_client,
+            file_scan_dynamodb_table,
+            pending_file_id,
+            user.user_id,
+            FileScanStatus.COMPLETE,
+        )
+
+        resp = client.get(
+            _build_url(pending_file_id),
+            headers={"X-SGG-Token": user_auth_token},
+        )
+
+        assert resp.status_code == 500
 
     def test_missing_user_id_returns_500(
         self,
@@ -512,4 +573,6 @@ class TestGetFileScanResults500:
         # were yielded.
         if body:
             chunks = [json.loads(line) for line in body.splitlines() if line.strip()]
-            assert chunks == [{"data": {"status": FileScanStatus.PENDING.value}}]
+            assert chunks == [
+                {"data": {"status": FileScanStatus.PENDING.value, "file_metadata": None}}
+            ]


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10500  

## Changes proposed

- Updated file_schemas.py to add a `FileMetadataSchema` and a nullable `file_metadata` field on `FileScanResultsDataSchema`.
- Updated stream_file_scan_results.py to add a `FileMetadata` dataclass, a `get_file_metadata` function, and a `_metadata_for_status helper`.
- Updated conftest.py to add a reusable `mock_dynamodb_and_s3` fixture.
- Updated test_get_file_scan_results.py to cover the new metadata field across statuses, add a 500 test for the missing-DB-record case, switch to the shared `mock_dynamodb_and_s3` fixture, and replace a self-referential download_path assertion with explicit field checks.

## Context for reviewers

The scan-results stream now returns file metadata (size, name, presigned download URL) once a scan completes and null otherwise. The DB session is only checked out when we reach a complete status so a long poll never holds a connection. Resolving the initial record's metadata before streaming begins lets an already-complete scan with a missing DB row return a clean 500, while a missing row found mid-stream aborts the connection and logs it.

## Validation steps

Confirm tests pass.