### PR TITLE
[Issue #11235] Log incoming request headers to s3

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -560,6 +560,15 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
                     soap_request.data.head().decode("utf-8"),
                     content_type=text_content_type,
                 )
+                request_headers_s3_path = file_util.join(
+                    base_path,
+                    "request_headers.txt",
+                )
+                file_util.write_to_file(
+                    request_headers_s3_path,
+                    json.dumps(soap_request.headers),
+                    content_type=text_content_type,
+                )
             response_s3_path = file_util.join(
                 base_path,
                 "response.txt",
@@ -569,12 +578,12 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
                 soap_response.to_bytes().decode("utf-8"),
                 content_type=text_content_type,
             )
-            response_s3_path = file_util.join(
+            response_headers_s3_path = file_util.join(
                 base_path,
-                "headers.txt",
+                "response_headers.txt",
             )
             file_util.write_to_file(
-                response_s3_path,
+                response_headers_s3_path,
                 json.dumps(soap_response.headers),
                 content_type=text_content_type,
             )

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -5,6 +5,7 @@ import boto3
 from grants_shared.util import file_util
 
 from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
+from src.legacy_soap_api.legacy_soap_api_config import GRANTOR_SOAP_ACTION_PATH
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_utils import write_debug_data_to_s3
 from tests.lib.data_factories import create_soap_request
@@ -78,14 +79,23 @@ def test_write_debug_data_to_s3(
     response_contents = file_util.read_file(
         f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
     )
-    headers_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/headers.txt"
+    response_headers_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response_headers.txt"
+    )
+    request_headers_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request_headers.txt"
     )
     assert request_contents.replace("\n", "") == SOAP_PAYLOAD.decode().replace("\n", "")
     assert response_contents.replace("\r", "") == SOAP_LEGACY_RESPONSE_PAYLOAD.decode().replace(
         "\r", ""
     )
-    assert headers_contents.replace("\r", "") == json.dumps({"xyz": "abc"})
+    assert response_headers_contents.replace("\r", "") == json.dumps({"xyz": "abc"})
+    assert request_headers_contents.replace("\r", "") == json.dumps(
+        {
+            "X-Gg-S2S-Uri": "https://google.com/xyz",
+            "Soapaction": f"{GRANTOR_SOAP_ACTION_PATH}/GetSubmissionListExpanded",
+        }
+    )
 
 
 def test_write_debug_data_to_s3_handles_a_null_soap_request(
@@ -165,4 +175,4 @@ def test_write_debug_data_to_s3_runs_on_any_endpoint(
         create_soap_request(SOAP_PAYLOAD, operation_name="Y"), soap_legacy_response
     )
     objects = s3_client.list_objects_v2(Bucket="local-mock-draft-bucket")
-    assert len(objects.get("Contents")) == 21
+    assert len(objects.get("Contents")) == 28


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11235  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Add logs of incoming soap request headers to s3

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We want to get the entire headers for testing purposes to try and find why Grant Solutions calls are failing.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
 - [ ] logs show up in s3
 - [ ] tests passing
