### PR TITLE
[Unticketed] Add defaults for file scanning configuration

### DIFF
--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -31,8 +31,8 @@ SCAN_RECORD_STATUS_ATTR = "status"
 
 
 class FileScanStreamConfig(PydanticBaseEnvConfig):
-    poll_interval_seconds: float = Field(alias="FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS")
-    max_duration_seconds: float = Field(alias="FILE_SCAN_RESULTS_MAX_DURATION_SECONDS")
+    poll_interval_seconds: float = Field(alias="FILE_SCAN_RESULTS_POLL_INTERVAL_SECONDS", default=3)
+    max_duration_seconds: float = Field(alias="FILE_SCAN_RESULTS_MAX_DURATION_SECONDS", default=60)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

## Changes proposed
- Add defaults for the file scanning env vars

## Context for reviewers
These aren't set in our terraform, so the endpoint fails. I'm instead adding defaults rather than setting them in terraform as we would just set them all this way anyways. We can override them for a given environment still if needed.
