### PR TITLE
[Issue #9016] [FE] Enrich frontend logs with correlation ID

### DIFF
--- a/frontend/src/components/core/CorrelationIdTracker.test.tsx
+++ b/frontend/src/components/core/CorrelationIdTracker.test.tsx
@@ -1,0 +1,176 @@
+import { jest } from "@jest/globals";
+import { render, waitFor } from "@testing-library/react";
+
+const waitForNewRelicMock = jest.fn(() => Promise.resolve(false));
+const setNewRelicCorrelationIdAttributeMock = jest.fn();
+
+jest.mock("src/utils/analyticsUtil", () => ({
+  __esModule: true,
+  waitForNewRelic: waitForNewRelicMock,
+  setNewRelicCorrelationIdAttribute: setNewRelicCorrelationIdAttributeMock,
+}));
+
+let CorrelationIdTracker: typeof import("src/components/core/CorrelationIdTracker").CorrelationIdTracker;
+
+const analyticsUtil = {
+  waitForNewRelic: waitForNewRelicMock,
+  setNewRelicCorrelationIdAttribute: setNewRelicCorrelationIdAttributeMock,
+};
+
+beforeAll(async () => {
+  const importedModule = await import(
+    "src/components/core/CorrelationIdTracker"
+  );
+  CorrelationIdTracker = importedModule.CorrelationIdTracker;
+});
+
+describe("CorrelationIdTracker", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    analyticsUtil.waitForNewRelic.mockResolvedValue(false);
+  });
+
+  it("renders without errors and returns null", () => {
+    const { container } = render(
+      <CorrelationIdTracker correlationId="test-id-123" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does not call waitForNewRelic when correlationId is not provided", () => {
+    render(<CorrelationIdTracker />);
+
+    expect(analyticsUtil.waitForNewRelic).not.toHaveBeenCalled();
+  });
+
+  it("does not call waitForNewRelic when correlationId is empty string", () => {
+    render(<CorrelationIdTracker correlationId="" />);
+
+    expect(analyticsUtil.waitForNewRelic).not.toHaveBeenCalled();
+  });
+
+  it("waits for newrelic and sets correlation ID when correlationId is provided", async () => {
+    analyticsUtil.waitForNewRelic.mockResolvedValue(true);
+
+    render(<CorrelationIdTracker correlationId="test-correlation-id" />);
+
+    await waitFor(() => {
+      expect(analyticsUtil.waitForNewRelic).toHaveBeenCalled();
+    });
+
+    expect(
+      analyticsUtil.setNewRelicCorrelationIdAttribute,
+    ).toHaveBeenCalledWith("test-correlation-id");
+  });
+
+  it("does not set correlation ID when newrelic is not ready", async () => {
+    analyticsUtil.waitForNewRelic.mockResolvedValue(false);
+
+    render(<CorrelationIdTracker correlationId="test-correlation-id" />);
+
+    await waitFor(() => {
+      expect(analyticsUtil.waitForNewRelic).toHaveBeenCalled();
+    });
+
+    expect(
+      analyticsUtil.setNewRelicCorrelationIdAttribute,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending operation on unmount", async () => {
+    let resolvePromise: (value: boolean) => void = () => {};
+
+    analyticsUtil.waitForNewRelic.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolvePromise = resolve;
+        }),
+    );
+
+    const { unmount } = render(
+      <CorrelationIdTracker correlationId="test-correlation-id" />,
+    );
+
+    unmount();
+    resolvePromise(true);
+
+    await waitFor(() => {
+      expect(
+        analyticsUtil.setNewRelicCorrelationIdAttribute,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  it("updates correlation ID when correlationId prop changes", async () => {
+    analyticsUtil.waitForNewRelic.mockResolvedValue(true);
+
+    const { rerender } = render(
+      <CorrelationIdTracker correlationId="correlation-id-1" />,
+    );
+
+    await waitFor(() => {
+      expect(
+        analyticsUtil.setNewRelicCorrelationIdAttribute,
+      ).toHaveBeenCalledWith("correlation-id-1");
+    });
+
+    expect(
+      analyticsUtil.setNewRelicCorrelationIdAttribute,
+    ).toHaveBeenCalledTimes(1);
+
+    rerender(<CorrelationIdTracker correlationId="correlation-id-2" />);
+
+    await waitFor(() => {
+      expect(
+        analyticsUtil.setNewRelicCorrelationIdAttribute,
+      ).toHaveBeenCalledWith("correlation-id-2");
+    });
+
+    expect(
+      analyticsUtil.setNewRelicCorrelationIdAttribute,
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  it("removes correlation tracking when correlationId changes to empty", async () => {
+    analyticsUtil.waitForNewRelic.mockResolvedValue(true);
+
+    const { rerender } = render(
+      <CorrelationIdTracker correlationId="correlation-id-1" />,
+    );
+
+    await waitFor(() => {
+      expect(
+        analyticsUtil.setNewRelicCorrelationIdAttribute,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<CorrelationIdTracker correlationId="" />);
+
+    await waitFor(() => {
+      expect(
+        analyticsUtil.setNewRelicCorrelationIdAttribute,
+      ).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("handles errors from waitForNewRelic gracefully", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    analyticsUtil.waitForNewRelic.mockRejectedValue(new Error("Test error"));
+
+    render(<CorrelationIdTracker correlationId="test-correlation-id" />);
+
+    await waitFor(() => {
+      expect(analyticsUtil.waitForNewRelic).toHaveBeenCalled();
+    });
+
+    expect(
+      analyticsUtil.setNewRelicCorrelationIdAttribute,
+    ).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/frontend/src/components/core/CorrelationIdTracker.test.tsx
+++ b/frontend/src/components/core/CorrelationIdTracker.test.tsx
@@ -132,7 +132,7 @@ describe("CorrelationIdTracker", () => {
     ).toHaveBeenCalledTimes(2);
   });
 
-  it("removes correlation tracking when correlationId changes to empty", async () => {
+  it("does not set a new Correlation ID when correlationId becomes empty", async () => {
     analyticsUtil.waitForNewRelic.mockResolvedValue(true);
 
     const { rerender } = render(

--- a/frontend/src/components/core/CorrelationIdTracker.tsx
+++ b/frontend/src/components/core/CorrelationIdTracker.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import noop from "lodash/noop";
+import {
+  setNewRelicCorrelationIdAttribute,
+  waitForNewRelic,
+} from "src/utils/analyticsUtil";
+
+import { useEffect } from "react";
+
+export const CorrelationIdTracker = ({
+  correlationId,
+}: {
+  correlationId?: string;
+}) => {
+  useEffect(() => {
+    if (!correlationId) {
+      return;
+    }
+
+    let isCancelled = false;
+
+    const attachCorrelationId = async () => {
+      const ready = await waitForNewRelic();
+      if (!ready || isCancelled) {
+        return;
+      }
+
+      setNewRelicCorrelationIdAttribute(correlationId);
+    };
+
+    attachCorrelationId().catch(noop);
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [correlationId]);
+
+  return null;
+};

--- a/frontend/src/components/core/RootLayoutWrapper.tsx
+++ b/frontend/src/components/core/RootLayoutWrapper.tsx
@@ -11,10 +11,13 @@ import Script from "next/script";
 
 import "src/styles/styles.scss";
 
+import { getCorrelationId } from "src/services/correlationId/correlationId";
 import { LayoutProps } from "src/types/generalTypes";
 
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
+
+import { CorrelationIdTracker } from "src/components/core/CorrelationIdTracker";
 
 const typedNewRelic = newrelic as NewRelicWithCorrectTypes;
 
@@ -50,6 +53,8 @@ export default async function RootLayoutWrapper({
       })
     : "";
 
+  const correlationId = await getCorrelationId();
+
   // note that if we need to conditionally include third party scripts on the page, a component was implemented
   // to do that in commit 46566b4c0ad but later removed. We can bring it back if it is ever useful. - DWS
   return (
@@ -65,6 +70,7 @@ export default async function RootLayoutWrapper({
       </head>
       <body>
         <NextIntlClientProvider messages={messages}>
+          <CorrelationIdTracker correlationId={correlationId} />
           {children}
         </NextIntlClientProvider>
         {environment.IS_CI !== "true" && (

--- a/frontend/src/utils/analyticsUtil.test.ts
+++ b/frontend/src/utils/analyticsUtil.test.ts
@@ -39,7 +39,9 @@ describe("analyticsUtil", () => {
 
   describe("waitForNewRelic", () => {
     it("returns true immediately if newrelic is already present", async () => {
-      const mockNewRelic = { setCustomAttribute: jest.fn() } as unknown as Window["newrelic"];
+      const mockNewRelic = {
+        setCustomAttribute: jest.fn(),
+      } as unknown as NonNullable<Window["newrelic"]>;
       window.newrelic = mockNewRelic;
 
       const result = await waitForNewRelic();
@@ -52,8 +54,9 @@ describe("analyticsUtil", () => {
 
       // Simulate newrelic becoming available after a few ticks
       setTimeout(() => {
-        window.newrelic =
-          ({ setCustomAttribute: jest.fn() } as unknown) as Window["newrelic"];
+        window.newrelic = {
+          setCustomAttribute: jest.fn(),
+        } as unknown as Window["newrelic"];
       }, 100);
 
       jest.advanceTimersByTime(100);
@@ -82,9 +85,9 @@ describe("analyticsUtil", () => {
   describe("setNewRelicCustomAttribute", () => {
     it("sets a custom attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic =
-        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
-          Window["newrelic"];
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      } as unknown as Window["newrelic"];
 
       setNewRelicCustomAttribute("test_key", "test_value");
 
@@ -96,9 +99,9 @@ describe("analyticsUtil", () => {
 
     it("sets a numeric custom attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic =
-        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
-          Window["newrelic"];
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      } as unknown as Window["newrelic"];
 
       setNewRelicCustomAttribute("test_key", 42);
 
@@ -126,9 +129,9 @@ describe("analyticsUtil", () => {
   describe("setNewRelicCorrelationIdAttribute", () => {
     it("sets correlation_id attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic =
-        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
-          Window["newrelic"];
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      } as unknown as Window["newrelic"];
 
       const correlationId = "test-correlation-id-123";
       setNewRelicCorrelationIdAttribute(correlationId);
@@ -156,9 +159,9 @@ describe("analyticsUtil", () => {
   describe("unsetAllNewRelicQueryAttributes", () => {
     it("unsets all query attributes and query_length", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic =
-        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
-          Window["newrelic"];
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      } as unknown as Window["newrelic"];
 
       unsetAllNewRelicQueryAttributes();
 

--- a/frontend/src/utils/analyticsUtil.test.ts
+++ b/frontend/src/utils/analyticsUtil.test.ts
@@ -20,6 +20,11 @@ const deleteNewRelic = () => {
   delete win.newrelic;
 };
 
+const setMockNewRelic = (value: NewRelicBrowser) => {
+  const win = window as WindowWithNewRelic;
+  win.newrelic = value;
+};
+
 describe("analyticsUtil", () => {
   let consoleErrorSpy: jest.SpyInstance;
 
@@ -39,10 +44,7 @@ describe("analyticsUtil", () => {
 
   describe("waitForNewRelic", () => {
     it("returns true immediately if newrelic is already present", async () => {
-      const mockNewRelic = {
-        setCustomAttribute: jest.fn(),
-      } as unknown as NonNullable<Window["newrelic"]>;
-      window.newrelic = mockNewRelic;
+      setMockNewRelic({ setCustomAttribute: jest.fn() });
 
       const result = await waitForNewRelic();
       expect(result).toBe(true);
@@ -54,9 +56,7 @@ describe("analyticsUtil", () => {
 
       // Simulate newrelic becoming available after a few ticks
       setTimeout(() => {
-        window.newrelic = {
-          setCustomAttribute: jest.fn(),
-        } as unknown as Window["newrelic"];
+        setMockNewRelic({ setCustomAttribute: jest.fn() });
       }, 100);
 
       jest.advanceTimersByTime(100);
@@ -85,9 +85,7 @@ describe("analyticsUtil", () => {
   describe("setNewRelicCustomAttribute", () => {
     it("sets a custom attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      } as unknown as Window["newrelic"];
+      setMockNewRelic({ setCustomAttribute: mockSetCustomAttribute });
 
       setNewRelicCustomAttribute("test_key", "test_value");
 
@@ -99,9 +97,7 @@ describe("analyticsUtil", () => {
 
     it("sets a numeric custom attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      } as unknown as Window["newrelic"];
+      setMockNewRelic({ setCustomAttribute: mockSetCustomAttribute });
 
       setNewRelicCustomAttribute("test_key", 42);
 
@@ -129,9 +125,7 @@ describe("analyticsUtil", () => {
   describe("setNewRelicCorrelationIdAttribute", () => {
     it("sets correlation_id attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      } as unknown as Window["newrelic"];
+      setMockNewRelic({ setCustomAttribute: mockSetCustomAttribute });
 
       const correlationId = "test-correlation-id-123";
       setNewRelicCorrelationIdAttribute(correlationId);
@@ -159,9 +153,7 @@ describe("analyticsUtil", () => {
   describe("unsetAllNewRelicQueryAttributes", () => {
     it("unsets all query attributes and query_length", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      } as unknown as Window["newrelic"];
+      setMockNewRelic({ setCustomAttribute: mockSetCustomAttribute });
 
       unsetAllNewRelicQueryAttributes();
 

--- a/frontend/src/utils/analyticsUtil.test.ts
+++ b/frontend/src/utils/analyticsUtil.test.ts
@@ -1,0 +1,191 @@
+import { validSearchQueryParamKeys } from "src/types/search/searchQueryTypes";
+import {
+  setNewRelicCorrelationIdAttribute,
+  setNewRelicCustomAttribute,
+  unsetAllNewRelicQueryAttributes,
+  waitForNewRelic,
+  type NewRelicBrowser,
+} from "src/utils/analyticsUtil";
+
+declare global {
+  interface Window {
+    newrelic?: NewRelicBrowser;
+  }
+}
+
+describe("analyticsUtil", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+    // Clean up the mock newrelic object
+    if (window.newrelic) {
+      delete window.newrelic;
+    }
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  describe("waitForNewRelic", () => {
+    it("returns true immediately if newrelic is already present", async () => {
+      const mockNewRelic: NewRelicBrowser = { setCustomAttribute: jest.fn() };
+      window.newrelic = mockNewRelic;
+
+      const result = await waitForNewRelic();
+      expect(result).toBe(true);
+    });
+
+    it("waits and returns true when newrelic becomes available", async () => {
+      jest.useFakeTimers();
+      const waitPromise = waitForNewRelic();
+
+      // Simulate newrelic becoming available after a few ticks
+      setTimeout(() => {
+        window.newrelic = { setCustomAttribute: jest.fn() };
+      }, 100);
+
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+      await jest.runOnlyPendingTimersAsync();
+      const result = await waitPromise;
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false and logs error when timeout is reached", async () => {
+      jest.useFakeTimers();
+      const resultPromise = waitForNewRelic();
+
+      await jest.runAllTimersAsync();
+      await Promise.resolve();
+      const result = await resultPromise;
+
+      expect(result).toBe(false);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Timed out waiting for new relic browser object",
+      );
+    });
+  });
+
+  describe("setNewRelicCustomAttribute", () => {
+    it("sets a custom attribute when newrelic is available", () => {
+      const mockSetCustomAttribute = jest.fn();
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      };
+
+      setNewRelicCustomAttribute("test_key", "test_value");
+
+      expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+        "search_param_test_key",
+        "test_value",
+      );
+    });
+
+    it("sets a numeric custom attribute when newrelic is available", () => {
+      const mockSetCustomAttribute = jest.fn();
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      };
+
+      setNewRelicCustomAttribute("test_key", 42);
+
+      expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+        "search_param_test_key",
+        42,
+      );
+    });
+
+    it("logs error and returns undefined when newrelic is not available", () => {
+      // Ensure newrelic is not defined
+      if (window.newrelic) {
+        delete window.newrelic;
+      }
+
+      const result = setNewRelicCustomAttribute("test_key", "test_value");
+
+      expect(result).toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "New Relic not defined setting custom attribute",
+      );
+    });
+  });
+
+  describe("setNewRelicCorrelationIdAttribute", () => {
+    it("sets correlation_id attribute when newrelic is available", () => {
+      const mockSetCustomAttribute = jest.fn();
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      };
+
+      const correlationId = "test-correlation-id-123";
+      setNewRelicCorrelationIdAttribute(correlationId);
+
+      expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+        "correlation_id",
+        correlationId,
+      );
+    });
+
+    it("logs error and returns undefined when newrelic is not available", () => {
+      if (window.newrelic) {
+        delete window.newrelic;
+      }
+
+      const result = setNewRelicCorrelationIdAttribute("test-correlation-id");
+
+      expect(result).toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "New Relic not defined setting correlation_id attribute",
+      );
+    });
+  });
+
+  describe("unsetAllNewRelicQueryAttributes", () => {
+    it("unsets all query attributes and query_length", () => {
+      const mockSetCustomAttribute = jest.fn();
+      window.newrelic = {
+        setCustomAttribute: mockSetCustomAttribute,
+      };
+
+      unsetAllNewRelicQueryAttributes();
+
+      // Should be called once for each valid search query param key + 1 for query_length
+      expect(mockSetCustomAttribute).toHaveBeenCalledTimes(
+        validSearchQueryParamKeys.length + 1,
+      );
+
+      // Verify each search param was called with empty string
+      validSearchQueryParamKeys.forEach((key) => {
+        expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+          `search_param_${key}`,
+          "",
+        );
+      });
+
+      // Verify query_length was called with 0
+      expect(mockSetCustomAttribute).toHaveBeenCalledWith(
+        "search_param_query_length",
+        0,
+      );
+    });
+
+    it("handles when newrelic is not available", () => {
+      if (window.newrelic) {
+        delete window.newrelic;
+      }
+
+      // Should not throw an error
+      expect(() => {
+        unsetAllNewRelicQueryAttributes();
+      }).not.toThrow();
+
+      // Should log errors for each attempted call
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/utils/analyticsUtil.test.ts
+++ b/frontend/src/utils/analyticsUtil.test.ts
@@ -13,6 +13,13 @@ declare global {
   }
 }
 
+type WindowWithNewRelic = Window & { newrelic?: NewRelicBrowser };
+
+const deleteNewRelic = () => {
+  const win = window as WindowWithNewRelic;
+  delete win.newrelic;
+};
+
 describe("analyticsUtil", () => {
   let consoleErrorSpy: jest.SpyInstance;
 
@@ -20,7 +27,7 @@ describe("analyticsUtil", () => {
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
     // Clean up the mock newrelic object
     if (window.newrelic) {
-      delete window.newrelic;
+      deleteNewRelic();
     }
   });
 
@@ -32,7 +39,7 @@ describe("analyticsUtil", () => {
 
   describe("waitForNewRelic", () => {
     it("returns true immediately if newrelic is already present", async () => {
-      const mockNewRelic: NewRelicBrowser = { setCustomAttribute: jest.fn() };
+      const mockNewRelic = { setCustomAttribute: jest.fn() } as unknown as Window["newrelic"];
       window.newrelic = mockNewRelic;
 
       const result = await waitForNewRelic();
@@ -45,7 +52,8 @@ describe("analyticsUtil", () => {
 
       // Simulate newrelic becoming available after a few ticks
       setTimeout(() => {
-        window.newrelic = { setCustomAttribute: jest.fn() };
+        window.newrelic =
+          ({ setCustomAttribute: jest.fn() } as unknown) as Window["newrelic"];
       }, 100);
 
       jest.advanceTimersByTime(100);
@@ -74,9 +82,9 @@ describe("analyticsUtil", () => {
   describe("setNewRelicCustomAttribute", () => {
     it("sets a custom attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      };
+      window.newrelic =
+        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
+          Window["newrelic"];
 
       setNewRelicCustomAttribute("test_key", "test_value");
 
@@ -88,9 +96,9 @@ describe("analyticsUtil", () => {
 
     it("sets a numeric custom attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      };
+      window.newrelic =
+        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
+          Window["newrelic"];
 
       setNewRelicCustomAttribute("test_key", 42);
 
@@ -103,7 +111,7 @@ describe("analyticsUtil", () => {
     it("logs error and returns undefined when newrelic is not available", () => {
       // Ensure newrelic is not defined
       if (window.newrelic) {
-        delete window.newrelic;
+        deleteNewRelic();
       }
 
       const result = setNewRelicCustomAttribute("test_key", "test_value");
@@ -118,9 +126,9 @@ describe("analyticsUtil", () => {
   describe("setNewRelicCorrelationIdAttribute", () => {
     it("sets correlation_id attribute when newrelic is available", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      };
+      window.newrelic =
+        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
+          Window["newrelic"];
 
       const correlationId = "test-correlation-id-123";
       setNewRelicCorrelationIdAttribute(correlationId);
@@ -133,7 +141,7 @@ describe("analyticsUtil", () => {
 
     it("logs error and returns undefined when newrelic is not available", () => {
       if (window.newrelic) {
-        delete window.newrelic;
+        deleteNewRelic();
       }
 
       const result = setNewRelicCorrelationIdAttribute("test-correlation-id");
@@ -148,9 +156,9 @@ describe("analyticsUtil", () => {
   describe("unsetAllNewRelicQueryAttributes", () => {
     it("unsets all query attributes and query_length", () => {
       const mockSetCustomAttribute = jest.fn();
-      window.newrelic = {
-        setCustomAttribute: mockSetCustomAttribute,
-      };
+      window.newrelic =
+        ({ setCustomAttribute: mockSetCustomAttribute } as unknown) as
+          Window["newrelic"];
 
       unsetAllNewRelicQueryAttributes();
 
@@ -176,7 +184,7 @@ describe("analyticsUtil", () => {
 
     it("handles when newrelic is not available", () => {
       if (window.newrelic) {
-        delete window.newrelic;
+        deleteNewRelic();
       }
 
       // Should not throw an error

--- a/frontend/src/utils/analyticsUtil.ts
+++ b/frontend/src/utils/analyticsUtil.ts
@@ -2,7 +2,9 @@ import { validSearchQueryParamKeys } from "src/types/search/searchQueryTypes";
 
 // note that the `newrelic` referenced here is the newrelic object added to window when
 // client side new relic scripts are loaded and run, rather than anything explicity imported
-type NewRelicBrowser = typeof newrelic;
+export type NewRelicBrowser = {
+  setCustomAttribute?: (key: string, value: string | number) => void;
+};
 
 const NEW_RELIC_POLL_INTERVAL = 2;
 const NEW_RELIC_POLL_TIMEOUT = 500;
@@ -19,12 +21,12 @@ export const waitForNewRelic = async (): Promise<boolean> => {
   let timedOut = false;
 
   while (!present && !timedOut) {
-    elapsed += NEW_RELIC_POLL_INTERVAL;
     await new Promise((resolve) => {
       setTimeout(() => {
         return resolve(null);
-      }, elapsed);
+      }, NEW_RELIC_POLL_INTERVAL);
     });
+    elapsed += NEW_RELIC_POLL_INTERVAL;
     present = !!window.newrelic;
     if (elapsed >= NEW_RELIC_POLL_TIMEOUT) {
       console.error("Timed out waiting for new relic browser object");
@@ -48,7 +50,17 @@ export const setNewRelicCustomAttribute = (
     return;
   }
   // using underscores since NR has problems with querying fields with dashes
-  newRelic.setCustomAttribute(`search_param_${key}`, value);
+  newRelic.setCustomAttribute!(`search_param_${key}`, value);
+};
+export const setNewRelicCorrelationIdAttribute = (
+  correlationId: string,
+): undefined => {
+  const newRelic = getNewRelicBrowserInstance();
+  if (!newRelic) {
+    console.error("New Relic not defined setting correlation_id attribute");
+    return;
+  }
+  newRelic.setCustomAttribute!("correlation_id", correlationId);
 };
 
 // TODO does setting "" as the value effectively `unset` the attribute?


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9016 

Enrich frontend New Relic browser telemetry with the existing `correlation_id` so client-side telemetry can be correlated with the full user journey.

## Changes proposed

- Added a client-side `CorrelationIdTracker` component that registers the existing `correlation_id` with the New Relic Browser agent.
- Updated `RootLayoutWrapper` to retrieve the `correlation_id` and initialize the tracker at the application root.
- Added a dedicated helper in `analyticsUtil` to set the `correlation_id` custom attribute without affecting the existing search analytics helpers.
- Reused the existing New Relic initialization pattern and `waitForNewRelic()` utility to ensure the browser agent is available before setting the custom attribute.

## Context for reviewers

The `correlation_id` is already generated by the existing middleware/proxy and exposed through the correlation ID service. This PR does **not** generate a new correlation ID or introduce a new frontend logging pipeline.

Following the existing analytics architecture, the root-level `CorrelationIdTracker` registers the `correlation_id` with the New Relic Browser agent once on initial client render. After registration, New Relic automatically attaches the attribute to browser telemetry generated during the session.

The optional POST API endpoint mentioned in the issue was not implemented because it was identified as a consideration rather than a requirement, and the current implementation satisfies the acceptance criteria using the existing New Relic Browser functionality.

## Validation steps

- Verify the `correlation_id` is registered with the New Relic Browser agent after initial client render.
- Confirm that new New Relic events include the `correlation_id` attribute for:
    `PageView`
    `AjaxRequest`
    `BrowserInteraction`
- Confirm that new telemetry generated after deployment includes the `correlation_id` when present.
- In New Relic use "Query Your Data" to fetch the frontend logs

```
FROM AjaxRequest,BrowserInteraction,PageView 
SELECT correlation_id,actionText,pageUrl, *
WHERE correlation_id IS NOT NULL
SINCE 3 day ago
LIMIT 5000
```

