### PR TITLE
[Issue #11469] Use the submission id for the content-id

### DIFF
--- a/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 
 import grants_shared.adapters.db as db
 from botocore.exceptions import ClientError
@@ -17,13 +16,7 @@ from src.legacy_soap_api.legacy_soap_api_utils import (
 logger = logging.getLogger(__name__)
 
 
-def get_application_zip_response(
-    db_session: db.Session,
-    soap_request: SOAPRequest,
-    get_application_zip_request: grantor_schemas.GetApplicationZipRequest,
-    soap_config: SOAPOperationConfig,
-) -> grantor_schemas.GetApplicationZipResponseSOAPEnvelope:
-    content_id = f"{uuid.uuid4()}-1@apply.grants.gov"
+def build_schema(content_id: str = "") -> grantor_schemas.GetApplicationZipResponseSOAPEnvelope:
     xop_data_instance = grantor_schemas.XOPIncludeData(**{"@href": f"cid:{content_id}"})
     file_handler_instance = grantor_schemas.FileDataHandler(**{"xop:Include": xop_data_instance})
     get_response_instance = grantor_schemas.GetApplicationZipResponse(
@@ -35,6 +28,17 @@ def get_application_zip_response(
         )
     )
     schema._content_id = content_id
+    schema._mtom_file_stream = None
+    return schema
+
+
+def get_application_zip_response(
+    db_session: db.Session,
+    soap_request: SOAPRequest,
+    get_application_zip_request: grantor_schemas.GetApplicationZipRequest,
+    soap_config: SOAPOperationConfig,
+) -> grantor_schemas.GetApplicationZipResponseSOAPEnvelope:
+    schema = build_schema()
     legacy_tracking_number = get_application_zip_request.grants_gov_tracking_number
     if not legacy_tracking_number:
         return schema
@@ -42,6 +46,8 @@ def get_application_zip_response(
         db_session, legacy_tracking_number
     )
     if application_submission:
+        content_id = f"{application_submission.application_submission_id}-1@apply.grants.gov"
+        schema = build_schema(content_id)
         certificate = validate_certificate(
             db_session, soap_auth=soap_request.auth, api_name=soap_request.api_name
         )

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -1,6 +1,4 @@
 import io
-import uuid
-from unittest.mock import patch
 
 import pytest
 
@@ -20,7 +18,6 @@ from tests.src.db.models.factories import (
 )
 
 GRANTS_GOV_TRACKING_NUMBER = "GRANT80000000"
-CID_UUID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
 BOUNDARY_UUID = "cccccccc-1111-2222-3333-dddddddddddd"
 
 
@@ -57,25 +54,26 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
             operation_name="GetApplicationZipRequest",
             auth=auth,
         )
-        with patch.object(uuid, "uuid4", return_value=CID_UUID):
-            client = SimplerGrantorsS2SClient(soap_request, db_session)
-            result = client.get_application_zip_request().to_soap_envelope_dict(
-                operation_name="GetApplicationZipResponse"
-            )
-            result.pop("_mtom_file_stream")
-            expected = {
-                "Envelope": {
-                    "Body": {
-                        "ns2:GetApplicationZipResponse": {
-                            "ns2:FileDataHandler": {
-                                "xop:Include": {"@href": f"cid:{CID_UUID}-1@apply.grants.gov"}
+        client = SimplerGrantorsS2SClient(soap_request, db_session)
+        result = client.get_application_zip_request().to_soap_envelope_dict(
+            operation_name="GetApplicationZipResponse"
+        )
+        result.pop("_mtom_file_stream")
+        expected = {
+            "Envelope": {
+                "Body": {
+                    "ns2:GetApplicationZipResponse": {
+                        "ns2:FileDataHandler": {
+                            "xop:Include": {
+                                "@href": f"cid:{submission.application_submission_id}-1@apply.grants.gov"
                             }
                         }
                     }
-                },
-                "_content_id": f"{CID_UUID}-1@apply.grants.gov",
-            }
-            assert result == expected
+                }
+            },
+            "_content_id": f"{submission.application_submission_id}-1@apply.grants.gov",
+        }
+        assert result == expected
 
     def test_get_soap_request_dict_turns_request_xml_to_dict(self, db_session):
         request_xml_bytes = (

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -462,7 +462,7 @@ class TestSimplerSOAPGetApplicationZip:
         )
         mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
-            mock_uuid4.side_effect = [CID_UUID, ADDITIONAL_UUID, BOUNDARY_UUID]
+            mock_uuid4.side_effect = [ADDITIONAL_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             expected = (
@@ -485,7 +485,7 @@ class TestSimplerSOAPGetApplicationZip:
                 'xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
                 'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
                 "<ns2:FileDataHandler>"
-                '<xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb-1@apply.grants.gov"/>'
+                f'<xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:{submission.application_submission_id}-1@apply.grants.gov"/>'
                 "</ns2:FileDataHandler>"
                 "</ns2:GetApplicationZipResponse>"
                 "</soap:Body>"
@@ -493,7 +493,7 @@ class TestSimplerSOAPGetApplicationZip:
                 "--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\n"
                 "Content-Type: application/octet-stream\r\n"
                 "Content-Transfer-Encoding: binary\r\n"
-                f"Content-ID: <{CID_UUID}-1@apply.grants.gov>\r\n"
+                f"Content-ID: <{submission.application_submission_id}-1@apply.grants.gov>\r\n"
                 'Content-Disposition: attachment;name="AgencyApplicationDownload.zip"\r\n\r\n'
                 f"{submission_text}\r\n"
                 "--uuid:cccccccc-1111-2222-3333-dddddddddddd--"
@@ -541,7 +541,7 @@ class TestSimplerSOAPGetApplicationZip:
         )
         mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
         with patch.object(uuid, "uuid4") as mock_uuid4:
-            mock_uuid4.side_effect = [CID_UUID, ADDITIONAL_UUID, BOUNDARY_UUID]
+            mock_uuid4.side_effect = [ADDITIONAL_UUID, BOUNDARY_UUID]
             client = SimplerGrantorsS2SClient(soap_request, db_session)
             result = client.get_simpler_soap_response(mock_proxy_response)
             assert result.headers == {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11469  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- changed the `Content-ID` in `GetApplicationZipResponse` to the `ApplicationSubmission.application_submission_id`

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We were generating a new uuid for every call when we should really be using just one id for consistency. 

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
After deploy
- [ ] get the same content id for every call for the same submission
