### PR TITLE
[Issue #10648] Enhance List AR endpoint with total applications received

### DIFF
--- a/api/src/services/award_recommendations/list_award_recommendations.py
+++ b/api/src/services/award_recommendations/list_award_recommendations.py
@@ -8,13 +8,16 @@ from grants_shared.pagination.pagination_models import PaginationInfo, Paginatio
 from grants_shared.pagination.paginator import Paginator
 from grants_shared.pagination.sorting_util import apply_sorting
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import selectinload
 
 from src.auth.endpoint_access_util import verify_access
 from src.constants.lookup_constants import Privilege
 from src.db.models.agency_models import Agency
-from src.db.models.award_recommendation_models import AwardRecommendation
+from src.db.models.award_recommendation_models import (
+    AwardRecommendation,
+    AwardRecommendationApplicationSubmission,
+)
 from src.db.models.opportunity_models import CurrentOpportunitySummary, Opportunity
 from src.db.models.user_models import User
 from src.search.search_models import UuidSearchFilter
@@ -103,4 +106,43 @@ def list_award_recommendations(
     paginated_results = paginator.page_at(page_offset=params.pagination.page_offset)
     pagination_info = PaginationInfo.from_pagination_params(params.pagination, paginator)
 
+    add_total_received_count_to_award_recommendations(db_session, paginated_results)
+
     return paginated_results, pagination_info
+
+
+def add_total_received_count_to_award_recommendations(
+    db_session: db.Session, award_recommendations: Sequence[AwardRecommendation]
+) -> None:
+    award_recommendation_ids = [
+        award_recommendation.award_recommendation_id
+        for award_recommendation in award_recommendations
+    ]
+
+    if not award_recommendation_ids:
+        return
+
+    count_rows = db_session.execute(
+        select(
+            AwardRecommendationApplicationSubmission.award_recommendation_id,
+            func.count(
+                AwardRecommendationApplicationSubmission.award_recommendation_application_submission_id
+            ).label("total_received_count"),
+        )
+        .where(
+            AwardRecommendationApplicationSubmission.award_recommendation_id.in_(
+                award_recommendation_ids
+            )
+        )
+        .group_by(AwardRecommendationApplicationSubmission.award_recommendation_id)
+    ).all()
+    total_received_counts = {
+        row.award_recommendation_id: int(row.total_received_count) for row in count_rows
+    }
+
+    for award_recommendation in award_recommendations:
+        award_recommendation.award_recommendation_summary = {  # type: ignore[attr-defined]
+            "total_received_count": total_received_counts.get(
+                award_recommendation.award_recommendation_id, 0
+            )
+        }

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
@@ -11,6 +11,7 @@ from tests.lib.agency_test_utils import (
 )
 from tests.src.db.models.factories import (
     AgencyFactory,
+    AwardRecommendationApplicationSubmissionFactory,
     AwardRecommendationFactory,
     OpportunityFactory,
 )
@@ -247,6 +248,46 @@ class TestListAwardRecommendations200:
         assert resp.json["data"] == []
         assert resp.json["pagination_info"]["total_records"] == 0
         assert resp.json["pagination_info"]["total_pages"] == 0
+
+    def test_list_award_recommendations_200_includes_total_received_count(
+        self, client, db_session, agency, opportunity
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        ar_with_submissions = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        ar_without_submissions = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        AwardRecommendationApplicationSubmissionFactory.create(
+            award_recommendation=ar_with_submissions
+        )
+        AwardRecommendationApplicationSubmissionFactory.create(
+            award_recommendation=ar_with_submissions
+        )
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json=_build_request([agency.agency_id]),
+        )
+
+        assert resp.status_code == 200
+        counts_by_id = {
+            row["award_recommendation_id"]: row["award_recommendation_summary"][
+                "total_received_count"
+            ]
+            for row in resp.json["data"]
+        }
+        assert counts_by_id[str(ar_with_submissions.award_recommendation_id)] == 2
+        assert counts_by_id[str(ar_without_submissions.award_recommendation_id)] == 0
 
 
 ####################################


### PR DESCRIPTION
## Summary

PR 1/3
Work for #10648 

## Changes proposed

- Add `award_recommendation_summary.total_received_count` to each item returned by the award recommendations list endpoint.
- Add API coverage for award recommendations with and without application submissions.

## Context for reviewers

This supports the frontend award recommendation list table’s “Applications received” column without requiring detail endpoint calls per row.

This is the first of a few PRs for adding the table.

## Validation steps

- [ ] Run `make remake-backend && docker compose up`
- [ ] Navigate to http://localhost:8080/docs#/Award%20Recommendation%20Alpha/post_alpha_award_recommendations_list
- [ ] Validate as an AR user
- [ ] Locate `Award Recommendation Test Agency` in the `agency` table and copy `agency_id` into the request body
- [ ] Verify that `total_received_count` is included and correctly calculated in the response for each AR