### PR TITLE
[unticketed]: update gunicorn.conf file with params moved from the api dockerfile cmd line 

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -141,4 +141,4 @@ USER ${RUN_USER}
 # from the WORKDIR (/api) when the file is present. We pass it explicitly as a guardrail --
 # if the config is ever dropped from the image again, gunicorn fails fast at startup
 # instead of silently falling back to its defaults (1 sync worker, 1 thread).
-CMD ["gunicorn", "-c", "gunicorn.conf.py", "--worker-tmp-dir=/dev/shm", "src.app:create_app()", "--log-level", "debug", "--limit-request-field_size", "16384", "--limit-request-fields", "50"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "--worker-tmp-dir=/dev/shm", "src.app:create_app()", "--log-level", "debug"]

--- a/api/gunicorn.conf.py
+++ b/api/gunicorn.conf.py
@@ -37,3 +37,11 @@ worker_class = "gthread"
 # long-running streaming requests. Setting this to 125s ensures ALB always closes first.
 # See: https://lincolnloop.com/blog/gunicorn-keepalive-and-aws-elb-502-errors/
 keepalive = 125
+
+# Limit the size (in bytes) of an individual HTTP request header field. Default is 8190.
+# We raise it to 16384 to accommodate large headers (e.g. JWT/Authorization tokens, cookies).
+limit_request_field_size = 16384
+
+# Limit the number of header fields in a single request. Default is 100.
+# We tighten it to 50 as a defense against header-based denial-of-service attacks.
+limit_request_fields = 50


### PR DESCRIPTION
## Summary

Updated the gunicorn.conf file with the 2 parameters below: 

1. limit_request_field_size
2. limit_request_fields

## Validation steps

Deployed to dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/28453390690)

All scans should be passing below. 