### PR TITLE
[Issue #11022] (2/4) Fix tables to expose log info in a generic pattern

### DIFF
--- a/backend/grants_shared/pyproject.toml
+++ b/backend/grants_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grants-shared"
-version = "0.2.13"
+version = "0.2.14"
 description = "Shared code used by the Simpler Grants.gov repo"
 readme = "README.md"
 license = "CC0-1.0"

--- a/backend/grants_shared/src/grants_shared/db/models/auth_base_models.py
+++ b/backend/grants_shared/src/grants_shared/db/models/auth_base_models.py
@@ -10,6 +10,7 @@ without it referencing the concrete API tables directly.
 
 import uuid
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -31,6 +32,10 @@ class BaseUser(Base):
 
         return primary_key[0]
 
+    def get_log_extra(self) -> dict[str, Any]:
+        """Get logging info, do not include anything secretive in this function - extend it in derived classes to add more"""
+        return {"auth.user_id": self.get_user_id()}
+
 
 class BaseUserTokenSession(Base):
     __abstract__ = True
@@ -42,6 +47,13 @@ class BaseUserTokenSession(Base):
     # When a user logs out, we set this flag to False.
     is_valid: Mapped[bool] = mapped_column(default=True)
 
+    def get_log_extra(self) -> dict[str, Any]:
+        """Get logging info, do not include anything secretive in this function - extend it in derived classes to add more"""
+        return {
+            "auth.token_id": self.token_id,
+            "auth.expires_at": self.expires_at,
+        }
+
 
 class BaseUserApiKey(Base):
     __abstract__ = True
@@ -50,8 +62,6 @@ class BaseUserApiKey(Base):
     key_id: Mapped[str] = mapped_column(
         unique=True, index=True, comment="AWS API Gateway key identifier"
     )
-    # The concrete table redeclares this with a ForeignKey to the user table.
-    user_id: Mapped[uuid.UUID] = mapped_column(index=True)
     last_used: Mapped[datetime | None]
     is_active: Mapped[bool] = mapped_column(default=True)
 

--- a/backend/grants_shared/src/grants_shared/db/models/base.py
+++ b/backend/grants_shared/src/grants_shared/db/models/base.py
@@ -91,6 +91,11 @@ class Base(DeclarativeBase):
         # Note that identity_key returns some other info, but we just return the primary key tuple
         return identity_key(instance=self)[1]
 
+    def get_log_extra(self) -> dict[str, Any]:
+        """Get logging info, do not include anything secretive in this function - extend it in derived classes to add more"""
+        # nothing at this layer, derived classes can extend
+        return {}
+
 
 def same_as_created_at(context: Any) -> Any:
     return context.get_current_parameters()["created_at"]

--- a/backend/grants_shared/uv.lock
+++ b/backend/grants_shared/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.13"
+version = "0.2.14"
 source = { virtual = "." }
 dependencies = [
     { name = "apiflask" },


### PR DESCRIPTION
## Summary
Work for #11022

## Changes proposed
* Adjusted how our auth tables expose their keys for logging

## Context for reviewers
When trying to adjust the DB tables/authN logic to allow for generically defined primary keys, ran into several issues with needing a way to generically get the primary key for logging purposes (eg. to log `user_id` regardless of what the column is actually called). This problem only comes up in our generic logic for logging, so just made it so our DB tables have a `get_log_extra` function that we can override in derived classes to set as needed. We already have this sort of pattern on a few tables, it just further establishes it.

## Validation steps
n/a - just exposing some logging utils to be used on the API side
