### PR TITLE
[Issue #9602] form data to json opportunity edit

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
@@ -246,15 +246,15 @@ describe("OpportunityEditForm — rendering", () => {
     ).toBeDisabled();
   });
 
-  // it("pre-checks eligibility checkboxes from initialValues", () => {
-  //   renderOpportunityEditForm();
+  it("pre-checks eligibility checkboxes from initialValues", () => {
+    renderOpportunityEditForm();
 
-  //   // initialValues.eligibleApplicants includes "individuals" - verify it renders checked
-  //   const individualsCheckbox = screen.getByRole("checkbox", {
-  //     name: /individuals/i,
-  //   });
-  //   expect(individualsCheckbox).toBeChecked();
-  // });
+    // initialValues.eligibleApplicants includes "individuals" - verify it renders checked
+    const individualsCheckbox = screen.getByRole("checkbox", {
+      name: /individuals/i,
+    });
+    expect(individualsCheckbox).toBeChecked();
+  });
 
   it("has no accessibility violations", async () => {
     const { container } = renderOpportunityEditForm();
@@ -485,44 +485,44 @@ describe("OpportunityEditForm — eligibility checkboxes", () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  // it("clicking one checkbox from each eligibility group updates state independently", () => {
-  //   // Exercises the onToggle lambda in all five EligibilityCheckboxGroup instances
-  //   renderOpportunityEditForm({
-  //     initialValues: { ...initialValues, applicant_types: [] },
-  //   });
+  it("clicking one checkbox from each eligibility group updates state independently", () => {
+    // Exercises the onToggle lambda in all five EligibilityCheckboxGroup instances
+    renderOpportunityEditForm({
+      initialValues: { ...initialValues, applicant_types: [] },
+    });
 
-  //   // education group
-  //   fireEvent.click(
-  //     screen.getByRole("checkbox", { name: /independent school districts/i }),
-  //   );
-  //   // government group
-  //   fireEvent.click(
-  //     screen.getByRole("checkbox", { name: /state governments/i }),
-  //   );
-  //   // nonprofit group
-  //   fireEvent.click(
-  //     screen.getByRole("checkbox", {
-  //       name: /other native american tribal organizations/i,
-  //     }),
-  //   );
-  //   // misc group
-  //   fireEvent.click(screen.getByRole("checkbox", { name: /^individuals$/i }));
+    // education group
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /independent school districts/i }),
+    );
+    // government group
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: /state governments/i }),
+    );
+    // nonprofit group
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /other native american tribal organizations/i,
+      }),
+    );
+    // misc group
+    fireEvent.click(screen.getByRole("checkbox", { name: /^individuals$/i }));
 
-  //   expect(
-  //     screen.getByRole("checkbox", { name: /independent school districts/i }),
-  //   ).toBeChecked();
-  //   expect(
-  //     screen.getByRole("checkbox", { name: /state governments/i }),
-  //   ).toBeChecked();
-  //   expect(
-  //     screen.getByRole("checkbox", {
-  //       name: /other native american tribal organizations/i,
-  //     }),
-  //   ).toBeChecked();
-  //   expect(
-  //     screen.getByRole("checkbox", { name: /^individuals$/i }),
-  //   ).toBeChecked();
-  // });
+    expect(
+      screen.getByRole("checkbox", { name: /independent school districts/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /state governments/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", {
+        name: /other native american tribal organizations/i,
+      }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: /^individuals$/i }),
+    ).toBeChecked();
+  });
 });
 
 // ─── Save state ───────────────────────────────────────────────────────────────

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
@@ -38,29 +38,29 @@ jest.mock("src/hooks/useClientFetch", () => ({
 }));
 
 const initialValues: OpportunityEditFormValues = {
-  opportunityNumber: "ABC-123",
-  title: "Test opportunity",
-  awardSelectionMethod: "discretionary",
-  awardSelectionMethodExplanation: "",
-  description: "Summary text",
-  fundingType: "grant",
-  costSharing: false,
-  publishDate: "2026-03-11",
-  closeDate: "2026-04-11",
-  closeDateExplanation: "",
-  fundingCategories: "education",
-  fundingCategoryExplanation: "",
-  expectedNumberOfAwards: "3",
-  estimatedTotalProgramFunding: "500000",
-  awardMinimum: "1000",
-  awardMaximum: "10000",
-  eligibleApplicants: ["individuals"],
-  additionalEligibilityInfo: "",
-  additionalInfoUrl: "https://example.com",
-  additionalInfoUrlText: "More information",
-  grantorContactDetails: "Grants team",
-  contactEmail: "grants@example.com",
-  contactEmailText: "Email the grants team",
+  opportunity_number: "ABC-123",
+  opportunity_title: "Test opportunity",
+  category: "discretionary",
+  category_explanation: "",
+  summary_description: "Summary text",
+  funding_instruments: "grant",
+  is_cost_sharing: false,
+  post_date: "2026-03-11",
+  close_date: "2026-04-11",
+  close_date_description: "",
+  funding_categories: "education",
+  funding_category_description: "",
+  expected_number_of_awards: "3",
+  estimated_total_program_funding: "500000",
+  award_floor: "1000",
+  award_ceiling: "10000",
+  applicant_types: ["individuals"],
+  applicant_eligibility_description: "",
+  additional_info_url: "https://example.com",
+  additional_info_url_description: "More information",
+  agency_contact_description: "Grants team",
+  agency_email_address: "grants@example.com",
+  agency_email_address_description: "Email the grants team",
 };
 
 const renderOpportunityEditForm = (
@@ -122,20 +122,71 @@ describe("OpportunityEditForm — rendering", () => {
 
     expect(screen.getByDisplayValue("opportunity-123")).toHaveAttribute(
       "name",
-      "opportunityId",
+      "opportunity_id",
     );
     expect(screen.getByDisplayValue("summary-456")).toHaveAttribute(
       "name",
-      "opportunitySummaryId",
+      "opportunity_summary_id",
     );
     expect(screen.getByTestId("isForecast-input")).toHaveValue("true");
     expect(screen.getByDisplayValue("Test opportunity")).toHaveAttribute(
       "name",
-      "title",
+      "opportunity_title",
     );
     expect(screen.getByDisplayValue("discretionary")).toHaveAttribute(
       "name",
-      "awardSelectionMethod",
+      "category",
+    );
+  });
+
+  it("communicates applicant type selections to submitted form data using hidden fields", () => {
+    const mockFormAction = jest.fn<void, [FormData]>();
+    mockUseActionState.mockReturnValue([
+      { validationErrors: {} },
+      mockFormAction,
+      false,
+    ]);
+    render(
+      <OpportunityEditForm
+        opportunityId="opportunity-123"
+        opportunitySummaryId="summary-456"
+        initialValues={{ ...initialValues, applicant_types: [] }}
+        isDraft
+        saveLabel="Save"
+        previewLabel="Preview"
+        publishLabel="Publish"
+      />,
+    );
+
+    const checkboxOne = screen.getByRole("checkbox", {
+      name: /for-profit organizations other than small businesses/i,
+    });
+
+    const checkboxTwo = screen.getByRole("checkbox", {
+      name: /individuals/i,
+    });
+
+    expect(checkboxOne).not.toBeChecked();
+    expect(checkboxTwo).not.toBeChecked();
+
+    fireEvent.click(checkboxOne);
+    expect(checkboxOne).toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockFormAction).toHaveBeenCalledTimes(1);
+    expect(mockFormAction).toHaveBeenCalledWith(expect.any(FormData));
+    expect(mockFormAction.mock.calls[0][0].get("applicant_types[0]")).toEqual(
+      "for_profit_organizations_other_than_small_businesses",
+    );
+
+    fireEvent.click(checkboxTwo);
+    expect(checkboxTwo).toBeChecked();
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockFormAction).toHaveBeenCalledTimes(2);
+    expect(mockFormAction).toHaveBeenCalledWith(expect.any(FormData));
+    expect(mockFormAction.mock.calls[1][0].get("applicant_types[1]")).toEqual(
+      "individuals",
     );
   });
 
