### PR TITLE
[Issue #11368] file upload cancellation fixes

### DIFF
--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -146,16 +146,11 @@ export const SimplerFileInput = ({
   // note the usage of functional state setters in these functions
   // it's necessary to avoid referencing stale closed over state values up the call stack
   const trackUploadSuccess = (uploadId: string) => {
-    setActiveUploads((previousActiveUploads) => {
-      const previousCopy = [...previousActiveUploads];
-      const successIndex = previousCopy.findIndex(
-        (item) => item.uploadId === uploadId,
-      );
-      if (successIndex > -1) {
-        previousCopy.splice(successIndex, 1);
-      }
-      return previousCopy;
-    });
+    setActiveUploads((previousActiveUploads) =>
+      previousActiveUploads.filter(
+        (activeUpload) => activeUpload.uploadId !== uploadId,
+      ),
+    );
   };
   const trackUploadError = (uploadId: string) => {
     setUploadErrors((previousUploadErrors) => [
@@ -165,26 +160,17 @@ export const SimplerFileInput = ({
   };
 
   const dismissError = (uploadId: string) => {
-    setUploadErrors((previousUploadErrors) => {
-      const errorIndex = previousUploadErrors.indexOf(uploadId);
-      if (errorIndex > -1) {
-        previousUploadErrors.splice(errorIndex, 1);
-      }
-      return previousUploadErrors;
-    });
+    setUploadErrors((previousUploadErrors) =>
+      previousUploadErrors.filter((uploadError) => uploadError !== uploadId),
+    );
   };
 
   const trackUploadCancel = (uploadId: string) => {
-    setActiveUploads((previousActiveUploads) => {
-      const previousCopy = [...previousActiveUploads];
-      const canceledIndex = previousCopy.findIndex(
-        (item) => item.uploadId === uploadId,
-      );
-      if (canceledIndex > -1) {
-        previousCopy.splice(canceledIndex, 1);
-      }
-      return previousCopy;
-    });
+    setActiveUploads((previousActiveUploads) =>
+      previousActiveUploads.filter(
+        (activeUpload) => activeUpload.uploadId !== uploadId,
+      ),
+    );
   };
 
   return (

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -68,7 +68,7 @@ export const SimplerFileInput = ({
   );
   // upload id is only used for tracking internal to this component
   const [activeUploads, setActiveUploads] = useState<
-    { uploadId: string; file: File; complete?: boolean; canceled?: boolean }[]
+    { uploadId: string; file: File }[]
   >([]);
   const [uploadErrors, setUploadErrors] = useState<string[]>([]);
 
@@ -210,8 +210,6 @@ export const SimplerFileInput = ({
           key={uploadId}
           fileToUpload={file}
           onCancel={() => {
-            // this runs but does not cause an update to render if error logic is removed
-            // I guess the error logic is doing something else that is triggering a render, and the other state is picked up along with it?
             trackUploadCancel(uploadId);
             if (!multiFile) {
               fileInputRef?.current?.clearFiles();

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -208,6 +208,9 @@ export const SimplerFileInput = ({
           onUploadSuccess={(postUploadResult: unknown) => {
             trackUploadComplete(uploadId);
             onSuccess(postUploadResult);
+            if (!multiFile) {
+              fileInputRef?.current?.clearFiles();
+            }
           }}
           onComplete={onComplete}
           onUploadError={(e: Error) => {

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -145,7 +145,7 @@ export const SimplerFileInput = ({
 
   // note the usage of functional state setters in these functions
   // it's necessary to avoid referencing stale closed over state values up the call stack
-  const trackUploadSuccess = (uploadId: string) => {
+  const trackUploadComplete = (uploadId: string) => {
     setActiveUploads((previousActiveUploads) =>
       previousActiveUploads.filter(
         (activeUpload) => activeUpload.uploadId !== uploadId,
@@ -163,14 +163,11 @@ export const SimplerFileInput = ({
     setUploadErrors((previousUploadErrors) =>
       previousUploadErrors.filter((uploadError) => uploadError !== uploadId),
     );
-  };
-
-  const trackUploadCancel = (uploadId: string) => {
-    setActiveUploads((previousActiveUploads) =>
-      previousActiveUploads.filter(
-        (activeUpload) => activeUpload.uploadId !== uploadId,
-      ),
-    );
+    // we want to show the upload input again after dismissing a single error
+    trackUploadComplete(uploadId);
+    if (!multiFile) {
+      fileInputRef?.current?.clearFiles();
+    }
   };
 
   return (
@@ -196,7 +193,7 @@ export const SimplerFileInput = ({
           key={uploadId}
           fileToUpload={file}
           onCancel={() => {
-            trackUploadCancel(uploadId);
+            trackUploadComplete(uploadId);
             if (!multiFile) {
               fileInputRef?.current?.clearFiles();
             }
@@ -209,7 +206,7 @@ export const SimplerFileInput = ({
           postUploadActionErrorMessage={postUploadActionErrorMessage}
           onStart={onStart}
           onUploadSuccess={(postUploadResult: unknown) => {
-            trackUploadSuccess(uploadId);
+            trackUploadComplete(uploadId);
             onSuccess(postUploadResult);
           }}
           onComplete={onComplete}

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -68,7 +68,7 @@ export const SimplerFileInput = ({
   );
   // upload id is only used for tracking internal to this component
   const [activeUploads, setActiveUploads] = useState<
-    { uploadId: string; file: File; complete?: boolean }[]
+    { uploadId: string; file: File; complete?: boolean; canceled?: boolean }[]
   >([]);
   const [uploadErrors, setUploadErrors] = useState<string[]>([]);
 
@@ -118,7 +118,6 @@ export const SimplerFileInput = ({
         return;
       })
       .catch((e) => {
-        // do we want to do anything else here to surface the error?
         console.error("Error deleting file", e);
         setDeletePending(false);
         setFilePendingDeletion(undefined);
@@ -139,23 +138,23 @@ export const SimplerFileInput = ({
     if (existingFiles?.length) {
       return true;
     }
-    // if there is any active upload that has not yet completed
-    if (activeUploads.some((activeUpload) => !activeUpload.complete)) {
+    if (activeUploads.length) {
       return true;
     }
-  }, [multiFile, activeUploads, existingFiles]);
+  }, [multiFile, existingFiles?.length, activeUploads.length]);
 
   // note the usage of functional state setters in these functions
   // it's necessary to avoid referencing stale closed over state values up the call stack
   const trackUploadSuccess = (uploadId: string) => {
     setActiveUploads((previousActiveUploads) => {
-      const completedIndex = previousActiveUploads.findIndex(
+      const previousCopy = [...previousActiveUploads];
+      const successIndex = previousCopy.findIndex(
         (item) => item.uploadId === uploadId,
       );
-      if (completedIndex > -1) {
-        previousActiveUploads[completedIndex].complete = true;
+      if (successIndex > -1) {
+        previousCopy.splice(successIndex, 1);
       }
-      return previousActiveUploads;
+      return previousCopy;
     });
   };
   const trackUploadError = (uploadId: string) => {
@@ -177,15 +176,17 @@ export const SimplerFileInput = ({
 
   const trackUploadCancel = (uploadId: string) => {
     setActiveUploads((previousActiveUploads) => {
-      const canceledIndex = previousActiveUploads.findIndex(
+      const previousCopy = [...previousActiveUploads];
+      const canceledIndex = previousCopy.findIndex(
         (item) => item.uploadId === uploadId,
       );
       if (canceledIndex > -1) {
-        previousActiveUploads.splice(canceledIndex, 1);
+        previousCopy.splice(canceledIndex, 1);
       }
-      return previousActiveUploads;
+      return previousCopy;
     });
   };
+
   return (
     <>
       <FileInput
@@ -209,12 +210,16 @@ export const SimplerFileInput = ({
           key={uploadId}
           fileToUpload={file}
           onCancel={() => {
+            // this runs but does not cause an update to render if error logic is removed
+            // I guess the error logic is doing something else that is triggering a render, and the other state is picked up along with it?
             trackUploadCancel(uploadId);
             if (!multiFile) {
               fileInputRef?.current?.clearFiles();
             }
           }}
-          onDismiss={() => dismissError(uploadId)}
+          onDismiss={() => {
+            dismissError(uploadId);
+          }}
           postUploadActionProgressMessage={postUploadActionProgressMessage}
           postUploadActionSuccessMessage={postUploadActionSuccessMessage}
           postUploadActionErrorMessage={postUploadActionErrorMessage}
@@ -225,8 +230,8 @@ export const SimplerFileInput = ({
           }}
           onComplete={onComplete}
           onUploadError={(e: Error) => {
-            trackUploadError(uploadId);
             onError(e);
+            trackUploadError(uploadId);
           }}
           postUploadAction={postUploadAction}
         />

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -44,17 +44,33 @@ export const useFileUpload = ({
   // exposed methods for upload management
   const handleError = useCallback(
     (e: Error) => {
-      onError(e);
-      setUploadError(e.message);
+      // skip handling for expected abort related errors
+      if (e.name !== "AbortError") {
+        onError(e);
+        setUploadError(e.message);
+      }
     },
     [setUploadError, onError],
   );
 
   const handleCancel = useCallback(async () => {
     setCurrentStatus(undefined);
-    uploadController?.abort();
-    postUploadController?.abort();
-    await responseReader?.cancel();
+    try {
+      uploadController?.abort();
+    } catch (_e) {
+      // if the controller has already been aborted, no problem
+    }
+    try {
+      postUploadController?.abort();
+    } catch (_e) {
+      // if the controller has already been aborted, no problem
+    }
+    try {
+      await responseReader?.cancel();
+    } catch (_e) {
+      // if the reader is already closed, no problem
+      return;
+    }
   }, [uploadController, postUploadController, responseReader]);
 
   const dismissError = useCallback(() => {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11368 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes two issues with upload cancellation:

* cancellation of an upload on a single file uploader was not triggering the reappearance of the input. This was because of a bug in the react lifecycle code implementation that was causing the variable controlling appearance of the input to not be recalculated after upload cancellation
* cancellation was triggering onError callbacks and other error handling logic. Since cancellation is enacted intentionally through the UI here, we can assume that the user does not intend it to be interpreted as an error

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->


1.  run `npm run local` on this `upload-cancel-fixes-POC` branch, which includes changes to the opportunity edit form to include the simpler file inpu
2. visit http://localhost:3000/grantor/opportunities
3. create a new opportunity
4. upload a file
5. cancel the upload
6. _VERIFY_: file input reappears
7. _VERIFY_: no errors are logged in the console