### PR TITLE
[Issue #10890] Publish Button behavior for Opportunity Overview page

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/_components/OverviewButtons.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/_components/OverviewButtons.tsx
@@ -3,8 +3,7 @@
 import { Button, Alert } from "@trussworks/react-uswds";
 import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
-import { publishFromOverview } from "../actions";
-
+import { publishFromOverview } from "src/app/[locale]/(base)/grantor/opportunity/[id]/overview/actions";
 type OverviewButtonsProps = {
   opportunityId: string;
   publishEnabled: boolean;

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/_components/OverviewButtons.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/_components/OverviewButtons.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { Button, Alert } from "@trussworks/react-uswds";
+import { publishFromOverview } from "src/app/[locale]/(base)/grantor/opportunity/[id]/overview/actions";
+
 import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
-import { publishFromOverview } from "src/app/[locale]/(base)/grantor/opportunity/[id]/overview/actions";
+import { Alert, Button } from "@trussworks/react-uswds";
+
 type OverviewButtonsProps = {
   opportunityId: string;
   publishEnabled: boolean;

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/_components/OverviewButtons.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/_components/OverviewButtons.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Button, Alert } from "@trussworks/react-uswds";
+import { useTranslations } from "next-intl";
+import { useState, useTransition } from "react";
+import { publishFromOverview } from "../actions";
+
+type OverviewButtonsProps = {
+  opportunityId: string;
+  publishEnabled: boolean;
+};
+
+export function OverviewButtons({
+  opportunityId,
+  publishEnabled,
+}: OverviewButtonsProps) {
+  const t = useTranslations("OpportunityOverview");
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePublish = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await publishFromOverview(opportunityId);
+      if (result?.errorMessage) {
+        setError(result.errorMessage);
+      }
+    });
+  };
+
+  return (
+    <>
+      {error && (
+        <Alert type="error" heading="Error" headingLevel="h4">
+          {error}
+        </Alert>
+      )}
+      <Button type="button" outline disabled>
+        {t("labels.previewButton")}
+      </Button>
+      <Button
+        type="button"
+        disabled={!publishEnabled || isPending}
+        onClick={handlePublish}
+        className="margin-left-1"
+      >
+        {t("labels.publishButton")}
+      </Button>
+    </>
+  );
+}

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/actions.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/actions.ts
@@ -1,7 +1,8 @@
 "use server";
 
-import { publishOpportunityForGrantor } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
+import { publishOpportunityForGrantor } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
+
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/actions.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/actions.ts
@@ -1,0 +1,30 @@
+"use server";
+
+import { publishOpportunityForGrantor } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
+import { ApiRequestError, parseErrorStatus } from "src/errors";
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+
+export async function publishFromOverview(opportunityId: string) {
+  const alerts = await getTranslations("OpportunityEdit.content.alerts");
+
+  try {
+    await publishOpportunityForGrantor(opportunityId);
+  } catch (error) {
+    const status =
+      error instanceof ApiRequestError ? parseErrorStatus(error) : null;
+
+    if (status === 401) {
+      return { errorMessage: alerts("unauthenticated") };
+    }
+    if (status === 403) {
+      return { errorMessage: alerts("forbidden") };
+    }
+    if (status === 404) {
+      return { errorMessage: alerts("notFound") };
+    }
+    return { errorMessage: alerts("genericError") };
+  }
+
+  redirect("/grantor/opportunities");
+}

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/page.tsx
@@ -12,8 +12,8 @@ import { Link } from "@trussworks/react-uswds";
 
 import { UnauthorizedMessage } from "src/components/core/UnauthorizedMessage";
 import { OpportunityDetailsHeader } from "src/components/grantor-opportunities/OpportunityDetailsHeader";
