### PR TITLE
[Issue #9602] make formDataToJson flexible to be used outside of apply form context

### DIFF
--- a/frontend/src/utils/applyForm/applyFormUtils.test.ts
+++ b/frontend/src/utils/applyForm/applyFormUtils.test.ts
@@ -10,7 +10,6 @@ import {
   formatValidationWarning,
   getFieldListLabelFromDefinition,
   getFieldNameForHtml,
-  getFieldPathFromHtml,
   getFieldSchema,
   getFieldsForNav,
   getHtmlFieldForWarning,
@@ -439,12 +438,6 @@ describe("getRequiredProperties", () => {
       "signature_block/name/first_name",
       "signature_block/name/last_name",
     ]);
-  });
-});
-
-describe("getFieldPathFromHtml", () => {
-  it("converts field name to JSON pointer path", () => {
-    expect(getFieldPathFromHtml("foo--bar")).toBe("/foo/bar");
   });
 });
 

--- a/frontend/src/utils/applyForm/applyFormUtils.ts
+++ b/frontend/src/utils/applyForm/applyFormUtils.ts
@@ -1,5 +1,4 @@
 import { RJSFSchema } from "@rjsf/utils";
-import { get as getSchemaObjectFromPointer } from "json-pointer";
 import { JSONSchema7 } from "json-schema";
 import mergeAllOf from "json-schema-merge-allof";
 import { isObject } from "lodash";
@@ -12,9 +11,16 @@ import {
   UiSchemaNode,
 } from "src/types/applyForm/types";
 import { extricateConditionalValidationRules } from "src/utils/applyForm/formSchemaProcessors";
+import { formDataToObject } from "src/utils/formData/formDataToJson";
+import {
+  FORM_DATA_NESTING_DELIMITER,
+  getByPointer,
+  JSON_SCHEMA_NESTING_DELIMITER,
+} from "src/utils/formData/formDataUtils";
 import { isBasicallyAnObject } from "src/utils/generalUtils";
 
