### PR TITLE
[Issue #11342] failure-path-opportunity-overview-initial-state

### DIFF
--- a/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
@@ -65,13 +65,17 @@ test.describe("Grantor opportunity overview failure path - initial state gating"
       const overviewUrl = page.url();
 
       // When I attempt to click Preview, navigation should not occur.
-      await page.getByRole("button", { name: "Preview" }).click({ force: true });
+      await page
+        .getByRole("button", { name: "Preview" })
+        .click({ force: true });
 
       // Then I should still be on the same overview URL.
       await expect(page).toHaveURL(overviewUrl);
 
       // When I attempt to click Publish, navigation should not occur.
-      await page.getByRole("button", { name: "Publish" }).click({ force: true });
+      await page
+        .getByRole("button", { name: "Publish" })
+        .click({ force: true });
 
       // Then I should still be on the same overview URL.
       await expect(page).toHaveURL(overviewUrl);

--- a/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
@@ -22,6 +22,7 @@ import { buildOpportunityHappyPathFillData } from "tests/e2e/opportunity/fixture
 import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { assertButtonEnabledDisabledStates } from "tests/e2e/utils/common/index";
 import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
 
 const { GRANTOR, CORE_REGRESSION } = VALID_TAGS;
@@ -61,7 +62,11 @@ test.describe("Grantor opportunity overview failure path - initial state gating"
       await expect(page).toHaveURL(
         /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
       );
-
+// And I should see the "Preview", and "Publish" buttons disabled.
+await assertButtonEnabledDisabledStates(page, {
+  Preview: false,
+  Publish: false,
+});
       const overviewUrl = page.url();
 
       // When I attempt to click Preview, navigation should not occur.

--- a/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * @feature Opportunity Overview - failure path initial state
+ * @featureFile e2e/opportunity/features/failure-path-opportunity-overview-initial-state.feature
+ * @scenario Verifies bypass attempt fails and stays on the same overview page
+ *
+ * Notes for reviewer (what happens in this test):
+ * 1) Authenticates a grantor user.
+ * 2) Creates a new opportunity using happy-path fixture data.
+ * 3) Verifies the user lands on the opportunity overview page.
+ * 4) Attempts to bypass gating by force-clicking Preview and Publish actions.
+ * 5) Verifies bypass attempt fails by asserting URL remains on the same overview page.
+ */
+
+import {
+  expect,
+  test,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+import { buildOpportunityHappyPathFillData } from "tests/e2e/opportunity/fixtures/opportunity-pages-fill-data";
+import playwrightEnv from "tests/e2e/playwright-env";
+import { VALID_TAGS } from "tests/e2e/tags";
+import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
+
+const { GRANTOR, CORE_REGRESSION } = VALID_TAGS;
+const { targetEnv } = playwrightEnv;
+
+test.describe("Grantor opportunity overview failure path - initial state gating", () => {
+  test.beforeEach(({ page: _ }, testInfo) => {
+    if (targetEnv === "staging") {
+      test.skip(
+        testInfo.project.name !== "Chrome",
+        "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
+      );
+    }
+  });
+
+  test(
+    "Verifies bypass attempt fails and stays on the same overview page",
+    { tag: [GRANTOR, CORE_REGRESSION] },
+    async (
+      { page, context }: { page: Page; context: BrowserContext },
+      testInfo: TestInfo,
+    ) => {
+      test.setTimeout(300_000);
+
+      await authenticateE2eUser(
+        page,
+        context,
+        !!testInfo.project.name.match(/[Mm]obile/),
+      );
+
+      const fillData = buildOpportunityHappyPathFillData(new Date());
+
+      // Given I create a new opportunity with happy-path fixture data.
+      await createOpportunity(page, fillData);
+
+      // Then I should land on the overview page.
+      await expect(page).toHaveURL(
+        /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
+      );
+
+      const overviewUrl = page.url();
+
+      // When I attempt to click Preview, navigation should not occur.
+      await page.getByRole("button", { name: "Preview" }).click({ force: true });
+
+      // Then I should still be on the same overview URL.
+      await expect(page).toHaveURL(overviewUrl);
+
+      // When I attempt to click Publish, navigation should not occur.
+      await page.getByRole("button", { name: "Publish" }).click({ force: true });
+
+      // Then I should still be on the same overview URL.
+      await expect(page).toHaveURL(overviewUrl);
+    },
+  );
+});

--- a/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-overview-initial-state.spec.ts
@@ -62,11 +62,13 @@ test.describe("Grantor opportunity overview failure path - initial state gating"
       await expect(page).toHaveURL(
         /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
       );
-// And I should see the "Preview", and "Publish" buttons disabled.
-await assertButtonEnabledDisabledStates(page, {
-  Preview: false,
-  Publish: false,
-});
+
+      // And I should see the "Preview" and "Publish" buttons disabled.
+      await assertButtonEnabledDisabledStates(page, {
+        Preview: false,
+        Publish: false,
+      });
+
       const overviewUrl = page.url();
 
       // When I attempt to click Preview, navigation should not occur.


### PR DESCRIPTION
This test verifies that a grantor user cannot bypass the gating mechanism on the opportunity overview page by force-clicking the Preview and Publish actions, ensuring they remain on the same page.

## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11342 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

1. Authenticates a grantor user.
2. Creates a new opportunity using happy-path fixture data.
3. Verifies the user lands on the opportunity overview page.
4. Attempts to bypass gating by force-clicking Preview and Publish actions.
5. Verifies bypass attempt fails by asserting URL remains on the same overview page.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Verified:
E2E Tests (Local Github Target) #11824: https://github.com/HHS/simpler-grants-gov/actions/runs/29361915545
E2E Tests (Deployed Target) #971: https://github.com/HHS/simpler-grants-gov/actions/runs/29358074999
