### PR TITLE
Fix API blocking during streaming by switching to gevent workers

### DIFF
--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -22,8 +22,14 @@ bind = app_config.host + ':' + str(app_config.port)
 # os.sched_getaffinity(pid): Return the set of CPUs the process with PID pid is restricted to.
 # os.cpu_count(): Return the number of CPUs in the system.
 
+# Use gevent async workers to handle concurrent requests without blocking during streaming.
+# Sync workers (default) block during long-running streaming responses, exhausting the
+# worker pool and making the entire API unresponsive. Gevent workers use greenlets to
+# handle thousands of concurrent connections efficiently, allowing streaming requests
+# to run without blocking other API endpoints.
+# See: https://docs.gunicorn.org/en/stable/design.html#async-workers
+worker_class = 'gevent'
 workers = (len(os.sched_getaffinity(0)) * 2) + 1
-threads = 4
 
 # Set keepalive higher than ALB idle timeout (120s) to prevent connection pool exhaustion.
 # When gunicorn's keepalive is lower than ALB's idle timeout, gunicorn closes connections

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "python-statemachine>=3.0.0,<4",
     "beautifulsoup4>=4.14.3,<5",
     "grants-shared==0.2.8",
+    "gevent>=25.5.0,<26",
 ]
 
 [project.scripts]

--- a/api/src/app.py
+++ b/api/src/app.py
@@ -1,3 +1,10 @@
+# Monkey patch standard library for gevent compatibility.
+# This must be done before any other imports to ensure all blocking operations
+# (sockets, SSL, threading, etc.) are replaced with gevent's async versions.
+# See: https://www.gevent.org/api/gevent.monkey.html
+from gevent import monkey
+monkey.patch_all()
+
 import json
 import logging
 import os


### PR DESCRIPTION
## Summary
Fixes #9868 - API becomes unresponsive 5-10 seconds after streaming starts

## What Changed
Switched from sync workers (with threads) to gevent async workers:
- Added `gevent>=25.5.0` dependency
- Set `worker_class='gevent'` in gunicorn configuration
- Added gevent monkey patching at app initialization

## Root Cause Analysis (Updated)

PR #11133 added keepalive configuration but didn't solve the underlying issue. The real problem is **worker/thread exhaustion with sync workers during streaming**.

**The Issue:**
- Sync workers (even with `threads=4`) block during long-running requests
- Streaming requests hold a worker/thread for up to 15 minutes
- With ~5 workers × 4 threads = 20 total threads in staging
- After 5-10 seconds of concurrent streaming, all threads become busy
- New requests (including healthcheck) cannot be processed → API appears blocked
- Stream continues working (already has its thread) until completion

**Michael's Observation:**
> "If I start streaming a response, for the first few seconds, I can simultaneously make a separate request to the API (just pinging the healthcheck endpoint for simplicity). After about 5-10 seconds, that ping stops working."

This timing (5-10 seconds) matches how long it takes for concurrent requests to exhaust the 20-thread pool.

## Solution

**Gevent Async Workers** solve this by using greenlets (lightweight cooperative multitasking) instead of threads:

- Single worker can handle **thousands** of concurrent connections
- Streaming requests don't block other requests
- No thread pool exhaustion
- Maintains compatibility with Flask's `stream_with_context()`

Reference: https://docs.gunicorn.org/en/stable/design.html#async-workers

## Why Gevent?

- **Active maintenance**: Gevent is actively maintained, unlike Eventlet (in maintenance mode)
- **Better performance**: C-based libev hub provides lower latency
- **Production proven**: Widely used for streaming/SSE/WebSocket applications
- **Flask compatible**: Works seamlessly with Flask and most Python libraries

## Testing Plan

1. Deploy to staging
2. Start streaming: `GET /v1/files/{pending_file_id}/results`
3. **Continuously** test other endpoints while streaming (for >10 seconds):
   - `GET /health`
   - `GET /v1/opportunities`
4. Verify all endpoints remain responsive throughout streaming
5. Test with multiple concurrent streaming requests

Expected behavior: All non-streaming endpoints should respond quickly (<1s) even while multiple 15-minute streams are active.

## Related
- Issue: #9868
- Previous attempt: #11133 (keepalive - necessary but insufficient)