### PR TITLE
[Issue #11400] Add '\r' to soap response

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -328,15 +328,16 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
 
     def get_simpler_soap_response(self, proxy_response: SOAPResponse) -> SOAPResponse:
         # MTOM message is assembled here
-        # 1. --uuid: {boundary_uuid}\n
+        # The expected newlines are \r\n instead of \n
+        # 1. --uuid: {boundary_uuid}\r\n
         # 2. headers:
-        #    'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-        #    "Content-Transfer-Encoding: binary\n"
-        #    "Content-ID: <root.message@cxf.apache.org>\n\n"
+        #    'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        #    "Content-Transfer-Encoding: binary\r\n"
+        #    "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
         # 3. MTOM xml body
-        # 4. --uuid: {boundary_uuid}
+        # 4. \r\n--uuid: {boundary_uuid}\r\n
         # 5. the file bytes from the file being attached
-        # 6. --uuid: {boundary_uuid}--
+        # 6. \r\n--uuid: {boundary_uuid}--
         simpler_response_soap_dict = self.get_soap_response_dict(proxy_response)
         mtom_file_stream = simpler_response_soap_dict.pop("_mtom_file_stream", None)
         log_local(

--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -324,7 +324,7 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
                     break
         finally:
             mtom_file_stream.close()
-        yield b"\n" + boundary.encode("utf-8") + b"--"
+        yield b"\r\n" + boundary.encode("utf-8") + b"--"
 
     def get_simpler_soap_response(self, proxy_response: SOAPResponse) -> SOAPResponse:
         # MTOM message is assembled here
@@ -357,13 +357,13 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
             root=self.operation_config.response_operation_name,
         )
         if self.operation_config.response_operation_name != "GetApplicationZipResponse":
-            mime_message += f"\n--uuid:{boundary_uuid}--".encode("utf-8")
+            mime_message += f"\r\n--uuid:{boundary_uuid}--".encode("utf-8")
             return get_soap_response(
                 data=mime_message,
                 headers=update_headers,
             )
         if mtom_file_stream:
-            mime_message += ("\n" + boundary + "\n").encode("utf8")
+            mime_message += ("\r\n" + boundary + "\r\n").encode("utf8")
             return get_soap_response(
                 data=self._gen_response_data(mime_message, boundary, mtom_file_stream),
                 headers=update_headers,

--- a/api/src/legacy_soap_api/soap_payload_handler.py
+++ b/api/src/legacy_soap_api/soap_payload_handler.py
@@ -376,10 +376,10 @@ def build_mtom_response_from_dict(
     xml_bytes = etree.tostring(soap_env, encoding="UTF-8", xml_declaration=False)
     boundary = f"uuid:{raw_uuid}"
     mime_header = (
-        f"--{boundary}\n"
-        f'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-        f"Content-Transfer-Encoding: binary\n"
-        f"Content-ID: <root.message@cxf.apache.org>\n\n"
+        f"--{boundary}\r\n"
+        f'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        f"Content-Transfer-Encoding: binary\r\n"
+        f"Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
     )
     return mime_header.encode("utf-8") + xml_bytes
 

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_confirm_application_delivery_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_confirm_application_delivery_schema.py
@@ -225,10 +225,10 @@ class TestLegacySoapGrantorConfirmApplicationResponseSchema:
 
     def test_can_convert_confirm_application_delivery_response_dict_to_mtom_message(self):
         response_xml_bytes = (
-            f"--uuid:{BOUNDARY_UUID}"
-            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
-            "Content-Transfer-Encoding: binary"
-            "Content-ID: <root.message@cxf.apache.org>"
+            f"--uuid:{BOUNDARY_UUID}\r\n"
+            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+            "Content-Transfer-Encoding: binary\r\n"
+            "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
             '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
             "<soap:Body>"
             "<ns2:ConfirmApplicationDeliveryResponse "
@@ -279,5 +279,5 @@ class TestLegacySoapGrantorConfirmApplicationResponseSchema:
         mtom_response = build_mtom_response_from_dict(
             result, raw_uuid=BOUNDARY_UUID, root="", namespaces=ns
         )
-        cleaned_mtom_response = mtom_response.decode().replace("\n", "").encode("utf-8")
-        assert cleaned_mtom_response == response_xml_bytes
+        # cleaned_mtom_response = mtom_response.decode().replace("\n", "").encode("utf-8")
+        assert mtom_response == response_xml_bytes

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_confirm_application_delivery_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_confirm_application_delivery_schema.py
@@ -279,5 +279,4 @@ class TestLegacySoapGrantorConfirmApplicationResponseSchema:
         mtom_response = build_mtom_response_from_dict(
             result, raw_uuid=BOUNDARY_UUID, root="", namespaces=ns
         )
-        # cleaned_mtom_response = mtom_response.decode().replace("\n", "").encode("utf-8")
         assert mtom_response == response_xml_bytes

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -466,14 +466,14 @@ class TestSimplerSOAPGetApplicationZip:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                '--uuid:cccccccc-1111-2222-3333-dddddddddddd\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org'
-                '>\n\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:GetApplicationZipResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns11="htt'
+                '--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org'
+                '>\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:GetApplicationZipResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns11="htt'
                 'p://schemas.xmlsoap.org/wsdl/" xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" xmlns'
                 ':ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" xmlns:ns6="http://apply.grants.gov/system/GrantsP'
                 'ackage-V1.0" xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" xmlns:ns3="http://apply.grants.gov'
                 '/system/GrantsTemplate-V1.0" xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0"><ns2:FileDataHandler>'
                 '<xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb-0001@apply.grants.gov"/></ns2:FileDataHandler></ns2:GetApplicationZipResp'
-                f"onse></soap:Body></soap:Envelope>\n--uuid:cccccccc-1111-2222-3333-dddddddddddd\n{submission_text}\n--uuid:cccccccc-1111-2222-3333-dddddddddddd--"
+                f"onse></soap:Body></soap:Envelope>\r\n--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\n{submission_text}\r\n--uuid:cccccccc-1111-2222-3333-dddddddddddd--"
             ).encode("utf-8")
             assert isinstance(result.data, Iterator)
             assert b"".join(list(result.data)) == expected
@@ -763,9 +763,10 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListExpandedResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -795,8 +796,8 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListExpandedResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "</soap:Envelope>\r\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
             assert result.status_code == 200
@@ -845,10 +846,10 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
-                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-                "Content-Transfer-Encoding: binary\n"
-                "Content-ID: <root.message@cxf.apache.org>\n\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 "<ns2:GetSubmissionListExpandedResponse "
@@ -896,7 +897,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListExpandedResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>\n"
+                "</soap:Envelope>\r\n"
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
@@ -988,10 +989,10 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
-                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-                "Content-Transfer-Encoding: binary\n"
-                "Content-ID: <root.message@cxf.apache.org>\n\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 "<ns2:GetSubmissionListExpandedResponse "
@@ -1053,7 +1054,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListExpandedResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>\n"
+                "</soap:Envelope>\r\n"
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
@@ -1129,10 +1130,10 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
-                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-                "Content-Transfer-Encoding: binary\n"
-                "Content-ID: <root.message@cxf.apache.org>\n\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 "<ns2:GetSubmissionListExpandedResponse "
@@ -1166,7 +1167,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListExpandedResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>\n"
+                "</soap:Envelope>\r\n"
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
@@ -1207,9 +1208,10 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListExpandedResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -1240,7 +1242,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 "</ns2:GetSubmissionListExpandedResponse>"
                 "</soap:Body>"
                 "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "\r\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
 
@@ -1284,9 +1286,10 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 mock_parse.side_effect = Exception()
                 result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListExpandedResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -1316,8 +1319,8 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListExpandedResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "</soap:Envelope>\r\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
             assert "Failed to parse submission list XML response" in caplog.messages
@@ -1401,9 +1404,10 @@ class TestSimplerSOAPGetSubmissionListExpanded:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListExpandedResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -1448,7 +1452,7 @@ class TestSimplerSOAPGetSubmissionListExpanded:
                 "</ns2:GetSubmissionListExpandedResponse>"
                 "</soap:Body>"
                 "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "\r\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert "Skipping invalid submission due to validation error" in caplog.messages
             assert result.data == expected
@@ -1529,9 +1533,10 @@ class TestSimplerSOAPGetSubmissionList:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -1561,7 +1566,7 @@ class TestSimplerSOAPGetSubmissionList:
                 "</ns2:GetSubmissionListResponse>"
                 "</soap:Body>"
                 "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "\r\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
             assert result.status_code == 200
@@ -1610,10 +1615,10 @@ class TestSimplerSOAPGetSubmissionList:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
-                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-                "Content-Transfer-Encoding: binary\n"
-                "Content-ID: <root.message@cxf.apache.org>\n\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 "<ns2:GetSubmissionListResponse "
@@ -1659,7 +1664,7 @@ class TestSimplerSOAPGetSubmissionList:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>\n"
+                "</soap:Envelope>\r\n"
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
@@ -1750,10 +1755,10 @@ class TestSimplerSOAPGetSubmissionList:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
-                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-                "Content-Transfer-Encoding: binary\n"
-                "Content-ID: <root.message@cxf.apache.org>\n\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 "<ns2:GetSubmissionListResponse "
@@ -1812,7 +1817,7 @@ class TestSimplerSOAPGetSubmissionList:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>\n"
+                "</soap:Envelope>\r\n"
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
@@ -1887,10 +1892,10 @@ class TestSimplerSOAPGetSubmissionList:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\n"
-                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\n'
-                "Content-Transfer-Encoding: binary\n"
-                "Content-ID: <root.message@cxf.apache.org>\n\n"
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 "<ns2:GetSubmissionListResponse "
@@ -1923,7 +1928,7 @@ class TestSimplerSOAPGetSubmissionList:
                 "</ns2:SubmissionInfo>"
                 "</ns2:GetSubmissionListResponse>"
                 "</soap:Body>"
-                "</soap:Envelope>\n"
+                "</soap:Envelope>\r\n"
                 "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
@@ -1964,9 +1969,10 @@ class TestSimplerSOAPGetSubmissionList:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -1996,7 +2002,7 @@ class TestSimplerSOAPGetSubmissionList:
                 "</ns2:GetSubmissionListResponse>"
                 "</soap:Body>"
                 "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "\r\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
 
@@ -2040,9 +2046,10 @@ class TestSimplerSOAPGetSubmissionList:
                 mock_parse.side_effect = Exception()
                 result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -2072,7 +2079,7 @@ class TestSimplerSOAPGetSubmissionList:
                 "</ns2:GetSubmissionListResponse>"
                 "</soap:Body>"
                 "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "\r\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert result.data == expected
             assert "Failed to parse submission list XML response" in caplog.messages
@@ -2155,9 +2162,10 @@ class TestSimplerSOAPGetSubmissionList:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
-                "\nContent-Type: application/xop+xml; charset=UTF-8; type"
-                '="text/xml"\nContent-Transfer-Encoding: binary\nContent-ID: <root.message@cxf.apache.org>\n\n'
+                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
                 "<soap:Body>"
                 '<ns2:GetSubmissionListResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1'
@@ -2200,7 +2208,7 @@ class TestSimplerSOAPGetSubmissionList:
                 "</ns2:GetSubmissionListResponse>"
                 "</soap:Body>"
                 "</soap:Envelope>"
-                "\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
+                "\r\n--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
             ).encode("utf-8")
             assert "Skipping invalid submission due to validation error" in caplog.messages
             assert result.data == expected


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11400  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- [ ] Add `\r` to some lines in the soap response.
- [ ] update tests

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
When comparing the response from grants and the response from the proxy we discovered that one difference is that there were `/r` with the newlines in the response from grants, specifically around these lines:
```
                "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb\r\n"
                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
                "Content-Transfer-Encoding: binary\r\n"
                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
                 ...
                  "</soap:Envelope>\r\n"
                  "--uuid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb--"
```
This ticket adds into those `/r` so we have `/r/n` now for those lines.

## Validation steps
- [ ] tests passing
After deploy:
- [ ] hit the SOAP/Proxy endpoint
```
curl -X POST 'https://soap.training.simpler.grants.gov/grantsws-agency/services/v2/AgencyWebServicesSoapPort' \
  --cert "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/SIMP/soap_grantee1_teams_simpler_grants_gov.cer" \
  --key "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/SIMP/soap.grantee1.teams.simpler.grants.gov.key" \
  --header 'Content-Type: text/xml; charset=UTF-8' \
  --data $'<?xml version=\'1.0\' encoding=\'UTF-8\'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><agen:GetSubmissionListRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0"></agen:GetSubmissionListRequest></soapenv:Body></soapenv:Envelope>' \
  -o ~/Desktop/tmp2/body.raw
  ```
- [ ] use `grep -c $'\r' /tmp/body.raw` on the output
- [ ] hit the grants endpoint
```
curl -X POST 'https://soap.training.simpler.grants.gov/grantsws-agency/services/v2/AgencyWebServicesSoapPort' \
  --cert "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/SIMP/soap_grantee1_teams_simpler_grants_gov.cer" \
  --key "/Users/$(whoami)/Downloads/grants_s2s_soap_certs/SIMP/soap.grantee1.teams.simpler.grants.gov.key" \
  --header 'Content-Type: text/xml; charset=UTF-8' \
  --data $'<?xml version=\'1.0\' encoding=\'UTF-8\'?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><agen:GetSubmissionListRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0"></agen:GetSubmissionListRequest></soapenv:Body></soapenv:Envelope>' \
  -o ~/Desktop/tmp2/body.raw
  ```
- [ ] use `grep -c $'\r' /tmp/body.raw` on the output
- [ ] check if they return the same number
<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
