### PR TITLE
[Issue #11113] Add Grantor Role to Local E2E Test User

### DIFF
--- a/api/tests/lib/seed_e2e.py
+++ b/api/tests/lib/seed_e2e.py
@@ -6,8 +6,13 @@ import grants_shared.adapters.db as db
 from grants_shared.util.file_util import write_to_file
 from pydantic import Field
 
-from src.constants.static_role_values import E2E_TEST_USER_MANAGER_ROLE, E2E_TEST_USER_ROLE
+from src.constants.static_role_values import (
+    E2E_TEST_USER_MANAGER_ROLE,
+    E2E_TEST_USER_ROLE,
+    OPPORTUNITY_PUBLISHER,
+)
 from src.util.env_config import PydanticBaseEnvConfig
+from tests.lib.seed_agencies_and_users import setup_agency
 from tests.lib.seed_data_utils import UserBuilder
 
 logger = logging.getLogger(__name__)
@@ -25,6 +30,11 @@ logger = logging.getLogger(__name__)
 # test user UUIDs.
 E2E_MANAGER_USER_ID = uuid.UUID("c3d4e5f6-a7b8-4c5d-9e0f-1a2b3c4d5e6f")
 
+# Dedicated agency for the E2E test user's grantor role. Kept separate from the
+# agencies in seed_agencies_and_users so opportunities created by E2E runs stay
+# isolated, and so the grantor opportunities page auto-selects a single agency.
+E2E_AGENCY_ID = uuid.UUID("d4e5f6a7-b8c9-4d5e-9f0a-1b2c3d4e5f60")
+
 
 class _SeedE2EConfig(PydanticBaseEnvConfig):
     local_test_user_manager_api_key: str = Field(alias="LOCAL_TEST_USER_MANAGER_API_KEY")
@@ -39,6 +49,13 @@ def _write_token_to_file(token: str) -> None:
 def _build_users_and_tokens(db_session: db.Session) -> None:
     config = _SeedE2EConfig()
 
+    e2e_agency = setup_agency(
+        db_session,
+        agency_id=E2E_AGENCY_ID,
+        agency_code="E2E",
+        agency_name="E2E Test Agency",
+    )
+
     builder = (
         # Reuse the seeded one_org_user so the spoofed E2E session always has
         # organization membership in local/CI runs.
@@ -46,6 +63,9 @@ def _build_users_and_tokens(db_session: db.Session) -> None:
         .with_jwt_auth()
         .with_api_key("e2e-test-key")
         .with_internal_role(E2E_TEST_USER_ROLE)
+        # Grantor role so the Create Opportunity link shows and opportunity
+        # creation E2E tests can create and publish opportunities.
+        .with_agency(e2e_agency, roles=[OPPORTUNITY_PUBLISHER])
     )
 
     builder.build()


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11113  

## Changes proposed

- Updated seed_e2e.py to seed a dedicated E2E Test Agency and grant the local/CI E2E test user the Opportunity Publisher role

## Context for reviewers

The E2E test user previously had only the internal `E2E_TEST_USER_ROLE`, so it lacked the agency-scoped `create_opportunity` privilege. The Create Opportunity link never rendered and opportunity-creation E2E tests failed locally and in CI E2E Local (they passed in staging only because that user already had a grantor role).

## Validation steps

1. Re-seed the local db with `make db-seed-local`.
2. Confirm the role assignment in the db (should return one row):
```
SELECT u.user_id, a.agency_code, a.agency_name, r.role_name
FROM api.agency_user au
JOIN api."user" u             ON u.user_id = au.user_id
JOIN api.agency a             ON a.agency_id = au.agency_id
JOIN api.agency_user_role aur ON aur.agency_user_id = au.agency_user_id
JOIN api.role r               ON r.role_id = aur.role_id
WHERE u.user_id = 'f15c7491-7ebc-4f4f-8de6-3ac0594d9c63';
```
3. Log in locally as `one_org_user`, navigate to `/grantor/opportunities`, and confirm the Create Opportunity button is visible.
4. Confirm tests pass.