### PR TITLE
[Issue #6904] Create Key Contacts JSON Schema and Rules Schema

### DIFF
--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -174,6 +174,8 @@ class FormType(StrEnum):
     EPA_FORM_4700_4 = "EPAForm4700-4"
     EPA_KEY_CONTACTS = "EPAKeyContacts"
 
+    KEY_CONTACTS = "KeyContacts"
+
     ATTACHMENT_FORM = "AttachmentForm"
 
     PROJECT_PERFORMANCE_SITE_LOCATION = "ProjectPerformanceSiteLocation"

--- a/api/src/db/models/lookup_models.py
+++ b/api/src/db/models/lookup_models.py
@@ -203,6 +203,7 @@ FORM_TYPE_CONFIG: LookupConfig[FormType] = LookupConfig(
         LookupStr(FormType.EPA_KEY_CONTACTS, 15),
         LookupStr(FormType.ATTACHMENT_FORM, 16),
         LookupStr(FormType.PROJECT_PERFORMANCE_SITE_LOCATION, 17),
+        LookupStr(FormType.KEY_CONTACTS, 18),
     ]
 )
 

--- a/api/src/form_schema/forms/__init__.py
+++ b/api/src/form_schema/forms/__init__.py
@@ -9,6 +9,7 @@ from .cd511 import CD511_v1_1
 from .epa_form_4700_4 import EPA_FORM_4700_4_v5_0
 from .epa_key_contacts import EPA_KEY_CONTACT_v2_0
 from .gg_lobbying_form import GG_LobbyingForm_v1_1
+from .key_contacts import KeyContacts_v2_0
 from .other_narrative_attachment import OtherNarrativeAttachment_v1_2
 from .project_abstract import ProjectAbstract_v1_2
 from .project_abstract_summary import ProjectAbstractSummary_v2_0
@@ -40,6 +41,7 @@ _ALL_FORMS: list[Form] = [
     GG_LobbyingForm_v1_1,
     EPA_FORM_4700_4_v5_0,
     EPA_KEY_CONTACT_v2_0,
+    KeyContacts_v2_0,
     ProjectPerformanceSiteLocation_v4_0,
 ]
 

