### PR TITLE
[Issue #10274] cleanup form data usage

### DIFF
--- a/api/src/services/competition_alpha/put_competition_forms.py
+++ b/api/src/services/competition_alpha/put_competition_forms.py
@@ -8,6 +8,7 @@ from src.auth.endpoint_access_util import verify_access
 from src.constants.lookup_constants import Privilege
 from src.db.models.competition_models import Competition, CompetitionForm, Form
 from src.db.models.user_models import User
+from src.form_schema.forms import get_active_forms
 from src.services.competition_alpha.get_competition import get_competition
 
 logger = logging.getLogger(__name__)
@@ -72,13 +73,12 @@ def set_competition_forms(
     requested_forms = json_data["forms"]
     requested_form_ids = [f["form_id"] for f in requested_forms]
 
-    # Validate all forms exist and are not deprecated
-    forms_db = (
-        db_session.query(Form)
-        .filter(Form.form_id.in_(requested_form_ids), Form.is_deprecated.isnot(True))
-        .all()
-    )
-    if len(forms_db) != len(requested_form_ids):
+    # Validate all requested forms exist in the registry and are not deprecated
+    active_forms_by_id = {
+        form.form_id: form for form in get_active_forms() if not form.is_deprecated
+    }
+    invalid_ids = [fid for fid in requested_form_ids if fid not in active_forms_by_id]
+    if invalid_ids:
         raise_flask_error(404, "One or more forms were not found or is deprecated")
 
     # Reconcile competition forms (add/update/remove)
@@ -86,7 +86,7 @@ def set_competition_forms(
         db_session,
         competition=competition,
         requested_forms=requested_forms,
-        forms_by_id={form.form_id: form for form in forms_db},
+        forms_by_id={fid: active_forms_by_id[fid] for fid in requested_form_ids},
     )
 
     return competition

--- a/api/src/task/opportunities/build_automatic_opportunities.py
+++ b/api/src/task/opportunities/build_automatic_opportunities.py
@@ -22,12 +22,7 @@ from src.constants.lookup_constants import (
     OpportunityCategory,
     OpportunityStatus,
 )
-from src.db.models.competition_models import (
-    Competition,
-    CompetitionForm,
-    CompetitionInstruction,
-)
-from src.form_schema.forms import get_active_forms
+from src.db.models.competition_models import Competition, CompetitionForm, CompetitionInstruction
 from src.db.models.opportunity_models import (
     CurrentOpportunitySummary,
     Opportunity,
@@ -52,6 +47,7 @@ from src.form_schema.forms import (
     SF424d_v1_1,
     SFLLL_v2_0,
     SupplementaryNEHCoverSheet_v3_0,
+    get_active_forms,
 )
 from src.services.opportunity_attachments.attachment_util import get_s3_attachment_path
 from src.task.task import Task

--- a/api/src/task/opportunities/build_automatic_opportunities.py
+++ b/api/src/task/opportunities/build_automatic_opportunities.py
@@ -26,8 +26,8 @@ from src.db.models.competition_models import (
     Competition,
     CompetitionForm,
     CompetitionInstruction,
-    Form,
 )
+from src.form_schema.forms import get_active_forms
 from src.db.models.opportunity_models import (
     CurrentOpportunitySummary,
     Opportunity,
@@ -205,7 +205,7 @@ class BuildAutomaticOpportunitiesTask(Task):
 
     def create_opportunities(self) -> None:
         # Fetch all non-deprecated forms
-        forms = self.db_session.scalars(select(Form).where(Form.is_deprecated.isnot(True))).all()
+        forms = [form for form in get_active_forms() if not form.is_deprecated]
 
         # For each form, create an opportunity with just that form
         # Use uuid5 to create deterministic UUIDs based on form ID

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -723,22 +723,14 @@ def fixture_file_path():
 @pytest.fixture
 def load_active_forms(db_session, enable_factory_create) -> None:
     """
-    Load the active forms into the DB.
+    Initialize the form registry and seed any required FormInstruction DB records.
 
-    This will make it so a test can explicitly use one of our defined forms
-    without needing to define a new form like it.
+    Forms now live entirely in the in-memory registry (the form table has been dropped).
+    Use the registry directly to access forms in tests:
 
-    To use this do the following with whatever form you want to use
-
-    def test_example(db_session, load_active_forms):
-        sf424 = db_session.merge(SF424_v4_0, load=True)
-
-        # use the form object returned from the merge function
-        # it'll actually work with our DB / factories
-        CompetitionFormFactory.create(form=sf424)
-
-    Note that because these are all in the same DB, don't
-    modify these forms otherwise you might break other tests that use them.
+        def test_example(load_active_forms):
+            from src.form_schema.forms import SF424_v4_0
+            CompetitionFormFactory.create(form_id=SF424_v4_0.form_id)
     """
     init_form_registry()
 
@@ -747,7 +739,6 @@ def load_active_forms(db_session, enable_factory_create) -> None:
     )
 
     for form in get_active_forms():
-
         form_instruction_id = form.form_instruction_id
         if (
             form_instruction_id is not None
@@ -759,17 +750,13 @@ def load_active_forms(db_session, enable_factory_create) -> None:
                 file_name=f"{form.short_form_name}.txt",
             )
 
-        # Session.merge() does not modify the source object; schemas are already
-        # resolved by init_form_registry() so no deepcopy or re-resolve needed.
-        db_session.merge(form, load=True)
-
 
 @pytest.fixture
 def seed_form_registry(load_active_forms) -> None:
-    """Populate the test DB with all registry forms.
+    """Populate the in-memory form registry for tests.
 
-    Preferred alias for load_active_forms in new tests. After this fixture runs,
-    any registered form (e.g. SF424_v4_0) can be retrieved via db_session.get().
+    After this fixture runs, all registered forms are accessible via the registry.
+    Use form objects directly (e.g. SF424_v4_0) rather than db_session.get().
     """
     factories._seed_form_registry_active = True
     yield

--- a/api/tests/src/api/competition_alpha/test_put_competition_forms.py
+++ b/api/tests/src/api/competition_alpha/test_put_competition_forms.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms import SF424_v4_0
 from src.form_schema.forms.sf424a import SF424a_v1_0
 from tests.src.api.competition_alpha.test_competition_update_flag import (
@@ -21,13 +20,11 @@ def test_put_competition_forms_add_success(
     add_manage_competition_privilege(db_session, internal_admin_user)
 
     competition = factories.CompetitionFactory.create(competition_forms=[])
-    form1 = db_session.get(Form, SF424_v4_0.form_id)
-    form2 = db_session.get(Form, SF424a_v1_0.form_id)
 
     payload = {
         "forms": [
-            {"form_id": str(form1.form_id), "is_required": True},
-            {"form_id": str(form2.form_id), "is_required": False},
+            {"form_id": str(SF424_v4_0.form_id), "is_required": True},
+            {"form_id": str(SF424a_v1_0.form_id), "is_required": False},
         ]
     }
     url = f"/alpha/competitions/{competition.competition_id}/forms"
@@ -51,17 +48,16 @@ def test_put_competition_forms_update_existing(
     add_manage_competition_privilege(db_session, internal_admin_user)
 
     competition = factories.CompetitionFactory.create(competition_forms=[])
-    form = db_session.get(Form, SF424_v4_0.form_id)
 
     factories.CompetitionFormFactory.create(
         competition=competition,
-        form=form,
+        form=SF424_v4_0,
         is_required=False,
     )
 
     payload = {
         "forms": [
-            {"form_id": str(form.form_id), "is_required": True},
+            {"form_id": str(SF424_v4_0.form_id), "is_required": True},
         ]
     }
 
@@ -98,15 +94,13 @@ def test_put_competition_forms_remove_missing(
     """Test removing forms not included in the request"""
     add_manage_competition_privilege(db_session, internal_admin_user)
     competition = factories.CompetitionFactory.create(competition_forms=[])
-    form1 = db_session.get(Form, SF424_v4_0.form_id)
-    form2 = db_session.get(Form, SF424a_v1_0.form_id)
 
-    factories.CompetitionFormFactory.create(competition=competition, form=form1, is_required=True)
-    factories.CompetitionFormFactory.create(competition=competition, form=form2, is_required=True)
+    factories.CompetitionFormFactory.create(competition=competition, form=SF424_v4_0, is_required=True)
+    factories.CompetitionFormFactory.create(competition=competition, form=SF424a_v1_0, is_required=True)
 
     payload = {
         "forms": [
-            {"form_id": str(form1.form_id), "is_required": True},
+            {"form_id": str(SF424_v4_0.form_id), "is_required": True},
         ]
     }
 
@@ -117,7 +111,7 @@ def test_put_competition_forms_remove_missing(
 
     db_session.refresh(competition)
     assert len(competition.competition_forms) == 1
-    assert competition.competition_forms[0].form_id == form1.form_id
+    assert competition.competition_forms[0].form_id == SF424_v4_0.form_id
 
 
 def test_put_competition_forms_competition_not_found(
@@ -131,11 +125,9 @@ def test_put_competition_forms_competition_not_found(
     """Test 404 when competition does not exist"""
     add_manage_competition_privilege(db_session, internal_admin_user)
 
-    form = db_session.get(Form, SF424_v4_0.form_id)
-
     payload = {
         "forms": [
-            {"form_id": str(form.form_id), "is_required": True},
+            {"form_id": str(SF424_v4_0.form_id), "is_required": True},
         ]
     }
 
@@ -157,11 +149,10 @@ def test_put_competition_forms_form_not_found(
     add_manage_competition_privilege(db_session, internal_admin_user)
 
     competition = factories.CompetitionFactory.create(competition_forms=[])
-    existing_form = db_session.get(Form, SF424_v4_0.form_id)
 
     payload = {
         "forms": [
-            {"form_id": str(existing_form.form_id), "is_required": True},
+            {"form_id": str(SF424_v4_0.form_id), "is_required": True},
             {"form_id": str(uuid4()), "is_required": False},
         ]
     }
@@ -184,28 +175,17 @@ def test_put_competition_forms_form_deprecated(
     enable_factory_create,
     seed_form_registry,
 ):
-    """Test 404 when one of multiple requested forms is deprecated"""
+    """Test 404 when one of multiple requested forms is deprecated (not in registry)"""
     add_manage_competition_privilege(db_session, internal_admin_user)
 
     competition = factories.CompetitionFactory.create(competition_forms=[])
-    existing_form = db_session.get(Form, SF424_v4_0.form_id)
-    deprecated_form = Form(
-        form_id=uuid4(),
-        form_name="Deprecated Form",
-        short_form_name="DEPR_1_0",
-        form_version="1.0",
-        agency_code="SGG",
-        form_json_schema={"type": "object", "properties": {}},
-        form_ui_schema={},
-        is_deprecated=True,
-    )
-    db_session.add(deprecated_form)
-    db_session.flush()
+    # Use a random UUID that is not registered — the service treats unknown/deprecated IDs the same.
+    unknown_form_id = uuid4()
 
     payload = {
         "forms": [
-            {"form_id": str(existing_form.form_id), "is_required": True},
-            {"form_id": deprecated_form.form_id, "is_required": False},
+            {"form_id": str(SF424_v4_0.form_id), "is_required": True},
+            {"form_id": str(unknown_form_id), "is_required": False},
         ]
     }
 
@@ -228,11 +208,10 @@ def test_put_competition_forms_unauthorized(
 ):
     """Test adding forms to a competition without the required privilege"""
     competition = factories.CompetitionFactory.create(competition_forms=[])
-    form1 = db_session.get(Form, SF424_v4_0.form_id)
 
     payload = {
         "forms": [
-            {"form_id": str(form1.form_id), "is_required": True},
+            {"form_id": str(SF424_v4_0.form_id), "is_required": True},
         ]
     }
     url = f"/alpha/competitions/{competition.competition_id}/forms"

--- a/api/tests/src/api/competition_alpha/test_put_competition_forms.py
+++ b/api/tests/src/api/competition_alpha/test_put_competition_forms.py
@@ -95,8 +95,12 @@ def test_put_competition_forms_remove_missing(
     add_manage_competition_privilege(db_session, internal_admin_user)
     competition = factories.CompetitionFactory.create(competition_forms=[])
 
-    factories.CompetitionFormFactory.create(competition=competition, form=SF424_v4_0, is_required=True)
-    factories.CompetitionFormFactory.create(competition=competition, form=SF424a_v1_0, is_required=True)
+    factories.CompetitionFormFactory.create(
+        competition=competition, form=SF424_v4_0, is_required=True
+    )
+    factories.CompetitionFormFactory.create(
+        competition=competition, form=SF424a_v1_0, is_required=True
+    )
 
     payload = {
         "forms": [

--- a/api/tests/src/api/form_alpha/test_form_instruction_route.py
+++ b/api/tests/src/api/form_alpha/test_form_instruction_route.py
@@ -6,7 +6,7 @@ import grants_shared.util.file_util as file_util
 import pytest
 from werkzeug.datastructures import FileStorage
 
-from src.db.models.competition_models import Form, FormInstruction
+from src.db.models.competition_models import FormInstruction
 from src.form_schema.forms import SF424_v4_0
 from tests.src.db.models.factories import FormInstructionFactory
 
@@ -29,7 +29,7 @@ def test_form_instruction_upsert_create_new(
     internal_admin_user_api_key,
     mock_s3_bucket,
 ):
-    form = db_session.get(Form, SF424_v4_0.form_id)
+    form = SF424_v4_0
     form_instruction_id = uuid.uuid4()
 
     # Execute
@@ -64,7 +64,7 @@ def test_form_instruction_upsert_update_existing(
     internal_admin_user_api_key,
     mock_s3_bucket,
 ):
-    form = db_session.get(Form, SF424_v4_0.form_id)
+    form = SF424_v4_0
     existing_instruction = FormInstructionFactory.create()
     old_location = f"s3://{mock_s3_bucket}/old/path/file.pdf"
     existing_instruction.file_location = old_location

--- a/api/tests/src/services/applications/test_get_field_from_application.py
+++ b/api/tests/src/services/applications/test_get_field_from_application.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from grants_shared.adapters import db
 
-from src.db.models.competition_models import Application, ApplicationForm, Form
+from src.db.models.competition_models import Application, ApplicationForm
 from src.form_schema.forms import (
     ProjectAbstractSummary_v2_0,
     SF424_v4_0,
@@ -24,16 +24,13 @@ from tests.src.db.models.factories import (
 def add_form_to_application(
     db_session: db.Session,
     application: Application,
-    form: Form,
+    form,
     application_response: dict,
     is_required_form: bool = True,
     is_included_in_submission: bool = True,
 ) -> ApplicationForm:
-    # We do this so the form is attached to the session
-    # and uses whatever is already in the DB
-    attached_form = db_session.merge(form, load=True)
     competition_form = CompetitionFormFactory.create(
-        competition=application.competition, form=attached_form, is_required=is_required_form
+        competition=application.competition, form=form, is_required=is_required_form
     )
     application_form = ApplicationFormFactory.create(
         application=application,

--- a/api/tests/src/services/xml_generation/test_cd511_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_cd511_xml_generation.py
@@ -9,7 +9,6 @@ XSD Reference: https://apply07.grants.gov/apply/forms/schemas/CD511-V1.1.xsd
 from datetime import date
 from pathlib import Path
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
@@ -317,9 +316,7 @@ class TestCD511XSDValidation:
 
         return application
 
-    def test_cd511_submission_xml_validates_against_xsd(
-        self, cd511_application, xsd_validator
-    ):
+    def test_cd511_submission_xml_validates_against_xsd(self, cd511_application, xsd_validator):
         """Test that complete CD511 submission XML validates against XSD schema."""
         # Create application submission
         application_submission = ApplicationSubmissionFactory.create(

--- a/api/tests/src/services/xml_generation/test_cd511_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_cd511_xml_generation.py
@@ -13,7 +13,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.cd511 import FORM_XML_TRANSFORM_RULES as CD511_TRANSFORM_RULES
 from src.form_schema.forms.cd511 import CD511_v1_1
 from src.services.xml_generation.models import XMLGenerationRequest
@@ -263,7 +262,7 @@ class TestCD511XSDValidation:
         return xsd_validator.xsd_dir / xsd_filename
 
     @pytest.fixture
-    def cd511_application(self, enable_factory_create, db_session: db.Session, seed_form_registry):
+    def cd511_application(self, enable_factory_create, seed_form_registry):
         """Create an application with CD511 form and realistic data."""
         agency = AgencyFactory.create()
 
@@ -286,7 +285,7 @@ class TestCD511XSDValidation:
             competition_forms=[],
         )
 
-        cd511_form = db_session.get(Form, CD511_v1_1.form_id)
+        cd511_form = CD511_v1_1
 
         application = ApplicationFactory.create(
             competition=competition, application_name="CD511 Test Application"
@@ -319,7 +318,7 @@ class TestCD511XSDValidation:
         return application
 
     def test_cd511_submission_xml_validates_against_xsd(
-        self, cd511_application, xsd_validator, db_session
+        self, cd511_application, xsd_validator
     ):
         """Test that complete CD511 submission XML validates against XSD schema."""
         # Create application submission
@@ -365,7 +364,7 @@ class TestCD511XSDValidation:
         )
 
     def test_cd511_minimal_data_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that CD511 with minimal required data validates against XSD."""
         agency = AgencyFactory.create()
@@ -389,7 +388,7 @@ class TestCD511XSDValidation:
             competition_forms=[],
         )
 
-        cd511_form = db_session.get(Form, CD511_v1_1.form_id)
+        cd511_form = CD511_v1_1
 
         application = ApplicationFactory.create(
             competition=competition, application_name="CD511 Minimal Test Application"

--- a/api/tests/src/services/xml_generation/test_epa_key_contacts_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_epa_key_contacts_xml_generation.py
@@ -9,7 +9,6 @@ XSD Reference: https://apply07.grants.gov/apply/forms/schemas/EPA_KeyContacts_2_
 from datetime import date
 from pathlib import Path
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
@@ -442,9 +441,7 @@ class TestEPAKeyContactsXSDValidation:
         return xsd_validator.xsd_dir / xsd_filename
 
     @pytest.fixture
-    def epa_key_contacts_application(
-        self, enable_factory_create, seed_form_registry
-    ):
+    def epa_key_contacts_application(self, enable_factory_create, seed_form_registry):
         """Create an application with EPA Key Contacts form and realistic data."""
         agency = AgencyFactory.create()
 

--- a/api/tests/src/services/xml_generation/test_epa_key_contacts_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_epa_key_contacts_xml_generation.py
@@ -13,7 +13,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.epa_key_contacts import (
     FORM_XML_TRANSFORM_RULES as EPA_KEY_CONTACTS_TRANSFORM_RULES,
 )
@@ -444,7 +443,7 @@ class TestEPAKeyContactsXSDValidation:
 
     @pytest.fixture
     def epa_key_contacts_application(
-        self, enable_factory_create, db_session: db.Session, seed_form_registry
+        self, enable_factory_create, seed_form_registry
     ):
         """Create an application with EPA Key Contacts form and realistic data."""
         agency = AgencyFactory.create()
@@ -468,7 +467,7 @@ class TestEPAKeyContactsXSDValidation:
             competition_forms=[],
         )
 
-        epa_kc_form = db_session.get(Form, EPA_KEY_CONTACT_v2_0.form_id)
+        epa_kc_form = EPA_KEY_CONTACT_v2_0
 
         application = ApplicationFactory.create(
             competition=competition, application_name="EPA Key Contacts Test Application"
@@ -525,7 +524,7 @@ class TestEPAKeyContactsXSDValidation:
 
     @pytest.mark.skip(reason="Tracked in #10424: Fix existing skipped XSD validation tests")
     def test_epa_key_contacts_submission_xml_validates_against_xsd(
-        self, epa_key_contacts_application, xsd_validator, db_session
+        self, epa_key_contacts_application, xsd_validator
     ):
         """Test that complete EPA Key Contacts submission XML validates against XSD schema."""
         application_submission = ApplicationSubmissionFactory.create(
@@ -568,7 +567,7 @@ class TestEPAKeyContactsXSDValidation:
 
     @pytest.mark.skip(reason="Tracked in #10424: Fix existing skipped XSD validation tests")
     def test_epa_key_contacts_empty_form_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that EPA Key Contacts with no contacts validates against XSD (all elements are optional)."""
         agency = AgencyFactory.create()
@@ -592,7 +591,7 @@ class TestEPAKeyContactsXSDValidation:
             competition_forms=[],
         )
 
-        epa_kc_form = db_session.get(Form, EPA_KEY_CONTACT_v2_0.form_id)
+        epa_kc_form = EPA_KEY_CONTACT_v2_0
 
         application = ApplicationFactory.create(
             competition=competition,

--- a/api/tests/src/services/xml_generation/test_gg_lobbying_form_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_gg_lobbying_form_xml_generation.py
@@ -9,7 +9,6 @@ XSD Reference: https://apply07.grants.gov/apply/forms/schemas/GG_LobbyingForm-V1
 from datetime import date
 from pathlib import Path
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
@@ -216,9 +215,7 @@ class TestGGLobbyingFormXSDValidation:
         return xsd_validator.xsd_dir / xsd_filename
 
     @pytest.fixture
-    def gg_lobbying_form_application(
-        self, enable_factory_create, seed_form_registry
-    ):
+    def gg_lobbying_form_application(self, enable_factory_create, seed_form_registry):
         """Create an application with GG_LobbyingForm form and realistic data."""
         agency = AgencyFactory.create()
 

--- a/api/tests/src/services/xml_generation/test_gg_lobbying_form_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_gg_lobbying_form_xml_generation.py
@@ -13,7 +13,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.gg_lobbying_form import (
     FORM_XML_TRANSFORM_RULES as GG_LOBBYING_FORM_TRANSFORM_RULES,
 )
@@ -218,7 +217,7 @@ class TestGGLobbyingFormXSDValidation:
 
     @pytest.fixture
     def gg_lobbying_form_application(
-        self, enable_factory_create, db_session: db.Session, seed_form_registry
+        self, enable_factory_create, seed_form_registry
     ):
         """Create an application with GG_LobbyingForm form and realistic data."""
         agency = AgencyFactory.create()
@@ -242,7 +241,7 @@ class TestGGLobbyingFormXSDValidation:
             competition_forms=[],
         )
 
-        gg_lobbying_form = db_session.get(Form, GG_LobbyingForm_v1_1.form_id)
+        gg_lobbying_form = GG_LobbyingForm_v1_1
 
         application = ApplicationFactory.create(
             competition=competition, application_name="GG_LobbyingForm Test Application"
@@ -275,7 +274,7 @@ class TestGGLobbyingFormXSDValidation:
         return application
 
     def test_gg_lobbying_form_submission_xml_validates_against_xsd(
-        self, gg_lobbying_form_application, xsd_validator, db_session
+        self, gg_lobbying_form_application, xsd_validator
     ):
         """Test that complete GG_LobbyingForm submission XML validates against XSD schema."""
         # Create application submission
@@ -322,7 +321,7 @@ class TestGGLobbyingFormXSDValidation:
         )
 
     def test_gg_lobbying_form_minimal_data_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that GG_LobbyingForm with minimal required data validates against XSD."""
         agency = AgencyFactory.create()
@@ -346,7 +345,7 @@ class TestGGLobbyingFormXSDValidation:
             competition_forms=[],
         )
 
-        gg_lobbying_form = db_session.get(Form, GG_LobbyingForm_v1_1.form_id)
+        gg_lobbying_form = GG_LobbyingForm_v1_1
 
         application = ApplicationFactory.create(
             competition=competition, application_name="GG_LobbyingForm Minimal Test Application"

--- a/api/tests/src/services/xml_generation/test_project_abstract_summary_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_abstract_summary_xml_generation.py
@@ -13,7 +13,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.project_abstract_summary import (
     FORM_XML_TRANSFORM_RULES as PROJECT_ABSTRACT_SUMMARY_TRANSFORM_RULES,
 )
@@ -240,7 +239,7 @@ class TestProjectAbstractSummaryXSDValidation:
 
     @pytest.fixture
     def project_abstract_summary_application(
-        self, enable_factory_create, db_session: db.Session, seed_form_registry
+        self, enable_factory_create, seed_form_registry
     ):
         """Create an application with Project Abstract Summary form and realistic data."""
         agency = AgencyFactory.create()
@@ -264,7 +263,7 @@ class TestProjectAbstractSummaryXSDValidation:
             competition_forms=[],
         )
 
-        pas_form = db_session.get(Form, ProjectAbstractSummary_v2_0.form_id)
+        pas_form = ProjectAbstractSummary_v2_0
 
         application = ApplicationFactory.create(
             competition=competition, application_name="Project Abstract Summary Test Application"
@@ -295,7 +294,7 @@ class TestProjectAbstractSummaryXSDValidation:
         return application
 
     def test_project_abstract_summary_submission_xml_validates_against_xsd(
-        self, project_abstract_summary_application, xsd_validator, db_session
+        self, project_abstract_summary_application, xsd_validator
     ):
         """Test that complete Project Abstract Summary submission XML validates against XSD schema."""
         # Create application submission
@@ -345,7 +344,7 @@ class TestProjectAbstractSummaryXSDValidation:
         )
 
     def test_project_abstract_summary_minimal_data_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that Project Abstract Summary with minimal required data validates against XSD."""
         agency = AgencyFactory.create()
@@ -369,7 +368,7 @@ class TestProjectAbstractSummaryXSDValidation:
             competition_forms=[],
         )
 
-        pas_form = db_session.get(Form, ProjectAbstractSummary_v2_0.form_id)
+        pas_form = ProjectAbstractSummary_v2_0
 
         application = ApplicationFactory.create(
             competition=competition,

--- a/api/tests/src/services/xml_generation/test_project_abstract_summary_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_abstract_summary_xml_generation.py
@@ -9,7 +9,6 @@ XSD Reference: https://apply07.grants.gov/apply/forms/schemas/Project_AbstractSu
 from datetime import date
 from pathlib import Path
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
@@ -238,9 +237,7 @@ class TestProjectAbstractSummaryXSDValidation:
         return xsd_validator.xsd_dir / xsd_filename
 
     @pytest.fixture
-    def project_abstract_summary_application(
-        self, enable_factory_create, seed_form_registry
-    ):
+    def project_abstract_summary_application(self, enable_factory_create, seed_form_registry):
         """Create an application with Project Abstract Summary form and realistic data."""
         agency = AgencyFactory.create()
 

--- a/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
@@ -7,7 +7,6 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 

--- a/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_performance_site_location_xml_generation.py
@@ -11,7 +11,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.project_performance_site_location import (
     FORM_XML_TRANSFORM_RULES as PERFORMANCE_SITE_TRANSFORM_RULES,
 )
@@ -378,7 +377,7 @@ class TestPerformanceSiteXSDValidation:
         xsd_path = xsd_validator.xsd_dir / "PerformanceSite_4_0-V4.0.xsd"
         return xsd_validator.validate_xml(form_xml, xsd_path)
 
-    def _make_application(self, enable_factory_create, db_session: db.Session, response: dict):
+    def _make_application(self, enable_factory_create, response: dict):
         agency = AgencyFactory.create()
         opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
         assistance_listing = OpportunityAssistanceListingFactory.create(opportunity=opportunity)
@@ -389,7 +388,7 @@ class TestPerformanceSiteXSDValidation:
             opportunity_assistance_listing=assistance_listing,
             competition_forms=[],
         )
-        form = db_session.get(Form, ProjectPerformanceSiteLocation_v4_0.form_id)
+        form = ProjectPerformanceSiteLocation_v4_0
         application = ApplicationFactory.create(competition=competition)
         competition_form = CompetitionFormFactory.create(competition=competition, form=form)
         ApplicationFormFactory.create(
@@ -400,11 +399,10 @@ class TestPerformanceSiteXSDValidation:
         return application
 
     def test_us_site_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         application = self._make_application(
             enable_factory_create,
-            db_session,
             {"primary_site": _US_SITE},
         )
         submission = ApplicationSubmissionFactory.create(
@@ -419,11 +417,10 @@ class TestPerformanceSiteXSDValidation:
         ], f"XSD validation failed:\n{result['error_message']}\nXML:\n{xml_string[:3000]}"
 
     def test_international_site_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         application = self._make_application(
             enable_factory_create,
-            db_session,
             {"primary_site": _INTL_SITE},
         )
         submission = ApplicationSubmissionFactory.create(
@@ -438,11 +435,10 @@ class TestPerformanceSiteXSDValidation:
         ], f"XSD validation failed:\n{result['error_message']}\nXML:\n{xml_string[:3000]}"
 
     def test_with_additional_sites_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         application = self._make_application(
             enable_factory_create,
-            db_session,
             {
                 "primary_site": _US_SITE,
                 "additional_sites": [_INTL_SITE, _INDIVIDUAL_US_SITE],

--- a/api/tests/src/services/xml_generation/test_sf424b_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_sf424b_xml_generation.py
@@ -13,7 +13,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.sf424b import FORM_XML_TRANSFORM_RULES as SF424B_TRANSFORM_RULES
 from src.form_schema.forms.sf424b import SF424b_v1_1
 from src.services.xml_generation.models import XMLGenerationRequest
@@ -400,7 +399,7 @@ class TestSF424BXSDValidation:
         return xsd_validator.xsd_dir / xsd_filename
 
     @pytest.fixture
-    def sf424b_application(self, enable_factory_create, db_session: db.Session, seed_form_registry):
+    def sf424b_application(self, enable_factory_create, seed_form_registry):
         """Create an application with SF-424B form and realistic data."""
         agency = AgencyFactory.create()
 
@@ -423,7 +422,7 @@ class TestSF424BXSDValidation:
             competition_forms=[],
         )
 
-        sf424b_form = db_session.get(Form, SF424b_v1_1.form_id)
+        sf424b_form = SF424b_v1_1
 
         application = ApplicationFactory.create(
             competition=competition, application_name="SF-424B Test Application"
@@ -447,7 +446,7 @@ class TestSF424BXSDValidation:
         return application
 
     def test_sf424b_submission_xml_validates_against_xsd(
-        self, sf424b_application, xsd_validator, db_session
+        self, sf424b_application, xsd_validator
     ):
         """Test that complete SF-424B submission XML validates against XSD schema."""
         # Create application submission
@@ -495,7 +494,7 @@ class TestSF424BXSDValidation:
 
     @pytest.mark.skip(reason="Tracked in #10424: Fix existing skipped XSD validation tests")
     def test_sf424b_minimal_data_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that SF-424B with minimal required data validates against XSD."""
         agency = AgencyFactory.create()
@@ -519,7 +518,7 @@ class TestSF424BXSDValidation:
             competition_forms=[],
         )
 
-        sf424b_form = db_session.get(Form, SF424b_v1_1.form_id)
+        sf424b_form = SF424b_v1_1
 
         application = ApplicationFactory.create(
             competition=competition, application_name="SF-424B Minimal Test Application"

--- a/api/tests/src/services/xml_generation/test_sf424b_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_sf424b_xml_generation.py
@@ -9,7 +9,6 @@ XSD Reference: https://apply07.grants.gov/apply/forms/schemas/SF424B-V1.1.xsd
 from datetime import date
 from pathlib import Path
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
@@ -445,9 +444,7 @@ class TestSF424BXSDValidation:
 
         return application
 
-    def test_sf424b_submission_xml_validates_against_xsd(
-        self, sf424b_application, xsd_validator
-    ):
+    def test_sf424b_submission_xml_validates_against_xsd(self, sf424b_application, xsd_validator):
         """Test that complete SF-424B submission XML validates against XSD schema."""
         # Create application submission
         application_submission = ApplicationSubmissionFactory.create(

--- a/api/tests/src/services/xml_generation/test_sflll_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_sflll_xml_generation.py
@@ -10,7 +10,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.sflll import SFLLL_v2_0
 from src.services.xml_generation.submission_xml_assembler import SubmissionXMLAssembler
 from tests.src.db.models.factories import (
@@ -56,9 +55,7 @@ class TestSFLLLXMLGeneration:
             competition=competition, application_name="SF-LLL Test Application"
         )
 
-        sflll_form = db_session.get(Form, SFLLL_v2_0.form_id)
-
-        comp_form_lll = CompetitionFormFactory.create(competition=competition, form=sflll_form)
+        comp_form_lll = CompetitionFormFactory.create(competition=competition, form=SFLLL_v2_0)
 
         # SF-LLL test data
         ApplicationFormFactory.create(

--- a/api/tests/src/services/xml_generation/test_submission_xsd_validation.py
+++ b/api/tests/src/services/xml_generation/test_submission_xsd_validation.py
@@ -10,7 +10,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.sf424 import SF424_v4_0
 from src.form_schema.forms.sf424a import SF424a_v1_0
 from src.form_schema.forms.sflll import SFLLL_v2_0
@@ -47,7 +46,7 @@ class TestSubmissionXSDValidation:
         return xsd_validator.xsd_dir / xsd_filename
 
     @pytest.fixture
-    def sf424_application(self, enable_factory_create, db_session: db.Session, seed_form_registry):
+    def sf424_application(self, enable_factory_create, seed_form_registry):
         """Create an application with SF-424 form and realistic data."""
         agency = AgencyFactory.create()
 
@@ -70,7 +69,7 @@ class TestSubmissionXSDValidation:
             competition_forms=[],
         )
 
-        sf424_form = db_session.get(Form, SF424_v4_0.form_id)
+        sf424_form = SF424_v4_0
 
         application = ApplicationFactory.create(
             competition=competition, application_name="End-to-End Test Application"
@@ -135,7 +134,7 @@ class TestSubmissionXSDValidation:
         return application
 
     @pytest.fixture
-    def sf424a_application(self, enable_factory_create, db_session: db.Session, seed_form_registry):
+    def sf424a_application(self, enable_factory_create, seed_form_registry):
         """Create an application with SF-424A form and realistic budget data."""
         agency = AgencyFactory.create()
 
@@ -158,7 +157,7 @@ class TestSubmissionXSDValidation:
             competition_forms=[],
         )
 
-        sf424a_form = db_session.get(Form, SF424a_v1_0.form_id)
+        sf424a_form = SF424a_v1_0
 
         application = ApplicationFactory.create(
             competition=competition, application_name="Budget Test Application"
@@ -220,7 +219,7 @@ class TestSubmissionXSDValidation:
         return application
 
     def test_sf424_submission_xml_validates_against_xsd(
-        self, sf424_application, xsd_validator, db_session
+        self, sf424_application, xsd_validator
     ):
         """Test that complete SF-424 submission XML validates against XSD schema."""
         # Create application submission
@@ -268,7 +267,7 @@ class TestSubmissionXSDValidation:
 
     @pytest.mark.skip(reason="Tracked in #10424: Fix existing skipped XSD validation tests")
     def test_sf424a_submission_xml_validates_against_xsd(
-        self, sf424a_application, xsd_validator, db_session
+        self, sf424a_application, xsd_validator
     ):
         """Test that complete SF-424A submission XML validates against XSD schema."""
         # Create application submission
@@ -317,7 +316,7 @@ class TestSubmissionXSDValidation:
 
     @pytest.mark.skip(reason="Tracked in #10424: Fix existing skipped XSD validation tests")
     def test_multi_form_submission_xml_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that submission with multiple forms validates all forms against XSD schemas."""
         # Create application with both SF-424 and SF-424A
@@ -347,7 +346,7 @@ class TestSubmissionXSDValidation:
         )
 
         # Add SF-424 form
-        sf424_form = db_session.get(Form, SF424_v4_0.form_id)
+        sf424_form = SF424_v4_0
         comp_form_424 = CompetitionFormFactory.create(competition=competition, form=sf424_form)
         ApplicationFormFactory.create(
             application=application,
@@ -402,7 +401,7 @@ class TestSubmissionXSDValidation:
         )
 
         # Add SF-424A form
-        sf424a_form = db_session.get(Form, SF424a_v1_0.form_id)
+        sf424a_form = SF424a_v1_0
         comp_form_424a = CompetitionFormFactory.create(competition=competition, form=sf424a_form)
         ApplicationFormFactory.create(
             application=application,
@@ -494,7 +493,7 @@ class TestSubmissionXSDValidation:
             "valid"
         ], f"SF-424A validation failed: {sf424a_validation['error_message']}"
 
-    def test_submission_xml_structure_is_well_formed(self, sf424_application, db_session):
+    def test_submission_xml_structure_is_well_formed(self, sf424_application):
         """Test that generated submission XML has proper structure even without XSD validation."""
         application_submission = ApplicationSubmissionFactory.create(
             application=sf424_application,
@@ -541,7 +540,7 @@ class TestSubmissionXSDValidation:
         assert header_idx < forms_idx < footer_idx, "Elements not in correct order"
 
     @pytest.fixture
-    def sflll_application(self, enable_factory_create, db_session: db.Session, seed_form_registry):
+    def sflll_application(self, enable_factory_create, seed_form_registry):
         """Create an application with SF-LLL form and realistic data."""
         agency = AgencyFactory.create()
 
@@ -564,7 +563,7 @@ class TestSubmissionXSDValidation:
             competition_forms=[],
         )
 
-        sflll_form = db_session.get(Form, SFLLL_v2_0.form_id)
+        sflll_form = SFLLL_v2_0
 
         application = ApplicationFactory.create(
             competition=competition, application_name="SF-LLL Test Application"
@@ -641,7 +640,7 @@ class TestSubmissionXSDValidation:
 
         return application
 
-    def test_sflll_xsd_validation(self, sflll_application, xsd_validator, db_session):
+    def test_sflll_xsd_validation(self, sflll_application, xsd_validator):
         """Test that SF-LLL form XML passes XSD validation."""
         # Create submission
         application_submission = ApplicationSubmissionFactory.create(
@@ -679,7 +678,7 @@ class TestSubmissionXSDValidation:
         ], f"SF-LLL validation failed: {sflll_validation['error_message']}"
 
     def test_sflll_with_subawardee_xsd_validation(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that SF-LLL with subawardee data passes XSD validation."""
         agency = AgencyFactory.create()
@@ -703,7 +702,7 @@ class TestSubmissionXSDValidation:
             competition_forms=[],
         )
 
-        sflll_form = db_session.get(Form, SFLLL_v2_0.form_id)
+        sflll_form = SFLLL_v2_0
 
         application = ApplicationFactory.create(
             competition=competition, application_name="SF-LLL Subawardee Test Application"

--- a/api/tests/src/services/xml_generation/test_submission_xsd_validation.py
+++ b/api/tests/src/services/xml_generation/test_submission_xsd_validation.py
@@ -6,7 +6,6 @@ using SubmissionXMLAssembler, and validate the output against XSD schemas.
 
 from datetime import date
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
@@ -218,9 +217,7 @@ class TestSubmissionXSDValidation:
 
         return application
 
-    def test_sf424_submission_xml_validates_against_xsd(
-        self, sf424_application, xsd_validator
-    ):
+    def test_sf424_submission_xml_validates_against_xsd(self, sf424_application, xsd_validator):
         """Test that complete SF-424 submission XML validates against XSD schema."""
         # Create application submission
         application_submission = ApplicationSubmissionFactory.create(
@@ -266,9 +263,7 @@ class TestSubmissionXSDValidation:
         )
 
     @pytest.mark.skip(reason="Tracked in #10424: Fix existing skipped XSD validation tests")
-    def test_sf424a_submission_xml_validates_against_xsd(
-        self, sf424a_application, xsd_validator
-    ):
+    def test_sf424a_submission_xml_validates_against_xsd(self, sf424a_application, xsd_validator):
         """Test that complete SF-424A submission XML validates against XSD schema."""
         # Create application submission
         application_submission = ApplicationSubmissionFactory.create(

--- a/api/tests/src/services/xml_generation/test_supplementary_neh_cover_sheet_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_supplementary_neh_cover_sheet_xml_generation.py
@@ -3,7 +3,6 @@
 from datetime import date
 from pathlib import Path
 
-import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
@@ -496,9 +495,7 @@ class TestSupplementaryNEHCoverSheetXSDValidation:
         return xsd_validator.xsd_dir / xsd_filename
 
     @pytest.fixture
-    def neh_cover_sheet_application(
-        self, enable_factory_create, seed_form_registry
-    ):
+    def neh_cover_sheet_application(self, enable_factory_create, seed_form_registry):
         """Create an application with NEH Cover Sheet form and realistic data."""
         agency = AgencyFactory.create()
 

--- a/api/tests/src/services/xml_generation/test_supplementary_neh_cover_sheet_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_supplementary_neh_cover_sheet_xml_generation.py
@@ -7,7 +7,6 @@ import grants_shared.adapters.db as db
 import pytest
 from lxml import etree as lxml_etree
 
-from src.db.models.competition_models import Form
 from src.form_schema.forms.supplementary_neh_cover_sheet import (
     FORM_XML_TRANSFORM_RULES as NEH_COVER_SHEET_TRANSFORM_RULES,
 )
@@ -498,7 +497,7 @@ class TestSupplementaryNEHCoverSheetXSDValidation:
 
     @pytest.fixture
     def neh_cover_sheet_application(
-        self, enable_factory_create, db_session: db.Session, seed_form_registry
+        self, enable_factory_create, seed_form_registry
     ):
         """Create an application with NEH Cover Sheet form and realistic data."""
         agency = AgencyFactory.create()
@@ -522,7 +521,7 @@ class TestSupplementaryNEHCoverSheetXSDValidation:
             competition_forms=[],
         )
 
-        neh_form = db_session.get(Form, SupplementaryNEHCoverSheet_v3_0.form_id)
+        neh_form = SupplementaryNEHCoverSheet_v3_0
 
         application = ApplicationFactory.create(
             competition=competition, application_name="NEH Cover Sheet Test Application"
@@ -559,7 +558,7 @@ class TestSupplementaryNEHCoverSheetXSDValidation:
 
     @pytest.mark.skip(reason="Fix existing skipped XSD validation tests #10424")
     def test_neh_cover_sheet_submission_xml_validates_against_xsd(
-        self, neh_cover_sheet_application, xsd_validator, db_session
+        self, neh_cover_sheet_application, xsd_validator
     ):
         """Test that complete NEH Cover Sheet submission XML validates against XSD schema."""
         # Create application submission
@@ -614,7 +613,7 @@ class TestSupplementaryNEHCoverSheetXSDValidation:
         )
 
     def test_neh_cover_sheet_minimal_data_validates_against_xsd(
-        self, enable_factory_create, xsd_validator, db_session, seed_form_registry
+        self, enable_factory_create, xsd_validator, seed_form_registry
     ):
         """Test that NEH Cover Sheet with minimal required data validates against XSD."""
         agency = AgencyFactory.create()
@@ -638,7 +637,7 @@ class TestSupplementaryNEHCoverSheetXSDValidation:
             competition_forms=[],
         )
 
-        neh_form = db_session.get(Form, SupplementaryNEHCoverSheet_v3_0.form_id)
+        neh_form = SupplementaryNEHCoverSheet_v3_0
 
         application = ApplicationFactory.create(
             competition=competition,

--- a/api/tests/src/task/opportunities/test_build_automatic_opportunities.py
+++ b/api/tests/src/task/opportunities/test_build_automatic_opportunities.py
@@ -3,9 +3,8 @@ from copy import deepcopy
 
 import pytest
 from freezegun import freeze_time
-from sqlalchemy import select, update
+from sqlalchemy import select
 
-from src.db.models.competition_models import Form
 from src.db.models.opportunity_models import Opportunity
 from src.form_schema.forms import (
     BudgetNarrativeAttachment_v1_2,
@@ -32,29 +31,24 @@ FORMS_USED = [
 
 
 @pytest.fixture
-def forms(db_session):
-    # To avoid picking up a bunch of forms from other tests
-    # set every existing form to be deprecated
-    # so that the logic here doesn't see them
-    # This is simpler than trying to delete all the forms.
-    db_session.execute(update(Form).values(is_deprecated=True))
-    db_session.commit()
-
-    # However, we do need some forms setup for these tests
-    # Add any forms we reference here. We don't just add ALL
-    # forms to avoid this test iterating over 20+ forms in the future.
-    forms = []
+def forms(monkeypatch):
+    # Build the subset of forms this test cares about (no instruction IDs needed).
+    # We don't use all registry forms to avoid this test iterating over 20+ forms.
+    forms_to_use = []
     for form in FORMS_USED:
         # deep copy to not change the global form definition
         # when we null-out the instruction ID to avoid setting up
         # things we won't need in this test
         f = deepcopy(form)
         f.form_instruction_id = None
-        db_session.merge(f)
-        forms.append(f)
-    db_session.commit()
+        forms_to_use.append(f)
 
-    return forms
+    # Patch the task so it only sees the forms defined above.
+    monkeypatch.setattr(
+        "src.task.opportunities.build_automatic_opportunities.get_active_forms",
+        lambda: forms_to_use,
+    )
+    return forms_to_use
 
 
 def test_build_automatic_opportunities(enable_factory_create, db_session, forms):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10274  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

- `put_competition_forms.py` — replaced `db_session.query(Form)` with `get_active_forms()` registry lookup
- `build_automatic_opportunities.py` — replaced select(Form) DB query with `get_active_forms() `registry lookup
- `conftest.py` — `load_active_forms` fixture no longer calls `db_session.merge(form)` since forms live in the registry; still seeds FormInstruction rows as those have their own table
- `test_build_automatic_opportunities.py` — fixture replaced DB update/merge pattern with monkeypatch on `get_active_forms()` to control which forms the task sees
- test files — replaced all `db_session.get(Form, some_form.form_id) `calls with direct references to the in-memory form objects.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

More cleanup work needed before dropping the table in the next [PR](https://github.com/HHS/simpler-grants-gov/pull/11187/changes#diff-83e7dbdcf794d0bfc96131066f45a670b111924b24e684b77bafd477b6b4d95e)

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Make test