### PR TITLE
[Issue #11022] (3/4) Adjust API table defintions for user/authN tables to use more generic approach

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "urllib3>=2.7.0,<3",
     "python-statemachine>=3.0.0,<4",
     "beautifulsoup4>=4.14.3,<5",
-    "grants-shared==0.2.12",
+    "grants-shared==0.2.14",
 ]
 
 [project.scripts]

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -591,11 +591,7 @@ def user_create_api_key(
 
     logger.info(
         "Created API key for user",
-        extra={
-            "user_id": user_id,
-            "api_key_id": api_key.api_key_id,
-            "key_name": api_key.key_name,
-        },
+        extra=api_key.get_log_extra(),
     )
 
     return response.ApiResponse(message="Success", data=api_key)

--- a/api/src/auth/api_jwt_auth.py
+++ b/api/src/auth/api_jwt_auth.py
@@ -60,12 +60,7 @@ def decode_token(db_session: db.Session, token: str) -> BaseUserTokenSession:
     try:
         user_token_session = parse_jwt_for_user(token, db_session)
 
-        add_extra_data_to_current_request_logs(
-            {
-                "auth.user_id": user_token_session.user_id,
-                "auth.token_id": user_token_session.token_id,
-            }
-        )
+        add_extra_data_to_current_request_logs(user_token_session.get_log_extra())
         logger.info("JWT Authentication Successful")
 
         # Return the user token session object

--- a/api/src/auth/api_user_key_auth.py
+++ b/api/src/auth/api_user_key_auth.py
@@ -66,12 +66,7 @@ def verify_api_key(db_session: db.Session, token: str) -> BaseUserApiKey:
         api_key.last_used = datetime_util.utcnow()
         db_session.add(api_key)
 
-        add_extra_data_to_current_request_logs(
-            {
-                "auth.user_id": api_key.user_id,
-                "auth.api_key_id": str(api_key.api_key_id),
-            }
-        )
+        add_extra_data_to_current_request_logs(api_key.get_log_extra())
 
         logger.info("API Gateway key authentication successful")
 

--- a/api/src/db/models/user_models.py
+++ b/api/src/db/models/user_models.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import date, datetime
+from typing import Any
 
 from grants_shared.adapters.db.type_decorators.postgres_type_decorators import LookupColumn
 from grants_shared.db.models.auth_base_models import (
@@ -28,6 +29,8 @@ from src.db.models.opportunity_models import Opportunity
 
 class User(BaseUser, ApiSchemaTable, TimestampMixin):
     __tablename__ = "user"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True, default=uuid.uuid4)
 
     saved_opportunities: Mapped[list[UserSavedOpportunity]] = relationship(
         "UserSavedOpportunity",
@@ -131,13 +134,24 @@ class UserTokenSession(BaseUserTokenSession, ApiSchemaTable, TimestampMixin):
     __tablename__ = "user_token_session"
 
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey(User.user_id), primary_key=True)
+    token_id: Mapped[uuid.UUID] = mapped_column(primary_key=True)
+
     user: Mapped[User] = relationship(User)
+
+    def get_log_extra(self) -> dict[str, Any]:
+        """Get logging info"""
+        return {
+            "auth.token_id": self.token_id,
+            "auth.user_id": self.user_id,
+        }
 
 
 class LoginGovState(BaseLoginGovState, ApiSchemaTable, TimestampMixin):
     """Table used to store temporary state during the OAuth login flow"""
 
     __tablename__ = "login_gov_state"
+
+    login_gov_state_id: Mapped[uuid.UUID] = mapped_column(UUID, primary_key=True)
 
 
 class UserSavedOpportunity(ApiSchemaTable, TimestampMixin):
@@ -347,9 +361,18 @@ class UserApiKey(BaseUserApiKey, ApiSchemaTable, TimestampMixin):
 
     __tablename__ = "user_api_key"
 
+    api_key_id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey(User.user_id), index=True)
 
     user: Mapped[User] = relationship(User, back_populates="api_keys", uselist=False)
