### PR TITLE
[Issue #11344] happy-path-opportunity-overview-initial-state

### DIFF
--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-overview-initial-state.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-overview-initial-state.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * @feature Opportunity Overview - Happy Path
+ * @featureFile e2e/opportunity/features/happy-path-opportunity-overview.feature
+ * @scenario Happy path opportunity overview
+ *
+ * Notes for reviewer (what happens in this test):
+ * 1) Authenticates a grantor user.
+ * 2) Creates a new opportunity using happy-path fixture data.
+ * 3) Verifies the user lands on the opportunity overview page.
+ * 4) Verifies overview statuses:
+ *    - Opportunity Summary: Not started
+ *    - Application Package: Not started
+ * 5) Verifies "Preview" and "Publish" buttons are disabled when no sections are complete.
+ *
+ * Tester parameter guide:
+ * - Dynamic values are generated in buildOpportunityHappyPathFillData(new Date()).
+ * - To adjust opportunity creation inputs, update the fixture builder in:
+ *   - tests/e2e/opportunity/fixtures/opportunity-pages-fill-data.ts
+ * - This scenario validates initial overview state only (before any section is completed).
+ */
+
+import {
+  expect,
+  test,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+import { buildOpportunityHappyPathFillData } from "tests/e2e/opportunity/fixtures/opportunity-pages-fill-data";
+import playwrightEnv from "tests/e2e/playwright-env";
+import { VALID_TAGS } from "tests/e2e/tags";
+import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { assertButtonEnabledDisabledStates } from "tests/e2e/utils/common/index";
+import { assertOverviewSectionStatus } from "tests/e2e/utils/opportunities/overview-status-utils";
+import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
+
+const { GRANTOR, CORE_REGRESSION } = VALID_TAGS;
+const { targetEnv } = playwrightEnv;
+
+test.describe("Grantor opportunity overview happy path - initial state", () => {
+  test.beforeEach(({ page: _ }, testInfo) => {
+    if (targetEnv === "staging") {
+      test.skip(
+        testInfo.project.name !== "Chrome",
+        "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
+      );
+    }
+  });
+
+  test(
+    "Verifies initial state of opportunity overview page with happy path fixture data",
+    { tag: [GRANTOR, CORE_REGRESSION] },
+    async (
+      { page, context }: { page: Page; context: BrowserContext },
+      testInfo: TestInfo,
+    ) => {
+      test.setTimeout(300_000);
+
+      //--------------Test setup start here----------------
+      await authenticateE2eUser(
+        page,
+        context,
+        !!testInfo.project.name.match(/[Mm]obile/),
+      );
+
+      // Define commonly used values for assertions and form filling at the beginning of the test for better readability of the scenario steps.
+      const fillData = buildOpportunityHappyPathFillData(new Date());
+      // const opportunityTitle = fillData.opportunityTitle;
+
+      //--------------Scenario steps start here----------------
+
+      // Given I create a new opportunity with happy path fixture data.
+      await createOpportunity(page, fillData);
+
+      // And I should be redirected to the opportunity overview page.
+      await expect(page).toHaveURL(
+        /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
+      );
+
+      // Then I should see overview statuses for key sections.
+      await assertOverviewSectionStatus(page, {
+        "Opportunity Summary": "Not started",
+        "Application Package": "Not started",
+
+        /* Enable this when the overview page is updated to include these sections.
+        "Key information": "Not started",
+        "Funding type": "Not started",
+        "Eligibility": "Not started",
+        "Additional information": "Not started",
+        "Attachments": "Not started",
+        "Application requirements": "Not started",
+        "Forms": "Not started",        
+        */
+      });
+
+      // And I should see the "Preview" and "Publish" buttons are disabled.
+      await assertButtonEnabledDisabledStates(page, {
+        Preview: false,
+        Publish: false,
+      });
+
+      //--------------Scenario steps end here----------------
+    },
+  );
+});

--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-overview-initial-state.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-overview-initial-state.spec.ts
@@ -65,7 +65,6 @@ test.describe("Grantor opportunity overview happy path - initial state", () => {
 
       // Define commonly used values for assertions and form filling at the beginning of the test for better readability of the scenario steps.
       const fillData = buildOpportunityHappyPathFillData(new Date());
-      // const opportunityTitle = fillData.opportunityTitle;
 
       //--------------Scenario steps start here----------------
 


### PR DESCRIPTION
This test verifies the initial state of the opportunity overview page for a grantor user using happy path fixture data, including the status of key sections and the state of buttons.

## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11344 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

 * Notes for reviewer (what happens in this test):
 * 1) Authenticates a grantor user.
 * 2) Creates a new opportunity using happy-path fixture data.
 * 3) Verifies the user lands on the opportunity overview page.
 * 4) Verifies overview statuses:
 *    - Opportunity Summary: Not started
 *    - Application Package: Not started
 * 5) Verifies "Preview" and "Publish" buttons are disabled when no sections are complete.
 *

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Verified:
E2E Tests (Local Github Target) #11795:https://github.com/HHS/simpler-grants-gov/actions/runs/29355217486
E2E Tests (Deployed Target) #969: https://github.com/HHS/simpler-grants-gov/actions/runs/29354180968
