### PR TITLE
[Issue #11517] Handle GetApplicationZip request with header and footer

### DIFF
--- a/api/src/legacy_soap_api/soap_payload_handler.py
+++ b/api/src/legacy_soap_api/soap_payload_handler.py
@@ -15,6 +15,10 @@ XML_DICT_KEY_ATTRIBUTE_PREFIX = "@"
 XML_DICT_KEY_TEXT_VALUE_KEY = "#text"
 CHUNK_SIZE = 1000
 NUMBER_OF_CHUNKS = 5
+SOAP_ENV_SHORT_PATTERNS = (b"<soap:Envelope", b"</soap:Envelope>")
+SOAP_ENV_LONG_PATTERNS = (b"<soapenv:Envelope", b"</soapenv:Envelope>")
+SOAP_PATTERNS = [SOAP_ENV_SHORT_PATTERNS, SOAP_ENV_LONG_PATTERNS]
+MAX_TAG_SIZE = len(SOAP_ENV_LONG_PATTERNS[1])
 
 
 class SOAPPayload:
@@ -207,11 +211,6 @@ def get_soap_envelope_from_payload(soap_message: str) -> SOAPEnvelopeData:
 
 
 def extract_soap_xml(soap_bytes: bytes) -> bytes:
-    soap_patterns = [
-        (b"<soap:Envelope", b"</soap:Envelope>"),
-        (b"<soapenv:Envelope", b"</soapenv:Envelope>"),
-    ]
-    max_tag_size = max(len(p[0]) for p in soap_patterns)
     bytes_stream = io.BytesIO(soap_bytes)
     buffer = b""
     total_bytes_read = 0
@@ -226,7 +225,7 @@ def extract_soap_xml(soap_bytes: bytes) -> bytes:
         if not chunk:
             break
         current_data = buffer + chunk
-        for start_pattern, end_pattern in soap_patterns:
+        for start_pattern, end_pattern in SOAP_PATTERNS:
             match_index = current_data.find(start_pattern)
             if match_index != -1:
                 start_position = (total_bytes_read - len(buffer)) + match_index
@@ -234,7 +233,7 @@ def extract_soap_xml(soap_bytes: bytes) -> bytes:
                 break
         if start_position != -1:
             break
-        buffer = current_data[-max_tag_size:]
+        buffer = current_data[-MAX_TAG_SIZE:]
         total_bytes_read += len(chunk)
         count -= 1
 

--- a/api/src/legacy_soap_api/soap_payload_handler.py
+++ b/api/src/legacy_soap_api/soap_payload_handler.py
@@ -207,25 +207,48 @@ def get_soap_envelope_from_payload(soap_message: str) -> SOAPEnvelopeData:
 
 
 def extract_soap_xml(soap_bytes: bytes) -> bytes:
-    soap_patterns = [b"<soap:Envelope", b"<soapenv:Envelope"]
-    max_tag_size = len(soap_patterns[1])
+    soap_patterns = [
+        (b"<soap:Envelope", b"</soap:Envelope>"),
+        (b"<soapenv:Envelope", b"</soapenv:Envelope>"),
+    ]
+    max_tag_size = max(len(p[0]) for p in soap_patterns)
     bytes_stream = io.BytesIO(soap_bytes)
     buffer = b""
     total_bytes_read = 0
     count = NUMBER_OF_CHUNKS
+
+    start_position = -1
+    matched_end_pattern = None
+
+    # Scan chunk for opening tag
     while count > 0:
         chunk = bytes_stream.read(CHUNK_SIZE)
         if not chunk:
             break
         current_data = buffer + chunk
-        for pattern in soap_patterns:
-            match_index = current_data.find(pattern)
+        for start_pattern, end_pattern in soap_patterns:
+            match_index = current_data.find(start_pattern)
             if match_index != -1:
                 start_position = (total_bytes_read - len(buffer)) + match_index
-                return soap_bytes[start_position:]
+                matched_end_pattern = end_pattern
+                break
+        if start_position != -1:
+            break
         buffer = current_data[-max_tag_size:]
         total_bytes_read += len(chunk)
         count -= 1
+
+    if start_position == -1:
+        return b""
+
+    if matched_end_pattern is not None:
+        end_index = soap_bytes.find(matched_end_pattern, start_position)
+        # To handle scenarios where the xml is not closed, if you can't find the end tag then just return everything
+        if end_index == -1:
+            return soap_bytes[start_position:]
+
+        end_position = end_index + len(matched_end_pattern)
+        return soap_bytes[start_position:end_position]
     return b""
 
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -805,6 +805,62 @@ def test_invalid_xml_server_error_500(client) -> None:
 
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
+def test_getapplication_operation_returns_not_found_response_if_simpler_id_is_used_with_mime_boundaries(
+    mock_get_soap_response, mock_uuid, client, fixture_from_file, enable_factory_create
+) -> None:
+    test_uuid = "00000000-aaaa-0000-bbbb-000000000000"
+    mock_uuid.return_value = test_uuid
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: binary\r\n"
+        "Content-ID: <0.urn:uuid:9467EB4D41266EA2C91784229922208@apache.org>\r\n\r\n"
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:GetApplicationRequest>"
+        f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">{SIMPLER_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>'
+        "</agen:GetApplicationRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>/r/n"
+        "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207--"
+    )
+    agency = AgencyFactory.create()
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
+    response = client.post(
+        full_path,
+        data=mock_data,
+        headers={"Connection": "close", MTLS_CERT_HEADER_KEY: mtls_cert},
+    )
+    expected = (
+        f"--uuid:{test_uuid}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: binary\r\n"
+        "Content-ID: <root.message@cxf.apache.org>"
+        '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body><soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        f"<faultstring>Failed to get application.(Grant Application not found for tracking number:{SIMPLER_TRACKING_NUMBER})"
+        "</faultstring></soap:Fault></soap:Body></soap:Envelope>\r\n"
+        f"--uuid:{test_uuid}--"
+    ).encode("utf-8")
+    mock_get_soap_response.assert_not_called()
+    assert response.status_code == 500
+    assert expected == response.data
+    assert (
+        response.headers["Content-Type"]
+        == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
+    )
+    assert response.headers["Set-Cookie"] == "None; Path=/grantsws-agency; Secure; HttpOnly"
+
+
+@mock.patch("uuid.uuid4")
+@mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
 def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is_used_with_mime_boundaries(
     mock_get_soap_response, mock_uuid, client, fixture_from_file, enable_factory_create
 ) -> None:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -805,23 +805,36 @@ def test_invalid_xml_server_error_500(client) -> None:
 
 @mock.patch("uuid.uuid4")
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
-def test_getapplication_operation_returns_not_found_response_if_simpler_id_is_used(
+def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is_used_with_mime_boundaries(
     mock_get_soap_response, mock_uuid, client, fixture_from_file, enable_factory_create
 ) -> None:
     test_uuid = "00000000-aaaa-0000-bbbb-000000000000"
     mock_uuid.return_value = test_uuid
     full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
-    fixture_path = "/legacy_soap_api/grantors/get_application_request.xml"
-    mock_data = fixture_from_file(fixture_path)
-    envelope = etree.fromstring(mock_data)
-    tracking_number = envelope.find(GET_APPLICATION_PATH)
-    tracking_number.text = SIMPLER_TRACKING_NUMBER
+    mock_data = (
+        "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: binary\r\n"
+        "Content-ID: <0.urn:uuid:9467EB4D41266EA2C91784229922208@apache.org>\r\n\r\n"
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:GetApplicationZipRequest>"
+        f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">{SIMPLER_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>'
+        "</agen:GetApplicationZipRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>/r/n"
+        "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207--"
+    )
     agency = AgencyFactory.create()
     privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
     user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
     response = client.post(
         full_path,
-        data=etree.tostring(envelope),
+        data=mock_data,
         headers={"Connection": "close", MTLS_CERT_HEADER_KEY: mtls_cert},
     )
     expected = (
@@ -832,14 +845,13 @@ def test_getapplication_operation_returns_not_found_response_if_simpler_id_is_us
         '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
         "<soap:Body><soap:Fault>"
         "<faultcode>soap:Server</faultcode>"
-        f"<faultstring>Failed to get application.(Grant Application not found for tracking number:{tracking_number.text})"
+        f"<faultstring>Failed to get application zip.(Grant Application not found for tracking number:{SIMPLER_TRACKING_NUMBER})"
         "</faultstring></soap:Fault></soap:Body></soap:Envelope>\r\n"
         f"--uuid:{test_uuid}--"
     ).encode("utf-8")
     mock_get_soap_response.assert_not_called()
     assert response.status_code == 500
     assert expected == response.data
-    assert response.headers["Content-Length"] == "523"
     assert (
         response.headers["Content-Type"]
         == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'

--- a/api/tests/src/legacy_soap_api/test_soap_payload_handler.py
+++ b/api/tests/src/legacy_soap_api/test_soap_payload_handler.py
@@ -2,10 +2,12 @@ import unittest
 
 import pytest
 
+from src.legacy_soap_api.legacy_soap_api_utils import get_gov_grants_tracking_number
 from src.legacy_soap_api.soap_payload_handler import (
     SOAPEnvelopeData,
     SOAPPayload,
     build_xml_from_dict,
+    extract_soap_xml,
     get_envelope_dict,
     get_soap_envelope_from_payload,
     get_soap_operation_name,
@@ -51,7 +53,7 @@ MOCK_SOAP_REQUEST_ENVELOPE = f"""
     "utf-8"
 )
 MOCK_SOAP_REQUEST_ALT_ENVELOPE = f"""
-    <soap:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:app="http://schemas.xmlsoap.org/services/ApplicantWebServices-V2.0">
+    <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:app="http://schemas.xmlsoap.org/services/ApplicantWebServices-V2.0">
     \n   <soapenv:Header/>\n   <soapenv:Body>\n      <app:{MOCK_SOAP_OPERATION_NAME}>\n         <app:OperationName2>
     </app:OperationName2>\n<!--Zero or more repetitions:-->\n          <gran:Attachment>\n
                  <gran:FileContentId>Dummy.pdf</gran:FileContentId>\n\t        <gran:FileDataHandler>
@@ -325,3 +327,59 @@ class TestGetSoapOperationName(unittest.TestCase):
             (FIVE_CHUNKS + MOCK_SOAP_REQUEST_ENVELOPE.decode()).encode("utf-8")
         )
         assert result == ""
+
+
+class TestExtractSoapXML(unittest.TestCase):
+    def test_extract_soap_xml_can_handle_incoming_soap_xml_with_header_and_footer(self):
+        soap_bytes = (
+            "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207"
+            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"'
+            "Content-Transfer-Encoding: binary"
+            "Content-ID: <0.urn:uuid:9467EB4D41266EA2C91784229922208@apache.org>"
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<soapenv:Body><agen:GetApplicationZipRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">'
+            '<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT80000038</gran:GrantsGovTrackingNumber></agen:GetApplicationZipRequest></soapenv:Body></soapenv:Envelope>'
+            "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207--"
+        ).encode("utf-8")
+        xml_bytes = extract_soap_xml(soap_bytes)
+        expected = (
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">'
+            "<soapenv:Body>"
+            '<agen:GetApplicationZipRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">'
+            '<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT80000038</gran:GrantsGovTrackingNumber>'
+            "</agen:GetApplicationZipRequest>"
+            "</soapenv:Body>"
+            "</soapenv:Envelope>"
+        ).encode("utf-8")
+        assert xml_bytes == expected
+
+    def test_extract_soap_xml_can_handle_incoming_soap_xml_without_header_and_footer(self):
+        soap_bytes = (
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<soapenv:Body><agen:GetApplicationZipRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">'
+            '<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT80000038</gran:GrantsGovTrackingNumber></agen:GetApplicationZipRequest></soapenv:Body></soapenv:Envelope>'
+        ).encode("utf-8")
+        xml_bytes = extract_soap_xml(soap_bytes)
+        expected = (
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">'
+            "<soapenv:Body>"
+            '<agen:GetApplicationZipRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">'
+            '<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT80000038</gran:GrantsGovTrackingNumber>'
+            "</agen:GetApplicationZipRequest>"
+            "</soapenv:Body>"
+            "</soapenv:Envelope>"
+        ).encode("utf-8")
+        assert xml_bytes == expected
+
+    def test_can_get_grants_gov_tracking_number_from_incoming_soap_xml_without_headers(self):
+        soap_bytes = (
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<soapenv:Body><agen:GetApplicationZipRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">'
+            '<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT80000038</gran:GrantsGovTrackingNumber></agen:GetApplicationZipRequest></soapenv:Body></soapenv:Envelope>'
+        ).encode("utf-8")
+        xml_bytes = extract_soap_xml(soap_bytes)
+        result = get_gov_grants_tracking_number(xml_bytes)
+        assert result == "GRANT80000038"

--- a/api/tests/validate_legacy_soap_api/validate_soap_endpoints.py
+++ b/api/tests/validate_legacy_soap_api/validate_soap_endpoints.py
@@ -22,6 +22,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from grants_shared.adapters.db import PostgresDBClient
+from grants_shared.util import file_util
 from grants_shared.util.local import error_if_not_local
 from lxml import etree
 from pydantic import Field
@@ -33,7 +34,6 @@ from src.db.models import staging
 from src.db.models.agency_models import Agency
 from src.db.models.competition_models import ApplicationSubmission
 from src.db.models.user_models import LegacyCertificate
-from src.util import file_util
 from src.util.env_config import PydanticBaseEnvConfig
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11517 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Modified the `extract_soap_xml` method to stop if it can find a closing tag
- Adding a `field_validator` to handle case where incoming request data is dictified with a dict value for `GrantsGovTrackingNumber`
- Changed a FaultException message

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Grant Solutions `GetApplicationZip` requests are failing and it looks like their requests are in an unexpected format. This code updates how we handle this format of soap message. The FaultException message was for ConfirmApplicationDelivery so I updated that to a more generic one to not be confusing.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
- [ ] can use format with headers to query soap proxy
