### PR TITLE
[#Issue 11295] Remove mime header to fix parsing

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -344,7 +344,6 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         )
         boundary_uuid = str(uuid.uuid4())
         update_headers = {
-            "MIME-Version": "1.0",
             "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{boundary_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
             # TODO: removing till we can confirm GS needs this
             # "Soapaction": self.operation_config.soap_action,

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -476,7 +476,6 @@ class TestSimplerSOAPGetApplicationZip:
             assert result.status_code == 200
             assert result.headers == {
                 "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{BOUNDARY_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-                "MIME-Version": "1.0",
             }
 
     def test_get_simpler_soap_response_returns_soap_action_in_header(
@@ -520,7 +519,6 @@ class TestSimplerSOAPGetApplicationZip:
             result = client.get_simpler_soap_response(mock_proxy_response)
             assert result.headers == {
                 "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{BOUNDARY_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-                "MIME-Version": "1.0",
             }
 
     def test_get_simpler_soap_response_can_access_endpoint_if_certificate_user_has_privileges(
@@ -797,7 +795,6 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             assert result.status_code == 200
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-                "MIME-Version": "1.0",
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects(
@@ -897,7 +894,6 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             assert result.status_code == 200
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-                "MIME-Version": "1.0",
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects_merges_response_from_proxy_and_simpler(
@@ -1548,7 +1544,6 @@ class TestSimplerSOAPGetSubmissionList:
             assert result.status_code == 200
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-                "MIME-Version": "1.0",
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects(
@@ -1646,7 +1641,6 @@ class TestSimplerSOAPGetSubmissionList:
             assert result.status_code == 200
             assert result.headers == {
                 "Content-Type": 'multipart/related; type="application/xop+xml"; boundary="uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-                "MIME-Version": "1.0",
             }
 
     def test_get_simpler_soap_response_returns_multiple_objects_merges_response_from_proxy_and_simpler(


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11295  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Removed Mime from header in response.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We suspect from the logs that this Mime header might be causing the parsing issues we've been seeing.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] Grant Solutions can hit the proxy and parse the response.
