### PR TITLE
[Issue #11012] Create empty competition for Application Package page

### DIFF
--- a/api/src/services/opportunities_grantor_v1/get_opportunity.py
+++ b/api/src/services/opportunities_grantor_v1/get_opportunity.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import selectinload
 from src.auth.endpoint_access_util import verify_access
 from src.constants.lookup_constants import Privilege
 from src.db.models.agency_models import Agency
+from src.db.models.competition_models import Competition
 from src.db.models.opportunity_models import (
     CurrentOpportunitySummary,
     Opportunity,
@@ -44,7 +45,12 @@ def _get_opportunity_for_grantors(
                 CurrentOpportunitySummary.opportunity_summary
             ),
             selectinload(Opportunity.opportunity_attachments),
-            selectinload(Opportunity.competitions),
+            selectinload(Opportunity.competitions).options(
+                selectinload(Competition.competition_instructions),
+                selectinload(Competition.opportunity_assistance_listing),
+                selectinload(Competition.link_competition_open_to_applicant),
+                selectinload(Competition.competition_forms),
+            ),
         )
     )
 

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_get.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_get.py
@@ -76,6 +76,28 @@ def test_get_opportunity_success(client, db_session, grantor_auth_data, opportun
     assert response_data["category"] == opportunity.category.value
 
 
+def test_get_opportunity_with_competition_and_forms(
+    client, db_session, enable_factory_create, grantor_auth_data, opportunity
+):
+    """Regression test: GET should not 500 when opportunity has a competition with competition_forms.
+    Before the fix, competition_forms was lazy-loaded after the session closed, causing a
+    DetachedInstanceError. See Issue #11012."""
+    user, agency, token, _ = grantor_auth_data
+
+    from tests.src.db.models.factories import CompetitionFactory
+
+    CompetitionFactory.create(opportunity=opportunity)
+
+    response = client.get(
+        f"/v1/grantors/opportunities/{opportunity.opportunity_id}",
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 200
+    response_data = response.get_json()["data"]
+    assert len(response_data["competitions"]) == 1
+
+
 def test_get_opportunity_with_invalid_jwt_token(client, opportunity):
     """Test 401 response for opportunity retrieval with invalid JWT token"""
     response = client.get(

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/_components/CompetitionForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/_components/CompetitionForm.tsx
@@ -8,7 +8,13 @@ import { Button } from "@trussworks/react-uswds";
 
 import LeftHandFormNav from "src/components/core/forms/LeftHandFormNav";
 
-export function CompetitionForm() {
+type CompetitionFormProps = {
+  competitionId: string;
+};
+
+export function CompetitionForm({
+  competitionId: _competitionId,
+}: CompetitionFormProps) {
   const t = useTranslations("OpportunityCompetition.sections");
 
   const navigationItems = [

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/page.test.tsx
@@ -1,0 +1,204 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { identity } from "lodash";
+import OpportunityCompetitionPage from "src/app/[locale]/(base)/grantor/opportunity/[id]/competition/page";
+import { MissingAuthError } from "src/errors";
+import { GrantorOpportunityDetail } from "src/types/opportunity/opportunityResponseTypes";
+import { DeepPartial } from "src/utils/testing/commonTestUtils";
+import { useTranslationsMock } from "src/utils/testing/intlMocks";
+
+const testOpportunityId = "opp-abc-123";
+const pageParams = Promise.resolve({ id: testOpportunityId, locale: "en" });
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => useTranslationsMock(),
+}));
+
+jest.mock("next-intl/server", () => ({
+  getTranslations: identity,
+}));
+
+jest.mock("next/navigation", () => ({
+  notFound: jest.fn(),
+  redirect: jest.fn(),
+}));
+
+jest.mock("src/services/featureFlags/withFeatureFlag", () => ({
+  __esModule: true,
+  default: (WrappedComponent: React.FunctionComponent) => (props: unknown) =>
+    WrappedComponent(props as never),
+}));
+
+jest.mock(
+  "src/components/grantor-opportunities/OpportunityDetailsHeader",
+  () => ({
+    OpportunityDetailsHeader: () => (
+      <div data-testid="opportunity-details-header" />
+    ),
+  }),
+);
+
+jest.mock(
+  "src/app/[locale]/(base)/grantor/opportunity/[id]/competition/_components/CompetitionForm",
+  () => ({
+    CompetitionForm: ({ competitionId }: { competitionId: string }) => (
+      <div data-testid="competition-form" data-competition-id={competitionId} />
+    ),
+  }),
+);
+
+const mockGetOpportunityForGrantor = jest.fn();
+const mockCreateCompetitionForGrantor = jest.fn();
+
+jest.mock(
+  "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher",
+  () => ({
+    getOpportunityForGrantor: (...args: unknown[]) =>
+      mockGetOpportunityForGrantor(...args) as unknown,
+    createCompetitionForGrantor: (...args: unknown[]) =>
+      mockCreateCompetitionForGrantor(...args) as unknown,
+  }),
+);
+
+const baseOpportunityData: DeepPartial<GrantorOpportunityDetail> = {
+  opportunity_id: "opp-abc-123",
+  opportunity_title: "Test Opportunity",
+  competitions: null,
+};
+
+describe("OpportunityCompetitionPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when opportunity has no existing competition", () => {
+    beforeEach(() => {
+      mockGetOpportunityForGrantor.mockResolvedValue({
+        data: { ...baseOpportunityData, competitions: null },
+      });
+      mockCreateCompetitionForGrantor.mockResolvedValue({
+        data: { competition_id: "new-competition-id" },
+      });
+    });
+
+    it("calls createCompetitionForGrantor when competitions is an empty array", async () => {
+      mockGetOpportunityForGrantor.mockResolvedValue({
+        data: { ...baseOpportunityData, competitions: [] },
+      });
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(mockCreateCompetitionForGrantor).toHaveBeenCalledTimes(1);
+      expect(mockCreateCompetitionForGrantor).toHaveBeenCalledWith(
+        testOpportunityId,
+      );
+    });
+
+    it("calls createCompetitionForGrantor with the opportunity id", async () => {
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(mockCreateCompetitionForGrantor).toHaveBeenCalledTimes(1);
+      expect(mockCreateCompetitionForGrantor).toHaveBeenCalledWith(
+        testOpportunityId,
+      );
+    });
+
+    it("passes the new competition_id to CompetitionForm", async () => {
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(screen.getByTestId("competition-form")).toHaveAttribute(
+        "data-competition-id",
+        "new-competition-id",
+      );
+    });
+
+    it("passes accessibility scan", async () => {
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      const { container } = render(component);
+      const results = await waitFor(() => axe(container));
+
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe("when opportunity already has a competition", () => {
+    beforeEach(() => {
+      mockGetOpportunityForGrantor.mockResolvedValue({
+        data: {
+          ...baseOpportunityData,
+          competitions: [{ competition_id: "existing-competition-id" }],
+        },
+      });
+    });
+
+    it("does not call createCompetitionForGrantor", async () => {
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(mockCreateCompetitionForGrantor).not.toHaveBeenCalled();
+    });
+
+    it("passes the existing competition_id to CompetitionForm", async () => {
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(screen.getByTestId("competition-form")).toHaveAttribute(
+        "data-competition-id",
+        "existing-competition-id",
+      );
+    });
+
+    it("passes accessibility scan", async () => {
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      const { container } = render(component);
+      const results = await waitFor(() => axe(container));
+
+      expect(results).toHaveNoViolations();
+    });
+  });
+
+  describe("MissingAuthError handling", () => {
+    it("returns UnauthorizedMessage when getOpportunityForGrantor throws MissingAuthError", async () => {
+      mockGetOpportunityForGrantor.mockRejectedValue(
+        new MissingAuthError("Missing auth"),
+      );
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(screen.getByTestId("alert")).toBeVisible();
+    });
+
+    it("returns UnauthorizedMessage when createCompetitionForGrantor throws MissingAuthError", async () => {
+      mockGetOpportunityForGrantor.mockResolvedValue({
+        data: { ...baseOpportunityData, competitions: null },
+      });
+      mockCreateCompetitionForGrantor.mockRejectedValue(
+        new MissingAuthError("Missing auth"),
+      );
+      const component = await OpportunityCompetitionPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(screen.getByTestId("alert")).toBeVisible();
+    });
+  });
+});

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/page.tsx
@@ -1,7 +1,14 @@
 import { CompetitionForm } from "src/app/[locale]/(base)/grantor/opportunity/[id]/competition/_components/CompetitionForm";
-import { ApiRequestError, parseErrorStatus } from "src/errors";
+import {
+  ApiRequestError,
+  MissingAuthError,
+  parseErrorStatus,
+} from "src/errors";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
-import { getOpportunityForGrantor } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
+import {
+  createCompetitionForGrantor,
+  getOpportunityForGrantor,
+} from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
 
 import { notFound, redirect } from "next/navigation";
 
@@ -22,6 +29,9 @@ async function OpportunityCompetitionPage({ params }: PageProps) {
     const response = await getOpportunityForGrantor(id);
     opportunityData = response.data;
   } catch (error) {
+    if (error instanceof MissingAuthError) {
+      return <UnauthorizedMessage />;
+    }
     const status = parseErrorStatus(error as ApiRequestError);
     if (status === 404) {
       notFound();
@@ -32,13 +42,35 @@ async function OpportunityCompetitionPage({ params }: PageProps) {
     throw error;
   }
 
+  let competitionId: string;
+  if (opportunityData.competitions?.[0]?.competition_id) {
+    competitionId = opportunityData.competitions[0].competition_id;
+  } else {
+    try {
+      const competitionResponse = await createCompetitionForGrantor(id);
+      competitionId = competitionResponse.data.competition_id;
+    } catch (error) {
+      if (error instanceof MissingAuthError) {
+        return <UnauthorizedMessage />;
+      }
+      const status = parseErrorStatus(error as ApiRequestError);
+      if (status === 404) {
+        notFound();
+      }
+      if (status === 403) {
+        return <UnauthorizedMessage />;
+      }
+      throw error;
+    }
+  }
+
   return (
     <>
       <OpportunityDetailsHeader
         opportunityData={opportunityData}
         locale={locale}
       />
-      <CompetitionForm />
+      <CompetitionForm competitionId={competitionId} />
     </>
   );
 }

--- a/frontend/src/services/fetch/fetchers/opportunitySummaryGrantorFetcher.test.ts
+++ b/frontend/src/services/fetch/fetchers/opportunitySummaryGrantorFetcher.test.ts
@@ -1,0 +1,44 @@
+import { createCompetitionForGrantor } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
+
+const mockFetchGrantorOpportunityWithMethod = jest.fn();
+const mockJson = jest.fn();
+
+jest.mock("src/services/fetch/fetchers/fetchers", () => ({
+  fetchGrantorOpportunityWithMethod:
+    (method: string) =>
+    (params: unknown): unknown => {
+      return mockFetchGrantorOpportunityWithMethod(method, params);
+    },
+}));
+
+describe("createCompetitionForGrantor", () => {
+  beforeEach(() => {
+    mockJson.mockResolvedValue({
+      data: { competition_id: "new-competition-id" },
+    });
+    mockFetchGrantorOpportunityWithMethod.mockResolvedValue({ json: mockJson });
+  });
+  afterEach(() => jest.clearAllMocks());
+
+  it("calls fetchGrantorOpportunityWithMethod with POST and the correct subPath", async () => {
+    await createCompetitionForGrantor("opp-123");
+
+    expect(mockFetchGrantorOpportunityWithMethod).toHaveBeenCalledWith("POST", {
+      subPath: "opp-123/competitions",
+      body: {
+        competition_title: "",
+        opening_date: null,
+        closing_date: null,
+        contact_info: null,
+        open_to_applicants: ["individual", "organization"],
+      },
+    });
+  });
+
+  it("returns the parsed JSON response", async () => {
+    const result = await createCompetitionForGrantor("opp-123");
+
+    expect(mockJson).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ data: { competition_id: "new-competition-id" } });
+  });
+});

--- a/frontend/src/services/fetch/fetchers/opportunitySummaryGrantorFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/opportunitySummaryGrantorFetcher.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
 import {
+  CompetitionCreateApiResponse,
+  CompetitionCreateRequest,
+} from "src/types/competitionsResponseTypes";
+import {
   GrantorOpportunityApiResponse,
   OpportunitySummaryCreateRequest,
   OpportunitySummaryDetailApiResponse,
@@ -62,4 +66,24 @@ export async function publishOpportunityForGrantor(
   });
 
   return (await response.json()) as GrantorOpportunityApiResponse;
+}
+
+export async function createCompetitionForGrantor(
+  opportunityId: string,
+): Promise<CompetitionCreateApiResponse> {
+  // All nullable fields are intentionally null; competition_title is intentionally ""
+  // because the API accepts an empty string and the grantor fills it in later.
+  // open_to_applicants requires minItems: 1, so both values are sent as the most
+  // permissive default until the grantor configures the field.
+  const response = await fetchGrantorOpportunityWithMethod("POST")({
+    subPath: `${opportunityId}/competitions`,
+    body: {
+      competition_title: "",
+      opening_date: null,
+      closing_date: null,
+      contact_info: null,
+      open_to_applicants: ["individual", "organization"],
+    } satisfies CompetitionCreateRequest,
+  });
+  return (await response.json()) as CompetitionCreateApiResponse;
 }

--- a/frontend/src/types/competitionsResponseTypes.ts
+++ b/frontend/src/types/competitionsResponseTypes.ts
@@ -1,3 +1,4 @@
+import { APIResponse } from "./apiResponseTypes";
 import { FormDetail } from "./formResponseTypes";
 import {
   BaseOpportunity,
@@ -10,9 +11,21 @@ export interface CompetitionInstructions {
   file_name: string;
   updated_at: string;
 }
-export type CompetitionForms = [{ form: FormDetail; is_required: boolean }];
+export type CompetitionForms = { form: FormDetail; is_required: boolean }[];
 
 export type ApplicantTypes = "individual" | "organization";
+
+export type CompetitionCreateRequest = {
+  competition_title: string;
+  opening_date: string | null;
+  closing_date: string | null;
+  contact_info: string | null;
+  open_to_applicants: ApplicantTypes[];
+};
+
+export interface CompetitionCreateApiResponse extends APIResponse {
+  data: Competition;
+}
 
 export type Competition = {
   closing_date: string;
@@ -21,7 +34,7 @@ export type Competition = {
   competition_info: string;
   competition_instructions: CompetitionInstructions[];
   competition_title: string;
-  contact_info: null;
+  contact_info: string | null;
   is_open: boolean;
   open_to_applicants: ApplicantTypes[];
   opening_date: string;


### PR DESCRIPTION
## Summary

Work for #11012

## Changes proposed

**Frontend**
- Add `CompetitionCreateRequest` and `CompetitionCreateApiResponse` types to `competitionsResponseTypes.ts`
- Add `createCompetitionForGrantor(opportunityId)` fetcher in `opportunitySummaryGrantorFetcher.ts` — POSTs a blank competition to `grantors/opportunities/{id}/competitions`
- Update `competition/page.tsx` to resolve a `competition_id` on load: uses the existing competition if one is present on the opportunity response, otherwise calls `createCompetitionForGrantor`; handles `MissingAuthError`, 403, and 404 from both fetch calls
- Update `CompetitionForm` to accept `competitionId: string` prop (unused for now, ready for follow-on tickets that make PUT calls)
- Fix `CompetitionForms` type from a fixed-length tuple to an array (matches API schema)
- Fix `contact_info` field type from literal `null` to `string | null` (matches API schema)

**API**
- Fix `_get_opportunity_for_grantors` in `get_opportunity.py` to eager-load all competition sub-relationships (`competition_forms`, `competition_instructions`, `opportunity_assistance_listing`, `link_competition_open_to_applicant`) — matches the pattern already used in the public `get_opportunity.py`

**Tests**
- `opportunitySummaryGrantorFetcher.test.ts` — unit tests for `createCompetitionForGrantor`
- `competition/page.test.tsx` — page tests covering: no competition (null), no competition (empty array), existing competition, `MissingAuthError` on both fetch paths, axe accessibility scans on both render branches
- `test_opportunity_route_get.py` — regression test confirming GET does not 500 when an opportunity has a competition with `competition_forms`

## Context for reviewers

`getOpportunityForGrantor` already returns a `competitions` array on the opportunity response, so no extra API call is needed to check for an existing competition — the page reads `opportunityData.competitions?.[0]?.competition_id` directly.

The `createCompetitionForGrantor` POST body uses blank defaults for all fields. `open_to_applicants` requires `minItems: 1` per the API schema, so both values are sent as the most permissive default until the grantor configures the field.

The API bug (`DetachedInstanceError` on `competition_forms`) was a pre-existing gap: `_get_opportunity_for_grantors` loaded the `competitions` relationship without chaining the nested `selectinload` calls that the public endpoint already had. It was never hit before because no competition records existed. This PR creates competition records, which exposed it.

## Validation steps

1. Log in as `one_agency_opp_edit` via the TestUserSelect dropdown
2. Open a draft opportunity for USAID-ETH and navigate to the Application Package page
   - **AC1 (no competition):** `docker logs grants-api --tail 10 | grep "competition_id"` shows a POST with status 200 and a new `competition_id` in the logs
   - Verify a row was inserted in the `competition` table
3. Navigate away and back to the same Application Package page
   - **AC2 (competition exists):** `docker logs grants-api --tail 10 | grep "request.method=POST.*competitions"` returns nothing — no second POST was made