### PR TITLE
[Issue #10247] Support new multi user testing strategy in CI

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -72,6 +72,9 @@ inputs:
   staging_client_session_secret:
     description: "encode key for client side JWTs, used in spoofing staging user logins"
     default: ""
+  test_user_manager_api_key:
+    description: "manager API key for the new multi-user test system, used to request auth tokens for test users via POST /v1/internal/e2e-token"
+    default: ""
 
 outputs:
   artifact-id:
@@ -149,6 +152,7 @@ runs:
         STAGING_TEST_USER_MANAGER_API_KEY: ${{ inputs.staging_test_user_manager_api_key }}
         STAGING_TEST_USER_ID: ${{ inputs.staging_test_user_id }}
         SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
+        TEST_USER_MANAGER_API_KEY: ${{ inputs.test_user_manager_api_key }}
 
       run: |
         npm run test:e2e
@@ -170,6 +174,7 @@ runs:
         STAGING_TEST_USER_MANAGER_API_KEY: ${{ inputs.staging_test_user_manager_api_key }}
         STAGING_TEST_USER_ID: ${{ inputs.staging_test_user_id }}
         SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
+        TEST_USER_MANAGER_API_KEY: ${{ inputs.test_user_manager_api_key }}
 
       run: |
         npm run test:e2e -- --grep "${{ inputs.playwright_tags }}"

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -351,7 +351,8 @@ jobs:
           {
             cat .env.development
             sed -En '/API_JWT_PUBLIC_KEY/,/-----END PUBLIC KEY-----/p' ../api/override.env
-            cat ../api/e2e_token.tmp
+            # e2e_token.tmp may not exist once seeding moves to the new test user system; don't fail if it's absent
+            cat ../api/e2e_token.tmp 2>/dev/null || true
           } >> .env.local
           # Use the 127.0.0.1 url for tests (IPv4 only)
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
@@ -398,9 +399,7 @@ jobs:
           current_shard: ${{ matrix.shard }}
           api_logs: ${{ inputs.api_logs && 'true' || 'false' }}
           playwright_tags: ${{ env.test_group_tags }}
-          staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
-          staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
-          staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
+          test_user_manager_api_key: ${{ secrets.LOCAL_TEST_USER_MANAGER_API_KEY }}
           # shard 2 is the firefox shard
           do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
           # shard 3 is the webkit shard

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -67,6 +67,7 @@ jobs:
           staging_test_user_manager_api_key: ${{ secrets.STAGING_TEST_USER_MANAGER_API_KEY }}
           staging_test_user_id: ${{ secrets.STAGING_TEST_USER_ID }}
           staging_client_session_secret: ${{ secrets.STAGING_CLIENT_SESSION_SECRET }}
+          test_user_manager_api_key: ${{ secrets.STAGING_TEST_USER_MANAGER_API_KEY }}
           do-chrome-install: "true"
   create-report:
     name: Create Merged Test Report


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10247 

## Changes proposed

- Updated action.yml to add a `test_user_manager_api_key` input and forward it to the test steps as the `TEST_USER_MANAGER_API_KEY` env var.
- Updated ci-frontend-e2e.yml to remove the unused `staging_test_user_email`/`password`/`mfa_key` inputs (this job only targets local), pass `test_user_manager_api_key` from `secrets.LOCAL_TEST_USER_MANAGER_API_KEY`, and tolerate a missing e2e_token.tmp so the job no longer fails when the token isn't produced.
- Updated e2e-staging.yml to pass `test_user_manager_api_key` from `secrets.STAGING_TEST_USER_MANAGER_API_KEY`.

## Context for reviewers

This wires the new multi-user test-user manager API key through CI for both local and staging while leaving the previous test-user process intact, so jobs keep working before and after the test-system changes land. The composite action input stays environment-agnostic - each workflow picks the correct secret.

## Validation steps

Confirm ci-frontend-e2e and e2e-staging parse and run on this PR.