--- a/api/src/form_schema/forms/key_contacts/1/0/form_json.py
+++ b/api/src/form_schema/forms/key_contacts/1/0/form_json.py
@@ -1,0 +1,366 @@
+import uuid
+
+from src.constants.lookup_constants import FormType
+from src.db.models.competition_models import Form
+from src.form_schema.shared import ADDRESS_SHARED_V1, COMMON_SHARED_V1
+
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    # The applicant organization and at least one key contact are required,
+    # matching the legacy XSD (ApplicantOrganizationName + RoleOnProject minOccurs=1).
+    "required": ["applicant_organization_name", "key_contacts"],
+    "properties": {
+        "applicant_organization_name": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
+            "title": "Applicant Organization Name",
+            "description": "Enter the name of the applicant organization.",
+        },
+        "key_contacts": {
+            "type": "array",
+            "title": "Key Contacts",
+            "description": "Enter between 1 and 4 key contacts and their role on the project.",
+            # XSD RoleOnProject: minOccurs defaults to 1, maxOccurs=4
+            "minItems": 1,
+            "maxItems": 4,
+            "items": {"$ref": "#/$defs/key_contact_person"},
+        },
+    },
+    "$defs": {
+        "key_contact_person": {
+            "type": "object",
+            "required": ["project_role", "name", "address", "phone", "email"],
+            "properties": {
+                "project_role": {
+                    "type": "string",
+                    "title": "Project Role",
+                    "description": "Enter the contact's role on the project.",
+                    "minLength": 1,
+                    "maxLength": 45,
+                },
+                "name": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
+                    "title": "Name",
+                },
+                "title": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
+                    "title": "Title",
+                },
+                "organizational_affiliation": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
+                    "title": "Organizational Affiliation",
+                    "description": "Enter the contact's organizational affiliation.",
+                },
+                "address": {
+                    # Use the full address (with county/province) per the epic:
+                    # the Province field is shown at all times on this form.
+                    "allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("address")}],
+                },
+                "phone": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
+                    "title": "Phone Number",
+                },
+                "fax": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
+                    "title": "Fax Number",
+                },
+                "email": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_email")}],
+                    "title": "E-mail Address",
+                },
+            },
+        }
+    },
+}
+
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "Key Contacts",
+        "name": "key_contacts",
+        "description": "Enter between 1 and 4 key contacts and their role on the project.",
+        "children": [
+            # Applicant Organization Name is the first field and is not part of the FieldList.
+            {
+                "type": "field",
+                "definition": "/properties/applicant_organization_name",
+            },
+            {
+                "type": "fieldList",
+                "name": "key_contacts",
+                "label": "Key Contact",
+                "description": "Enter between 1 and 4 key contacts and their role on the project.",
+                "children": [
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/project_role",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/name/properties/prefix",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/name/properties/first_name",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/name/properties/middle_name",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/name/properties/last_name",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/name/properties/suffix",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/title",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/organizational_affiliation",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/street1",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/street2",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/city",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/county",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/state",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/province",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/zip_code",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/address/properties/country",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/phone",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/fax",
+                    },
+                    {
+                        "type": "field",
+                        "definition": "/properties/key_contacts/items/properties/email",
+                    },
+                ],
+            },
+        ],
+    },
+]
+
+
+def _key_contact_xml_fields() -> dict:
+    """XML field mappings for a single RoleOnProject entry.
+
+    The RoleOnProject element and its direct children belong to the form
+    namespace (default), while the contents of the HumanNameDataType and
+    AddressDataTypeV3 types come from the GlobalLibrary namespace.
+    """
+    return {
+        "project_role": {
+            "xml_transform": {
+                "target": "ContactProjectRole",
+            }
+        },
+        "name": {
+            "xml_transform": {
+                "target": "ContactName",
+                "type": "nested_object",
+            },
+            "prefix": {
+                "xml_transform": {
+                    "target": "PrefixName",
+                    "namespace": "globLib",
+                }
+            },
+            "first_name": {
+                "xml_transform": {
+                    "target": "FirstName",
+                    "namespace": "globLib",
+                }
+            },
+            "middle_name": {
+                "xml_transform": {
+                    "target": "MiddleName",
+                    "namespace": "globLib",
+                }
+            },
+            "last_name": {
+                "xml_transform": {
+                    "target": "LastName",
+                    "namespace": "globLib",
+                }
+            },
+            "suffix": {
+                "xml_transform": {
+                    "target": "SuffixName",
+                    "namespace": "globLib",
+                }
+            },
+        },
+        "title": {
+            "xml_transform": {
+                "target": "ContactTitle",
+            }
+        },
+        "organizational_affiliation": {
+            "xml_transform": {
+                "target": "ContactOrganizationalAffiliation",
+            }
+        },
+        "address": {
+            "xml_transform": {
+                "target": "ContactAddress",
+                "type": "nested_object",
+            },
+            # Order matches AddressDataTypeV3 XSD sequence: Street1, Street2, City,
+            # County, State|Province, ZipPostalCode, Country
+            "street1": {
+                "xml_transform": {
+                    "target": "Street1",
+                    "namespace": "globLib",
+                }
+            },
+            "street2": {
+                "xml_transform": {
+                    "target": "Street2",
+                    "namespace": "globLib",
+                }
+            },
+            "city": {
+                "xml_transform": {
+                    "target": "City",
+                    "namespace": "globLib",
+                }
+            },
+            "county": {
+                "xml_transform": {
+                    "target": "County",
+                    "namespace": "globLib",
+                }
+            },
+            "state": {
+                "xml_transform": {
+                    "target": "State",
+                    "namespace": "globLib",
+                }
+            },
+            "province": {
+                "xml_transform": {
+                    "target": "Province",
+                    "namespace": "globLib",
+                }
+            },
+            "zip_code": {
+                "xml_transform": {
+                    "target": "ZipPostalCode",
+                    "namespace": "globLib",
+                }
+            },
+            "country": {
+                "xml_transform": {
+                    "target": "Country",
+                    "namespace": "globLib",
+                }
+            },
+        },
+        "phone": {
+            "xml_transform": {
+                "target": "ContactPhone",
+            }
+        },
+        "fax": {
+            "xml_transform": {
+                "target": "ContactFax",
+            }
+        },
+        "email": {
+            "xml_transform": {
+                "target": "ContactEmail",
+            }
+        },
+    }
+
+
+# XML Transformation Rules for Key Contacts v2.0
+FORM_XML_TRANSFORM_RULES = {
+    "_xml_config": {
+        "description": "XML transformation rules for Key Contacts form",
+        "version": "1.0",
+        "form_name": "Key_Contacts_2_0",
+        "namespaces": {
+            "default": "http://apply.grants.gov/forms/Key_Contacts_2_0-V2.0",
+            "Key_Contacts_2_0": "http://apply.grants.gov/forms/Key_Contacts_2_0-V2.0",
+            "globLib": "http://apply.grants.gov/system/GlobalLibrary-V2.0",
+            "codes": "http://apply.grants.gov/system/UniversalCodes-V2.0",
+        },
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/Key_Contacts_2_0-V2.0.xsd",
+        "xml_structure": {
+            "root_element": "Key_Contacts_2_0",
+            "root_namespace_prefix": "Key_Contacts_2_0",
+            "root_attributes": {
+                "FormVersion": "2.0",
+            },
+        },
+        "null_handling_options": {
+            "exclude": "Default - exclude field entirely from XML (recommended)",
+        },
+    },
+    # Field mappings - order matches XSD sequence
+    "applicant_organization_name": {
+        "xml_transform": {
+            "target": "ApplicantOrganizationName",
+        }
+    },
+    "key_contacts": {
+        "xml_transform": {
+            "target": "RoleOnProject",
+            "type": "array",
+        },
+        "items": _key_contact_xml_fields(),
+    },
+}
+
+KeyContacts_v2_0 = Form(
+    # https://www.grants.gov/forms/form-items-description/fid/683
+    form_id=uuid.UUID("f140c7db-724d-4954-bebd-081c0527908c"),
+    legacy_form_id=683,
+    form_name="KEY CONTACTS",
+    short_form_name="Key_Contacts",
+    form_version="2.0",
+    agency_code="SGG",
+    omb_number="4040-0010",
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    # No rule schema needed — no conditional fields, attachments, or pre/post-population
+    form_rule_schema=None,
+    json_to_xml_schema=FORM_XML_TRANSFORM_RULES,
+    form_instruction_id=None,
+    form_type=FormType.KEY_CONTACTS,
+    sgg_version="1.0",
+    is_deprecated=False,
+)

