### PR TITLE
[unticketed]: parameterize clamav lambda provisioned concurrency config for prod and training

### DIFF
--- a/infra/api/app-config/env-config/outputs.tf
+++ b/infra/api/app-config/env-config/outputs.tf
@@ -42,6 +42,7 @@ output "service_config" {
     newrelic_entity_guid            = var.service_newrelic_entity_guid
     newrelic_mtls_entity_guid       = var.service_newrelic_mtls_entity_guid
     newrelic_host_entity_guid       = var.api_host_newrelic_entity_guid
+    scanner_provisioned_concurrency = var.scanner_provisioned_concurrency
 
     extra_environment_variables = merge(
       local.default_extra_environment_variables,

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -265,6 +265,12 @@ variable "workflow_service_desired_count" {
   default     = 1
 }
 
+variable "scanner_provisioned_concurrency" {
+  description = "Number of execution environments to keep warm for the ClamAV scanner Lambda via provisioned concurrency. Each warmed environment loads the signature database into memory ahead of time, so scans skip the multi-second cold-start load. 0 (the default) leaves the scanner fully on-demand. Billed continuously, so set this only in environments that need consistently low scan latency. Must not exceed the scanner's reserved concurrency (10)."
+  type        = number
+  default     = 0
+}
+
 variable "service_newrelic_entity_guid" {
   type        = string
   description = "New Relic entity GUID for the primary ALB, used to correlate logs with the infrastructure entity in New Relic."

--- a/infra/api/app-config/env-config/variables.tf
+++ b/infra/api/app-config/env-config/variables.tf
@@ -266,7 +266,7 @@ variable "workflow_service_desired_count" {
 }
 
 variable "scanner_provisioned_concurrency" {
-  description = "Number of execution environments to keep warm for the ClamAV scanner Lambda via provisioned concurrency. Each warmed environment loads the signature database into memory ahead of time, so scans skip the multi-second cold-start load. 0 (the default) leaves the scanner fully on-demand. Billed continuously, so set this only in environments that need consistently low scan latency. Must not exceed the scanner's reserved concurrency (10)."
+  description = "Number of execution environments to keep warm for the ClamAV scanner Lambda via provisioned concurrency."
   type        = number
   default     = 0
 }

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -102,6 +102,8 @@ module "prod_config" {
   instance_cpu    = 2048
   instance_memory = 4096
 
+  scanner_provisioned_concurrency = 1
+
   # Enables ECS Exec access for debugging or jump access.
   # Defaults to `false`. Uncomment the next line to enable.
   # ⚠️ Warning! It is not recommended to enable this in a production environment.

--- a/infra/api/app-config/training.tf
+++ b/infra/api/app-config/training.tf
@@ -65,4 +65,6 @@ module "training_config" {
   # enable_command_execution = true
 
   enable_workflow_service = true
+
+  scanner_provisioned_concurrency = 1
 }

--- a/infra/api/service/clamav.tf
+++ b/infra/api/service/clamav.tf
@@ -37,4 +37,6 @@ module "clamav" {
   dynamodb_write_policy_arn  = module.file_scan_cache.write_access_policy_arn
 
   newrelic_entity_guid = local.service_config.newrelic_host_entity_guid
+
+  scanner_provisioned_concurrency = local.service_config.scanner_provisioned_concurrency
 }

--- a/infra/modules/clamav/scanner.tf
+++ b/infra/modules/clamav/scanner.tf
@@ -143,6 +143,8 @@ resource "aws_lambda_function" "scanner" {
   memory_size = var.scanner_memory_size
   timeout     = var.scanner_timeout
 
+  publish = true
+
   # Bound parallel scans so a burst of uploads can't exhaust the account
   # Lambda quota or overwhelm EFS. Tune via var.scanner_reserved_concurrency.
   reserved_concurrent_executions = var.scanner_reserved_concurrency
@@ -173,6 +175,8 @@ resource "aws_lambda_function" "scanner" {
       API_BASE_URL               = var.api_base_url
       FILE_SCAN_API_KEY          = var.file_scan_api_key
       FILE_SCAN_CACHE_TABLE_NAME = var.file_scan_cache_table_name
+
+      CLAMD_WARM_ON_INIT = var.scanner_provisioned_concurrency > 0 ? "true" : "false"
     }
   }
 
@@ -187,10 +191,26 @@ resource "aws_lambda_function" "scanner" {
   ]
 }
 
+resource "aws_lambda_alias" "scanner_live" {
+  name             = "live"
+  description      = "Target of the S3 trigger and of provisioned concurrency."
+  function_name    = aws_lambda_function.scanner.function_name
+  function_version = aws_lambda_function.scanner.version
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "scanner" {
+  count = var.scanner_provisioned_concurrency > 0 ? 1 : 0
+
+  function_name                     = aws_lambda_function.scanner.function_name
+  qualifier                         = aws_lambda_alias.scanner_live.name
+  provisioned_concurrent_executions = var.scanner_provisioned_concurrency
+}
+
 resource "aws_lambda_permission" "allow_s3_invoke" {
   statement_id  = "AllowS3Invoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.scanner.function_name
+  qualifier     = aws_lambda_alias.scanner_live.name
   principal     = "s3.amazonaws.com"
   source_arn    = var.s3_bucket_arn
 }
@@ -199,7 +219,7 @@ resource "aws_s3_bucket_notification" "scanner" {
   bucket = var.s3_bucket_id
 
   lambda_function {
-    lambda_function_arn = aws_lambda_function.scanner.arn
+    lambda_function_arn = aws_lambda_alias.scanner_live.arn
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = var.unscanned_prefix
   }

--- a/infra/modules/clamav/src/scan.py
+++ b/infra/modules/clamav/src/scan.py
@@ -100,7 +100,11 @@ CLAMD_LOG = "/tmp/clamd.log"
 # How long to wait for clamd to load the signature DB and start accepting
 # connections on a cold container. The load is bounded by EFS read throughput;
 # 120s leaves generous headroom under the Lambda timeout.
-CLAMD_STARTUP_TIMEOUT_SECONDS = int(os.environ.get("CLAMD_STARTUP_TIMEOUT_SECONDS", "120"))
+CLAMD_STARTUP_TIMEOUT_SECONDS = int(
+    os.environ.get("CLAMD_STARTUP_TIMEOUT_SECONDS", "120")
+)
+
+WARM_CLAMD_ON_INIT = os.environ.get("CLAMD_WARM_ON_INIT", "false").lower() == "true"
 
 # Guards clamd startup. A Lambda container only ever handles one invocation at
 # a time, so this is effectively uncontended — it just protects the global.
@@ -471,3 +475,10 @@ def _delete_object(bucket, key):
 
 def _log(payload):
     print(json.dumps(payload), flush=True)
+
+
+if WARM_CLAMD_ON_INIT:
+    try:
+        _ensure_clamd_running()
+    except Exception as err:  # noqa: BLE001 - init warm-up must not crash the container
+        _log({"outcome": "clamd_init_warmup_skipped", "error": str(err)})

--- a/infra/modules/clamav/variables.tf
+++ b/infra/modules/clamav/variables.tf
@@ -93,7 +93,7 @@ variable "scanner_reserved_concurrency" {
 }
 
 variable "scanner_provisioned_concurrency" {
-  description = "Number of execution environments to keep warm for the scanner Lambda via provisioned concurrency. Each warmed environment runs its INIT ahead of time -- which starts clamd and loads the signature database into memory -- so scans it serves skip the multi-second cold-start DB load. 0 (the default) leaves the scanner fully on-demand. Provisioned concurrency is billed continuously, so reserve it for environments that need consistently low scan latency. Must not exceed scanner_reserved_concurrency."
+  description = "Number of execution environments to keep warm for the scanner Lambda via provisioned concurrency."
   type        = number
   default     = 0
 }

--- a/infra/modules/clamav/variables.tf
+++ b/infra/modules/clamav/variables.tf
@@ -92,6 +92,12 @@ variable "scanner_reserved_concurrency" {
   default     = 10
 }
 
+variable "scanner_provisioned_concurrency" {
+  description = "Number of execution environments to keep warm for the scanner Lambda via provisioned concurrency. Each warmed environment runs its INIT ahead of time -- which starts clamd and loads the signature database into memory -- so scans it serves skip the multi-second cold-start DB load. 0 (the default) leaves the scanner fully on-demand. Provisioned concurrency is billed continuously, so reserve it for environments that need consistently low scan latency. Must not exceed scanner_reserved_concurrency."
+  type        = number
+  default     = 0
+}
+
 variable "scanner_max_file_size_bytes" {
   description = "Maximum object size the scanner will download to /tmp. Files above this threshold are moved to the failed prefix with an explicit reason rather than failing with a confusing disk-space error. Default is 450 MiB to leave headroom under Lambda's 512 MiB /tmp limit."
   type        = number


### PR DESCRIPTION
## Summary

Parameterize clamav lambda provisioned concurrency config for prod and training.

The provisioned concurrency will reduced cold start latency in prod. 

## Validation steps

Deployed to staging: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28265244346)

All scans should be passing below. 