### PR TITLE
[unticketed]: update api docker file to copy gunicorn conf

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -137,4 +137,8 @@ ENV PATH="/api/.venv/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin" \
 # Run as the non-root user
 USER ${RUN_USER}
 
+# `-c gunicorn.conf.py` is technically redundant: gunicorn auto-loads ./gunicorn.conf.py
+# from the WORKDIR (/api) when the file is present. We pass it explicitly as a guardrail --
+# if the config is ever dropped from the image again, gunicorn fails fast at startup
+# instead of silently falling back to its defaults (1 sync worker, 1 thread).
 CMD ["gunicorn", "-c", "gunicorn.conf.py", "--worker-tmp-dir=/dev/shm", "src.app:create_app()", "--log-level", "debug", "--limit-request-field_size", "16384", "--limit-request-fields", "50"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -26,6 +26,8 @@ RUN rm -rf /api/.venv || true
 COPY src /api/src
 COPY newrelic.ini /api/newrelic.ini
 
+COPY gunicorn.conf.py /api/gunicorn.conf.py
+
 # Disable dev dependencies in UV sync
 ENV UV_NO_DEV=1
 # Compile python to *.pyc files for performance
@@ -135,4 +137,4 @@ ENV PATH="/api/.venv/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin" \
 # Run as the non-root user
 USER ${RUN_USER}
 
-CMD ["gunicorn", "--worker-tmp-dir=/dev/shm", "src.app:create_app()", "--log-level", "debug", "--limit-request-field_size", "16384", "--limit-request-fields", "50"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "--worker-tmp-dir=/dev/shm", "src.app:create_app()", "--log-level", "debug", "--limit-request-field_size", "16384", "--limit-request-fields", "50"]

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -25,6 +25,10 @@ bind = app_config.host + ":" + str(app_config.port)
 workers = (len(os.sched_getaffinity(0)) * 2) + 1
 threads = 4
 
+# Set the worker class explicitly. This is redundant: gunicorn already auto-promotes the
+# default 'sync' worker to 'gthread' whenever threads > 1. We state it
+# anyway so the concurrency model is obvious and doesn't silently revert to one-request-
+# per-worker 'sync' if the thread count is ever lowered to 1.
 worker_class = "gthread"
 
 # Set keepalive higher than ALB idle timeout (120s) to prevent connection pool exhaustion.

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -15,7 +15,7 @@ from src.app_config import AppConfig
 
 app_config = AppConfig()
 
-bind = app_config.host + ':' + str(app_config.port)
+bind = app_config.host + ":" + str(app_config.port)
 # Calculates the number of usable cores and doubles it. Recommended number of workers per core is two.
 # https://docs.gunicorn.org/en/latest/design.html#how-many-workers
 # We use 'os.sched_getaffinity(pid)' not 'os.cpu_count()' because it returns only allowable CPUs.
@@ -24,6 +24,8 @@ bind = app_config.host + ':' + str(app_config.port)
 
 workers = (len(os.sched_getaffinity(0)) * 2) + 1
 threads = 4
+
+worker_class = "gthread"
 
 # Set keepalive higher than ALB idle timeout (120s) to prevent connection pool exhaustion.
 # When gunicorn's keepalive is lower than ALB's idle timeout, gunicorn closes connections

--- a/infra/modules/service/load_balancer.tf
+++ b/infra/modules/service/load_balancer.tf
@@ -180,7 +180,7 @@ resource "aws_lb_target_group" "app_tg" {
     port                = var.container_port
     healthy_threshold   = 2
     unhealthy_threshold = 10
-    interval            = 30
+    interval            = 60
     timeout             = 29
     matcher             = "200-299"
   }
@@ -208,7 +208,7 @@ resource "aws_lb_target_group" "mtls_tg" {
     port                = var.container_port
     healthy_threshold   = 2
     unhealthy_threshold = 10
-    interval            = 30
+    interval            = 60
     timeout             = 29
     matcher             = "200-299"
   }


### PR DESCRIPTION
## Summary

While debugging the api gateway streaming issue noticed the gunicorn conf wasn't copied in to the release image. While testing in staging we noticed synchronous behavior. When we try to test the streaming and the /health endpoint concurrently, the /health endpoing was hanging. 

## Validation steps

Deployed to staging: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28385807374/job/84101135899)

Deployed to dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28387106367)