### PR TITLE
[Issue #11221] Log filtered headers being sent to legacy system & commenting out soapaction in response

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -346,7 +346,8 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         update_headers = {
             "MIME-Version": "1.0",
             "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{boundary_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-            "Soapaction": self.operation_config.soap_action,
+            # TODO: removing till we can confirm GS needs this
+            # "Soapaction": self.operation_config.soap_action,
         }
         boundary = "--uuid:" + boundary_uuid
         mime_message: Iterator[bytes] | bytes = b""

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -46,6 +46,10 @@ def get_proxy_headers(
     filtered_headers = filter_headers(
         soap_request.headers, [config.gg_s2s_proxy_header_key, MTLS_CERT_HEADER_KEY]
     )
+    logger.info(
+        "soap_client: filtered headers being sent to legacy",
+        extra={"filtered_headers": filtered_headers},
+    )
     if not soap_auth:
         return filtered_headers
     return {

--- a/api/src/legacy_soap_api/legacy_soap_api_proxy.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_proxy.py
@@ -48,7 +48,7 @@ def get_proxy_headers(
     )
     logger.info(
         "soap_client: filtered headers being sent to legacy",
-        extra={"filtered_headers": filtered_headers},
+        extra={"filtered_header_keys": filtered_headers.keys()},
     )
     if not soap_auth:
         return filtered_headers

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -569,6 +569,15 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
                 soap_response.to_bytes().decode("utf-8"),
                 content_type=text_content_type,
             )
+            response_s3_path = file_util.join(
+                base_path,
+                "headers.txt",
+            )
+            file_util.write_to_file(
+                response_s3_path,
+                json.dumps(soap_response.headers),
+                content_type=text_content_type,
+            )
             logger.info(
                 "soap_client: debug info uploaded to s3",
                 extra={"debug_identifier": debug_identifier},

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -477,7 +477,6 @@ class TestSimplerSOAPGetApplicationZip:
             assert result.headers == {
                 "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{BOUNDARY_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
                 "MIME-Version": "1.0",
-                "Soapaction": client.operation_config.soap_action,
             }
 
     def test_get_simpler_soap_response_returns_soap_action_in_header(
@@ -522,7 +521,6 @@ class TestSimplerSOAPGetApplicationZip:
             assert result.headers == {
                 "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{BOUNDARY_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
                 "MIME-Version": "1.0",
-                "Soapaction": client.operation_config.soap_action,
             }
 
     def test_get_simpler_soap_response_can_access_endpoint_if_certificate_user_has_privileges(
@@ -800,7 +798,6 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
                 "MIME-Version": "1.0",
-                "Soapaction": client.operation_config.soap_action,
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects(
@@ -901,7 +898,6 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
                 "MIME-Version": "1.0",
-                "Soapaction": client.operation_config.soap_action,
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects_merges_response_from_proxy_and_simpler(
@@ -1553,7 +1549,6 @@ class TestSimplerSOAPGetSubmissionList:
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
                 "MIME-Version": "1.0",
-                "Soapaction": client.operation_config.soap_action,
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects(
@@ -1652,7 +1647,6 @@ class TestSimplerSOAPGetSubmissionList:
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
                 "MIME-Version": "1.0",
-                "Soapaction": client.operation_config.soap_action,
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects_merges_response_from_proxy_and_simpler(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -169,7 +169,7 @@ def test_request_gets_correct_proxy_headers_when_no_auth(enable_factory_create, 
         for r in caplog.records
         if r.message == "soap_client: filtered headers being sent to legacy"
     )
-    assert record.filtered_headers == {"x": "1"}
+    assert list(record.filtered_header_keys) == ["x"]
 
 
 def test_request_gets_correct_proxy_headers_when_there_is_auth(enable_factory_create):

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -155,7 +155,8 @@ def test_request_gets_correct_proxy_url_when_request_has_auth_for_applicants(ena
         assert mock_request.call_args_list[0][0][0].url == expected
 
 
-def test_request_gets_correct_proxy_headers_when_no_auth(enable_factory_create):
+def test_request_gets_correct_proxy_headers_when_no_auth(enable_factory_create, caplog):
+    caplog.set_level(logging.INFO)
     soap_request = create_soap_request(SOAP_PAYLOAD)
     soap_request.auth = None
     soap_request.headers = {"X-Gg-S2S-Uri": "https://google.com/xyz", "x": "1"}
@@ -163,6 +164,8 @@ def test_request_gets_correct_proxy_headers_when_no_auth(enable_factory_create):
     headers = get_proxy_headers(soap_request, config, soap_request.auth)
     expected = {"x": "1"}
     assert headers == expected
+    record = next(r for r in caplog.records if r.message == "soap_client: filtered headers being sent to legacy")
+    assert record.filtered_headers == {"x": "1"}
 
 
 def test_request_gets_correct_proxy_headers_when_there_is_auth(enable_factory_create):

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_proxy.py
@@ -164,7 +164,11 @@ def test_request_gets_correct_proxy_headers_when_no_auth(enable_factory_create, 
     headers = get_proxy_headers(soap_request, config, soap_request.auth)
     expected = {"x": "1"}
     assert headers == expected
-    record = next(r for r in caplog.records if r.message == "soap_client: filtered headers being sent to legacy")
+    record = next(
+        r
+        for r in caplog.records
+        if r.message == "soap_client: filtered headers being sent to legacy"
+    )
     assert record.filtered_headers == {"x": "1"}
 
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import boto3
@@ -62,7 +63,7 @@ def test_write_debug_data_to_s3(
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
     soap_legacy_response = SOAPResponse(
-        data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
+        data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={"xyz": "abc"}
     )
     soap_request = create_soap_request(
         SOAP_PAYLOAD, operation_name="GetSubmissionListExpandedRequest"
@@ -77,10 +78,14 @@ def test_write_debug_data_to_s3(
     response_contents = file_util.read_file(
         f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
     )
+    headers_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/headers.txt"
+    )
     assert request_contents.replace("\n", "") == SOAP_PAYLOAD.decode().replace("\n", "")
     assert response_contents.replace("\r", "") == SOAP_LEGACY_RESPONSE_PAYLOAD.decode().replace(
         "\r", ""
     )
+    assert headers_contents.replace("\r", "") == json.dumps({"xyz": "abc"})
 
 
 def test_write_debug_data_to_s3_handles_a_null_soap_request(
@@ -160,4 +165,4 @@ def test_write_debug_data_to_s3_runs_on_any_endpoint(
         create_soap_request(SOAP_PAYLOAD, operation_name="Y"), soap_legacy_response
     )
     objects = s3_client.list_objects_v2(Bucket="local-mock-draft-bucket")
-    assert len(objects.get("Contents")) == 14
+    assert len(objects.get("Contents")) == 21


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11221  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Commented out the `Soapaction` in our response till we confirm that GS actually needs it
- Logged `filtered_headers` to new relic

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We want to check the headers we send in order to try and match the headers Grant Solutions is sending in. We suspect that is part of the problem with their issues getting our responses. I also commented out the `Soapaction` for now till we confirm that they actually need it in their response.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests pass
- [ ] `filtered_headers` gets logged
- [ ] `Soapaction` is not in response
