### PR TITLE
[Issue #10856] Add maintenance-mode check to workflow service main loop

### DIFF
--- a/api/src/workflow/manager/workflow_manager.py
+++ b/api/src/workflow/manager/workflow_manager.py
@@ -2,10 +2,12 @@ import json
 import logging
 import signal
 import sys
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime
+from enum import StrEnum
 from types import FrameType
 
 from flask import Flask, current_app
@@ -13,6 +15,7 @@ from grants_shared.adapters import db
 from grants_shared.adapters.aws import SQSConfig
 from grants_shared.adapters.aws.sqs_adapter import SQSClient, SQSMessage
 from grants_shared.adapters.db import flask_db
+from grants_shared.api.maintenance_mode import is_maintenance_mode_enabled
 from grants_shared.util import datetime_util
 from grants_shared.util.json_util import json_encoder
 from pydantic import ValidationError
@@ -29,6 +32,12 @@ from src.workflow.workflow_background_task import workflow_transaction
 from src.workflow.workflow_errors import NonRetryableWorkflowError, RetryableWorkflowError
 
 logger = logging.getLogger(__name__)
+
+
+class WorkflowManagerLogEvent(StrEnum):
+    """Distinct, queryable event types for workflow manager log records."""
+
+    MAINTENANCE_MODE_SKIP = "maintenance_mode_workflow_processing_skipped"
 
 
 class WorkflowManagerConfig(PydanticBaseEnvConfig):
@@ -55,6 +64,9 @@ class WorkflowManager:
 
     def __init__(self, config: WorkflowManagerConfig | None = None):
         self.sigterm_received = False
+        # Set when a shutdown signal is received so the maintenance-mode idle loop
+        # can wake immediately rather than waiting out a full sleep interval.
+        self._shutdown_event = threading.Event()
         self._register_signal_handlers()
 
         if config is None:
@@ -102,9 +114,11 @@ class WorkflowManager:
             "Received interrupt signal, will allow current processing to complete before exiting."
         )
         self.sigterm_received = True
+        self._shutdown_event.set()
 
     def handle_interrupt(self, signum: int, frame: FrameType | None) -> None:
         logger.info("Received keyboard interrupt, exiting immediately.")
+        self._shutdown_event.set()
         sys.exit(0)
 
     def parse_event(self, message: SQSMessage) -> WorkflowEvent:
