### PR TITLE
[Issue #11348] Modify update application form endpoint and attachment audit logging

### DIFF
--- a/api/src/services/applications/create_application_attachment.py
+++ b/api/src/services/applications/create_application_attachment.py
@@ -11,10 +11,9 @@ from werkzeug.datastructures import FileStorage
 
 from src.app_config import AppConfig
 from src.auth.endpoint_access_util import check_user_access
-from src.constants.lookup_constants import ApplicationAuditEvent, Privilege, SubmissionIssue
+from src.constants.lookup_constants import Privilege, SubmissionIssue
 from src.db.models.competition_models import Application, ApplicationAttachment
 from src.db.models.user_models import User
-from src.services.applications.application_audit import add_audit_event
 from src.services.applications.get_application import get_application
 
 logger = logging.getLogger(__name__)
@@ -64,13 +63,8 @@ def create_application_attachment(
         application_attachment=None,
     )
 
-    add_audit_event(
-        db_session=db_session,
-        application=application,
-        user=user,
-        audit_event=ApplicationAuditEvent.ATTACHMENT_ADDED,
-        target_attachment=application_attachment,
-    )
+    # The ATTACHMENT_ADDED audit event is intentionally not emitted here. It is
+    # emitted on form save when the attachment is diffed into the form response.
     return application_attachment
 
 

--- a/api/src/services/applications/delete_application_attachment.py
+++ b/api/src/services/applications/delete_application_attachment.py
@@ -5,9 +5,8 @@ import grants_shared.adapters.db as db
 from grants_shared.util import file_util
 
 from src.auth.endpoint_access_util import check_user_access
-from src.constants.lookup_constants import ApplicationAuditEvent, Privilege
+from src.constants.lookup_constants import Privilege
 from src.db.models.user_models import User
-from src.services.applications.application_audit import add_audit_event
 from src.services.applications.get_application_attachment import get_application_attachment
 
 logger = logging.getLogger(__name__)
@@ -40,10 +39,5 @@ def delete_application_attachment(
     # Remove the s3 path to make clear it's gone.
     application_attachment.file_location = "DELETED"
 
-    add_audit_event(
-        db_session=db_session,
-        application=application_attachment.application,
-        user=user,
-        audit_event=ApplicationAuditEvent.ATTACHMENT_DELETED,
-        target_attachment=application_attachment,
-    )
+    # The ATTACHMENT_DELETED audit event is intentionally not emitted here. It is
+    # emitted on form save when the attachment is diffed out of the form response.

--- a/api/src/services/applications/process_application_attachment_changes.py
+++ b/api/src/services/applications/process_application_attachment_changes.py
@@ -1,0 +1,185 @@
+import logging
+import uuid
+
+import grants_shared.adapters.db as db
+import grants_shared.util.file_util as file_util
+from grants_shared.util.dict_util import get_nested_value
+from sqlalchemy import select
+
+from src.constants.lookup_constants import ApplicationAuditEvent
+from src.db.models.competition_models import Application, ApplicationAttachment, Form
+from src.db.models.user_models import User
+from src.services.applications.application_audit import add_audit_event
+
+logger = logging.getLogger(__name__)
+
+# UI schema widgets that indicate a form field holds one or more attachments
+ATTACHMENT_WIDGETS = {"Attachment", "AttachmentArray"}
+
+
+def _definition_to_path(definition: str) -> list[str]:
+    """Convert a UI schema field definition JSON pointer into a response path.
+
+    For example ``/properties/att1`` becomes ``["att1"]`` and a nested
+    ``/properties/foo/properties/bar`` becomes ``["foo", "bar"]``.
+    """
+    return [token for token in definition.split("/") if token and token != "properties"]
+
+
+def _collect_attachment_field_paths(ui_schema_node: object, paths: list[list[str]]) -> None:
+    """Recursively walk a form UI schema collecting attachment field paths."""
+    if isinstance(ui_schema_node, list):
+        for child in ui_schema_node:
+            _collect_attachment_field_paths(child, paths)
+        return
+
+    if isinstance(ui_schema_node, dict):
+        definition = ui_schema_node.get("definition")
+        if ui_schema_node.get("widget") in ATTACHMENT_WIDGETS and isinstance(definition, str):
+            paths.append(_definition_to_path(definition))
+        _collect_attachment_field_paths(ui_schema_node.get("children"), paths)
+
+
+def get_attachment_field_paths(form: Form) -> list[list[str]]:
+    """Determine which form fields contain attachment data from the UI schema.
+
+    Attachment fields are identified by their ``Attachment`` (single) or
+    ``AttachmentArray`` (multi) widget in the form's UI schema.
+    """
+    paths: list[list[str]] = []
+    _collect_attachment_field_paths(form.form_ui_schema, paths)
+    return paths
+
+
+def collect_attachment_ids(
+    application_response: dict, attachment_field_paths: list[list[str]]
+) -> set[str]:
+    """Gather every attachment UUID referenced by the attachment fields in a response."""
+    attachment_ids: set[str] = set()
+    for path in attachment_field_paths:
+        value = get_nested_value(application_response, path)
+        if value is None:
+            continue
+        # Multi-attachment fields store a list of UUIDs, single fields a lone UUID
+        values = value if isinstance(value, list) else [value]
+        attachment_ids.update(v for v in values if isinstance(v, str))
+    return attachment_ids
+
+
+def _get_application_attachment(
+    db_session: db.Session, application: Application, attachment_id: str
+) -> ApplicationAttachment | None:
+    """Fetch an attachment (including deleted ones) by its string UUID."""
+    try:
+        attachment_uuid = uuid.UUID(attachment_id)
+    except ValueError:
+        logger.info(
+            "Attachment field references a value that is not a valid UUID",
+            extra={"application_id": application.application_id, "attachment_id": attachment_id},
+        )
+        return None
+
+    return db_session.execute(
+        select(ApplicationAttachment).where(
+            ApplicationAttachment.application_id == application.application_id,
+            ApplicationAttachment.application_attachment_id == attachment_uuid,
+        )
+    ).scalar_one_or_none()
+
+
+def _process_added_attachment(
+    db_session: db.Session, application: Application, user: User, attachment_id: str
+) -> None:
+    application_attachment = _get_application_attachment(db_session, application, attachment_id)
+    if application_attachment is None:
+        logger.warning(
+            "Added attachment identified in form diff does not exist on the application",
+            extra={"application_id": application.application_id, "attachment_id": attachment_id},
+        )
+        return
+
+    add_audit_event(
+        db_session=db_session,
+        application=application,
+        user=user,
+        audit_event=ApplicationAuditEvent.ATTACHMENT_ADDED,
+        target_attachment=application_attachment,
+    )
+
+
+def _process_deleted_attachment(
+    db_session: db.Session, application: Application, user: User, attachment_id: str
+) -> None:
+    application_attachment = _get_application_attachment(db_session, application, attachment_id)
+    if application_attachment is None:
+        logger.warning(
+            "Deleted attachment identified in form diff does not exist on the application",
+            extra={"application_id": application.application_id, "attachment_id": attachment_id},
+        )
+        return
+
+    # If the attachment has already been deleted (e.g. via the delete endpoint)
+    # there is nothing left to clean up, otherwise remove the underlying file.
+    if application_attachment.is_deleted:
+        logger.info(
+            "Attachment identified as deleted in form diff was already deleted",
+            extra={
+                "application_id": application.application_id,
+                "application_attachment_id": application_attachment.application_attachment_id,
+            },
+        )
+    else:
+        logger.info(
+            "Attachment identified as deleted in form diff but not yet deleted, deleting now",
+            extra={
+                "application_id": application.application_id,
+                "application_attachment_id": application_attachment.application_attachment_id,
+            },
+        )
+        # Delete the file from s3
+        file_util.delete_file(application_attachment.file_location)
+        # Mark the attachment as deleted, keeping the record for auditing purposes
+        application_attachment.is_deleted = True
+        # Remove the s3 path to make clear it's gone.
+        application_attachment.file_location = "DELETED"
+
+    add_audit_event(
+        db_session=db_session,
+        application=application,
+        user=user,
+        audit_event=ApplicationAuditEvent.ATTACHMENT_DELETED,
+        target_attachment=application_attachment,
+    )
+
+
+def process_application_attachment_changes(
+    db_session: db.Session,
+    application: Application,
+    form: Form,
+    user: User,
+    old_application_response: dict | None,
+    new_application_response: dict | None,
+) -> None:
+    """Diff the attachment fields of a form response and audit added/deleted attachments.
+
+    Determines which attachment form fields exist for the form, then compares the
+    attachment UUIDs referenced before and after the update. Newly referenced
+    attachments generate an ``ATTACHMENT_ADDED`` audit event, and no-longer-referenced
+    attachments are deleted (if not already) and generate an ``ATTACHMENT_DELETED``
+    audit event.
+    """
+    attachment_field_paths = get_attachment_field_paths(form)
+    if not attachment_field_paths:
+        return
+
+    old_ids = collect_attachment_ids(old_application_response or {}, attachment_field_paths)
+    new_ids = collect_attachment_ids(new_application_response or {}, attachment_field_paths)
+
+    added_ids = new_ids - old_ids
+    deleted_ids = old_ids - new_ids
+
+    for attachment_id in added_ids:
+        _process_added_attachment(db_session, application, user, attachment_id)
+
+    for attachment_id in deleted_ids:
+        _process_deleted_attachment(db_session, application, user, attachment_id)

--- a/api/src/services/applications/update_application_form.py
+++ b/api/src/services/applications/update_application_form.py
@@ -17,6 +17,9 @@ from src.services.applications.application_validation import (
     validate_application_in_progress,
 )
 from src.services.applications.get_application import get_application
+from src.services.applications.process_application_attachment_changes import (
+    process_application_attachment_changes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,9 +102,13 @@ def update_application_form(
         )
     ).scalar_one_or_none()
 
+    # Capture the previous response before overwriting so we can diff attachments
+    old_application_response: dict = {}
+
     if application_form:
         # Update existing application form
         if application_response is not None:
+            old_application_response = application_form.application_response or {}
             application_form.application_response = application_response
         if is_included_in_submission is not None:
             application_form.is_included_in_submission = is_included_in_submission
@@ -150,5 +157,17 @@ def update_application_form(
         audit_event=ApplicationAuditEvent.FORM_UPDATED,
         target_application_form=application_form,
     )
+
+    # When the form response changes, diff the attachment fields to audit
+    # attachments that were added or deleted as part of this save.
+    if application_response is not None:
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=competition_form.form,
+            user=user,
+            old_application_response=old_application_response,
+            new_application_response=application_response,
+        )
 
     return application_form, warnings

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -775,6 +775,7 @@ def create_test_form(db_session):
         form_name: str = "Test Form",
         form_json_schema: dict | None = None,
         form_rule_schema: dict | None = None,
+        form_ui_schema: dict | list | None = None,
         **kwargs,
     ) -> FormModel:
         form = FormModel(
@@ -784,7 +785,7 @@ def create_test_form(db_session):
             form_version=kwargs.get("form_version", "1.0"),
             agency_code="SGG",
             form_json_schema=form_json_schema or {"type": "object", "properties": {}},
-            form_ui_schema={},
+            form_ui_schema=form_ui_schema if form_ui_schema is not None else {},
             form_rule_schema=form_rule_schema,
             json_to_xml_schema=kwargs.get("json_to_xml_schema", None),
         )

