### PR TITLE
[Issue #11153] pdf generation / print view bug

### DIFF
--- a/frontend/src/services/fetch/endpointConfigs.ts
+++ b/frontend/src/services/fetch/endpointConfigs.ts
@@ -147,7 +147,7 @@ export const getLocalUsersEndpoint = {
 
 // opting out of traditional X-SGG based auth since these requests will use the
 // internal auth token instead
-export const getApplicationForPrint = {
+export const getApplicationForPrintEndpoint = {
   basePath: environment.API_URL,
   version: "alpha",
   namespace: "applications",

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -1,4 +1,7 @@
-import { fetchApplicationWithMethod } from "src/services/fetch/fetchers/fetchers";
+import {
+  fetchApplicationWithMethod,
+  getApplicationForPrint,
+} from "src/services/fetch/fetchers/fetchers";
 import { ApplicationSubmissionsRequestBody } from "src/types/application/applicationSubmissionRequestTypes";
 import { ApplicationSubmission } from "src/types/application/applicationSubmissionTypes";
 import {
@@ -178,7 +181,12 @@ export const getApplicationFormDetailsForPrint = async (
   const additionalHeaders = {
     "X-SGG-Internal-Token": internalToken,
   };
-  const response = await fetchApplicationWithMethod("GET")({
+  // const response = await fetchApplicationWithMethod("GET")({
+  //   subPath: `${applicationId}/application_form/${applicationFormId}`,
+  //   additionalHeaders,
+  // });
+
+  const response = getApplicationForPrint({
     subPath: `${applicationId}/application_form/${applicationFormId}`,
     additionalHeaders,
   });

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -186,7 +186,7 @@ export const getApplicationFormDetailsForPrint = async (
   //   additionalHeaders,
   // });
 
-  const response = getApplicationForPrint({
+  const response = await getApplicationForPrint({
     subPath: `${applicationId}/application_form/${applicationFormId}`,
     additionalHeaders,
   });

--- a/frontend/src/services/fetch/fetchers/applicationFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/applicationFetcher.ts
@@ -181,11 +181,6 @@ export const getApplicationFormDetailsForPrint = async (
   const additionalHeaders = {
     "X-SGG-Internal-Token": internalToken,
   };
-  // const response = await fetchApplicationWithMethod("GET")({
-  //   subPath: `${applicationId}/application_form/${applicationFormId}`,
-  //   additionalHeaders,
-  // });
-
   const response = await getApplicationForPrint({
     subPath: `${applicationId}/application_form/${applicationFormId}`,
     additionalHeaders,

--- a/frontend/src/services/fetch/fetchers/fetchers.ts
+++ b/frontend/src/services/fetch/fetchers/fetchers.ts
@@ -7,6 +7,7 @@ import {
   fetchCompetitionEndpoint,
   fetchFormEndpoint,
   fetchOpportunityEndpoint,
+  getApplicationForPrintEndpoint,
   getLocalUsersEndpoint,
   opportunitySearchEndpoint,
   searchAgenciesEndpoint,
@@ -171,3 +172,7 @@ export const fetchGrantorWithMethod = (type: "POST") =>
 
 export const fetchFileUploadWithMethod = (type: "POST" | "GET") =>
   requesterForEndpoint(toDynamicFilesEndpoint(type));
+
+export const getApplicationForPrint = requesterForEndpoint(
+  getApplicationForPrintEndpoint,
+);


### PR DESCRIPTION
## Summary

Work for #11153 

## Changes proposed

updates the fetcher to use `getApplicationForPrint`

## Context for reviewers

- PDF generation was failing because docraptor needed to provide an internal session token
- Doug already had `getApplicationForPrintEndpoint` built, we just used it

## Validation steps

- create a tunnel using `localTunnel` or `Cloudfront Tunnel`
- update your `local.env` and `override.env `'s `FRONTEND_URL` variable to the local tunnel's provided url
- update your `local.env`'s variable `DOCRAPTOR_API_KEY`  with your personal docraptor account
- sign in, apply, and fill out a form, submit
- [ ] after submission wait for application to be `Submitted` and `Download your submitted application` to appear
- [ ] download and unzip your application
- [ ] verify that pdf gets generated as expected