### PR TITLE
[Issue #10893] Consolidate our two sorting utilities together

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "urllib3>=2.7.0,<3",
     "python-statemachine>=3.0.0,<4",
     "beautifulsoup4>=4.14.3,<5",
-    "grants-shared==0.2.9",
+    "grants-shared==0.2.11",
 ]
 
 [project.scripts]

--- a/api/src/services/applications/list_application_audit.py
+++ b/api/src/services/applications/list_application_audit.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 import grants_shared.adapters.db as db
 from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams
 from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -15,7 +16,6 @@ from src.db.models.competition_models import ApplicationAudit, ApplicationForm
 from src.db.models.user_models import User
 from src.search.search_models import StrSearchFilter
 from src.services.applications.get_application import get_application
-from src.services.service_utils import apply_sorting
 
 
 class ApplicationAuditFilters(BaseModel):
@@ -77,7 +77,7 @@ def list_application_audit(
         )
     )
     stmt = apply_filters(stmt, params.filters)
-    stmt = apply_sorting(stmt, ApplicationAudit, params.pagination.sort_order)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, ApplicationAudit)
 
     # Paginate the results
     paginator: Paginator[ApplicationAudit] = Paginator(

--- a/api/src/services/applications/list_application_submissions.py
+++ b/api/src/services/applications/list_application_submissions.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 import grants_shared.adapters.db as db
 from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams
 from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.sql import Select
@@ -13,7 +14,6 @@ from src.constants.lookup_constants import Privilege
 from src.db.models.competition_models import ApplicationSubmission
 from src.db.models.user_models import User
 from src.services.applications.get_application import get_application
-from src.services.service_utils import apply_sorting
 
 
 class ApplicationSubmissionsRequest(BaseModel):
@@ -32,7 +32,7 @@ def list_application_submissions(
     stmt: Select = select(ApplicationSubmission).where(
         ApplicationSubmission.application_id == application_id
     )
-    stmt = apply_sorting(stmt, ApplicationSubmission, params.pagination.sort_order)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, ApplicationSubmission)
 
     paginator: Paginator[ApplicationSubmission] = Paginator(
         ApplicationSubmission, stmt, db_session, page_size=params.pagination.page_size

--- a/api/src/services/award_recommendations/list_award_recommendation_audit.py
+++ b/api/src/services/award_recommendations/list_award_recommendation_audit.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 import grants_shared.adapters.db as db
 from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams
 from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
@@ -18,7 +19,6 @@ from src.search.search_models import StrSearchFilter
 from src.services.award_recommendations.get_award_recommendation import (
     get_award_recommendation_and_verify_access,
 )
-from src.services.service_utils import apply_sorting
 
 
 class AwardRecommendationAuditFilters(BaseModel):
@@ -78,7 +78,7 @@ def list_award_recommendation_audit(
         )
     )
     stmt = apply_filters(stmt, params.filters)
-    stmt = apply_sorting(stmt, AwardRecommendationAudit, params.pagination.sort_order)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, AwardRecommendationAudit)
 
     paginator: Paginator[AwardRecommendationAudit] = Paginator(
         AwardRecommendationAudit, stmt, db_session, page_size=params.pagination.page_size

--- a/api/src/services/award_recommendations/list_award_recommendation_risks.py
+++ b/api/src/services/award_recommendations/list_award_recommendation_risks.py
@@ -52,7 +52,7 @@ def list_award_recommendation_risks(
             .selectinload(AwardRecommendationApplicationSubmission.application_submission)
         )
     )
