### PR TITLE
[Issue #8762] Create Award Rec List page

### DIFF
--- a/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListHeader.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListHeader.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { identity } from "lodash";
+import AwardRecommendationsListHeader from "src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListHeader";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => identity,
+}));
+
+jest.mock(
+  "src/app/[locale]/(base)/grantor/opportunities/_components/AgencySelector",
+  () => ({
+    AgencySelector: () => <div data-testid="agency-selector" />,
+  }),
+);
+
+const agencies: RelevantAgencyRecord[] = [
+  {
+    agency_id: 1,
+    agency_name: "Agency One",
+    agency_code: "A1",
+    top_level_agency: null,
+  },
+  {
+    agency_id: 2,
+    agency_name: "Agency Two",
+    agency_code: "A2",
+    top_level_agency: null,
+  },
+];
+
+describe("AwardRecommendationsListHeader", () => {
+  it("renders the count, agency selector, and create button", () => {
+    render(
+      <AwardRecommendationsListHeader
+        awardRecommendationsCount={10}
+        agencies={agencies}
+        currentAgencyId="1"
+      />,
+    );
+
+    expect(screen.getByText("numAwardRecommendations")).toBeInTheDocument();
+    expect(screen.getByTestId("agency-selector")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "createRecommendationButton" }),
+    ).toHaveAttribute("href", "/award-recommendation/create");
+  });
+
+  it("hides the count and create button when no agency is selected", () => {
+    render(
+      <AwardRecommendationsListHeader
+        awardRecommendationsCount={0}
+        agencies={agencies}
+        currentAgencyId=""
+      />,
+    );
+
+    expect(
+      screen.queryByText("numAwardRecommendations"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("agency-selector")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "createRecommendationButton" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListHeader.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListHeader.tsx
@@ -1,0 +1,47 @@
+import { AgencySelector } from "src/app/[locale]/(base)/grantor/opportunities/_components/AgencySelector";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
+
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+
+interface AwardRecommendationsListHeaderProps {
+  awardRecommendationsCount: number;
+  agencies: RelevantAgencyRecord[];
+  currentAgencyId: string;
+}
+
+export default function AwardRecommendationsListHeader({
+  awardRecommendationsCount,
+  agencies,
+  currentAgencyId,
+}: AwardRecommendationsListHeaderProps) {
+  const t = useTranslations("AwardRecommendation.list");
+  const showHeaderControls = currentAgencyId !== "";
+
+  return (
+    <div className="display-flex flex-column gap-3 margin-bottom-4">
+      {showHeaderControls && (
+        <div className="font-sans-lg text-bold">
+          {t("numAwardRecommendations", { num: awardRecommendationsCount })}
+        </div>
+      )}
+      <div className="display-flex flex-justify flex-align-end">
+        <div className="maxw-mobile-lg width-full">
+          <AgencySelector
+            agencies={agencies}
+            currentAgencyId={currentAgencyId}
+            className="usa-form-group margin-bottom-0"
+          />
+        </div>
+        {showHeaderControls && (
+          <Link
+            href="/award-recommendation/create"
+            className="usa-button margin-left-auto"
+          >
+            {t("createRecommendationButton")}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/(base)/award-recommendation/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/page.test.tsx
@@ -4,6 +4,7 @@ import AwardRecommendationsListPage, {
   generateMetadata,
 } from "src/app/[locale]/(base)/award-recommendation/page";
 import { MissingAuthError } from "src/errors";
+import { UserSession } from "src/types/authTypes";
 import { LocalizedPageProps } from "src/types/intl";
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import { FeatureFlaggedPageWrapper } from "src/types/uiTypes";
@@ -78,11 +79,12 @@ const mockGetSession = jest.fn();
 const mockGetUserAgencies = jest.fn();
 
 jest.mock("src/services/auth/session", () => ({
-  getSession: () => mockGetSession(),
+  getSession: () => mockGetSession() as Promise<UserSession | null>,
 }));
 
 jest.mock("src/services/fetch/fetchers/agenciesFetcher", () => ({
-  getUserAgencies: (userId: string) => mockGetUserAgencies(userId),
+  getUserAgencies: (userId: string) =>
+    mockGetUserAgencies(userId) as Promise<RelevantAgencyRecord[]>,
 }));
 
 const agencies: RelevantAgencyRecord[] = [

--- a/frontend/src/app/[locale]/(base)/award-recommendation/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/page.test.tsx
@@ -5,8 +5,8 @@ import AwardRecommendationsListPage, {
 } from "src/app/[locale]/(base)/award-recommendation/page";
 import { MissingAuthError } from "src/errors";
 import { LocalizedPageProps } from "src/types/intl";
-import { FeatureFlaggedPageWrapper } from "src/types/uiTypes";
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
+import { FeatureFlaggedPageWrapper } from "src/types/uiTypes";
 
 import { FunctionComponent, ReactNode } from "react";
 
@@ -64,12 +64,15 @@ jest.mock(
   }),
 );
 
-jest.mock("src/components/award-recommendation/AwardRecommendationHero", () => ({
-  __esModule: true,
-  default: ({ heading }: { heading?: string }) => (
-    <div data-testid="award-recommendation-hero">{heading}</div>
-  ),
-}));
+jest.mock(
+  "src/components/award-recommendation/AwardRecommendationHero",
+  () => ({
+    __esModule: true,
+    default: ({ heading }: { heading?: string }) => (
+      <div data-testid="award-recommendation-hero">{heading}</div>
+    ),
+  }),
+);
 
 const mockGetSession = jest.fn();
 const mockGetUserAgencies = jest.fn();

--- a/frontend/src/app/[locale]/(base)/award-recommendation/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/page.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from "@testing-library/react";
+import { identity } from "lodash";
+import AwardRecommendationsListPage, {
+  generateMetadata,
+} from "src/app/[locale]/(base)/award-recommendation/page";
+import { MissingAuthError } from "src/errors";
+import { LocalizedPageProps } from "src/types/intl";
+import { FeatureFlaggedPageWrapper } from "src/types/uiTypes";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
+
+import { FunctionComponent, ReactNode } from "react";
+
+type onEnabled = (props: LocalizedPageProps) => ReactNode;
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => identity,
+}));
+
+jest.mock("next-intl/server", () => ({
+  getTranslations: () => identity,
+}));
+
+jest.mock("react", () => ({
+  ...jest.requireActual<typeof import("react")>("react"),
+  use: jest.fn(() => ({
+    locale: "en",
+  })),
+}));
+
+const redirectMock = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  redirect: (location: string) => redirectMock(location) as unknown,
+}));
+
+const withFeatureFlagMock = jest.fn();
+
+jest.mock("src/services/featureFlags/withFeatureFlag", () => ({
+  __esModule: true,
+  default:
+    (
+      WrappedComponent: FunctionComponent<LocalizedPageProps>,
+      _featureFlagName: string,
+      onEnabled: onEnabled,
+    ) =>
+    (props: LocalizedPageProps) =>
+      (
+        withFeatureFlagMock as FeatureFlaggedPageWrapper<
+          LocalizedPageProps,
+          ReactNode
+        >
+      )(
+        WrappedComponent,
+        _featureFlagName,
+        onEnabled,
+      )(props) as FunctionComponent<LocalizedPageProps>,
+}));
+
+jest.mock(
+  "src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListHeader",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="award-recommendations-list-header" />,
+  }),
+);
+
+jest.mock("src/components/award-recommendation/AwardRecommendationHero", () => ({
+  __esModule: true,
+  default: ({ heading }: { heading?: string }) => (
+    <div data-testid="award-recommendation-hero">{heading}</div>
+  ),
+}));
+
+const mockGetSession = jest.fn();
+const mockGetUserAgencies = jest.fn();
+
+jest.mock("src/services/auth/session", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+jest.mock("src/services/fetch/fetchers/agenciesFetcher", () => ({
+  getUserAgencies: (userId: string) => mockGetUserAgencies(userId),
+}));
+
+const agencies: RelevantAgencyRecord[] = [
+  {
+    agency_id: 1,
+    agency_name: "Agency One",
+    agency_code: "A1",
+    top_level_agency: null,
+  },
+];
+
+describe("AwardRecommendationsListPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    withFeatureFlagMock.mockImplementation(
+      (
+        WrappedComponent: FunctionComponent<LocalizedPageProps>,
+        _featureFlagName: string,
+        _onEnabled: onEnabled,
+      ) =>
+        (props: {
+          params: Promise<{ locale: string }>;
+          searchParams?: Promise<Record<string, string>>;
+        }) =>
+          WrappedComponent(props) as unknown,
+    );
+    mockGetSession.mockResolvedValue({
+      token: "token",
+      user_id: "user-id",
+    });
+    mockGetUserAgencies.mockResolvedValue(agencies);
+  });
+
+  it("generates metadata", async () => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ locale: "en" }),
+    });
+
+    expect(metadata).toEqual({
+      title: "AwardRecommendation.list.pageTitle",
+      description: "AwardRecommendation.metaDescription",
+    });
+  });
+
+  it("redirects to the first agency when none is selected", async () => {
+    await AwardRecommendationsListPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(redirectMock).toHaveBeenCalledWith("?agency=1");
+  });
+
+  it("renders the list header when an agency is selected", async () => {
+    const page = await AwardRecommendationsListPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({ agency: "1" }),
+    });
+
+    render(page);
+
+    expect(screen.getByTestId("award-recommendation-hero")).toHaveTextContent(
+      "list.pageHeading",
+    );
+    expect(
+      screen.getByTestId("award-recommendations-list-header"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the unauthenticated page when agencies cannot be loaded", async () => {
+    mockGetUserAgencies.mockRejectedValue(new MissingAuthError("Missing auth"));
+
+    const page = await AwardRecommendationsListPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({ agency: "1" }),
+    });
+
+    render(page);
+
+    expect(screen.getByText("unauthenticated")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/[locale]/(base)/award-recommendation/page.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/page.tsx
@@ -1,0 +1,122 @@
+import { Metadata } from "next";
+import AwardRecommendationsListHeader from "src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListHeader";
+import TopLevelError from "src/app/[locale]/(base)/error/page";
+import Unauthenticated from "src/app/[locale]/(base)/unauthenticated/page";
+import { MissingAuthError } from "src/errors";
+import { getSession } from "src/services/auth/session";
+import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
+import { getUserAgencies } from "src/services/fetch/fetchers/agenciesFetcher";
+import { LocalizedPageProps } from "src/types/intl";
+import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
+import { WithFeatureFlagProps } from "src/types/uiTypes";
+
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { Alert, GridContainer } from "@trussworks/react-uswds";
+
+import AwardRecommendationHero from "src/components/award-recommendation/AwardRecommendationHero";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale });
+  const meta: Metadata = {
+    title: t("AwardRecommendation.list.pageTitle"),
+    description: t("AwardRecommendation.metaDescription"),
+  };
+  return meta;
+}
+
+export const dynamic = "force-dynamic";
+
+export type AwardRecommendationsListPageProps = LocalizedPageProps &
+  WithFeatureFlagProps;
+
+async function AwardRecommendationsListPage({
+  searchParams,
+}: AwardRecommendationsListPageProps) {
+  const t = await getTranslations("AwardRecommendation");
+
+  const resolvedSearchParams: Record<string, string | string[] | undefined> =
+    searchParams ? await searchParams : {};
+  const selectedAgencyParam: string | string[] | undefined =
+    resolvedSearchParams.agency;
+  const selectedAgencyId: string | undefined = Array.isArray(
+    selectedAgencyParam,
+  )
+    ? selectedAgencyParam[0]
+    : selectedAgencyParam;
+
+  const userSession = await getSession();
+  if (!userSession?.token) {
+    return <TopLevelError />;
+  }
+
+  let userAgencies: RelevantAgencyRecord[];
+  try {
+    userAgencies = await getUserAgencies(userSession.user_id);
+  } catch (error) {
+    if (error instanceof MissingAuthError) {
+      return <Unauthenticated />;
+    }
+    return (
+      <Alert heading={t("list.pageHeading")} headingLevel="h2" type="error">
+        {t("errorMessage")}
+      </Alert>
+    );
+  }
+
+  if (!userAgencies.length) {
+    return (
+      <Alert heading={t("list.pageHeading")} headingLevel="h2" type="error">
+        {t("list.noAgencies")}
+      </Alert>
+    );
+  }
+
+  const sortedUserAgencies = [...userAgencies].sort((a, b) =>
+    a.agency_name.localeCompare(b.agency_name),
+  );
+
+  if (!selectedAgencyId) {
+    redirect(`?agency=${sortedUserAgencies[0].agency_id}`);
+  }
+
+  const selectedAgency = sortedUserAgencies.find(
+    (agency) => agency.agency_id.toString() === selectedAgencyId,
+  );
+  if (!selectedAgency) {
+    return (
+      <Alert heading={t("list.pageHeading")} headingLevel="h2" type="error">
+        {t("list.agencyNotAuthorized")}
+      </Alert>
+    );
+  }
+
+  return (
+    <>
+      <AwardRecommendationHero
+        heading={t("list.pageHeading")}
+        showDateAndStatus={false}
+      />
+      <GridContainer>
+        <div className="margin-top-4">
+          <AwardRecommendationsListHeader
+            awardRecommendationsCount={0}
+            agencies={sortedUserAgencies}
+            currentAgencyId={selectedAgencyId}
+          />
+        </div>
+      </GridContainer>
+    </>
+  );
+}
+
+export default withFeatureFlag<AwardRecommendationsListPageProps, never>(
+  AwardRecommendationsListPage,
+  "awardRecommendationOff",
+  () => redirect("/maintenance"),
+);

