### PR TITLE
[Issue #10245] Update local seed script for multi user testing

### DIFF
--- a/api/tests/lib/seed_data_utils.py
+++ b/api/tests/lib/seed_data_utils.py
@@ -7,6 +7,7 @@ import grants_shared.adapters.db as db
 
 import tests.src.db.models.factories as factories
 from src.auth.api_jwt_auth import ApiJwtConfig, create_jwt_for_user
+from src.constants.static_role_values import E2E_TEST_USER_ROLE
 from src.db.models.agency_models import Agency
 from src.db.models.competition_models import Competition, Form
 from src.db.models.entity_models import Organization
@@ -156,6 +157,14 @@ class UserBuilder:
             )
 
         return self
+
+    def with_e2e_test_user(self) -> Self:
+        """Flag the user as an E2E test user.
+
+        Grants E2E_TEST_USER_ROLE (the READ_TEST_USER_TOKEN privilege) so the user's auth token
+        can be fetched by the manager API key via POST /v1/internal/e2e-token.
+        """
+        return self.with_internal_role(E2E_TEST_USER_ROLE)
 
     def with_profile(self, first_name: str, last_name: str, middle_name: str | None = None) -> Self:
         """Add a profile to the user."""

--- a/api/tests/lib/seed_e2e.py
+++ b/api/tests/lib/seed_e2e.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import os
 import uuid
@@ -10,21 +11,30 @@ from src.constants.static_role_values import (
     E2E_TEST_USER_MANAGER_ROLE,
     E2E_TEST_USER_ROLE,
     OPPORTUNITY_PUBLISHER,
+    ORG_MEMBER,
 )
+from src.db.models.agency_models import Agency
+from src.db.models.entity_models import Organization
 from src.util.env_config import PydanticBaseEnvConfig
 from tests.lib.seed_agencies_and_users import setup_agency
 from tests.lib.seed_data_utils import UserBuilder
+from tests.lib.seed_orgs_and_users import setup_org
 from tests.src.db.models.factories import AssistanceListingFactory
 
 logger = logging.getLogger(__name__)
 
 ###############################
 # This script will
-# * seed the local database with a user that can be used for fake or potentially real logins from automated e2e tests
+# * seed the local database with one or more test users that can be used for fake or potentially
+#   real logins from automated e2e tests. Every test user is granted E2E_TEST_USER_ROLE, which
+#   carries the READ_TEST_USER_TOKEN privilege -- this is what "flags" a user as available to have
+#   its auth token statically returned via POST /v1/internal/e2e-token.
 # * seed a "manager" user whose API key the e2e orchestrator uses to call
 #   POST /v1/internal/e2e-token (mirrors the staging manager-key flow)
-# * create an authorization token entry tied to the test user, seeding the database accordingly
-# * write the resulting token into the e2e_token.tmp file (where it can be retrieved by CI processes for frontend / e2e use)
+# * write the primary test user's token into the e2e_token.tmp file (where it can be retrieved by
+#   CI processes for frontend / e2e use)
+#
+# To add a new test user, append an E2ETestUserConfig to E2E_TEST_USERS with a static user id.
 ###############################
 
 # Static UUID for the local E2E manager user. Documented to QA alongside the
@@ -42,6 +52,63 @@ E2E_AGENCY_ID = uuid.UUID("d4e5f6a7-b8c9-4d5e-9f0a-1b2c3d4e5f60")
 E2E_ASSISTANCE_LISTING_ID = uuid.UUID("e5f6a7b8-c9d0-4e5f-a0b1-2c3d4e5f6a70")
 E2E_ASSISTANCE_LISTING_NUMBER = "00.000"
 
