### PR TITLE
Fix API blocking during streaming by setting gunicorn keepalive

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -24,3 +24,10 @@ bind = app_config.host + ':' + str(app_config.port)
 
 workers = (len(os.sched_getaffinity(0)) * 2) + 1
 threads = 4
+
+# Set keepalive higher than ALB idle timeout (120s) to prevent connection pool exhaustion.
+# When gunicorn's keepalive is lower than ALB's idle timeout, gunicorn closes connections
+# that ALB thinks are still alive, leading to 502 errors and worker exhaustion during
+# long-running streaming requests. Setting this to 125s ensures ALB always closes first.
+# See: https://lincolnloop.com/blog/gunicorn-keepalive-and-aws-elb-502-errors/
+keepalive = 125


### PR DESCRIPTION
## Summary
Fixes #9868 - API becomes unresponsive while streaming file scan results

## What Changed
Added `keepalive = 125` configuration to gunicorn to prevent worker pool exhaustion during streaming responses.

## Root Cause Analysis

The blocking behavior was caused by a mismatch between ALB and gunicorn keepalive settings:

1. **ALB Configuration**: 120 second idle timeout (`infra/modules/service/load_balancer.tf:18`)
2. **Gunicorn Default**: 2 second keepalive (not previously configured)
3. **Worker Pool**: ~5 workers on 2 CPU staging environment

**What was happening:**
- Streaming requests hold workers for up to 15 minutes (API Gateway timeout)
- Gunicorn closes idle connections after 2 seconds
- ALB doesn't know the connection is dead, keeps it in its pool for 120 seconds
- ALB tries to reuse dead connections → requests fail/queue
- With limited workers, a few streaming requests exhaust the entire worker pool
- All API endpoints become unresponsive

**Why it worked locally but not in AWS:**
- Local development bypasses ALB entirely
- The issue only manifests with the ALB connection pooling layer

## Solution

Set gunicorn `keepalive` to **125 seconds** (5 seconds higher than ALB's 120 second idle timeout).

This ensures:
- ALB always closes connections first
- No dead connections in ALB's connection pool
- Workers remain available for new requests
- Streaming requests don't block the entire API

Reference: https://lincolnloop.com/blog/gunicorn-keepalive-and-aws-elb-502-errors/

## Testing Plan

1. Deploy to staging
2. Run concurrent requests test while streaming is active:
   - Start streaming: `GET /v1/files/{pending_file_id}/results`
   - While streaming, test: `GET /v1/health` and `GET /v1/opportunities`
3. Verify non-streaming endpoints remain responsive throughout the streaming request
4. Repeat with multiple concurrent streaming requests

## Related
- Issue: #9868
- Original streaming PR: #11085