### PR TITLE
[unticketed]: update api service module w/ ddb write permissions

### DIFF
--- a/infra/api/service/main.tf
+++ b/infra/api/service/main.tf
@@ -255,8 +255,9 @@ module "service" {
   extra_policies = merge(
     {
       # storage_access = module.storage.access_policy_arn
-      sqs_access           = module.sqs_queue.access_policy_arn
-      file_scan_cache_read = module.file_scan_cache.read_access_policy_arn
+      sqs_access            = module.sqs_queue.access_policy_arn
+      file_scan_cache_read  = module.file_scan_cache.read_access_policy_arn
+      file_scan_cache_write = module.file_scan_cache.write_access_policy_arn
     },
     module.app_config.enable_identity_provider ? {
       # identity_provider_access = module.identity_provider_client[0].access_policy_arn,


### PR DESCRIPTION
## Summary

In api dev we are getting the error below: 

```
ClientError('An error occurred (AccessDeniedException) when calling the PutItem operation: User: arn:aws:sts::315341936575:assumed-role/api-dev-app/b6e26eb0ecd346f29cb0541ab1b0f998 is not authorized to perform: dynamodb:PutItem on resource: arn:aws:dynamodb:us-east-1:315341936575:table/api-dev-file-scan-cache because no identity-based policy allows the dynamodb:PutItem action')
```

Updated the api dev w/ dynamodb write permissions.

## Validation steps

All scans should be passing below. 

Deployed to api dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28175687508)