### PR TITLE
[Issue #11428] Add mtom header to filestream section

### DIFF
--- a/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
@@ -29,9 +29,14 @@ class GetApplicationZipResponseSOAPBody(BaseModel):
 class GetApplicationZipResponseSOAPEnvelope(BaseModel):
     Body: GetApplicationZipResponseSOAPBody
     _mtom_file_stream: Any | None = PrivateAttr(default=None)
+    _content_id: str
 
     def to_soap_envelope_dict(self, operation_name: str) -> dict:
-        envelope_dict = {"Envelope": {"Body": self.Body.model_dump(by_alias=True)}}
+        # We need the _content_id for the header
+        envelope_dict = {
+            "Envelope": {"Body": self.Body.model_dump(by_alias=True)},
+            "_content_id": self._content_id,
+        }
         if self._mtom_file_stream:
             envelope_dict["_mtom_file_stream"] = self._mtom_file_stream
         return envelope_dict

--- a/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
@@ -23,9 +23,8 @@ def get_application_zip_response(
     get_application_zip_request: grantor_schemas.GetApplicationZipRequest,
     soap_config: SOAPOperationConfig,
 ) -> grantor_schemas.GetApplicationZipResponseSOAPEnvelope:
-    xop_data_instance = grantor_schemas.XOPIncludeData(
-        **{"@href": f"cid:{uuid.uuid4()}-0001@apply.grants.gov"}
-    )
+    content_id = f"{uuid.uuid4()}-1@apply.grants.gov"
+    xop_data_instance = grantor_schemas.XOPIncludeData(**{"@href": f"cid:{content_id}"})
     file_handler_instance = grantor_schemas.FileDataHandler(**{"xop:Include": xop_data_instance})
     get_response_instance = grantor_schemas.GetApplicationZipResponse(
         **{"ns2:FileDataHandler": file_handler_instance}
@@ -35,6 +34,7 @@ def get_application_zip_response(
             **{"ns2:GetApplicationZipResponse": get_response_instance}
         )
     )
+    schema._content_id = content_id
     legacy_tracking_number = get_application_zip_request.grants_gov_tracking_number
     if not legacy_tracking_number:
         return schema

--- a/api/src/legacy_soap_api/legacy_soap_api_client.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_client.py
@@ -346,8 +346,6 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
         boundary_uuid = str(uuid.uuid4())
         update_headers = {
             "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{boundary_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
-            # TODO: removing till we can confirm GS needs this
-            # "Soapaction": self.operation_config.soap_action,
         }
         boundary = "--uuid:" + boundary_uuid
         mime_message: Iterator[bytes] | bytes = b""
@@ -364,9 +362,24 @@ class SimplerGrantorsS2SClient(BaseSOAPClient):
                 headers=update_headers,
             )
         if mtom_file_stream:
-            mime_message += ("\r\n" + boundary + "\r\n").encode("utf8")
+            content_id = simpler_response_soap_dict.pop("_content_id", None)
+            mime_message += self.get_mtom_file_stream_header(content_id, boundary)
             return get_soap_response(
                 data=self._gen_response_data(mime_message, boundary, mtom_file_stream),
                 headers=update_headers,
             )
         return proxy_response
+
+    def get_mtom_file_stream_header(self, content_id: str, boundary: str) -> bytes:
+        # The mtom file stream header is formatted like this
+        # Content-Type: application/octet-stream\r\n
+        # Content-Transfer-Encoding: binary\r\n
+        # Content-ID: <{content_id}>\r\n
+        # Content-Disposition: attachment;name="AgencyApplicationDownload.zip"\r\n\r\n
+        return (
+            "\r\n" + boundary + "\r\n"
+            "Content-Type: application/octet-stream\r\n"
+            "Content-Transfer-Encoding: binary\r\n"
+            f"Content-ID: <{content_id}>\r\n"
+            'Content-Disposition: attachment;name="AgencyApplicationDownload.zip"\r\n\r\n'
+        ).encode("utf-8")

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -68,11 +68,12 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
                     "Body": {
                         "ns2:GetApplicationZipResponse": {
                             "ns2:FileDataHandler": {
-                                "xop:Include": {"@href": f"cid:{CID_UUID}-0001@apply.grants.gov"}
+                                "xop:Include": {"@href": f"cid:{CID_UUID}-1@apply.grants.gov"}
                             }
                         }
                     }
-                }
+                },
+                "_content_id": f"{CID_UUID}-1@apply.grants.gov",
             }
             assert result == expected
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -466,14 +466,37 @@ class TestSimplerSOAPGetApplicationZip:
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
-                '--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\nContent-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\nContent-Transfer-Encoding: binary\r\nContent-ID: <root.message@cxf.apache.org'
-                '>\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:GetApplicationZipResponse xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns11="htt'
-                'p://schemas.xmlsoap.org/wsdl/" xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" xmlns'
-                ':ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" xmlns:ns6="http://apply.grants.gov/system/GrantsP'
-                'ackage-V1.0" xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" xmlns:ns3="http://apply.grants.gov'
-                '/system/GrantsTemplate-V1.0" xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0"><ns2:FileDataHandler>'
-                '<xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb-0001@apply.grants.gov"/></ns2:FileDataHandler></ns2:GetApplicationZipResp'
-                f"onse></soap:Body></soap:Envelope>\r\n--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\n{submission_text}\r\n--uuid:cccccccc-1111-2222-3333-dddddddddddd--"
+                "--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+                '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+                "<soap:Body>"
+                "<ns2:GetApplicationZipResponse "
+                'xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" '
+                'xmlns:ns11="http://schemas.xmlsoap.org/wsdl/" '
+                'xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" '
+                'xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" '
+                'xmlns:ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" '
+                'xmlns:ns6="http://apply.grants.gov/system/GrantsPackage-V1.0" '
+                'xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" '
+                'xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" '
+                'xmlns:ns3="http://apply.grants.gov/system/GrantsTemplate-V1.0" '
+                'xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+                'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+                "<ns2:FileDataHandler>"
+                '<xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb-1@apply.grants.gov"/>'
+                "</ns2:FileDataHandler>"
+                "</ns2:GetApplicationZipResponse>"
+                "</soap:Body>"
+                "</soap:Envelope>\r\n"
+                "--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\n"
+                "Content-Type: application/octet-stream\r\n"
+                "Content-Transfer-Encoding: binary\r\n"
+                f"Content-ID: <{CID_UUID}-1@apply.grants.gov>\r\n"
+                'Content-Disposition: attachment;name="AgencyApplicationDownload.zip"\r\n\r\n'
+                f"{submission_text}\r\n"
+                "--uuid:cccccccc-1111-2222-3333-dddddddddddd--"
             ).encode("utf-8")
             assert isinstance(result.data, Iterator)
             assert b"".join(list(result.data)) == expected


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11428  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Add a method that injects a header into the mtom file section of a soap response for `GetApplicationZip`
- Add a way to attach the `content_id` to the schema object so we can use it later for the new header

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The current `GetApplicationZip` is missing a header under the section with the file data:
```
Content-Type: application/octet-stream\r\n
Content-Transfer-Encoding: binary\r\n
Content-ID: <bf208f6c-170c-40e6-b87f-13305da5ca03-422@apply.grants.gov>\r\n
Content-Disposition: attachment;name="AgencyApplicationDownload.zip"\r\n\r\n
```
We need to add this so that the response is identical to the grants response and so Grant Solutions can parse it.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
- [ ] after deploy, the header appears
