### PR TITLE
[Issue #11293] Add unit tests to grants_shared for api_jwt_auth

### DIFF
--- a/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
+++ b/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
@@ -4,12 +4,12 @@ from datetime import datetime
 
 import jwt
 import pytest
-from apiflask import APIBlueprint, APIFlask
-from flask import request
+from apiflask import APIBlueprint, APIFlask, APIKeyHeaderAuth
 from freezegun import freeze_time
 
 import grants_shared.logs
 from grants_shared.api.response import restructure_error_response
+from grants_shared.api.route_utils import raise_flask_error
 from grants_shared.api.schemas.response_schema import ErrorResponseSchema
 from grants_shared.auth import api_jwt_auth
 from grants_shared.auth.api_jwt_auth import ApiJwtConfig, JwtAuth, refresh_token_expiration
@@ -39,28 +39,34 @@ def simple_app(monkeypatch):
     def error_processor(error):
         return restructure_error_response(error)
 
-    @app.errorhandler(JwtValidationError)
-    def handle_jwt_validation_error(error):
-        return {"message": error.message, "data": {}, "errors": []}, 401
-
     with grants_shared.logs.init(__package__):
         yield app
 
 
 @pytest.fixture
-def simple_client(simple_app, db_session, jwt_config):
+def simple_client(simple_app, db_session, jwt_config, monkeypatch):
     """Register test blueprint and return test client"""
-    # Create a JWT auth instance for testing
-    jwt_auth = JwtAuth(AuthHandler(db_session), jwt_config)
+    # Create auth object following the production pattern
+    test_jwt_auth = APIKeyHeaderAuth(
+        "ApiKey", param_name="X-SGG-Token", security_scheme_name="ApiJwtAuth"
+    )
+
+    @test_jwt_auth.verify_token
+    def decode_token(token: str):
+        """Verify token and return token session (following production pattern)"""
+        try:
+            token_session = JwtAuth(AuthHandler(db_session), jwt_config).parse_jwt_for_user(token)
+            return token_session
+        except JwtValidationError as e:
+            raise_flask_error(401, e.message)
 
     # Create a test blueprint
     test_blueprint = APIBlueprint("test_jwt", __name__, tag="test")
 
     @test_blueprint.get("/test_jwt_endpoint")
+    @test_blueprint.auth_required(test_jwt_auth)
     def test_jwt_endpoint():
-        token = request.headers.get("X-SGG-Token")
-        token_session = jwt_auth.parse_jwt_for_user(token)
-
+        token_session = test_jwt_auth.current_user
         return {
             "message": "Success",
             "data": {
@@ -124,7 +130,6 @@ def test_parse_jwt_for_user_succeeds(simple_client, enable_factory_create, db_se
     """Test JWT auth succeeds with valid token in HTTP context"""
     user = SharedUserFactory.create()
     token, _ = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(user, None)
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
@@ -150,11 +155,9 @@ def test_parse_jwt_for_user_fails_when_token_not_yet_valid(
         "user_id": str(user.shared_user_id),
     }
     token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token not yet valid"
 
 
@@ -173,11 +176,9 @@ def test_parse_jwt_for_user_fails_when_token_has_unknown_issuer(
         "user_id": str(user.shared_user_id),
     }
     token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Unknown Issuer"
 
 
@@ -196,11 +197,9 @@ def test_parse_jwt_for_user_fails_when_token_has_unknown_audience(
         "user_id": str(user.shared_user_id),
     }
     token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Unknown Audience"
 
 
@@ -220,11 +219,9 @@ def test_parse_jwt_for_user_fails_when_unable_to_process_token(
     }
     other_private_key = other_rsa_key_pair[0]
     token = jwt.encode(payload, other_private_key, algorithm="RS256")
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Unable to process token"
 
 
@@ -242,11 +239,9 @@ def test_parse_jwt_for_user_fails_when_token_missing_sub_field(
         "user_id": str(user.shared_user_id),
     }
     token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token missing sub field"
 
 
@@ -264,11 +259,9 @@ def test_parse_jwt_for_user_fails_when_token_session_is_none(
         "user_id": str(uuid.uuid4()),
     }
     token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token session does not exist"
 
 
@@ -281,11 +274,9 @@ def test_parse_jwt_for_user_fails_when_token_is_expired(
         user, None
     )
     token_session.expires_at = datetime.fromisoformat("1980-01-01 12:00:00+00:00")
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token expired"
 
 
@@ -298,11 +289,9 @@ def test_parse_jwt_for_user_fails_when_token_is_no_longer_valid(
         user, None
     )
     token_session.is_valid = False
-    db_session.commit()
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
-    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token is no longer valid"
 
 

--- a/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
+++ b/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
@@ -158,6 +158,7 @@ def test_parse_jwt_for_user_fails_when_token_not_yet_valid(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token not yet valid"
 
 
@@ -179,6 +180,7 @@ def test_parse_jwt_for_user_fails_when_token_has_unknown_issuer(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Unknown Issuer"
 
 
@@ -200,6 +202,7 @@ def test_parse_jwt_for_user_fails_when_token_has_unknown_audience(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Unknown Audience"
 
 
@@ -222,6 +225,7 @@ def test_parse_jwt_for_user_fails_when_unable_to_process_token(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Unable to process token"
 
 
@@ -242,6 +246,7 @@ def test_parse_jwt_for_user_fails_when_token_missing_sub_field(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token missing sub field"
 
 
@@ -262,6 +267,7 @@ def test_parse_jwt_for_user_fails_when_token_session_is_none(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token session does not exist"
 
 
@@ -277,6 +283,7 @@ def test_parse_jwt_for_user_fails_when_token_is_expired(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token expired"
 
 
@@ -292,6 +299,7 @@ def test_parse_jwt_for_user_fails_when_token_is_no_longer_valid(
 
     resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
 
+    assert resp.status_code == 401
     assert resp.get_json()["message"] == "Token is no longer valid"
 
 

--- a/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
+++ b/backend/grants_shared/tests/grants_shared/auth/test_api_jwt_auth.py
@@ -1,11 +1,19 @@
+import uuid
 from calendar import timegm
 from datetime import datetime
 
 import jwt
 import pytest
+from apiflask import APIBlueprint, APIFlask
+from flask import request
 from freezegun import freeze_time
 
-from grants_shared.auth.api_jwt_auth import ApiJwtConfig, JwtAuth
+import grants_shared.logs
+from grants_shared.api.response import restructure_error_response
+from grants_shared.api.schemas.response_schema import ErrorResponseSchema
+from grants_shared.auth import api_jwt_auth
+from grants_shared.auth.api_jwt_auth import ApiJwtConfig, JwtAuth, refresh_token_expiration
+from grants_shared.auth.auth_errors import JwtValidationError
 from tests.grants_shared.db.models.factories import SharedLinkExternalUserFactory, SharedUserFactory
 from tests.grants_shared.db_test_models.db_test_models import SharedUserTokenSession
 from tests.grants_shared.test_utils.auth_handler import AuthHandler
@@ -19,8 +27,55 @@ def jwt_config(private_rsa_key, public_rsa_key):
     )
 
 
+@pytest.fixture
+def simple_app(monkeypatch):
+    """Create a minimal Flask app for testing JWT auth in HTTP context"""
+    app = APIFlask(__name__, title="test_jwt_app")
+
+    app.config["HTTP_ERROR_SCHEMA"] = ErrorResponseSchema
+    app.config["VALIDATION_ERROR_SCHEMA"] = ErrorResponseSchema
+
+    @app.error_processor
+    def error_processor(error):
+        return restructure_error_response(error)
+
+    @app.errorhandler(JwtValidationError)
+    def handle_jwt_validation_error(error):
+        return {"message": error.message, "data": {}, "errors": []}, 401
+
+    with grants_shared.logs.init(__package__):
+        yield app
+
+
+@pytest.fixture
+def simple_client(simple_app, db_session, jwt_config):
+    """Register test blueprint and return test client"""
+    # Create a JWT auth instance for testing
+    jwt_auth = JwtAuth(AuthHandler(db_session), jwt_config)
+
+    # Create a test blueprint
+    test_blueprint = APIBlueprint("test_jwt", __name__, tag="test")
+
+    @test_blueprint.get("/test_jwt_endpoint")
+    def test_jwt_endpoint():
+        token = request.headers.get("X-SGG-Token")
+        token_session = jwt_auth.parse_jwt_for_user(token)
+
+        return {
+            "message": "Success",
+            "data": {
+                "user_id": str(token_session.shared_user_id),
+                "token_id": str(token_session.token_id),
+            },
+        }
+
+    simple_app.register_blueprint(test_blueprint)
+    return simple_app.test_client()
+
+
 @freeze_time("2024-11-14 12:00:00", tz_offset=0)
 def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
+    """Unit test for JWT creation - validates token structure and database session"""
     user = SharedUserFactory.create()
     linked_external_user = SharedLinkExternalUserFactory.create(shared_user=user)
     token, token_session = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(
@@ -65,15 +120,224 @@ def test_create_jwt_for_user(enable_factory_create, db_session, jwt_config):
     assert user_session.shared_user_id == user.shared_user_id
 
 
-# TODO: Unit tests that need to be added:
-# * JwtAuth.parse_jwt_for_user succeeds
-# * JwtAuth.parse_jwt_for_user fails when token is not yet valid
-# * JwtAuth.parse_jwt_for_user fails when token has unknown issuer
-# * JwtAuth.parse_jwt_for_user fails when token has unknown audience
-# * JwtAuth.parse_jwt_for_user fails when unable to process token
-# * JwtAuth.parse_jwt_for_user fails when token is missing sub field
-# * JwtAuth.parse_jwt_for_user fails when token session is none
-# * JwtAuth.parse_jwt_for_user fails when token is expired
-# * JwtAuth.parse_jwt_for_user fails when token is no longer valid
-# * refresh_token_experience succeeds
-# * refresh_token_experience handles a config of None
+def test_parse_jwt_for_user_succeeds(simple_client, enable_factory_create, db_session, jwt_config):
+    """Test JWT auth succeeds with valid token in HTTP context"""
+    user = SharedUserFactory.create()
+    token, _ = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(user, None)
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "Success"
+    assert resp_json["data"]["user_id"] == str(user.shared_user_id)
+
+
+@freeze_time("2024-11-14 12:00:00", tz_offset=0)
+def test_parse_jwt_for_user_fails_when_token_not_yet_valid(
+    simple_client, enable_factory_create, db_session, jwt_config
+):
+    """Test JWT auth fails when token has future iat timestamp"""
+    user = SharedUserFactory.create()
+
+    future_time = datetime.fromisoformat("2024-11-14 13:00:00+00:00")
+    payload = {
+        "sub": str(user.shared_user_id),
+        "iat": future_time,
+        "aud": jwt_config.audience,
+        "iss": jwt_config.issuer,
+        "user_id": str(user.shared_user_id),
+    }
+    token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Token not yet valid"
+
+
+def test_parse_jwt_for_user_fails_when_token_has_unknown_issuer(
+    simple_client, enable_factory_create, db_session, jwt_config
+):
+    """Test JWT auth fails with unknown issuer in HTTP context"""
+    user = SharedUserFactory.create()
+
+    current_time = datetime.fromisoformat("2024-11-14 12:00:00+00:00")
+    payload = {
+        "sub": str(user.shared_user_id),
+        "iat": current_time,
+        "aud": jwt_config.audience,
+        "iss": "unknown-issuer",
+        "user_id": str(user.shared_user_id),
+    }
+    token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Unknown Issuer"
+
+
+def test_parse_jwt_for_user_fails_when_token_has_unknown_audience(
+    simple_client, enable_factory_create, db_session, jwt_config
+):
+    """Test JWT auth fails with unknown audience in HTTP context"""
+    user = SharedUserFactory.create()
+
+    current_time = datetime.fromisoformat("2024-11-14 12:00:00+00:00")
+    payload = {
+        "sub": str(user.shared_user_id),
+        "iat": current_time,
+        "aud": "unknown-audience",
+        "iss": jwt_config.issuer,
+        "user_id": str(user.shared_user_id),
+    }
+    token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Unknown Audience"
+
+
+def test_parse_jwt_for_user_fails_when_unable_to_process_token(
+    simple_client, enable_factory_create, db_session, jwt_config, other_rsa_key_pair
+):
+    """Test JWT auth fails when token is signed with different key"""
+    user = SharedUserFactory.create()
+
+    current_time = datetime.fromisoformat("2024-11-14 12:00:00+00:00")
+    payload = {
+        "sub": str(user.shared_user_id),
+        "iat": current_time,
+        "aud": jwt_config.audience,
+        "iss": jwt_config.issuer,
+        "user_id": str(user.shared_user_id),
+    }
+    other_private_key = other_rsa_key_pair[0]
+    token = jwt.encode(payload, other_private_key, algorithm="RS256")
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Unable to process token"
+
+
+def test_parse_jwt_for_user_fails_when_token_missing_sub_field(
+    simple_client, enable_factory_create, db_session, jwt_config
+):
+    """Test JWT auth fails when token is missing sub field"""
+    user = SharedUserFactory.create()
+
+    current_time = datetime.fromisoformat("2024-11-14 12:00:00+00:00")
+    payload = {
+        "iat": current_time,
+        "aud": jwt_config.audience,
+        "iss": jwt_config.issuer,
+        "user_id": str(user.shared_user_id),
+    }
+    token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Token missing sub field"
+
+
+def test_parse_jwt_for_user_fails_when_token_session_is_none(
+    simple_client, enable_factory_create, db_session, jwt_config
+):
+    """Test JWT auth fails when token session doesn't exist in DB"""
+    current_time = datetime.fromisoformat("2024-11-14 12:00:00+00:00")
+    non_existent_token_id = str(uuid.uuid4())
+    payload = {
+        "sub": non_existent_token_id,
+        "iat": current_time,
+        "aud": jwt_config.audience,
+        "iss": jwt_config.issuer,
+        "user_id": str(uuid.uuid4()),
+    }
+    token = jwt.encode(payload, jwt_config.private_key, algorithm="RS256")
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Token session does not exist"
+
+
+def test_parse_jwt_for_user_fails_when_token_is_expired(
+    simple_client, enable_factory_create, db_session, jwt_config
+):
+    """Test JWT auth fails with expired token in HTTP context"""
+    user = SharedUserFactory.create()
+    token, token_session = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(
+        user, None
+    )
+    token_session.expires_at = datetime.fromisoformat("1980-01-01 12:00:00+00:00")
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Token expired"
+
+
+def test_parse_jwt_for_user_fails_when_token_is_no_longer_valid(
+    simple_client, enable_factory_create, db_session, jwt_config
+):
+    """Test JWT auth fails with invalidated token in HTTP context"""
+    user = SharedUserFactory.create()
+    token, token_session = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(
+        user, None
+    )
+    token_session.is_valid = False
+    db_session.commit()
+
+    resp = simple_client.get("/test_jwt_endpoint", headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Token is no longer valid"
+
+
+@freeze_time("2024-11-14 12:00:00", tz_offset=0)
+def test_refresh_token_expiration_succeeds(enable_factory_create, db_session, jwt_config):
+    user = SharedUserFactory.create()
+    token, token_session = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(
+        user, None
+    )
+
+    original_expiration = token_session.expires_at
+    assert original_expiration == datetime.fromisoformat("2024-11-14 12:30:00+00:00")
+
+    with freeze_time("2024-11-14 12:15:00", tz_offset=0):
+        refreshed_session = refresh_token_expiration(token_session, jwt_config)
+
+        assert refreshed_session.expires_at == datetime.fromisoformat("2024-11-14 12:45:00+00:00")
+        assert refreshed_session.expires_at != original_expiration
+
+
+@freeze_time("2024-11-14 12:00:00", tz_offset=0)
+def test_refresh_token_expiration_handles_config_of_none(
+    enable_factory_create, db_session, jwt_config, monkeypatch
+):
+    monkeypatch.setattr(api_jwt_auth, "_config", jwt_config)
+
+    user = SharedUserFactory.create()
+    token, token_session = JwtAuth(AuthHandler(db_session), jwt_config).create_jwt_for_user(
+        user, None
+    )
+
+    original_expiration = token_session.expires_at
+
+    with freeze_time("2024-11-14 12:15:00", tz_offset=0):
+        refreshed_session = refresh_token_expiration(token_session, config=None)
+
+        assert refreshed_session.expires_at == datetime.fromisoformat("2024-11-14 12:45:00+00:00")
+        assert refreshed_session.expires_at != original_expiration


### PR DESCRIPTION
## Summary

Fixes #11293 

## Changes proposed

Add unittests for api_jwt_auth function, in the grants_shared

## Context for reviewers

- JwtAuth.parse_jwt_for_user succeeds
- JwtAuth.parse_jwt_for_user fails when token is not yet valid
- JwtAuth.parse_jwt_for_user fails when token has unknown issuer
- JwtAuth.parse_jwt_for_user fails when token has unknown audience
- JwtAuth.parse_jwt_for_user fails when unable to process token
- JwtAuth.parse_jwt_for_user fails when token is missing sub field
- JwtAuth.parse_jwt_for_user fails when token session is none
- JwtAuth.parse_jwt_for_user fails when token is expired
- JwtAuth.parse_jwt_for_user fails when token is no longer valid
- refresh_token_experience succeeds
- refresh_token_experience handles a config of None

## Validation steps

- tests added and passing
