### PR TITLE
[Unticketed] When logging info about a scan, record the file size

### DIFF
--- a/api/src/services/files/update_pending_file_scan_status.py
+++ b/api/src/services/files/update_pending_file_scan_status.py
@@ -52,6 +52,15 @@ def update_pending_file_scan_status(
     now = datetime_util.utcnow()
     scan_duration_seconds = (now - pending_file.created_at).total_seconds()
 
+    # Calculate the file length of the file for logging purposes
+    # If this fails for whatever reason, we don't want to fail
+    # the API call, just log the error and move on.
+    try:
+        file_length = file_util.get_file_length_bytes(file_location)
+    except Exception:
+        logger.exception("Failed to get file length")
+        file_length = None
+
     logger.info(
         "Updated pending file scan status",
         extra={
@@ -61,5 +70,6 @@ def update_pending_file_scan_status(
             "prior_file_scan_status": prior_file_scan_status,
             "file_scan_status": file_scan_status,
             "scan_duration_seconds": scan_duration_seconds,
+            "file_length_bytes": file_length,
         },
     )

--- a/api/tests/src/api/files_v1/test_update_pending_file_scan_status.py
+++ b/api/tests/src/api/files_v1/test_update_pending_file_scan_status.py
@@ -98,6 +98,7 @@ class TestUpdateFileScanStatusSuccess:
         assert record.file_scan_status == FileScanStatus.COMPLETE
         assert record.scan_duration_seconds >= 0
         assert record.prior_file_scan_status == FileScanStatus.PENDING
+        assert record.file_length_bytes > 0
 
 
 class TestUpdateFileScanStatus401:


### PR DESCRIPTION
## Summary

## Changes proposed
* When updating the status for a file scan, record the file size.

## Context for reviewers
This is a metric we want for our dashboards, so calculate using a utility we already have.
