### PR TITLE
[Issue #11163] Setup API key auth for grantor API

### DIFF
--- a/backend/grants_management_api/src/auth/api_user_key_auth.py
+++ b/backend/grants_management_api/src/auth/api_user_key_auth.py
@@ -1,0 +1,94 @@
+"""API key authentication for grants management API.
+
+Provides X-API-Key header authentication following the same pattern as the find/apply API.
+"""
+
+import logging
+from typing import cast
+
+import grants_shared.util.datetime_util as datetime_util
+from apiflask import APIKeyHeaderAuth
+from grants_shared.adapters import db
+from grants_shared.adapters.db import flask_db
+from grants_shared.api.route_utils import raise_flask_error
+from grants_shared.logs.flask_logger import add_extra_data_to_current_request_logs
+
+from src.auth.auth_handler import MgmtAuthHandler
+from src.db.models.user_models import MgmtUser, MgmtUserApiKey
+
+logger = logging.getLogger(__name__)
+
+
+class ApiUserKeyHttpTokenAuth(APIKeyHeaderAuth):
+    """Custom HTTPTokenAuth that provides typed access to the current user API key and user."""
+
+    def get_user_api_key(self) -> MgmtUserApiKey:
+        """Wrapper method around the current_user value to handle type issues.
+
+        Note that this value gets set based on whatever is returned from the method
+        you configure for @<your ApiUserKeyHttpTokenAuth obj>.verify_token
+        """
+        return cast(MgmtUserApiKey, self.current_user)
+
+    def get_user(self) -> MgmtUser:
+        """Get the User associated with the current API key.
+
+        This is a convenience method since we typically only care about
+        the user, not the API key itself.
+        """
+        return self.get_user_api_key().mgmt_user
+
+
+# Initialize the authorization context for API Gateway key authentication
+# This uses the X-API-Key header which is the standard header that AWS API Gateway
+# forwards when api_key_required is set to true
+api_user_key_auth = ApiUserKeyHttpTokenAuth(
+    "ApiKey", param_name="X-API-Key", security_scheme_name="ApiUserKeyAuth"
+)
+
+
+class ApiKeyValidationError(Exception):
+    """Exception raised when API key validation fails"""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
+@api_user_key_auth.verify_token
+@flask_db.with_db_session()
+def verify_api_key(db_session: db.Session, token: str) -> MgmtUserApiKey:
+    logger.info("Authenticating API Gateway key")
+
+    with db_session.begin():
+        try:
+            api_key = validate_api_key_in_db(token, db_session)
+        except ApiKeyValidationError as e:
+            logger.info("API Gateway key authentication failed", extra={"auth.issue": e.message})
+            raise_flask_error(401, e.message)
+
+        api_key.last_used = datetime_util.utcnow()
+        db_session.add(api_key)
+
+        add_extra_data_to_current_request_logs(
+            {
+                "auth.user_id": api_key.mgmt_user_id,
+                "auth.api_key_id": str(api_key.mgmt_api_key_id),
+            }
+        )
+
+        logger.info("API Gateway key authentication successful")
+
+        return api_key
+
+
+def validate_api_key_in_db(api_key: str, db_session: db.Session) -> MgmtUserApiKey:
+    user_api_key = MgmtAuthHandler(db_session).get_api_key_by_key_id(api_key)
+
+    if user_api_key is None:
+        raise ApiKeyValidationError("Invalid API key")
+
+    if not user_api_key.is_active:
+        raise ApiKeyValidationError("API key is inactive")
+
+    return user_api_key

--- a/backend/grants_management_api/src/auth/api_user_key_auth.py
+++ b/backend/grants_management_api/src/auth/api_user_key_auth.py
@@ -70,12 +70,7 @@ def verify_api_key(db_session: db.Session, token: str) -> MgmtUserApiKey:
         api_key.last_used = datetime_util.utcnow()
         db_session.add(api_key)
 
-        add_extra_data_to_current_request_logs(
-            {
-                "auth.user_id": api_key.mgmt_user_id,
-                "auth.api_key_id": str(api_key.mgmt_api_key_id),
-            }
-        )
+        add_extra_data_to_current_request_logs(api_key.get_log_extra())
 
         logger.info("API Gateway key authentication successful")
 

--- a/backend/grants_management_api/tests/auth/test_api_user_key_auth.py
+++ b/backend/grants_management_api/tests/auth/test_api_user_key_auth.py
@@ -14,10 +14,11 @@ from tests.db.models.factories import MgmtUserApiKeyFactory, MgmtUserFactory
 
 @pytest.fixture(scope="module")
 def mini_app(monkeypatch_module):
+    """Create a separate app that we can modify separate from the base one used by other tests"""
+
     def stub(app):
         pass
 
-    """Create a separate app that we can modify separate from the base one used by other tests"""
     monkeypatch_module.setattr(app_entry, "register_blueprints", stub)
     monkeypatch_module.setattr(app_entry, "setup_logging", stub)
     mini_app = app_entry.create_app()

--- a/backend/grants_management_api/tests/auth/test_api_user_key_auth.py
+++ b/backend/grants_management_api/tests/auth/test_api_user_key_auth.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import grants_shared.logs
 import pytest
 from freezegun import freeze_time
@@ -65,6 +67,7 @@ def test_validate_api_key_in_db_key_inactive(enable_factory_create, db_session):
 @freeze_time("2024-11-14 12:00:00", tz_offset=0)
 def test_api_user_key_auth_happy_path(mini_app, enable_factory_create, db_session):
     """Test successful API Gateway key authentication"""
+
     user = MgmtUserFactory.create()
     api_key = MgmtUserApiKeyFactory.create(
         mgmt_user=user, key_id="valid-gateway-key", is_active=True, last_used=None
@@ -78,7 +81,7 @@ def test_api_user_key_auth_happy_path(mini_app, enable_factory_create, db_sessio
     assert resp.get_json()["message"] == "ok"
 
     db_session.refresh(api_key)
-    assert api_key.last_used is not None
+    assert api_key.last_used == datetime(2024, 11, 14, 12, 0, 0, tzinfo=timezone.utc)
 
 
 def test_api_user_key_auth_invalid_key(mini_app, enable_factory_create, db_session):

--- a/backend/grants_management_api/tests/auth/test_api_user_key_auth.py
+++ b/backend/grants_management_api/tests/auth/test_api_user_key_auth.py
@@ -1,0 +1,135 @@
+import grants_shared.logs
+import pytest
+from freezegun import freeze_time
+
+import src.app as app_entry
+from src.auth.api_user_key_auth import (
+    ApiKeyValidationError,
+    api_user_key_auth,
+    validate_api_key_in_db,
+)
+from src.db.models.user_models import MgmtUserApiKey
+from tests.db.models.factories import MgmtUserApiKeyFactory, MgmtUserFactory
+
+
+@pytest.fixture(scope="module")
+def mini_app(monkeypatch_module):
+    def stub(app):
+        pass
+
+    """Create a separate app that we can modify separate from the base one used by other tests"""
+    monkeypatch_module.setattr(app_entry, "register_blueprints", stub)
+    monkeypatch_module.setattr(app_entry, "setup_logging", stub)
+    mini_app = app_entry.create_app()
+
+    @mini_app.get("/dummy_auth_endpoint")
+    @mini_app.auth_required(api_user_key_auth)
+    def dummy_endpoint():
+        assert api_user_key_auth.current_user is not None
+        assert isinstance(api_user_key_auth.current_user, MgmtUserApiKey)
+
+        return {"message": "ok"}
+
+    with grants_shared.logs.init(__package__):
+        yield mini_app
+
+
+def test_validate_api_key_in_db_success(enable_factory_create, db_session):
+    """Test successful API key validation"""
+    user = MgmtUserFactory.create()
+    api_key = MgmtUserApiKeyFactory.create(mgmt_user=user, key_id="test-key-123", is_active=True)
+
+    result = validate_api_key_in_db("test-key-123", db_session)
+
+    assert result.mgmt_api_key_id == api_key.mgmt_api_key_id
+    assert result.mgmt_user_id == user.mgmt_user_id
+    assert result.is_active is True
+
+
+def test_validate_api_key_in_db_key_not_found(enable_factory_create, db_session):
+    """Test API key validation when key doesn't exist"""
+    with pytest.raises(ApiKeyValidationError, match="Invalid API key"):
+        validate_api_key_in_db("nonexistent-key", db_session)
+
+
+def test_validate_api_key_in_db_key_inactive(enable_factory_create, db_session):
+    """Test API key validation when key is inactive"""
+    user = MgmtUserFactory.create()
+    MgmtUserApiKeyFactory.create(mgmt_user=user, key_id="inactive-key", is_active=False)
+
+    with pytest.raises(ApiKeyValidationError, match="API key is inactive"):
+        validate_api_key_in_db("inactive-key", db_session)
+
+
+@freeze_time("2024-11-14 12:00:00", tz_offset=0)
+def test_api_user_key_auth_happy_path(mini_app, enable_factory_create, db_session):
+    """Test successful API Gateway key authentication"""
+    user = MgmtUserFactory.create()
+    api_key = MgmtUserApiKeyFactory.create(
+        mgmt_user=user, key_id="valid-gateway-key", is_active=True, last_used=None
+    )
+
+    resp = mini_app.test_client().get(
+        "/dummy_auth_endpoint", headers={"X-API-Key": "valid-gateway-key"}
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["message"] == "ok"
+
+    db_session.refresh(api_key)
+    assert api_key.last_used is not None
+
+
+def test_api_user_key_auth_invalid_key(mini_app, enable_factory_create, db_session):
+    """Test API Gateway key authentication with invalid key"""
+    resp = mini_app.test_client().get("/dummy_auth_endpoint", headers={"X-API-Key": "invalid-key"})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Invalid API key"
+
+
+def test_api_user_key_auth_inactive_key(mini_app, enable_factory_create, db_session):
+    """Test API Gateway key authentication with inactive key"""
+    user = MgmtUserFactory.create()
+    MgmtUserApiKeyFactory.create(mgmt_user=user, key_id="inactive-gateway-key", is_active=False)
+
+    resp = mini_app.test_client().get(
+        "/dummy_auth_endpoint", headers={"X-API-Key": "inactive-gateway-key"}
+    )
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "API key is inactive"
+
+
+def test_api_user_key_auth_no_key_header(mini_app, enable_factory_create, db_session):
+    """Test API Gateway key authentication with missing header"""
+    resp = mini_app.test_client().get("/dummy_auth_endpoint", headers={})
+
+    assert resp.status_code == 401
+
+
+def test_api_user_key_auth_empty_key_header(mini_app, enable_factory_create, db_session):
+    """Test API Gateway key authentication with empty header"""
+    resp = mini_app.test_client().get("/dummy_auth_endpoint", headers={"X-API-Key": ""})
+
+    assert resp.status_code == 401
+    assert resp.get_json()["message"] == "Unauthorized"
+
+
+def test_api_user_key_auth_multiple_active_keys(mini_app, enable_factory_create, db_session):
+    """Test that different API keys for the same user work independently"""
+    user = MgmtUserFactory.create()
+    api_key1 = MgmtUserApiKeyFactory.create(mgmt_user=user, key_id="user-key-1", is_active=True)
+    api_key2 = MgmtUserApiKeyFactory.create(mgmt_user=user, key_id="user-key-2", is_active=True)
+
+    resp1 = mini_app.test_client().get("/dummy_auth_endpoint", headers={"X-API-Key": "user-key-1"})
+    assert resp1.status_code == 200
+
+    resp2 = mini_app.test_client().get("/dummy_auth_endpoint", headers={"X-API-Key": "user-key-2"})
+    assert resp2.status_code == 200
+
+    # Verify both keys had their last_used updated
+    db_session.refresh(api_key1)
+    db_session.refresh(api_key2)
+    assert api_key1.last_used is not None
+    assert api_key2.last_used is not None

--- a/backend/grants_management_api/tests/db/models/factories.py
+++ b/backend/grants_management_api/tests/db/models/factories.py
@@ -1,3 +1,4 @@
+import random
 from datetime import datetime
 
 import factory
@@ -16,6 +17,14 @@ from src.constants.lookup_constants import (
     MgmtResourceType,
     MgmtUserType,
 )
+
+
+def sometimes_none(factory_value, none_chance: float = 0.5):
+    return factory.Maybe(
+        decider=factory.LazyAttribute(lambda s: random.random() > none_chance),
+        yes_declaration=factory_value,
+        no_declaration=None,
+    )
 
 
 class CustomProvider(BaseProvider):
@@ -278,3 +287,32 @@ class MgmtRoleFactory(BaseFactory):
             resource_types=[MgmtResourceType.TEAM],
             privileges=[MgmtPrivilege.VIEW_TEAM],
         )
+
+
+class MgmtUserApiKeyFactory(BaseFactory):
+    class Meta:
+        model = user_models.MgmtUserApiKey
+
+    mgmt_api_key_id = Generators.UuidObj
+    mgmt_user = factory.SubFactory(MgmtUserFactory)
+    mgmt_user_id = factory.LazyAttribute(lambda s: s.mgmt_user.mgmt_user_id)
+
+    key_name = factory.Faker("sentence", nb_words=3)
+    key_id = factory.Sequence(lambda n: f"aws-api-gateway-key-{n:08d}")
+
+    last_used = sometimes_none(
+        factory.Faker("date_time_between", start_date="-30d", end_date="now"), none_chance=0.3
+    )
+    is_active = True
+
+    class Params:
+        # Trait for inactive keys
+        inactive = factory.Trait(is_active=False)
+
+        # Trait for recently used keys
+        recently_used = factory.Trait(
+            last_used=factory.Faker("date_time_between", start_date="-7d", end_date="now")
+        )
+
+        # Trait for unused keys
+        never_used = factory.Trait(last_used=None)

--- a/backend/grants_management_api/tests/lib/seed_data_utils.py
+++ b/backend/grants_management_api/tests/lib/seed_data_utils.py
@@ -54,7 +54,7 @@ class UserBuilder:
 
     def with_api_key(self, key_id: str, key_name: str = "Local Development Key") -> Self:
         """Add an API key to the user for X-API-Key authentication.
-        
+
         For example, if you passed in "my_test_key", you could authenticate
         by passing X-API-Key: my_test_key in your request headers.
         """

--- a/backend/grants_management_api/tests/lib/seed_data_utils.py
+++ b/backend/grants_management_api/tests/lib/seed_data_utils.py
@@ -52,11 +52,26 @@ class UserBuilder:
         self.jwt_token = token
         return self
 
+    def with_api_key(self, key_id: str, key_name: str = "Local Development Key") -> Self:
+        """Add an API key to the user for X-API-Key authentication.
+        
+        For example, if you passed in "my_test_key", you could authenticate
+        by passing X-API-Key: my_test_key in your request headers.
+        """
+        api_key = factories.MgmtUserApiKeyFactory.build(
+            mgmt_user=self.user, key_id=key_id, key_name=key_name, is_active=True
+        )
+        self.db_session.add(api_key)
+        self.api_key_id = key_id
+        return self
+
     def build(self) -> MgmtUser:
         log_msg = f"Updating {self.scenario_name}:"
         if self.link_external_id:
             log_msg += f" '{self.link_external_id}'"
         if self.jwt_token:
             log_msg += f" with X-MGMT-Token: '{self.jwt_token}'"
+        if self.api_key_id:
+            log_msg += f" with X-API-Key: '{self.api_key_id}'"
         logger.info(log_msg)
         return self.user

--- a/backend/grants_management_api/tests/lib/seed_data_utils.py
+++ b/backend/grants_management_api/tests/lib/seed_data_utils.py
@@ -58,10 +58,22 @@ class UserBuilder:
         For example, if you passed in "my_test_key", you could authenticate
         by passing X-API-Key: my_test_key in your request headers.
         """
-        api_key = factories.MgmtUserApiKeyFactory.build(
-            mgmt_user=self.user, key_id=key_id, key_name=key_name, is_active=True
-        )
-        self.db_session.add(api_key)
+        # Check if we previously setup this API key
+        user_api_key = None
+        for key in self.user.api_keys:
+            if key.key_id == key_id:
+                user_api_key = key
+                break
+
+        if user_api_key is None:
+            user_api_key = factories.MgmtUserApiKeyFactory.build(mgmt_user=self.user)
+
+        user_api_key.key_id = key_id
+        user_api_key.key_name = key_name
+        user_api_key.is_active = True
+
+        self.db_session.add(user_api_key)
+
         self.api_key_id = key_id
         return self
 

--- a/backend/grants_management_api/tests/lib/seed_local_db.py
+++ b/backend/grants_management_api/tests/lib/seed_local_db.py
@@ -54,6 +54,19 @@ def create_users(db_session: db.Session) -> None:
         scenario_name="Another JWT User",
     ).with_oauth_login("another_jwt_user").with_jwt_auth().build()
 
+    # Create users with API key auth setup
+    UserBuilder(
+        user_id=uuid.UUID("a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d"),
+        db_session=db_session,
+        scenario_name="API Key User",
+    ).with_oauth_login("api_key_user").with_api_key("local-dev-api-key-1").build()
+
+    UserBuilder(
+        user_id=uuid.UUID("b2c3d4e5-f6a7-4b5c-9d0e-1f2a3b4c5d6e"),
+        db_session=db_session,
+        scenario_name="Another API Key User",
+    ).with_oauth_login("another_api_key_user").with_api_key("local-dev-api-key-2").build()
+
 
 def create_teams() -> None:
     teams = f.TeamFactory.create_batch(size=10)


### PR DESCRIPTION
## Summary

Fixes #11163  

## Changes proposed

We want to setup our API auth logic to allow for API keys to be used. We do not yet need to support creating API keys / registering them with API gateway, just the ability to use them.

## Context for reviewers

For that we need to setup the following logic - basically copying the same approach we have on the find/apply API side:

- Setup a DB table for api keys - user_api_key  ***Note: This is previously implemented with renaming to "mgmt_user_api_key"***
- Add the ability to pass the auth key into a route via with X-API-Key header - this must validate that the key is valid and determine the user from it.
- Add any utilities we need for test setup so we can easily generate an API key for a user
- Add the ability to generate an API key for a user in our seed script (the factory pattern from the find/apply side is recommended)

## Validation steps

- Added API key table connected to user
- Tests added to validate all of this
- Added a dummy endpoint for testing that accepts an API key