--- a/api/src/form_schema/forms/key_contacts/__init__.py
+++ b/api/src/form_schema/forms/key_contacts/__init__.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from src.form_schema.forms._loader import load_versioned_form
+
+_mod = load_versioned_form(Path(__file__).parent, "1.0")
+FORM_JSON_SCHEMA = _mod.FORM_JSON_SCHEMA
+FORM_UI_SCHEMA = _mod.FORM_UI_SCHEMA
+# No FORM_RULE_SCHEMA — this form has no conditional fields, attachments, or pre/post-population
+FORM_XML_TRANSFORM_RULES = _mod.FORM_XML_TRANSFORM_RULES
+KeyContacts_v2_0 = _mod.KeyContacts_v2_0
+del _mod

--- a/api/src/form_schema/forms/key_contacts/config.py
+++ b/api/src/form_schema/forms/key_contacts/config.py
@@ -1,0 +1,5 @@
+import uuid
+
+# Stable identifiers for this form — do not change across versions.
+FORM_ID = uuid.UUID("f140c7db-724d-4954-bebd-081c0527908c")
+SHORT_FORM_NAME = "Key_Contacts"

--- a/api/tests/src/form_schema/forms/conftest.py
+++ b/api/tests/src/form_schema/forms/conftest.py
@@ -10,6 +10,7 @@ from src.form_schema.forms import (
     EPA_FORM_4700_4_v5_0,
     EPA_KEY_CONTACT_v2_0,
     GG_LobbyingForm_v1_1,
+    KeyContacts_v2_0,
     OtherNarrativeAttachment_v1_2,
     ProjectAbstract_v1_2,
     ProjectAbstractSummary_v2_0,
@@ -135,6 +136,11 @@ def epa_form_4700_4_v5_0():
 @pytest.fixture(scope="session")
 def epa_key_contact_v2_0():
     return setup_resolved_form(EPA_KEY_CONTACT_v2_0)
+
+
+@pytest.fixture(scope="session")
+def key_contacts_v2_0():
+    return setup_resolved_form(KeyContacts_v2_0)
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/src/form_schema/forms/test_key_contacts.py
+++ b/api/tests/src/form_schema/forms/test_key_contacts.py
@@ -1,0 +1,244 @@
+import pytest
+
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+from tests.src.form_schema.forms.conftest import (
+    validate_max_length,
+    validate_min_length,
+    validate_required,
+)
+
+
+@pytest.fixture
+def contact_full() -> dict:
+    return {
+        "project_role": "Principal Investigator",
+        "name": {
+            "prefix": "Doctor",
+            "first_name": "Sue",
+            "middle_name": "Sally",
+            "last_name": "Storm",
+            "suffix": "Esquire",
+        },
+        "title": "Director",
+        "organizational_affiliation": "Acme University",
+        "address": {
+            "street1": "123 Main Street",
+            "street2": "Apt 123",
+            "city": "Placeville",
+            "state": "WY: Wyoming",
+            "zip_code": "56789-1234",
+            "country": "USA: UNITED STATES",
+        },
+        "phone": "1234567890",
+        "fax": "1112223333",
+        "email": "example@example.com",
+    }
+
+
+@pytest.fixture
+def contact_minimal() -> dict:
+    return {
+        "project_role": "Project Manager",
+        "name": {
+            "first_name": "Joe",
+            "last_name": "Smithers",
+        },
+        "address": {
+            "street1": "456 Rio",
+            "city": "Montevideo",
+            "country": "URY: URUGUAY",
+        },
+        "phone": "1234567890",
+        "email": "person@place.com",
+    }
+
+
+def test_key_contacts_v2_0_full_valid(contact_full, contact_minimal, key_contacts_v2_0):
+    data = {
+        "applicant_organization_name": "Acme Corporation",
+        "key_contacts": [contact_full, contact_minimal, contact_full, contact_minimal],
+    }
+    validate_required(data, [], key_contacts_v2_0)
+
+
+def test_key_contacts_v2_0_minimal_valid(contact_minimal, key_contacts_v2_0):
+    data = {
+        "applicant_organization_name": "Acme Corporation",
+        "key_contacts": [contact_minimal],
+    }
+    validate_required(data, [], key_contacts_v2_0)
+
+
+def test_key_contacts_v2_0_empty(key_contacts_v2_0):
+    validate_required({}, ["$.applicant_organization_name", "$.key_contacts"], key_contacts_v2_0)
+
+
+def test_key_contacts_v2_0_empty_array(key_contacts_v2_0):
+    data = {"applicant_organization_name": "Acme Corporation", "key_contacts": []}
+    issues = validate_json_schema_for_form(data, key_contacts_v2_0)
+    assert len(issues) == 1
+    assert issues[0].type == "minItems"
+    assert issues[0].field == "$.key_contacts"
+
+
+def test_key_contacts_v2_0_too_many(contact_minimal, key_contacts_v2_0):
+    data = {
+        "applicant_organization_name": "Acme Corporation",
+        "key_contacts": [contact_minimal] * 5,
+    }
+    issues = validate_json_schema_for_form(data, key_contacts_v2_0)
+    assert len(issues) == 1
+    assert issues[0].type == "maxItems"
+    assert issues[0].field == "$.key_contacts"
+
+
+def test_key_contacts_v2_0_nested_required(key_contacts_v2_0):
+    data = {
+        "applicant_organization_name": "Acme Corporation",
+        "key_contacts": [{"name": {}, "address": {}}],
+    }
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.key_contacts[0].project_role",
+        "$.key_contacts[0].phone",
+        "$.key_contacts[0].email",
+        "$.key_contacts[0].name.first_name",
+        "$.key_contacts[0].name.last_name",
+        "$.key_contacts[0].address.street1",
+        "$.key_contacts[0].address.city",
+        "$.key_contacts[0].address.country",
+    ]
+    validate_required(data, EXPECTED_REQUIRED_FIELDS, key_contacts_v2_0)
+
+
+def test_key_contacts_v2_0_min_length(key_contacts_v2_0):
+    data = {
+        "applicant_organization_name": "",
+        "key_contacts": [
+            {
+                "project_role": "",
+                "name": {
+                    "prefix": "",
+                    "first_name": "",
+                    "middle_name": "",
+                    "last_name": "",
+                    "suffix": "",
+                },
+                "title": "",
+                "organizational_affiliation": "",
+                "address": {
+                    "street1": "",
+                    "street2": "",
+                    "city": "",
+                    "county": "",
+                    "province": "",
+                    "zip_code": "",
+                    "country": "CAN: CANADA",
+                },
+                "phone": "",
+                "fax": "",
+                "email": "example@example.com",
+            }
+        ],
+    }
+    EXPECTED_ERROR_FIELDS = [
+        "$.applicant_organization_name",
+        "$.key_contacts[0].project_role",
+        "$.key_contacts[0].name.prefix",
+        "$.key_contacts[0].name.first_name",
+        "$.key_contacts[0].name.middle_name",
+        "$.key_contacts[0].name.last_name",
+        "$.key_contacts[0].name.suffix",
+        "$.key_contacts[0].title",
+        "$.key_contacts[0].organizational_affiliation",
+        "$.key_contacts[0].address.street1",
+        "$.key_contacts[0].address.street2",
+        "$.key_contacts[0].address.city",
+        "$.key_contacts[0].address.county",
+        "$.key_contacts[0].address.province",
+        "$.key_contacts[0].address.zip_code",
+        "$.key_contacts[0].phone",
+        "$.key_contacts[0].fax",
+    ]
+    validate_min_length(data, EXPECTED_ERROR_FIELDS, key_contacts_v2_0)
+
+
+def test_key_contacts_v2_0_max_length(key_contacts_v2_0):
+    data = {
+        "applicant_organization_name": "A" * 61,
+        "key_contacts": [
+            {
+                "project_role": "B" * 46,
+                "name": {
+                    "prefix": "C" * 11,
+                    "first_name": "D" * 36,
+                    "middle_name": "E" * 26,
+                    "last_name": "F" * 61,
+                    "suffix": "G" * 11,
+                },
+                "title": "H" * 46,
+                "organizational_affiliation": "I" * 61,
+                "address": {
+                    "street1": "J" * 56,
+                    "street2": "K" * 56,
+                    "city": "L" * 36,
+                    "county": "P" * 31,
+                    "province": "Q" * 31,
+                    "zip_code": "M" * 31,
+                    "country": "CAN: CANADA",
+                },
+                "phone": "N" * 26,
+                "fax": "O" * 26,
+                "email": "@" * 61,
+            }
+        ],
+    }
+    EXPECTED_ERROR_FIELDS = [
+        "$.applicant_organization_name",
+        "$.key_contacts[0].project_role",
+        "$.key_contacts[0].name.prefix",
+        "$.key_contacts[0].name.first_name",
+        "$.key_contacts[0].name.middle_name",
+        "$.key_contacts[0].name.last_name",
+        "$.key_contacts[0].name.suffix",
+        "$.key_contacts[0].title",
+        "$.key_contacts[0].organizational_affiliation",
+        "$.key_contacts[0].address.street1",
+        "$.key_contacts[0].address.street2",
+        "$.key_contacts[0].address.city",
+        "$.key_contacts[0].address.county",
+        "$.key_contacts[0].address.province",
+        "$.key_contacts[0].address.zip_code",
+        "$.key_contacts[0].phone",
+        "$.key_contacts[0].fax",
+        "$.key_contacts[0].email",
+    ]
+    validate_max_length(data, EXPECTED_ERROR_FIELDS, key_contacts_v2_0)
+
+
+def test_key_contacts_v2_0_invalid_email_format(contact_minimal, key_contacts_v2_0):
+    contact_minimal["email"] = "not-an-email"
+    data = {
+        "applicant_organization_name": "Acme Corporation",
+        "key_contacts": [contact_minimal],
+    }
+    issues = validate_json_schema_for_form(data, key_contacts_v2_0)
+    assert len(issues) == 1
+    assert issues[0].type == "format"
+    assert issues[0].field == "$.key_contacts[0].email"
+
+
+def test_key_contacts_v2_0_us_address_requires_state_zip(contact_minimal, key_contacts_v2_0):
+    contact_minimal["address"] = {
+        "street1": "123 Main Street",
+        "city": "Placeville",
+        "country": "USA: UNITED STATES",
+    }
+    data = {
+        "applicant_organization_name": "Acme Corporation",
+        "key_contacts": [contact_minimal],
+    }
+    EXPECTED_REQUIRED_FIELDS = [
+        "$.key_contacts[0].address.state",
+        "$.key_contacts[0].address.zip_code",
+    ]
+    validate_required(data, EXPECTED_REQUIRED_FIELDS, key_contacts_v2_0)