-import { ProgressChecker } from "src/components/grantor-opportunities/ProgressChecker";
-import {
+import { OverviewButtons } from "./_components/OverviewButtons";
+import { ProgressChecker, getProgress, progressType } from "src/components/grantor-opportunities/ProgressChecker";import {
   competitionRequiredFields,
   summaryRequiredFields,
 } from "./RequiredFields";
@@ -41,19 +41,37 @@ async function OpportunityOverviewPage({ params }: PageProps) {
   }
   const editUrl = "../" + id + "/edit";
   const competitionUrl = "../" + id + "/competition";
-  const summary: Summary = opportunityData.summary;
+  const summary: Summary =
+    opportunityData.summary ??
+    opportunityData.non_forecast_summary ??
+    opportunityData.forecast_summary;
   let competition = {};
   if (opportunityData.competitions && opportunityData.competitions.length > 0) {
     // For now, use the first competition
     competition = opportunityData.competitions[0];
   }
 
+  const summaryStatus = getProgress(summaryRequiredFields, summary);
+  const competitionStatus = getProgress(competitionRequiredFields, competition);
+
+  const publishEnabled =
+    opportunityData.is_draft &&
+    (summaryStatus === progressType.complete ||
+      competitionStatus === progressType.complete) &&
+    summaryStatus !== progressType.inProgress &&
+    competitionStatus !== progressType.inProgress;
+
   return (
     <div className="bg-white">
       <OpportunityDetailsHeader
         opportunityData={opportunityData}
         locale={locale}
-      />
+        >
+        <OverviewButtons
+          opportunityId={id}
+          publishEnabled={publishEnabled}
+        />
+      </OpportunityDetailsHeader>
       <div className="grid-container padding-top-4 padding-bottom-4">
         <div className="grid-row grid-gap-2 padding-top-2">
           <div className="tablet:grid-col">

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/page.tsx
@@ -12,8 +12,13 @@ import { Link } from "@trussworks/react-uswds";
 
 import { UnauthorizedMessage } from "src/components/core/UnauthorizedMessage";
 import { OpportunityDetailsHeader } from "src/components/grantor-opportunities/OpportunityDetailsHeader";
+import {
+  getProgress,
+  ProgressChecker,
+  progressType,
+} from "src/components/grantor-opportunities/ProgressChecker";
 import { OverviewButtons } from "./_components/OverviewButtons";
-import { ProgressChecker, getProgress, progressType } from "src/components/grantor-opportunities/ProgressChecker";import {
+import {
   competitionRequiredFields,
   summaryRequiredFields,
 } from "./RequiredFields";
@@ -71,10 +76,7 @@ async function OpportunityOverviewPage({ params, searchParams }: PageProps) {
         locale={locale}
         isNewlyCreated={isNewlyCreated}
       >
-        <OverviewButtons
-          opportunityId={id}
-          publishEnabled={publishEnabled}
-        />
+        <OverviewButtons opportunityId={id} publishEnabled={publishEnabled} />
       </OpportunityDetailsHeader>
       <div className="grid-container padding-top-4 padding-bottom-4">
         <div className="grid-row grid-gap-2 padding-top-2">

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/overview/page.tsx
@@ -69,14 +69,13 @@ async function OpportunityOverviewPage({ params, searchParams }: PageProps) {
       <OpportunityDetailsHeader
         opportunityData={opportunityData}
         locale={locale}
-        >
+        isNewlyCreated={isNewlyCreated}
+      >
         <OverviewButtons
           opportunityId={id}
           publishEnabled={publishEnabled}
         />
       </OpportunityDetailsHeader>
-        isNewlyCreated={isNewlyCreated}
-      />
       <div className="grid-container padding-top-4 padding-bottom-4">
         <div className="grid-row grid-gap-2 padding-top-2">
           <div className="tablet:grid-col">

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2384,6 +2384,8 @@ export const messages = {
     labels: {
       editOpportunityLink: "Opportunity Summary",
       competitionLink: "Application Package",
+      previewButton: "Preview",
+      publishButton: "Publish",
     },
   },
   CreateOpportunity: {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10890 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
-Added a disabled Preview button and a conditionally disabled Publish button on the overview page component header.
-Added a _components folder and added OverviewButtons.tsx for handling publish call for the button
-Added actions.ts and copied over existing logic for the publish button from the edit opportunity page (which will be removed from the edit opportunity page in future ticket)
-Fixed progress tracker to check summary field fallback chain: summary → non_forecast_summary → forecast_summary
-Added translation keys for button labels

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

As part of the header of the Opportunity Overview, there should be a disabled "Preview" button and a "Publish" button. The "Publish" button should be initially disabled, but should become enabled provided:

-The opportunity is not published
-Either Opportunity Summary or Application Package is "Complete"
-Neither Opportunity Summary nor Application Package is "In Progress"

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Non-Published Opportunity/Not Started Opportunity Summary
<img width="1402" height="544" alt="image" src="https://github.com/user-attachments/assets/dc6f82f4-a740-4c22-9279-54b3d333047e" />


Non-Published Opportunity/Completed Opportunity Summary
<img width="1410" height="584" alt="image" src="https://github.com/user-attachments/assets/e0314f17-2467-46ba-b262-1667a8e69a7b" />


Published Opportunity
<img width="1399" height="559" alt="image" src="https://github.com/user-attachments/assets/9b43aba7-7461-4ed4-9b19-9955ec79469a" />

