### PR TITLE
[Hot fix] - Refactor opportunity happy-path E2E flow for draft creation UI changes

### DIFF
--- a/frontend/tests/e2e/opportunity/features/happy-path-create-opportunity.feature
+++ b/frontend/tests/e2e/opportunity/features/happy-path-create-opportunity.feature
@@ -1,127 +1,41 @@
 # Feature: Opportunity - Happy Path
 # Related spec: e2e/opportunity/specs/happy-path-create-opportunity.spec.ts
-# Scenario: Happy Path - Create Opportunity
+# Scenario: Happy path create opportunity draft
 #
-# ============== Notes for reviewer =================================================
-# - The name of the edit page is dynamic.
-# - The status in the opportunities list may not update immediately after publishing; you may see "Draft" instead of "Posted".
-# - Use today's date and today's date plus 30 days for publish/close date fields.
-# - Requested update: status assertion should use "Posted".
-# ===================================================================================
+# ============== Notes for reviewer ===============================================
+# - This scenario validates draft creation only (no publish flow).
+# - Opportunity number and title use timestamp-based dynamic values.
+# - The row-status assertion verifies the new opportunity appears as "Draft".
+# ================================================================================
 
-Feature: Opportunity happy path create and publish
-	As a grantor user
-	I want to create and complete an opportunity draft
-	So that I can publish the opportunity
+Feature: Opportunity happy path draft creation
+  As a grantor user
+  I want to create an opportunity draft
+  So that I can confirm draft status on the opportunities list
 
-	@GRANTOR
-	Scenario: Happy path create opportunity
-		Given I am authenticated as a grantor user
-		And I use direct URL "/grantor/opportunities" to navigate to the "Opportunities List" page
-		And I should be on the "Opportunities List" page
+  @GRANTOR
+  Scenario: Happy path create opportunity draft
+    Given I am authenticated as a grantor user
+    And I use direct URL "/grantor/opportunities" to navigate to the "Opportunities List" page
+    And I should be on the "Opportunities List" page
 
-		When I click "Create Opportunity"
-		And I should be on the "Create Opportunity" page
-		And I enter the following values
-			| Page Name               | Label                     | Field Type | Value                      |
-			| Create Opportunity page | Opportunity number        | text       | Opp-mm-dd-yyyy-hh-mm-sec   |
-			| Create Opportunity page | Opportunity title         | text       | Title-mm-dd-yyyy-hh-mm-sec |
-			| Create Opportunity page | Grant selection method    | select     | Discretionary              |
-			| Create Opportunity page | Assistance listing number | text       | 00.000                     |
-		And I click "Save and continue" button
-		Then I should be on the "Opportunity Overview" page
-		And the URL should include "fromCreate=true"
-		And I should see "Opportunity draft started" confirmation message
-		And I should see the "Opportunity Summary" link
-		And I click "Opportunity Summary"
-		Then I should be on the "Edit Opportunity" page
-		And the "Save" button should be enabled
-		And the "Publish" button should be disabled
-		And the "Preview" button should be disabled
+    When I click "Create Opportunity"
+    And I should be on the "Create Opportunity" page
+    And I enter the following values
+      | Page Name               | Label                     | Field Type | Value                      |
+      | Create Opportunity page | Opportunity number        | text       | Opp-mm-dd-yyyy-hh-mm-sec   |
+      | Create Opportunity page | Opportunity title         | text       | Title-mm-dd-yyyy-hh-mm-sec |
+      | Create Opportunity page | Grant selection method    | select     | Discretionary              |
+      | Create Opportunity page | Assistance listing number | text       | 00.000                     |
+    And I click "Save and continue" button
 
-		When I update "Funding details" section
-		And I enter the following values
-			| Page Name             | Label                           | Field Type | Value             |
-			| Opportunity edit page | Funding type                    | select     | Grant             |
-			| Opportunity edit page | Category                        | select     | Recovery Act      |
-			| Opportunity edit page | Expected number of awards       | text       | 20                |
-			| Opportunity edit page | Estimated total program funding | text       | 1000000           |
-			| Opportunity edit page | Award minimum                   | text       | 50000             |
-			| Opportunity edit page | Award maximum                   | text       | 100000            |
-			| Opportunity edit page | Publish date                    | date       | <today date>      |
-			| Opportunity edit page | Close date                      | date       | <today + 30 days> |
+    Then I should be on the "Opportunity Overview" page
+    And the URL should include "fromCreate=true"
+    And I should see "Opportunity draft started" confirmation message
+    And I should see the "Opportunity Summary" link
+    And the "Preview" button should be disabled
+    And the "Publish" button should be disabled
 
