### PR TITLE
[unticketed]: optimize clamav scanner lambda performance

### DIFF
--- a/infra/modules/clamav/build-layer.sh
+++ b/infra/modules/clamav/build-layer.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Build the ClamAV Lambda layer.
 #
-# Runs an Amazon Linux 2023 container, installs clamav + clamav-update,
-# copies clamscan / freshclam plus their shared-library dependencies, and
-# zips them into layer.zip in the layout Lambda expects:
+# Runs an Amazon Linux 2023 container, installs clamav + clamav-update + clamd,
+# copies the binaries plus their shared-library dependencies, and zips them
+# into layer.zip in the layout Lambda expects:
 #
 #   layer.zip
 #   ├── bin/         (added to PATH automatically)
 #   │   ├── clamscan
+#   │   ├── clamdscan   (thin client the scanner uses to talk to clamd)
+#   │   ├── clamd       (resident daemon that keeps the signature DB in RAM)
 #   │   └── freshclam
 #   └── lib/         (added to LD_LIBRARY_PATH automatically)
 #       └── libclamav.so.* + transitive deps
@@ -27,14 +29,23 @@ docker run --rm --platform linux/amd64 \
   public.ecr.aws/amazonlinux/amazonlinux:2023 \
   bash -c '
     set -e
-    dnf install -y --setopt=install_weak_deps=False clamav clamav-update zip > /dev/null
+    dnf install -y --setopt=install_weak_deps=False clamav clamav-update clamd zip > /dev/null
 
-    cp /usr/bin/clamscan  /out/bin/
-    cp /usr/bin/freshclam /out/bin/
+    # clamd (the resident daemon) and clamdscan (its thin client) join clamscan
+    # and freshclam. clamd lives in /usr/sbin, so resolve each path rather than
+    # assuming /usr/bin.
+    for tool in clamscan clamdscan clamd freshclam; do
+      src="$(command -v "$tool" || true)"
+      if [ -z "$src" ]; then
+        echo "ERROR: $tool not found after install" >&2
+        exit 1
+      fi
+      cp "$src" /out/bin/
+    done
 
     # Copy each transitive shared-library dependency. Lambda already ships
     # glibc so duplicates here are harmless — its loader prefers /opt/lib.
