### PR TITLE
[Issue #10648] Add Delete Functionality to Award Rec List Table

### DIFF
--- a/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListTable.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListTable.test.tsx
@@ -157,24 +157,26 @@ describe("AwardRecommendationsListTable", () => {
 
   it("calls delete endpoint when delete is clicked", async () => {
     let deleted = false;
-    mockClientFetch.mockImplementation(async (_url, options) => {
-      if (options?.method === "DELETE") {
-        deleted = true;
-        return {};
-      }
+    mockClientFetch.mockImplementation(
+      (_url: string, options?: RequestInit): unknown => {
+        if (options?.method === "DELETE") {
+          deleted = true;
+          return {};
+        }
 
-      if (deleted) {
+        if (deleted) {
+          return {
+            data: [],
+            pagination_info: { total_pages: 1, total_records: 0 },
+          };
+        }
+
         return {
-          data: [],
-          pagination_info: { total_pages: 1, total_records: 0 },
+          data: [mockDraftAwardRecommendationListItem],
+          pagination_info: { total_pages: 1, total_records: 1 },
         };
-      }
-
-      return {
-        data: [mockDraftAwardRecommendationListItem],
-        pagination_info: { total_pages: 1, total_records: 1 },
-      };
-    });
+      },
+    );
 
     render(<AwardRecommendationsListTable currentAgencyId="1" />);
 

--- a/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListTable.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { identity } from "lodash";
 import AwardRecommendationsListTable from "src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListTable";
 import {
@@ -47,6 +47,12 @@ jest.mock(
   }),
 );
 
+jest.mock("src/components/core/PopoverMenu", () => ({
+  PopoverMenu: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-menu">{children}</div>
+  ),
+}));
+
 jest.mock("src/components/core/SimplerAlert", () => ({
   __esModule: true,
   default: ({ messageText }: { messageText: string }) => (
@@ -65,7 +71,7 @@ jest.mock("@trussworks/react-uswds", () => ({
 
 describe("AwardRecommendationsListTable", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    mockClientFetch.mockReset();
     mockClientFetch.mockResolvedValue({
       data: [mockAwardRecommendationListItem],
       pagination_info: { total_pages: 1, total_records: 1 },
@@ -105,6 +111,7 @@ describe("AwardRecommendationsListTable", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.queryByText("actions.delete")).not.toBeInTheDocument();
   });
 
   it("renders zero applications received when summary count is zero", async () => {
@@ -126,7 +133,7 @@ describe("AwardRecommendationsListTable", () => {
     expect(screen.getByText("0")).toBeInTheDocument();
   });
 
-  it("renders edit link for draft award recommendations", async () => {
+  it("renders edit link and delete action for draft award recommendations", async () => {
     mockClientFetch.mockResolvedValue({
       data: [mockDraftAwardRecommendationListItem],
       pagination_info: { total_pages: 1, total_records: 1 },
@@ -142,6 +149,45 @@ describe("AwardRecommendationsListTable", () => {
       ).toHaveAttribute(
         "href",
         `/award-recommendation/${mockDraftAwardRecommendationListItem.award_recommendation_id}/edit`,
+      );
+    });
+
+    expect(screen.getByText("actions.delete")).toBeInTheDocument();
+  });
+
+  it("calls delete endpoint when delete is clicked", async () => {
+    let deleted = false;
+    mockClientFetch.mockImplementation(async (_url, options) => {
+      if (options?.method === "DELETE") {
+        deleted = true;
+        return {};
+      }
+
+      if (deleted) {
+        return {
+          data: [],
+          pagination_info: { total_pages: 1, total_records: 0 },
+        };
+      }
+
+      return {
+        data: [mockDraftAwardRecommendationListItem],
+        pagination_info: { total_pages: 1, total_records: 1 },
+      };
+    });
+
+    render(<AwardRecommendationsListTable currentAgencyId="1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("actions.delete")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("actions.delete"));
+
+    await waitFor(() => {
+      expect(mockClientFetch).toHaveBeenCalledWith(
+        `/api/award-recommendations/${mockDraftAwardRecommendationListItem.award_recommendation_id}`,
+        expect.objectContaining({ method: "DELETE" }),
       );
     });
   });

--- a/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListTable.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/_components/AwardRecommendationsListTable.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from "react";
 import { Pagination } from "@trussworks/react-uswds";
 
 import AwardRecommendationStatusTag from "src/components/award-recommendation/AwardRecommendationStatusTag";
+import { PopoverMenu } from "src/components/core/PopoverMenu";
 import SimplerAlert from "src/components/core/SimplerAlert";
 import Spinner from "src/components/core/Spinner";
 import {
@@ -101,6 +102,21 @@ export default function AwardRecommendationsListTable({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentAgencyId, page, clientFetch]);
 
+  const handleDelete = async (awardRecommendationId: string) => {
+    try {
+      setLoading(true);
+      await clientFetch(`/api/award-recommendations/${awardRecommendationId}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+      });
+      await fetchAwardRecommendations();
+    } catch (error) {
+      setApiError(true);
+      console.error(error);
+      setLoading(false);
+    }
+  };
+
   const headers: TableCellData[] = [
     { cellData: t("columns.awardRecId") },
     { cellData: t("columns.opportunityName") },
@@ -157,7 +173,20 @@ export default function AwardRecommendationsListTable({
           ),
         },
         {
-          cellData: null,
+          cellData:
+            award_recommendation_status === "draft" ? (
+              <PopoverMenu>
+                <button
+                  className="usa-button usa-button--unstyled width-full text-left padding-y-1 padding-x-2 hover:bg-base-lighter"
+                  onClick={() => {
+                    void handleDelete(award_recommendation_id);
+                  }}
+                  type="button"
+                >
+                  {t("actions.delete")}
+                </button>
+              </PopoverMenu>
+            ) : null,
         },
       ];
     },

--- a/frontend/src/app/api/award-recommendations/[id]/handler.test.tsx
+++ b/frontend/src/app/api/award-recommendations/[id]/handler.test.tsx
@@ -1,0 +1,65 @@
+import * as fetcherModule from "src/services/fetch/fetchers/awardRecommendationFetcher";
+
+import { NextRequest } from "next/server";
+
+import { deleteAwardRecommendationById } from "./handler";
+
+jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher");
+
+jest.mock("src/services/auth/sessionUtils", () => ({
+  decrypt: jest.fn(),
+  encrypt: jest.fn(),
+  CLIENT_JWT_ENCRYPTION_ALGORITHM: "HS256",
+  API_JWT_ENCRYPTION_ALGORITHM: "RS256",
+  newExpirationDate: () => new Date(0),
+}));
+
+interface MockResponse {
+  json: () => Promise<unknown>;
+  status: number;
+}
+
+global.Response = class Response {
+  constructor(
+    public body: unknown,
+    public init?: ResponseInit,
+  ) {}
+  static json(data: unknown, init?: ResponseInit): MockResponse {
+    return {
+      json: jest.fn().mockResolvedValue(data),
+      status: init?.status || 200,
+      ...init,
+    } as MockResponse;
+  }
+} as unknown as typeof globalThis.Response;
+
+describe("deleteAwardRecommendationById", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns success response when delete is successful", async () => {
+    (fetcherModule.deleteAwardRecommendation as jest.Mock).mockResolvedValue({
+      success: true,
+      message: "Deleted",
+    });
+    const req = {} as unknown as NextRequest;
+    const params = Promise.resolve({ id: "award-rec-id" });
+    const res = await deleteAwardRecommendationById(req, { params });
+    const json = (await res.json()) as { success: boolean; message: string };
+
+    expect(fetcherModule.deleteAwardRecommendation).toHaveBeenCalledWith(
+      "award-rec-id",
+    );
+    expect(json.success).toBe(true);
+    expect(json.message).toBe("Deleted");
+  });
+
+  it("returns 500 when award recommendation ID is missing", async () => {
+    const req = {} as unknown as NextRequest;
+    const params = Promise.resolve({ id: "" });
+    const res = await deleteAwardRecommendationById(req, { params });
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/frontend/src/app/api/award-recommendations/[id]/handler.ts
+++ b/frontend/src/app/api/award-recommendations/[id]/handler.ts
@@ -1,0 +1,32 @@
+import { readError } from "src/errors";
+import { deleteAwardRecommendation } from "src/services/fetch/fetchers/awardRecommendationFetcher";
+
+import { NextRequest } from "next/server";
+
+export async function deleteAwardRecommendationById(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+
+  try {
+    if (!id) {
+      throw new Error("Award recommendation ID is required");
+    }
+
+    const result = await deleteAwardRecommendation(id);
+
+    return Response.json({
+      message: result.message || "Award recommendation deleted successfully",
+      success: result.success,
+    });
+  } catch (e) {
+    const { status, message } = readError(e as Error, 500);
+    return Response.json(
+      {
+        message: `Error attempting to delete award recommendation: ${message}`,
+      },
+      { status },
+    );
+  }
+}

--- a/frontend/src/app/api/award-recommendations/[id]/route.ts
+++ b/frontend/src/app/api/award-recommendations/[id]/route.ts
@@ -1,0 +1,5 @@
+import { respondWithTraceAndLogs } from "src/utils/apiUtils";
+
+import { deleteAwardRecommendationById } from "./handler";
+
+export const DELETE = respondWithTraceAndLogs(deleteAwardRecommendationById);

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2048,6 +2048,9 @@ export const messages = {
         status: "Status",
         action: "Action",
       },
+      actions: {
+        delete: "Delete",
+      },
     },
     summary: {
       showDescription: "Show full description",

--- a/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.test.ts
+++ b/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.test.ts
@@ -1,4 +1,5 @@
 import {
+  deleteAwardRecommendation,
   deleteAwardRecommendationRisk,
   getAwardRecommendationDetails,
   getAwardRecommendationRisk,
@@ -167,6 +168,36 @@ describe("listAwardRecommendationsPaginated", () => {
       mockAwardRecommendationListItem,
     ]);
     expect(result.paginationInfo).toEqual({ total_pages: 1, total_records: 1 });
+  });
+});
+
+describe("deleteAwardRecommendation", () => {
+  beforeEach(() => {
+    mockInnerFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        message: "Deleted",
+      } as APIResponse),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls fetchAwardRecommendationWithMethod with the award recommendation id", async () => {
+    await deleteAwardRecommendation("award-rec-id");
+
+    expect(mockInnerFetch).toHaveBeenCalledWith({
+      subPath: "award-rec-id",
+    });
+  });
+
+  it("returns success when delete succeeds", async () => {
+    const result = await deleteAwardRecommendation("award-rec-id");
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("Deleted");
   });
 });
 

--- a/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/awardRecommendationFetcher.ts
@@ -47,6 +47,20 @@ export const listAwardRecommendationsPaginated = async (
   };
 };
 
+export const deleteAwardRecommendation = async (
+  awardRecommendationId: string,
+): Promise<{ success: boolean; message?: string }> => {
+  const response = await fetchAwardRecommendationWithMethod("DELETE")({
+    subPath: awardRecommendationId,
+  });
+  const responseBody = (await response.json()) as APIResponse;
+
+  return {
+    success: response.ok,
+    message: responseBody.message,
+  };
+};
+
 export const listAwardRecommendationSubmissionsPaginated = async (
   id: string,
   pagination: PaginationRequestBody,


### PR DESCRIPTION
## Summary

PR 3/3 (Previous PRs: #11243, #11248)
Work for #10648

## Changes proposed

- Add soft-delete action for draft award recommendations from the list table Action column (3-dot menu)
- Add `DELETE /api/award-recommendations/:id` Next.js API proxy route
- Add `deleteAwardRecommendation` fetcher and tests
- Add/extend list table tests to verify:
   - delete action renders only for draft rows
   - delete calls the delete endpoint and refetches

## Context for reviewers

This is the final PR to complete the Award Recommendations list table work. The list table and pagination were added in #11248, and this PR adds the remaining delete behavior.

Delete is intentionally limited to draft award recommendations, matching the intended workflow and permissions for soft-delete.

## Validation steps

- [ ] Visit localhost:3000/award-recommendation
- [ ] Verify draft rows show a 3-dot menu with Delete
- [ ] Click Delete and confirm the row is removed after the list refetches
- [ ] Verify non-draft rows do not show a Delete option

### Screenshot
<img width="1301" height="647" alt="image" src="https://github.com/user-attachments/assets/b10b05fa-28e0-45a0-814c-c35703f133b7" />