-    stmt = apply_sorting(stmt, params.pagination.sort_order, COLUMN_MAPPING)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, COLUMN_MAPPING, nulls_last=True)
 
     paginator: Paginator[AwardRecommendationRisk] = Paginator(
         AwardRecommendationRisk,

--- a/api/src/services/award_recommendations/list_award_recommendation_submissions.py
+++ b/api/src/services/award_recommendations/list_award_recommendation_submissions.py
@@ -105,7 +105,7 @@ def list_award_recommendation_submissions(
     )
 
     stmt = apply_filters(stmt, params.filters)
-    stmt = apply_sorting(stmt, params.pagination.sort_order, COLUMN_MAPPING)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, COLUMN_MAPPING, nulls_last=True)
 
     paginator: Paginator[AwardRecommendationApplicationSubmission] = Paginator(
         AwardRecommendationApplicationSubmission,

--- a/api/src/services/award_recommendations/list_award_recommendations.py
+++ b/api/src/services/award_recommendations/list_award_recommendations.py
@@ -92,7 +92,7 @@ def list_award_recommendations(
             selectinload(AwardRecommendation.award_recommendation_reviews),
         )
     )
-    stmt = apply_sorting(stmt, params.pagination.sort_order, COLUMN_MAPPING)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, COLUMN_MAPPING, nulls_last=True)
 
     paginator: Paginator[AwardRecommendation] = Paginator(
         AwardRecommendation,

--- a/api/src/services/opportunities_grantor_v1/get_opportunity_list.py
+++ b/api/src/services/opportunities_grantor_v1/get_opportunity_list.py
@@ -6,6 +6,7 @@ from typing import Any
 import grants_shared.adapters.db as db
 from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams, SortOrder
 from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel, Field
 from sqlalchemy import Select, func, select
 from sqlalchemy.orm import selectinload
@@ -22,7 +23,6 @@ from src.db.models.opportunity_models import (
 from src.db.models.user_models import AgencyUser, AgencyUserRole, LinkRolePrivilege, Role, User
 from src.search.search_models import BoolSearchFilter
 from src.services.opportunities_grantor_v1.get_agency import get_agency
-from src.services.service_utils import apply_sorting
 
 
 class OpportunityListFilterParams(BaseModel):
@@ -162,7 +162,7 @@ def _paginate_opportunity_stmt(
 ) -> tuple[Sequence[OpportunityListItem], PaginationInfo]:
     """Apply filters, sorting, submitted application counts, and pagination."""
     stmt = _apply_opportunity_filters(stmt, params)
-    stmt = apply_sorting(stmt, Opportunity, params.pagination.sort_order)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, Opportunity)
 
     paginator: Paginator[Opportunity] = Paginator(
         table_model=Opportunity,

--- a/api/src/services/organizations_v1/list_organization_users.py
+++ b/api/src/services/organizations_v1/list_organization_users.py
@@ -167,6 +167,7 @@ def get_organization_users_and_verify_access(
             "last_name": UserProfile.last_name,
             "created_at": OrganizationUser.created_at,
         },
+        nulls_last=True,
     )
 
     # Paginate

--- a/api/src/services/service_utils.py
+++ b/api/src/services/service_utils.py
@@ -1,7 +1,4 @@
-from grants_shared.pagination.pagination_models import SortDirection
 from pydantic import BaseModel
-from sqlalchemy import asc, desc
-from sqlalchemy.sql import Select
 
 from src.adapters import search
 from src.search.search_models import (
@@ -10,27 +7,6 @@ from src.search.search_models import (
     IntSearchFilter,
     StrSearchFilter,
 )
-
-
-def apply_sorting(stmt: Select, model: type, sort_order: list) -> Select:
-    """
-    Applies sorting to a SQLAlchemy select statement based on the provided sorting orders.
-
-    :param stmt: The SQLAlchemy query statement to which sorting should be applied.
-    :param model: The model class on which the sorting should be applied.
-    :param sort_order: A list of object describing the sorting order for a column.
-    :return: The modified query statement with the applied sorting.
-    """
-
-    order_cols: list = []
-    for order in sort_order:
-        column = getattr(model, order.order_by)
-        if order.sort_direction == SortDirection.ASCENDING:
-            order_cols.append(asc(column))
-        elif order.sort_direction == SortDirection.DESCENDING:
-            order_cols.append(desc(column))
-
-    return stmt.order_by(*order_cols)
 
 
 def _adjust_field_name(field: str, request_field_name_mapping: dict) -> str:

--- a/api/src/services/users/get_saved_searches.py
+++ b/api/src/services/users/get_saved_searches.py
@@ -4,11 +4,11 @@ from uuid import UUID
 from grants_shared.adapters import db
 from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams
 from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel
 from sqlalchemy import select
 
 from src.db.models.user_models import UserSavedSearch
-from src.services.service_utils import apply_sorting
 
 
 class SavedSearchListParams(BaseModel):
@@ -26,7 +26,7 @@ def get_saved_searches(
         UserSavedSearch.user_id == user_id, UserSavedSearch.is_deleted.isnot(True)
     )
 
-    stmt = apply_sorting(stmt, UserSavedSearch, search_params.pagination.sort_order)
+    stmt = apply_sorting(stmt, search_params.pagination.sort_order, UserSavedSearch)
 
     paginator: Paginator[UserSavedSearch] = Paginator(
         UserSavedSearch, stmt, db_session, page_size=search_params.pagination.page_size

--- a/api/src/services/users/get_user_applications.py
+++ b/api/src/services/users/get_user_applications.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import grants_shared.adapters.db as db
 from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams
 from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import selectinload
@@ -21,7 +22,6 @@ from src.db.models.user_models import (
     OrganizationUserRole,
 )
 from src.search.search_models import StrSearchFilter, UuidSearchFilter
-from src.services.service_utils import apply_sorting
 
 logger = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ def get_user_applications(
     if filter_clauses:
         stmt = stmt.where(and_(*filter_clauses))
     # Sort
-    stmt = apply_sorting(stmt, Application, list_params.pagination.sort_order)
+    stmt = apply_sorting(stmt, list_params.pagination.sort_order, Application)
     # Paginate
     paginator: Paginator[Application] = Paginator(
         Application, stmt, db_session, page_size=list_params.pagination.page_size

--- a/api/src/services/workflows/get_workflow_audits.py
+++ b/api/src/services/workflows/get_workflow_audits.py
@@ -4,13 +4,13 @@ from collections.abc import Sequence
 import grants_shared.adapters.db as db
 from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams
 from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from src.db.models.user_models import User
 from src.db.models.workflow_models import WorkflowAudit
-from src.services.service_utils import apply_sorting
 from src.services.workflows.get_workflow import get_workflow_and_verify_access
 
 
@@ -47,7 +47,7 @@ def get_workflow_audits(
         )
     )
 
-    stmt = apply_sorting(stmt, WorkflowAudit, params.pagination.sort_order)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, WorkflowAudit)
 
     # Paginate the results
     paginator: Paginator[WorkflowAudit] = Paginator(

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.9"
+version = "0.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apiflask" },
@@ -629,9 +629,9 @@ dependencies = [
     { name = "smart-open" },
     { name = "sqlalchemy", extra = ["mypy"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/4d/428f661359588a0b993af884fce1b8057abac33990f25fdfab766b31747e/grants_shared-0.2.9.tar.gz", hash = "sha256:b51615632eead1c3f5bcc05f52d7c26680abdcdf73dd77de9de266db88272813", size = 57872, upload-time = "2026-06-25T17:42:36.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/f2/7672c7ab2380f580747a64af0327e426a560d37d2e9142800e01d0745b52/grants_shared-0.2.11.tar.gz", hash = "sha256:b62cf576e86f39b5c4d0a18220af9b6ac03648c874ec46c4eaf8ba7e701bef4c", size = 58082, upload-time = "2026-07-02T14:49:33.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/9d/90d61adf46ab65c7a0ef1f2b489a7fb2af3719df864e4e12c4b0a7615d04/grants_shared-0.2.9-py3-none-any.whl", hash = "sha256:d8e578e2a29d6ad593692e347946960c6309dd799b69a7709082c522130c2d89", size = 73424, upload-time = "2026-06-25T17:42:35.631Z" },
+    { url = "https://files.pythonhosted.org/packages/90/19/78b3dfaea0217654d36db59bed78a8b5cb7588c79534e941c8716151f5f1/grants_shared-0.2.11-py3-none-any.whl", hash = "sha256:2d2187049d9049765b9396520b566510d7aecccd5130e3452158668cc4b7b2f0", size = 73702, upload-time = "2026-07-02T14:49:32.153Z" },
 ]
 
 [[package]]
@@ -1773,7 +1773,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1,<0.8" },
     { name = "docraptor", specifier = ">=3.0.0,<4" },
     { name = "flask-cors", specifier = ">=6.0.0,<7" },
-    { name = "grants-shared", specifier = "==0.2.9" },
+    { name = "grants-shared", specifier = "==0.2.11" },
     { name = "gunicorn", specifier = ">=23.0.0,<24" },
     { name = "jinja2", specifier = ">=3.1.5" },
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },

--- a/backend/grants_shared/pyproject.toml
+++ b/backend/grants_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grants-shared"
-version = "0.2.10"
+version = "0.2.11"
 description = "Shared code used by the Simpler Grants.gov repo"
 readme = "README.md"
 license = "CC0-1.0"

--- a/backend/grants_shared/pyproject.toml
+++ b/backend/grants_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grants-shared"
-version = "0.2.9"
+version = "0.2.10"
 description = "Shared code used by the Simpler Grants.gov repo"
 readme = "README.md"
 license = "CC0-1.0"

--- a/backend/grants_shared/src/grants_shared/pagination/sorting_util.py
+++ b/backend/grants_shared/src/grants_shared/pagination/sorting_util.py
@@ -7,43 +7,62 @@ from sqlalchemy.sql.selectable import Select
 from grants_shared.pagination.pagination_models import SortDirection, SortOrderParams
 
 
+def _resolve_column(
+    model_or_mapping: type | dict[str, InstrumentedAttribute], order_by: str
+) -> InstrumentedAttribute:
+    if isinstance(model_or_mapping, dict):
+        column = model_or_mapping.get(order_by)
+        if column is None:
+            # This indicates a configuration error - the schema allows a sort field
+            # that we don't have a mapping for. This should be caught early.
+            raise ValueError(
+                f"Sort field '{order_by}' not found in column mapping. "
+                f"Available fields: {list(model_or_mapping.keys())}"
+            )
+        return column
+
+    return getattr(model_or_mapping, order_by)
+
+
 def apply_sorting(
     stmt: Select,
     sort_order: list[SortOrderParams],
-    column_mapping: dict[str, InstrumentedAttribute],
+    model_or_mapping: type | dict[str, InstrumentedAttribute],
+    nulls_last: bool = False,
 ) -> Select:
-    """Apply sorting to a query using a custom column mapping.
+    """Apply sorting to a SQLAlchemy select statement.
 
-    This utility is useful when sorting fields come from joined tables.
+    Columns to sort on are resolved one of two ways (never a mix):
+      * Pass a model class to look up each sort field via ``getattr(model, field)``.
+      * Pass a ``dict`` mapping sort field names to SQLAlchemy column objects, which
+        is useful when sorting fields come from joined tables.
+        Example: {"email": LinkExternalUser.email, "first_name": UserProfile.first_name}
 
     Args:
         stmt: The SQLAlchemy query statement to apply sorting to
         sort_order: List of SortOrderParams describing the sorting order
-        column_mapping: Dictionary mapping sort field names to SQLAlchemy column objects
-                       Example: {"email": LinkExternalUser.email, "first_name": UserProfile.first_name}
+        model_or_mapping: A model class (getattr approach) or a dict mapping sort field
+                          names to column objects
+        nulls_last: When True, append NULLS LAST to each ordering so null values sort
+                    to the end regardless of direction
 
     Returns:
         The modified query statement with applied sorting
 
     Raises:
-        ValueError: If a sort field is not found in the column_mapping
+        ValueError: If a mapping is provided and a sort field is not found in it
     """
     order_cols = []
 
     for order in sort_order:
-        column = column_mapping.get(order.order_by)
+        column = _resolve_column(model_or_mapping, order.order_by)
 
-        if column is None:
-            # This indicates a configuration error - the schema allows a sort field
-            # that we don't have a mapping for. This should be caught early.
-            raise ValueError(
-                f"Sort field '{order.order_by}' not found in column mapping. "
-                f"Available fields: {list(column_mapping.keys())}"
-            )
+        direction = asc if order.sort_direction == SortDirection.ASCENDING else desc
+        ordering = direction(column)
 
-        if order.sort_direction == SortDirection.ASCENDING:
-            order_cols.append(asc(column).nulls_last())
-        elif order.sort_direction == SortDirection.DESCENDING:
-            order_cols.append(desc(column).nulls_last())
+        if nulls_last:
+            ordering = ordering.nulls_last()
+
+        order_cols.append(ordering)
 
     return stmt.order_by(*order_cols)

--- a/backend/grants_shared/src/grants_shared/pagination/sorting_util.py
+++ b/backend/grants_shared/src/grants_shared/pagination/sorting_util.py
@@ -4,21 +4,23 @@ from sqlalchemy import asc, desc
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.selectable import Select
 
+from grants_shared.db.models.base import Base
 from grants_shared.pagination.pagination_models import SortDirection, SortOrderParams
 
 
 def _resolve_column(
-    model_or_mapping: type | dict[str, InstrumentedAttribute], order_by: str
+    model_or_mapping: type[Base] | dict[str, InstrumentedAttribute], order_by: str
 ) -> InstrumentedAttribute:
     if isinstance(model_or_mapping, dict):
         column = model_or_mapping.get(order_by)
         if column is None:
             # This indicates a configuration error - the schema allows a sort field
             # that we don't have a mapping for. This should be caught early.
-            raise ValueError(
+            msg = (
                 f"Sort field '{order_by}' not found in column mapping. "
                 f"Available fields: {list(model_or_mapping.keys())}"
             )
+            raise ValueError(msg)
         return column
 
     return getattr(model_or_mapping, order_by)
@@ -27,7 +29,7 @@ def _resolve_column(
 def apply_sorting(
     stmt: Select,
     sort_order: list[SortOrderParams],
-    model_or_mapping: type | dict[str, InstrumentedAttribute],
+    model_or_mapping: type[Base] | dict[str, InstrumentedAttribute],
     nulls_last: bool = False,
 ) -> Select:
     """Apply sorting to a SQLAlchemy select statement.

--- a/backend/grants_shared/tests/grants_shared/pagination/test_sorting_util.py
+++ b/backend/grants_shared/tests/grants_shared/pagination/test_sorting_util.py
@@ -18,7 +18,7 @@ COLUMN_MAPPING = {
 }
 
 
-def test_apply_sorting():
+def test_apply_sorting_with_mapping_nulls_last():
     base_stmt = select(ExampleTable)
 
     # Sort by one field
@@ -26,6 +26,7 @@ def test_apply_sorting():
         base_stmt,
         [SortOrderParams(order_by="example_id", sort_direction=SortDirection.ASCENDING)],
         COLUMN_MAPPING,
+        nulls_last=True,
     )
     validate_order_by(result, "ORDER BY grants_shared.example.example_id ASC NULLS LAST")
 
@@ -37,6 +38,7 @@ def test_apply_sorting():
             SortOrderParams(order_by="my_count", sort_direction=SortDirection.ASCENDING),
         ],
         COLUMN_MAPPING,
+        nulls_last=True,
     )
     validate_order_by(
         result,
@@ -52,11 +54,62 @@ def test_apply_sorting():
             SortOrderParams(order_by="my_count", sort_direction=SortDirection.DESCENDING),
         ],
         COLUMN_MAPPING,
+        nulls_last=True,
     )
     validate_order_by(
         result,
         "ORDER BY grants_shared.example.description ASC NULLS LAST, grants_shared.example.example_id DESC NULLS LAST, grants_shared.example.my_count DESC NULLS LAST",
     )
