### PR TITLE
[Issue#10304]- multi select recommendation applications

### DIFF
--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
@@ -142,7 +142,7 @@ describe("RecommendationDetailForm", () => {
   describe("edge cases", () => {
     it("returns null when no submission or submissions provided", () => {
       const { container } = render(<RecommendationDetailForm />);
-      expect(container.firstChild).toBeNull();
+      expect(container).toBeEmptyDOMElement();
     });
 
     it("treats single item in submissions array as single submission", () => {

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react";
+import { identity } from "lodash";
+import { RecommendationDetailForm } from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
+import { AwardRecommendationSubmission } from "src/types/awardRecommendationTypes";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => identity,
+}));
+
+const mockSubmission: AwardRecommendationSubmission = {
+  award_recommendation_application_submission_id: "test-id-1",
+  application_submission: {
+    application_submission_id: "app-sub-1",
+    application_submission_number: "SUB-001",
+    project_title: "Test Project",
+    total_requested_amount: "100000.00",
+    application: {
+      application_id: "app-1",
+      competition_id: "comp-1",
+      organization: {
+        organization_id: "org-1",
+        organization_name: "Test Org",
+        uei: "UEI123",
+      },
+    },
+  },
+  submission_detail: {
+    award_recommendation_type: "recommended_for_funding",
+    recommended_amount: "75000.00",
+    general_comment: "Test comment",
+    has_exception: false,
+  },
+};
+
+const mockSubmission2: AwardRecommendationSubmission = {
+  award_recommendation_application_submission_id: "test-id-2",
+  application_submission: {
+    application_submission_id: "app-sub-2",
+    application_submission_number: "SUB-002",
+    project_title: "Test Project 2",
+    total_requested_amount: "50000.00",
+    application: {
+      application_id: "app-2",
+      competition_id: "comp-1",
+    },
+  },
+  submission_detail: {
+    award_recommendation_type: "recommended_for_funding",
+    recommended_amount: "25000.00",
+  },
+};
+
+describe("RecommendationDetailForm", () => {
+  describe("single submission mode", () => {
+    it("renders recommendation fields for single submission", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      expect(screen.getByText("recommendationLabel")).toBeInTheDocument();
+      expect(screen.getByText("amountRequestedLabel")).toBeInTheDocument();
+      expect(screen.getByText("amountRecommendedLabel")).toBeInTheDocument();
+    });
+
+    it("displays formatted amounts for single submission", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      expect(screen.getByText("$100,000")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("$75,000")).toBeInTheDocument();
+    });
+  });
+
+  describe("multiple submissions mode", () => {
+    it("renders recommendation fields for multiple submissions", () => {
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, mockSubmission2]}
+        />,
+      );
+
+      expect(screen.getByText("recommendationLabel")).toBeInTheDocument();
+      expect(screen.getByText("commentsLabel")).toBeInTheDocument();
+      expect(screen.getByText("fundingHeading")).toBeInTheDocument();
+    });
+
+    it("renders table with multiple submissions", () => {
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, mockSubmission2]}
+        />,
+      );
+
+      expect(screen.getByText("applicationIdLabel")).toBeInTheDocument();
+      // Table shows application_id, not application_submission_number
+      expect(screen.getByText("app-1")).toBeInTheDocument();
+      expect(screen.getByText("app-2")).toBeInTheDocument();
+    });
+
+    it("calculates and displays correct totals for requested amounts", () => {
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, mockSubmission2]}
+        />,
+      );
+
+      expect(screen.getByText("totalLabel")).toBeInTheDocument();
+      // Total requested: $100,000 + $50,000 = $150,000
+      expect(screen.getByText("$150,000")).toBeInTheDocument();
+    });
+
+    it("calculates and displays correct totals for recommended amounts", () => {
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, mockSubmission2]}
+        />,
+      );
+
+      // Total recommended: $75,000 + $25,000 = $100,000
+      // Note: $100,000 also appears as individual requested amount
+      const hundredThousandElements = screen.getAllByText("$100,000");
+      expect(hundredThousandElements.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("handles submissions with missing amounts", () => {
+      const submissionWithoutAmounts: AwardRecommendationSubmission = {
+        award_recommendation_application_submission_id: "test-id-3",
+        application_submission: {
+          application_submission_id: "app-sub-3",
+          application_submission_number: "SUB-003",
+        },
+      };
+
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, submissionWithoutAmounts]}
+        />,
+      );
+
+      // Should still calculate totals, treating missing values as 0
+      expect(screen.getByText("totalLabel")).toBeInTheDocument();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns null when no submission or submissions provided", () => {
+      const { container } = render(<RecommendationDetailForm />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("treats single item in submissions array as single submission", () => {
+      render(<RecommendationDetailForm submissions={[mockSubmission]} />);
+
+      // Should render single submission view, not table
+      expect(screen.queryByText("applicationIdLabel")).not.toBeInTheDocument();
+      expect(screen.getByText("recommendationLabel")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
@@ -329,7 +329,7 @@ export const RecommendationDetailForm = ({
           submissionId="bulk"
           namePrefix="bulk_edit["
         />
-        <FundingSectionMultiple submissions={submissions!} />
+        <FundingSectionMultiple submissions={submissions} />
       </div>
     );
   }

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
@@ -76,7 +76,7 @@ const RecommendationFields = ({
         </Label>
         <Select
           id={`award_recommendation_type_${submissionId}`}
-          name={`${namePrefix}award_recommendation_type`}
+          name={`${namePrefix}[award_recommendation_type]`}
           value={recommendationType}
           onChange={(event) => {
             const nextRecommendationType = event.target
@@ -104,7 +104,7 @@ const RecommendationFields = ({
       {canHaveException && (
         <Checkbox
           id={`has_exception_${submissionId}`}
-          name={`${namePrefix}has_exception`}
+          name={`${namePrefix}[has_exception]`}
           label={t("hasExceptionLabel")}
           checked={hasException}
           onChange={(event) => setHasException(event.target.checked)}
@@ -120,7 +120,7 @@ const RecommendationFields = ({
         </p>
         <CharacterCount
           id={`general_comment_${submissionId}`}
-          name={`${namePrefix}general_comment`}
+          name={`${namePrefix}[general_comment]`}
           maxLength={1000}
           isTextArea
           defaultValue={generalCommentDefaultValue || ""}
@@ -141,7 +141,7 @@ const RecommendationFields = ({
           </p>
           <CharacterCount
             id={`exception_detail_${submissionId}`}
-            name={`${namePrefix}exception_detail`}
+            name={`${namePrefix}[exception_detail]`}
             maxLength={1000}
             isTextArea
             defaultValue={exceptionDetailDefaultValue || ""}

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
@@ -4,7 +4,7 @@ import {
   AwardRecommendationSubmission,
   AwardRecommendationType,
 } from "src/types/awardRecommendationTypes";
-import { formatCurrencyString } from "src/utils/formatCurrencyUtil";
+import { formatCurrency, formatCurrencyString, getNumericAmountFromString } from "src/utils/formatCurrencyUtil";
 
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -34,33 +34,38 @@ const defaultHasExceptionByRecommendationType: Record<
 };
 
 type RecommendationDetailFormProps = {
-  submission: AwardRecommendationSubmission;
+  submission?: AwardRecommendationSubmission;
+  submissions?: AwardRecommendationSubmission[];
 };
 
-const RecommendationDetailForm = ({
-  submission,
-}: RecommendationDetailFormProps) => {
+type RecommendationFieldsProps = {
+  submissionId: string;
+  namePrefix: string;
+  generalCommentDefaultValue?: string;
+  exceptionDetailDefaultValue?: string;
+  initialRecommendationType?: AwardRecommendationType;
+  initialHasException?: boolean;
+};
+
+const RecommendationFields = ({
+  submissionId,
+  namePrefix,
+  generalCommentDefaultValue,
+  exceptionDetailDefaultValue,
+  initialRecommendationType = "recommended_for_funding",
+  initialHasException = false,
+}: RecommendationFieldsProps) => {
   const t = useTranslations("AwardRecommendation.recommendationDetails");
-  const detail = submission.submission_detail;
-  const submissionId =
-    submission.award_recommendation_application_submission_id;
-  const initialRecommendationType =
-    detail?.award_recommendation_type ?? "recommended_for_funding";
   const [recommendationType, setRecommendationType] =
     useState<AwardRecommendationType>(initialRecommendationType);
-  const [hasException, setHasException] = useState(
-    Boolean(detail?.has_exception),
-  );
-  const [recommendedAmount, setRecommendedAmount] = useState(
-    formatCurrencyString(detail?.recommended_amount),
-  );
+  const [hasException, setHasException] = useState(initialHasException);
 
   const canHaveException =
     exceptionEligibleRecommendationTypes.includes(recommendationType);
   const showExceptionDetail = canHaveException && hasException;
 
   return (
-    <div className="margin-bottom-4" data-testid="recommendation-detail-form">
+    <>
       <div className="margin-bottom-3">
         <Label
           htmlFor={`award_recommendation_type_${submissionId}`}
@@ -71,7 +76,7 @@ const RecommendationDetailForm = ({
         </Label>
         <Select
           id={`award_recommendation_type_${submissionId}`}
-          name={`award_recommendation_submissions[${submissionId}][award_recommendation_type]`}
+          name={`${namePrefix}award_recommendation_type`}
           value={recommendationType}
           onChange={(event) => {
             const nextRecommendationType = event.target
@@ -99,7 +104,7 @@ const RecommendationDetailForm = ({
       {canHaveException && (
         <Checkbox
           id={`has_exception_${submissionId}`}
-          name={`award_recommendation_submissions[${submissionId}][has_exception]`}
+          name={`${namePrefix}has_exception`}
           label={t("hasExceptionLabel")}
           checked={hasException}
           onChange={(event) => setHasException(event.target.checked)}
@@ -115,10 +120,10 @@ const RecommendationDetailForm = ({
         </p>
         <CharacterCount
           id={`general_comment_${submissionId}`}
-          name={`award_recommendation_submissions[${submissionId}][general_comment]`}
+          name={`${namePrefix}general_comment`}
           maxLength={1000}
           isTextArea
-          defaultValue={detail?.general_comment || ""}
+          defaultValue={generalCommentDefaultValue || ""}
           rows={6}
           className="maxw-full"
           data-testid="recommendation-comments-textarea"
@@ -136,10 +141,10 @@ const RecommendationDetailForm = ({
           </p>
           <CharacterCount
             id={`exception_detail_${submissionId}`}
-            name={`award_recommendation_submissions[${submissionId}][exception_detail]`}
+            name={`${namePrefix}exception_detail`}
             maxLength={1000}
             isTextArea
-            defaultValue={detail?.exception_detail || ""}
+            defaultValue={exceptionDetailDefaultValue || ""}
             rows={6}
             className="maxw-full"
             data-testid="exception-detail-textarea"
@@ -147,44 +152,205 @@ const RecommendationDetailForm = ({
           />
         </div>
       )}
+    </>
+  );
+};
 
-      <div className="margin-top-4">
-        <h3 className="margin-top-0 margin-bottom-3 font-sans-md">
-          {t("fundingHeading")}
-        </h3>
-        <Grid row gap>
-          <Grid col={12} tablet={{ col: 6 }}>
-            <p className="text-bold margin-bottom-1 font-sans-sm">
-              {t("amountRequestedLabel")}
-            </p>
-            <p className="margin-top-1">
-              {formatCurrencyString(
-                submission.application_submission.total_requested_amount,
-              )}
-            </p>
-          </Grid>
-          <Grid col={12} tablet={{ col: 6 }}>
-            <Label
-              htmlFor={`recommended_amount_${submissionId}`}
-              className="text-bold margin-top-0 margin-bottom-1"
-            >
-              <span>{t("amountRecommendedLabel")}</span>
-              <RequiredFieldIndicator> *</RequiredFieldIndicator>
-            </Label>
-            <TextInput
-              id={`recommended_amount_${submissionId}`}
-              name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
-              type="text"
-              value={recommendedAmount}
-              onChange={(event) => setRecommendedAmount(event.target.value)}
-              onBlur={(event) =>
-                setRecommendedAmount(formatCurrencyString(event.target.value))
-              }
-              required
-            />
-          </Grid>
-        </Grid>
+const FundingRecommendationRow = ({
+  submission,
+}: {
+  submission: AwardRecommendationSubmission;
+}) => {
+  const submissionId =
+    submission.award_recommendation_application_submission_id;
+  const [recommendedAmount, setRecommendedAmount] = useState(
+    formatCurrencyString(submission.submission_detail?.recommended_amount),
+  );
+
+  return (
+    <tr>
+      <td>{submission.application_submission.application?.application_id}</td>
+      <td>
+        {formatCurrencyString(
+          submission.application_submission.total_requested_amount,
+        )}
+      </td>
+      <td>
+        <TextInput
+          id={`recommended_amount_${submissionId}`}
+          name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
+          type="text"
+          value={recommendedAmount}
+          onChange={(event) => setRecommendedAmount(event.target.value)}
+          onBlur={(event) =>
+            setRecommendedAmount(formatCurrencyString(event.target.value))
+          }
+          required
+        />
+      </td>
+    </tr>
+  );
+};
+
+const FundingSectionMultiple = ({
+  submissions,
+}: {
+  submissions: AwardRecommendationSubmission[];
+}) => {
+  const t = useTranslations("AwardRecommendation.recommendationDetails");
+
+  return (
+    <div className="margin-top-4">
+      <h3 className="margin-top-0 margin-bottom-3 font-sans-md">
+        {t("fundingHeading")}
+      </h3>
+      <div className="usa-table-container--scrollable" tabIndex={0}>
+        <table className="usa-table usa-table--borderless width-full">
+          <thead>
+            <tr>
+              <th scope="col" className="bg-base-lightest padding-y-205 minw-15">{t("applicationIdLabel")}</th>
+              <th scope="col" className="bg-base-lightest padding-y-205 minw-15">{t("amountRequestedLabel")}</th>
+              <th scope="col" className="bg-base-lightest padding-y-205 minw-15">
+                <span>{t("amountRecommendedLabel")}</span>
+                <RequiredFieldIndicator> *</RequiredFieldIndicator>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {submissions.map((sub) => (
+              <FundingRecommendationRow
+                key={sub.award_recommendation_application_submission_id}
+                submission={sub}
+              />
+            ))}
+            <tr>
+              <td>{t("totalLabel")}</td>
+              <td>
+                {formatCurrency(
+                  submissions.reduce(
+                    (sum, s) =>
+                      sum +
+                      getNumericAmountFromString(
+                        s.application_submission.total_requested_amount,
+                      ),
+                    0,
+                  ),
+                )}
+              </td>
+              <td>
+                {formatCurrency(
+                  submissions.reduce(
+                    (sum, s) =>
+                      sum +
+                      getNumericAmountFromString(
+                        s.submission_detail?.recommended_amount,
+                      ),
+                    0,
+                  ),
+                )}
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
+    </div>
+  );
+};
+
+const FundingSectionSingle = ({
+  submission,
+}: {
+  submission: AwardRecommendationSubmission;
+}) => {
+  const t = useTranslations("AwardRecommendation.recommendationDetails");
+  const submissionId =
+    submission.award_recommendation_application_submission_id;
+  const [recommendedAmount, setRecommendedAmount] = useState(
+    formatCurrencyString(submission.submission_detail?.recommended_amount),
+  );
+
+  return (
+    <div className="margin-top-4">
+      <h3 className="margin-top-0 margin-bottom-3 font-sans-md">
+        {t("fundingHeading")}
+      </h3>
+      <Grid row gap>
+        <Grid col={12} tablet={{ col: 6 }}>
+          <p className="text-bold margin-bottom-1 font-sans-sm">
+            {t("amountRequestedLabel")}
+          </p>
+          <p className="margin-top-1">
+            {formatCurrencyString(
+              submission.application_submission.total_requested_amount,
+            )}
+          </p>
+        </Grid>
+        <Grid col={12} tablet={{ col: 6 }}>
+          <Label
+            htmlFor={`recommended_amount_${submissionId}`}
+            className="text-bold margin-top-0 margin-bottom-1"
+          >
+            <span>{t("amountRecommendedLabel")}</span>
+            <RequiredFieldIndicator> *</RequiredFieldIndicator>
+          </Label>
+          <TextInput
+            id={`recommended_amount_${submissionId}`}
+            name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
+            type="text"
+            value={recommendedAmount}
+            onChange={(event) => setRecommendedAmount(event.target.value)}
+            onBlur={(event) =>
+              setRecommendedAmount(formatCurrencyString(event.target.value))
+            }
+            required
+          />
+        </Grid>
+      </Grid>
+    </div>
+  );
+};
+
+export const RecommendationDetailForm = ({
+  submission,
+  submissions,
+}: RecommendationDetailFormProps) => {
+  const isMultipleSubmissions = submissions && submissions.length > 1;
+  const singleSubmission =
+    submission || (submissions && submissions.length === 1 ? submissions[0] : null);
+
+  if (!singleSubmission && !isMultipleSubmissions) {
+    return null;
+  }
+
+  if (isMultipleSubmissions) {
+    return (
+      <div className="margin-bottom-4" data-testid="recommendation-detail-form">
+        <RecommendationFields
+          submissionId="bulk"
+          namePrefix="bulk_edit["
+        />
+        <FundingSectionMultiple submissions={submissions!} />
+      </div>
+    );
+  }
+
+  const detail = singleSubmission!.submission_detail;
+  const submissionId =
+    singleSubmission!.award_recommendation_application_submission_id;
+
+  return (
+    <div className="margin-bottom-4" data-testid="recommendation-detail-form">
+      <RecommendationFields
+        submissionId={submissionId}
+        namePrefix={`award_recommendation_submissions[${submissionId}]`}
+        generalCommentDefaultValue={detail?.general_comment}
+        exceptionDetailDefaultValue={detail?.exception_detail}
+        initialRecommendationType={
+          detail?.award_recommendation_type ?? "recommended_for_funding"
+        }
+        initialHasException={Boolean(detail?.has_exception)}
+      />
+      <FundingSectionSingle submission={singleSubmission!} />
     </div>
   );
 };

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
@@ -4,7 +4,11 @@ import {
   AwardRecommendationSubmission,
   AwardRecommendationType,
 } from "src/types/awardRecommendationTypes";
-import { formatCurrency, formatCurrencyString, getNumericAmountFromString } from "src/utils/formatCurrencyUtil";
+import {
+  formatCurrency,
+  formatCurrencyString,
+  getNumericAmountFromString,
+} from "src/utils/formatCurrencyUtil";
 
 import { useTranslations } from "next-intl";
 import { useState } from "react";
@@ -208,9 +212,22 @@ const FundingSectionMultiple = ({
         <table className="usa-table usa-table--borderless width-full">
           <thead>
             <tr>
-              <th scope="col" className="bg-base-lightest padding-y-205 minw-15">{t("applicationIdLabel")}</th>
-              <th scope="col" className="bg-base-lightest padding-y-205 minw-15">{t("amountRequestedLabel")}</th>
-              <th scope="col" className="bg-base-lightest padding-y-205 minw-15">
+              <th
+                scope="col"
+                className="bg-base-lightest padding-y-205 minw-15"
+              >
+                {t("applicationIdLabel")}
+              </th>
+              <th
+                scope="col"
+                className="bg-base-lightest padding-y-205 minw-15"
+              >
+                {t("amountRequestedLabel")}
+              </th>
+              <th
+                scope="col"
+                className="bg-base-lightest padding-y-205 minw-15"
+              >
                 <span>{t("amountRecommendedLabel")}</span>
                 <RequiredFieldIndicator> *</RequiredFieldIndicator>
               </th>
@@ -316,7 +333,8 @@ export const RecommendationDetailForm = ({
 }: RecommendationDetailFormProps) => {
   const isMultipleSubmissions = submissions && submissions.length > 1;
   const singleSubmission =
-    submission || (submissions && submissions.length === 1 ? submissions[0] : null);
+    submission ||
+    (submissions && submissions.length === 1 ? submissions[0] : null);
 
   if (!singleSubmission && !isMultipleSubmissions) {
     return null;
@@ -325,10 +343,7 @@ export const RecommendationDetailForm = ({
   if (isMultipleSubmissions) {
     return (
       <div className="margin-bottom-4" data-testid="recommendation-detail-form">
-        <RecommendationFields
-          submissionId="bulk"
-          namePrefix="bulk_edit["
-        />
+        <RecommendationFields submissionId="bulk" namePrefix="bulk_edit[" />
         <FundingSectionMultiple submissions={submissions} />
       </div>
     );

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
@@ -17,7 +17,7 @@ jest.mock("next/navigation", () => ({
 
 const mockUseSelectedSubmissions = jest.fn();
 jest.mock("src/hooks/useSelectedSubmissions", () => ({
-  useSelectedSubmissions: (awardRecommendationId: string) =>
+  useSelectedSubmissions: (awardRecommendationId: string): ReturnType<typeof mockUseSelectedSubmissions> =>
     mockUseSelectedSubmissions(awardRecommendationId),
 }));
 

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
@@ -1,0 +1,330 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { identity } from "lodash";
+import EditRecommendationsForm from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm";
+import { AwardRecommendationSubmission } from "src/types/awardRecommendationTypes";
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => identity,
+}));
+
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+const mockUseSelectedSubmissions = jest.fn();
+jest.mock("src/hooks/useSelectedSubmissions", () => ({
+  useSelectedSubmissions: (awardRecommendationId: string) =>
+    mockUseSelectedSubmissions(awardRecommendationId),
+}));
+
+jest.mock("src/components/award-recommendation/SelectedApplicationsTable", () => {
+  return function MockSelectedApplicationsTable() {
+    return <div data-testid="selected-applications-table">Mock Table</div>;
+  };
+});
+
+jest.mock("src/components/core/SimplerAlert", () => {
+  return function MockSimplerAlert({
+    messageText,
+    buttonId,
+  }: {
+    messageText: string;
+    buttonId: string;
+  }) {
+    return (
+      <div data-testid={buttonId} role="alert">
+        {messageText}
+      </div>
+    );
+  };
+});
+
+const mockSingleSubmission: AwardRecommendationSubmission = {
+  award_recommendation_application_submission_id: "test-id-1",
+  application_submission: {
+    application_submission_id: "app-sub-1",
+    application_submission_number: "SUB-001",
+    project_title: "Test Project",
+    total_requested_amount: "100000.00",
+    application: {
+      application_id: "app-1",
+      competition_id: "comp-1",
+      organization: {
+        organization_id: "org-1",
+        organization_name: "Test Org",
+        uei: "UEI123",
+      },
+    },
+  },
+  submission_detail: {
+    award_recommendation_type: "recommended_for_funding",
+    recommended_amount: "75000.00",
+    general_comment: "Test comment",
+    has_exception: false,
+  },
+};
+
+const mockMultipleSubmissions: AwardRecommendationSubmission[] = [
+  mockSingleSubmission,
+  {
+    award_recommendation_application_submission_id: "test-id-2",
+    application_submission: {
+      application_submission_id: "app-sub-2",
+      application_submission_number: "SUB-002",
+      project_title: "Test Project 2",
+      total_requested_amount: "50000.00",
+      application: {
+        application_id: "app-2",
+        competition_id: "comp-1",
+      },
+    },
+    submission_detail: {
+      award_recommendation_type: "recommended_for_funding",
+      recommended_amount: "25000.00",
+    },
+  },
+];
+
+describe("EditRecommendationsForm", () => {
+  const awardRecommendationId = "AR-26-0001";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("when no selections exist", () => {
+    beforeEach(() => {
+      mockUseSelectedSubmissions.mockReturnValue({
+        selectedSubmissions: [],
+        hasSelections: false,
+        selectedSubmissionIds: new Set(),
+        setSelectedSubmissionIds: jest.fn(),
+        addSubmission: jest.fn(),
+        removeSubmission: jest.fn(),
+        addMultipleSubmissions: jest.fn(),
+        clearSelections: jest.fn(),
+      });
+    });
+
+    it("displays error alert when no submissions are selected", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.getByTestId("no-selections-alert")).toBeInTheDocument();
+      expect(screen.getByText("noSelectionsMessage")).toBeInTheDocument();
+    });
+
+    it("does not render the form content", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(
+        screen.queryByTestId("selected-applications-table"),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText("saveButton")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when single submission is selected", () => {
+    beforeEach(() => {
+      mockUseSelectedSubmissions.mockReturnValue({
+        selectedSubmissions: [mockSingleSubmission],
+        hasSelections: true,
+        selectedSubmissionIds: new Set(["test-id-1"]),
+        setSelectedSubmissionIds: jest.fn(),
+        addSubmission: jest.fn(),
+        removeSubmission: jest.fn(),
+        addMultipleSubmissions: jest.fn(),
+        clearSelections: jest.fn(),
+      });
+    });
+
+    it("renders the form with selected applications table", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.getByText("selectedApplications")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("selected-applications-table"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders single submission form with funding section", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.getByText("fundingHeading")).toBeInTheDocument();
+    });
+
+    it("renders save and cancel buttons", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.getByText("saveButton")).toBeInTheDocument();
+      expect(screen.getByText("cancelButton")).toBeInTheDocument();
+    });
+
+    it("navigates back when cancel is clicked", async () => {
+      const user = userEvent.setup();
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      const cancelButton = screen.getByText("cancelButton");
+      await user.click(cancelButton);
+
+      expect(mockPush).toHaveBeenCalledWith(
+        `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+      );
+    });
+
+    it("handles save action and navigates back", async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ delay: null });
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      const saveButton = screen.getByText("saveButton");
+      await user.click(saveButton);
+
+      expect(screen.getByText("saving")).toBeInTheDocument();
+
+      jest.advanceTimersByTime(500);
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+        );
+      });
+
+      jest.useRealTimers();
+    });
+
+    it("disables buttons while submitting", async () => {
+      const user = userEvent.setup();
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      const saveButton = screen.getByText("saveButton");
+      await user.click(saveButton);
+
+      expect(screen.getByText("saving")).toBeDisabled();
+      expect(screen.getByText("cancelButton")).toBeDisabled();
+    });
+  });
+
+  describe("when multiple submissions are selected", () => {
+    beforeEach(() => {
+      mockUseSelectedSubmissions.mockReturnValue({
+        selectedSubmissions: mockMultipleSubmissions,
+        hasSelections: true,
+        selectedSubmissionIds: new Set(["test-id-1", "test-id-2"]),
+        setSelectedSubmissionIds: jest.fn(),
+        addSubmission: jest.fn(),
+        removeSubmission: jest.fn(),
+        addMultipleSubmissions: jest.fn(),
+        clearSelections: jest.fn(),
+      });
+    });
+
+    it("renders the form with multiple submissions", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.getByText("selectedApplications")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("selected-applications-table"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays recommendation fields for multiple submissions", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.getByText("recommendationLabel")).toBeInTheDocument();
+      expect(screen.getByText("commentsLabel")).toBeInTheDocument();
+      expect(screen.getByText("fundingHeading")).toBeInTheDocument();
+    });
+
+    it("renders table view with totals for multiple submissions", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.getByText("applicationIdLabel")).toBeInTheDocument();
+      expect(screen.getByText("totalLabel")).toBeInTheDocument();
+    });
+
+    it("calculates correct totals for multiple submissions", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      // Total requested: $100,000 + $50,000 = $150,000
+      expect(screen.getByText("$150,000")).toBeInTheDocument();
+      // Total recommended: $75,000 + $25,000 = $100,000
+      // Note: $100,000 appears twice (individual requested amount and total recommended)
+      const hundredThousandElements = screen.getAllByText("$100,000");
+      expect(hundredThousandElements.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      mockUseSelectedSubmissions.mockReturnValue({
+        selectedSubmissions: [mockSingleSubmission],
+        hasSelections: true,
+        selectedSubmissionIds: new Set(["test-id-1"]),
+        setSelectedSubmissionIds: jest.fn(),
+        addSubmission: jest.fn(),
+        removeSubmission: jest.fn(),
+        addMultipleSubmissions: jest.fn(),
+        clearSelections: jest.fn(),
+      });
+    });
+
+    it("does not display error alert initially", () => {
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(screen.queryByTestId("error-alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("hook integration", () => {
+    it("calls useSelectedSubmissions with correct award recommendation id", () => {
+      mockUseSelectedSubmissions.mockReturnValue({
+        selectedSubmissions: [],
+        hasSelections: false,
+        selectedSubmissionIds: new Set(),
+        setSelectedSubmissionIds: jest.fn(),
+        addSubmission: jest.fn(),
+        removeSubmission: jest.fn(),
+        addMultipleSubmissions: jest.fn(),
+        clearSelections: jest.fn(),
+      });
+
+      render(
+        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+      );
+
+      expect(mockUseSelectedSubmissions).toHaveBeenCalledWith(
+        awardRecommendationId,
+      );
+    });
+  });
+});

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
@@ -17,15 +17,20 @@ jest.mock("next/navigation", () => ({
 
 const mockUseSelectedSubmissions = jest.fn();
 jest.mock("src/hooks/useSelectedSubmissions", () => ({
-  useSelectedSubmissions: (awardRecommendationId: string): ReturnType<typeof mockUseSelectedSubmissions> =>
+  useSelectedSubmissions: (
+    awardRecommendationId: string,
+  ): ReturnType<typeof mockUseSelectedSubmissions> =>
     mockUseSelectedSubmissions(awardRecommendationId),
 }));
 
-jest.mock("src/components/award-recommendation/SelectedApplicationsTable", () => {
-  return function MockSelectedApplicationsTable() {
-    return <div data-testid="selected-applications-table">Mock Table</div>;
-  };
-});
+jest.mock(
+  "src/components/award-recommendation/SelectedApplicationsTable",
+  () => {
+    return function MockSelectedApplicationsTable() {
+      return <div data-testid="selected-applications-table">Mock Table</div>;
+    };
+  },
+);
 
 jest.mock("src/components/core/SimplerAlert", () => {
   return function MockSimplerAlert({
@@ -112,7 +117,9 @@ describe("EditRecommendationsForm", () => {
 
     it("displays error alert when no submissions are selected", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.getByTestId("no-selections-alert")).toBeInTheDocument();
@@ -121,7 +128,9 @@ describe("EditRecommendationsForm", () => {
 
     it("does not render the form content", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(
@@ -147,7 +156,9 @@ describe("EditRecommendationsForm", () => {
 
     it("renders the form with selected applications table", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.getByText("selectedApplications")).toBeInTheDocument();
@@ -158,7 +169,9 @@ describe("EditRecommendationsForm", () => {
 
     it("renders single submission form with funding section", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.getByText("fundingHeading")).toBeInTheDocument();
@@ -166,7 +179,9 @@ describe("EditRecommendationsForm", () => {
 
     it("renders save and cancel buttons", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.getByText("saveButton")).toBeInTheDocument();
@@ -176,7 +191,9 @@ describe("EditRecommendationsForm", () => {
     it("navigates back when cancel is clicked", async () => {
       const user = userEvent.setup();
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       const cancelButton = screen.getByText("cancelButton");
@@ -191,7 +208,9 @@ describe("EditRecommendationsForm", () => {
       jest.useFakeTimers();
       const user = userEvent.setup({ delay: null });
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       const saveButton = screen.getByText("saveButton");
@@ -213,7 +232,9 @@ describe("EditRecommendationsForm", () => {
     it("disables buttons while submitting", async () => {
       const user = userEvent.setup();
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       const saveButton = screen.getByText("saveButton");
@@ -240,7 +261,9 @@ describe("EditRecommendationsForm", () => {
 
     it("renders the form with multiple submissions", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.getByText("selectedApplications")).toBeInTheDocument();
@@ -251,7 +274,9 @@ describe("EditRecommendationsForm", () => {
 
     it("displays recommendation fields for multiple submissions", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.getByText("recommendationLabel")).toBeInTheDocument();
@@ -261,7 +286,9 @@ describe("EditRecommendationsForm", () => {
 
     it("renders table view with totals for multiple submissions", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.getByText("applicationIdLabel")).toBeInTheDocument();
@@ -270,7 +297,9 @@ describe("EditRecommendationsForm", () => {
 
     it("calculates correct totals for multiple submissions", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       // Total requested: $100,000 + $50,000 = $150,000
@@ -298,7 +327,9 @@ describe("EditRecommendationsForm", () => {
 
     it("does not display error alert initially", () => {
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(screen.queryByTestId("error-alert")).not.toBeInTheDocument();
@@ -319,7 +350,9 @@ describe("EditRecommendationsForm", () => {
       });
 
       render(
-        <EditRecommendationsForm awardRecommendationId={awardRecommendationId} />,
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
       );
 
       expect(mockUseSelectedSubmissions).toHaveBeenCalledWith(

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
@@ -36,7 +36,7 @@ export default function EditRecommendationsForm({
     );
   };
 
-  const handleSave = async () => {
+  const handleSave = () => {
     setIsSubmitting(true);
     setError(null);
 
@@ -101,7 +101,7 @@ export default function EditRecommendationsForm({
         <ButtonGroup className="margin-top-4">
           <Button
             type="button"
-            onClick={() => void handleSave()}
+            onClick={handleSave}
             disabled={isSubmitting}
           >
             {isSubmitting ? t("saving") : t("saveButton")}

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useSelectedSubmissions } from "src/hooks/useSelectedSubmissions";
-import { AwardRecommendationType } from "src/types/awardRecommendationTypes";
 
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Button, ButtonGroup, Label, Select } from "@trussworks/react-uswds";
+import { Button, ButtonGroup } from "@trussworks/react-uswds";
 
+import { RecommendationDetailForm } from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
 import SelectedApplicationsTable from "src/components/award-recommendation/SelectedApplicationsTable";
 import SimplerAlert from "src/components/core/SimplerAlert";
 
@@ -19,18 +19,16 @@ export default function EditRecommendationsForm({
   awardRecommendationId,
 }: EditRecommendationsFormProps) {
   const t = useTranslations("AwardRecommendation.editRecommendations");
-  const tOptions = useTranslations(
-    "AwardRecommendation.recommendations.submissions.recommendationOptions",
-  );
   const router = useRouter();
-  const [selectedRecommendation, setSelectedRecommendation] =
-    useState<AwardRecommendationType>("recommended_for_funding");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const { selectedSubmissions, hasSelections } = useSelectedSubmissions(
     awardRecommendationId,
   );
+
+  const isSingleSubmission = selectedSubmissions.length === 1;
+  const isMultipleSubmissions = selectedSubmissions.length > 1;
 
   const handleCancel = () => {
     router.push(
@@ -83,41 +81,22 @@ export default function EditRecommendationsForm({
         {t("selectedApplications")}
       </h2>
 
+      {isMultipleSubmissions && (
+        <p className="margin-top-0 margin-bottom-2 text-base">
+          {selectedSubmissions.length} {t("submissionsSelected")}
+        </p>
+      )}
+
       <SelectedApplicationsTable
         awardRecommendationId={awardRecommendationId}
         submissions={selectedSubmissions}
       />
 
       <div className="margin-top-4">
-        <h3 className="margin-top-0 margin-bottom-2">
-          {t("bulkEditHeading")}
-        </h3>
-        <p className="text-base-dark margin-top-0 margin-bottom-3">
-          {t("bulkEditDescription")}
-        </p>
-
-        <div className="maxw-tablet">
-          <Label htmlFor="recommendation-type">{t("recommendationType")}</Label>
-          <Select
-            id="recommendation-type"
-            name="recommendation-type"
-            value={selectedRecommendation}
-            onChange={(e) =>
-              setSelectedRecommendation(e.target.value as AwardRecommendationType)
-            }
-            disabled={isSubmitting}
-          >
-            <option value="recommended_for_funding">
-              {tOptions("recommended")}
-            </option>
-            <option value="recommended_without_funding">
-              {tOptions("recommendedWithoutFunding")}
-            </option>
-            <option value="not_recommended">
-              {tOptions("notRecommended")}
-            </option>
-          </Select>
-        </div>
+        <RecommendationDetailForm
+          submission={isSingleSubmission ? selectedSubmissions[0] : undefined}
+          submissions={isMultipleSubmissions ? selectedSubmissions : undefined}
+        />
 
         <ButtonGroup className="margin-top-4">
           <Button

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { RecommendationDetailForm } from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
 import { useSelectedSubmissions } from "src/hooks/useSelectedSubmissions";
 
 import { useTranslations } from "next-intl";
@@ -7,7 +8,6 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button, ButtonGroup } from "@trussworks/react-uswds";
 
-import { RecommendationDetailForm } from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
 import SelectedApplicationsTable from "src/components/award-recommendation/SelectedApplicationsTable";
 import SimplerAlert from "src/components/core/SimplerAlert";
 
@@ -99,11 +99,7 @@ export default function EditRecommendationsForm({
         />
 
         <ButtonGroup className="margin-top-4">
-          <Button
-            type="button"
-            onClick={handleSave}
-            disabled={isSubmitting}
-          >
+          <Button type="button" onClick={handleSave} disabled={isSubmitting}>
             {isSubmitting ? t("saving") : t("saveButton")}
           </Button>
           <Button

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useSelectedSubmissions } from "src/hooks/useSelectedSubmissions";
+import { AwardRecommendationType } from "src/types/awardRecommendationTypes";
+
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button, ButtonGroup, Label, Select } from "@trussworks/react-uswds";
+
+import SelectedApplicationsTable from "src/components/award-recommendation/SelectedApplicationsTable";
+import SimplerAlert from "src/components/core/SimplerAlert";
+
+interface EditRecommendationsFormProps {
+  awardRecommendationId: string;
+}
+
+export default function EditRecommendationsForm({
+  awardRecommendationId,
+}: EditRecommendationsFormProps) {
+  const t = useTranslations("AwardRecommendation.editRecommendations");
+  const tOptions = useTranslations(
+    "AwardRecommendation.recommendations.submissions.recommendationOptions",
+  );
+  const router = useRouter();
+  const [selectedRecommendation, setSelectedRecommendation] =
+    useState<AwardRecommendationType>("recommended_for_funding");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { selectedSubmissions, hasSelections } = useSelectedSubmissions(
+    awardRecommendationId,
+  );
+
+  const handleCancel = () => {
+    router.push(
+      `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+    );
+  };
+
+  const handleSave = async () => {
+    setIsSubmitting(true);
+    setError(null);
+
+    // TODO: Implement bulk update API call
+    // For now, just navigate back
+    setTimeout(() => {
+      router.push(
+        `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+      );
+    }, 500);
+  };
+
+  if (!hasSelections) {
+    return (
+      <SimplerAlert
+        alertClick={() =>
+          router.push(
+            `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+          )
+        }
+        buttonId="no-selections-alert"
+        messageText={t("noSelectionsMessage")}
+        type="error"
+      />
+    );
+  }
+
+  return (
+    <div>
+      {error && (
+        <div className="margin-bottom-4">
+          <SimplerAlert
+            alertClick={() => setError(null)}
+            buttonId="error-alert"
+            messageText={error}
+            type="error"
+          />
+        </div>
+      )}
+
+      <h2 className="margin-top-0 margin-bottom-3">
+        {t("selectedApplications")}
+      </h2>
+
+      <SelectedApplicationsTable
+        awardRecommendationId={awardRecommendationId}
+        submissions={selectedSubmissions}
+      />
+
+      <div className="margin-top-4">
+        <h3 className="margin-top-0 margin-bottom-2">
+          {t("bulkEditHeading")}
+        </h3>
+        <p className="text-base-dark margin-top-0 margin-bottom-3">
+          {t("bulkEditDescription")}
+        </p>
+
+        <div className="maxw-tablet">
+          <Label htmlFor="recommendation-type">{t("recommendationType")}</Label>
+          <Select
+            id="recommendation-type"
+            name="recommendation-type"
+            value={selectedRecommendation}
+            onChange={(e) =>
+              setSelectedRecommendation(e.target.value as AwardRecommendationType)
+            }
+            disabled={isSubmitting}
+          >
+            <option value="recommended_for_funding">
+              {tOptions("recommended")}
+            </option>
+            <option value="recommended_without_funding">
+              {tOptions("recommendedWithoutFunding")}
+            </option>
+            <option value="not_recommended">
+              {tOptions("notRecommended")}
+            </option>
+          </Select>
+        </div>
+
+        <ButtonGroup className="margin-top-4">
+          <Button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? t("saving") : t("saveButton")}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleCancel}
+            disabled={isSubmitting}
+            unstyled
+            className="padding-105 text-center"
+          >
+            {t("cancelButton")}
+          </Button>
+        </ButtonGroup>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.test.tsx
@@ -74,13 +74,17 @@ const mockGetAwardRecommendationDetails = jest
   .mockResolvedValue(mockAwardRecommendationDetails);
 
 jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher", () => ({
-  getAwardRecommendationDetails: (awardRecommendationId: string): ReturnType<typeof mockGetAwardRecommendationDetails> =>
+  getAwardRecommendationDetails: (
+    awardRecommendationId: string,
+  ): ReturnType<typeof mockGetAwardRecommendationDetails> =>
     mockGetAwardRecommendationDetails(awardRecommendationId),
 }));
 
 const mockUseSelectedSubmissions = jest.fn();
 jest.mock("src/hooks/useSelectedSubmissions", () => ({
-  useSelectedSubmissions: (awardRecommendationId: string): ReturnType<typeof mockUseSelectedSubmissions> =>
+  useSelectedSubmissions: (
+    awardRecommendationId: string,
+  ): ReturnType<typeof mockUseSelectedSubmissions> =>
     mockUseSelectedSubmissions(awardRecommendationId),
 }));
 
@@ -142,7 +146,6 @@ describe("BulkEditRecommendationsPage", () => {
         await screen.findByTestId("award-recommendation-hero-fallback"),
       ).toBeInTheDocument();
     });
-
 
     it("renders the EditRecommendationsForm component", async () => {
       const component = await BulkEditRecommendationsPage({

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.test.tsx
@@ -1,0 +1,452 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { identity } from "lodash";
+import BulkEditRecommendationsPage from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page";
+import { AwardRecommendationDetails } from "src/types/awardRecommendationTypes";
+import { LocalizedPageProps } from "src/types/intl";
+import { FeatureFlaggedPageWrapper } from "src/types/uiTypes";
+import { wrapForExpectedError } from "src/utils/testing/commonTestUtils";
+
+import { FunctionComponent, ReactNode } from "react";
+
+type onEnabled = (props: LocalizedPageProps) => ReactNode;
+
+jest.mock("next-intl/server", () => ({
+  getTranslations: () => identity,
+}));
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => identity,
+}));
+
+const mockRedirect = jest.fn();
+jest.mock("next/navigation", () => ({
+  redirect: (...args: unknown[]) => {
+    mockRedirect(...args);
+    throw new Error("NEXT_REDIRECT");
+  },
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+const withFeatureFlagMock = jest.fn();
+
+jest.mock("src/services/featureFlags/withFeatureFlag", () => ({
+  __esModule: true,
+  default:
+    (
+      WrappedComponent: FunctionComponent<LocalizedPageProps>,
+      _featureFlagName: string,
+      onEnabled: onEnabled,
+    ) =>
+    (props: LocalizedPageProps) =>
+      (
+        withFeatureFlagMock as FeatureFlaggedPageWrapper<
+          LocalizedPageProps,
+          ReactNode
+        >
+      )(
+        WrappedComponent,
+        _featureFlagName,
+        onEnabled,
+      )(props) as FunctionComponent<LocalizedPageProps>,
+}));
+
+const mockAwardRecommendationDetails: AwardRecommendationDetails = {
+  award_recommendation_id: "AR-26-0001",
+  award_recommendation_number: "AR-26-0001",
+  award_recommendation_status: "draft",
+  award_selection_method: "merit-review-only",
+  opportunity: {
+    opportunity_id: "opp-1",
+    opportunity_number: "OPP-001",
+    opportunity_title: "Test Opportunity",
+    summary: {
+      opportunity_status: "posted",
+      summary_description: "Test description",
+    },
+  },
+};
+
+const mockGetAwardRecommendationDetails = jest
+  .fn()
+  .mockResolvedValue(mockAwardRecommendationDetails);
+
+jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher", () => ({
+  getAwardRecommendationDetails: (awardRecommendationId: string) =>
+    mockGetAwardRecommendationDetails(awardRecommendationId),
+}));
+
+const mockUseSelectedSubmissions = jest.fn();
+jest.mock("src/hooks/useSelectedSubmissions", () => ({
+  useSelectedSubmissions: (awardRecommendationId: string) =>
+    mockUseSelectedSubmissions(awardRecommendationId),
+}));
+
+const pageParams = Promise.resolve({
+  locale: "en",
+  id: "AR-26-0001",
+});
+
+describe("BulkEditRecommendationsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelectedSubmissions.mockReturnValue({
+      selectedSubmissions: [],
+      hasSelections: false,
+      selectedSubmissionIds: new Set(),
+      setSelectedSubmissionIds: jest.fn(),
+      addSubmission: jest.fn(),
+      removeSubmission: jest.fn(),
+      addMultipleSubmissions: jest.fn(),
+      clearSelections: jest.fn(),
+    });
+  });
+
+  describe("when feature flag is enabled", () => {
+    beforeEach(() => {
+      withFeatureFlagMock.mockImplementation(
+        (
+          WrappedComponent: FunctionComponent<LocalizedPageProps>,
+          _featureFlagName: string,
+          _onEnabled: onEnabled,
+        ) =>
+          (props: { params: Promise<{ locale: string }> }) =>
+            WrappedComponent(props) as unknown,
+      );
+
+      mockGetAwardRecommendationDetails.mockResolvedValue(
+        mockAwardRecommendationDetails,
+      );
+    });
+
+    it("fetches the award recommendation details", async () => {
+      await BulkEditRecommendationsPage({
+        params: pageParams,
+        searchParams: Promise.resolve({}),
+      });
+
+      expect(mockGetAwardRecommendationDetails).toHaveBeenCalledWith(
+        "AR-26-0001",
+      );
+    });
+
+    it("renders the page with hero fallback", async () => {
+      const component = await BulkEditRecommendationsPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(
+        await screen.findByTestId("award-recommendation-hero-fallback"),
+      ).toBeInTheDocument();
+    });
+
+
+    it("renders the EditRecommendationsForm component", async () => {
+      const component = await BulkEditRecommendationsPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(
+        await screen.findByText("noSelectionsMessage"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays error alert when award recommendation is not found", async () => {
+      mockGetAwardRecommendationDetails.mockResolvedValue(null);
+
+      const component = await BulkEditRecommendationsPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(
+        await screen.findByText("awardRecommendationNotFound"),
+      ).toBeVisible();
+    });
+
+    it("displays authentication error on 401", async () => {
+      mockGetAwardRecommendationDetails.mockRejectedValue({
+        message: "Unauthorized",
+        cause: { status: 401 },
+      });
+
+      const component = await BulkEditRecommendationsPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(
+        await screen.findByText("errorHeadingAuthentication"),
+      ).toBeVisible();
+      expect(screen.getByText("authenticationError")).toBeVisible();
+    });
+
+    it("displays authentication error on 403", async () => {
+      mockGetAwardRecommendationDetails.mockRejectedValue({
+        message: "Forbidden",
+        cause: { status: 403 },
+      });
+
+      const component = await BulkEditRecommendationsPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(
+        await screen.findByText("errorHeadingAuthentication"),
+      ).toBeVisible();
+      expect(screen.getByText("authenticationError")).toBeVisible();
+    });
+
+    it("displays fetch error on other errors", async () => {
+      mockGetAwardRecommendationDetails.mockRejectedValue({
+        message: "Server error",
+        cause: { status: 500 },
+      });
+
+      const component = await BulkEditRecommendationsPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(
+        await screen.findByText("errorHeadingAwardRecommendation"),
+      ).toBeVisible();
+      expect(screen.getByText("awardRecommendationFetchError")).toBeVisible();
+    });
+
+    describe("with single submission selected", () => {
+      beforeEach(() => {
+        mockUseSelectedSubmissions.mockReturnValue({
+          selectedSubmissions: [
+            {
+              award_recommendation_application_submission_id: "test-id-1",
+              application_submission: {
+                application_submission_id: "app-sub-1",
+                application_submission_number: "SUB-001",
+                project_title: "Test Project",
+                total_requested_amount: "100000.00",
+                application: {
+                  application_id: "app-1",
+                  competition_id: "comp-1",
+                },
+              },
+              submission_detail: {
+                award_recommendation_type: "recommended_for_funding",
+                recommended_amount: "75000.00",
+              },
+            },
+          ],
+          hasSelections: true,
+          selectedSubmissionIds: new Set(["test-id-1"]),
+          setSelectedSubmissionIds: jest.fn(),
+          addSubmission: jest.fn(),
+          removeSubmission: jest.fn(),
+          addMultipleSubmissions: jest.fn(),
+          clearSelections: jest.fn(),
+        });
+      });
+
+      it("renders single submission form", async () => {
+        const component = await BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+        render(component);
+
+        expect(await screen.findByText("selectedApplications")).toBeVisible();
+        expect(screen.getByText("recommendationLabel")).toBeVisible();
+        expect(screen.getByText("fundingHeading")).toBeVisible();
+      });
+
+      it("does not show submission count for single selection", async () => {
+        const component = await BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+        render(component);
+
+        await screen.findByText("selectedApplications");
+        expect(
+          screen.queryByText(/submissionsSelected/),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("with multiple submissions selected", () => {
+      beforeEach(() => {
+        mockUseSelectedSubmissions.mockReturnValue({
+          selectedSubmissions: [
+            {
+              award_recommendation_application_submission_id: "test-id-1",
+              application_submission: {
+                application_submission_id: "app-sub-1",
+                application_submission_number: "SUB-001",
+                project_title: "Test Project",
+                total_requested_amount: "100000.00",
+                application: {
+                  application_id: "app-1",
+                  competition_id: "comp-1",
+                },
+              },
+              submission_detail: {
+                award_recommendation_type: "recommended_for_funding",
+                recommended_amount: "75000.00",
+              },
+            },
+            {
+              award_recommendation_application_submission_id: "test-id-2",
+              application_submission: {
+                application_submission_id: "app-sub-2",
+                application_submission_number: "SUB-002",
+                project_title: "Test Project 2",
+                total_requested_amount: "50000.00",
+                application: {
+                  application_id: "app-2",
+                  competition_id: "comp-1",
+                },
+              },
+              submission_detail: {
+                award_recommendation_type: "recommended_for_funding",
+                recommended_amount: "25000.00",
+              },
+            },
+          ],
+          hasSelections: true,
+          selectedSubmissionIds: new Set(["test-id-1", "test-id-2"]),
+          setSelectedSubmissionIds: jest.fn(),
+          addSubmission: jest.fn(),
+          removeSubmission: jest.fn(),
+          addMultipleSubmissions: jest.fn(),
+          clearSelections: jest.fn(),
+        });
+      });
+
+      it("renders multiple submissions form with table", async () => {
+        const component = await BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+        render(component);
+
+        expect(await screen.findByText("selectedApplications")).toBeVisible();
+        expect(screen.getByText("recommendationLabel")).toBeVisible();
+        expect(screen.getByText("applicationIdLabel")).toBeVisible();
+        expect(screen.getByText("totalLabel")).toBeVisible();
+      });
+
+      it("shows submission count for multiple selections", async () => {
+        const component = await BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+        render(component);
+
+        await screen.findByText("selectedApplications");
+        expect(screen.getByText("2 submissionsSelected")).toBeVisible();
+      });
+
+      it("displays correct totals in funding table", async () => {
+        const component = await BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+        render(component);
+
+        await screen.findByText("totalLabel");
+        expect(screen.getByText("$150,000")).toBeVisible();
+        const hundredThousandElements = screen.getAllByText("$100,000");
+        expect(hundredThousandElements.length).toBeGreaterThanOrEqual(1);
+      });
+
+      it("shows exception checkbox when recommended_without_funding is selected", async () => {
+        const user = userEvent.setup();
+        const component = await BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+        render(component);
+
+        const recommendationSelect = await screen.findByRole("combobox");
+        await user.selectOptions(
+          recommendationSelect,
+          "recommended_without_funding",
+        );
+
+        expect(screen.getByLabelText("hasExceptionLabel")).toBeVisible();
+        expect(screen.getByLabelText("hasExceptionLabel")).toBeChecked();
+      });
+
+      it("shows exception detail textarea when checkbox is checked", async () => {
+        const user = userEvent.setup();
+        const component = await BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+        render(component);
+
+        const recommendationSelect = await screen.findByRole("combobox");
+        await user.selectOptions(recommendationSelect, "not_recommended");
+
+        const checkbox = screen.getByLabelText("hasExceptionLabel");
+        expect(checkbox).not.toBeChecked();
+
+        await user.click(checkbox);
+
+        expect(
+          screen.getByTestId("exception-detail-textarea"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("renders save and cancel buttons", async () => {
+      mockUseSelectedSubmissions.mockReturnValue({
+        selectedSubmissions: [
+          {
+            award_recommendation_application_submission_id: "test-id-1",
+            application_submission: {
+              application_submission_id: "app-sub-1",
+              total_requested_amount: "100000.00",
+            },
+          },
+        ],
+        hasSelections: true,
+        selectedSubmissionIds: new Set(["test-id-1"]),
+        setSelectedSubmissionIds: jest.fn(),
+        addSubmission: jest.fn(),
+        removeSubmission: jest.fn(),
+        addMultipleSubmissions: jest.fn(),
+        clearSelections: jest.fn(),
+      });
+
+      const component = await BulkEditRecommendationsPage({
+        params: pageParams,
+      });
+      render(component);
+
+      expect(await screen.findByText("saveButton")).toBeVisible();
+      expect(screen.getByText("cancelButton")).toBeVisible();
+    });
+  });
+
+  describe("when feature flag is disabled", () => {
+    beforeEach(() => {
+      withFeatureFlagMock.mockImplementation(
+        (
+          _WrappedComponent: FunctionComponent<LocalizedPageProps>,
+          _featureFlagName: string,
+          onEnabled: onEnabled,
+        ) =>
+          (props: { params: Promise<{ locale: string }> }) =>
+            onEnabled(props) as unknown,
+      );
+    });
+
+    it("redirects to /maintenance", async () => {
+      await wrapForExpectedError(() => {
+        return BulkEditRecommendationsPage({
+          params: pageParams,
+        });
+      });
+
+      expect(mockRedirect).toHaveBeenCalledWith("/maintenance");
+    });
+  });
+});

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.test.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.test.tsx
@@ -74,13 +74,13 @@ const mockGetAwardRecommendationDetails = jest
   .mockResolvedValue(mockAwardRecommendationDetails);
 
 jest.mock("src/services/fetch/fetchers/awardRecommendationFetcher", () => ({
-  getAwardRecommendationDetails: (awardRecommendationId: string) =>
+  getAwardRecommendationDetails: (awardRecommendationId: string): ReturnType<typeof mockGetAwardRecommendationDetails> =>
     mockGetAwardRecommendationDetails(awardRecommendationId),
 }));
 
 const mockUseSelectedSubmissions = jest.fn();
 jest.mock("src/hooks/useSelectedSubmissions", () => ({
-  useSelectedSubmissions: (awardRecommendationId: string) =>
+  useSelectedSubmissions: (awardRecommendationId: string): ReturnType<typeof mockUseSelectedSubmissions> =>
     mockUseSelectedSubmissions(awardRecommendationId),
 }));
 

--- a/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.tsx
+++ b/frontend/src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/page.tsx
@@ -1,0 +1,156 @@
+import { Metadata } from "next";
+import EditRecommendationsForm from "src/app/[locale]/(base)/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm";
+import { ApiRequestError, parseErrorStatus } from "src/errors";
+import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
+import { getAwardRecommendationDetails } from "src/services/fetch/fetchers/awardRecommendationFetcher";
+import { AwardRecommendationDetails } from "src/types/awardRecommendationTypes";
+import { WithFeatureFlagProps } from "src/types/uiTypes";
+
+import { getTranslations } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import { Alert, Grid, GridContainer } from "@trussworks/react-uswds";
+
+import AwardRecommendationHero, {
+  HeroButtonConfig,
+} from "src/components/award-recommendation/AwardRecommendationHero";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string; id?: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale });
+  const meta: Metadata = {
+    title: t("AwardRecommendation.editRecommendations.bulkEditPageTitle"),
+    description: t(
+      "AwardRecommendation.editRecommendations.bulkEditMetaDescription",
+    ),
+  };
+  return meta;
+}
+
+export const dynamic = "force-dynamic";
+
+export type BulkEditRecommendationsPageProps = {
+  params: Promise<{ locale: string; id?: string }>;
+} & WithFeatureFlagProps;
+
+async function BulkEditRecommendationsPageContent({
+  params,
+}: BulkEditRecommendationsPageProps) {
+  const { id: awardRecommendationId } = await params;
+
+  const t = await getTranslations("AwardRecommendation");
+
+  const heroButtons: HeroButtonConfig[] = [
+    {
+      type: "navigation",
+      label: t("heroButtons.backToSubmissions"),
+      href: `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+      outline: true,
+    },
+  ];
+
+  const heroHeading = t("editRecommendations.bulkEditTitle");
+
+  let awardRecommendationDetails: AwardRecommendationDetails | null = null;
+  if (awardRecommendationId) {
+    try {
+      awardRecommendationDetails = await getAwardRecommendationDetails(
+        awardRecommendationId,
+      );
+    } catch (error) {
+      console.error("Failed to fetch award recommendation details", error);
+      const errorStatus = parseErrorStatus(error as ApiRequestError);
+
+      if (errorStatus === 404) {
+        awardRecommendationDetails = null;
+      }
+
+      if (errorStatus === 401 || errorStatus === 403) {
+        return (
+          <Alert
+            heading={t("errorHeadingAuthentication")}
+            headingLevel="h2"
+            type="error"
+            validation
+          >
+            {t("authenticationError")}
+          </Alert>
+        );
+      }
+
+      return (
+        <Alert
+          heading={t("errorHeadingAwardRecommendation")}
+          headingLevel="h2"
+          type="warning"
+          validation
+        >
+          {t("awardRecommendationFetchError")}
+        </Alert>
+      );
+    }
+  }
+
+  if (!awardRecommendationDetails) {
+    return (
+      <Alert
+        heading={t("errorHeadingAwardRecommendation")}
+        headingLevel="h2"
+        type="warning"
+        validation
+      >
+        {t("awardRecommendationNotFound")}
+      </Alert>
+    );
+  }
+
+  return (
+    <>
+      <Suspense
+        fallback={
+          <span data-testid="award-recommendation-hero-fallback"></span>
+        }
+      >
+        <AwardRecommendationHero
+          awardRecommendationDetails={awardRecommendationDetails}
+          buttons={heroButtons}
+          heading={heroHeading}
+          showDateAndStatus={false}
+          additionalBreadcrumbs={[
+            {
+              title: t("editRecommendations.heading"),
+              path: `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+            },
+            {
+              title: heroHeading,
+              path: `/award-recommendation/${awardRecommendationId}/application-submissions/edit/bulk`,
+            },
+          ]}
+        />
+      </Suspense>
+      <GridContainer>
+        <Grid row>
+          <Grid col={12}>
+            <div className="margin-top-4">
+              {awardRecommendationId && (
+                <EditRecommendationsForm
+                  awardRecommendationId={awardRecommendationId}
+                />
+              )}
+            </div>
+          </Grid>
+        </Grid>
+      </GridContainer>
+    </>
+  );
+}
+
+export default withFeatureFlag<BulkEditRecommendationsPageProps, never>(
+  BulkEditRecommendationsPageContent,
+  "awardRecommendationOff",
+  () => redirect("/maintenance"),
+);

--- a/frontend/src/components/award-recommendation/EditRecommendationsTable.tsx
+++ b/frontend/src/components/award-recommendation/EditRecommendationsTable.tsx
@@ -316,7 +316,7 @@ export default function EditRecommendationsTable({
               className="usa-button"
               onClick={() => {
                 router.push(
-                  `/award-recommendation/${awardRecommendationId}/application-submissions/edit`,
+                  `/award-recommendation/${awardRecommendationId}/application-submissions/edit/bulk`,
                 );
               }}
             >

--- a/frontend/src/components/award-recommendation/SelectedApplicationsTable.tsx
+++ b/frontend/src/components/award-recommendation/SelectedApplicationsTable.tsx
@@ -25,7 +25,7 @@ const tableCell = (
 });
 
 const recommendationTypeTagBaseClass =
-  "usa-tag font-sans-sm text-no-uppercase text-ink radius-2";
+  "usa-tag font-sans-sm text-no-uppercase text-ink radius-2 text-no-wrap";
 
 const RecommendationTypeTag = ({
   recommendationType,

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2094,6 +2094,7 @@ export const messages = {
         "Bulk edit award recommendations for selected applications",
       bulkEditTitle: "Bulk Edit Recommendations",
       selectedApplications: "Selected Applications",
+      submissionsSelected: "submissions selected",
       bulkEditHeading: "Update Recommendation",
       bulkEditDescription:
         "Select a recommendation type to apply to all selected applications.",
@@ -2193,8 +2194,12 @@ export const messages = {
       exceptionDetailDescription:
         "Select one or more applications and explain any exceptions to the general selection method. For example, the reasons for any applications skipped on the merit review ranking or other similar exceptions.",
       fundingHeading: "Funding recommendations",
+      fundingDescription:
+        "Review and provide the updates to recommended funding as needed.",
+      applicationIdLabel: "Application ID",
       amountRequestedLabel: "Amount Requested",
       amountRecommendedLabel: "Amount Recommended",
+      totalLabel: "Total",
     },
     errorHeadingAwardRecommendation:
       "Error fetching award recommendation details",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2089,6 +2089,20 @@ export const messages = {
       loading: "Loading...",
       errorLoading: "Error loading submissions. Please try again.",
       editButton: "Edit",
+      bulkEditPageTitle: "Bulk Edit Recommendations",
+      bulkEditMetaDescription:
+        "Bulk edit award recommendations for selected applications",
+      bulkEditTitle: "Bulk Edit Recommendations",
+      selectedApplications: "Selected Applications",
+      bulkEditHeading: "Update Recommendation",
+      bulkEditDescription:
+        "Select a recommendation type to apply to all selected applications.",
+      recommendationType: "Recommendation Type",
+      noSelectionsMessage:
+        "No submissions selected. Please select submissions to edit.",
+      saveButton: "Save",
+      saving: "Saving...",
+      cancelButton: "Cancel",
       columns: {
         appNumber: "App #",
         projectTitle: "Project Title",

--- a/frontend/src/utils/getRoutes.test.ts
+++ b/frontend/src/utils/getRoutes.test.ts
@@ -10,6 +10,7 @@ describe("getNextRoutes", () => {
     expect(result).toEqual([
       "/(base)/[...not-found]",
       "/(base)/award-recommendation/1/application-submissions/[applicationSubmissionId]/edit",
+      "/(base)/award-recommendation/1/application-submissions/edit/bulk",
       "/(base)/award-recommendation/1/application-submissions/edit",
       "/(base)/award-recommendation/1/edit",
       "/(base)/award-recommendation/1",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10304 

## Changes proposed

multi select recommendation applications on table
navigate to bulk edit page 

## Context for reviewers

multi select recommendation applications on table
navigate to bulk edit page 
Updated existing RecommendedDetailsSection which work for single submission and multiple submissions.


## Validation steps


- For any awardrecommendation on local navigate to Edit Award Recommendation page http://localhost:3000/award-recommendation/{awardRecommendationId}/edit
- Click on Edit recommended award link
- Table with submitted applications for an opportunity are populated (observe submissions of all award recommendation types are shown in the table)
- We can select/deselect , selectAll/deselectAll submissions from the table and Edit button is displayed.
- Clicking on Edit button navigates to bulk edit page we have two different layouts seen based on single or multi selecting submissions.
- Save and minor UI issues [#10305 ]will be implemented as part of different ticket 
- Also verify existing Edit Submission Details UI and save functionality as the component used for that has been shared across edit submission details save page and bulk update page.

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/87672756-2357-4b50-95b0-29ee2e607f7d" />
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/16cc5da7-0d84-479b-b88b-e100f3b4ac12" />
