### PR TITLE
[Issue #11121] removed pre-population of uei field — Project/Performance Site Location(s)

### DIFF
--- a/api/src/form_schema/forms/project_performance_site_location/1/0/form_json.py
+++ b/api/src/form_schema/forms/project_performance_site_location/1/0/form_json.py
@@ -246,10 +246,6 @@ FORM_UI_SCHEMA = [
 ]
 
 FORM_RULE_SCHEMA = {
-    "primary_site": {
-        # Pre-populate UEI from the applicant organization
-        "uei": {"gg_pre_population": {"rule": "uei"}},
-    },
     # Validate the attachment ID exists on the application
     "additional_locations_attachment": {"gg_validation": {"rule": "attachment"}},
 }


### PR DESCRIPTION
## Summary

Work for #11121  

Removes UEI pre-population from the Project/Performance Site Location(s) form.

The Performance Site UEI is now user-entered rather than automatically populated from the applicant organization. The field remains optional and editable.

## UAT

Requires UAT in the feature environment:

- Create a new application and open the Project/Performance Site Location(s) form.
- Confirm the primary-site UEI is not pre-populated from the applicant organization.
- Confirm the UEI can be left blank.
- Enter and save a 12-character UEI.
- Reload or make another form edit and confirm the entered UEI remains unchanged.

example of uei with 11 characters (1 char short)
<img width="678" height="165" alt="Screenshot 2026-06-29 at 1 17 26 PM" src="https://github.com/user-attachments/assets/8a2858c8-ac51-4b6e-8450-2b80237865ec" />

## Validation steps

- [ ] Confirmed a blank UEI can be saved.
- [ ] Confirmed a 12-character UEI, such as TESTUEI12345, can be saved.
- [ ] Confirmed an 11-character UEI, such as TESTUEI1234, shows the expected validation error.
- [ ] Existing shared-schema validation continues to require exactly 12 characters when a UEI is provided.
