### PR TITLE
Move maintenance mode logic to grants_shared

### DIFF
--- a/backend/grants_shared/src/grants_shared/api/maintenance_mode.py
+++ b/backend/grants_shared/src/grants_shared/api/maintenance_mode.py
@@ -1,0 +1,74 @@
+import logging
+from collections.abc import Collection
+from enum import StrEnum
+from functools import cache
+
+from apiflask import APIFlask
+from flask import request
+from pydantic import Field
+
+from grants_shared.api.route_utils import raise_flask_error
+from grants_shared.util.env_config import PydanticBaseEnvConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MaintenanceModeLogEvent(StrEnum):
+    """Distinct, queryable event types for maintenance-mode log records."""
+
+    REQUEST_REJECTED = "maintenance_mode_request_rejected"
+
+
+class MaintenanceModeConfig(PydanticBaseEnvConfig):
+    """Configuration for maintenance mode.
+
+    The flag is sourced from SSM Parameter Store and injected into each container
+    as the ``ENABLE_MAINTENANCE_MODE`` env var at task launch. Flipping it is an ops
+    action (update SSM + force-new-deployment), not a code deploy, so the value is
+    fixed for the lifetime of a task and can be read once and cached.
+    """
+
+    enable_maintenance_mode: bool = Field(False, alias="ENABLE_MAINTENANCE_MODE")
+    retry_after_seconds: int = Field(3600, alias="MAINTENANCE_RETRY_AFTER_SECONDS")
+
+
+@cache
+def get_maintenance_mode_config() -> MaintenanceModeConfig:
+    # Cached since the env var is resolved at task launch; changing it requires a
+    # new deployment (and therefore a new process) anyway.
+    return MaintenanceModeConfig()
+
+
+def is_maintenance_mode_enabled() -> bool:
+    return get_maintenance_mode_config().enable_maintenance_mode
+
+
+def register_maintenance_mode_handler(app: APIFlask, allowlist: Collection[str]) -> None:
+    """Register a ``before_request`` handler that returns a 503 for every request
+    while maintenance mode is enabled, except for paths in ``allowlist``.
+
+    Register this after logging is initialized (so rejections still produce the
+    normal start/end request logs) and before authentication (so unauthenticated
+    clients receive a 503 rather than a 401). ``allowlist`` is the per-system set of
+    paths that must keep serving during a maintenance window (e.g. ``{"/health"}``
+    so ALB/Docker healthchecks stay green).
+    """
+    allowed_paths = frozenset(allowlist)
+
+    @app.before_request
+    def reject_if_maintenance_mode() -> None:
+        if not is_maintenance_mode_enabled():
+            return
+
+        if request.path in allowed_paths:
+            return
+
+        logger.info(
+            "Request rejected due to maintenance mode",
+            extra={"maintenance_mode_event": MaintenanceModeLogEvent.REQUEST_REJECTED},
+        )
+        raise_flask_error(
+            503,
+            message="API is undergoing scheduled maintenance",
+            headers={"Retry-After": str(get_maintenance_mode_config().retry_after_seconds)},
+        )

