### PR TITLE
[unticketed]: resolve anchore cve, added CVE-2026-12003 to grype ignore

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -49,3 +49,8 @@ ignore:
   # https://github.com/HHS/simpler-grants-gov/issues/8109
   # Last checked: 06/08/2026
   - vulnerability: CVE-2026-7774
+
+  # Fix only in pre-release Python 3.15 (3.15.0b3); no fix in any GA 3.14.x yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 07/01/2026
+  - vulnerability: CVE-2026-12003


### PR DESCRIPTION
## Summary

Added the CVE-2026-12003 to grype ignore as it's not released yet. 

## Validation steps

All scans should be passing below. 