### PR TITLE
[Issue#10305]- Bulk Edit Page Changes/Fixes

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
@@ -154,7 +154,7 @@ describe("RecommendationDetailForm", () => {
     });
   });
 
-    describe("recommendation type interactions", () => {
+  describe("recommendation type interactions", () => {
     it("shows exception checkbox for 'recommended_without_funding'", () => {
       render(<RecommendationDetailForm submission={mockSubmission} />);
 

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { identity } from "lodash";
 import { RecommendationDetailForm } from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
 import { AwardRecommendationSubmission } from "src/types/awardRecommendationTypes";
@@ -151,6 +151,194 @@ describe("RecommendationDetailForm", () => {
       // Should render single submission view, not table
       expect(screen.queryByText("applicationIdLabel")).not.toBeInTheDocument();
       expect(screen.getByText("recommendationLabel")).toBeInTheDocument();
+    });
+  });
+
+    describe("recommendation type interactions", () => {
+    it("shows exception checkbox for 'recommended_without_funding'", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      const select = screen.getByRole("combobox", {
+        name: /recommendationLabel/i,
+      });
+      fireEvent.change(select, {
+        target: { value: "recommended_without_funding" },
+      });
+
+      expect(screen.getByText("hasExceptionLabel")).toBeInTheDocument();
+    });
+
+    it("shows exception checkbox for 'not_recommended'", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      const select = screen.getByRole("combobox", {
+        name: /recommendationLabel/i,
+      });
+      fireEvent.change(select, { target: { value: "not_recommended" } });
+
+      expect(screen.getByText("hasExceptionLabel")).toBeInTheDocument();
+    });
+
+    it("does not show exception checkbox for 'recommended_for_funding'", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      expect(screen.queryByText("hasExceptionLabel")).not.toBeInTheDocument();
+    });
+
+    it("shows exception detail textarea when exception is checked", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      const select = screen.getByRole("combobox", {
+        name: /recommendationLabel/i,
+      });
+      fireEvent.change(select, {
+        target: { value: "recommended_without_funding" },
+      });
+
+      // Exception is auto-checked, so it should already be visible
+      expect(screen.getByText(/exceptionDetailLabel/i)).toBeInTheDocument();
+      expect(
+        screen.getByTestId("exception-detail-textarea"),
+      ).toBeInTheDocument();
+    });
+
+    it("automatically checks exception for 'recommended_without_funding'", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      const select = screen.getByRole("combobox", {
+        name: /recommendationLabel/i,
+      });
+      fireEvent.change(select, {
+        target: { value: "recommended_without_funding" },
+      });
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: /hasExceptionLabel/i,
+      });
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  describe("form field pre-population", () => {
+    it("pre-populates general comment from submission_detail", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      const textarea = screen.getByTestId("recommendation-comments-textarea");
+      expect(textarea).toHaveValue("Test comment");
+    });
+
+    it("pre-populates exception detail when provided", () => {
+      const submissionWithException: AwardRecommendationSubmission = {
+        ...mockSubmission,
+        submission_detail: {
+          award_recommendation_type: "recommended_without_funding",
+          recommended_amount: "75000.00",
+          has_exception: true,
+          exception_detail: "Exception reason here",
+        },
+      };
+
+      render(<RecommendationDetailForm submission={submissionWithException} />);
+
+      const textarea = screen.getByTestId("exception-detail-textarea");
+      expect(textarea).toHaveValue("Exception reason here");
+    });
+
+    it("pre-selects correct recommendation type", () => {
+      const submissionNotRecommended: AwardRecommendationSubmission = {
+        ...mockSubmission,
+        submission_detail: {
+          award_recommendation_type: "not_recommended",
+          recommended_amount: "0.00",
+        },
+      };
+
+      render(
+        <RecommendationDetailForm submission={submissionNotRecommended} />,
+      );
+
+      const select = screen.getByRole("combobox", {
+        name: /recommendationLabel/i,
+      });
+      expect(select).toHaveValue("not_recommended");
+    });
+  });
+
+  describe("multiple submissions table", () => {
+    it("renders input fields for each submission", () => {
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, mockSubmission2]}
+        />,
+      );
+
+      // Check that both recommended amount inputs are rendered
+      expect(screen.getByDisplayValue("$75,000")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("$25,000")).toBeInTheDocument();
+    });
+
+    it("displays application IDs in table rows", () => {
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, mockSubmission2]}
+        />,
+      );
+
+      expect(screen.getByText("app-1")).toBeInTheDocument();
+      expect(screen.getByText("app-2")).toBeInTheDocument();
+    });
+
+    it("handles missing application data gracefully", () => {
+      const submissionNoApp: AwardRecommendationSubmission = {
+        award_recommendation_application_submission_id: "test-id-3",
+        application_submission: {
+          application_submission_id: "app-sub-3",
+          total_requested_amount: "30000.00",
+        },
+      };
+
+      render(
+        <RecommendationDetailForm
+          submissions={[mockSubmission, submissionNoApp]}
+        />,
+      );
+
+      expect(screen.getByText("totalLabel")).toBeInTheDocument();
+    });
+  });
+
+  describe("required fields", () => {
+    it("marks recommendation type as required", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      const select = screen.getByRole("combobox", {
+        name: /recommendationLabel/i,
+      });
+      expect(select).toBeRequired();
+    });
+
+    it("marks recommended amount as required", () => {
+      render(<RecommendationDetailForm submission={mockSubmission} />);
+
+      const input = screen.getByDisplayValue("$75,000");
+      expect(input).toBeRequired();
+    });
+
+    it("marks exception detail as required when shown", () => {
+      const submissionWithException: AwardRecommendationSubmission = {
+        ...mockSubmission,
+        submission_detail: {
+          award_recommendation_type: "recommended_without_funding",
+          recommended_amount: "75000.00",
+          has_exception: true,
+          exception_detail: "Test exception",
+        },
+      };
+
+      render(<RecommendationDetailForm submission={submissionWithException} />);
+
+      const textarea = screen.getByTestId("exception-detail-textarea");
+      expect(textarea).toBeRequired();
     });
   });
 });

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
@@ -162,14 +162,15 @@ const RecommendationFields = ({
 
 const FundingRecommendationRow = ({
   submission,
+  recommendedAmount,
+  onRecommendedAmountChange,
 }: {
   submission: AwardRecommendationSubmission;
+  recommendedAmount: string;
+  onRecommendedAmountChange: (value: string) => void;
 }) => {
   const submissionId =
     submission.award_recommendation_application_submission_id;
-  const [recommendedAmount, setRecommendedAmount] = useState(
-    formatCurrencyString(submission.submission_detail?.recommended_amount),
-  );
 
   return (
     <tr>
@@ -185,9 +186,9 @@ const FundingRecommendationRow = ({
           name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
           type="text"
           value={recommendedAmount}
-          onChange={(event) => setRecommendedAmount(event.target.value)}
+          onChange={(event) => onRecommendedAmountChange(event.target.value)}
           onBlur={(event) =>
-            setRecommendedAmount(formatCurrencyString(event.target.value))
+            onRecommendedAmountChange(formatCurrencyString(event.target.value))
           }
           required
         />
@@ -202,6 +203,36 @@ const FundingSectionMultiple = ({
   submissions: AwardRecommendationSubmission[];
 }) => {
   const t = useTranslations("AwardRecommendation.recommendationDetails");
+
+  const [recommendedAmounts, setRecommendedAmounts] = useState<
+    Record<string, string>
+  >(() => {
+    const initial: Record<string, string> = {};
+    submissions.forEach((sub) => {
+      initial[sub.award_recommendation_application_submission_id] =
+        formatCurrencyString(sub.submission_detail?.recommended_amount);
+    });
+    return initial;
+  });
+
+  const handleAmountChange = (submissionId: string, value: string) => {
+    setRecommendedAmounts((prev) => ({
+      ...prev,
+      [submissionId]: value,
+    }));
+  };
+
+  const totalRequested = submissions.reduce(
+    (sum, s) =>
+      sum +
+      getNumericAmountFromString(s.application_submission.total_requested_amount),
+    0,
+  );
+
+  const totalRecommended = submissions.reduce((sum, s) => {
+    const submissionId = s.award_recommendation_application_submission_id;
+    return sum + getNumericAmountFromString(recommendedAmounts[submissionId]);
+  }, 0);
 
   return (
     <div className="margin-top-4">
@@ -238,34 +269,23 @@ const FundingSectionMultiple = ({
               <FundingRecommendationRow
                 key={sub.award_recommendation_application_submission_id}
                 submission={sub}
+                recommendedAmount={
+                  recommendedAmounts[
+                    sub.award_recommendation_application_submission_id
+                  ]
+                }
+                onRecommendedAmountChange={(value) =>
+                  handleAmountChange(
+                    sub.award_recommendation_application_submission_id,
+                    value,
+                  )
+                }
               />
             ))}
             <tr>
               <td>{t("totalLabel")}</td>
-              <td>
-                {formatCurrency(
-                  submissions.reduce(
-                    (sum, s) =>
-                      sum +
-                      getNumericAmountFromString(
-                        s.application_submission.total_requested_amount,
-                      ),
-                    0,
-                  ),
-                )}
-              </td>
-              <td>
-                {formatCurrency(
-                  submissions.reduce(
-                    (sum, s) =>
-                      sum +
-                      getNumericAmountFromString(
-                        s.submission_detail?.recommended_amount,
-                      ),
-                    0,
-                  ),
-                )}
-              </td>
+              <td>{formatCurrency(totalRequested)}</td>
+              <td>{formatCurrency(totalRecommended)}</td>
             </tr>
           </tbody>
         </table>

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
@@ -225,7 +225,9 @@ const FundingSectionMultiple = ({
   const totalRequested = submissions.reduce(
     (sum, s) =>
       sum +
-      getNumericAmountFromString(s.application_submission.total_requested_amount),
+      getNumericAmountFromString(
+        s.application_submission.total_requested_amount,
+      ),
     0,
   );
 

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
@@ -309,6 +309,40 @@ describe("EditRecommendationsForm", () => {
       const hundredThousandElements = screen.getAllByText("$100,000");
       expect(hundredThousandElements.length).toBeGreaterThanOrEqual(1);
     });
+
+    it("updates total recommended amount when user changes individual amounts", async () => {
+      const user = userEvent.setup();
+      render(
+        <EditRecommendationsForm
+          awardRecommendationId={awardRecommendationId}
+        />,
+      );
+
+      // Verify initial state - total requested and total recommended
+      const initialTotalRequested = screen.getByText("$150,000");
+      expect(initialTotalRequested).toBeInTheDocument();
+      
+      // Initial total recommended: $75,000 + $25,000 = $100,000
+      // Note: $100,000 appears twice (as requested amount and total recommended)
+      const hundredThousandElements = screen.getAllByText("$100,000");
+      expect(hundredThousandElements.length).toBeGreaterThanOrEqual(2);
+
+      // Find the first recommended amount input by its display value
+      const firstInput = screen.getByDisplayValue("$75,000");
+
+      // Clear and update the first submission's recommended amount to $80,000
+      await user.clear(firstInput);
+      await user.type(firstInput, "80000");
+      await user.tab();
+
+      // New total should be: $80,000 + $25,000 = $105,000
+      await waitFor(() => {
+        expect(screen.getByText("$105,000")).toBeInTheDocument();
+      });
+      
+      // Verify total requested hasn't changed
+      expect(screen.getByText("$150,000")).toBeInTheDocument();
+    });
   });
 
   describe("error handling", () => {

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.test.tsx
@@ -321,7 +321,7 @@ describe("EditRecommendationsForm", () => {
       // Verify initial state - total requested and total recommended
       const initialTotalRequested = screen.getByText("$150,000");
       expect(initialTotalRequested).toBeInTheDocument();
-      
+
       // Initial total recommended: $75,000 + $25,000 = $100,000
       // Note: $100,000 appears twice (as requested amount and total recommended)
       const hundredThousandElements = screen.getAllByText("$100,000");
@@ -339,7 +339,7 @@ describe("EditRecommendationsForm", () => {
       await waitFor(() => {
         expect(screen.getByText("$105,000")).toBeInTheDocument();
       });
-      
+
       // Verify total requested hasn't changed
       expect(screen.getByText("$150,000")).toBeInTheDocument();
     });

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
@@ -82,7 +82,7 @@ export default function EditRecommendationsForm({
       </h2>
 
       {isMultipleSubmissions && (
-       <div className="bg-base-lightest padding-2 margin-bottom-2">
+        <div className="bg-base-lightest padding-2 margin-bottom-2">
           <p className="margin-0 text-bold">
             {selectedSubmissions.length} {t("submissionsSelected")}
           </p>

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
@@ -82,9 +82,11 @@ export default function EditRecommendationsForm({
       </h2>
 
       {isMultipleSubmissions && (
-        <p className="margin-top-0 margin-bottom-2 text-base">
-          {selectedSubmissions.length} {t("submissionsSelected")}
-        </p>
+       <div className="bg-base-lightest padding-2 margin-bottom-2">
+          <p className="margin-0 text-bold">
+            {selectedSubmissions.length} {t("submissionsSelected")}
+          </p>
+        </div>
       )}
 
       <SelectedApplicationsTable

--- a/frontend/src/utils/formatCurrencyUtil.test.ts
+++ b/frontend/src/utils/formatCurrencyUtil.test.ts
@@ -76,4 +76,16 @@ describe("getNumericAmountFromString", () => {
   it("returns 0 for non-numeric strings", () => {
     expect(getNumericAmountFromString("abc")).toBe(0);
   });
+
+  it("parses a formatted currency string with dollar sign and commas", () => {
+    expect(getNumericAmountFromString("$1,234")).toBe(1234);
+  });
+
+  it("parses a formatted currency string with dollar sign", () => {
+    expect(getNumericAmountFromString("$75000")).toBe(75000);
+  });
+
+  it("parses large formatted amounts", () => {
+    expect(getNumericAmountFromString("$1,234,567.89")).toBe(1234567.89);
+  });
 });

--- a/frontend/src/utils/formatCurrencyUtil.ts
+++ b/frontend/src/utils/formatCurrencyUtil.ts
@@ -22,6 +22,6 @@ export const formatCurrencyString = (value?: string) => {
 export const getNumericAmountFromString = (
   value: string | null | undefined,
 ): number => {
-  const raw = (value ?? "").replace(/,/g, "");
+  const raw = (value ?? "").replace(/[$,\s]/g, "");
   return Number(raw) || 0;
 };


### PR DESCRIPTION
Summary
Fixes https://github.com/HHS/simpler-grants-gov/issues/10305

Changes proposed
Styling fixes in Bulk Edit Page
Added More Unit Test cases

Context for reviewers
Most of the dev work for this is completed as part of https://github.com/HHS/simpler-grants-gov/issues/10304
Styling fixes in Bulk Edit Page
Added More Unit Test cases

Validation steps

- Navigate to Edit award recommendation page and click on Edit Recommended awards, If submissions are done for an opportunity those will be shown in the table
- we can select/deselect single or multiple submissions from the table.
- selecting a single submission and click on edit button redirects us to bulk edit screen with selected submission in table and controls for recommendation type, comments and amount related controls, checking on checkbox shows exception detail text input area.
- we can observe almost the same behavior if we select multiple submissions except multiple submissions are shown in the table and table is shown for requested and recommended amounts.