@@ -147,6 +161,10 @@ class WorkflowManager:
 
         The 'main' loop of the workflow manager.
         """
+        if is_maintenance_mode_enabled():
+            self._idle_during_maintenance()
+            return
+
         logger.info("Processing workflow events")
         initialize_workflow_client_registry()
 
@@ -180,6 +198,22 @@ class WorkflowManager:
                 break
 
         logger.info("Finished processing workflow events - exiting process", extra=self.metrics)
+
+    def _idle_during_maintenance(self) -> None:
+        """Idle without touching SQS or the DB while maintenance mode is enabled.
+
+        The flag is resolved at task launch and flipped via force-new-deployment,
+        so a single check at loop entry is sufficient. We wait for the SIGTERM that
+        the redeploy sends, checking periodically so shutdown stays responsive.
+        """
+        logger.info(
+            "Skipping workflow processing due to maintenance mode",
+            extra={"maintenance_mode_event": WorkflowManagerLogEvent.MAINTENANCE_MODE_SKIP},
+        )
+        # Block until a shutdown signal wakes us. handle_exit/handle_interrupt set the
+        # event, so this returns promptly on SIGTERM instead of waiting out a sleep.
+        self._shutdown_event.wait()
+        logger.info("Exiting after receiving SIGTERM.")
 
     def process_batch(self) -> tuple[list[str], list[str]]:
         """Fetch and process a batch of events from SQS."""

--- a/api/tests/src/workflow/manager/test_workflow_manager.py
+++ b/api/tests/src/workflow/manager/test_workflow_manager.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import signal
 import threading
 import uuid
 from unittest.mock import patch
@@ -7,6 +8,7 @@ from unittest.mock import patch
 import boto3
 import pytest
 from grants_shared.adapters.aws.sqs_adapter import SQSClient, SQSMessage
+from grants_shared.api.maintenance_mode import get_maintenance_mode_config
 
 from src.constants.lookup_constants import (
     WorkflowEntityType,
@@ -19,6 +21,7 @@ from src.workflow.event.workflow_event import ProcessWorkflowEventContext, Workf
 from src.workflow.manager.workflow_manager import (
     WorkflowManager,
     WorkflowManagerConfig,
+    WorkflowManagerLogEvent,
     handle_event,
 )
 from tests.src.db.models.factories import OpportunityFactory, UserFactory, WorkflowFactory
@@ -47,6 +50,60 @@ def test_workflow_manager(workflow_sqs_queue, app, valid_sqs_message):
     metrics = workflow_manager.metrics
     assert metrics["batches_processed"] == 3
     assert metrics["events_processed"] >= 3
+
+
+@pytest.fixture
+def enable_maintenance_mode(monkeypatch):
+    """Turn maintenance mode on for the duration of a test.
+
+    The maintenance-mode config is @cached, so clear it around the env change.
+    """
+    monkeypatch.setenv("ENABLE_MAINTENANCE_MODE", "true")
+    get_maintenance_mode_config.cache_clear()
+    yield
+    get_maintenance_mode_config.cache_clear()
+
+
+def test_process_events_skips_when_maintenance_mode_enabled(
+    app, workflow_sqs_queue, valid_sqs_message, enable_maintenance_mode, caplog
+):
+    """With maintenance mode on, process_events idles without fetching from SQS or
+    processing a batch, and exits cleanly once a SIGTERM has been received."""
+    caplog.set_level(logging.INFO)
+
+    boto_client = boto3.client("sqs", region_name="us-east-1")
+    sqs_client = SQSClient(queue_url=workflow_sqs_queue, sqs_client=boto_client)
+    sqs_client.send_message(json.loads(valid_sqs_message.body))
+
+    config = WorkflowManagerConfig(workflow_cycle_duration=0)
+    workflow_manager = WorkflowManager(config=config)
+    # Simulate the SIGTERM the force-new-deployment sends, so the idle loop wakes
+    # and exits instead of blocking. Exercise the real handler rather than poking
+    # internal state so we cover the shutdown path end to end.
+    workflow_manager.handle_exit(signal.SIGTERM, None)
+
+    with app.app_context():
+        workflow_manager.process_events()
+
+    assert workflow_manager.sigterm_received is True
+
+    # No batch was processed - the manager never touched SQS or the DB.
+    assert workflow_manager.metrics["batches_processed"] == 0
+    assert workflow_manager.metrics["events_processed"] == 0
+
+    # The message we enqueued is still on the queue - fetch_messages was never called.
+    remaining = sqs_client.receive_messages(max_messages=1, wait_time=0)
+    assert len(remaining) == 1
+
+    # A distinct, queryable skip event was logged.
+    skip_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "maintenance_mode_event", None)
+        == WorkflowManagerLogEvent.MAINTENANCE_MODE_SKIP
+    ]
+    assert len(skip_records) == 1
+    assert skip_records[0].message == "Skipping workflow processing due to maintenance mode"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10856  

## Changes proposed

- Updated `workflow_manager.py` to short-circuit `WorkflowManager.process_events` when `ENABLE_MAINTENANCE_MODE` is set. It logs a distinct skip event and idles on a shutdown `threading.Event` (set by the existing SIGTERM/SIGINT handlers) instead of fetching from SQS or touching the DB. Added a `WorkflowManagerLogEvent` enum for the queryable skip event.
- Updated `test_workflow_manager.py` to cover the maintenance-on path. It asserts no batch is processed, the enqueued SQS message is untouched, the distinct skip event is logged, and shutdown exits cleanly via the real `handle_exit` handler.

## Context for reviewers

During a planned maintenance window (primarily DB migrations), the workflow service must stop writing to the DB. This uses the same shared `ENABLE_MAINTENANCE_MODE` env var flip (SSM + `force-new-deployment`) introduced in #10855. The maintenance-off path is unchanged - the guard only adds an early exit at loop entry. I used a `threading.Event` rather than a plain `time.sleep` poll so the idle loop reacts to SIGTERM immediately rather than waiting out a full `workflow_cycle_duration`.

## Validation steps

Confirm tests pass.

Quick local test:
```
   cd api
   make run-workflow-service DOCKER_EXEC_ARGS="-e ENABLE_MAINTENANCE_MODE=true"
```
The logs should show "Skipping workflow processing due to maintenance mode" and no "Processing workflow events."