+
+    def get_log_extra(self) -> dict[str, Any]:
+        """Get logging info"""
+        return {
+            "auth.api_key_id": self.api_key_id,
+            "auth.user_id": self.user_id,
+        }
 
 
 class Role(ApiSchemaTable, TimestampMixin):

--- a/api/src/services/internal/setup_file_scan_scanner_user.py
+++ b/api/src/services/internal/setup_file_scan_scanner_user.py
@@ -101,7 +101,7 @@ def _create_api_key(db_session: db.Session, user: User) -> UserApiKey:
     )
     logger.info(
         "Registered file-scan scanner API key",
-        extra={"user_id": user.user_id, "api_key_id": api_key.api_key_id},
+        extra={"user_id": user.user_id} | api_key.get_log_extra(),
     )
     return api_key
 

--- a/api/src/services/users/create_api_key.py
+++ b/api/src/services/users/create_api_key.py
@@ -49,12 +49,7 @@ def create_api_key(db_session: db.Session, user_id: UUID, json_data: dict) -> Ba
 
     logger.info(
         "Created new API key",
-        extra={
-            "api_key_id": api_key.api_key_id,
-            "user_id": user_id,
-            "key_name": key_name,
-            "is_active": api_key.is_active,
-        },
+        extra=api_key.get_log_extra(),
     )
 
     return api_key
@@ -65,10 +60,17 @@ def _import_api_key_to_aws_gateway(api_key: BaseUserApiKey) -> None:
     try:
         config = ApiGatewayConfig()
 
+        # Use the log extra to get info for the description we put in api gateway
+        # Will look like "api_key_id=<uuid>, user_id=<uuid>" depending on what is added to the
+        # log extra function of the derived implementation.
+        description_info = ", ".join(
+            [f"{k.removeprefix('auth.')}={v}" for k, v in api_key.get_log_extra().items()]
+        )
+
         gateway_response = import_api_key(
             api_key=api_key.key_id,
             name=api_key.key_name,
-            description=f"API key for user {api_key.user_id}",
+            description=f"API key for {description_info}",
             enabled=api_key.is_active,
             usage_plan_id=config.default_usage_plan_id,
         )
@@ -76,10 +78,10 @@ def _import_api_key_to_aws_gateway(api_key: BaseUserApiKey) -> None:
         logger.info(
             "Successfully imported API key to AWS API Gateway and associated with usage plan",
             extra={
-                "api_key_id": api_key.api_key_id,
                 "gateway_key_id": gateway_response.id,
                 "usage_plan_id": config.default_usage_plan_id,
-            },
+            }
+            | api_key.get_log_extra(),
         )
 
     except Exception as e:

--- a/api/src/services/users/rename_api_key.py
+++ b/api/src/services/users/rename_api_key.py
@@ -28,10 +28,7 @@ def rename_api_key(
 
     logger.info(
         "Renamed API key",
-        extra={
-            "api_key_id": api_key.api_key_id,
-            "user_id": user_id,
-        },
+        extra=api_key.get_log_extra(),
     )
 
     return api_key

--- a/api/tests/src/services/users/test_create_api_key.py
+++ b/api/tests/src/services/users/test_create_api_key.py
@@ -159,12 +159,8 @@ def test_create_api_key_logging_success(enable_factory_create, db_session: db.Se
     log_record = next(
         record for record in caplog.records if "Created new API key" in record.message
     )
-    assert hasattr(log_record, "api_key_id")
-    assert str(log_record.api_key_id) == str(api_key.api_key_id)
-    assert hasattr(log_record, "user_id")
-    assert str(log_record.user_id) == str(user.user_id)
-    assert hasattr(log_record, "key_name")
-    assert log_record.key_name == key_name
+    assert str(getattr(log_record, "auth.api_key_id")) == str(api_key.api_key_id)
+    assert str(getattr(log_record, "auth.user_id")) == str(api_key.user_id)
 
 
 def test_create_api_key_logging_max_retries(enable_factory_create, db_session: db.Session, caplog):

--- a/api/tests/src/services/users/test_rename_api_key.py
+++ b/api/tests/src/services/users/test_rename_api_key.py
@@ -122,10 +122,8 @@ def test_rename_api_key_logging_success(enable_factory_create, db_session: db.Se
     assert any("Renamed API key" in record.message for record in caplog.records)
 
     log_record = next(record for record in caplog.records if "Renamed API key" in record.message)
-    assert hasattr(log_record, "api_key_id")
-    assert str(log_record.api_key_id) == str(api_key.api_key_id)
-    assert hasattr(log_record, "user_id")
-    assert str(log_record.user_id) == str(user.user_id)
+    assert str(getattr(log_record, "auth.api_key_id")) == str(api_key.api_key_id)
+    assert str(getattr(log_record, "auth.user_id")) == str(api_key.user_id)
 
 
 def test_rename_api_key_multiple_keys_same_user(enable_factory_create, db_session: db.Session):

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -606,7 +606,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.12"
+version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apiflask" },
@@ -629,9 +629,9 @@ dependencies = [
     { name = "smart-open" },
     { name = "sqlalchemy", extra = ["mypy"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/4e/3bdae36e613926c89510ca6771d2a9ce17cb28d23bdd36a5520257605980/grants_shared-0.2.12.tar.gz", hash = "sha256:fff98f0a3642e1f181376baa5d261d2809cef67552d526d49b47a0f779beb316", size = 68987, upload-time = "2026-07-06T17:38:32.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/9c/9d5a3b5e2e8d0c8e08d1f28832dca7b6c1f6c30a716a1eb978bfa1b2ba0e/grants_shared-0.2.14.tar.gz", hash = "sha256:a24882c586c2d9ad9c61788b4bf613e2a7b66ffa6f0233fa019a142e4a116500", size = 69312, upload-time = "2026-07-08T14:03:27.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/e3/92f7a87f3c5198569551a2a8ac185bbee9e36113b9bc8b8ab736ca7c0e18/grants_shared-0.2.12-py3-none-any.whl", hash = "sha256:03d8524be32971391f797fd8b3b539725dff429d70c78bbd2824848dda2ca8db", size = 89395, upload-time = "2026-07-06T17:38:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/22/19683889d0e18c467c5f0f1d74d353b341ac6fce5ec3ba174ea2c5442a4b/grants_shared-0.2.14-py3-none-any.whl", hash = "sha256:582b4e0443b6fe5ead5efa0c2d1a292d16276fe2d089dc95c595a0746f80e30f", size = 89865, upload-time = "2026-07-08T14:03:25.96Z" },
 ]
 
 [[package]]
@@ -1773,7 +1773,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1,<0.8" },
     { name = "docraptor", specifier = ">=3.0.0,<4" },
     { name = "flask-cors", specifier = ">=6.0.0,<7" },
-    { name = "grants-shared", specifier = "==0.2.12" },
+    { name = "grants-shared", specifier = "==0.2.14" },
     { name = "gunicorn", specifier = ">=23.0.0,<24" },
     { name = "jinja2", specifier = ">=3.1.5" },
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },


### PR DESCRIPTION
## Summary
Work for #11022

## Changes proposed
* Adjusted the user/authN tables to instead define primary keys in derived implementations
* Adjusted some logging in the api key logic to handle generic implementations

## Context for reviewers
To make it easier to define our user/authN tables with more specific names (eg. `grants_mgmt_user` instead of just `user`) we adjusted the base tables for user/authN to no longer define the primary keys. Our core shared logic doesn't use the primary key values except for logging. So, to work around that, I made it so each table can specify a log extra object for that purpose and we simply implement it on each side of the system to get the desired logging.

## Validation steps
None of the tables are actually changed, I simply added back the primary keys that I removed from the base tables.