--- a/backend/grants_shared/tests/grants_shared/api/test_maintenance_mode.py
+++ b/backend/grants_shared/tests/grants_shared/api/test_maintenance_mode.py
@@ -1,0 +1,136 @@
+import logging
+
+import pytest
+from apiflask import APIFlask
+
+import grants_shared.logs
+from grants_shared.api.maintenance_mode import (
+    MaintenanceModeLogEvent,
+    get_maintenance_mode_config,
+    is_maintenance_mode_enabled,
+    register_maintenance_mode_handler,
+)
+from grants_shared.api.response import restructure_error_response
+from grants_shared.api.schemas.response_schema import ErrorResponseSchema
+
+ALLOW_LISTED_PATH = "/health"
+
+
+@pytest.fixture(autouse=True)
+def clear_maintenance_config_cache():
+    get_maintenance_mode_config.cache_clear()
+    yield
+    get_maintenance_mode_config.cache_clear()
+
+
+@pytest.fixture
+def enable_maintenance_mode(monkeypatch):
+    monkeypatch.setenv("ENABLE_MAINTENANCE_MODE", "true")
+    get_maintenance_mode_config.cache_clear()
+
+
+@pytest.fixture
+def maintenance_client(monkeypatch):
+    app = APIFlask(__name__, title="maintenance_test_app")
+    app.config["HTTP_ERROR_SCHEMA"] = ErrorResponseSchema
+    app.config["VALIDATION_ERROR_SCHEMA"] = ErrorResponseSchema
+
+    @app.error_processor
+    def error_processor(error):
+        return restructure_error_response(error)
+
+    register_maintenance_mode_handler(app, {ALLOW_LISTED_PATH})
+
+    @app.get("/example")
+    def example():
+        return {"message": "ok"}
+
+    @app.get(ALLOW_LISTED_PATH)
+    def health():
+        return {"message": "healthy"}
+
+    with grants_shared.logs.init(__package__):
+        yield app.test_client()
+
+
+#################
+# Config / helper
+#################
+
+
+def test_maintenance_mode_defaults_to_disabled(monkeypatch):
+    monkeypatch.delenv("ENABLE_MAINTENANCE_MODE", raising=False)
+    assert is_maintenance_mode_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["true", "True", "TRUE", "1"])
+def test_maintenance_mode_enabled_for_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("ENABLE_MAINTENANCE_MODE", value)
+    assert is_maintenance_mode_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "False", "FALSE", "0"])
+def test_maintenance_mode_disabled_for_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("ENABLE_MAINTENANCE_MODE", value)
+    assert is_maintenance_mode_enabled() is False
+
+
+def test_retry_after_seconds_defaults_to_3600(monkeypatch):
+    monkeypatch.delenv("MAINTENANCE_RETRY_AFTER_SECONDS", raising=False)
+    assert get_maintenance_mode_config().retry_after_seconds == 3600
+
+
+def test_retry_after_seconds_honors_override(monkeypatch):
+    monkeypatch.setenv("MAINTENANCE_RETRY_AFTER_SECONDS", "120")
+    assert get_maintenance_mode_config().retry_after_seconds == 120
+
+
+#################
+# Handler
+#################
+
+
+def test_request_proceeds_normally_when_maintenance_mode_off(maintenance_client):
+    response = maintenance_client.get("/example")
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "ok"
+
+
+def test_non_allow_listed_request_returns_503_when_maintenance_mode_on(
+    maintenance_client, enable_maintenance_mode
+):
+    response = maintenance_client.get("/example")
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == str(get_maintenance_mode_config().retry_after_seconds)
+
+    resp_json = response.get_json()
+    assert resp_json["message"] == "API is undergoing scheduled maintenance"
+    assert resp_json["status_code"] == 503
+    assert resp_json["errors"] == []
+
+
+def test_allow_listed_path_is_served_when_maintenance_mode_on(
+    maintenance_client, enable_maintenance_mode
+):
+    response = maintenance_client.get(ALLOW_LISTED_PATH)
+
+    assert response.status_code == 200
+    assert response.get_json()["message"] == "healthy"
+
+
+def test_maintenance_rejection_emits_distinct_log_event(
+    maintenance_client, enable_maintenance_mode, caplog
+):
+    caplog.set_level(logging.INFO)
+
+    maintenance_client.get("/example")
+
+    rejection_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "maintenance_mode_event", None)
+        == MaintenanceModeLogEvent.REQUEST_REJECTED
+    ]
+    assert len(rejection_records) == 1
+    assert rejection_records[0].message == "Request rejected due to maintenance mode"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10855  

## Changes proposed

Created maintenance_mode.py and test_maintenance_mode.py in grants_shared

- Created maintenance_mode.py to add the `MaintenanceModeConfig` reading `ENABLE_MAINTENANCE_MODE`/`MAINTENANCE_RETRY_AFTER_SECONDS`, a cached `get_maintenance_mode_config()`, the `is_maintenance_mode_enabled()` helper, and the `MaintenanceModeLogEvent` enum
- Created test_maintenance_mode.py to cover the config/helper

## Context for reviewers

This is the primary logic for enabling maintenance mode for the API. In order to make it part of the grants_shared package, it must be merged on it's own first (making this PR 1). The second PR (11357) already exists. 

## Validation steps

Confirm tests pass.