### PR TITLE
[Issue #11011] Upload Competition Instructions Backend Endpoint

### DIFF
--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
@@ -368,7 +368,7 @@ def competition_instructions_upload(
         {"opportunity_id": opportunity_id, "competition_id": competition_id}
     )
     logger.info(
-        f"POST /v1/grantors/opportunities/{opportunity_id}/competitions/{competition_id}/instructions"
+        "POST /v1/grantors/opportunities/:opportunity_id/competitions/:competition_id/instructions"
     )
 
     with db_session.begin():

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
@@ -12,6 +12,9 @@ from src.api.opportunities_grantor_v1.opportunity_grantor_blueprint import (
 )
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.services.opportunities_grantor_v1.competition_creation import create_competition
+from src.services.opportunities_grantor_v1.competition_instruction_upload import (
+    upload_competition_instructions,
+)
 from src.services.opportunities_grantor_v1.competition_update import update_competition
 from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
 from src.services.opportunities_grantor_v1.get_opportunity_list import (
@@ -343,3 +346,40 @@ def competition_update(
         )
 
     return response.ApiResponse(message="Success", data=competition)
+
+
+@opportunity_grantor_blueprint.post(
+    "/opportunities/<uuid:opportunity_id>/competitions/<uuid:competition_id>/instructions"
+)
+@opportunity_grantor_blueprint.input(
+    opportunity_grantor_schemas.CompetitionInstructionUploadRequestV1Schema(), location="files"
+)
+@opportunity_grantor_blueprint.output(
+    opportunity_grantor_schemas.CompetitionInstructionUploadResponseV1Schema()
+)
+@opportunity_grantor_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@opportunity_grantor_blueprint.doc(responses=[200, 403, 404, 422, 500])
+@flask_db.with_db_session()
+def competition_instructions_upload(
+    db_session: db.Session, opportunity_id: UUID, competition_id: UUID, files_data: dict
+) -> response.ApiResponse:
+    """Upload instruction files to a competition"""
+    add_extra_data_to_current_request_logs(
+        {"opportunity_id": opportunity_id, "competition_id": competition_id}
+    )
+    logger.info(
+        f"POST /v1/grantors/opportunities/{opportunity_id}/competitions/{competition_id}/instructions"
+    )
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        instruction_ids = upload_competition_instructions(
+            db_session, user, opportunity_id, competition_id, files_data["file_attachment"]
+        )
+
+    return response.ApiResponse(
+        message="Instructions uploaded successfully",
+        data={"competition_instruction_id": instruction_ids},
+    )

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
@@ -13,7 +13,7 @@ from src.api.opportunities_grantor_v1.opportunity_grantor_blueprint import (
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.services.opportunities_grantor_v1.competition_creation import create_competition
 from src.services.opportunities_grantor_v1.competition_instruction_upload import (
-    upload_competition_instructions,
+    upload_competition_instruction,
 )
 from src.services.opportunities_grantor_v1.competition_update import update_competition
 from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
@@ -360,10 +360,10 @@ def competition_update(
 @opportunity_grantor_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
 @opportunity_grantor_blueprint.doc(responses=[200, 403, 404, 422, 500])
 @flask_db.with_db_session()
-def competition_instructions_upload(
+def competition_instruction_upload(
     db_session: db.Session, opportunity_id: UUID, competition_id: UUID, files_data: dict
 ) -> response.ApiResponse:
-    """Upload instruction files to a competition"""
+    """Upload an instruction file to a competition"""
     add_extra_data_to_current_request_logs(
         {"opportunity_id": opportunity_id, "competition_id": competition_id}
     )
@@ -375,11 +375,11 @@ def competition_instructions_upload(
         user = jwt_or_api_user_key_multi_auth.get_user()
         db_session.add(user)
 
-        instruction_ids = upload_competition_instructions(
+        instruction_id = upload_competition_instruction(
             db_session, user, opportunity_id, competition_id, files_data["file_attachment"]
         )
 
     return response.ApiResponse(
-        message="Instructions uploaded successfully",
-        data={"competition_instruction_id": instruction_ids},
+        message="Instruction uploaded successfully",
+        data={"competition_instruction_id": instruction_id},
     )

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
@@ -716,25 +716,19 @@ class CompetitionUpdateResponseSchema(AbstractResponseSchema):
 class CompetitionInstructionUploadRequestV1Schema(Schema):
     """Schema for POST /v1/grantors/opportunities/:opportunity_id/competitions/:competition_id/instructions request"""
 
-    file_attachment = fields.List(
-        fields.File(
-            required=True,
-            allow_none=False,
-            metadata={"description": "The file attachments to upload"},
-        ),
+    file_attachment = fields.File(
         required=True,
-        validate=validators.Length(min=1),
-        metadata={"description": "List of instruction files to upload"},
+        allow_none=False,
+        metadata={"description": "The instruction file to upload"},
     )
 
 
 class CompetitionInstructionUploadResponseDataV1Schema(Schema):
     """Data schema for competition instruction upload response"""
 
-    competition_instruction_id = fields.List(
-        fields.String(),
+    competition_instruction_id = fields.String(
         required=True,
-        metadata={"description": "List of created competition instruction IDs"},
+        metadata={"description": "The created competition instruction ID"},
     )
 
 

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
@@ -711,3 +711,34 @@ class CompetitionUpdateResponseSchema(AbstractResponseSchema):
     """Schema for PUT /v1/grantors/opportunities/:opportunity_id/competitions/:competition_id response"""
 
     data = fields.Nested(CompetitionAlphaSchema())
+
+
+class CompetitionInstructionUploadRequestV1Schema(Schema):
+    """Schema for POST /v1/grantors/opportunities/:opportunity_id/competitions/:competition_id/instructions request"""
+
+    file_attachment = fields.List(
+        fields.File(
+            required=True,
+            allow_none=False,
+            metadata={"description": "The file attachments to upload"},
+        ),
+        required=True,
+        validate=validators.Length(min=1),
+        metadata={"description": "List of instruction files to upload"},
+    )
+
+
+class CompetitionInstructionUploadResponseDataV1Schema(Schema):
+    """Data schema for competition instruction upload response"""
+
+    competition_instruction_id = fields.List(
+        fields.String(),
+        required=True,
+        metadata={"description": "List of created competition instruction IDs"},
+    )
+
+
+class CompetitionInstructionUploadResponseV1Schema(ResponseWithErrorsSchema):
+    """Response Schema for Upload Competition Instructions Endpoint"""
+
+    data = fields.Nested(CompetitionInstructionUploadResponseDataV1Schema())

--- a/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
+++ b/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
@@ -1,0 +1,95 @@
+import logging
+import uuid
+
+import grants_shared.adapters.db as db
+from grants_shared.adapters.aws import S3Config
+from grants_shared.api.route_utils import raise_flask_error
+from grants_shared.util import file_util
+from werkzeug.datastructures import FileStorage
+
+from src.auth.endpoint_access_util import verify_access
+from src.constants.lookup_constants import Privilege
+from src.db.models.competition_models import CompetitionInstruction
+from src.db.models.user_models import User
+from src.services.competition_alpha.get_competition import get_competition
+from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
+from src.services.opportunity_attachments.attachment_util import (
+    adjust_legacy_file_name,
+    get_s3_competition_instruction_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def upload_competition_instructions(
+    db_session: db.Session,
+    user: User,
+    opportunity_id: uuid.UUID,
+    competition_id: uuid.UUID,
+    file_data_list: list[FileStorage],
+) -> list[str]:
+    """Upload instruction attachments to a competition"""
+    # Get the opportunity and verify it exists
+    opportunity = get_opportunity_for_grantors(db_session, user, opportunity_id)
+
+    # Check if user has permission to update opportunities for this agency
+    verify_access(user, {Privilege.UPDATE_OPPORTUNITY}, opportunity.agency_record)
+
+    # Get the competition and verify it exists
+    competition = get_competition(db_session, competition_id)
+
+    # Verify competition belongs to the opportunity
+    if competition.opportunity_id != opportunity_id:
+        raise_flask_error(
+            404, message=f"Competition {competition_id} not found for opportunity {opportunity_id}"
+        )
+
+    # Process each file
+    instruction_ids = []
+    s3_config = S3Config()
+
+    for file_data in file_data_list:
+        instruction_id = uuid.uuid4()
+
+        # Extract file metadata
+        if not file_data.filename:
+            raise_flask_error(422, "File must have a filename")
+
+        file_name = adjust_legacy_file_name(file_data.filename)
+
+        # Create S3 path for the file
+        file_path = get_s3_competition_instruction_path(
+            file_name=file_name,
+            competition_instruction_id=instruction_id,
+            competition=competition,
+            s3_config=s3_config,
+        )
+
+        # Write the file to S3
+        mime_type = file_data.mimetype or "application/octet-stream"
+        with file_util.open_stream(file_path, "wb", content_type=mime_type) as f:
+            file_data.save(f)
+
+        # Create the instruction record
+        instruction = CompetitionInstruction(
+            competition_instruction_id=instruction_id,
+            competition_id=competition_id,
+            file_location=file_path,
+            file_name=file_name,
+            legacy_competition_id=None,
+        )
+
+        db_session.add(instruction)
+        instruction_ids.append(str(instruction_id))
+
+        logger.info(
+            "Added instruction to competition",
+            extra={
+                "competition_id": competition_id,
+                "opportunity_id": opportunity_id,
+                "instruction_id": instruction_id,
+                "file_name": file_name,
+            },
+        )
+
+    return instruction_ids

--- a/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
+++ b/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
@@ -89,7 +89,7 @@ def upload_competition_instruction(
         extra={
             "competition_id": competition_id,
             "opportunity_id": opportunity_id,
-            "instruction_id": instruction_id,
+            "competition_instruction_id": instruction_id,
             "file_name": file_name,
         },
     )

--- a/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
+++ b/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
@@ -13,6 +13,9 @@ from src.db.models.competition_models import CompetitionInstruction
 from src.db.models.user_models import User
 from src.services.competition_alpha.get_competition import get_competition
 from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
+from src.services.opportunities_grantor_v1.opportunity_utils import (
+    validate_opportunity_created_in_simpler_grants,
+)
 from src.services.opportunity_attachments.attachment_util import (
     adjust_legacy_file_name,
     get_s3_competition_instruction_path,
@@ -28,12 +31,15 @@ def upload_competition_instructions(
     competition_id: uuid.UUID,
     file_data_list: list[FileStorage],
 ) -> list[str]:
-    """Upload instruction attachments to a competition"""
+    """Upload instruction files to a competition"""
     # Get the opportunity and verify it exists
     opportunity = get_opportunity_for_grantors(db_session, user, opportunity_id)
 
     # Check if user has permission to update opportunities for this agency
     verify_access(user, {Privilege.UPDATE_OPPORTUNITY}, opportunity.agency_record)
+
+    # Verify opportunity was created in Simpler Grants
+    validate_opportunity_created_in_simpler_grants(opportunity)
 
     # Get the competition and verify it exists
     competition = get_competition(db_session, competition_id)

--- a/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
+++ b/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
@@ -24,14 +24,14 @@ from src.services.opportunity_attachments.attachment_util import adjust_legacy_f
 logger = logging.getLogger(__name__)
 
 
-def upload_competition_instructions(
+def upload_competition_instruction(
     db_session: db.Session,
     user: User,
     opportunity_id: uuid.UUID,
     competition_id: uuid.UUID,
-    file_data_list: list[FileStorage],
-) -> list[str]:
-    """Upload instruction files to a competition"""
+    file_data: FileStorage,
+) -> str:
+    """Upload an instruction file to a competition"""
     # Get the opportunity and verify it exists
     opportunity = get_opportunity_for_grantors(db_session, user, opportunity_id)
 
@@ -50,52 +50,48 @@ def upload_competition_instructions(
             404, message=f"Competition {competition_id} not found for opportunity {opportunity_id}"
         )
 
-    # Process each file
-    instruction_ids = []
+    # Process the file
     s3_config = S3Config()
+    instruction_id = uuid.uuid4()
 
-    for file_data in file_data_list:
-        instruction_id = uuid.uuid4()
+    # Extract file metadata
+    if not file_data.filename:
+        raise_flask_error(422, "File must have a filename")
 
-        # Extract file metadata
-        if not file_data.filename:
-            raise_flask_error(422, "File must have a filename")
+    file_name = adjust_legacy_file_name(file_data.filename)
 
-        file_name = adjust_legacy_file_name(file_data.filename)
+    # Create S3 path for the file
+    file_path = get_s3_competition_instruction_path(
+        file_name=file_name,
+        competition_instruction_id=instruction_id,
+        competition=competition,
+        s3_config=s3_config,
+    )
 
-        # Create S3 path for the file
-        file_path = get_s3_competition_instruction_path(
-            file_name=file_name,
-            competition_instruction_id=instruction_id,
-            competition=competition,
-            s3_config=s3_config,
-        )
+    # Write the file to S3
+    mime_type = file_data.mimetype or "application/octet-stream"
+    with file_util.open_stream(file_path, "wb", content_type=mime_type) as f:
+        file_data.save(f)
 
-        # Write the file to S3
-        mime_type = file_data.mimetype or "application/octet-stream"
-        with file_util.open_stream(file_path, "wb", content_type=mime_type) as f:
-            file_data.save(f)
+    # Create the instruction record
+    instruction = CompetitionInstruction(
+        competition_instruction_id=instruction_id,
+        competition_id=competition_id,
+        file_location=file_path,
+        file_name=file_name,
+        legacy_competition_id=None,
+    )
 
-        # Create the instruction record
-        instruction = CompetitionInstruction(
-            competition_instruction_id=instruction_id,
-            competition_id=competition_id,
-            file_location=file_path,
-            file_name=file_name,
-            legacy_competition_id=None,
-        )
+    db_session.add(instruction)
 
-        db_session.add(instruction)
-        instruction_ids.append(str(instruction_id))
+    logger.info(
+        "Added instruction to competition",
+        extra={
+            "competition_id": competition_id,
+            "opportunity_id": opportunity_id,
+            "instruction_id": instruction_id,
+            "file_name": file_name,
+        },
+    )
 
-        logger.info(
-            "Added instruction to competition",
-            extra={
-                "competition_id": competition_id,
-                "opportunity_id": opportunity_id,
-                "instruction_id": instruction_id,
-                "file_name": file_name,
-            },
-        )
-
-    return instruction_ids
+    return str(instruction_id)

--- a/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
+++ b/api/src/services/opportunities_grantor_v1/competition_instruction_upload.py
@@ -11,15 +11,15 @@ from src.auth.endpoint_access_util import verify_access
 from src.constants.lookup_constants import Privilege
 from src.db.models.competition_models import CompetitionInstruction
 from src.db.models.user_models import User
+from src.services.competition_alpha.competition_instruction_util import (
+    get_s3_competition_instruction_path,
+)
 from src.services.competition_alpha.get_competition import get_competition
 from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
 from src.services.opportunities_grantor_v1.opportunity_utils import (
     validate_opportunity_created_in_simpler_grants,
 )
-from src.services.opportunity_attachments.attachment_util import (
-    adjust_legacy_file_name,
-    get_s3_competition_instruction_path,
-)
+from src.services.opportunity_attachments.attachment_util import adjust_legacy_file_name
 
 logger = logging.getLogger(__name__)
 

--- a/api/src/services/opportunity_attachments/attachment_util.py
+++ b/api/src/services/opportunity_attachments/attachment_util.py
@@ -4,7 +4,6 @@ import uuid
 from grants_shared.adapters.aws import S3Config
 from grants_shared.util import file_util
 
-from src.db.models.competition_models import Competition
 from src.db.models.opportunity_models import Opportunity
 
 
@@ -36,41 +35,6 @@ def get_s3_attachment_path(
         str(opportunity.opportunity_id),
         "attachments",
         str(opportunity_attachment_id),
-        file_name,
-    )
-
-
-def get_s3_competition_instruction_path(
-    file_name: str,
-    competition_instruction_id: uuid.UUID,
-    competition: Competition,
-    s3_config: S3Config,
-) -> str:
-    """Construct a path to the competition instructions on s3
-
-    Will be formatted like:
-
-        s3://<bucket>/opportunities/<opportunity_id>/competitions/<competition_id>/instructions/<instruction_id>/<file_name>
-
-    Note that we store the files under a "folder" with the instruction ID as
-    the legacy system doesn't guarantee file names are unique within a competition.
-    """
-
-    # Competition instructions should go in draft bucket if opportunity is draft
-    base_path = (
-        s3_config.draft_files_bucket_path
-        if competition.opportunity.is_draft
-        else s3_config.public_files_bucket_path
-    )
-
-    return file_util.join(
-        base_path,
-        "opportunities",
-        str(competition.opportunity_id),
-        "competitions",
-        str(competition.competition_id),
-        "instructions",
-        str(competition_instruction_id),
         file_name,
     )
 

--- a/api/src/services/opportunity_attachments/attachment_util.py
+++ b/api/src/services/opportunity_attachments/attachment_util.py
@@ -4,6 +4,7 @@ import uuid
 from grants_shared.adapters.aws import S3Config
 from grants_shared.util import file_util
 
+from src.db.models.competition_models import Competition
 from src.db.models.opportunity_models import Opportunity
 
 
@@ -35,6 +36,41 @@ def get_s3_attachment_path(
         str(opportunity.opportunity_id),
         "attachments",
         str(opportunity_attachment_id),
+        file_name,
+    )
+
+
+def get_s3_competition_instruction_path(
+    file_name: str,
+    competition_instruction_id: uuid.UUID,
+    competition: Competition,
+    s3_config: S3Config,
+) -> str:
+    """Construct a path to the competition instructions on s3
+
+    Will be formatted like:
+
+        s3://<bucket>/opportunities/<opportunity_id>/competitions/<competition_id>/instructions/<instruction_id>/<file_name>
+
+    Note that we store the files under a "folder" with the instruction ID as
+    the legacy system doesn't guarantee file names are unique within a competition.
+    """
+
+    # Competition instructions should go in draft bucket if opportunity is draft
+    base_path = (
+        s3_config.draft_files_bucket_path
+        if competition.opportunity.is_draft
+        else s3_config.public_files_bucket_path
+    )
+
+    return file_util.join(
+        base_path,
+        "opportunities",
+        str(competition.opportunity_id),
+        "competitions",
+        str(competition.competition_id),
+        "instructions",
+        str(competition_instruction_id),
         file_name,
     )
 

--- a/api/tests/src/api/opportunities_grantors_v1/test_competition_attachments.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_competition_attachments.py
@@ -24,7 +24,9 @@ def grantor_auth_data(db_session, enable_factory_create):
 def existing_opportunity(grantor_auth_data, enable_factory_create):
     """Create an opportunity belonging to the grantor's agency"""
     user, agency, _, _ = grantor_auth_data
-    return OpportunityFactory.create(agency_code=agency.agency_code, is_draft=True)
+    return OpportunityFactory.create(
+        agency_code=agency.agency_code, is_draft=True, is_simpler_grants_opportunity=True
+    )
 
 
 @pytest.fixture
@@ -198,7 +200,9 @@ def test_upload_instructions_competition_wrong_opportunity(
     _, agency, token, _ = grantor_auth_data
 
     # Create a different opportunity
-    other_opportunity = OpportunityFactory.create(agency_code=agency.agency_code, is_draft=True)
+    other_opportunity = OpportunityFactory.create(
+        agency_code=agency.agency_code, is_draft=True, is_simpler_grants_opportunity=True
+    )
 
     competition = existing_competition
     file_content = b"This is instruction content"
@@ -249,3 +253,32 @@ def test_upload_instructions_empty_file_list(
     assert resp.status_code == 422
     response_json = resp.get_json()
     assert response_json["message"] == "Validation error"
+
+
+def test_upload_instructions_non_sgm_opportunity(
+    client, db_session, grantor_auth_data, enable_factory_create
+):
+    """Test upload to a non-SGM opportunity"""
+    _, agency, token, _ = grantor_auth_data
+
+    # Create a non-SGM opportunity
+    non_sgm_opportunity = OpportunityFactory.create(
+        agency_code=agency.agency_code, is_draft=True, is_simpler_grants_opportunity=False
+    )
+
+    # Create a competition for this opportunity
+    competition = CompetitionFactory.create(
+        opportunity=non_sgm_opportunity, opportunity_id=non_sgm_opportunity.opportunity_id
+    )
+
+    file_content = b"This is instruction content"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{non_sgm_opportunity.opportunity_id}/competitions/{competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+    )
+
+    assert resp.status_code == 422
+    response_json = resp.get_json()
+    assert response_json["message"] == "Only opportunities created in Simpler Grants can be updated"

--- a/api/tests/src/api/opportunities_grantors_v1/test_competition_attachments.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_competition_attachments.py
@@ -1,0 +1,251 @@
+import uuid
+from io import BytesIO
+
+import pytest
+from grants_shared.util import file_util
+
+from src.constants.lookup_constants import Privilege
+from src.db.models import competition_models
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt_and_api_key
+from tests.src.db.models.factories import CompetitionFactory, OpportunityFactory
+
+
+@pytest.fixture
+def grantor_auth_data(db_session, enable_factory_create):
+    """Create a user with UPDATE_OPPORTUNITY permission"""
+    user, agency, token, api_key_id = create_user_in_agency_with_jwt_and_api_key(
+        db_session=db_session,
+        privileges=[Privilege.VIEW_OPPORTUNITY, Privilege.UPDATE_OPPORTUNITY],
+    )
+    return user, agency, token, api_key_id
+
+
+@pytest.fixture
+def existing_opportunity(grantor_auth_data, enable_factory_create):
+    """Create an opportunity belonging to the grantor's agency"""
+    user, agency, _, _ = grantor_auth_data
+    return OpportunityFactory.create(agency_code=agency.agency_code, is_draft=True)
+
+
+@pytest.fixture
+def existing_competition(existing_opportunity, enable_factory_create):
+    """Create a competition for the opportunity"""
+    return CompetitionFactory.create(
+        opportunity=existing_opportunity, opportunity_id=existing_opportunity.opportunity_id
+    )
+
+
+def test_upload_instructions_success_single_file(
+    client,
+    grantor_auth_data,
+    existing_opportunity,
+    existing_competition,
+    mock_s3_bucket,
+    other_mock_s3_bucket,
+    db_session,
+):
+    """Test successful upload of a single instruction file"""
+    _, _, token, _ = grantor_auth_data
+
+    file_content = b"This is instruction content"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+    )
+
+    assert resp.status_code == 200
+    response_json = resp.get_json()
+    assert response_json["message"] == "Instructions uploaded successfully"
+    assert "data" in response_json
+    assert "competition_instruction_id" in response_json["data"]
+    assert isinstance(response_json["data"]["competition_instruction_id"], list)
+    assert len(response_json["data"]["competition_instruction_id"]) == 1
+
+    # Verify database record
+    instruction_id = response_json["data"]["competition_instruction_id"][0]
+    instruction = (
+        db_session.query(competition_models.CompetitionInstruction)
+        .filter_by(competition_instruction_id=instruction_id)
+        .first()
+    )
+
+    assert instruction is not None
+    assert instruction.file_name == "instructions.pdf"
+    assert file_util.file_exists(instruction.file_location) is True
+
+
+def test_upload_instructions_success_multiple_files(
+    client,
+    grantor_auth_data,
+    existing_opportunity,
+    existing_competition,
+    mock_s3_bucket,
+    other_mock_s3_bucket,
+    db_session,
+):
+    """Test successful upload of multiple instruction files"""
+    _, _, token, _ = grantor_auth_data
+
+    file_content_1 = b"First instruction content"
+    file_content_2 = b"Second instruction content"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={
+            "file_attachment": [
+                (BytesIO(file_content_1), "instructions1.pdf", "application/pdf"),
+                (
+                    BytesIO(file_content_2),
+                    "instructions2.docx",
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                ),
+            ]
+        },
+    )
+
+    assert resp.status_code == 200
+    response_json = resp.get_json()
+    assert response_json["message"] == "Instructions uploaded successfully"
+    assert len(response_json["data"]["competition_instruction_id"]) == 2
+
+    # Verify both files in database
+    for instruction_id in response_json["data"]["competition_instruction_id"]:
+        instruction = (
+            db_session.query(competition_models.CompetitionInstruction)
+            .filter_by(competition_instruction_id=instruction_id)
+            .first()
+        )
+        assert instruction is not None
+        assert file_util.file_exists(instruction.file_location) is True
+
+
+def test_upload_instructions_unauthorized(
+    client, db_session, existing_opportunity, existing_competition
+):
+    """Test upload without proper authorization"""
+    # Create a user without UPDATE_OPPORTUNITY privilege
+    user, agency, token, _ = create_user_in_agency_with_jwt_and_api_key(
+        db_session=db_session,
+        privileges=[Privilege.VIEW_OPPORTUNITY],
+    )
+
+    file_content = b"This is instruction content"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+    )
+
+    assert resp.status_code == 403
+    response_json = resp.get_json()
+    assert response_json["message"] == "Forbidden"
+
+
+def test_upload_instructions_nonexistent_opportunity(
+    client, grantor_auth_data, existing_competition
+):
+    """Test upload with non-existent opportunity ID"""
+    _, _, token, _ = grantor_auth_data
+
+    non_existent_opportunity_id = uuid.uuid4()
+    file_content = b"This is instruction content"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{non_existent_opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+    )
+
+    assert resp.status_code == 404
+    response_json = resp.get_json()
+    assert (
+        response_json["message"]
+        == f"Could not find Opportunity with ID {non_existent_opportunity_id}"
+    )
+
+
+def test_upload_instructions_nonexistent_competition(
+    client, grantor_auth_data, existing_opportunity
+):
+    """Test upload with non-existent competition ID"""
+    _, _, token, _ = grantor_auth_data
+
+    non_existent_competition_id = uuid.uuid4()
+    file_content = b"This is instruction content"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{non_existent_competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+    )
+
+    assert resp.status_code == 404
+    response_json = resp.get_json()
+    assert (
+        response_json["message"]
+        == f"Could not find Competition with ID {non_existent_competition_id}"
+    )
+
+
+def test_upload_instructions_competition_wrong_opportunity(
+    client, grantor_auth_data, existing_competition, enable_factory_create
+):
+    """Test upload when competition doesn't belong to the specified opportunity"""
+    _, agency, token, _ = grantor_auth_data
+
+    # Create a different opportunity
+    other_opportunity = OpportunityFactory.create(agency_code=agency.agency_code, is_draft=True)
+
+    competition = existing_competition
+    file_content = b"This is instruction content"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{other_opportunity.opportunity_id}/competitions/{competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+    )
+
+    assert resp.status_code == 404
+    response_json = resp.get_json()
+    assert "not found for opportunity" in response_json["message"]
+
+
+def test_upload_instructions_invalid_file(
+    client, grantor_auth_data, existing_opportunity, existing_competition
+):
+    """Test upload with invalid file data"""
+    _, _, token, _ = grantor_auth_data
+
+    # Create an invalid "file" (just a string, not a file storage object)
+    invalid_file = "This is not a valid file"
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": invalid_file},
+    )
+
+    assert resp.status_code == 422
+    response_json = resp.get_json()
+    assert response_json["message"] == "Validation error"
+
+
+def test_upload_instructions_empty_file_list(
+    client, grantor_auth_data, existing_opportunity, existing_competition
+):
+    """Test upload with empty file list"""
+    _, _, token, _ = grantor_auth_data
+
+    resp = client.post(
+        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
+        headers={"X-SGG-Token": token},
+        data={"file_attachment": []},
+    )
+
+    assert resp.status_code == 422
+    response_json = resp.get_json()
+    assert response_json["message"] == "Validation error"

--- a/api/tests/src/api/opportunities_grantors_v1/test_competition_attachments.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_competition_attachments.py
@@ -54,19 +54,18 @@ def test_upload_instructions_success_single_file(
     resp = client.post(
         f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
         headers={"X-SGG-Token": token},
-        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+        data={"file_attachment": (BytesIO(file_content), "instructions.pdf", "application/pdf")},
     )
 
     assert resp.status_code == 200
     response_json = resp.get_json()
-    assert response_json["message"] == "Instructions uploaded successfully"
+    assert response_json["message"] == "Instruction uploaded successfully"
     assert "data" in response_json
     assert "competition_instruction_id" in response_json["data"]
-    assert isinstance(response_json["data"]["competition_instruction_id"], list)
-    assert len(response_json["data"]["competition_instruction_id"]) == 1
+    assert isinstance(response_json["data"]["competition_instruction_id"], str)
 
     # Verify database record
-    instruction_id = response_json["data"]["competition_instruction_id"][0]
+    instruction_id = response_json["data"]["competition_instruction_id"]
     instruction = (
         db_session.query(competition_models.CompetitionInstruction)
         .filter_by(competition_instruction_id=instruction_id)
@@ -76,52 +75,6 @@ def test_upload_instructions_success_single_file(
     assert instruction is not None
     assert instruction.file_name == "instructions.pdf"
     assert file_util.file_exists(instruction.file_location) is True
-
-
-def test_upload_instructions_success_multiple_files(
-    client,
-    grantor_auth_data,
-    existing_opportunity,
-    existing_competition,
-    mock_s3_bucket,
-    other_mock_s3_bucket,
-    db_session,
-):
-    """Test successful upload of multiple instruction files"""
-    _, _, token, _ = grantor_auth_data
-
-    file_content_1 = b"First instruction content"
-    file_content_2 = b"Second instruction content"
-
-    resp = client.post(
-        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
-        headers={"X-SGG-Token": token},
-        data={
-            "file_attachment": [
-                (BytesIO(file_content_1), "instructions1.pdf", "application/pdf"),
-                (
-                    BytesIO(file_content_2),
-                    "instructions2.docx",
-                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                ),
-            ]
-        },
-    )
-
-    assert resp.status_code == 200
-    response_json = resp.get_json()
-    assert response_json["message"] == "Instructions uploaded successfully"
-    assert len(response_json["data"]["competition_instruction_id"]) == 2
-
-    # Verify both files in database
-    for instruction_id in response_json["data"]["competition_instruction_id"]:
-        instruction = (
-            db_session.query(competition_models.CompetitionInstruction)
-            .filter_by(competition_instruction_id=instruction_id)
-            .first()
-        )
-        assert instruction is not None
-        assert file_util.file_exists(instruction.file_location) is True
 
 
 def test_upload_instructions_unauthorized(
@@ -139,7 +92,7 @@ def test_upload_instructions_unauthorized(
     resp = client.post(
         f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
         headers={"X-SGG-Token": token},
-        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+        data={"file_attachment": (BytesIO(file_content), "instructions.pdf", "application/pdf")},
     )
 
     assert resp.status_code == 403
@@ -159,7 +112,7 @@ def test_upload_instructions_nonexistent_opportunity(
     resp = client.post(
         f"/v1/grantors/opportunities/{non_existent_opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
         headers={"X-SGG-Token": token},
-        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+        data={"file_attachment": (BytesIO(file_content), "instructions.pdf", "application/pdf")},
     )
 
     assert resp.status_code == 404
@@ -182,7 +135,7 @@ def test_upload_instructions_nonexistent_competition(
     resp = client.post(
         f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{non_existent_competition_id}/instructions",
         headers={"X-SGG-Token": token},
-        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+        data={"file_attachment": (BytesIO(file_content), "instructions.pdf", "application/pdf")},
     )
 
     assert resp.status_code == 404
@@ -210,7 +163,7 @@ def test_upload_instructions_competition_wrong_opportunity(
     resp = client.post(
         f"/v1/grantors/opportunities/{other_opportunity.opportunity_id}/competitions/{competition.competition_id}/instructions",
         headers={"X-SGG-Token": token},
-        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+        data={"file_attachment": (BytesIO(file_content), "instructions.pdf", "application/pdf")},
     )
 
     assert resp.status_code == 404
@@ -231,23 +184,6 @@ def test_upload_instructions_invalid_file(
         f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
         headers={"X-SGG-Token": token},
         data={"file_attachment": invalid_file},
-    )
-
-    assert resp.status_code == 422
-    response_json = resp.get_json()
-    assert response_json["message"] == "Validation error"
-
-
-def test_upload_instructions_empty_file_list(
-    client, grantor_auth_data, existing_opportunity, existing_competition
-):
-    """Test upload with empty file list"""
-    _, _, token, _ = grantor_auth_data
-
-    resp = client.post(
-        f"/v1/grantors/opportunities/{existing_opportunity.opportunity_id}/competitions/{existing_competition.competition_id}/instructions",
-        headers={"X-SGG-Token": token},
-        data={"file_attachment": []},
     )
 
     assert resp.status_code == 422
@@ -276,7 +212,7 @@ def test_upload_instructions_non_sgm_opportunity(
     resp = client.post(
         f"/v1/grantors/opportunities/{non_sgm_opportunity.opportunity_id}/competitions/{competition.competition_id}/instructions",
         headers={"X-SGG-Token": token},
-        data={"file_attachment": [(BytesIO(file_content), "instructions.pdf", "application/pdf")]},
+        data={"file_attachment": (BytesIO(file_content), "instructions.pdf", "application/pdf")},
     )
 
     assert resp.status_code == 422


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11011 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Create an upload endpoint based on the Upload Instructions schema detailed [here](https://navasage.atlassian.net/wiki/spaces/Grantsgov/pages/3027992702/Tech+Spec+Quad+6+Enable+Grantors+to+Post+Application+Packages+With+Opportunities#API-%2F-Integration-Details). While we will be switching to a new attachment system in the future, for now we will use a similar system to other upload endpoints.
Endpoint should be located at `/v1/grantors/opportunities/:opportunity_id/competitions/:competition_id/instructions`

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] Successful expected API responses returned
- [x] Verified entries are created in competition_instruction DB table upon successful upload
- [x] 7 Unit Tests passing
