### PR TITLE
[Issue #10836] Define maintenance-mode SSM parameter and wire to ECS task definitions

### DIFF
--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -128,7 +128,7 @@ locals {
 
     ENABLE_MAINTENANCE_MODE = {
       manage_method     = "manual"
-      secret_store_name = "/api/${var.environment}/maintenance-mode"
+      secret_store_name = "/api/${var.environment}/enable-maintenance-mode"
     }
 
     SAVE_SOAP_MESSAGES_TO_S3 = {

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -126,6 +126,11 @@ locals {
       secret_store_name = "/api/${var.environment}/enable-simpler-route"
     }
 
+    MAINTENANCE_MODE = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/maintenance-mode"
+    }
+
     SAVE_SOAP_MESSAGES_TO_S3 = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/save-soap-messages-to-s3"

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -126,7 +126,7 @@ locals {
       secret_store_name = "/api/${var.environment}/enable-simpler-route"
     }
 
-    MAINTENANCE_MODE = {
+    ENABLE_MAINTENANCE_MODE = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/maintenance-mode"
     }


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10836  

## Changes proposed

- Updated environment_variables.tf to add `MAINTENANCE_MODE` to the `secrets` map

## Context for reviewers

This is the infra part of implementing the maintenance mode for the API. The SSM Params for all six environments (dev, staging, training, prod, grantee1, grantee2) have already been created in AWS.

## Validation steps

Deploys do not fail because the SSM Params exist. 