-		And I update "Eligibility" section
-		And I enter the following values
-			| Page Name             | Label               | Field Type | Value                                      |
-			| Opportunity edit page | Eligible applicants | checkbox   | Small businesses                           |
-			| Opportunity edit page | Eligible applicants | checkbox   | Other Native American tribal organizations |
-			| Opportunity edit page | Eligible applicants | checkbox   | Independent school districts               |
-			| Opportunity edit page | Eligible applicants | checkbox   | Individuals                                |
-			| Opportunity edit page | Eligible applicants | checkbox   | State governments                          |
-
-		And I update "Additional information" section
-		And I enter the following values
-			| Page Name             | Label                          | Field Type | Value                                      |
-			| Opportunity edit page | Description                    | textarea   | Additional - Test opportunity description  |
-			| Opportunity edit page | Link to additional information | text       | https://www.example.com/additional-info    |
-			| Opportunity edit page | Link display text              | text       | Additional Info                            |
-			| Opportunity edit page | Grantor contact details        | textarea   | Test grantor contact details               |
-			| Opportunity edit page | Contact email                  | email      | test@example.com                           |
-			| Opportunity edit page | Email display text             | text       | Contact Email                              |
-
-		And I click "Save" button
-		Then I should see "Saved successfully"
-		And I should see "Your changes have been saved."
-		And I should see the following values
-			| Page Name             | Label              | Field Type | Value                      |
-			| Opportunity edit page | Opportunity status | text       | Draft                      |
-			| Opportunity edit page | Opportunity title  | text       | Title-mm-dd-yyyy-hh-mm-sec |
-			| Opportunity edit page | Opportunity number | text       | Opp-mm-dd-yyyy-hh-mm-sec   |
-
-		And the "Save" button should be enabled
-		And the "Publish" button should be enabled
-		And the "Preview" button should be disabled
-
-		When I select "Select" in "Funding type"
-		And the "Save" button should be enabled
-		And the "Publish" button should be disabled
-		And the "Preview" button should be disabled
-
-		When I select "Cooperative Agreement" in "Funding type"
-		And the "Save" button should be enabled
-		And the "Publish" button should be enabled
-		And the "Preview" button should be disabled
-        
-		And I click "Publish" button
-		Then I should be on the "Opportunities List" page
-		And I should see "posted" status in the "Status" column for "Title-mm-dd-yyyy-hh-mm-sec"
-		And I should see "Edit" under Actions column for "Title-mm-dd-yyyy-hh-mm-sec"
-		And I should not see "Copy", "Delete" under Actions column for "Title-mm-dd-yyyy-hh-mm-sec"
-
-		When I click on "Title-mm-dd-yyyy-hh-mm-sec"
-		Then I should be on the "Title-mm-dd-yyyy-hh-mm-sec" page
-		And I should see the following values
-			| Page Name                | Label                           | Field Type | Value                                      |
-			| Opportunity details page | Opportunity title               | text       | Title-mm-dd-yyyy-hh-mm-sec                |
-			| Opportunity details page | Funding opportunity number      | text       | Opp-mm-dd-yyyy-hh-mm-sec                  |
-			| Opportunity details page | Assistance Listings:            | text       | 00.000                                    |
-			| Opportunity details page | Funding instrument type         | select     | Cooperative agreement                      |
-			| Opportunity details page | Category of Funding Activity    | select     | Recovery act                               |
-			| Opportunity details page | Expected awards                 | text       | 20                                         |
-			| Opportunity details page | Award Minimum                   | currency   | $50,000                                    |
-			| Opportunity details page | Award Maximum                   | currency   | $100,000                                   |
-			| Opportunity details page | Program Funding                 | currency   | $1,000,000                                 |
-			| Opportunity details page | Eligible applicants             | checkbox   | Small businesses                           |
-			| Opportunity details page | Eligible applicants             | checkbox   | Other Native American tribal organizations |
-			| Opportunity details page | Eligible applicants             | checkbox   | Independent school districts               |
-			| Opportunity details page | Eligible applicants             | checkbox   | Individuals                                |
-			| Opportunity details page | Eligible applicants             | checkbox   | State governments                          |
-			| Opportunity details page | Description                     | textarea   | Additional - Test opportunity description  |
-			| Opportunity details page | Link display text               | text       | Additional Info                            |
-			| Opportunity details page | Grantor contact details         | textarea   | Test grantor contact details               |
-			| Opportunity details page | Contact email                   | email      | test@example.com                           |
-			| Opportunity details page | Email display text              | text       | Contact Email                              |
-
-		And I verify the opportunity visibility on search results page after publishing
-		
+    When I navigate directly to "/grantor/opportunities"
+    Then I should see "Draft" status for "Title-mm-dd-yyyy-hh-mm-sec"
+    And the matching "Draft" opportunity row should be visible