+# Dedicated organization for E2E test users that need organization membership.
+# Mirrors the setup of the staging test user's organization. This id is
+# local-only and does not need to match staging's organization id.
+E2E_ORGANIZATION_ID = uuid.UUID("e5f6a7b8-c9d0-4e5f-8a0b-1c2d3e4f5061")
+
+# Static id for the secondary E2E test user, a member of the E2E test organization.
+E2E_ORG_MEMBER_USER_ID = uuid.UUID("a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d")
+
+
+@dataclasses.dataclass
+class E2ETestUserConfig:
+    """Declarative definition of an E2E test user.
+
+    Every user built from this config is granted E2E_TEST_USER_ROLE, so its token can be
+    fetched by the manager API key via POST /v1/internal/e2e-token.
+    """
+
+    user_id: uuid.UUID
+    scenario_name: str
+    api_key: str | None = None
+    add_jwt_auth: bool = False
+    write_token_to_file: bool = False
+    in_grantor_agency: bool = False
+    in_test_organization: bool = False
+
+    def __post_init__(self) -> None:
+        # The token written to e2e_token.tmp is the JWT, so writing it requires JWT auth.
+        # Guard here so a bad config fails when the registry is defined rather than silently
+        # writing E2E_USER_AUTH_TOKEN="None" to the file at seed time.
+        if self.write_token_to_file and not self.add_jwt_auth:
+            raise ValueError(
+                f"write_token_to_file requires add_jwt_auth for user {self.scenario_name}"
+            )
+
+
+# The set of test users seeded for E2E / multi-user testing. Append to this list to add a new
+# test user -- each entry needs a static user id so it can be referenced.
+E2E_TEST_USERS = [
+    # Primary test user. Reuses the seeded one_org_user id so the spoofed E2E session always has
+    # organization membership in local/CI runs, and holds a grantor role so opportunity creation
+    # E2E tests can create and publish opportunities.
+    E2ETestUserConfig(
+        user_id=uuid.UUID("f15c7491-7ebc-4f4f-8de6-3ac0594d9c63"),
+        scenario_name="user for e2e",
+        api_key="e2e-test-key",
+        add_jwt_auth=True,
+        write_token_to_file=True,
+        in_grantor_agency=True,
+    ),
+    # Secondary test user with organization membership, mirroring the staging test user.
+    E2ETestUserConfig(
+        user_id=E2E_ORG_MEMBER_USER_ID,
+        scenario_name="e2e org member test user",
+        in_test_organization=True,
+    ),
+]
+
 
 class _SeedE2EConfig(PydanticBaseEnvConfig):
     local_test_user_manager_api_key: str = Field(alias="LOCAL_TEST_USER_MANAGER_API_KEY")
@@ -51,6 +118,31 @@ def _write_token_to_file(token: str) -> None:
     path_to_tmp_token_file = os.path.join(os.path.dirname(__file__), "..", "..", "e2e_token.tmp")
     token_declaration = 'E2E_USER_AUTH_TOKEN="' + token + '"'
     write_to_file(path_to_tmp_token_file, token_declaration)
+
+
+def _build_test_user(
+    db_session: db.Session,
+    config: E2ETestUserConfig,
+    e2e_agency: Agency,
+    e2e_organization: Organization,
+) -> None:
+    builder = UserBuilder(config.user_id, db_session, config.scenario_name).with_internal_role(
+        E2E_TEST_USER_ROLE
+    )
+
+    if config.add_jwt_auth:
+        builder.with_jwt_auth()
+    if config.api_key:
+        builder.with_api_key(config.api_key)
+    if config.in_grantor_agency:
+        builder.with_agency(e2e_agency, roles=[OPPORTUNITY_PUBLISHER])
+    if config.in_test_organization:
+        builder.with_organization(e2e_organization, roles=[ORG_MEMBER])
+
+    builder.build()
+
+    if config.write_token_to_file:
+        _write_token_to_file(builder.jwt_token)
 
 
 def _build_users_and_tokens(db_session: db.Session) -> None:
@@ -74,21 +166,15 @@ def _build_users_and_tokens(db_session: db.Session) -> None:
         agency_code="E2E",
         agency_name="E2E Test Agency",
     )