+
+
+def test_apply_sorting_with_mapping_no_nulls_last():
+    result = apply_sorting(
+        select(ExampleTable),
+        [
+            SortOrderParams(order_by="description", sort_direction=SortDirection.DESCENDING),
+            SortOrderParams(order_by="my_count", sort_direction=SortDirection.ASCENDING),
+        ],
+        COLUMN_MAPPING,
+    )
+    validate_order_by(
+        result,
+        "ORDER BY grants_shared.example.description DESC, grants_shared.example.my_count ASC",
+    )
+    # No NULLS LAST should be emitted when the flag is left at its default
+    assert "NULLS LAST" not in str(result.compile())
+
+
+def test_apply_sorting_with_model_getattr():
+    # Passing the model class resolves columns via getattr, no NULLS LAST by default
+    result = apply_sorting(
+        select(ExampleTable),
+        [
+            SortOrderParams(order_by="example_id", sort_direction=SortDirection.ASCENDING),
+            SortOrderParams(order_by="my_count", sort_direction=SortDirection.DESCENDING),
+        ],
+        ExampleTable,
+    )
+    validate_order_by(
+        result,
+        "ORDER BY grants_shared.example.example_id ASC, grants_shared.example.my_count DESC",
+    )
+    assert "NULLS LAST" not in str(result.compile())
+
+
+def test_apply_sorting_with_model_getattr_nulls_last():
+    result = apply_sorting(
+        select(ExampleTable),
+        [SortOrderParams(order_by="my_count", sort_direction=SortDirection.ASCENDING)],
+        ExampleTable,
+        nulls_last=True,
+    )
+    validate_order_by(result, "ORDER BY grants_shared.example.my_count ASC NULLS LAST")
+
+
+def test_apply_sorting_empty_sort_order():
+    # An empty sort order should not add an ORDER BY clause
+    result = apply_sorting(select(ExampleTable), [], COLUMN_MAPPING)
+    assert "ORDER BY" not in str(result.compile())
 
 
 def test_apply_sorting_missing_column_mapping():