--- a/api/tests/src/services/xml_generation/test_key_contacts_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_key_contacts_xml_generation.py
@@ -1,0 +1,78 @@
+"""Tests for Key Contacts form XML generation.
+
+XSD Reference: https://apply07.grants.gov/apply/forms/schemas/Key_Contacts_2_0-V2.0.xsd
+"""
+
+from lxml import etree as lxml_etree
+
+from src.form_schema.forms.key_contacts import FORM_XML_TRANSFORM_RULES
+from src.services.xml_generation.models import XMLGenerationRequest
+from src.services.xml_generation.service import XMLGenerationService
+
+KC_NS = "http://apply.grants.gov/forms/Key_Contacts_2_0-V2.0"
+GLOB_NS = "http://apply.grants.gov/system/GlobalLibrary-V2.0"
+
+
+def test_key_contacts_xml_structure():
+    """Generate XML for multiple key contacts and verify the RoleOnProject array structure."""
+    application_data = {
+        "applicant_organization_name": "Acme Corporation",
+        "key_contacts": [
+            {
+                "project_role": "Principal Investigator",
+                "name": {"prefix": "Dr.", "first_name": "Sue", "last_name": "Storm"},
+                "address": {
+                    "street1": "123 Main St",
+                    "city": "Placeville",
+                    "state": "WY: Wyoming",
+                    "zip_code": "56789",
+                    "country": "USA: UNITED STATES",
+                },
+                "phone": "1234567890",
+                "email": "sue@example.com",
+            },
+            {
+                "project_role": "Project Manager",
+                "name": {"first_name": "Joe", "last_name": "Smith"},
+                "address": {
+                    "street1": "456 Rio",
+                    "city": "Montevideo",
+                    "country": "URY: URUGUAY",
+                },
+                "phone": "5556667777",
+                "email": "joe@place.com",
+            },
+        ],
+    }
+
+    response = XMLGenerationService().generate_xml(
+        XMLGenerationRequest(
+            application_data=application_data, transform_config=FORM_XML_TRANSFORM_RULES
+        )
+    )
+    assert response.success is True
+
+    root = lxml_etree.fromstring(response.xml_data.encode("utf-8"))
+    assert root.tag == f"{{{KC_NS}}}Key_Contacts_2_0"
+    assert root.get(f"{{{KC_NS}}}FormVersion") == "2.0"
+    assert root.find(f"{{{KC_NS}}}ApplicantOrganizationName").text == "Acme Corporation"
+
+    # Each key contact maps to a RoleOnProject element (form namespace), in order
+    roles = root.findall(f"{{{KC_NS}}}RoleOnProject")
+    assert len(roles) == 2
+
+    pi = roles[0]
+    assert pi.find(f"{{{KC_NS}}}ContactProjectRole").text == "Principal Investigator"
+
+    # Name/Address are form-namespace wrappers with globLib children (per GlobalLibrary types)
+    name = pi.find(f"{{{KC_NS}}}ContactName")
+    assert name.find(f"{{{GLOB_NS}}}FirstName").text == "Sue"
+    assert name.find(f"{{{GLOB_NS}}}LastName").text == "Storm"
+
+    address = pi.find(f"{{{KC_NS}}}ContactAddress")
+    assert address.find(f"{{{GLOB_NS}}}Street1").text == "123 Main St"
+    assert address.find(f"{{{GLOB_NS}}}State").text == "WY: Wyoming"
+    assert address.find(f"{{{GLOB_NS}}}Country").text == "USA: UNITED STATES"
+
+    assert pi.find(f"{{{KC_NS}}}ContactPhone").text == "1234567890"
+    assert pi.find(f"{{{KC_NS}}}ContactEmail").text == "sue@example.com"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #6904

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add new form in `key_contacts`.
Registered `FormType.KEY_CONTACTS` in `lookup_constants.py` and `FORM_TYPE_CONFIG` lookup_models.py.
Registered `KeyContacts_v2_0` in forms/__init__.py.
Adds unit tests covering full XSD validation rules.
Added `test_key_contacts_xml_generation.py` to cover the json_to_xml_schema transform.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Schema constraints were verified against `Key_Contacts_2_0-V2.0.xsd` Per the epic, there are no validation-constraint deviations from the XSD, and no pre- or post-population.
No rule schema is needed (no attachments, conditional fields, or population rules), so there are no separate "rules tests"; JSON schema validation covers the constraints.
Added an XML test since other forms with XML transform rules has a companion XML-generation test, and this verifies the `RoleOnProject` array correctly maps to the form/globLib namespaces and XSD element order.


## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See new unit tests