--- a/frontend/tests/e2e/opportunity/specs/happy-path-create-opportunity.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-create-opportunity.spec.ts
@@ -12,30 +12,16 @@ import {
   type TestInfo,
 } from "@playwright/test";
 import {
-  ADDITIONAL_INFORMATION_FIELD_DEFINITIONS,
   buildPageFieldsFromDefinitions,
   CREATE_OPPORTUNITY_FIELD_DEFINITIONS,
-  ELIGIBILITY_FIELD_DEFINITIONS,
-  FUNDING_DETAILS_FIELD_DEFINITIONS,
 } from "tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions";
 import { buildOpportunityHappyPathFillData } from "tests/e2e/opportunity/fixtures/opportunity-pages-fill-data";
 import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
-import {
-  assertActionsColumnLinksByStatus,
-  assertButtonEnabledDisabledStates,
-  assertPageHeadingAndTextsVisible,
-  assertTextsVisibleOnPage,
-  formatNumberWithCommas,
-  selectOptionByLabel,
-} from "tests/e2e/utils/common/index";
-import {
-  clickRowTitle,
-  waitForOpportunityRowByStatus,
-} from "tests/e2e/utils/opportunities/table-row-utils";
+import { assertButtonEnabledDisabledStates } from "tests/e2e/utils/common/index";
+import { waitForOpportunityRowByStatus } from "tests/e2e/utils/opportunities/table-row-utils";
 import { fillPageFields } from "tests/e2e/utils/pages/general-pages-filling";
-import { verifyOpportunityInSearchByTitleAndNumber } from "tests/e2e/utils/search/searchSpecUtil";
 
 const { GRANTOR, CORE_REGRESSION } = VALID_TAGS;
 const { targetEnv } = playwrightEnv;