@@ -65,4 +118,13 @@ def test_apply_sorting_missing_column_mapping():
             select(ExampleTable),
             [SortOrderParams(order_by="not_a_field", sort_direction=SortDirection.ASCENDING)],
             COLUMN_MAPPING,
+        )
+
+
+def test_apply_sorting_missing_model_attribute():
+    with pytest.raises(AttributeError):
+        apply_sorting(
+            select(ExampleTable),
+            [SortOrderParams(order_by="not_a_field", sort_direction=SortDirection.ASCENDING)],
+            ExampleTable,
         )

--- a/backend/grants_shared/uv.lock
+++ b/backend/grants_shared/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.9"
+version = "0.2.10"
 source = { virtual = "." }
 dependencies = [
     { name = "apiflask" },

--- a/backend/grants_shared/uv.lock
+++ b/backend/grants_shared/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.10"
+version = "0.2.11"
 source = { virtual = "." }
 dependencies = [
     { name = "apiflask" },


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10893 

## Changes proposed

- Updated sorting_util.py to consolidate our two `apply_sorting` implementations into a single configurable function. Pass either a model class or a `dict` mapping, and opt into `NULLS LAST` with a `nulls_last` flag. Added a `_resolve_column` helper for the model-vs-mapping resolution.
- Updated `test_sorting_util.py` to cover both resolution modes (model + mapping) across `nulls_last` on/off, an empty sort order, and both missing-field error paths.
- Updated `pyproject.toml` to bump the package version 0.2.9 → 0.2.11. (0.2.10 was already created by #10626 but not yet on main)
- Updated `uv.lock` to relock against the new version.

## Context for reviewers

This is the first of two PRs. This PR adds the consolidated `apply_sorting` to grants_shared and bumps the version. Once approved, I'll publish 0.2.10 from this branch and open the second PR (which switches the API over to the new function and deletes the two old implementations) based off this branch, then merge that back into this one so it all goes to main as a single change.

The new function replaces both the old grants_shared `apply_sorting` (mapping + always `nulls_last`) and the API's `service_utils.apply_sorting` (model `getattr`, no `nulls_last`). Each existing caller is configured in the API PR to behave exactly as before.

## Validation steps

Confirm new tests pass.

API-side behavior (all callers configured to match prior behavior) is validated in the follow-up PR against the published 0.2.11 package.