--- a/frontend/src/components/award-recommendation/AwardRecommendationHero.test.tsx
+++ b/frontend/src/components/award-recommendation/AwardRecommendationHero.test.tsx
@@ -128,6 +128,19 @@ describe("AwardRecommendationHero", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders only the heading when no award recommendation details are provided", async () => {
+    const customHeading = "Award recommendations";
+    const component = await AwardRecommendationHero({
+      heading: customHeading,
+      showDateAndStatus: false,
+    });
+    render(component);
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading).toHaveTextContent(customHeading);
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+  });
+
   it("shows date and status when showDateAndStatus is true", async () => {
     const component = await AwardRecommendationHero({
       awardRecommendationDetails: mockAwardRecommendationDetails,

--- a/frontend/src/components/award-recommendation/AwardRecommendationHero.tsx
+++ b/frontend/src/components/award-recommendation/AwardRecommendationHero.tsx
@@ -28,7 +28,7 @@ export type NavigationButtonConfig = {
 export type HeroButtonConfig = ActionButtonConfig | NavigationButtonConfig;
 
 interface AwardRecommendationHeroProps {
-  awardRecommendationDetails: AwardRecommendationDetails;
+  awardRecommendationDetails?: AwardRecommendationDetails | null;
   buttons?: HeroButtonConfig[];
   heading?: string;
   showDateAndStatus?: boolean;
@@ -47,13 +47,32 @@ export default async function AwardRecommendationHero({
 }: AwardRecommendationHeroProps) {
   const t = await getTranslations("AwardRecommendation");
 
-  const awardRecNum = awardRecommendationDetails.award_recommendation_number;
+  const awardRecNum = awardRecommendationDetails?.award_recommendation_number;
 
-  const preparedDate = awardRecommendationDetails.created_at
+  const preparedDate = awardRecommendationDetails?.created_at
     ? new Date(awardRecommendationDetails.created_at).toLocaleDateString()
     : new Date().toLocaleDateString();
 
-  const statusValue = awardRecommendationDetails.award_recommendation_status;
+  const statusValue = awardRecommendationDetails?.award_recommendation_status;
+
+  const defaultHeading = awardRecNum ? `${t("heroTitle")}: ${awardRecNum}` : "";
+
+  const breadcrumbList = [
+    ...(awardRecommendationDetails
+      ? [
+          {
+            title: t("awardRecs"),
+            // TODO: add link to award recommendations page
+            path: "/",
+          },
+          {
+            title: `${t("heroTitle")}: ${awardRecNum}`,
+            path: `/`,
+          },
+        ]
+      : []),
+    ...(additionalBreadcrumbs || []),
+  ];
 
   return (
     <div
@@ -62,26 +81,17 @@ export default async function AwardRecommendationHero({
     >
       <GridContainer>
         <Grid>
-          <Breadcrumbs
-            className="padding-y-0 bg-transparent"
-            breadcrumbList={[
-              {
-                title: t("awardRecs"),
-                // TODO: add link to award recommendations page
-                path: "/",
-              },
-              {
-                title: `${t("heroTitle")}: ${awardRecNum}`,
-                path: `/`,
-              },
-              ...(additionalBreadcrumbs || []),
-            ]}
-          />
-          {showDateAndStatus ? (
+          {breadcrumbList.length > 0 && (
+            <Breadcrumbs
+              className="padding-y-0 bg-transparent"
+              breadcrumbList={breadcrumbList}
+            />
+          )}
+          {showDateAndStatus && awardRecommendationDetails ? (
             <>
               <Grid className="padding-bottom-4 mobile-lg:padding-y-4 tablet:padding-y-3">
                 <h1 className="font-sans-xl tablet:font-sans-2xl">
-                  {heading || `${t("heroTitle")}: ${awardRecNum}`}
+                  {heading || defaultHeading}
                 </h1>
               </Grid>
               <Grid row gap>
@@ -95,7 +105,9 @@ export default async function AwardRecommendationHero({
                   <Grid className="padding-top-2 tablet:padding-top-2 display-flex flex-align-center">
                     <strong>{t("status")}:</strong>{" "}
                     <span className="margin-left-1 display-inline-flex flex-align-center">
-                      <AwardRecommendationStatusTag status={statusValue} />
+                      {statusValue && (
+                        <AwardRecommendationStatusTag status={statusValue} />
+                      )}
                     </span>
                   </Grid>
                 </Grid>
@@ -140,7 +152,7 @@ export default async function AwardRecommendationHero({
             >
               <Grid tablet={{ col: "fill" }}>
                 <h1 className="font-sans-xl tablet:font-sans-2xl margin-0">
-                  {heading || `${t("heroTitle")}: ${awardRecNum}`}
+                  {heading || defaultHeading}
                 </h1>
               </Grid>
               {buttons && buttons.length > 0 && (

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2034,6 +2034,16 @@ export const messages = {
     breadcrumbOrganizations: "Organizations",
   },
   AwardRecommendation: {
+    list: {
+      pageTitle: "Award recommendations",
+      pageHeading: "Award recommendations",
+      numAwardRecommendations:
+        "{num, plural, =1 {1 Award recommendation} other {# Award recommendations}}",
+      createRecommendationButton: "Create recommendation",
+      agencyNotAuthorized:
+        "You do not have access to this agency's award recommendations.",
+      noAgencies: "You are not associated with any agencies.",
+    },
     summary: {
       showDescription: "Show full description",
       hideSummaryDescription: "Hide full description",

--- a/frontend/src/utils/getRoutes.test.ts
+++ b/frontend/src/utils/getRoutes.test.ts
@@ -16,6 +16,7 @@ describe("getNextRoutes", () => {
       "/(base)/award-recommendation/1/risks/add",
       "/(base)/award-recommendation/1/risks",
       "/(base)/award-recommendation/create",
+      "/(base)/award-recommendation",
       "/(base)/award-recommendation/select-opportunity",
       "/(base)/dev/feature-flags",
       "/(base)/developers/api-dashboard",


### PR DESCRIPTION
## Summary

Work for #8762 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Added the Award Recommendations list page at `/award-recommendation` with shared `AwardRecommendationHero`, agency selector, and a Create recommendation CTA
- Made `awardRecommendationDetails` optional on `AwardRecommendationHero` so the list page works before a specific AR is selected
- Added i18n, route, and unit tests

## Context for reviewers

This is a page shell only - table, sorting, pagination, and list API wiring come in follow-up tickets. The record count is hardcoded to 0 for now. Agency handling follows the same pattern as the grantor opportunities list page.

## Validation steps

- [ ] Navigate to `localhost:3000/award-recommendation` - loads with hero, agency selector, and Create recommendation CTA
- [ ] Agency switching works via ?agency=; missing param redirects to first agency
- [ ] Existing AR detail/edit pages still render the hero correctly
