### PR TITLE
[unticketed]: update prod es cluster to 2 per az

### DIFF
--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -56,9 +56,10 @@ module "prod_config" {
   # Scale the search_data_instance_count number to meet your compute needs.
   # The search_data_instance_count should be a multiple of the number of availability zones.
   # Use the AWS Console to determine the number of availability zones in your region.
-  search_data_instance_type      = "or1.medium.search"
-  search_data_volume_size        = 20
-  search_data_instance_count     = 3
+  search_data_instance_type = "or1.medium.search"
+  search_data_volume_size   = 20
+  # 2 data nodes per availability zone across 3 AZs (must be a multiple of az zone count).
+  search_data_instance_count     = 6
   search_availability_zone_count = 3
   # Versions: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version
   search_engine_version = "OpenSearch_2.15"


### PR DESCRIPTION
## Summary

Updated the prod es cluster to 2 nodes per az zone. The number of nodes has to be a multiple of the number of az zones. 

## Validation steps

Already deployed to prod. The db module deploy is a manual step. 