-
-    builder = (
-        # Reuse the seeded one_org_user so the spoofed E2E session always has
-        # organization membership in local/CI runs.
-        UserBuilder(uuid.UUID("f15c7491-7ebc-4f4f-8de6-3ac0594d9c63"), db_session, "user for e2e")
-        .with_jwt_auth()
-        .with_api_key("e2e-test-key")
-        .with_internal_role(E2E_TEST_USER_ROLE)
-        # Grantor role so the Create Opportunity link shows and opportunity
-        # creation E2E tests can create and publish opportunities.
-        .with_agency(e2e_agency, roles=[OPPORTUNITY_PUBLISHER])
+    e2e_organization = setup_org(
+        db_session,
+        organization_id=E2E_ORGANIZATION_ID,
+        legal_business_name="E2E Test Organization",
+        uei="FAKEUEIE2E01",
     )
 
-    builder.build()
-    _write_token_to_file(builder.jwt_token)
+    for test_user in E2E_TEST_USERS:
+        _build_test_user(db_session, test_user, e2e_agency, e2e_organization)
 
     # Manager user: holds the API key the e2e orchestrator uses to request
     # tokens for any test user via POST /v1/internal/e2e-token.

--- a/api/tests/lib/seed_e2e.py
+++ b/api/tests/lib/seed_e2e.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 import os
 import uuid
@@ -9,12 +8,9 @@ from pydantic import Field
 
 from src.constants.static_role_values import (
     E2E_TEST_USER_MANAGER_ROLE,
-    E2E_TEST_USER_ROLE,
     OPPORTUNITY_PUBLISHER,
     ORG_MEMBER,
 )
-from src.db.models.agency_models import Agency
-from src.db.models.entity_models import Organization
 from src.util.env_config import PydanticBaseEnvConfig
 from tests.lib.seed_agencies_and_users import setup_agency
 from tests.lib.seed_data_utils import UserBuilder
@@ -25,16 +21,17 @@ logger = logging.getLogger(__name__)
 
 ###############################
 # This script will
-# * seed the local database with one or more test users that can be used for fake or potentially
-#   real logins from automated e2e tests. Every test user is granted E2E_TEST_USER_ROLE, which
-#   carries the READ_TEST_USER_TOKEN privilege -- this is what "flags" a user as available to have
-#   its auth token statically returned via POST /v1/internal/e2e-token.
+# * seed the local database with one or more test users for fake or potentially real logins from
+#   automated e2e tests. Each is flagged via UserBuilder.with_e2e_test_user(), which grants
+#   E2E_TEST_USER_ROLE (the READ_TEST_USER_TOKEN privilege) so its auth token can be returned via
+#   POST /v1/internal/e2e-token.
 # * seed a "manager" user whose API key the e2e orchestrator uses to call
 #   POST /v1/internal/e2e-token (mirrors the staging manager-key flow)
 # * write the primary test user's token into the e2e_token.tmp file (where it can be retrieved by
 #   CI processes for frontend / e2e use)
 #
-# To add a new test user, append an E2ETestUserConfig to E2E_TEST_USERS with a static user id.
+# To add a new test user, add another UserBuilder(...).with_e2e_test_user()... block below with a
+# static user id.
 ###############################
 
 # Static UUID for the local E2E manager user. Documented to QA alongside the
@@ -61,55 +58,6 @@ E2E_ORGANIZATION_ID = uuid.UUID("e5f6a7b8-c9d0-4e5f-8a0b-1c2d3e4f5061")
 E2E_ORG_MEMBER_USER_ID = uuid.UUID("a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d")
 
 
-@dataclasses.dataclass
-class E2ETestUserConfig:
-    """Declarative definition of an E2E test user.
-
-    Every user built from this config is granted E2E_TEST_USER_ROLE, so its token can be
-    fetched by the manager API key via POST /v1/internal/e2e-token.
-    """
-
-    user_id: uuid.UUID
-    scenario_name: str
-    api_key: str | None = None
-    add_jwt_auth: bool = False
-    write_token_to_file: bool = False
-    in_grantor_agency: bool = False
-    in_test_organization: bool = False
-
-    def __post_init__(self) -> None:
-        # The token written to e2e_token.tmp is the JWT, so writing it requires JWT auth.
-        # Guard here so a bad config fails when the registry is defined rather than silently
-        # writing E2E_USER_AUTH_TOKEN="None" to the file at seed time.
-        if self.write_token_to_file and not self.add_jwt_auth:
-            raise ValueError(
-                f"write_token_to_file requires add_jwt_auth for user {self.scenario_name}"
-            )
-
-
-# The set of test users seeded for E2E / multi-user testing. Append to this list to add a new
-# test user -- each entry needs a static user id so it can be referenced.
-E2E_TEST_USERS = [
-    # Primary test user. Reuses the seeded one_org_user id so the spoofed E2E session always has
-    # organization membership in local/CI runs, and holds a grantor role so opportunity creation
-    # E2E tests can create and publish opportunities.
-    E2ETestUserConfig(
-        user_id=uuid.UUID("f15c7491-7ebc-4f4f-8de6-3ac0594d9c63"),
-        scenario_name="user for e2e",
-        api_key="e2e-test-key",
-        add_jwt_auth=True,
-        write_token_to_file=True,
-        in_grantor_agency=True,
-    ),
-    # Secondary test user with organization membership, mirroring the staging test user.
-    E2ETestUserConfig(
-        user_id=E2E_ORG_MEMBER_USER_ID,
-        scenario_name="e2e org member test user",
-        in_test_organization=True,
-    ),
-]
-
-
 class _SeedE2EConfig(PydanticBaseEnvConfig):
     local_test_user_manager_api_key: str = Field(alias="LOCAL_TEST_USER_MANAGER_API_KEY")
 
@@ -118,31 +66,6 @@ def _write_token_to_file(token: str) -> None:
     path_to_tmp_token_file = os.path.join(os.path.dirname(__file__), "..", "..", "e2e_token.tmp")
     token_declaration = 'E2E_USER_AUTH_TOKEN="' + token + '"'
     write_to_file(path_to_tmp_token_file, token_declaration)
-
-
-def _build_test_user(
-    db_session: db.Session,
-    config: E2ETestUserConfig,
-    e2e_agency: Agency,
-    e2e_organization: Organization,
-) -> None:
-    builder = UserBuilder(config.user_id, db_session, config.scenario_name).with_internal_role(
-        E2E_TEST_USER_ROLE
-    )
-
-    if config.add_jwt_auth:
-        builder.with_jwt_auth()
-    if config.api_key:
-        builder.with_api_key(config.api_key)
-    if config.in_grantor_agency:
-        builder.with_agency(e2e_agency, roles=[OPPORTUNITY_PUBLISHER])
-    if config.in_test_organization:
-        builder.with_organization(e2e_organization, roles=[ORG_MEMBER])
-
-    builder.build()
-
-    if config.write_token_to_file:
-        _write_token_to_file(builder.jwt_token)
 
 
 def _build_users_and_tokens(db_session: db.Session) -> None:
@@ -173,8 +96,29 @@ def _build_users_and_tokens(db_session: db.Session) -> None:
         uei="FAKEUEIE2E01",
     )
 
