### PR TITLE
[Issue #11022] (1/3) Adjust grants shared authN tables to not define primary keys

### DIFF
--- a/backend/grants_shared/pyproject.toml
+++ b/backend/grants_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grants-shared"
-version = "0.2.12"
+version = "0.2.13"
 description = "Shared code used by the Simpler Grants.gov repo"
 readme = "README.md"
 license = "CC0-1.0"

--- a/backend/grants_shared/src/grants_shared/auth/api_jwt_auth.py
+++ b/backend/grants_shared/src/grants_shared/auth/api_jwt_auth.py
@@ -76,7 +76,7 @@ def generate_jwt(
         "aud": config.audience,
         "iss": config.issuer,
         "email": email,
-        "user_id": str(user.user_id),
+        "user_id": str(user.get_user_id()),
         "session_duration_minutes": config.token_expiration_minutes,
     }
 
@@ -116,7 +116,7 @@ class JwtAuth[USER: BaseUser, USER_TOKEN_SESSION: BaseUserTokenSession]:
         logger.info(
             "Created JWT token",
             extra={
-                "auth.user_id": user.user_id,
+                "auth.user_id": user.get_user_id(),
                 "auth.token_id": user_token_session.token_id,
             },
         )

--- a/backend/grants_shared/src/grants_shared/db/models/auth_base_models.py
+++ b/backend/grants_shared/src/grants_shared/db/models/auth_base_models.py
@@ -11,7 +11,6 @@ without it referencing the concrete API tables directly.
 import uuid
 from datetime import datetime
 
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from grants_shared.db.models.base import Base
@@ -20,14 +19,21 @@ from grants_shared.db.models.base import Base
 class BaseUser(Base):
     __abstract__ = True
 
-    user_id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+    def get_user_id(self) -> uuid.UUID:
+        """Get the user ID (ie. primary key) for this user. Does not need the primary key to be named
+        exactly user_id in the derived table, but does assume that the user doesn't have a multi-column primary key.
+
+        Mainly used as a convenience in our authN logic which wants to put an ID in the JWTs we generate.
+        """
+        primary_key = self.get_primary_key_value()
+        if len(primary_key) != 1:
+            raise Exception("Unexpected number of primary keys for user, expected exactly 1")
+
+        return primary_key[0]
 
 
 class BaseUserTokenSession(Base):
     __abstract__ = True
-
-    # The concrete table redeclares this with a ForeignKey to the user table.
-    user_id: Mapped[uuid.UUID] = mapped_column(primary_key=True)
 
     token_id: Mapped[uuid.UUID] = mapped_column(primary_key=True)
 
@@ -40,7 +46,6 @@ class BaseUserTokenSession(Base):
 class BaseUserApiKey(Base):
     __abstract__ = True
 
-    api_key_id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     key_name: Mapped[str]
     key_id: Mapped[str] = mapped_column(
         unique=True, index=True, comment="AWS API Gateway key identifier"
@@ -54,8 +59,6 @@ class BaseUserApiKey(Base):
 class BaseLoginGovState(Base):
     __abstract__ = True
 
-    login_gov_state_id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True)
-
     # https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes
     nonce: Mapped[uuid.UUID]
 
@@ -64,8 +67,5 @@ class BaseLinkExternalUser(Base):
     __abstract__ = True
 
     external_user_id: Mapped[str] = mapped_column(index=True, unique=True)
-
-    # The concrete table redeclares this with a ForeignKey to the user table.
-    user_id: Mapped[uuid.UUID] = mapped_column(index=True)
 
     email: Mapped[str] = mapped_column(index=True)

--- a/backend/grants_shared/src/grants_shared/db/models/base.py
+++ b/backend/grants_shared/src/grants_shared/db/models/base.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlalchemy import TIMESTAMP, MetaData, Text, inspect
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import DeclarativeBase, Mapped, declarative_mixin, mapped_column
+from sqlalchemy.orm.util import identity_key
 from sqlalchemy.sql.functions import now as sqlnow
 
 from grants_shared.util import datetime_util
@@ -84,6 +85,11 @@ class Base(DeclarativeBase):
         See https://rich.readthedocs.io/en/latest/pretty.html#rich-repr-protocol
         """
         return self._dict().items()
+
+    def get_primary_key_value(self) -> tuple:
+        """Get the primary key value for the model as a tuple."""
+        # Note that identity_key returns some other info, but we just return the primary key tuple
+        return identity_key(instance=self)[1]
 
 
 def same_as_created_at(context: Any) -> Any:

--- a/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
+++ b/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
@@ -6,8 +6,8 @@ import pytest
 from freezegun import freeze_time
 
 from grants_shared.auth.api_jwt_auth import ApiJwtConfig, JwtAuth
-from tests.grants_shared.db.models.factories import LinkExternalUserFactory, UserFactory
-from tests.grants_shared.db_test_models.db_test_models import UserTokenSession
+from tests.grants_shared.db.models.factories import SharedLinkExternalUserFactory, SharedUserFactory
+from tests.grants_shared.db_test_models.db_test_models import SharedUserTokenSession
 from tests.grants_shared.test_utils.auth_handler import AuthHandler
 
 
@@ -21,8 +21,8 @@ def jwt_config(private_rsa_key, public_rsa_key):
 
 @freeze_time("2024-11-14 12:00:00", tz_offset=0)
 def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
-    user = UserFactory.create()
-    linked_external_user = LinkExternalUserFactory.create(user=user)
+    user = SharedUserFactory.create()
+    linked_external_user = SharedLinkExternalUserFactory.create(shared_user=user)
     token, token_session = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(
         user, None
     )
@@ -35,7 +35,7 @@ def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
     assert decoded_token["iat"] == timegm(
         datetime.fromisoformat("2024-11-14 12:00:00+00:00").utctimetuple()
     )
-    assert decoded_token["user_id"] == str(user.user_id)
+    assert decoded_token["user_id"] == str(user.shared_user_id)
     assert decoded_token["email"] is None
     assert decoded_token["iss"] == jwt_config.issuer
     assert decoded_token["aud"] == jwt_config.audience
@@ -50,19 +50,19 @@ def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
 
     # Verify that the sub_id returned can be used to fetch a UserTokenSession object
     token_session = (
-        db_session.query(UserTokenSession)
-        .filter(UserTokenSession.token_id == decoded_token["sub"])
+        db_session.query(SharedUserTokenSession)
+        .filter(SharedUserTokenSession.token_id == decoded_token["sub"])
         .one_or_none()
     )
 
-    assert token_session.user_id == user.user_id
+    assert token_session.shared_user_id == user.shared_user_id
     assert token_session.is_valid is True
     # Verify expires_at is set to 30 minutes after now by default
     assert token_session.expires_at == datetime.fromisoformat("2024-11-14 12:30:00+00:00")
 
     # Basic testing that the JWT we create for a user can in turn be fetched and processed later
     user_session = JwtAuth(AuthHandler(db_session), jwt_config).parse_jwt_for_user(token)
-    assert user_session.user_id == user.user_id
+    assert user_session.shared_user_id == user.shared_user_id
 
 
 # TODO: Unit tests that need to be added:

--- a/backend/grants_shared/tests/grants_shared/db/models/factories.py
+++ b/backend/grants_shared/tests/grants_shared/db/models/factories.py
@@ -85,27 +85,27 @@ class FriendTableFactory(BaseFactory):
     )
 
 
-class UserFactory(BaseFactory):
+class SharedUserFactory(BaseFactory):
     class Meta:
-        model = db_test_models.User
+        model = db_test_models.SharedUser
 
-    user_id = Generators.UuidObj
+    shared_user_id = Generators.UuidObj
 
 
-class LinkExternalUserFactory(BaseFactory):
+class SharedLinkExternalUserFactory(BaseFactory):
     class Meta:
-        model = db_test_models.LinkExternalUser
+        model = db_test_models.SharedLinkExternalUser
 
     link_external_user_id = Generators.UuidObj
     external_user_id = Generators.UuidObj
-    user = factory.SubFactory(UserFactory)
-    user_id = factory.LazyAttribute(lambda s: s.user.user_id)
+    shared_user = factory.SubFactory(SharedUserFactory)
+    shared_user_id = factory.LazyAttribute(lambda s: s.shared_user.shared_user_id)
     email = factory.Faker("email")
 
 
-class LoginGovStateFactory(BaseFactory):
+class SharedLoginGovStateFactory(BaseFactory):
     class Meta:
-        model = db_test_models.LoginGovState
+        model = db_test_models.SharedLoginGovState
 
-    login_gov_state_id = Generators.UuidObj
+    shared_login_gov_state_id = Generators.UuidObj
     nonce = Generators.UuidObj

--- a/backend/grants_shared/tests/grants_shared/db_test_models/db_test_models.py
+++ b/backend/grants_shared/tests/grants_shared/db_test_models/db_test_models.py
@@ -179,13 +179,15 @@ class LinkFriendType(OtherSchemaTable, TimestampMixin):
     )
 
 
-class User(BaseUser, OtherSchemaTable, TimestampMixin):
-    __tablename__ = "user"
+class SharedUser(BaseUser, OtherSchemaTable, TimestampMixin):
+    __tablename__ = "shared_user"
 
-    linked_login_gov_external_user: Mapped[LinkExternalUser | None] = relationship(
-        "LinkExternalUser",
+    shared_user_id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
+
+    linked_login_gov_external_user: Mapped[SharedLinkExternalUser | None] = relationship(
+        "SharedLinkExternalUser",
         primaryjoin=lambda: and_(
-            LinkExternalUser.user_id == User.user_id,
+            SharedLinkExternalUser.shared_user_id == SharedUser.shared_user_id,
         ),
         uselist=False,
         viewonly=True,
@@ -198,22 +200,28 @@ class User(BaseUser, OtherSchemaTable, TimestampMixin):
         return None
 
 
-class LinkExternalUser(BaseLinkExternalUser, OtherSchemaTable, TimestampMixin):
-    __tablename__ = "link_external_user"
+class SharedLinkExternalUser(BaseLinkExternalUser, OtherSchemaTable, TimestampMixin):
+    __tablename__ = "shared_link_external_user"
 
     link_external_user_id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey(User.user_id), index=True)
-    user: Mapped[User] = relationship(User)
+    shared_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(SharedUser.shared_user_id), index=True
+    )
+    shared_user: Mapped[SharedUser] = relationship(SharedUser)
 
 
-class UserTokenSession(BaseUserTokenSession, OtherSchemaTable, TimestampMixin):
-    __tablename__ = "user_token_session"
+class SharedUserTokenSession(BaseUserTokenSession, OtherSchemaTable, TimestampMixin):
+    __tablename__ = "shared_user_token_session"
 
-    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey(User.user_id), primary_key=True)
-    user: Mapped[User] = relationship(User)
+    shared_user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey(SharedUser.shared_user_id), primary_key=True
+    )
+    shared_user: Mapped[SharedUser] = relationship(SharedUser)
 
 
-class LoginGovState(BaseLoginGovState, OtherSchemaTable, TimestampMixin):
+class SharedLoginGovState(BaseLoginGovState, OtherSchemaTable, TimestampMixin):
     """Table used to store temporary state during the OAuth login flow"""
 
-    __tablename__ = "login_gov_state"
+    __tablename__ = "shared_login_gov_state"
+
+    shared_login_gov_state_id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True)

--- a/backend/grants_shared/tests/grants_shared/services/users/test_login_gov_callback_handler.py
+++ b/backend/grants_shared/tests/grants_shared/services/users/test_login_gov_callback_handler.py
@@ -1,7 +1,7 @@
 import pytest
 
 from grants_shared.auth.api_jwt_auth import ApiJwtConfig, JwtAuth
-from tests.grants_shared.db.models.factories import LoginGovStateFactory
+from tests.grants_shared.db.models.factories import SharedLoginGovStateFactory
 from tests.grants_shared.test_utils.auth_handler import AuthHandler
 from tests.grants_shared.test_utils.login_gov_callback_handler import LoginGovCallbackHandler
 
@@ -32,10 +32,10 @@ def test_login_callback_handler_handle_callback_request(
     auth_handler = AuthHandler(db_session)
     jwt_auth = JwtAuth(auth_handler, jwt_config)
     login_gov_callback_handler = LoginGovCallbackHandler(auth_handler, jwt_auth)
-    login_gov_state = LoginGovStateFactory.create()
+    login_gov_state = SharedLoginGovStateFactory.create()
     query = {
         "code": "1234",
-        "state": str(login_gov_state.login_gov_state_id),
+        "state": str(login_gov_state.shared_login_gov_state_id),
     }
     login_gov_data_container = login_gov_callback_handler.handle_callback_request(query)
     assert login_gov_data_container.code == query["code"]

--- a/backend/grants_shared/tests/grants_shared/test_utils/auth_handler.py
+++ b/backend/grants_shared/tests/grants_shared/test_utils/auth_handler.py
@@ -2,22 +2,27 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from grants_shared.auth.auth_handler import AbstractAuthHandler
-from tests.grants_shared.db_test_models.db_test_models import LoginGovState, UserTokenSession
+from tests.grants_shared.db_test_models.db_test_models import (
+    SharedLoginGovState,
+    SharedUserTokenSession,
+)
 
 
 class AuthHandler(AbstractAuthHandler):
     """Concrete auth handler backed by the API's user tables."""
 
     def create_token_session(self, user, token_id, expires_at):
-        user_token_session = UserTokenSession(user=user, token_id=token_id, expires_at=expires_at)
+        user_token_session = SharedUserTokenSession(
+            shared_user=user, token_id=token_id, expires_at=expires_at
+        )
         self.db_session.add(user_token_session)
         return user_token_session
 
-    def get_token_session_by_token_id(self, token_id: str) -> UserTokenSession | None:
+    def get_token_session_by_token_id(self, token_id: str) -> SharedUserTokenSession | None:
         return self.db_session.execute(
-            select(UserTokenSession)
-            .where(UserTokenSession.token_id == token_id)
-            .options(selectinload(UserTokenSession.user))
+            select(SharedUserTokenSession)
+            .where(SharedUserTokenSession.token_id == token_id)
+            .options(selectinload(SharedUserTokenSession.shared_user))
         ).scalar()
 
     def get_api_key_by_key_id(self, key_id): ...
@@ -32,7 +37,9 @@ class AuthHandler(AbstractAuthHandler):
 
     def get_login_gov_state(self, state_id):
         return self.db_session.execute(
-            select(LoginGovState).where(LoginGovState.login_gov_state_id == state_id)
+            select(SharedLoginGovState).where(
+                SharedLoginGovState.shared_login_gov_state_id == state_id
+            )
         ).scalar_one_or_none()
 
     def get_link_external_user(self, external_user_id): ...

--- a/backend/grants_shared/uv.lock
+++ b/backend/grants_shared/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.12"
+version = "0.2.13"
 source = { virtual = "." }
 dependencies = [
     { name = "apiflask" },


### PR DESCRIPTION
## Summary
Work for #11022 

First of 3 parts. 2nd part will fix the API to use this. 3rd part will setup auth in the grants management API.

## Changes proposed
Removed the primary key definitions from the base user/auth tables

## Context for reviewers
After some recent discussions, we want our user/auth tables which exist in both sides of the system to have distinct names (eg. avoid having `user` on both sides, but instead we want `grants_mgmt_user`). Since our approach also always makes our primary keys `<table>_id`, we don't want the primary keys defined in the base table. We'll need to define them in each given implementation instead. Only the other data columns will be defined in the base table. A follow-up PR will fix the definitions in our simpler grants API before we port this to grants management (note those tables will stay `user` for now as that's a larger refactor).

The main non-table change needed were the few places we refer to the `user_id`. I made a new function that gets the user ID primary key - and automatically handles it for any derived implementations. None of the other primary keys are ever used in the generic part of the implementation.

## Validation steps
To verify all this works, I renamed/reworked the test DB tables to all be `shared_X`. 