-import { formDataToObject } from "./formDataToJson";
+// API side validation library delimits nesting with a dot rather than a slash
+const VALIDATION_ERROR_NESTING_DELIMITER = ".";
 
 const nestedWarningsForField = ({
   definition,
@@ -119,7 +125,9 @@ export const findValidationErrors = (
   }) as SchemaField;
   const path = definition ? jsonSchemaPointerToPath(definition) : "";
   const fieldName = definition
-    ? definition.split("/")[definition.split("/").length - 1]
+    ? definition.split(JSON_SCHEMA_NESTING_DELIMITER)[
+        definition.split(JSON_SCHEMA_NESTING_DELIMITER).length - 1
+      ]
     : "";
   const directWarnings = errors.filter((error) => {
     if (error.field === path) {
@@ -133,7 +141,10 @@ export const findValidationErrors = (
       return false;
     }
     const [, fieldListName, childDefinitionPath] = fieldListMatch;
-    const childFieldPath = childDefinitionPath.replace(/\/properties\//g, ".");
+    const childFieldPath = childDefinitionPath.replace(
+      /\/properties\//g,
+      VALIDATION_ERROR_NESTING_DELIMITER,
+    );
     return new RegExp(
       `^\\$\\.${fieldListName}\\[(\\d+)\\]\\.${childFieldPath}$`,
     ).test(error.field);
@@ -314,10 +325,10 @@ export const getFieldNameForHtml = ({
   schema?: SchemaField;
 }): string => {
   if (definition) {
-    const definitionParts = definition.split("/");
+    const definitionParts = definition.split(JSON_SCHEMA_NESTING_DELIMITER);
     return definitionParts
       .filter((part) => part && part !== "properties")
-      .join("--"); // using hyphens since that will work better for html attributes than slashes and will have less conflict with other characters
+      .join(FORM_DATA_NESTING_DELIMITER);
   }
   return (schema?.title ?? "untitled").replace(/\s/g, "-");
 };
@@ -342,8 +353,14 @@ export function getHtmlFieldForWarning({
   }
 
   const [, fieldListName, childDefinitionPath] = match;
-  const childFieldPath = childDefinitionPath.replace(/\/properties\//g, ".");
-  const childHtmlPath = childFieldPath.replace(/\./g, "--");
+  const childFieldPath = childDefinitionPath.replace(
+    /\/properties\//g,
+    VALIDATION_ERROR_NESTING_DELIMITER,
+  );
+  const childHtmlPath = childFieldPath.replace(
+    /\./g,
+    FORM_DATA_NESTING_DELIMITER,
+  );
 
   const entryMatch = field?.match(
     new RegExp(`^\\$\\.${fieldListName}\\[(\\d+)\\]\\.${childFieldPath}$`),
@@ -402,27 +419,6 @@ export function getFieldListLabelFromDefinition({
 
   return findFieldListLabel(uiSchema);
 }
-
-// transform a form data field name / id into a json path that can be used to reference the form schema
-export const getFieldPathFromHtml = (fieldName: string) =>
-  `/${fieldName.replace(/--/g, "/")}`;
-
-export const getByPointer = (target: object, path: string): unknown => {
-  if (!Object.keys(target).length) {
-    return;
-  }
-  try {
-    return getSchemaObjectFromPointer(target, path);
-  } catch (e) {
-    // this is not ideal, but it seems like the desired behavior is to return undefined if the
-    // path is not found on the target, and the library throws an error instead
-    if ((e as Error).message.includes("Invalid reference token:")) {
-      return undefined;
-    }
-    console.error("error referencing schema path", e, target, path);
-    throw e;
-  }
-};
 
 // changes a json pointer /properties/field_name/properties/field_child to path $.field_name.field_child
 export const jsonSchemaPointerToPath = (jsonPointer: string) => {
@@ -660,7 +656,8 @@ export const shapeFormData = <T extends object>(
     formData,
     condenseFormSchemaProperties(formSchema),
     {
-      delimiter: "--",
+      delimiter: FORM_DATA_NESTING_DELIMITER,
+      useUndefinedDefaultValue: true, // apply form handlers will expect empty fields to be `undefined` rather than `null`
     },
   );
   return pruneEmptyNestedFields(
@@ -772,6 +769,7 @@ export const processFormSchema = (
     throw e;
   }
 };
+
 /*
   this will flatten any properties objects so that we can directly reference field paths
   within a json schema without traversing nested "properties". Any other object attributes
@@ -802,7 +800,7 @@ export const condenseFormSchemaProperties = (schema: object): object => {
 };
 
 export const pointerToFieldName = (pointer: string): string => {
-  return pointer.replace("$.", "").replace(/\./g, "--");
+  return pointer.replace("$.", "").replace(/\./g, FORM_DATA_NESTING_DELIMITER);
 };
 
 export function addPrintWidgetToFields(uiSchema: UiSchema): UiSchema {

--- a/frontend/src/utils/applyForm/applyFormUtils.ts
+++ b/frontend/src/utils/applyForm/applyFormUtils.ts
@@ -16,11 +16,9 @@ import {
   FORM_DATA_NESTING_DELIMITER,
   getByPointer,
   JSON_SCHEMA_NESTING_DELIMITER,
+  VALIDATION_ERROR_NESTING_DELIMITER,
 } from "src/utils/formData/formDataUtils";
 import { isBasicallyAnObject } from "src/utils/generalUtils";
-
-// API side validation library delimits nesting with a dot rather than a slash
-const VALIDATION_ERROR_NESTING_DELIMITER = ".";
 
 const nestedWarningsForField = ({
   definition,
@@ -655,10 +653,7 @@ export const shapeFormData = <T extends object>(
   const structuredFormData = formDataToObject(
     formData,
     condenseFormSchemaProperties(formSchema),
-    {
-      delimiter: FORM_DATA_NESTING_DELIMITER,
-      useUndefinedDefaultValue: true, // apply form handlers will expect empty fields to be `undefined` rather than `null`
-    },
+    undefined,
   );
   return pruneEmptyNestedFields(
     structuredFormData,

--- a/frontend/src/utils/applyForm/getFieldConfig.ts
+++ b/frontend/src/utils/applyForm/getFieldConfig.ts
@@ -14,13 +14,12 @@ import {
   UswdsWidgetProps,
   WidgetTypes,
 } from "src/types/applyForm/types";
-
 import {
   getByPointer,
-  getFieldNameForHtml,
   getFieldPathFromHtml,
-  getFieldSchema,
-} from "./applyFormUtils";
+} from "src/utils/formData/formDataUtils";
+
+import { getFieldNameForHtml, getFieldSchema } from "./applyFormUtils";
 
 type WidgetOptions = NonNullable<UswdsWidgetProps["options"]>;
 
@@ -225,6 +224,9 @@ export const getWarningsForField = ({
   });
 };
 
+// returns either the final slash delimited path segment from definition
+// or the "title" attribute from the field schema (with dashes for whitespace)
+// or "untitled"
 export const getNameFromDef = ({
   definition,
   schema,
@@ -251,7 +253,7 @@ const getBasicFieldInfo = ({
 }: {
   uiFieldObject: UiSchemaField;
   formSchema: RJSFSchema;
-  formData: object;
+  formData: object; // this will be either the saved form JSON, or an empty FormData object (?s)
   errors: FormattedFormValidationWarning[] | null;
 }): FieldInfo<string> => {
   const { schema } = uiFieldObject;
@@ -266,6 +268,19 @@ const getBasicFieldInfo = ({
     schema,
     formSchema,
   }) as RJSFSchema;
+
+  /*
+    this section of code formats the field's name and path for various use cases
+    by way of example, where `definition` = `/properties/applicant/properties/state`
+      * `fieldName` = `state`
+        * used as a fallback ID in case htmlFieldName can't be computed
+        * seems like it'd be used for something else, like a label, but it's not
+      * `htmlFieldName` = `applicant--state`
+        * used for referencing data values within HTML form's FormData
+        * used for defining ID on each widget
+      * `formDataPath` =  `/applicant/state`
+        * used for retrieving data from saved form data JSON
+  */
   const fieldName = getNameFromDef({ definition, schema });
   const htmlFieldName = getFieldNameForHtml({ definition, schema });
   const formDataPath = getFieldPathFromHtml(htmlFieldName);

--- a/frontend/src/utils/formData/formDataToJson.test.ts
+++ b/frontend/src/utils/formData/formDataToJson.test.ts
@@ -60,15 +60,15 @@ describe("formDataToObject", () => {
       user: {
         age: "30",
         name: "Alice",
-        emptyString: undefined,
-        emptyNumber: undefined,
+        emptyString: null,
+        emptyNumber: null,
         skills: ["JavaScript", "TypeScript", { surprise: "more stuff" }],
         deeper: {
           value: "hello",
         },
       },
       nonUser: false,
-      empty: undefined,
+      empty: null,
       numeral: 100,
     };
 
@@ -120,7 +120,7 @@ describe("formDataToObject", () => {
   it("handles array paths", () => {
     const formData = new FormData();
 
-    formData.append("something[0]--whatever", "a value");
+    formData.append("something[0].whatever", "a value");
 
     const formSchema = {
       something: {
@@ -128,10 +128,59 @@ describe("formDataToObject", () => {
       },
     };
 
-    const result = formDataToObject(formData, formSchema, { delimiter: "--" });
+    const result = formDataToObject(formData, formSchema);
 
     // eslint-disable-next-line
     // @ts-ignore
     expect(result.something[0]).toEqual({ whatever: "a value" });
+  });
+  it("respects alternate nested path delimiters", () => {
+    const formData = new FormData();
+
+    formData.append("something[0].whatever", "a value");
+
+    const formSchema = {
+      something: {
+        items: { type: "object", properties: { whatever: { type: "string" } } },
+      },
+    };
+
+    const result = formDataToObject(formData, formSchema, { delimiter: "." });
+
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(result.something[0]).toEqual({ whatever: "a value" });
+  });
+  it("defaults to null for empty values", () => {
+    const formData = new FormData();
+    formData.append("whatever", "");
+    const formSchema = {
+      something: {
+        items: { type: "object", properties: { whatever: { type: "string" } } },
+      },
+    };
+
+    const result = formDataToObject(formData, formSchema);
+
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(result).toEqual({ whatever: null });
+  });
+  it("defaults to undefined for empty values if option provided", () => {
+    const formData = new FormData();
+    formData.append("whatever", "");
+    const formSchema = {
+      something: {
+        items: { type: "object", properties: { whatever: { type: "string" } } },
+      },
+    };
+
+    const result = formDataToObject(formData, formSchema, {
+      useUndefinedDefaultValue: true,
+    });
+
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(result).toEqual({ whatever: undefined });
   });
 });

--- a/frontend/src/utils/formData/formDataToJson.test.ts
+++ b/frontend/src/utils/formData/formDataToJson.test.ts
@@ -118,11 +118,11 @@ describe("formDataToObject", () => {
   it("handles array paths", () => {
     const formData = new FormData();
 
-    formData.append("something[0]--whatever", "a value");
+    formData.append("something[0]--whatever", "1");
 
     const formSchema = {
       something: {
-        items: { type: "object", properties: { whatever: { type: "string" } } },
+        items: { whatever: { type: "number" } },
       },
     };
 
@@ -130,7 +130,7 @@ describe("formDataToObject", () => {
 
     // eslint-disable-next-line
     // @ts-ignore
-    expect(result.something[0]).toEqual({ whatever: "a value" });
+    expect(result.something[0]).toEqual({ whatever: 1 });
   });
   it("respects alternate nested path delimiters", () => {
     const formData = new FormData();
@@ -139,7 +139,7 @@ describe("formDataToObject", () => {
 
     const formSchema = {
       something: {
-        items: { type: "object", properties: { whatever: { type: "number" } } },
+        items: { whatever: { type: "number" } },
       },
     };
 
@@ -156,7 +156,7 @@ describe("formDataToObject", () => {
     formData.append("whatever", "");
     const formSchema = {
       something: {
-        items: { type: "object", properties: { whatever: { type: "string" } } },
+        items: { whatever: { type: "string" } },
       },
     };
 
@@ -171,7 +171,7 @@ describe("formDataToObject", () => {
     formData.append("whatever", "");
     const formSchema = {
       something: {
-        items: { type: "object", properties: { whatever: { type: "string" } } },
+        items: { whatever: { type: "string" } },
       },
     };
 

--- a/frontend/src/utils/formData/formDataToJson.test.ts
+++ b/frontend/src/utils/formData/formDataToJson.test.ts
@@ -60,21 +60,19 @@ describe("formDataToObject", () => {
       user: {
         age: "30",
         name: "Alice",
-        emptyString: null,
-        emptyNumber: null,
+        emptyString: undefined,
+        emptyNumber: undefined,
         skills: ["JavaScript", "TypeScript", { surprise: "more stuff" }],
         deeper: {
           value: "hello",
         },
       },
       nonUser: false,
-      empty: null,
+      empty: undefined,
       numeral: 100,
     };
 
-    const result = formDataToObject(formData, formSchema, {
-      delimiter: "--",
-    });
+    const result = formDataToObject(formData, formSchema, undefined);
 
     expect(result).toEqual(expected);
   });
@@ -95,7 +93,7 @@ describe("formDataToObject", () => {
       complicated: { key: "value" },
     };
 
-    const result = formDataToObject(formData, formSchema);
+    const result = formDataToObject(formData, formSchema, undefined);
 
     expect(result).toEqual(expected);
   });
@@ -110,7 +108,7 @@ describe("formDataToObject", () => {
       },
     };
 
-    const result = formDataToObject(formData, formSchema, { delimiter: "--" });
+    const result = formDataToObject(formData, formSchema, undefined);
 
     expect(result.any).toEqual(undefined);
     // eslint-disable-next-line
@@ -120,7 +118,7 @@ describe("formDataToObject", () => {
   it("handles array paths", () => {
     const formData = new FormData();
 
-    formData.append("something[0].whatever", "a value");
+    formData.append("something[0]--whatever", "a value");
 
     const formSchema = {
       something: {
@@ -128,7 +126,7 @@ describe("formDataToObject", () => {
       },
     };
 
-    const result = formDataToObject(formData, formSchema);
+    const result = formDataToObject(formData, formSchema, undefined);
 
     // eslint-disable-next-line
     // @ts-ignore
@@ -137,21 +135,23 @@ describe("formDataToObject", () => {
   it("respects alternate nested path delimiters", () => {
     const formData = new FormData();
 
-    formData.append("something[0].whatever", "a value");
+    formData.append("something[0].whatever", "1");
 
     const formSchema = {
       something: {
-        items: { type: "object", properties: { whatever: { type: "string" } } },
+        items: { type: "object", properties: { whatever: { type: "number" } } },
       },
     };
 
-    const result = formDataToObject(formData, formSchema, { delimiter: "." });
+    const result = formDataToObject(formData, formSchema, undefined, {
+      delimiter: ".",
+    });
 
     // eslint-disable-next-line
     // @ts-ignore
-    expect(result.something[0]).toEqual({ whatever: "a value" });
+    expect(result.something[0]).toEqual({ whatever: 1 });
   });
-  it("defaults to null for empty values", () => {
+  it("defaults to null for empty values when specified", () => {
     const formData = new FormData();
     formData.append("whatever", "");
     const formSchema = {
@@ -160,13 +160,13 @@ describe("formDataToObject", () => {
       },
     };
 
-    const result = formDataToObject(formData, formSchema);
+    const result = formDataToObject(formData, formSchema, null);
 
     // eslint-disable-next-line
     // @ts-ignore
     expect(result).toEqual({ whatever: null });
   });
-  it("defaults to undefined for empty values if option provided", () => {
+  it("defaults to undefined for empty values when specified", () => {
     const formData = new FormData();
     formData.append("whatever", "");
     const formSchema = {
@@ -175,9 +175,7 @@ describe("formDataToObject", () => {
       },
     };
 
-    const result = formDataToObject(formData, formSchema, {
-      useUndefinedDefaultValue: true,
-    });
+    const result = formDataToObject(formData, formSchema, undefined);
 
     // eslint-disable-next-line
     // @ts-ignore

--- a/frontend/src/utils/formData/formDataToJson.ts
+++ b/frontend/src/utils/formData/formDataToJson.ts
@@ -2,6 +2,7 @@
 
 import { RJSFSchema } from "@rjsf/utils";
 import {
+  FORM_DATA_NESTING_DELIMITER,
   getByPointer,
   getFieldPathFromHtml,
 } from "src/utils/formData/formDataUtils";
@@ -17,10 +18,9 @@ type NestedObject = {
 type FormDataToJsonOptions = {
   // seems to be unused, but an optional path prefix to add when referencing schema location
   parentKey?: string;
-  // will default to `--` downstream if not provided. Used to convert representation of nested fields
+  // will default to the FORM_DATA_NESTING_DELIMITER (`--`) downstream if not provided. Used to convert representation of nested fields
   // from FormData / DOM level implementation to implementation used in schema
   delimiter?: string;
-  useUndefinedDefaultValue?: boolean;
 };
 
 /*
@@ -30,19 +30,19 @@ type FormDataToJsonOptions = {
   note:
   - string representations of booleans are cast to booleans
   - for number type fields, cast to number as long as a value is present
-  - for string type fields that represent a number, ensure they remain strings (or null)
+  - for string type fields that represent a number, ensure they remain strings (or undefined/null)
   - otherwise it may be an object or array, so try to cast to parse json
     - note that this will cast a number string ("1") to a number, thus the necessity of the previous case
-  - if the json parse fails, just return the string (or null)
-
-  Note that
+  - if the json parse fails, just return the string (or undefined/null)
+  - default undefined/null values are determined by the default value passed in the original formDataToObject call
+    - apply form validations require `undefined` values for empty fields
+    - all other forms should use `null`
 */
 const parseValue = (
   value: unknown,
   type: string,
-  useUndefinedDefaultValue = false,
+  defaultValue: null | undefined,
 ) => {
-  const defaultValue = useUndefinedDefaultValue ? undefined : null;
   if (value === "false") return false;
   if (value === "true") return true;
   if (
@@ -65,7 +65,8 @@ const parseValue = (
 const getFieldType = (
   currentKey: string, // FormData key
   formSchema: RJSFSchema,
-  options: FormDataToJsonOptions = {},
+  delimiter: string,
+  parentKey: string,
 ): string => {
   // for fields that represent array items in the form schema, we need to reference
   // the "items" property of the field's schema definition. The form data key will
@@ -74,13 +75,10 @@ const getFieldType = (
   // needed to handle activity line items in the budget form
   const keyWithArrayNotationStripped = currentKey.replace(
     /\[\d+\]/g,
-    "--items",
+    `${delimiter}items`,
   );
-  const path = getFieldPathFromHtml(
-    keyWithArrayNotationStripped,
-    options.delimiter,
-  );
-  const fullPath = options.parentKey ? `${options.parentKey}/${path}` : path;
+  const path = getFieldPathFromHtml(keyWithArrayNotationStripped, delimiter);
+  const fullPath = parentKey ? `${parentKey}/${path}` : path;
   const formFieldDefinition = getByPointer(formSchema, fullPath) as {
     type?: string;
   };
@@ -96,19 +94,26 @@ const getFieldType = (
 export function formDataToObject<T = NestedObject>(
   formData = new FormData(),
   formSchema: RJSFSchema, // expects that any "/properties" path segments have already been removed
+  // apply form validations require `undefined` values for empty fields
+  // all other forms should use `null`
+  defaultValue: null | undefined,
   options?: FormDataToJsonOptions,
 ): T {
-  const delimiter = options?.delimiter || ".";
+  const delimiter = options?.delimiter || FORM_DATA_NESTING_DELIMITER;
   const parentKey = options?.parentKey || "";
-  const useUndefinedDefaultValue = options?.useUndefinedDefaultValue || false;
   const result: NestedObject = {};
   const entries = formData.entries();
 
   for (const [key, value] of entries) {
     const currentKey = parentKey ? `${parentKey}${delimiter}${key}` : key;
     const chunks = currentKey.split(delimiter);
-    const fieldType = getFieldType(currentKey, formSchema, options);
-    const parsedValue = parseValue(value, fieldType, useUndefinedDefaultValue);
+    const fieldType = getFieldType(
+      currentKey,
+      formSchema,
+      delimiter,
+      parentKey,
+    );
+    const parsedValue = parseValue(value, fieldType, defaultValue);
 
     let current = result;
 

--- a/frontend/src/utils/formData/formDataToJson.ts
+++ b/frontend/src/utils/formData/formDataToJson.ts
@@ -1,8 +1,10 @@
 // based on https://github.com/ArturKot95/FormData2Json/blob/main/src/formDataToObject.ts
 
 import { RJSFSchema } from "@rjsf/utils";
-
-import { getByPointer, getFieldPathFromHtml } from "./applyFormUtils";
+import {
+  getByPointer,
+  getFieldPathFromHtml,
+} from "src/utils/formData/formDataUtils";
 
 // like, this is basically anything lol - DWS
 type NestedObject = {
@@ -13,19 +15,34 @@ type NestedObject = {
 };
 
 type FormDataToJsonOptions = {
+  // seems to be unused, but an optional path prefix to add when referencing schema location
   parentKey?: string;
+  // will default to `--` downstream if not provided. Used to convert representation of nested fields
+  // from FormData / DOM level implementation to implementation used in schema
   delimiter?: string;
+  useUndefinedDefaultValue?: boolean;
 };
 
 /*
+  parses form data values (which based on FormData defs are either string or blob)
+  into proper data types based on specified type from schema definition
+
+  note:
   - string representations of booleans are cast to booleans
   - for number type fields, cast to number as long as a value is present
-  - for string type fields that represent a number, ensure they remain strings (or undefined)
+  - for string type fields that represent a number, ensure they remain strings (or null)
   - otherwise it may be an object or array, so try to cast to parse json
     - note that this will cast a number string ("1") to a number, thus the necessity of the previous case
-  - if the json parse fails, just return the string (or undefined)
+  - if the json parse fails, just return the string (or null)
+
+  Note that
 */
-const parseValue = (value: unknown, type: string) => {
+const parseValue = (
+  value: unknown,
+  type: string,
+  useUndefinedDefaultValue = false,
+) => {
+  const defaultValue = useUndefinedDefaultValue ? undefined : null;
   if (value === "false") return false;
   if (value === "true") return true;
   if (
@@ -35,19 +52,20 @@ const parseValue = (value: unknown, type: string) => {
   )
     return Number(value);
   if (type === "string" && !isNaN(Number(value))) {
-    return value || undefined;
+    return value || defaultValue;
   }
   try {
     return JSON.parse(value as string) as unknown;
   } catch (_e) {
-    return value || undefined;
+    return value || defaultValue;
   }
 };
 
+// determines the proper type of a form field's value based on the form's schema
 const getFieldType = (
-  currentKey: string,
+  currentKey: string, // FormData key
   formSchema: RJSFSchema,
-  parentKey?: string,
+  options: FormDataToJsonOptions = {},
 ): string => {
   // for fields that represent array items in the form schema, we need to reference
   // the "items" property of the field's schema definition. The form data key will
@@ -58,8 +76,11 @@ const getFieldType = (
     /\[\d+\]/g,
     "--items",
   );
-  const path = getFieldPathFromHtml(keyWithArrayNotationStripped);
-  const fullPath = parentKey ? `${parentKey}/${path}` : path;
+  const path = getFieldPathFromHtml(
+    keyWithArrayNotationStripped,
+    options.delimiter,
+  );
+  const fullPath = options.parentKey ? `${options.parentKey}/${path}` : path;
   const formFieldDefinition = getByPointer(formSchema, fullPath) as {
     type?: string;
   };
@@ -70,21 +91,24 @@ const getFieldType = (
   return formFieldDefinition?.type;
 };
 
-export function formDataToObject(
+// basic functionality here was borrowed from https://github.com/ArturKot95/FormData2Json
+// handles conversion of FormData into a POJO, accounting for nested structures and arrays
+export function formDataToObject<T = NestedObject>(
   formData = new FormData(),
-  formSchema: RJSFSchema,
+  formSchema: RJSFSchema, // expects that any "/properties" path segments have already been removed
   options?: FormDataToJsonOptions,
-): NestedObject {
+): T {
   const delimiter = options?.delimiter || ".";
-  const { parentKey } = options ?? { parentKey: "" };
+  const parentKey = options?.parentKey || "";
+  const useUndefinedDefaultValue = options?.useUndefinedDefaultValue || false;
   const result: NestedObject = {};
   const entries = formData.entries();
 
   for (const [key, value] of entries) {
     const currentKey = parentKey ? `${parentKey}${delimiter}${key}` : key;
     const chunks = currentKey.split(delimiter);
-    const fieldType = getFieldType(currentKey, formSchema, parentKey);
-    const parsedValue = parseValue(value, fieldType);
+    const fieldType = getFieldType(currentKey, formSchema, options);
+    const parsedValue = parseValue(value, fieldType, useUndefinedDefaultValue);
 
     let current = result;
 
@@ -133,5 +157,5 @@ export function formDataToObject(
     }
   }
 
-  return result;
+  return result as T;
 }

--- a/frontend/src/utils/formData/formDataUtils.test.ts
+++ b/frontend/src/utils/formData/formDataUtils.test.ts
@@ -1,0 +1,50 @@
+import {
+  getByPointer,
+  getFieldPathFromHtml,
+} from "src/utils/formData/formDataUtils";
+
+jest.mock("json-pointer", () => ({
+  get: (...args: unknown[]) => mockJsonPointer(...args) as unknown,
+}));
+
+const mockJsonPointer = jest.fn();
+
+describe("getFieldPathFromHtml", () => {
+  it("converts field name to JSON pointer path", () => {
+    expect(getFieldPathFromHtml("foo--bar")).toBe("/foo/bar");
+  });
+  it("honors alternate html side delimiters", () => {
+    expect(getFieldPathFromHtml("foo.bar", ".")).toBe("/foo/bar");
+  });
+});
+
+describe("getByPointer", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+  it("returns undefined if target schema has no content", () => {
+    expect(getByPointer({}, "anythinger")).toEqual(undefined);
+  });
+
+  it("calls json-pointer with expected args", () => {
+    getByPointer({ something: "else " }, "whatever");
+    expect(mockJsonPointer).toHaveBeenCalledWith(
+      { something: "else " },
+      "whatever",
+    );
+  });
+
+  it("returns undefined if path is not found in target", () => {
+    mockJsonPointer.mockImplementation(() => {
+      throw new Error("Invalid reference token:");
+    });
+    const result = getByPointer({ something: "else " }, "whatever");
+    expect(result).toEqual(undefined);
+  });
+
+  it("returns value from json-pointer", () => {
+    mockJsonPointer.mockReturnValue("anything");
+    const result = getByPointer({ something: "else " }, "whatever");
+    expect(result).toEqual("anything");
+  });
+});

--- a/frontend/src/utils/formData/formDataUtils.ts
+++ b/frontend/src/utils/formData/formDataUtils.ts
@@ -1,0 +1,33 @@
+import { get as getSchemaObjectFromPointer } from "json-pointer";
+import { escapeRegExpString } from "src/utils/generalUtils";
+
+// when constructing field identifiers within the dom we will use hyphens rather than slashes
+// since that will cause less confusion for html attributes and will have less conflict with other characters
+export const FORM_DATA_NESTING_DELIMITER = "--";
+
+export const JSON_SCHEMA_NESTING_DELIMITER = "/";
+
+// transform a form data field name / id into a json path that can be used to reference the form schema
+// (assumes that any `/properties` path segments have been removed from schema)
+export const getFieldPathFromHtml = (
+  inputPath: string,
+  inputDelimiter = FORM_DATA_NESTING_DELIMITER,
+) =>
+  `/${inputPath.replace(new RegExp(`${escapeRegExpString(inputDelimiter)}`, "g"), JSON_SCHEMA_NESTING_DELIMITER)}`;
+
+export const getByPointer = (target: object, path: string): unknown => {
+  if (!Object.keys(target).length) {
+    return;
+  }
+  try {
+    return getSchemaObjectFromPointer(target, path);
+  } catch (e) {
+    // this is not ideal, but it seems like the desired behavior is to return undefined if the
+    // path is not found on the target, and the library throws an error instead
+    if ((e as Error).message.includes("Invalid reference token:")) {
+      return undefined;
+    }
+    console.error("error referencing schema path", e, target, path);
+    throw e;
+  }
+};

--- a/frontend/src/utils/formData/formDataUtils.ts
+++ b/frontend/src/utils/formData/formDataUtils.ts
@@ -7,6 +7,9 @@ export const FORM_DATA_NESTING_DELIMITER = "--";
 
 export const JSON_SCHEMA_NESTING_DELIMITER = "/";
 
+// API side validation library delimits nesting with a dot rather than a slash
+export const VALIDATION_ERROR_NESTING_DELIMITER = ".";
+
 // transform a form data field name / id into a json path that can be used to reference the form schema
 // (assumes that any `/properties` path segments have been removed from schema)
 export const getFieldPathFromHtml = (

--- a/frontend/src/utils/generalUtils.test.ts
+++ b/frontend/src/utils/generalUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  escapeRegExpString,
   findFirstWhitespace,
   formatTimestamp,
   getModifiedTimeDisplay,
@@ -251,5 +252,17 @@ describe("isBasicallyAnObject", () => {
     expect(isBasicallyAnObject(new Set())).toEqual(true);
     expect(isBasicallyAnObject({ a: "value" })).toEqual(true);
     expect(isBasicallyAnObject(new Date())).toEqual(true);
+  });
+});
+
+describe("escapeRegExpString", () => {
+  it("escapes all relevant characters in a string for use in a regexp", () => {
+    expect(
+      escapeRegExpString(
+        `All of these should be escaped: \\ ^ $ * + ? . ( ) | { } [ ]`,
+      ),
+    ).toEqual(
+      "\\x41ll\\x20of\\x20these\\x20should\\x20be\\x20escaped\\x3a\\x20\\\\\\x20\\^\\x20\\$\\x20\\*\\x20\\+\\x20\\?\\x20\\.\\x20\\(\\x20\\)\\x20\\|\\x20\\{\\x20\\}\\x20\\[\\x20\\]",
+    );
   });
 });

--- a/frontend/src/utils/generalUtils.ts
+++ b/frontend/src/utils/generalUtils.ts
@@ -8,6 +8,13 @@
 import { difference, isNumber } from "lodash";
 import { OptionalStringDict } from "src/types/generalTypes";
 
+// workaround for RegExp.escape not being fully supported yet
+declare global {
+  interface RegExpConstructor {
+    escape?(str: string): string;
+  }
+}
+
 // Refer to tests to see how this works in practice
 export const splitMarkup = (
   markupString: string,
@@ -177,4 +184,11 @@ export const printAwsHeaders = (headers: Headers): string => {
 
 export const printResponseInfo = (response: Response): string => {
   return `Ok?: ${response.ok ? "ok" : "no"}, status: ${response.status}`;
+};
+
+// polyfill for RegExp.escape found here https://stackoverflow.com/a/6969486
+export const escapeRegExpString = (regexpString: string) => {
+  return RegExp.escape
+    ? RegExp.escape(regexpString)
+    : regexpString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 };


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9602 

## Changes proposed

In the interest of allowing all forms in the application to benefit from the FormData -> JSON functionality built to support the apply form system, this introduces some changes to make the functionality more universal.

Note that with this change the functionality is not yet being used outside of the apply form system, but will be introduced in a subsequent page.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Changes made here include:

* making the nesting delimiter fully customizable
* moving non apply form specific functionality to a non apply form specific utils folder
* allowing customization of default "empty field" value
  * note that this is necessary due to API implementation details that result in all non-apply related forms accepting `null` for required fields, but apply forms requiring fields to be left out of a payload (or set as `undefined` which is effectively the same thing) in order to properly trigger required validations 

Also some more `quality of life` changes
* adding some code comments where I ran into questions in the existing apply form flow
* making path delimiters more explicit with constants
  * in order to support this I had to build out a `RegExp.escape` polyfill

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. general regression testing of apply form system
2. I tested that SFLLL, SF424, SF424A all worked as expected in terms of saving and retrieving data