@@ -171,7 +222,7 @@ describe("OpportunityEditForm — rendering", () => {
   it("disables fundingCategoryExplanation when isDraft is false and fundingCategories is 'other'", () => {
     renderOpportunityEditForm({
       isDraft: false,
-      initialValues: { ...initialValues, fundingCategories: "other" },
+      initialValues: { ...initialValues, funding_categories: "other" },
     });
 
     expect(
@@ -184,7 +235,7 @@ describe("OpportunityEditForm — rendering", () => {
   it("disables additionalEligibilityInfo when isDraft is false and eligibleApplicants includes 'other'", () => {
     renderOpportunityEditForm({
       isDraft: false,
-      initialValues: { ...initialValues, eligibleApplicants: ["other"] },
+      initialValues: { ...initialValues, applicant_types: ["other"] },
     });
 
     expect(
@@ -194,15 +245,15 @@ describe("OpportunityEditForm — rendering", () => {
     ).toBeDisabled();
   });
 
-  it("pre-checks eligibility checkboxes from initialValues", () => {
-    renderOpportunityEditForm();
+  // it("pre-checks eligibility checkboxes from initialValues", () => {
+  //   renderOpportunityEditForm();
 
-    // initialValues.eligibleApplicants includes "individuals" - verify it renders checked
-    const individualsCheckbox = screen.getByRole("checkbox", {
-      name: /individuals/i,
-    });
-    expect(individualsCheckbox).toBeChecked();
-  });
+  //   // initialValues.eligibleApplicants includes "individuals" - verify it renders checked
+  //   const individualsCheckbox = screen.getByRole("checkbox", {
+  //     name: /individuals/i,
+  //   });
+  //   expect(individualsCheckbox).toBeChecked();
+  // });
 
   it("has no accessibility violations", async () => {
     const { container } = renderOpportunityEditForm();
@@ -256,8 +307,8 @@ describe("OpportunityEditForm — alert banners", () => {
     mockUseActionState.mockReturnValue([
       {
         validationErrors: {
-          fundingType: ["Funding type is required"],
-          closeDate: ["Close date must be a valid date"],
+          funding_instruments: ["Funding type is required"],
+          close_date: ["Close date must be a valid date"],
         },
       },
       jest.fn(),
@@ -303,7 +354,7 @@ describe("OpportunityEditForm — conditional fields", () => {
 
   it("shows the funding category explanation textarea when fundingCategories is 'other'", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, fundingCategories: "other" },
+      initialValues: { ...initialValues, funding_categories: "other" },
     });
 
     expect(
@@ -325,7 +376,7 @@ describe("OpportunityEditForm — conditional fields", () => {
 
   it("shows the close date explanation textarea when closeDate is empty", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, closeDate: "" },
+      initialValues: { ...initialValues, close_date: "" },
     });
 
     expect(
@@ -347,7 +398,7 @@ describe("OpportunityEditForm — conditional fields", () => {
 
   it("shows additional eligibility info textarea when 'other' is in eligibleApplicants", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, eligibleApplicants: ["other"] },
+      initialValues: { ...initialValues, applicant_types: ["other"] },
     });
 
     expect(
@@ -361,7 +412,7 @@ describe("OpportunityEditForm — conditional fields", () => {
     renderOpportunityEditForm({
       initialValues: {
         ...initialValues,
-        eligibleApplicants: ["unrestricted"],
+        applicant_types: ["unrestricted"],
       },
     });
 
@@ -402,7 +453,7 @@ describe("OpportunityEditForm — eligibility checkboxes", () => {
     renderOpportunityEditForm({
       initialValues: {
         ...initialValues,
-        eligibleApplicants: [
+        applicant_types: [
           "for_profit_organizations_other_than_small_businesses",
         ],
       },
@@ -417,7 +468,7 @@ describe("OpportunityEditForm — eligibility checkboxes", () => {
 
   it("toggles an eligibility checkbox on then off", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, eligibleApplicants: [] },
+      initialValues: { ...initialValues, applicant_types: [] },
     });
 
     const checkbox = screen.getByRole("checkbox", {
@@ -433,44 +484,44 @@ describe("OpportunityEditForm — eligibility checkboxes", () => {
     expect(checkbox).not.toBeChecked();
   });
 
-  it("clicking one checkbox from each eligibility group updates state independently", () => {
-    // Exercises the onToggle lambda in all five EligibilityCheckboxGroup instances
-    renderOpportunityEditForm({
-      initialValues: { ...initialValues, eligibleApplicants: [] },
-    });
+  // it("clicking one checkbox from each eligibility group updates state independently", () => {
+  //   // Exercises the onToggle lambda in all five EligibilityCheckboxGroup instances
+  //   renderOpportunityEditForm({
+  //     initialValues: { ...initialValues, applicant_types: [] },
+  //   });
 
-    // education group
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /independent school districts/i }),
-    );
-    // government group
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: /state governments/i }),
-    );
-    // nonprofit group
-    fireEvent.click(
-      screen.getByRole("checkbox", {
-        name: /other native american tribal organizations/i,
-      }),
-    );
-    // misc group
-    fireEvent.click(screen.getByRole("checkbox", { name: /^individuals$/i }));
+  //   // education group
+  //   fireEvent.click(
+  //     screen.getByRole("checkbox", { name: /independent school districts/i }),
+  //   );
+  //   // government group
+  //   fireEvent.click(
+  //     screen.getByRole("checkbox", { name: /state governments/i }),
+  //   );
+  //   // nonprofit group
+  //   fireEvent.click(
+  //     screen.getByRole("checkbox", {
+  //       name: /other native american tribal organizations/i,
+  //     }),
+  //   );
+  //   // misc group
+  //   fireEvent.click(screen.getByRole("checkbox", { name: /^individuals$/i }));
 
-    expect(
-      screen.getByRole("checkbox", { name: /independent school districts/i }),
-    ).toBeChecked();
-    expect(
-      screen.getByRole("checkbox", { name: /state governments/i }),
-    ).toBeChecked();
-    expect(
-      screen.getByRole("checkbox", {
-        name: /other native american tribal organizations/i,
-      }),
-    ).toBeChecked();
-    expect(
-      screen.getByRole("checkbox", { name: /^individuals$/i }),
-    ).toBeChecked();
-  });
+  //   expect(
+  //     screen.getByRole("checkbox", { name: /independent school districts/i }),
+  //   ).toBeChecked();
+  //   expect(
+  //     screen.getByRole("checkbox", { name: /state governments/i }),
+  //   ).toBeChecked();
+  //   expect(
+  //     screen.getByRole("checkbox", {
+  //       name: /other native american tribal organizations/i,
+  //     }),
+  //   ).toBeChecked();
+  //   expect(
+  //     screen.getByRole("checkbox", { name: /^individuals$/i }),
+  //   ).toBeChecked();
+  // });
 });
 
 // ─── Save state ───────────────────────────────────────────────────────────────
@@ -495,7 +546,7 @@ describe("OpportunityEditForm — save state", () => {
 
     expect(screen.getByDisplayValue("new-summary-789")).toHaveAttribute(
       "name",
-      "opportunitySummaryId",
+      "opportunity_summary_id",
     );
   });
 });
@@ -516,7 +567,7 @@ describe("OpportunityEditForm — funding details interactions", () => {
     jest.resetAllMocks();
   });
 
-  it("updates fundingType when the Select value changes", () => {
+  it("updates funding_instruments when the Select value changes", () => {
     renderOpportunityEditForm();
 
     const select = screen.getByRole("combobox", {
@@ -527,9 +578,9 @@ describe("OpportunityEditForm — funding details interactions", () => {
     expect(select).toHaveValue("cooperative_agreement");
   });
 
-  it("updates costSharing to true when the Yes radio is clicked", () => {
+  it("updates is_cost_sharing to true when the Yes radio is clicked", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, costSharing: false },
+      initialValues: { ...initialValues, is_cost_sharing: false },
     });
 
     const radio = screen.getByRole("radio", { name: /labels\.yes/i });
@@ -538,9 +589,9 @@ describe("OpportunityEditForm — funding details interactions", () => {
     expect(radio).toBeChecked();
   });
 
-  it("updates costSharing to false when the No radio is clicked", () => {
+  it("updates is_cost_sharing to false when the No radio is clicked", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, costSharing: true },
+      initialValues: { ...initialValues, is_cost_sharing: true },
     });
 
     const radio = screen.getByRole("radio", { name: /labels\.no/i });
@@ -573,7 +624,7 @@ describe("OpportunityEditForm — funding details interactions", () => {
     renderOpportunityEditForm({
       initialValues: {
         ...initialValues,
-        estimatedTotalProgramFunding: "750000",
+        estimated_total_program_funding: "750000",
       },
     });
 
@@ -597,7 +648,7 @@ describe("OpportunityEditForm — funding details interactions", () => {
 
   it("formats awardMaximum with commas from initialValues", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, awardMaximum: "5000" },
+      initialValues: { ...initialValues, award_ceiling: "5000" },
     });
 
     const input = screen.getByRole("textbox", {
@@ -609,7 +660,7 @@ describe("OpportunityEditForm — funding details interactions", () => {
 
   it("updates fundingCategoryExplanation when the textarea changes", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, fundingCategories: "other" },
+      initialValues: { ...initialValues, funding_categories: "other" },
     });
 
     const textarea = screen.getByRole("textbox", {
@@ -622,7 +673,7 @@ describe("OpportunityEditForm — funding details interactions", () => {
 
   it("updates closeDateExplanation when the textarea changes", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, closeDate: "" },
+      initialValues: { ...initialValues, close_date: "" },
     });
 
     const textarea = screen.getByRole("textbox", {
@@ -652,7 +703,7 @@ describe("OpportunityEditForm — eligibility and additional info interactions",
 
   it("updates additionalEligibilityInfo when the textarea changes", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, eligibleApplicants: ["other"] },
+      initialValues: { ...initialValues, applicant_types: ["other"] },
     });
 
     const textarea = screen.getByRole("textbox", {
@@ -742,22 +793,24 @@ describe("OpportunityEditForm — inline validation errors", () => {
     mockUseActionState.mockReturnValue([
       {
         validationErrors: {
-          fundingType: ["Funding type required"],
-          fundingCategory: ["Funding category required"],
-          expectedNumberOfAwards: ["Must be a number"],
-          estimatedTotalProgramFunding: ["Must be a number"],
-          awardMinimum: ["Award minimum invalid"],
-          awardMaximum: ["Award maximum invalid"],
-          publishDate: ["Publish date required"],
-          closeDate: ["Close date required"],
-          eligibleApplicants: ["Eligible applicants required"],
-          description: ["Description required"],
-          additionalInfoUrl: ["Invalid URL"],
-          additionalInfoUrlText: ["URL text required"],
-          grantorContactDetails: ["Contact details required"],
-          contactEmail: ["Invalid email"],
-          contactEmailText: ["Contact email text required"],
-          additionalEligibilityInfo: ["Additional eligibility info required"],
+          funding_instruments: ["Funding type required"],
+          funding_categores: ["Funding category required"],
+          expected_number_of_awards: ["Must be a number"],
+          estimated_total_program_funding: ["Must be a number"],
+          award_floor: ["Award minimum invalid"],
+          award_ceiling: ["Award maximum invalid"],
+          post_date: ["Publish date required"],
+          close_date: ["Close date required"],
+          applicant_types: ["Eligible applicants required"],
+          summary_description: ["Description required"],
+          additional_info_url: ["Invalid URL"],
+          additional_info_url_description: ["URL text required"],
+          agency_contact_description: ["Contact details required"],
+          agency_email_address: ["Invalid email"],
+          agency_email_address_description: ["Contact email text required"],
+          applicant_eligibility_description: [
+            "Additional eligibility info required",
+          ],
         },
       },
       jest.fn(),
@@ -768,7 +821,7 @@ describe("OpportunityEditForm — inline validation errors", () => {
       initialValues: {
         ...initialValues,
         // show the additionalEligibilityInfo field so its inline error renders
-        eligibleApplicants: ["other"],
+        applicant_types: ["other"],
       },
     });
 
@@ -798,7 +851,7 @@ describe("OpportunityEditForm — number formatting edge cases", () => {
 
   it("displays a non-numeric awardMinimum value as-is without formatting", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, awardMinimum: "abc" },
+      initialValues: { ...initialValues, award_floor: "abc" },
     });
 
     const input = screen.getByRole("textbox", {
@@ -811,7 +864,7 @@ describe("OpportunityEditForm — number formatting edge cases", () => {
 
   it("displays an empty awardMaximum as an empty string without formatting", () => {
     renderOpportunityEditForm({
-      initialValues: { ...initialValues, awardMaximum: "" },
+      initialValues: { ...initialValues, award_ceiling: "" },
     });
 
     const input = screen.getByRole("textbox", {

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.test.tsx
@@ -152,9 +152,6 @@ describe("OpportunityEditForm — rendering", () => {
         opportunitySummaryId="summary-456"
         initialValues={{ ...initialValues, applicant_types: [] }}
         isDraft
-        saveLabel="Save"
-        previewLabel="Preview"
-        publishLabel="Publish"
       />,
     );
 
@@ -171,7 +168,9 @@ describe("OpportunityEditForm — rendering", () => {
 
     fireEvent.click(checkboxOne);
     expect(checkboxOne).toBeChecked();
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "button.saveAndContinue" }),
+    );
 
     expect(mockFormAction).toHaveBeenCalledTimes(1);
     expect(mockFormAction).toHaveBeenCalledWith(expect.any(FormData));
@@ -181,7 +180,9 @@ describe("OpportunityEditForm — rendering", () => {
 
     fireEvent.click(checkboxTwo);
     expect(checkboxTwo).toBeChecked();
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "button.saveAndContinue" }),
+    );
 
     expect(mockFormAction).toHaveBeenCalledTimes(2);
     expect(mockFormAction).toHaveBeenCalledWith(expect.any(FormData));

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
@@ -75,7 +75,9 @@ function EligibilityCheckboxGroup({
           <div key={option.value} className="padding-top-05">
             <Checkbox
               id={`${baseId}-${index}`}
-              name="eligibleApplicants"
+              // selected these values will be collected in hidden inputs populated by state
+              // so we don't want these inputs showing up in the form data
+              name={""}
               value={option.value}
               label={eligibilityDisplayLabels[option.value] ?? option.label}
               defaultChecked={initialSelectedValues.includes(option.value)}
@@ -114,11 +116,11 @@ export default function OpportunityEditForm({
   // State for fields that drive conditional show/hide rendering and
   // the publish button enabled state.
   const [fundingCategory, setFundingCategory] = useState(
-    initialValues.fundingCategories,
+    initialValues.funding_categories,
   );
-  const [closeDate, setCloseDate] = useState(initialValues.closeDate);
+  const [closeDate, setCloseDate] = useState(initialValues.close_date);
   const [selectedEligibility, setSelectedEligibility] = useState<string[]>(
-    initialValues.eligibleApplicants,
+    initialValues.applicant_types,
   );
   const [formState, formAction] = useActionState(opportunityEditFormAction, {
     validationErrors: {},
@@ -153,32 +155,32 @@ export default function OpportunityEditForm({
     if (!form) return;
     const formData = new FormData(form);
     const estTotalFunding = getNumericAmountFromString(
-      formData.get("estimatedTotalProgramFunding") as string | null,
+      formData.get("estimated_total_program_funding") as string | null,
     );
     const awardMin = getNumericAmountFromString(
-      formData.get("awardMinimum") as string | null,
+      formData.get("award_floor") as string | null,
     );
     const awardMax = getNumericAmountFromString(
-      formData.get("awardMaximum") as string | null,
+      formData.get("award_ceiling") as string | null,
     );
     // clear old error messages
-    setSingleFrontendError("awardMinimum", null);
-    setSingleFrontendError("awardMaximum", null);
-    setSingleFrontendError("estimatedTotalProgramFunding", null);
+    setSingleFrontendError("award_floor", null);
+    setSingleFrontendError("award_ceiling", null);
+    setSingleFrontendError("estimated_total_program_funding", null);
     const maxLimit = 1000000000000000;
 
     //--- min & max values for Award Minimum, Award Minimum and Total Program Funding ---
     if (awardMin < 0 || awardMin >= maxLimit) {
       const errMsg = t("validationErrors.awardMinCurrencyInput");
-      setSingleFrontendError("awardMinimum", errMsg);
+      setSingleFrontendError("award_floor", errMsg);
     }
     if (awardMax < 0 || awardMax >= maxLimit) {
       const errMsg = t("validationErrors.awardMaxCurrencyInput");
-      setSingleFrontendError("awardMaximum", errMsg);
+      setSingleFrontendError("award_ceiling", errMsg);
     }
     if (estTotalFunding < 0 || estTotalFunding >= maxLimit) {
       const errMsg = t("validationErrors.totalFundingCurrencyInput");
-      setSingleFrontendError("estimatedTotalProgramFunding", errMsg);
+      setSingleFrontendError("estimated_total_program_funding", errMsg);
     }
   };
 
@@ -232,24 +234,24 @@ export default function OpportunityEditForm({
       }}
       noValidate
     >
-      <input type="hidden" name="opportunityId" value={opportunityId} />
+      <input type="hidden" name="opportunity_id" value={opportunityId} />
       <input
         type="hidden"
-        name="opportunitySummaryId"
+        name="opportunity_summary_id"
         value={currentSummaryId}
       />
       <input
         type="hidden"
-        name="isForecast"
+        name="is_forecast"
         data-testid="isForecast-input"
         value={isForecast ? "true" : "false"}
       />
-      <input type="hidden" name="title" value={initialValues.title} />
       <input
         type="hidden"
-        name="awardSelectionMethod"
-        value={initialValues.awardSelectionMethod}
+        name="opportunity_title"
+        value={initialValues.opportunity_title}
       />
+      <input type="hidden" name="category" value={initialValues.category} />
 
       {!isDraft ? (
         <div className="margin-top-2">
@@ -319,20 +321,22 @@ export default function OpportunityEditForm({
         <div className="display-flex flex-column gap-3">
           <div className="grid-row grid-gap-lg">
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("fundingType")}>
+              <FormGroup error={!!getFieldError("funding_instruments")}>
                 <DynamicFieldLabel
-                  idFor="funding-type-values"
+                  idFor="funding_instruments"
                   title={t("labels.fundingType")}
                   required
                   description={t("content.fundingTypeHint")}
                 />
-                {getFieldError("fundingType") ? (
-                  <ErrorMessage>{getFieldError("fundingType")}</ErrorMessage>
+                {getFieldError("funding_instruments") ? (
+                  <ErrorMessage>
+                    {getFieldError("funding_instruments")}
+                  </ErrorMessage>
                 ) : null}
                 <Select
-                  id="funding-type-values"
-                  name="funding-type-values"
-                  defaultValue={initialValues.fundingType}
+                  id="funding_instruments"
+                  name="funding_instruments"
+                  defaultValue={initialValues.funding_instruments}
                   className="width-full"
                   disabled={!isDraft}
                 >
@@ -356,20 +360,20 @@ export default function OpportunityEditForm({
                   <div className="grid-col-6">
                     <Radio
                       id="cost-sharing-yes"
-                      name="costSharing"
+                      name="is_cost_sharing"
                       label={t("labels.yes")}
                       value="true"
-                      defaultChecked={initialValues.costSharing === true}
+                      defaultChecked={initialValues.is_cost_sharing === true}
                       disabled={!isDraft}
                     />
                   </div>
                   <div className="grid-col-6">
                     <Radio
                       id="cost-sharing-no"
-                      name="costSharing"
+                      name="is_cost_sharing"
                       label={t("labels.no")}
                       value="false"
-                      defaultChecked={initialValues.costSharing === false}
+                      defaultChecked={initialValues.is_cost_sharing === false}
                       disabled={!isDraft}
                     />
                   </div>
@@ -380,21 +384,21 @@ export default function OpportunityEditForm({
 
           <div className="grid-row grid-gap-lg">
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("fundingCategory")}>
+              <FormGroup error={!!getFieldError("funding_categories")}>
                 <DynamicFieldLabel
-                  idFor="funding-category-values"
+                  idFor="funding_categories"
                   title={t("labels.category")}
                   required
                   description={t("content.categoryHint")}
                 />
-                {getFieldError("fundingCategory") ? (
+                {getFieldError("funding_categories") ? (
                   <ErrorMessage>
-                    {getFieldError("fundingCategory")}
+                    {getFieldError("funding_categories")}
                   </ErrorMessage>
                 ) : null}
                 <Select
-                  id="funding-category-values"
-                  name="funding-category-values"
+                  id="funding_categories"
+                  name="funding_categories"
                   value={fundingCategory}
                   onChange={(event) => {
                     setFundingCategory(event.target.value);
@@ -419,10 +423,10 @@ export default function OpportunityEditForm({
                 isTextArea={true}
                 labelText={t("labels.fundingCategoryExplanation")}
                 description={t("content.fundingCategoryExplanationHint")}
-                fieldId="fundingCategoryExplanation"
+                fieldId="funding_category_description"
                 fieldMaxLength={2500}
                 isRequired={false}
-                defaultValue={initialValues.fundingCategoryExplanation}
+                defaultValue={initialValues.funding_category_description}
                 onTextChange={() => {}}
                 disabled={!isDraft}
               />
@@ -431,22 +435,22 @@ export default function OpportunityEditForm({
 
           <div className="grid-row grid-gap-lg">
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("expectedNumberOfAwards")}>
+              <FormGroup error={!!getFieldError("expected_number_of_awards")}>
                 <DynamicFieldLabel
-                  idFor="expected-number-of-awards"
+                  idFor="expected_number_of_awards"
                   title={t("labels.expectedNumberOfAwards")}
                   description={t("content.expectedNumberOfAwardsHint")}
                 />
-                {getFieldError("expectedNumberOfAwards") ? (
+                {getFieldError("expected_number_of_awards") ? (
                   <ErrorMessage>
-                    {getFieldError("expectedNumberOfAwards")}
+                    {getFieldError("expected_number_of_awards")}
                   </ErrorMessage>
                 ) : null}
                 <TextInput
-                  id="expected-number-of-awards"
-                  name="expectedNumberOfAwards"
+                  id="expected_number_of_awards"
+                  name="expected_number_of_awards"
                   type="text"
-                  defaultValue={initialValues.expectedNumberOfAwards}
+                  defaultValue={initialValues.expected_number_of_awards}
                   className="width-full"
                   disabled={!isDraft}
                 />
@@ -454,24 +458,24 @@ export default function OpportunityEditForm({
             </div>
             <div className="tablet:grid-col-6">
               <FormGroup
-                error={!!getFieldError("estimatedTotalProgramFunding")}
+                error={!!getFieldError("estimated_total_program_funding")}
               >
                 <DynamicFieldLabel
-                  idFor="estimated-total-program-funding"
+                  idFor="estimated_total_program_funding"
                   title={t("labels.estimatedTotalProgramFunding")}
                   description={t("content.estimatedTotalProgramFundingHint")}
                 />
-                {getFieldError("estimatedTotalProgramFunding") ? (
+                {getFieldError("estimated_total_program_funding") ? (
                   <ErrorMessage>
-                    {getFieldError("estimatedTotalProgramFunding")}
+                    {getFieldError("estimated_total_program_funding")}
                   </ErrorMessage>
                 ) : null}
                 <TextInput
-                  id="estimated-total-program-funding"
-                  name="estimatedTotalProgramFunding"
+                  id="estimated_total_program_funding"
+                  name="estimated_total_program_funding"
                   type="text"
                   defaultValue={formatNumber(
-                    initialValues.estimatedTotalProgramFunding,
+                    initialValues.estimated_total_program_funding,
                   )}
                   onBlur={singleFieldValidation}
                   className="width-full"
@@ -483,20 +487,20 @@ export default function OpportunityEditForm({
 
           <div className="grid-row grid-gap-lg">
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("awardMinimum")}>
+              <FormGroup error={!!getFieldError("award_floor")}>
                 <DynamicFieldLabel
-                  idFor="award-minimum"
+                  idFor="award_floor"
                   title={t("labels.awardMinimum")}
                   description={t("content.awardMinimumHint")}
                 />
-                {getFieldError("awardMinimum") ? (
-                  <ErrorMessage>{getFieldError("awardMinimum")}</ErrorMessage>
+                {getFieldError("award_floor") ? (
+                  <ErrorMessage>{getFieldError("award_floor")}</ErrorMessage>
                 ) : null}
                 <TextInput
-                  id="award-minimum"
-                  name="awardMinimum"
+                  id="award_floor"
+                  name="award_floor"
                   type="text"
-                  defaultValue={formatNumber(initialValues.awardMinimum)}
+                  defaultValue={formatNumber(initialValues.award_floor)}
                   onBlur={singleFieldValidation}
                   className="width-full"
                   disabled={!isDraft}
@@ -504,20 +508,20 @@ export default function OpportunityEditForm({
               </FormGroup>
             </div>
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("awardMaximum")}>
+              <FormGroup error={!!getFieldError("award_ceiling")}>
                 <DynamicFieldLabel
-                  idFor="award-maximum"
+                  idFor="award_ceiling"
                   title={t("labels.awardMaximum")}
                   description={t("content.awardMaximumHint")}
                 />
-                {getFieldError("awardMaximum") ? (
-                  <ErrorMessage>{getFieldError("awardMaximum")}</ErrorMessage>
+                {getFieldError("award_ceiling") ? (
+                  <ErrorMessage>{getFieldError("award_ceiling")}</ErrorMessage>
                 ) : null}
                 <TextInput
-                  id="award-maximum"
-                  name="awardMaximum"
+                  id="award_ceiling"
+                  name="award_ceiling"
                   type="text"
-                  defaultValue={formatNumber(initialValues.awardMaximum)}
+                  defaultValue={formatNumber(initialValues.award_ceiling)}
                   onBlur={singleFieldValidation}
                   className="width-full"
                   disabled={!isDraft}
@@ -528,20 +532,20 @@ export default function OpportunityEditForm({
 
           <div className="grid-row grid-gap-lg">
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("publishDate")}>
+              <FormGroup error={!!getFieldError("post_date")}>
                 <DynamicFieldLabel
-                  idFor="publish-date"
+                  idFor="post_date"
                   title={t("labels.publishDate")}
                   required
                   description={t("content.publishDateHint")}
                 />
-                {getFieldError("publishDate") ? (
-                  <ErrorMessage>{getFieldError("publishDate")}</ErrorMessage>
+                {getFieldError("post_date") ? (
+                  <ErrorMessage>{getFieldError("post_date")}</ErrorMessage>
                 ) : null}
                 <DatePicker
-                  id="publish-date"
-                  name="publishDate"
-                  defaultValue={initialValues.publishDate}
+                  id="post_date"
+                  name="post_date"
+                  defaultValue={initialValues.post_date}
                   placeholder="mm/dd/yyyy"
                   className="width-full"
                   disabled={!isDraft}
@@ -549,19 +553,19 @@ export default function OpportunityEditForm({
               </FormGroup>
             </div>
             <div className="tablet:grid-col-6">
-              <FormGroup error={!!getFieldError("closeDate")}>
+              <FormGroup error={!!getFieldError("close_date")}>
                 <DynamicFieldLabel
-                  idFor="close-date"
+                  idFor="close_date"
                   title={t("labels.closeDate")}
                   description={t("content.closeDateHint")}
                 />
-                {getFieldError("closeDate") ? (
-                  <ErrorMessage>{getFieldError("closeDate")}</ErrorMessage>
+                {getFieldError("close_date") ? (
+                  <ErrorMessage>{getFieldError("close_date")}</ErrorMessage>
                 ) : null}
                 <DatePicker
-                  id="close-date"
-                  name="closeDate"
-                  defaultValue={initialValues.closeDate}
+                  id="close_date"
+                  name="close_date"
+                  defaultValue={initialValues.close_date}
                   placeholder="mm/dd/yyyy"
                   onChange={(value) => setCloseDate(value ?? "")}
                   className="width-full"
@@ -575,14 +579,14 @@ export default function OpportunityEditForm({
             <div className="width-full">
               <FormGroup>
                 <DynamicFieldLabel
-                  idFor="close-date-explanation"
+                  idFor="close_date_description"
                   title={t("labels.closeDateExplanation")}
                   description={t("content.closeDateExplanationHint")}
                 />
                 <Textarea
-                  id="close-date-explanation"
-                  name="closeDateExplanation"
-                  defaultValue={initialValues.closeDateExplanation}
+                  id="close_date_description"
+                  name="close_date_description"
+                  defaultValue={initialValues.close_date_description}
                   rows={5}
                   className="width-full"
                   disabled={!isDraft}
@@ -607,15 +611,15 @@ export default function OpportunityEditForm({
         </div>
 
         <div className="display-flex flex-column gap-3">
-          <FormGroup error={!!getFieldError("eligibleApplicants")}>
+          <FormGroup error={!!getFieldError("applicant_types")}>
             <DynamicFieldLabel
-              idFor="eligible-applicants-values"
+              idFor="applicant_types"
               title={t("labels.eligibleApplicants")}
               required
               description={t("content.eligibleApplicantsHint")}
             />
-            {getFieldError("eligibleApplicants") ? (
-              <ErrorMessage>{getFieldError("eligibleApplicants")}</ErrorMessage>
+            {getFieldError("applicant_types") ? (
+              <ErrorMessage>{getFieldError("applicant_types")}</ErrorMessage>
             ) : null}
           </FormGroup>
 
@@ -626,7 +630,7 @@ export default function OpportunityEditForm({
                   title={t("labels.eligibilityBusiness")}
                   options={eligibilityGroups.business}
                   baseId="eligible-business"
-                  initialSelectedValues={initialValues.eligibleApplicants}
+                  initialSelectedValues={initialValues.applicant_types}
                   onToggle={handleEligibilityToggle}
                   disabled={!isDraft}
                 />
@@ -634,7 +638,7 @@ export default function OpportunityEditForm({
                   title={t("labels.eligibilityEducation")}
                   options={eligibilityGroups.education}
                   baseId="eligible-education"
-                  initialSelectedValues={initialValues.eligibleApplicants}
+                  initialSelectedValues={initialValues.applicant_types}
                   onToggle={handleEligibilityToggle}
                   disabled={!isDraft}
                 />
@@ -642,7 +646,7 @@ export default function OpportunityEditForm({
                   title={t("labels.eligibilityGovernment")}
                   options={eligibilityGroups.government}
                   baseId="eligible-government"
-                  initialSelectedValues={initialValues.eligibleApplicants}
+                  initialSelectedValues={initialValues.applicant_types}
                   onToggle={handleEligibilityToggle}
                   disabled={!isDraft}
                 />
@@ -654,7 +658,7 @@ export default function OpportunityEditForm({
                   title={t("labels.eligibilityNonprofit")}
                   options={eligibilityGroups.nonprofit}
                   baseId="eligible-nonprofit"
-                  initialSelectedValues={initialValues.eligibleApplicants}
+                  initialSelectedValues={initialValues.applicant_types}
                   onToggle={handleEligibilityToggle}
                   disabled={!isDraft}
                 />
@@ -662,12 +666,20 @@ export default function OpportunityEditForm({
                   title={t("labels.eligibilityMiscellaneous")}
                   options={eligibilityGroups.miscellaneous}
                   baseId="eligible-misc"
-                  initialSelectedValues={initialValues.eligibleApplicants}
+                  initialSelectedValues={initialValues.applicant_types}
                   onToggle={handleEligibilityToggle}
                   disabled={!isDraft}
                 />
               </div>
             </div>
+            {selectedEligibility.map((eligibility, index) => (
+              <input
+                key={`eligibility-${index}`}
+                type="hidden"
+                name={`applicant_types[${index}]`}
+                value={eligibility}
+              />
+            ))}
           </div>
 
           {(selectedEligibility.includes("other") ||
@@ -677,14 +689,18 @@ export default function OpportunityEditForm({
                 isTextArea={true}
                 labelText={t("labels.additionalEligibilityInfo")}
                 description={t("content.additionalEligibilityInfoHint")}
-                fieldId="additionalEligibilityInfo"
+                fieldId="applicant_eligibility_description"
                 fieldMaxLength={4000}
                 isRequired={false}
-                defaultValue={initialValues.additionalEligibilityInfo}
+                defaultValue={initialValues.applicant_eligibility_description}
                 onTextChange={() => {}}
                 rawErrors={
-                  getFieldError("additionalEligibilityInfo")
-                    ? [getFieldError("additionalEligibilityInfo") as string]
+                  getFieldError("applicant_eligibility_description")
+                    ? [
+                        getFieldError(
+                          "applicant_eligibility_description",
+                        ) as string,
+                      ]
                     : []
                 }
                 disabled={!isDraft}
@@ -713,14 +729,14 @@ export default function OpportunityEditForm({
               isTextArea={true}
               labelText={t("labels.description")}
               description={t("content.descriptionHint")}
-              fieldId="description"
+              fieldId="summary_description"
               fieldMaxLength={1800}
               isRequired={false}
-              defaultValue={initialValues.description}
+              defaultValue={initialValues.summary_description}
               onTextChange={() => {}}
               rawErrors={
-                getFieldError("description")
-                  ? [getFieldError("description") as string]
+                getFieldError("summary_description")
+                  ? [getFieldError("summary_description") as string]
                   : []
               }
               disabled={!isDraft}
@@ -733,14 +749,14 @@ export default function OpportunityEditForm({
                 inputType="url"
                 labelText={t("labels.additionalInfoUrl")}
                 description={t("content.additionalInfoUrlHint")}
-                fieldId="additionalInfoUrl"
+                fieldId="additional_info_url"
                 fieldMaxLength={250}
                 isRequired={false}
-                defaultValue={initialValues.additionalInfoUrl}
+                defaultValue={initialValues.additional_info_url}
                 onTextChange={() => {}}
                 rawErrors={
-                  getFieldError("additionalInfoUrl")
-                    ? [getFieldError("additionalInfoUrl") as string]
+                  getFieldError("additional_info_url")
+                    ? [getFieldError("additional_info_url") as string]
                     : []
                 }
                 disabled={!isDraft}
@@ -750,14 +766,18 @@ export default function OpportunityEditForm({
               <CommonCharacterCount
                 labelText={t("labels.additionalInfoUrlText")}
                 description={t("content.additionalInfoUrlTextHint")}
-                fieldId="additionalInfoUrlText"
+                fieldId="additional_info_url_description"
                 fieldMaxLength={250}
                 isRequired={false}
-                defaultValue={initialValues.additionalInfoUrlText}
+                defaultValue={initialValues.additional_info_url_description}
                 onTextChange={() => {}}
                 rawErrors={
-                  getFieldError("additionalInfoUrlText")
-                    ? [getFieldError("additionalInfoUrlText") as string]
+                  getFieldError("additional_info_url_description")
+                    ? [
+                        getFieldError(
+                          "additional_info_url_description",
+                        ) as string,
+                      ]
                     : []
                 }
                 disabled={!isDraft}
@@ -770,14 +790,14 @@ export default function OpportunityEditForm({
               isTextArea={true}
               labelText={t("labels.grantorContactDetails")}
               description={t("content.grantorContactDetailsHint")}
-              fieldId="grantorContactDetails"
+              fieldId="agency_contact_description"
               fieldMaxLength={1000}
               isRequired={false}
-              defaultValue={initialValues.grantorContactDetails}
+              defaultValue={initialValues.agency_contact_description}
               onTextChange={() => {}}
               rawErrors={
-                getFieldError("grantorContactDetails")
-                  ? [getFieldError("grantorContactDetails") as string]
+                getFieldError("agency_contact_description")
+                  ? [getFieldError("agency_contact_description") as string]
                   : []
               }
               disabled={!isDraft}
@@ -790,14 +810,14 @@ export default function OpportunityEditForm({
                 inputType="email"
                 labelText={t("labels.contactEmail")}
                 description={t("content.contactEmailHint")}
-                fieldId="contactEmail"
+                fieldId="agency_email_address"
                 fieldMaxLength={130}
                 isRequired={false}
-                defaultValue={initialValues.contactEmail}
+                defaultValue={initialValues.agency_email_address}
                 onTextChange={() => {}}
                 rawErrors={
-                  getFieldError("contactEmail")
-                    ? [getFieldError("contactEmail") as string]
+                  getFieldError("agency_email_address")
+                    ? [getFieldError("agency_email_address") as string]
                     : []
                 }
                 disabled={!isDraft}
@@ -807,14 +827,18 @@ export default function OpportunityEditForm({
               <CommonCharacterCount
                 labelText={t("labels.contactEmailText")}
                 description={t("content.contactEmailTextHint")}
-                fieldId="contactEmailText"
+                fieldId="agency_email_address_description"
                 fieldMaxLength={108}
                 isRequired={false}
-                defaultValue={initialValues.contactEmailText}
+                defaultValue={initialValues.agency_email_address_description}
                 onTextChange={() => {}}
                 rawErrors={
-                  getFieldError("contactEmailText")
-                    ? [getFieldError("contactEmailText") as string]
+                  getFieldError("agency_email_address_description")
+                    ? [
+                        getFieldError(
+                          "agency_email_address_description",
+                        ) as string,
+                      ]
                     : []
                 }
                 disabled={!isDraft}

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.test.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.test.ts
@@ -379,7 +379,7 @@ describe("saveOpportunityEditAction", () => {
   });
 });
 
-describe("submitOpportunityAction", () => {
+describe("opportunityEditFormAction", () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
@@ -390,7 +390,7 @@ describe("submitOpportunityAction", () => {
     formData.set("opportunity_summary_id", "sum-456");
     // post_date missing - triggers validation error
 
-    const result = await submitOpportunityAction(initialState, formData);
+    const result = await opportunityEditFormAction(initialState, formData);
 
     expect(result.validationErrors).toEqual({
       post_date: ["publishDate"],
@@ -398,22 +398,7 @@ describe("submitOpportunityAction", () => {
       funding_categories: ["fundingCategory"],
       applicant_types: ["eligibleApplicants"],
     });
-    expect(mockPublishOpportunityForGrantor).not.toHaveBeenCalled();
-  });
-
-  it("returns the save error and does not publish when save fails with an API error", async () => {
-    const formData = buildValidFormData();
-    formData.set("opportunity_id", "opp-123");
-    formData.set("opportunity_summary_id", "sum-456");
-
-    mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
-      new ApiRequestError("forbidden", "APIRequestError", 403),
-    );
-
-    const result = await submitOpportunityAction(initialState, formData);
-
-    expect(result).toEqual({ errorMessage: "forbidden" });
-    expect(mockPublishOpportunityForGrantor).not.toHaveBeenCalled();
+    expect(mockUpdateOpportunitySummaryForGrantor).not.toHaveBeenCalled();
   });
 
   it("returns the publish error when save succeeds but publish fails with 403", async () => {
@@ -424,11 +409,11 @@ describe("submitOpportunityAction", () => {
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
       successfulSummaryUpdateResponse,
     );
-    mockPublishOpportunityForGrantor.mockRejectedValue(
+    mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new ApiRequestError("forbidden", "APIRequestError", 403),
     );
 
-    const result = await submitOpportunityAction(initialState, formData);
+    const result = await opportunityEditFormAction(initialState, formData);
 
     expect(result).toEqual({ errorMessage: "forbidden" });
   });
@@ -441,11 +426,11 @@ describe("submitOpportunityAction", () => {
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
       successfulSummaryUpdateResponse,
     );
-    mockPublishOpportunityForGrantor.mockRejectedValue(
+    mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new ApiRequestError("not found", "APIRequestError", 404),
     );
 
-    const result = await submitOpportunityAction(initialState, formData);
+    const result = await opportunityEditFormAction(initialState, formData);
 
     expect(result).toEqual({ errorMessage: "notFound" });
   });
@@ -458,30 +443,13 @@ describe("submitOpportunityAction", () => {
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
       successfulSummaryUpdateResponse,
     );
-    mockPublishOpportunityForGrantor.mockRejectedValue(
+    mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new ApiRequestError("unauthenticated", "APIRequestError", 401),
     );
 
-    const result = await submitOpportunityAction(initialState, formData);
+    const result = await opportunityEditFormAction(initialState, formData);
 
     expect(result).toEqual({ errorMessage: "unauthenticated" });
-  });
-
-  it("redirects to /grantor/opportunities when save and publish both succeed", async () => {
-    const formData = buildValidFormData();
-    formData.set("opportunity_summary_id", "sum-456");
-
-    mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
-      successfulSummaryUpdateResponse,
-    );
-    mockPublishOpportunityForGrantor.mockResolvedValue(
-      // publishOpportunityAction discards the resolved value (only errors matter)
-      {} as Awaited<ReturnType<typeof publishOpportunityForGrantor>>,
-    );
-
-    await submitOpportunityAction(initialState, formData);
-
-    expect(mockRedirect).toHaveBeenCalledWith("/grantor/opportunities");
   });
 });
 
@@ -492,8 +460,8 @@ describe("opportunityEditFormAction", () => {
 
   it("delegates to saveOpportunityEditAction and redirects to the overview page when submitType = saveAndExit", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
     formData.set("submitType", "saveAndExit");
 
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
@@ -508,8 +476,8 @@ describe("opportunityEditFormAction", () => {
 
   it("delegates to saveOpportunityEditAction and redirects to the overview page when submitType = saveAndGoBack", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
     formData.set("submitType", "saveAndGoBack");
 
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
@@ -524,8 +492,8 @@ describe("opportunityEditFormAction", () => {
 
   it("delegates to saveOpportunityEditAction and redirects to the competition page when submitType = saveAndContinue", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
     formData.set("submitType", "saveAndContinue");
 
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
@@ -559,7 +527,7 @@ describe("opportunityEditFormAction", () => {
     formData.set("opportunity_id", "opp-123");
     formData.set("opportunity_summary_id", "sum-456");
     formData.set("submitType", "saveAndContinue");
-    formData.set("contactEmail", "not-an-email");
+    formData.set("agency_email_address", "not-an-email");
 
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
       successfulSummaryUpdateResponse,
@@ -570,7 +538,7 @@ describe("opportunityEditFormAction", () => {
     expect(mockUpdateOpportunitySummaryForGrantor).not.toHaveBeenCalledTimes(1);
     expect(mockRedirect).not.toHaveBeenCalledWith("../competition");
     expect(result.validationErrors).toEqual({
-      contactEmail: ["contactEmailInvalid"],
+      agency_email_address: ["contactEmailInvalid"],
     });
   });
 });

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.test.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.test.ts
@@ -4,7 +4,6 @@ import {
   createOpportunitySummaryForGrantor,
   updateOpportunitySummaryForGrantor,
 } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
-import { buildOpportunitySummaryUpdateRequest } from "src/utils/opportunityEditFormConfig";
 
 import {
   opportunityEditFormAction,
@@ -86,25 +85,25 @@ const successfulSummaryUpdateResponse: Awaited<
 
 function buildValidFormData() {
   const formData = new FormData();
-  formData.set("opportunityId", "opp-123");
-  formData.set("title", "Example opportunity");
-  formData.set("awardSelectionMethod", "discretionary");
-  formData.set("description", "Summary text");
-  formData.set("publishDate", "2026-03-11");
-  formData.set("closeDate", "2026-04-11");
-  formData.set("contactEmail", "grants@example.com");
-  formData.set("funding-type-values", "grant");
-  formData.set("funding-category-values", "health");
-  formData.set("expectedNumberOfAwards", "5");
-  formData.set("estimatedTotalProgramFunding", "100000");
-  formData.set("awardMinimum", "1000");
-  formData.set("awardMaximum", "5000");
-  formData.append("eligibleApplicants", "state_governments");
-  formData.set("additionalEligibilityInfo", "Must be US-based");
-  formData.set("additionalInfoUrl", "https://example.com");
-  formData.set("additionalInfoUrlText", "More info");
-  formData.set("grantorContactDetails", "Program office");
-  formData.set("contactEmailText", "Email us");
+  formData.set("opportunity_id", "opp-123");
+  formData.set("opportunity_title", "Example opportunity");
+  formData.set("caetgory", "discretionary");
+  formData.set("summary_description", "Summary text");
+  formData.set("post_date", "2026-03-11");
+  formData.set("close_date", "2026-04-11");
+  formData.set("agency_email_address", "grants@example.com");
+  formData.set("funding_instruments", "grant");
+  formData.set("funding_categories", "health");
+  formData.set("expected_number_of_awards", "5");
+  formData.set("estimated_total_program_funding", "100000");
+  formData.set("award_floor", "1000");
+  formData.set("award_ceiling", "5000");
+  formData.set("applicant_types[0]", "state_governments");
+  formData.set("applicant_eligibility_description", "Must be US-based");
+  formData.set("additional_info_url", "https://example.com");
+  formData.set("additional_info_url_description", "More info");
+  formData.set("agency_contact_description", "Program office");
+  formData.set("agency_email_address_description", "Email us");
 
   return formData;
 }
@@ -116,60 +115,60 @@ describe("saveOpportunityEditAction", () => {
 
   it("returns validation errors only for API-required fields when form is empty", async () => {
     const formData = new FormData();
-    formData.set("opportunityId", "opp-123");
+    formData.set("opportunity_id", "opp-123");
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
     expect(result.validationErrors).toEqual({
-      publishDate: ["publishDate"],
-      fundingType: ["fundingType"],
-      fundingCategory: ["fundingCategory"],
-      eligibleApplicants: ["eligibleApplicants"],
+      post_date: ["publishDate"],
+      funding_instruments: ["fundingType"],
+      funding_categories: ["fundingCategory"],
+      applicant_types: ["eligibleApplicants"],
     });
   });
 
   it("returns only the format error for a non-empty invalid email", async () => {
     const formData = buildValidFormData();
-    formData.set("contactEmail", "not-an-email");
+    formData.set("agency_email_address", "not-an-email");
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
     expect(result.validationErrors).toEqual({
-      contactEmail: ["contactEmailInvalid"],
+      agency_email_address: ["contactEmailInvalid"],
     });
   });
 
   it("returns an award maximum error when award minimum exceeds award maximum", async () => {
     const formData = buildValidFormData();
-    formData.set("awardMinimum", "5000");
-    formData.set("awardMaximum", "1000");
+    formData.set("award_floor", "5000");
+    formData.set("award_ceiling", "1000");
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
     expect(result.validationErrors).toEqual({
-      awardMinimum: ["awardMinLessThanMax"],
-      awardMaximum: ["awardMaxGreaterThanMin"],
+      award_floor: ["awardMinLessThanMax"],
+      award_ceiling: ["awardMaxGreaterThanMin"],
     });
   });
 
   it("returns exceedTotalFunding error when award min or max exceeds the total funding", async () => {
     const formData = buildValidFormData();
-    formData.set("estimatedTotalProgramFunding", "1000");
-    formData.set("awardMinimum", "5000");
-    formData.set("awardMaximum", "6000");
+    formData.set("estimated_total_program_funding", "1000");
+    formData.set("award_floor", "5000");
+    formData.set("award_ceiling", "6000");
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
     expect(result.validationErrors).toEqual({
-      awardMinimum: ["awardMinLessThanTotal"],
-      awardMaximum: ["awardMaxLessThanTotal"],
+      award_floor: ["awardMinLessThanTotal"],
+      award_ceiling: ["awardMaxLessThanTotal"],
     });
   });
 
   it("returns a close date error when close date is before publish date", async () => {
     const formData = buildValidFormData();
-    formData.set("publishDate", "2026-04-11");
-    formData.set("closeDate", "2026-03-11");
+    formData.set("post_date", "2026-04-11");
+    formData.set("close_date", "2026-03-11");
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
@@ -178,9 +177,9 @@ describe("saveOpportunityEditAction", () => {
     });
   });
 
-  it("maps an unparseable publishDate to a closeDateOrder error (format failure)", async () => {
+  it("maps an unparseable post_date to a closeDateOrder error (format failure)", async () => {
     const formData = buildValidFormData();
-    formData.set("publishDate", "not-a-date");
+    formData.set("post_date", "not-a-date");
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
@@ -189,9 +188,9 @@ describe("saveOpportunityEditAction", () => {
     });
   });
 
-  it("maps an unparseable closeDate to a closeDateOrder error (format failure)", async () => {
+  it("maps an unparseable close_date to a closeDateOrder error (format failure)", async () => {
     const formData = buildValidFormData();
-    formData.set("closeDate", "not-a-date");
+    formData.set("close_date", "not-a-date");
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
@@ -200,9 +199,9 @@ describe("saveOpportunityEditAction", () => {
     });
   });
 
-  it("returns an error when opportunityId is missing", async () => {
+  it("returns an error when opportunity_id is missing", async () => {
     const formData = buildValidFormData();
-    formData.delete("opportunityId"); // summary context is missing
+    formData.delete("opportunity_id"); // summary context is missing
 
     const result = await saveOpportunityEditAction(initialState, formData);
 
@@ -211,11 +210,11 @@ describe("saveOpportunityEditAction", () => {
     });
   });
 
-  it("calls the summary create fetcher when no opportunitySummaryId and returns new summary ID", async () => {
+  it("calls the summary create fetcher when no opportunity_summary_id and returns new summary ID", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("isForecast", "true");
-    // opportunitySummaryId not set
+    formData.set("opportunity_id", "opp-123");
+    formData.set("is_forecast", "true");
+    // opportunity_summary_id not set
 
     const createResponse: Awaited<
       ReturnType<typeof createOpportunitySummaryForGrantor>
@@ -276,8 +275,8 @@ describe("saveOpportunityEditAction", () => {
 
   it("calls the summary update fetcher and returns success", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
 
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
       successfulSummaryUpdateResponse,
@@ -301,8 +300,8 @@ describe("saveOpportunityEditAction", () => {
 
   it("maps 403 to a permission error", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
 
     mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new ApiRequestError("forbidden", "APIRequestError", 403),
@@ -317,8 +316,8 @@ describe("saveOpportunityEditAction", () => {
 
   it("maps 404 to a not found error", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
 
     mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new ApiRequestError("missing", "APIRequestError", 404),
@@ -333,8 +332,8 @@ describe("saveOpportunityEditAction", () => {
 
   it("maps 422 to a draft-state error", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
 
     mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new ApiRequestError("invalid", "APIRequestError", 422),
@@ -349,8 +348,8 @@ describe("saveOpportunityEditAction", () => {
 
   it("maps 401 to an unauthenticated error", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
 
     mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new ApiRequestError("unauthenticated", "APIRequestError", 401),
@@ -365,8 +364,8 @@ describe("saveOpportunityEditAction", () => {
 
   it("maps unknown failures to a generic save error", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
 
     mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
       new Error("unexpected"),
@@ -380,51 +379,109 @@ describe("saveOpportunityEditAction", () => {
   });
 });
 
-describe("buildOpportunitySummaryUpdateRequest", () => {
-  it("maps current edit form fields into the summary update payload", () => {
-    const formData = new FormData();
-    formData.set("description", "Summary text");
-    formData.set("publishDate", "2026-03-11");
-    formData.set("closeDate", "2026-04-11");
-    formData.set("closeDateExplanation", "Rolling deadline");
-    formData.set("expectedNumberOfAwards", "12");
-    formData.set("estimatedTotalProgramFunding", "150000");
-    formData.set("awardMinimum", "1000");
-    formData.set("awardMaximum", "5000");
-    formData.set("additionalInfoUrl", "https://example.com");
-    formData.set("additionalInfoUrlText", "More info");
-    formData.set("funding-category-values", "health");
-    formData.set("fundingCategoryExplanation", "Other category notes");
-    formData.set("funding-type-values", "grant");
-    formData.set("costSharing", "true");
-    formData.append("eligibleApplicants", "small_businesses");
-    formData.append("eligibleApplicants", "state_governments");
-    formData.set("additionalEligibilityInfo", "Must be US-based");
-    formData.set("grantorContactDetails", "Program office");
-    formData.set("contactEmail", "grants@example.com");
-    formData.set("contactEmailText", "Email us");
+describe("submitOpportunityAction", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
 
-    expect(buildOpportunitySummaryUpdateRequest(formData)).toEqual({
-      is_cost_sharing: true,
-      summary_description: "Summary text",
-      post_date: "2026-03-11",
-      close_date: "2026-04-11",
-      close_date_description: "Rolling deadline",
-      expected_number_of_awards: 12,
-      estimated_total_program_funding: 150000,
-      award_floor: 1000,
-      award_ceiling: 5000,
-      additional_info_url: "https://example.com",
-      additional_info_url_description: "More info",
-      funding_categories: ["health"],
-      funding_category_description: "Other category notes",
-      funding_instruments: ["grant"],
-      applicant_types: ["small_businesses", "state_governments"],
-      applicant_eligibility_description: "Must be US-based",
-      agency_contact_description: "Program office",
-      agency_email_address: "grants@example.com",
-      agency_email_address_description: "Email us",
+  it("returns validation errors and does not publish when save has validation errors", async () => {
+    const formData = new FormData();
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
+    // post_date missing - triggers validation error
+
+    const result = await submitOpportunityAction(initialState, formData);
+
+    expect(result.validationErrors).toEqual({
+      post_date: ["publishDate"],
+      funding_instruments: ["fundingType"],
+      funding_categories: ["fundingCategory"],
+      applicant_types: ["eligibleApplicants"],
     });
+    expect(mockPublishOpportunityForGrantor).not.toHaveBeenCalled();
+  });
+
+  it("returns the save error and does not publish when save fails with an API error", async () => {
+    const formData = buildValidFormData();
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
+
+    mockUpdateOpportunitySummaryForGrantor.mockRejectedValue(
+      new ApiRequestError("forbidden", "APIRequestError", 403),
+    );
+
+    const result = await submitOpportunityAction(initialState, formData);
+
+    expect(result).toEqual({ errorMessage: "forbidden" });
+    expect(mockPublishOpportunityForGrantor).not.toHaveBeenCalled();
+  });
+
+  it("returns the publish error when save succeeds but publish fails with 403", async () => {
+    const formData = buildValidFormData();
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
+
+    mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
+      successfulSummaryUpdateResponse,
+    );
+    mockPublishOpportunityForGrantor.mockRejectedValue(
+      new ApiRequestError("forbidden", "APIRequestError", 403),
+    );
+
+    const result = await submitOpportunityAction(initialState, formData);
+
+    expect(result).toEqual({ errorMessage: "forbidden" });
+  });
+
+  it("returns the publish error when save succeeds but publish fails with 404", async () => {
+    const formData = buildValidFormData();
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
+
+    mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
+      successfulSummaryUpdateResponse,
+    );
+    mockPublishOpportunityForGrantor.mockRejectedValue(
+      new ApiRequestError("not found", "APIRequestError", 404),
+    );
+
+    const result = await submitOpportunityAction(initialState, formData);
+
+    expect(result).toEqual({ errorMessage: "notFound" });
+  });
+
+  it("maps 401 from publish to an unauthenticated error", async () => {
+    const formData = buildValidFormData();
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
+
+    mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
+      successfulSummaryUpdateResponse,
+    );
+    mockPublishOpportunityForGrantor.mockRejectedValue(
+      new ApiRequestError("unauthenticated", "APIRequestError", 401),
+    );
+
+    const result = await submitOpportunityAction(initialState, formData);
+
+    expect(result).toEqual({ errorMessage: "unauthenticated" });
+  });
+
+  it("redirects to /grantor/opportunities when save and publish both succeed", async () => {
+    const formData = buildValidFormData();
+    formData.set("opportunity_summary_id", "sum-456");
+
+    mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
+      successfulSummaryUpdateResponse,
+    );
+    mockPublishOpportunityForGrantor.mockResolvedValue(
+      // publishOpportunityAction discards the resolved value (only errors matter)
+      {} as Awaited<ReturnType<typeof publishOpportunityForGrantor>>,
+    );
+
+    await submitOpportunityAction(initialState, formData);
+
+    expect(mockRedirect).toHaveBeenCalledWith("/grantor/opportunities");
   });
 });
 
@@ -483,8 +540,8 @@ describe("opportunityEditFormAction", () => {
 
   it("delegates to saveOpportunityEditAction and returns success when submitType none of three expected", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
     formData.set("submitType", "save");
 
     mockUpdateOpportunitySummaryForGrantor.mockResolvedValue(
@@ -499,8 +556,8 @@ describe("opportunityEditFormAction", () => {
 
   it("delegates to saveOpportunityEditAction and returns errors and does not redirect", async () => {
     const formData = buildValidFormData();
-    formData.set("opportunityId", "opp-123");
-    formData.set("opportunitySummaryId", "sum-456");
+    formData.set("opportunity_id", "opp-123");
+    formData.set("opportunity_summary_id", "sum-456");
     formData.set("submitType", "saveAndContinue");
     formData.set("contactEmail", "not-an-email");
 

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
@@ -264,7 +264,6 @@ export async function saveOpportunityEditAction(
       const createResponse = await createOpportunitySummaryForGrantor({
         opportunityId,
         body: {
-          // ...buildOpportunitySummaryUpdateRequest(formData),
           ...formDataToObject<OpportunitySummaryUpdateRequest>(
             formData,
             editOpportunityFormSchema,

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
@@ -5,32 +5,36 @@ import {
   createOpportunitySummaryForGrantor,
   updateOpportunitySummaryForGrantor,
 } from "src/services/fetch/fetchers/opportunitySummaryGrantorFetcher";
+import {
+  OpportunitySummaryUpdateRawData,
+  OpportunitySummaryUpdateRequest,
+} from "src/types/opportunity/opportunityResponseTypes";
 import { getConfiguredDayJs } from "src/utils/dateUtil";
-import { buildOpportunitySummaryUpdateRequest } from "src/utils/opportunityEditFormConfig";
+import { formDataToObject } from "src/utils/formData/formDataToJson";
 import { z } from "zod";
 
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 
 export type OpportunityEditValidationErrors = {
-  title?: string[];
-  awardSelectionMethod?: string[];
-  description?: string[];
-  publishDate?: string[];
-  closeDate?: string[];
-  contactEmail?: string[];
-  contactEmailText?: string[];
-  awardMinimum?: string[];
-  awardMaximum?: string[];
-  fundingType?: string[];
-  fundingCategory?: string[];
-  expectedNumberOfAwards?: string[];
-  estimatedTotalProgramFunding?: string[];
-  eligibleApplicants?: string[];
-  additionalEligibilityInfo?: string[];
-  additionalInfoUrl?: string[];
-  additionalInfoUrlText?: string[];
-  grantorContactDetails?: string[];
+  opportunity_title?: string[];
+  category?: string[];
+  summary_description?: string[];
+  post_date?: string[];
+  close_date?: string[];
+  agency_email_address?: string[];
+  agency_email_address_description?: string[];
+  award_floor?: string[];
+  award_ceiling?: string[];
+  funding_instruments?: string[];
+  funding_categories?: string[];
+  expected_number_of_awards?: string[];
+  estimated_total_program_funding?: string[];
+  applicant_types?: string[];
+  applicant_eligibility_description?: string[];
+  additional_info_url?: string[];
+  additional_info_url_description?: string[];
+  agency_contact_description?: string[];
 };
 
 export type OpportunityEditActionState = {
@@ -38,6 +42,31 @@ export type OpportunityEditActionState = {
   successMessage?: string;
   validationErrors?: OpportunityEditValidationErrors;
   newOpportunitySummaryId?: string;
+};
+
+const editOpportunityFormSchema = {
+  opportunity_id: { type: "string" },
+  opportunity_summary_id: { type: "string" },
+  is_forecast: { type: "boolean" },
+  opportunity_title: { type: "string" },
+  category: { type: "string" },
+  is_cost_sharing: { type: "boolean" },
+  expected_number_of_awards: { type: "number" },
+  estimated_total_program_funding: { type: "number" },
+  award_floor: { type: "number" },
+  award_ceiling: { type: "number" },
+  post_date: { type: "string" },
+  close_date: { type: "string" },
+  close_date_description: { type: "string" },
+  funding_instruments: { items: { type: "string" } }, // array
+  funding_categories: { items: { type: "string" } }, // array
+  applicant_types: { items: { type: "string" } }, // array
+  summary_description: { type: "string" },
+  additional_info_url: { type: "string" },
+  additional_info_url_description: { type: "string" },
+  agency_contact_description: { type: "string" },
+  agency_email_address: { type: "string" },
+  agency_email_address_description: { type: "string" },
 };
 
 function readStringValue(value: FormDataEntryValue | null): string {
@@ -50,15 +79,15 @@ async function validateOpportunityEditForm(formData: FormData) {
   );
   const reviewOpportunityEditSchema = z
     .object({
-      title: z.string().trim(),
-      awardSelectionMethod: z.string().trim(),
-      description: z.string().trim(),
-      publishDate: z
+      opportunity_title: z.string().trim(),
+      category: z.string().trim(),
+      summary_description: z.string().trim(),
+      post_date: z
         .string()
         .trim()
         .min(1, { message: validationErrors("publishDate") }),
-      closeDate: z.string().trim(),
-      contactEmail: z
+      close_date: z.string().trim(),
+      agency_email_address: z
         .string()
         .trim()
         .superRefine((value, ctx) => {
@@ -69,35 +98,35 @@ async function validateOpportunityEditForm(formData: FormData) {
             });
           }
         }),
-      contactEmailText: z.string().trim(),
-      fundingType: z
+      agency_email_address_description: z.string().trim(),
+      funding_instruments: z
         .string()
         .trim()
         .min(1, { message: validationErrors("fundingType") }),
-      fundingCategory: z
+      funding_categories: z
         .string()
         .trim()
         .min(1, { message: validationErrors("fundingCategory") }),
-      expectedNumberOfAwards: z.string().trim(),
-      estimatedTotalProgramFunding: z.string().trim(),
-      awardMinimum: z.string().trim(),
-      awardMaximum: z.string().trim(),
-      eligibleApplicants: z
+      expected_number_of_awards: z.string().trim(),
+      estimated_total_program_funding: z.string().trim(),
+      award_ceiling: z.string().trim(),
+      award_floor: z.string().trim(),
+      applicant_types: z
         .array(z.string())
         .min(1, { message: validationErrors("eligibleApplicants") }),
-      additionalEligibilityInfo: z.string().trim(),
-      additionalInfoUrl: z.string().trim(),
-      additionalInfoUrlText: z.string().trim(),
-      grantorContactDetails: z.string().trim(),
+      applicant_eligibility_description: z.string().trim(),
+      additional_info_url: z.string().trim(),
+      additional_info_url_description: z.string().trim(),
+      agency_contact_description: z.string().trim(),
     })
-    .superRefine(({ publishDate, closeDate }, ctx) => {
-      if (!publishDate || !closeDate) {
+    .superRefine(({ post_date, close_date }, ctx) => {
+      if (!post_date || !close_date) {
         return;
       }
 
       const dayjs = getConfiguredDayJs();
-      const close = dayjs(closeDate, "YYYY-MM-DD", true);
-      const publish = dayjs(publishDate, "YYYY-MM-DD", true);
+      const close = dayjs(close_date, "YYYY-MM-DD", true);
+      const publish = dayjs(post_date, "YYYY-MM-DD", true);
 
       if (!close.isValid() || !publish.isValid() || close.isBefore(publish)) {
         ctx.addIssue({
@@ -108,88 +137,97 @@ async function validateOpportunityEditForm(formData: FormData) {
       }
     })
     .superRefine(
-      ({ awardMinimum, awardMaximum, estimatedTotalProgramFunding }, ctx) => {
-        const min = Number(awardMinimum.replace(/,/g, ""));
-        const max = Number(awardMaximum.replace(/,/g, ""));
-        const total = Number(estimatedTotalProgramFunding.replace(/,/g, ""));
+      (
+        { award_floor, award_ceiling, estimated_total_program_funding },
+        ctx,
+      ) => {
+        const min = Number(award_floor.replace(/,/g, ""));
+        const max = Number(award_ceiling.replace(/,/g, ""));
+        const total = Number(estimated_total_program_funding.replace(/,/g, ""));
         // Award Minimum cannot exceed the Estimated Total Program Funding.
         if (
-          awardMinimum &&
-          estimatedTotalProgramFunding &&
+          award_floor &&
+          estimated_total_program_funding &&
           !isNaN(min) &&
           !isNaN(total) &&
           min > total
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            path: ["awardMinimum"],
+            path: ["award_floor"],
             message: validationErrors("awardMinLessThanTotal"),
           });
         }
         // Award Maximum cannot exceed the Estimated Total Program Funding.
         if (
-          awardMaximum &&
-          estimatedTotalProgramFunding &&
+          award_ceiling &&
+          estimated_total_program_funding &&
           !isNaN(max) &&
           !isNaN(total) &&
           max > total
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            path: ["awardMaximum"],
+            path: ["award_ceiling"],
             message: validationErrors("awardMaxLessThanTotal"),
           });
         }
         // Award Minimum cannot exceed Award Maximum.
         if (
-          awardMinimum &&
-          awardMaximum &&
+          award_floor &&
+          award_ceiling &&
           !isNaN(min) &&
           !isNaN(max) &&
           min > max
         ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            path: ["awardMinimum"],
+            path: ["award_floor"],
             message: validationErrors("awardMinLessThanMax"),
           });
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            path: ["awardMaximum"],
+            path: ["award_ceiling"],
             message: validationErrors("awardMaxGreaterThanMin"),
           });
         }
       },
     );
-
+  const applicantTypeKeys = Array.from(
+    formData.keys().filter((key) => key.includes("applicant_types[")),
+  );
   return reviewOpportunityEditSchema.safeParse({
-    title: readStringValue(formData.get("title")),
-    awardSelectionMethod: readStringValue(formData.get("awardSelectionMethod")),
-    description: readStringValue(formData.get("description")),
-    publishDate: readStringValue(formData.get("publishDate")),
-    closeDate: readStringValue(formData.get("closeDate")),
-    contactEmail: readStringValue(formData.get("contactEmail")),
-    contactEmailText: readStringValue(formData.get("contactEmailText")),
-    awardMinimum: readStringValue(formData.get("awardMinimum")),
-    awardMaximum: readStringValue(formData.get("awardMaximum")),
-    fundingType: readStringValue(formData.get("funding-type-values")),
-    fundingCategory: readStringValue(formData.get("funding-category-values")),
-    expectedNumberOfAwards: readStringValue(
-      formData.get("expectedNumberOfAwards"),
+    opportunity_title: readStringValue(formData.get("opportunity_title")),
+    category: readStringValue(formData.get("category")),
+    summary_description: readStringValue(formData.get("summary_description")),
+    post_date: readStringValue(formData.get("post_date")),
+    close_date: readStringValue(formData.get("close_date")),
+    agency_email_address: readStringValue(formData.get("agency_email_address")),
+    agency_email_address_description: readStringValue(
+      formData.get("agency_email_address_description"),
     ),
-    estimatedTotalProgramFunding: readStringValue(
-      formData.get("estimatedTotalProgramFunding"),
+    award_floor: readStringValue(formData.get("award_floor")),
+    award_ceiling: readStringValue(formData.get("award_ceiling")),
+    funding_instruments: readStringValue(formData.get("funding_instruments")),
+    funding_categories: readStringValue(formData.get("funding_categories")),
+    expected_number_of_awards: readStringValue(
+      formData.get("expected_number_of_awards"),
     ),
-    eligibleApplicants: formData.getAll("eligibleApplicants") as string[],
-    additionalEligibilityInfo: readStringValue(
-      formData.get("additionalEligibilityInfo"),
+    estimated_total_program_funding: readStringValue(
+      formData.get("estimated_total_program_funding"),
     ),
-    additionalInfoUrl: readStringValue(formData.get("additionalInfoUrl")),
-    additionalInfoUrlText: readStringValue(
-      formData.get("additionalInfoUrlText"),
+    applicant_types: applicantTypeKeys.map(
+      (key) => formData.get(key) as string,
     ),
-    grantorContactDetails: readStringValue(
-      formData.get("grantorContactDetails"),
+    applicant_eligibility_description: readStringValue(
+      formData.get("applicant_eligibility_description"),
+    ),
+    additional_info_url: readStringValue(formData.get("additional_info_url")),
+    additional_info_url_description: readStringValue(
+      formData.get("additional_info_url_description"),
+    ),
+    agency_contact_description: readStringValue(
+      formData.get("agency_contact_description"),
     ),
   });
 }
@@ -200,12 +238,12 @@ export async function saveOpportunityEditAction(
 ): Promise<OpportunityEditActionState> {
   const alerts = await getTranslations("OpportunityEdit.content.alerts");
 
-  const opportunityId = readStringValue(formData.get("opportunityId")).trim();
+  const opportunityId = readStringValue(formData.get("opportunity_id")).trim();
   const opportunitySummaryId = readStringValue(
-    formData.get("opportunitySummaryId"),
+    formData.get("opportunity_summary_id"),
   ).trim();
   const isForecast =
-    readStringValue(formData.get("isForecast")).trim() === "true";
+    readStringValue(formData.get("is_forecast")).trim() === "true";
 
   if (!opportunityId) {
     return {
@@ -226,7 +264,11 @@ export async function saveOpportunityEditAction(
       const createResponse = await createOpportunitySummaryForGrantor({
         opportunityId,
         body: {
-          ...buildOpportunitySummaryUpdateRequest(formData),
+          // ...buildOpportunitySummaryUpdateRequest(formData),
+          ...formDataToObject<OpportunitySummaryUpdateRequest>(
+            formData,
+            editOpportunityFormSchema,
+          ),
           is_forecast: isForecast,
         },
       });
@@ -237,12 +279,36 @@ export async function saveOpportunityEditAction(
       };
     }
 
-    await updateOpportunitySummaryForGrantor({
+    const rawBody = formDataToObject<OpportunitySummaryUpdateRawData>(
+      formData,
+      editOpportunityFormSchema,
+    );
+    /*
+      funding_instruments, funding_categories, applicant_types all need to be arrays of strings
+
+      * funding_instruments, funding_categories are not implemented as multiselects, so they just need to be reformatted
+      * applicant_types is handled via hidden inputs for collecting values
+    */
+
+    const body = {
+      ...rawBody,
+      funding_categories: [rawBody.funding_categories],
+      funding_instruments: [rawBody.funding_instruments],
+    };
+
+    const response = await updateOpportunitySummaryForGrantor({
       opportunityId,
       opportunitySummaryId,
-      body: buildOpportunitySummaryUpdateRequest(formData),
+      body,
     });
-
+    if (response.status_code === 422) {
+      console.error("API side validation errors:", response.errors);
+      throw new ApiRequestError(
+        "API side validation errors",
+        "validation",
+        422,
+      );
+    }
     return {
       successMessage: alerts("success"),
     };

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
@@ -268,6 +268,7 @@ export async function saveOpportunityEditAction(
           ...formDataToObject<OpportunitySummaryUpdateRequest>(
             formData,
             editOpportunityFormSchema,
+            null,
           ),
           is_forecast: isForecast,
         },
@@ -282,6 +283,7 @@ export async function saveOpportunityEditAction(
     const rawBody = formDataToObject<OpportunitySummaryUpdateRawData>(
       formData,
       editOpportunityFormSchema,
+      null,
     );
     /*
       funding_instruments, funding_categories, applicant_types all need to be arrays of strings
@@ -359,13 +361,12 @@ export async function opportunityEditFormAction(
     return saveResult;
   }
 
-  if (readStringValue(formData.get("submitType")) === "saveAndExit") {
+  const submitType = formData.get("submitType");
+  if (submitType === "saveAndExit") {
     redirect("../overview");
-  } else if (readStringValue(formData.get("submitType")) === "saveAndGoBack") {
+  } else if (submitType === "saveAndGoBack") {
     redirect("../overview");
-  } else if (
-    readStringValue(formData.get("submitType")) === "saveAndContinue"
-  ) {
+  } else if (submitType === "saveAndContinue") {
     redirect("../competition");
   } else {
     return saveResult;

--- a/frontend/src/services/fetch/fetchers/opportunitySummaryGrantorFetcher.ts
+++ b/frontend/src/services/fetch/fetchers/opportunitySummaryGrantorFetcher.ts
@@ -41,6 +41,7 @@ export async function updateOpportunitySummaryForGrantor({
   const response = await fetchGrantorOpportunityWithMethod("PUT")({
     subPath: `${opportunityId}/summaries/${opportunitySummaryId}`,
     body,
+    // allowedErrorStatuses: [422],
   });
 
   return (await response.json()) as OpportunitySummaryDetailApiResponse;

--- a/frontend/src/types/opportunity/opportunityResponseTypes.ts
+++ b/frontend/src/types/opportunity/opportunityResponseTypes.ts
@@ -58,7 +58,9 @@ export interface OpportunitySummaryDetail extends Summary {
   opportunity_summary_id: string;
 }
 
-export type OpportunitySummaryUpdateRequest = {
+// note that we're using a type with a union here because of awkwardness inferring index signatures
+// from interfaces in this case. See https://github.com/microsoft/TypeScript/issues/15300 for more info
+type OpportunitySummaryUpdateBase = {
   is_cost_sharing: boolean | null;
   summary_description: string | null;
   post_date: string | null;
@@ -70,15 +72,23 @@ export type OpportunitySummaryUpdateRequest = {
   award_ceiling: number | null;
   additional_info_url: string | null;
   additional_info_url_description: string | null;
-  funding_categories: string[];
   funding_category_description: string | null;
-  funding_instruments: string[];
-  applicant_types: string[];
-  applicant_eligibility_description: string | null;
   agency_contact_description: string | null;
   agency_email_address: string | null;
+  applicant_eligibility_description: string | null;
   agency_email_address_description: string | null;
+  applicant_types: string[];
 };
+
+export type OpportunitySummaryUpdateRequest = {
+  funding_categories: string[];
+  funding_instruments: string[];
+} & OpportunitySummaryUpdateBase;
+
+export type OpportunitySummaryUpdateRawData = {
+  funding_categories: string;
+  funding_instruments: string;
+} & OpportunitySummaryUpdateBase;
 
 export type OpportunitySummaryCreateRequest =
   OpportunitySummaryUpdateRequest & {

--- a/frontend/src/utils/opportunityEditFormConfig.test.ts
+++ b/frontend/src/utils/opportunityEditFormConfig.test.ts
@@ -1,21 +1,6 @@
 import { OpportunityDetail } from "src/types/opportunity/opportunityResponseTypes";
 
-import {
-  buildOpportunityEditInitialValues,
-  buildOpportunitySummaryUpdateRequest,
-} from "./opportunityEditFormConfig";
-
-function makeFormData(fields: Record<string, string | string[]>): FormData {
-  const formData = new FormData();
-  for (const [key, value] of Object.entries(fields)) {
-    if (Array.isArray(value)) {
-      value.forEach((v) => formData.append(key, v));
-    } else {
-      formData.append(key, value);
-    }
-  }
-  return formData;
-}
+import { buildOpportunityEditInitialValues } from "./opportunityEditFormConfig";
 
 function makeOpportunity(
   summaryOverrides: Partial<OpportunityDetail["summary"]> = {},
@@ -84,20 +69,20 @@ describe("buildOpportunityEditInitialValues", () => {
   it("maps opportunity and summary fields to form values", () => {
     const result = buildOpportunityEditInitialValues(makeOpportunity());
 
-    expect(result.title).toBe("Test Opportunity");
-    expect(result.awardSelectionMethod).toBe("discretionary");
-    expect(result.description).toBe("A test description");
-    expect(result.fundingType).toBe("grant");
-    expect(result.fundingCategories).toBe("education");
-    expect(result.awardMinimum).toBe("1000");
-    expect(result.awardMaximum).toBe("100000");
-    expect(result.estimatedTotalProgramFunding).toBe("500000");
-    expect(result.expectedNumberOfAwards).toBe("5");
-    expect(result.eligibleApplicants).toEqual(["individuals"]);
-    expect(result.costSharing).toBe(true);
-    expect(result.publishDate).toBe("2026-05-01");
-    expect(result.closeDate).toBe("2026-06-01");
-    expect(result.contactEmail).toBe("test@example.com");
+    expect(result.opportunity_title).toBe("Test Opportunity");
+    expect(result.category).toBe("discretionary");
+    expect(result.summary_description).toBe("A test description");
+    expect(result.funding_instruments).toBe("grant");
+    expect(result.funding_categories).toBe("education");
+    expect(result.award_floor).toBe("1000");
+    expect(result.award_ceiling).toBe("100000");
+    expect(result.estimated_total_program_funding).toBe("500000");
+    expect(result.expected_number_of_awards).toBe("5");
+    expect(result.applicant_types).toEqual(["individuals"]);
+    expect(result.is_cost_sharing).toBe(true);
+    expect(result.post_date).toBe("2026-05-01");
+    expect(result.close_date).toBe("2026-06-01");
+    expect(result.agency_email_address).toBe("test@example.com");
   });
 
   it("returns empty string for null numeric summary fields (numberToString null branch)", () => {
@@ -110,10 +95,10 @@ describe("buildOpportunityEditInitialValues", () => {
       }),
     );
 
-    expect(result.awardMinimum).toBe("");
-    expect(result.awardMaximum).toBe("");
-    expect(result.estimatedTotalProgramFunding).toBe("");
-    expect(result.expectedNumberOfAwards).toBe("");
+    expect(result.award_floor).toBe("");
+    expect(result.award_ceiling).toBe("");
+    expect(result.estimated_total_program_funding).toBe("");
+    expect(result.expected_number_of_awards).toBe("");
   });
 
   it("falls back to empty string when opportunity_title is null", () => {
@@ -121,7 +106,7 @@ describe("buildOpportunityEditInitialValues", () => {
       makeOpportunity({}, { opportunity_title: null }),
     );
 
-    expect(result.title).toBe("");
+    expect(result.opportunity_title).toBe("");
   });
 
   it("returns empty string when funding_instruments array is empty", () => {
@@ -129,7 +114,7 @@ describe("buildOpportunityEditInitialValues", () => {
       makeOpportunity({ funding_instruments: [] }),
     );
 
-    expect(result.fundingType).toBe("");
+    expect(result.funding_instruments).toBe("");
   });
 
   it("returns empty string when funding_instruments is null", () => {
@@ -137,7 +122,7 @@ describe("buildOpportunityEditInitialValues", () => {
       makeOpportunity({ funding_instruments: null }),
     );
 
-    expect(result.fundingType).toBe("");
+    expect(result.funding_instruments).toBe("");
   });
 
   it("returns empty array when applicant_types is null", () => {
@@ -145,7 +130,7 @@ describe("buildOpportunityEditInitialValues", () => {
       makeOpportunity({ applicant_types: null }),
     );
 
-    expect(result.eligibleApplicants).toEqual([]);
+    expect(result.applicant_types).toEqual([]);
   });
 
   it("returns empty string when funding_categories is empty", () => {
@@ -153,153 +138,6 @@ describe("buildOpportunityEditInitialValues", () => {
       makeOpportunity({ funding_categories: [] }),
     );
 
-    expect(result.fundingCategories).toBe("");
-  });
-});
-
-describe("buildOpportunitySummaryUpdateRequest", () => {
-  describe("stringToNullableNumber fields", () => {
-    it("parses a valid integer", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ expectedNumberOfAwards: "5" }),
-      );
-      expect(result.expected_number_of_awards).toBe(5);
-    });
-
-    it("parses a number with commas", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ estimatedTotalProgramFunding: "1,000,000" }),
-      );
-      expect(result.estimated_total_program_funding).toBe(1000000);
-    });
-
-    it("returns null for an empty string", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ awardMinimum: "" }),
-      );
-      expect(result.award_floor).toBeNull();
-    });
-
-    it("returns null for a whitespace-only string", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ awardMaximum: "   " }),
-      );
-      expect(result.award_ceiling).toBeNull();
-    });
-
-    it("returns null for a non-numeric string", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ expectedNumberOfAwards: "abc" }),
-      );
-      expect(result.expected_number_of_awards).toBeNull();
-    });
-
-    it("returns null when field is absent", () => {
-      const result = buildOpportunitySummaryUpdateRequest(new FormData());
-      expect(result.expected_number_of_awards).toBeNull();
-    });
-  });
-
-  describe("getMultiValueField fields", () => {
-    it("returns values from the funding-category-values field", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ "funding-category-values": ["education", "health"] }),
-      );
-      expect(result.funding_categories).toEqual(["education", "health"]);
-    });
-
-    it("returns values from the funding-type-values field", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({
-          "funding-type-values": ["grant", "cooperative_agreement"],
-        }),
-      );
-      expect(result.funding_instruments).toEqual([
-        "grant",
-        "cooperative_agreement",
-      ]);
-    });
-
-    it("filters out blank values", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({
-          "funding-type-values": ["grant", "  ", "cooperative_agreement"],
-        }),
-      );
-      expect(result.funding_instruments).toEqual([
-        "grant",
-        "cooperative_agreement",
-      ]);
-    });
-
-    it("returns an empty array when field is absent", () => {
-      const result = buildOpportunitySummaryUpdateRequest(new FormData());
-      expect(result.funding_categories).toEqual([]);
-    });
-
-    it("supports multiple eligible applicants via eligibleApplicants field", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({
-          eligibleApplicants: ["individuals", "state_governments"],
-        }),
-      );
-      expect(result.applicant_types).toEqual([
-        "individuals",
-        "state_governments",
-      ]);
-    });
-
-    it("falls back to eligible-applicants-values when eligibleApplicants is empty", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({
-          "eligible-applicants-values": ["state_governments"],
-        }),
-      );
-      expect(result.applicant_types).toEqual(["state_governments"]);
-    });
-  });
-
-  describe("is_cost_sharing", () => {
-    it("returns true when value is 'true'", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ costSharing: "true" }),
-      );
-      expect(result.is_cost_sharing).toBe(true);
-    });
-
-    it("returns false when value is 'false'", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ costSharing: "false" }),
-      );
-      expect(result.is_cost_sharing).toBe(false);
-    });
-
-    it("returns null when field is absent", () => {
-      const result = buildOpportunitySummaryUpdateRequest(new FormData());
-      expect(result.is_cost_sharing).toBeNull();
-    });
-  });
-
-  describe("emptyToNull string fields", () => {
-    it("returns the value for a non-empty string", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ description: "Some description" }),
-      );
-      expect(result.summary_description).toBe("Some description");
-    });
-
-    it("returns null for an empty string", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ description: "" }),
-      );
-      expect(result.summary_description).toBeNull();
-    });
-
-    it("returns null for a whitespace-only string", () => {
-      const result = buildOpportunitySummaryUpdateRequest(
-        makeFormData({ description: "   " }),
-      );
-      expect(result.summary_description).toBeNull();
-    });
+    expect(result.funding_categories).toBe("");
   });
 });

--- a/frontend/src/utils/opportunityEditFormConfig.ts
+++ b/frontend/src/utils/opportunityEditFormConfig.ts
@@ -1,32 +1,29 @@
-import {
-  OpportunityDetail,
-  OpportunitySummaryUpdateRequest,
-} from "src/types/opportunity/opportunityResponseTypes";
+import { OpportunityDetail } from "src/types/opportunity/opportunityResponseTypes";
 
 export type OpportunityEditFormValues = {
-  opportunityNumber: string;
-  title: string;
-  awardSelectionMethod: string;
-  awardSelectionMethodExplanation: string;
-  description: string;
-  fundingType: string;
-  costSharing: boolean | null;
-  publishDate: string;
-  closeDate: string;
-  closeDateExplanation: string;
-  fundingCategories: string;
-  fundingCategoryExplanation: string;
-  expectedNumberOfAwards: string;
-  estimatedTotalProgramFunding: string;
-  awardMinimum: string;
-  awardMaximum: string;
-  eligibleApplicants: string[];
-  additionalEligibilityInfo: string;
-  additionalInfoUrl: string;
-  additionalInfoUrlText: string;
-  grantorContactDetails: string;
-  contactEmail: string;
-  contactEmailText: string;
+  opportunity_number: string;
+  opportunity_title: string;
+  category: string;
+  category_explanation: string;
+  summary_description: string;
+  funding_instruments: string;
+  is_cost_sharing: boolean | null;
+  post_date: string;
+  close_date: string;
+  close_date_description: string;
+  funding_categories: string;
+  funding_category_description: string;
+  expected_number_of_awards: string;
+  estimated_total_program_funding: string;
+  award_floor: string;
+  award_ceiling: string;
+  applicant_types: string[];
+  applicant_eligibility_description: string;
+  additional_info_url: string;
+  additional_info_url_description: string;
+  agency_contact_description: string;
+  agency_email_address: string;
+  agency_email_address_description: string;
 };
 
 const emptyString = (value: string | null | undefined) => value ?? "";
@@ -40,131 +37,42 @@ export const buildOpportunityEditInitialValues = (
   const summary = opportunity.summary;
 
   return {
-    opportunityNumber: opportunity.opportunity_number ?? "",
-    title: emptyString(opportunity.opportunity_title),
-    awardSelectionMethod: emptyString(opportunity.category),
-    awardSelectionMethodExplanation: emptyString(
-      opportunity.category_explanation,
-    ),
-    description: emptyString(summary?.summary_description),
-    fundingType: summary?.funding_instruments?.[0] ?? "",
-    costSharing: summary?.is_cost_sharing ?? true,
-    publishDate: emptyString(summary?.post_date),
-    closeDate: emptyString(summary?.close_date),
-    closeDateExplanation: emptyString(summary?.close_date_description),
-    fundingCategories: summary?.funding_categories?.[0] ?? "",
-    fundingCategoryExplanation: emptyString(
+    opportunity_number: opportunity.opportunity_number ?? "",
+    opportunity_title: emptyString(opportunity.opportunity_title),
+    category: emptyString(opportunity.category),
+    category_explanation: emptyString(opportunity.category_explanation),
+    summary_description: emptyString(summary?.summary_description),
+    funding_instruments: summary?.funding_instruments?.[0] ?? "",
+    is_cost_sharing: summary?.is_cost_sharing ?? true,
+    post_date: emptyString(summary?.post_date),
+    close_date: emptyString(summary?.close_date),
+    close_date_description: emptyString(summary?.close_date_description),
+    funding_categories: summary?.funding_categories?.[0] ?? "",
+    funding_category_description: emptyString(
       summary?.funding_category_description,
     ),
-    expectedNumberOfAwards: numberToString(summary?.expected_number_of_awards),
-    estimatedTotalProgramFunding: numberToString(
+    expected_number_of_awards: numberToString(
+      summary?.expected_number_of_awards,
+    ),
+    estimated_total_program_funding: numberToString(
       summary?.estimated_total_program_funding,
     ),
-    awardMinimum: numberToString(summary?.award_floor),
-    awardMaximum: numberToString(summary?.award_ceiling),
-    eligibleApplicants: summary?.applicant_types ?? [],
-    additionalEligibilityInfo: emptyString(
+    award_floor: numberToString(summary?.award_floor),
+    award_ceiling: numberToString(summary?.award_ceiling),
+    applicant_types: summary?.applicant_types ?? [],
+    applicant_eligibility_description: emptyString(
       summary?.applicant_eligibility_description,
     ),
-    additionalInfoUrl: emptyString(summary?.additional_info_url),
-    additionalInfoUrlText: emptyString(
+    additional_info_url: emptyString(summary?.additional_info_url),
+    additional_info_url_description: emptyString(
       summary?.additional_info_url_description,
     ),
-    grantorContactDetails: emptyString(summary?.agency_contact_description),
-    contactEmail: emptyString(summary?.agency_email_address),
-    contactEmailText: emptyString(summary?.agency_email_address_description),
+    agency_contact_description: emptyString(
+      summary?.agency_contact_description,
+    ),
+    agency_email_address: emptyString(summary?.agency_email_address),
+    agency_email_address_description: emptyString(
+      summary?.agency_email_address_description,
+    ),
   };
 };
-
-// Private helpers for FormData → API payload mapping
-
-function readStringFromFormData(value: FormDataEntryValue | null): string {
-  return typeof value === "string" ? value : "";
-}
-
-function emptyToNull(value: FormDataEntryValue | null): string | null {
-  const normalizedValue = readStringFromFormData(value).trim();
-  return normalizedValue || null;
-}
-
-function stringToNullableNumber(
-  value: FormDataEntryValue | null,
-): number | null {
-  const normalizedValue = readStringFromFormData(value)
-    .trim()
-    .replace(/,/g, "");
-  if (!normalizedValue) {
-    return null;
-  }
-  const parsedValue = Number(normalizedValue);
-  return Number.isNaN(parsedValue) ? null : parsedValue;
-}
-
-function getMultiValueField(
-  formData: FormData,
-  fieldName: string,
-  fallbackFieldName?: string,
-): string[] {
-  const primaryValues = formData
-    .getAll(fieldName)
-    .flatMap((value) =>
-      typeof value === "string" && value.trim() ? [value.trim()] : [],
-    );
-
-  if (primaryValues.length > 0 || !fallbackFieldName) {
-    return primaryValues;
-  }
-
-  return formData
-    .getAll(fallbackFieldName)
-    .flatMap((value) =>
-      typeof value === "string" && value.trim() ? [value.trim()] : [],
-    );
-}
-
-export function buildOpportunitySummaryUpdateRequest(
-  formData: FormData,
-): OpportunitySummaryUpdateRequest {
-  return {
-    is_cost_sharing:
-      formData.get("costSharing") === null
-        ? null
-        : readStringFromFormData(formData.get("costSharing")) === "true",
-    summary_description: emptyToNull(formData.get("description")),
-    post_date: emptyToNull(formData.get("publishDate")),
-    close_date: emptyToNull(formData.get("closeDate")),
-    close_date_description: emptyToNull(formData.get("closeDateExplanation")),
-    expected_number_of_awards: stringToNullableNumber(
-      formData.get("expectedNumberOfAwards"),
-    ),
-    estimated_total_program_funding: stringToNullableNumber(
-      formData.get("estimatedTotalProgramFunding"),
-    ),
-    award_floor: stringToNullableNumber(formData.get("awardMinimum")),
-    award_ceiling: stringToNullableNumber(formData.get("awardMaximum")),
-    additional_info_url: emptyToNull(formData.get("additionalInfoUrl")),
-    additional_info_url_description: emptyToNull(
-      formData.get("additionalInfoUrlText"),
-    ),
-    funding_categories: getMultiValueField(formData, "funding-category-values"),
-    funding_category_description: emptyToNull(
-      formData.get("fundingCategoryExplanation"),
-    ),
-    funding_instruments: getMultiValueField(formData, "funding-type-values"),
-    applicant_types: getMultiValueField(
-      formData,
-      "eligibleApplicants",
-      "eligible-applicants-values",
-    ),
-    applicant_eligibility_description: emptyToNull(
-      formData.get("additionalEligibilityInfo"),
-    ),
-    agency_contact_description: emptyToNull(
-      formData.get("grantorContactDetails"),
-    ),
-    agency_email_address: emptyToNull(formData.get("contactEmail")),
-    agency_email_address_description: emptyToNull(
-      formData.get("contactEmailText"),
-    ),
-  };
-}

--- a/frontend/src/utils/testing/fixtures.ts
+++ b/frontend/src/utils/testing/fixtures.ts
@@ -230,6 +230,8 @@ export const mockOpportunityDetail = {
     funding_instruments: null,
     is_cost_sharing: null,
     version_number: 1,
+    opportunity_summary_id: "1",
+    updated_at: "2024-01-01T00:00:00Z",
   },
 };
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #9602 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

This builds on https://github.com/HHS/simpler-grants-gov/pull/11490 by implementing the formDataToJson functionality into the edit opportunity form.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The main changes here are:

* updating edit opportunity form field names to coincide with data keys
* replacing `buildOpportunitySummaryUpdateRequest` with `formDataToObject`

The diff is pretty big but that is mainly because there were a lot of data keys to switch over. The trickiest part to call out is applicant_types. In order for this to work with formDataToJson, this needed to be reimplemented using hidden inputs, following the pattern establishing in the MulitSelectWidget.

Note that this may break E2E tests, working on testing locally, but that does not need to block this PR

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. regression test of edit opportunity behavior. There should be no change to existing behavior