-    for test_user in E2E_TEST_USERS:
-        _build_test_user(db_session, test_user, e2e_agency, e2e_organization)
+    # Primary test user. Reuses the seeded one_org_user id so the spoofed E2E session always has
+    # organization membership in local/CI runs.
+    primary_user = (
+        UserBuilder(uuid.UUID("f15c7491-7ebc-4f4f-8de6-3ac0594d9c63"), db_session, "user for e2e")
+        .with_e2e_test_user()
+        .with_jwt_auth()
+        .with_api_key("e2e-test-key")
+        # Grantor role so the Create Opportunity link shows and opportunity
+        # creation E2E tests can create and publish opportunities.
+        .with_agency(e2e_agency, roles=[OPPORTUNITY_PUBLISHER])
+    )
+    primary_user.build()
+    # Temporary: the frontend / CI still reads the token from this file. This write goes away once
+    # the frontend migrates to fetching tokens via POST /v1/internal/e2e-token.
+    _write_token_to_file(primary_user.jwt_token)
+
+    # Secondary test user with organization membership, mirroring the staging test user.
+    (
+        UserBuilder(E2E_ORG_MEMBER_USER_ID, db_session, "e2e org member test user")
+        .with_e2e_test_user()
+        .with_organization(e2e_organization, roles=[ORG_MEMBER])
+        .build()
+    )
 
     # Manager user: holds the API key the e2e orchestrator uses to request
     # tokens for any test user via POST /v1/internal/e2e-token.


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10245 

## Changes proposed

- Updated seed_data_utils.py to add a `with_e2e_test_user()` method to UserBuilder to grant `E2E_TEST_USER_ROLE`
- Updated seed_e2e.py to rework the single hard-coded E2E test user into a multi-user seed, defined with the same `UserBuilder` as the rest of the seed script:
  - Primary test user (existing, reusing one_org_user): `with_e2e_test_user()` + JWT + `e2e-test-key` + grantor agency role. Its JWT is still written to e2e_token.tmp (temporary, removed once the frontend migrates).
  - Secondary test user (new): `with_e2e_test_user()` + `ORG_MEMBER` membership in a new self-contained E2E org.

## Context for reviewers

The `/v1/internal/e2e-token` endpoint already supports fetching tokens for any flagged test user. This PR is the local-seed half, making it easy to register multiple static test users and adding a second user with org membership for multi-user E2E testing. 

## Validation steps

1. Confirm tests pass.
2. With your local backend running and seeded (`make db-seed-local`), the following curl command should return a `200` with a JWT token:
```
curl -s -X POST http://localhost:8080/v1/internal/e2e-token \
  -H "Content-Type: application/json" \
  -H "X-API-Key: local-manager-key" \
  -d '{"user_id": "a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d"}'
```
3. The token returned from step 2 can be verified using the following curl command:
```
curl -s -X POST http://localhost:8080/v1/users/token/refresh \
  -H "X-SGG-Token: <token-from-step-2>"
```
