### PR TITLE
[Issue #11341] Feature file - failure-path-opportunity-overview-initial-state

### DIFF
--- a/frontend/tests/e2e/opportunity/features/failure-path-opportunity-overview-initial-state.feature
+++ b/frontend/tests/e2e/opportunity/features/failure-path-opportunity-overview-initial-state.feature
@@ -1,0 +1,24 @@
+# Feature: Opportunity Overview - Failure Path (Initial State)
+# Related spec: e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
+# Scenario: Verifies bypass attempt fails and stays on the same overview page
+#
+# Notes:
+# - This scenario verifies disabled-action gating on Opportunity Overview.
+# - Preview and Publish should not navigate when force-clicked in initial state.
+
+Feature: Opportunity overview failure path initial state gating
+  As a grantor user
+  I want disabled overview actions to block navigation
+  So that I cannot bypass incomplete setup and navigate incorrectly
+
+  @GRANTOR @CORE_REGRESSION
+  Scenario: Verifies bypass attempt fails and stays on the same overview page
+    Given I am authenticated as a grantor user
+    And I create a new opportunity with happy-path data
+    Then I should be on the "Opportunity Overview" page
+
+    When I force-click the "Preview" button
+    Then I should still be on the same overview page
+
+    When I force-click the "Publish" button
+    Then I should still be on the same overview page


### PR DESCRIPTION
This feature tests that disabled actions on the Opportunity Overview prevent navigation, ensuring users cannot bypass incomplete setups.

## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11341 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

- This scenario verifies disabled-action gating on Opportunity Overview.
- Preview and Publish should not navigate when force-clicked in initial state.