@@ -51,7 +37,7 @@ test.describe("Grantor Opportunity Happy Path", () => {
   });
 
   test(
-    "Create, publish, and validate opportunity details",
+    "Create opportunity draft and verify draft status on list page",
     { tag: [GRANTOR, CORE_REGRESSION] },
     async (
       { page, context }: { page: Page; context: BrowserContext },
@@ -68,7 +54,6 @@ test.describe("Grantor Opportunity Happy Path", () => {
 
       // Define commonly used values for assertions and form filling at the beginning of the test for better readability of the scenario steps.
       const fillData = buildOpportunityHappyPathFillData(new Date());
-      const opportunityNumber = fillData.opportunityNumber;
       const opportunityTitle = fillData.opportunityTitle;
 
       //--------------Scenario steps start here----------------
@@ -110,156 +95,24 @@ test.describe("Grantor Opportunity Happy Path", () => {
         page.getByRole("link", { name: "Opportunity Summary" }),
       ).toBeVisible();
 
-      // And I click "Opportunity Summary" link
-      await page.getByRole("link", { name: "Opportunity Summary" }).click();
-
-      // Then I should be on the "Edit Opportunity" page
-      await expect(page).toHaveURL(
-        /\/grantor\/opportunity\/([a-z0-9-]+?)\/edit/,
-      );
-
-      // And "Save" should be enabled while "Publish" and "Preview" remain disabled.
+      // And I should see the "Preview" and "Publish" buttons disabled.
       await assertButtonEnabledDisabledStates(page, {
-        Save: true,
+        Preview: false,
         Publish: false,
-        Preview: false,
       });
 
-      // Fill required Funding details values.
-      await fillPageFields(
-        page,
-        buildPageFieldsFromDefinitions(
-          FUNDING_DETAILS_FIELD_DEFINITIONS,
-          fillData,
-        ),
-      );
+      // When I navigate directly to opportunity list page
+      await page.goto("/grantor/opportunities");
 
-      // Fill required Eligibility values.
-      await fillPageFields(
-        page,
-        buildPageFieldsFromDefinitions(ELIGIBILITY_FIELD_DEFINITIONS, fillData),
-      );
-
-      // Fill optional Additional information values.
-      await fillPageFields(
-        page,
-        buildPageFieldsFromDefinitions(
-          ADDITIONAL_INFORMATION_FIELD_DEFINITIONS,
-          fillData,
-        ),
-      );
-
-      // And I click "Save" button
-      await page.getByRole("button", { name: "Save" }).click();
-
-      // Then I should see the edit-page save confirmation.
-      await expect(
-        page.getByText("Saved successfully", { exact: true }),
-      ).toBeVisible();
-
-      // And I should see the save confirmation body.
-      await expect(
-        page.getByText("Your changes have been saved.", { exact: true }),
-      ).toBeVisible();
-
-      // And I should see "Draft" status.
-      await expect(
-        page.locator("span.display-inline-flex", { hasText: "Draft" }).first(),
-      ).toBeVisible();
-
-      // And I should see Opportunity title / Opportunity number values
-      await assertTextsVisibleOnPage(page, [
-        opportunityTitle,
-        opportunityNumber,
-      ]);
-
-      // And "Save" and "Publish" should be enabled while "Preview" remains disabled.
-      await assertButtonEnabledDisabledStates(page, {
-        Save: true,
-        Publish: true,
-        Preview: false,
-      });
-
-      // When I set "Funding type" to "Select", "Publish" should become disabled.
-      await selectOptionByLabel(page, "Funding type", "Select");
-
-      // Then "Save" should remain enabled and "Publish" should be disabled.
-      await assertButtonEnabledDisabledStates(page, {
-        Save: true,
-        Publish: false,
-        Preview: false,
-      });
-
-      // When I set "Funding type" to "Cooperative Agreement", "Publish" should be enabled again.
-      await selectOptionByLabel(page, "Funding type", fillData.fundingType_2);
-
-      // Then "Save" and "Publish" should be enabled while "Preview" remains disabled.
-      await assertButtonEnabledDisabledStates(page, {
-        Save: true,
-        Publish: true,
-        Preview: false,
-      });
-
-      // And I click "Publish" button
-      await page.getByRole("button", { name: "Publish" }).click();
-
-      // Then I should return to the "Opportunities List" page.
-      await expect(page).toHaveURL(/\/grantor\/opportunities/);
-
-      // And I should see "posted" status for the created opportunity row.
+      // Then I should see "Draft" status for the created opportunity row.
       const matchingRow = await waitForOpportunityRowByStatus(page, {
         title: opportunityTitle,
-        status: "posted",
-        message: 'Waiting for "posted" opportunity row to appear on list',
+        status: "Draft",
+        message: 'Waiting for "Draft" opportunity row to appear on list',
       });
 
-      // And link visibility should match the expected "posted" actions behavior.
-      await assertActionsColumnLinksByStatus(matchingRow, {
-        status: "posted",
-        actionLinkVisibility: {
-          Edit: true,
-          Copy: false,
-          Delete: false,
-        },
-      });
-
-      // When I open the "Opportunity details" page from the row title.
-      await clickRowTitle(matchingRow, opportunityTitle);
-
-      // Then I should see all expected values on the "Opportunity details" page.
-      const finalAssertions = [
-        opportunityTitle,
-        opportunityNumber,
-        fillData.assistanceListingNumber,
-        fillData.fundingType_2,
-        fillData.category,
-        fillData.expectedNumberOfAwards,
-        formatNumberWithCommas(fillData.awardMinimum),
-        formatNumberWithCommas(fillData.awardMaximum),
-        formatNumberWithCommas(fillData.estimatedTotalProgramFunding),
-        fillData.eligibleApplicantSmallBusinesses,
-        fillData.eligibleApplicantOtherNativeAmericanTribalOrganizations,
-        fillData.eligibleApplicantIndependentSchoolDistricts,
-        fillData.eligibleApplicantIndividuals,
-        fillData.eligibleApplicantStateGovernments,
-        fillData.description,
-        fillData.linkDisplayText,
-        fillData.grantorContactDetails,
-        fillData.contactEmail,
-        fillData.emailDisplayText,
-      ];
-
-      await assertPageHeadingAndTextsVisible(page, {
-        heading: opportunityTitle,
-        texts: finalAssertions,
-      });
-
-      // And I verify the opportunity visibility on search results page after publishing
-      await verifyOpportunityInSearchByTitleAndNumber(
-        page,
-        opportunityTitle,
-        opportunityNumber,
-      );
+      // And the matching row should be visible.
+      await expect(matchingRow).toBeVisible();
 
       //--------------Scenario steps end here----------------
     },


### PR DESCRIPTION
## Summary
 - Regarding to the UI update from https://github.com/HHS/simpler-grants-gov/pull/11399
- update happy-path opportunity create coverage to align with the new draft-focused UI flow
- update/create Gherkin feature coverage for draft-creation and opportunity-summary scenarios

## Test updates
- adjusts button and navigation expectations for updated edit/competition flows
- validates draft status behavior in opportunities list

**Verified:**
E2E Tests (Deployed Target) #950: https://github.com/HHS/simpler-grants-gov/actions/runs/29278837724
E2E Tests (Local Github Target) #11701: https://github.com/HHS/simpler-grants-gov/actions/runs/29278872921