-    for bin in /usr/bin/clamscan /usr/bin/freshclam; do
+    for bin in /out/bin/*; do
       ldd "$bin" | awk "{print \$3}" | grep -E "^/" | sort -u | while read -r lib; do
         cp -L "$lib" /out/lib/ 2>/dev/null || true
       done

--- a/infra/modules/clamav/efs.tf
+++ b/infra/modules/clamav/efs.tf
@@ -36,6 +36,8 @@ resource "aws_efs_file_system" "clamav" {
   # checkov:skip=CKV2_AWS_18:DB is fully regenerable by the freshclam Lambda; backups add cost for no benefit
   encrypted = true
 
+  throughput_mode = "elastic"
+
   lifecycle_policy {
     transition_to_ia = "AFTER_30_DAYS"
   }

--- a/infra/modules/clamav/layer.tf
+++ b/infra/modules/clamav/layer.tf
@@ -1,12 +1,12 @@
-# Lambda layer that bundles the ClamAV binaries (clamscan, freshclam) and
-# their shared library dependencies. The layer.zip artifact is built by
-# build-layer.sh — run that script whenever the binaries need refreshing.
-# The signature database does NOT live in this layer; freshclam writes it
-# to the EFS access point at runtime.
+# Lambda layer that bundles the ClamAV binaries (clamscan, clamdscan, clamd,
+# freshclam) and their shared library dependencies. The layer.zip artifact is
+# built by build-layer.sh — run that script whenever the binaries need
+# refreshing. The signature database does NOT live in this layer; freshclam
+# writes it to the EFS access point at runtime.
 
 resource "aws_lambda_layer_version" "clamav" {
   layer_name          = local.layer_name
-  description         = "ClamAV binaries (clamscan, freshclam) built from Amazon Linux 2023"
+  description         = "ClamAV binaries (clamscan, clamdscan, clamd, freshclam) built from Amazon Linux 2023"
   compatible_runtimes = ["python3.12"]
 
   filename         = "${path.module}/layer.zip"

--- a/infra/modules/clamav/src/scan.py
+++ b/infra/modules/clamav/src/scan.py
@@ -11,7 +11,10 @@ For each triggering object the scanner:
      log an error and stop -- nothing downstream can correlate the result, and
      a retry can't make the metadata appear.
   2. Marks the DynamoDB scan-cache record ``in_progress``.
-  3. Runs clamscan against the downloaded object.
+  3. Scans the downloaded object with clamd -- a resident daemon that loads the
+     signature database into memory once and keeps it there across warm
+     invocations (see ``_ensure_clamd_running``), so only the first scan on a
+     cold container pays the multi-second DB load.
   4. Copies the object to scanned/ (clean) or infected/ (virus found).
   5. Reports the outcome to the API (POST /v1/files/<file_id>) and *then*
      updates the DynamoDB record to the terminal status. The API call lands
@@ -23,12 +26,13 @@ For each triggering object the scanner:
      the API call, and the DynamoDB write are all idempotent.
 
 The signature database lives on EFS at CLAMAV_DB_DIR and is refreshed
-out-of-band by the freshclam Lambda.
+out-of-band by the freshclam Lambda. clamd loads it at startup and picks up
+freshclam's updates on its periodic self-check.
 
 Behavior on failure:
   - Files larger than MAX_FILE_SIZE_BYTES are not downloaded; they can't be
     certified clean, so they are quarantined to infected/ rather than passed.
-  - A clamscan execution error (exit code >= 2, as opposed to a virus hit) is
+  - A clamd scan error (exit code >= 2, as opposed to a virus hit) is
     raised so Lambda retries the event and, after the retry budget, routes the
     original S3 payload to the DLQ for manual replay.
   - Duplicate S3 deliveries for a key whose source has already been moved are
@@ -37,7 +41,10 @@ Behavior on failure:
 
 import json
 import os
+import socket
 import subprocess
+import threading
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -72,14 +79,41 @@ USER_ID_METADATA_KEY = "user-id"
 
 # Layer drops binaries at /opt/bin and libs at /opt/lib — Lambda adds both
 # to PATH and LD_LIBRARY_PATH automatically.
-CLAMSCAN_BIN = "/opt/bin/clamscan"
+#
+# We scan via clamd (the resident daemon) rather than clamscan (the one-shot
+# CLI). clamscan reloads the ~hundreds-of-MB signature database into memory on
+# *every* invocation, and that load dominates scan latency. clamd loads the DB
+# once when it starts and keeps it resident, so warm invocations just connect
+# to the already-loaded daemon over a local socket via the thin clamdscan
+# client and finish in well under a second.
+CLAMD_BIN = "/opt/bin/clamd"
+CLAMDSCAN_BIN = "/opt/bin/clamdscan"
 
-# Fail fast at cold start rather than discovering a bad layer mid-scan,
-# where the error surfaces as a confusing subprocess failure.
-if not Path(CLAMSCAN_BIN).exists():
-    raise RuntimeError(
-        f"ClamAV binary not found at {CLAMSCAN_BIN}; layer build is missing or corrupted"
-    )
+# clamd is configured and run entirely out of /tmp — the only writable path in
+# the Lambda filesystem. The config is generated at startup so it can point
+# DatabaseDirectory at the EFS mount and raise the scan-size limits.
+CLAMD_SOCKET = "/tmp/clamd.sock"
+CLAMD_CONFIG = "/tmp/clamd.conf"
+CLAMD_PID = "/tmp/clamd.pid"
+CLAMD_LOG = "/tmp/clamd.log"
+
+# How long to wait for clamd to load the signature DB and start accepting
+# connections on a cold container. The load is bounded by EFS read throughput;
+# 120s leaves generous headroom under the Lambda timeout.
+CLAMD_STARTUP_TIMEOUT_SECONDS = int(os.environ.get("CLAMD_STARTUP_TIMEOUT_SECONDS", "120"))
+
+# Guards clamd startup. A Lambda container only ever handles one invocation at
+# a time, so this is effectively uncontended — it just protects the global.
+_clamd_lock = threading.Lock()
+_clamd_process = None
+
+# Fail fast at cold start rather than discovering a bad layer mid-scan, where
+# the error surfaces as a confusing subprocess failure.
+for _required_bin in (CLAMD_BIN, CLAMDSCAN_BIN):
+    if not Path(_required_bin).exists():
+        raise RuntimeError(
+            f"ClamAV binary not found at {_required_bin}; layer build is missing or corrupted"
+        )
 
 # Scan statuses, mirroring the API's FileScanStatus values. The scanner only
 # ever sets these three: in_progress on start, then complete or infected.
@@ -87,7 +121,7 @@ STATUS_IN_PROGRESS = "in_progress"
 STATUS_COMPLETE = "complete"
 STATUS_INFECTED = "infected"
 
-# clamscan exit codes: 0 = clean, 1 = virus found, 2 = scanning error.
+# clamscan / clamdscan exit codes: 0 = clean, 1 = virus found, 2 = scan error.
 _STATUS_BY_EXIT = {0: STATUS_COMPLETE, 1: STATUS_INFECTED}
 
 # Clean files go to scanned/, anything quarantined goes to infected/.
@@ -211,7 +245,7 @@ def _process_record(bucket, key):
 
 def _determine_status(bucket, key, size_bytes):
     """Return ``(status, detail)`` for the object. ``status`` is one of the
-    terminal scan statuses; ``detail`` carries clamscan output for logging."""
+    terminal scan statuses; ``detail`` carries clamdscan output for logging."""
     if size_bytes > MAX_FILE_SIZE_BYTES:
         # Too large to pull into /tmp for scanning. We can't certify it clean,
         # so quarantine it as infected rather than letting it through.
@@ -225,16 +259,21 @@ def _determine_status(bucket, key, size_bytes):
 
 
 def _scan_object(bucket, key):
+    _ensure_clamd_running()
+
     local_path = Path("/tmp") / Path(key).name
     s3.download_file(bucket, key, str(local_path))
 
     try:
         completed = subprocess.run(
             [
-                CLAMSCAN_BIN,
+                CLAMDSCAN_BIN,
+                "--config-file",
+                CLAMD_CONFIG,
+                # Hand clamd the open file descriptor so it reads the file
+                # directly (rather than streaming the bytes over the socket).
+                "--fdpass",
                 "--no-summary",
-                "--database",
-                CLAMAV_DB_DIR,
                 str(local_path),
             ],
             capture_output=True,
@@ -246,19 +285,99 @@ def _scan_object(bucket, key):
 
     status = _STATUS_BY_EXIT.get(completed.returncode)
     if status is None:
-        # clamscan exit code >= 2 means the scanner itself failed, not that
-        # the file is infected. Raise so the event retries and eventually
-        # lands on the DLQ for manual replay.
+        # clamdscan exit code >= 2 means the scan itself failed, not that the
+        # file is infected. Raise so the event retries and eventually lands on
+        # the DLQ for manual replay.
         raise ScanError(
-            f"clamscan failed for {bucket}/{key} "
+            f"clamdscan failed for {bucket}/{key} "
             f"(exit={completed.returncode}, stderr={completed.stderr.strip()!r})"
         )
 
     return status, {
-        "clamscan_exit_code": completed.returncode,
-        "clamscan_stdout": completed.stdout.strip(),
-        "clamscan_stderr": completed.stderr.strip(),
+        "clamdscan_exit_code": completed.returncode,
+        "clamdscan_stdout": completed.stdout.strip(),
+        "clamdscan_stderr": completed.stderr.strip(),
     }
+
+
+def _ensure_clamd_running():
+    """Start clamd if it isn't already serving, then block until it accepts
+    connections. Cheap and idempotent on warm containers (a single PING):
+    clamd loads the signature DB once at startup and stays resident across
+    invocations, so the DB-load cost is paid only on the first scan after a
+    cold start (or if clamd died and has to be restarted)."""
+    global _clamd_process
+    with _clamd_lock:
+        if _clamd_responds():
+            return
+
+        _write_clamd_config()
+        _clamd_process = subprocess.Popen(
+            [CLAMD_BIN, "--config-file", CLAMD_CONFIG],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        deadline = time.monotonic() + CLAMD_STARTUP_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if _clamd_process.poll() is not None:
+                raise ScanError(
+                    f"clamd exited during startup (code={_clamd_process.returncode}); "
+                    f"log tail: {_read_clamd_log()}"
+                )
+            if _clamd_responds():
+                return
+            time.sleep(0.5)
+
+        raise ScanError(
+            f"clamd did not become ready within {CLAMD_STARTUP_TIMEOUT_SECONDS}s; "
+            f"log tail: {_read_clamd_log()}"
+        )
+
+
+def _write_clamd_config():
+    """Generate clamd's config in /tmp (the only writable path). Points the
+    daemon at the EFS-mounted signature DB and raises the scan-size limits to
+    MAX_FILE_SIZE_BYTES so files up to the handler's size threshold are fully
+    scanned -- clamd's defaults (25M file / 100M scan) sit well below that, and
+    anything over a default limit would otherwise be passed through unscanned."""
+    config_lines = [
+        f"LocalSocket {CLAMD_SOCKET}",
+        f"PidFile {CLAMD_PID}",
+        f"LogFile {CLAMD_LOG}",
+        "LogTime yes",
+        f"DatabaseDirectory {CLAMAV_DB_DIR}",
+        "TemporaryDirectory /tmp",
+        # Run in the foreground so the Popen handle tracks the real process
+        # (clamd does not double-fork), which the liveness check relies on.
+        "Foreground yes",
+        # One invocation per container, so a couple of threads is plenty.
+        "MaxThreads 2",
+        f"MaxFileSize {MAX_FILE_SIZE_BYTES}",
+        f"MaxScanSize {MAX_FILE_SIZE_BYTES}",
+        f"StreamMaxLength {MAX_FILE_SIZE_BYTES}",
+    ]
+    Path(CLAMD_CONFIG).write_text("\n".join(config_lines) + "\n")
+
+
+def _clamd_responds():
+    """True if clamd answers PING on its local socket."""
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(5)
+            sock.connect(CLAMD_SOCKET)
+            sock.sendall(b"nPING\n")
+            return sock.recv(16).strip() == b"PONG"
+    except OSError:
+        return False
+
+
+def _read_clamd_log(max_chars=2000):
+    """Best-effort tail of clamd's log, for surfacing startup failures."""
+    try:
+        return Path(CLAMD_LOG).read_text()[-max_chars:].strip()
+    except OSError:
+        return "<no clamd log>"
 
 
 def _set_scan_status(file_id, user_id, status):


### PR DESCRIPTION
## Summary

Updated the clamav scanner lambda function to  load the DB once per warm container and updated the clamav lambda layer to inlcude the clamd into the layer reducing the amount of data we pull from efs. 

Also, update efs to use throuput mode elastic. 

## Validation steps

Deployed into staging from local. 

Verified the clamav lamba function duration is now decreased to 740 milliseconds from 14 seconds before. 

<img width="779" height="680" alt="Screenshot 2026-06-26 at 3 24 24 PM" src="https://github.com/user-attachments/assets/75442626-1316-4473-8cb0-1e452eaeb296" />


<img width="1245" height="443" alt="Screenshot 2026-06-26 at 3 22 43 PM" src="https://github.com/user-attachments/assets/17231cea-dfbf-4ce6-a804-41b57e6e62ea" />