--- a/api/tests/src/api/applications/test_application_attachment_routes.py
+++ b/api/tests/src/api/applications/test_application_attachment_routes.py
@@ -66,14 +66,9 @@ def test_application_attachment_create_200(
     assert application_attachment.file_size_bytes > 0
     assert file_util.file_exists(application_attachment.file_location) is True
 
-    # Verify audit event added
-    assert len(application.application_audits) == 1
-    assert (
-        application.application_audits[0].application_audit_event
-        == ApplicationAuditEvent.ATTACHMENT_ADDED
-    )
-    assert application.application_audits[0].user_id == user.user_id
-    assert str(application.application_audits[0].target_attachment_id) == application_attachment_id
+    # No audit event is emitted on attachment create; it is emitted on form save
+    # when the attachment is diffed into the form response.
+    assert len(application.application_audits) == 0
 
 
 def test_application_attachment_create_404_not_found(
@@ -699,17 +694,9 @@ def test_application_attachment_delete_200(db_session, enable_factory_create, cl
         == second_attachment.application_attachment_id
     )
 
-    # Verify audit event added
-    assert len(application.application_audits) == 1
-    assert (
-        application.application_audits[0].application_audit_event
-        == ApplicationAuditEvent.ATTACHMENT_DELETED
-    )
-    assert application.application_audits[0].user_id == user.user_id
-    assert (
-        application.application_audits[0].target_attachment_id
-        == application_attachment.application_attachment_id
-    )
+    # No audit event is emitted on attachment delete; it is emitted on form save
+    # when the attachment is diffed out of the form response.
+    assert len(application.application_audits) == 0
 
 
 def test_application_attachment_delete_404_application_not_found(

--- a/api/tests/src/api/applications/test_application_routes.py
+++ b/api/tests/src/api/applications/test_application_routes.py
@@ -2,6 +2,7 @@
 import uuid
 from datetime import date, timedelta
 
+import grants_shared.util.file_util as file_util
 import pytest
 from grants_shared.util import datetime_util
 from grants_shared.util.datetime_util import get_now_us_eastern_date
@@ -55,6 +56,10 @@ SIMPLE_ATTACHMENT_JSON_SCHEMA = {
 }
 
 SIMPLE_ATTACHMENT_RULE_SCHEMA = {"attachment_field": {"gg_validation": {"rule": "attachment"}}}
+
+SIMPLE_ATTACHMENT_UI_SCHEMA = [
+    {"type": "field", "definition": "/properties/attachment_field", "widget": "Attachment"},
+]
 
 
 def test_application_start_success(
@@ -680,6 +685,91 @@ def test_application_form_update_with_rule_validation_issues(
         application.application_audits[0].target_application_form_id
         == existing_application_form.application_form_id
     )
+
+
+def test_application_form_update_audits_added_attachment(
+    client, enable_factory_create, db_session, create_test_form
+):
+    """Adding an attachment to a form response emits an ATTACHMENT_ADDED audit on save"""
+    user, application, token = create_user_in_app(
+        db_session, privileges=[Privilege.MODIFY_APPLICATION]
+    )
+    form = create_test_form(
+        form_json_schema=SIMPLE_ATTACHMENT_JSON_SCHEMA,
+        form_rule_schema=SIMPLE_ATTACHMENT_RULE_SCHEMA,
+        form_ui_schema=SIMPLE_ATTACHMENT_UI_SCHEMA,
+    )
+    competition_form = CompetitionFormFactory.create(competition=application.competition, form=form)
+    ApplicationFormFactory.create(
+        application=application, competition_form=competition_form, application_response={}
+    )
+    attachment = ApplicationAttachmentFactory.create(application=application)
+
+    request_data = {
+        "application_response": {"attachment_field": str(attachment.application_attachment_id)}
+    }
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/forms/{form.form_id}",
+        json=request_data,
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 200
+
+    audit_events = {
+        (a.application_audit_event, a.target_attachment_id) for a in application.application_audits
+    }
+    assert (ApplicationAuditEvent.FORM_UPDATED, None) in audit_events
+    assert (
+        ApplicationAuditEvent.ATTACHMENT_ADDED,
+        attachment.application_attachment_id,
+    ) in audit_events
+
+
+def test_application_form_update_audits_deleted_attachment(
+    client, enable_factory_create, db_session, s3_config, create_test_form
+):
+    """Removing an attachment from a form response deletes it and emits ATTACHMENT_DELETED"""
+    user, application, token = create_user_in_app(
+        db_session, privileges=[Privilege.MODIFY_APPLICATION]
+    )
+    form = create_test_form(
+        form_json_schema=SIMPLE_ATTACHMENT_JSON_SCHEMA,
+        form_rule_schema=SIMPLE_ATTACHMENT_RULE_SCHEMA,
+        form_ui_schema=SIMPLE_ATTACHMENT_UI_SCHEMA,
+    )
+    competition_form = CompetitionFormFactory.create(competition=application.competition, form=form)
+    attachment = ApplicationAttachmentFactory.create(application=application)
+    ApplicationFormFactory.create(
+        application=application,
+        competition_form=competition_form,
+        application_response={"attachment_field": str(attachment.application_attachment_id)},
+    )
+
+    assert file_util.file_exists(attachment.file_location) is True
+
+    request_data = {"application_response": {}}
+    response = client.put(
+        f"/alpha/applications/{application.application_id}/forms/{form.form_id}",
+        json=request_data,
+        headers={"X-SGG-Token": token},
+    )
+
+    assert response.status_code == 200
+
+    db_session.refresh(attachment)
+    assert attachment.is_deleted is True
+    assert attachment.file_location == "DELETED"
+    assert file_util.file_exists(attachment.file_location) is False
+
+    audit_events = {
+        (a.application_audit_event, a.target_attachment_id) for a in application.application_audits
+    }
+    assert (ApplicationAuditEvent.FORM_UPDATED, None) in audit_events
+    assert (
+        ApplicationAuditEvent.ATTACHMENT_DELETED,
+        attachment.application_attachment_id,
+    ) in audit_events
 
 
 def test_application_form_update_with_invalid_schema_500(

--- a/api/tests/src/services/applications/test_process_application_attachment_changes.py
+++ b/api/tests/src/services/applications/test_process_application_attachment_changes.py
@@ -1,0 +1,267 @@
+import uuid
+
+import grants_shared.util.file_util as file_util
+from sqlalchemy import select
+
+from src.constants.lookup_constants import ApplicationAuditEvent
+from src.db.models.competition_models import ApplicationAudit
+from src.services.applications.process_application_attachment_changes import (
+    collect_attachment_ids,
+    get_attachment_field_paths,
+    process_application_attachment_changes,
+)
+from tests.src.db.models.factories import ApplicationAttachmentFactory, ApplicationFactory
+
+# A UI schema exercising both single and multi attachment widgets, nested in sections,
+# alongside non-attachment fields that should be ignored.
+UI_SCHEMA = [
+    {
+        "type": "section",
+        "label": "Attachments",
+        "children": [
+            {"type": "field", "definition": "/properties/att1", "widget": "Attachment"},
+            {"type": "field", "definition": "/properties/name", "widget": "Text"},
+            {
+                "type": "field",
+                "definition": "/properties/attachments",
+                "widget": "AttachmentArray",
+            },
+        ],
+    },
+]
+
+
+def _make_form(create_test_form, form_ui_schema=UI_SCHEMA):
+    return create_test_form(form_ui_schema=form_ui_schema)
+
+
+def _get_audits(db_session, application):
+    return (
+        db_session.execute(
+            select(ApplicationAudit).where(
+                ApplicationAudit.application_id == application.application_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def test_get_attachment_field_paths(create_test_form):
+    form = _make_form(create_test_form)
+    paths = get_attachment_field_paths(form)
+    assert sorted(paths) == [["att1"], ["attachments"]]
+
+
+def test_get_attachment_field_paths_nested_definition(create_test_form):
+    form = _make_form(
+        create_test_form,
+        form_ui_schema=[
+            {
+                "type": "field",
+                "definition": "/properties/group/properties/att",
+                "widget": "Attachment",
+            }
+        ],
+    )
+    assert get_attachment_field_paths(form) == [["group", "att"]]
+
+
+def test_get_attachment_field_paths_no_attachments(create_test_form):
+    form = _make_form(
+        create_test_form,
+        form_ui_schema=[{"type": "field", "definition": "/properties/name", "widget": "Text"}],
+    )
+    assert get_attachment_field_paths(form) == []
+
+
+def test_collect_attachment_ids_single_and_array():
+    paths = [["att1"], ["attachments"]]
+    response = {
+        "att1": "id-a",
+        "attachments": ["id-b", "id-c"],
+        "name": "ignored",
+    }
+    assert collect_attachment_ids(response, paths) == {"id-a", "id-b", "id-c"}
+
+
+def test_collect_attachment_ids_handles_missing_and_non_string():
+    paths = [["att1"], ["attachments"]]
+    response = {"attachments": ["id-b", None, 5]}
+    assert collect_attachment_ids(response, paths) == {"id-b"}
+
+
+def test_process_added_attachment_emits_audit(enable_factory_create, db_session, create_test_form):
+    application = ApplicationFactory.create()
+    attachment = ApplicationAttachmentFactory.create(application=application)
+    user = attachment.user
+    form = _make_form(create_test_form)
+
+    with db_session.begin():
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=form,
+            user=user,
+            old_application_response={},
+            new_application_response={"att1": str(attachment.application_attachment_id)},
+        )
+
+    audits = _get_audits(db_session, application)
+    assert len(audits) == 1
+    assert audits[0].application_audit_event == ApplicationAuditEvent.ATTACHMENT_ADDED
+    assert audits[0].target_attachment_id == attachment.application_attachment_id
+    assert audits[0].user_id == user.user_id
+
+
+def test_process_added_attachment_array(enable_factory_create, db_session, create_test_form):
+    application = ApplicationFactory.create()
+    attachment_1 = ApplicationAttachmentFactory.create(application=application)
+    attachment_2 = ApplicationAttachmentFactory.create(application=application)
+    user = attachment_1.user
+    form = _make_form(create_test_form)
+
+    with db_session.begin():
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=form,
+            user=user,
+            old_application_response={},
+            new_application_response={
+                "attachments": [
+                    str(attachment_1.application_attachment_id),
+                    str(attachment_2.application_attachment_id),
+                ]
+            },
+        )
+
+    audits = _get_audits(db_session, application)
+    assert len(audits) == 2
+    assert {a.target_attachment_id for a in audits} == {
+        attachment_1.application_attachment_id,
+        attachment_2.application_attachment_id,
+    }
+    assert all(a.application_audit_event == ApplicationAuditEvent.ATTACHMENT_ADDED for a in audits)
+
+
+def test_process_deleted_attachment_removes_file_and_audits(
+    enable_factory_create, db_session, s3_config, create_test_form
+):
+    application = ApplicationFactory.create()
+    attachment = ApplicationAttachmentFactory.create(application=application)
+    user = attachment.user
+    form = _make_form(create_test_form)
+
+    assert file_util.file_exists(attachment.file_location) is True
+
+    with db_session.begin():
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=form,
+            user=user,
+            old_application_response={"att1": str(attachment.application_attachment_id)},
+            new_application_response={},
+        )
+
+    db_session.refresh(attachment)
+    assert attachment.is_deleted is True
+    assert attachment.file_location == "DELETED"
+
+    audits = _get_audits(db_session, application)
+    assert len(audits) == 1
+    assert audits[0].application_audit_event == ApplicationAuditEvent.ATTACHMENT_DELETED
+    assert audits[0].target_attachment_id == attachment.application_attachment_id
+
+
+def test_process_deleted_attachment_already_deleted_audits_only(
+    enable_factory_create, db_session, s3_config, create_test_form
+):
+    application = ApplicationFactory.create()
+    attachment = ApplicationAttachmentFactory.create(application=application, setup_deleted=True)
+    user = attachment.user
+    form = _make_form(create_test_form)
+
+    with db_session.begin():
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=form,
+            user=user,
+            old_application_response={"att1": str(attachment.application_attachment_id)},
+            new_application_response={},
+        )
+
+    db_session.refresh(attachment)
+    # Still deleted, and file_location remains untouched.
+    assert attachment.is_deleted is True
+    assert attachment.file_location == "DELETED"
+
+    audits = _get_audits(db_session, application)
+    assert len(audits) == 1
+    assert audits[0].application_audit_event == ApplicationAuditEvent.ATTACHMENT_DELETED
+
+
+def test_process_no_change_no_audits(enable_factory_create, db_session, create_test_form):
+    application = ApplicationFactory.create()
+    attachment = ApplicationAttachmentFactory.create(application=application)
+    user = attachment.user
+    form = _make_form(create_test_form)
+
+    response = {"att1": str(attachment.application_attachment_id)}
+    with db_session.begin():
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=form,
+            user=user,
+            old_application_response=response,
+            new_application_response=response,
+        )
+
+    assert _get_audits(db_session, application) == []
+
+
+def test_process_form_without_attachment_fields_is_noop(
+    enable_factory_create, db_session, create_test_form
+):
+    application = ApplicationFactory.create()
+    attachment = ApplicationAttachmentFactory.create(application=application)
+    user = attachment.user
+    form = _make_form(
+        create_test_form,
+        form_ui_schema=[{"type": "field", "definition": "/properties/name", "widget": "Text"}],
+    )
+
+    with db_session.begin():
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=form,
+            user=user,
+            old_application_response={},
+            new_application_response={"att1": str(attachment.application_attachment_id)},
+        )
+
+    assert _get_audits(db_session, application) == []
+
+
+def test_process_unknown_attachment_id_is_skipped(
+    enable_factory_create, db_session, create_test_form
+):
+    application = ApplicationFactory.create()
+    user = ApplicationAttachmentFactory.create(application=application).user
+    form = _make_form(create_test_form)
+
+    with db_session.begin():
+        process_application_attachment_changes(
+            db_session=db_session,
+            application=application,
+            form=form,
+            user=user,
+            old_application_response={},
+            new_application_response={"att1": str(uuid.uuid4())},
+        )
+
+    assert _get_audits(db_session, application) == []


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11348

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Move attachment audit logging out of the attachment endpoints and onto form save, driven by a diff of the `application_response` payload.

- Add `process_application_attachment_changes`, which derives the attachment fields for a form, diffs the old and new `application_response`, and emits `ATTACHMENT_ADDED` / `ATTACHMENT_DELETED` audit events for the difference.
- Call it from `update_application_form` after the form response is saved, capturing the prior response before it is overwritten.
- Remove the `ATTACHMENT_ADDED` audit event from `create_application_attachment` and the `ATTACHMENT_DELETED` event from `delete_application_attachment`.
- Reconcile attachments that the diff identifies as deleted but that are not yet deleted: remove the file from S3, set `is_deleted=True` and `file_location='DELETED'`, and log that this happened.
- Allow `form_ui_schema` to be passed to the `create_test_form` fixture so tests can exercise attachment fields.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
In order to audit deleted attachments and associate added attachments to an application on form save, we need to update the [application form save endpoint](https://github.com/HHS/simpler-grants-gov/blob/57d298ba86497ac6faa93cfb7b4f0512019e9103/api/src/api/application_alpha/application_route.py#L154) to support diffing of the "application_response" payload we retrieve in the request JSON specifically for form fields that contain 1 or more attachments.

In addition we will need to remove the add and deleted audit events from the existing create application attachment and delete application attachment endpoints.In order to audit deleted attachments and associate added attachments to an application on form save, we need to update the [application form save endpoint](https://github.com/HHS/simpler-grants-gov/blob/57d298ba86497ac6faa93cfb7b4f0512019e9103/api/src/api/application_alpha/application_route.py#L154) to support diffing of the "application_response" payload we retrieve in the request JSON specifically for form fields that contain 1 or more attachments.

In addition we will need to remove the add and deleted audit events from the existing create application attachment and delete application attachment endpoints.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See updated unit tests.