### PR TITLE
[Issue #10435] Add paginated audit history endpoint for opportunities

### DIFF
--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
@@ -21,6 +21,7 @@ from src.services.opportunities_grantor_v1.get_opportunity_list import (
     get_opportunity_list_for_grantors,
     get_opportunity_list_for_user,
 )
+from src.services.opportunities_grantor_v1.list_opportunity_audit import list_opportunity_audit
 from src.services.opportunities_grantor_v1.opportunity_creation import create_opportunity
 from src.services.opportunities_grantor_v1.opportunity_summaries import (
     create_opportunity_summary,
@@ -382,4 +383,43 @@ def competition_instruction_upload(
     return response.ApiResponse(
         message="Instruction uploaded successfully",
         data={"competition_instruction_id": instruction_id},
+    )
+
+
+@opportunity_grantor_blueprint.post("/opportunities/<uuid:opportunity_id>/audit_history")
+@opportunity_grantor_blueprint.input(
+    opportunity_grantor_schemas.OpportunityAuditRequestSchema(), location="json"
+)
+@opportunity_grantor_blueprint.output(opportunity_grantor_schemas.OpportunityAuditResponseSchema())
+@opportunity_grantor_blueprint.doc(
+    summary="List Opportunity Audit History",
+    description="Get paginated audit history for an opportunity.",
+    responses=[200, 401, 403, 404, 422],
+)
+@opportunity_grantor_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def opportunity_audit_list(
+    db_session: db.Session, opportunity_id: UUID, json_data: dict
+) -> response.ApiResponse:
+    add_extra_data_to_current_request_logs({"opportunity_id": opportunity_id})
+    logger.info("POST /v1/grantors/opportunities/:opportunity_id/audit_history")
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        audit_events, pagination_info = list_opportunity_audit(
+            db_session, user, opportunity_id, json_data
+        )
+
+    add_extra_data_to_current_request_logs(
+        {
+            "response.pagination.total_pages": pagination_info.total_pages,
+            "response.pagination.total_records": pagination_info.total_records,
+        }
+    )
+    logger.info("Successfully fetched opportunity audit history")
+
+    return response.ApiResponse(
+        message="Success", data=audit_events, pagination_info=pagination_info
     )

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
@@ -737,6 +737,8 @@ class CompetitionInstructionUploadResponseDataV1Schema(Schema):
 class CompetitionInstructionUploadResponseV1Schema(ResponseWithErrorsSchema):
     """Response Schema for Upload Competition Instructions Endpoint"""
 
+    data = fields.Nested(CompetitionInstructionUploadResponseDataV1Schema())
+
 
 ####################################
 # Opportunity Audit History
@@ -783,6 +785,9 @@ class OpportunityAuditDataSchema(Schema):
         SimpleUserSchema(),
         metadata={"description": "The user who performed the audited action"},
     )
+    # These three columns are raw JSONB snapshots of the entity at audit time, not FK-linked
+    # objects, so fields.Dict is correct rather than fields.Nested typed schemas.
+    # Exactly one of the three will be non-None per row depending on the event type.
     opportunity = fields.Dict(
         allow_none=True,
         metadata={"description": "Opportunity data snapshot (populated for opportunity events)"},

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from grants_shared.api.schemas.extension import Schema, fields, validators
 from grants_shared.api.schemas.extension.schema_common import MarshmallowErrorContainer
 from grants_shared.api.schemas.response_schema import AbstractResponseSchema, PaginationMixinSchema
-from grants_shared.api.schemas.search_schema import BoolSearchSchemaBuilder
+from grants_shared.api.schemas.search_schema import BoolSearchSchemaBuilder, StrSearchSchemaBuilder
 from grants_shared.pagination.pagination_schema import generate_pagination_schema
 from marshmallow import ValidationError, validates_schema
 
@@ -13,11 +13,13 @@ from src.api.opportunities_v1.opportunity_schemas import (
     OpportunitySummaryV1Schema,
     OpportunityV1Schema,
 )
+from src.api.schemas.shared_schema import SimpleUserSchema
 from src.constants.lookup_constants import (
     ApplicantType,
     CompetitionOpenToApplicant,
     FundingCategory,
     FundingInstrument,
+    OpportunityAuditEvent,
     OpportunityCategory,
 )
 from src.validation.validation_constants import ValidationErrorType
@@ -735,4 +737,68 @@ class CompetitionInstructionUploadResponseDataV1Schema(Schema):
 class CompetitionInstructionUploadResponseV1Schema(ResponseWithErrorsSchema):
     """Response Schema for Upload Competition Instructions Endpoint"""
 
-    data = fields.Nested(CompetitionInstructionUploadResponseDataV1Schema())
+
+####################################
+# Opportunity Audit History
+####################################
+
+
+class OpportunityAuditFilterSchema(Schema):
+    """Schema for the opportunity audit history filters"""
+
+    opportunity_audit_event = fields.Nested(
+        StrSearchSchemaBuilder("OppAuditEventFilterSchema")
+        .with_one_of(
+            allowed_values=OpportunityAuditEvent,
+            example=OpportunityAuditEvent.OPPORTUNITY_CREATED,
+        )
+        .build()
+    )
+
+
+class OpportunityAuditRequestSchema(Schema):
+    """Schema for POST /v1/grantors/opportunities/:opportunity_id/audit_history request"""
+
+    filters = fields.Nested(OpportunityAuditFilterSchema(), required=False, allow_none=True)
+
+    pagination = fields.Nested(
+        generate_pagination_schema(
+            "OppAuditPaginationSchema",
+            ["created_at"],
+            default_sort_order=[{"order_by": "created_at", "sort_direction": "descending"}],
+        ),
+        required=True,
+    )
+
+
+class OpportunityAuditDataSchema(Schema):
+    """Schema for a single audit event in the response"""
+
+    opportunity_audit_id = fields.UUID(metadata={"description": "The ID of the audit event"})
+    opportunity_audit_event = fields.Enum(
+        OpportunityAuditEvent,
+        metadata={"description": "The type of audit event recorded"},
+    )
+    user = fields.Nested(
+        SimpleUserSchema(),
+        metadata={"description": "The user who performed the audited action"},
+    )
+    opportunity = fields.Dict(
+        allow_none=True,
+        metadata={"description": "Opportunity data snapshot (populated for opportunity events)"},
+    )
+    nonforecast_opportunity_summary = fields.Dict(
+        allow_none=True,
+        metadata={"description": "Summary data snapshot (populated for summary events)"},
+    )
+    competition = fields.Dict(
+        allow_none=True,
+        metadata={"description": "Competition data snapshot (populated for competition events)"},
+    )
+    created_at = fields.DateTime(metadata={"description": "When the audit event was created"})
+
+
+class OpportunityAuditResponseSchema(AbstractResponseSchema, PaginationMixinSchema):
+    """Schema for POST /v1/grantors/opportunities/:opportunity_id/audit_history response"""
+
+    data = fields.List(fields.Nested(OpportunityAuditDataSchema()))

--- a/api/src/services/opportunities_grantor_v1/list_opportunity_audit.py
+++ b/api/src/services/opportunities_grantor_v1/list_opportunity_audit.py
@@ -1,0 +1,92 @@
+import uuid
+from collections.abc import Sequence
+
+import grants_shared.adapters.db as db
+from grants_shared.pagination.pagination_models import PaginationInfo, PaginationParams
+from grants_shared.pagination.paginator import Paginator
+from grants_shared.pagination.sorting_util import apply_sorting
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+from sqlalchemy.sql import Select
+
+from src.db.models.opportunity_models import OpportunityAudit
+from src.db.models.user_models import User
+from src.search.search_models import StrSearchFilter
+from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
+
+
+class OpportunityAuditFilters(BaseModel):
+    opportunity_audit_event: StrSearchFilter | None = None
+
+
+class OpportunityAuditRequest(BaseModel):
+    filters: OpportunityAuditFilters | None = None
+    pagination: PaginationParams
+
+
+def apply_filters(stmt: Select, filters: OpportunityAuditFilters | None) -> Select:
+    """Apply filters from the request to the DB query for opportunity audit events"""
+    if filters is None:
+        return stmt
+
+    if (
+        filters.opportunity_audit_event is not None
+        and filters.opportunity_audit_event.one_of is not None
+    ):
+        stmt = stmt.where(
+            OpportunityAudit.opportunity_audit_event.in_(filters.opportunity_audit_event.one_of)
+        )
+
+    return stmt
+
+
+def list_opportunity_audit(
+    db_session: db.Session,
+    user: User,
+    opportunity_id: uuid.UUID,
+    request: dict,
+) -> tuple[list[dict], PaginationInfo]:
+    params = OpportunityAuditRequest.model_validate(request)
+
+    # Fetch the opportunity, verifying it exists and user has VIEW_OPPORTUNITY access
+    get_opportunity_for_grantors(db_session, user, opportunity_id)
+
+    stmt = (
+        select(OpportunityAudit)
+        .where(OpportunityAudit.opportunity_id == opportunity_id)
+        .options(
+            # Preload the user + their profile & login.gov email
+            selectinload(OpportunityAudit.user).options(
+                selectinload(User.profile), selectinload(User.linked_login_gov_external_user)
+            ),
+        )
+    )
+    stmt = apply_filters(stmt, params.filters)
+    stmt = apply_sorting(stmt, params.pagination.sort_order, OpportunityAudit)
+
+    paginator: Paginator[OpportunityAudit] = Paginator(
+        OpportunityAudit, stmt, db_session, page_size=params.pagination.page_size
+    )
+    paginated_results = paginator.page_at(page_offset=params.pagination.page_offset)
+    pagination_info = PaginationInfo.from_pagination_params(params.pagination, paginator)
+
+    return _transform_audit_events(paginated_results), pagination_info
+
+
+def _transform_audit_events(audit_events: Sequence[OpportunityAudit]) -> list[dict]:
+    results = []
+    for audit_event in audit_events:
+        results.append(
+            {
+                "opportunity_audit_id": audit_event.opportunity_audit_id,
+                "opportunity_audit_event": audit_event.opportunity_audit_event,
+                "user": audit_event.user,
+                "opportunity": audit_event.opportunity_data,
+                "nonforecast_opportunity_summary": audit_event.nonforecast_opportunity_summary,
+                "competition": audit_event.competition,
+                "created_at": audit_event.created_at,
+            }
+        )
+
+    return results

--- a/api/src/services/opportunities_grantor_v1/list_opportunity_audit.py
+++ b/api/src/services/opportunities_grantor_v1/list_opportunity_audit.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from collections.abc import Sequence
 
@@ -14,6 +15,8 @@ from src.db.models.opportunity_models import OpportunityAudit
 from src.db.models.user_models import User
 from src.search.search_models import StrSearchFilter
 from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
+
+logger = logging.getLogger(__name__)
 
 
 class OpportunityAuditFilters(BaseModel):

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_audit_list.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_audit_list.py
@@ -251,14 +251,14 @@ class TestListOpportunityAudit200:
 
 class TestListOpportunityAudit401:
 
-    def test_audit_list_no_token_401(self, client, enable_factory_create):
+    def test_audit_list_no_token_401(self, client):
         resp = client.post(
             f"{API_URL}/{uuid.uuid4()}/audit_history",
             json=DEFAULT_PAGINATION,
         )
         assert resp.status_code == 401
 
-    def test_audit_list_invalid_token_401(self, client, enable_factory_create):
+    def test_audit_list_invalid_token_401(self, client):
         resp = client.post(
             f"{API_URL}/{uuid.uuid4()}/audit_history",
             headers={"X-SGG-Token": "invalid-token"},
@@ -274,9 +274,7 @@ class TestListOpportunityAudit401:
 
 class TestListOpportunityAudit403:
 
-    def test_audit_list_wrong_agency_403(
-        self, client, db_session, enable_factory_create, opportunity
-    ):
+    def test_audit_list_wrong_agency_403(self, client, db_session, opportunity):
         """User from a different agency cannot view the audit history"""
         other_agency = AgencyFactory.create()
         _, _, token, _ = create_user_in_agency_with_jwt_and_api_key(

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_audit_list.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_audit_list.py
@@ -1,0 +1,366 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from src.constants.lookup_constants import OpportunityAuditEvent, Privilege
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt_and_api_key
+from tests.src.db.models.factories import AgencyFactory, OpportunityAuditFactory, OpportunityFactory
+
+API_URL = "/v1/grantors/opportunities"
+
+DEFAULT_PAGINATION = {"pagination": {"page_offset": 1, "page_size": 25}}
+
+
+def _make_datetime(hour: int) -> datetime:
+    return datetime(2026, 7, 1, hour, 0, 0, tzinfo=timezone.utc)
+
+
+####################################
+# Fixtures
+####################################
+
+
+@pytest.fixture
+def grantor_auth_data(db_session, enable_factory_create):
+    """Create a user with VIEW_OPPORTUNITY and UPDATE_OPPORTUNITY permissions"""
+    user, agency, token, api_key_id = create_user_in_agency_with_jwt_and_api_key(
+        db_session=db_session,
+        privileges=[Privilege.VIEW_OPPORTUNITY, Privilege.UPDATE_OPPORTUNITY],
+    )
+    return user, agency, token, api_key_id
+
+
+@pytest.fixture
+def opportunity(grantor_auth_data, enable_factory_create):
+    """Create an opportunity in the user's agency"""
+    _, agency, _, _ = grantor_auth_data
+    return OpportunityFactory.create(agency_id=agency.agency_id, agency_code=agency.agency_code)
+
+
+####################################
+# 200 Tests
+####################################
+
+
+class TestListOpportunityAudit200:
+
+    def test_audit_list_empty_200(self, client, db_session, grantor_auth_data, opportunity):
+        """No audit rows returns empty list"""
+        _, _, token, _ = grantor_auth_data
+
+        resp = client.post(
+            f"{API_URL}/{opportunity.opportunity_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json["data"] == []
+        assert resp.json["pagination_info"]["total_records"] == 0
+        assert resp.json["pagination_info"]["total_pages"] == 0
+
+    def test_audit_list_all_event_types_200(
+        self, client, db_session, grantor_auth_data, opportunity
+    ):
+        """Returns all 6 event types in descending order with correct JSONB columns"""
+        _, _, token, _ = grantor_auth_data
+
+        opp_created = OpportunityAuditFactory.create(
+            opportunity=opportunity,
+            is_opportunity_created=True,
+            opportunity_data={"title": "Test"},
+            created_at=_make_datetime(hour=1),
+        )
+        opp_updated = OpportunityAuditFactory.create(
+            opportunity=opportunity,
+            is_opportunity_updated=True,
+            opportunity_data={"title": "Updated"},
+            created_at=_make_datetime(hour=2),
+        )
+        summary_created = OpportunityAuditFactory.create(
+            opportunity=opportunity,
+            is_summary_created=True,
+            nonforecast_opportunity_summary={"summary_description": "Initial"},
+            created_at=_make_datetime(hour=3),
+        )
+        summary_updated = OpportunityAuditFactory.create(
+            opportunity=opportunity,
+            is_summary_updated=True,
+            nonforecast_opportunity_summary={"summary_description": "Updated"},
+            created_at=_make_datetime(hour=4),
+        )
+        competition_created = OpportunityAuditFactory.create(
+            opportunity=opportunity,
+            is_competition_created=True,
+            competition={"competition_title": "Initial"},
+            created_at=_make_datetime(hour=5),
+        )
+        competition_updated = OpportunityAuditFactory.create(
+            opportunity=opportunity,
+            is_competition_updated=True,
+            competition={"competition_title": "Updated"},
+            created_at=_make_datetime(hour=6),
+        )
+
+        events_asc = [
+            opp_created,
+            opp_updated,
+            summary_created,
+            summary_updated,
+            competition_created,
+            competition_updated,
+        ]
+
+        resp = client.post(
+            f"{API_URL}/{opportunity.opportunity_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 200
+        results = resp.json["data"]
+        assert len(results) == 6
+
+        # Default sort is descending by created_at
+        for result, event in zip(results, events_asc[::-1], strict=True):
+            assert result["opportunity_audit_id"] == str(event.opportunity_audit_id)
+            assert result["opportunity_audit_event"] == event.opportunity_audit_event
+            assert result["created_at"] == event.created_at.isoformat()
+            assert result["user"] == {
+                "user_id": str(event.user_id),
+                "email": event.user.email,
+                "first_name": event.user.first_name,
+                "last_name": event.user.last_name,
+            }
+
+        # Verify JSONB columns: only the relevant column is non-None per row
+        # Results are descending, so index 0 = competition_updated, index 5 = opp_created
+        comp_updated_result = results[0]
+        assert comp_updated_result["competition"] is not None
+        assert comp_updated_result["opportunity"] is None
+        assert comp_updated_result["nonforecast_opportunity_summary"] is None
+
+        opp_created_result = results[5]
+        assert opp_created_result["opportunity"] is not None
+        assert opp_created_result["competition"] is None
+        assert opp_created_result["nonforecast_opportunity_summary"] is None
+
+        summary_created_result = results[3]
+        assert summary_created_result["nonforecast_opportunity_summary"] is not None
+        assert summary_created_result["opportunity"] is None
+        assert summary_created_result["competition"] is None
+
+        pagination = resp.json["pagination_info"]
+        assert pagination["total_records"] == 6
+        assert pagination["sort_order"] == [
+            {"order_by": "created_at", "sort_direction": "descending"}
+        ]
+
+    def test_audit_list_filter_event_200(self, client, db_session, grantor_auth_data, opportunity):
+        """Filtering by event type returns only matching rows"""
+        _, _, token, _ = grantor_auth_data
+
+        events_map = {}
+        for event_type in OpportunityAuditEvent:
+            audit_event = OpportunityAuditFactory.create(
+                opportunity=opportunity,
+                opportunity_audit_event=event_type,
+            )
+            events_map[event_type] = audit_event
+
+        scenarios = [
+            # All events
+            list(OpportunityAuditEvent),
+            # Two specific events
+            [OpportunityAuditEvent.OPPORTUNITY_CREATED, OpportunityAuditEvent.COMPETITION_UPDATED],
+            # Single event
+            [OpportunityAuditEvent.OPPORTUNITY_SUMMARY_CREATED],
+        ]
+
+        for event_group in scenarios:
+            resp = client.post(
+                f"{API_URL}/{opportunity.opportunity_id}/audit_history",
+                json={
+                    "pagination": {"page_offset": 1, "page_size": 25},
+                    "filters": {"opportunity_audit_event": {"one_of": event_group}},
+                },
+                headers={"X-SGG-Token": token},
+            )
+
+            assert resp.status_code == 200
+            results = resp.json["data"]
+
+            result_ids = {r["opportunity_audit_id"] for r in results}
+            expected_ids = {
+                str(events_map[event_type].opportunity_audit_id) for event_type in event_group
+            }
+
+            assert len(result_ids) == len(expected_ids)
+            assert result_ids == expected_ids
+
+    def test_audit_list_pagination_200(self, client, db_session, grantor_auth_data, opportunity):
+        """Pagination and sort order work correctly"""
+        _, _, token, _ = grantor_auth_data
+
+        # Create 9 events with descending timestamps to match default descending sort
+        audit_events = []
+        for i in range(9, 0, -1):
+            audit_events.append(
+                OpportunityAuditFactory.create(
+                    opportunity=opportunity,
+                    created_at=_make_datetime(hour=i),
+                )
+            )
+
+        scenarios = [
+            # Fetch all (descending)
+            ({"page_offset": 1, "page_size": 25}, audit_events),
+            # Ascending sort
+            (
+                {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [{"order_by": "created_at", "sort_direction": "ascending"}],
+                },
+                audit_events[::-1],
+            ),
+            # Second page of 3
+            ({"page_offset": 2, "page_size": 3}, audit_events[3:6]),
+            # Past the end
+            ({"page_offset": 10, "page_size": 10}, []),
+        ]
+
+        for pagination, expected_events in scenarios:
+            resp = client.post(
+                f"{API_URL}/{opportunity.opportunity_id}/audit_history",
+                json={"pagination": pagination},
+                headers={"X-SGG-Token": token},
+            )
+
+            assert resp.status_code == 200
+            result_ids = [r["opportunity_audit_id"] for r in resp.json["data"]]
+            expected_ids = [str(e.opportunity_audit_id) for e in expected_events]
+            assert result_ids == expected_ids, f"Mismatch for pagination {pagination}"
+
+
+####################################
+# 401 Tests
+####################################
+
+
+class TestListOpportunityAudit401:
+
+    def test_audit_list_no_token_401(self, client, enable_factory_create):
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            json=DEFAULT_PAGINATION,
+        )
+        assert resp.status_code == 401
+
+    def test_audit_list_invalid_token_401(self, client, enable_factory_create):
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            headers={"X-SGG-Token": "invalid-token"},
+            json=DEFAULT_PAGINATION,
+        )
+        assert resp.status_code == 401
+
+
+####################################
+# 403 Tests
+####################################
+
+
+class TestListOpportunityAudit403:
+
+    def test_audit_list_wrong_agency_403(
+        self, client, db_session, enable_factory_create, opportunity
+    ):
+        """User from a different agency cannot view the audit history"""
+        other_agency = AgencyFactory.create()
+        _, _, token, _ = create_user_in_agency_with_jwt_and_api_key(
+            db_session=db_session,
+            agency=other_agency,
+            privileges=[Privilege.VIEW_OPPORTUNITY],
+        )
+
+        resp = client.post(
+            f"{API_URL}/{opportunity.opportunity_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+    def test_audit_list_no_privilege_403(
+        self, client, db_session, enable_factory_create, opportunity, grantor_auth_data
+    ):
+        """User in the same agency but with no privileges gets 403"""
+        _, agency, _, _ = grantor_auth_data
+        _, _, token, _ = create_user_in_agency_with_jwt_and_api_key(
+            db_session=db_session,
+            agency=agency,
+            privileges=[],
+        )
+
+        resp = client.post(
+            f"{API_URL}/{opportunity.opportunity_id}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+
+####################################
+# 404 Tests
+####################################
+
+
+class TestListOpportunityAudit404:
+
+    def test_audit_list_opportunity_not_found_404(
+        self, client, db_session, grantor_auth_data, enable_factory_create
+    ):
+        _, _, token, _ = grantor_auth_data
+
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            headers={"X-SGG-Token": token},
+            json=DEFAULT_PAGINATION,
+        )
+
+        assert resp.status_code == 404
+
+
+####################################
+# 422 Tests
+####################################
+
+
+class TestListOpportunityAudit422:
+
+    def test_audit_list_missing_pagination_422(
+        self, client, db_session, grantor_auth_data, enable_factory_create
+    ):
+        _, _, token, _ = grantor_auth_data
+
+        resp = client.post(
+            f"{API_URL}/{uuid.uuid4()}/audit_history",
+            json={},
+            headers={"X-SGG-Token": token},
+        )
+
+        assert resp.status_code == 422
+        assert resp.json["message"] == "Validation error"
+        assert resp.json["errors"] == [
+            {
+                "field": "pagination",
+                "message": "Missing data for required field.",
+                "type": "required",
+                "value": None,
+            }
+        ]


### PR DESCRIPTION
## Summary

Fixes #10435

## Changes proposed

- New service `list_opportunity_audit.py` — paginated query over `opportunity_audit` with optional `opportunity_audit_event` filter, sorting via `apply_sorting`, and user preloading via `selectinload`
- New route `POST /v1/grantors/opportunities/:opportunity_id/audit_history` on the grantor blueprint
- New request/response schemas: `OpportunityAuditRequestSchema`, `OpportunityAuditFilterSchema`, `OpportunityAuditDataSchema`, `OpportunityAuditResponseSchema`
- New test file `tests/src/api/opportunities_grantors_v1/test_opportunity_audit_list.py` covering 200 (empty list, all event types, filter, pagination), 401, 403, 404, and 422

## Context for reviewers

The implementation mirrors the `list_award_recommendation_audit` pattern (service + schema + route). Key points:

- Auth: `get_opportunity_for_grantors` is called first, which internally calls `verify_access(user, {Privilege.VIEW_OPPORTUNITY}, ...)` - no separate `verify_access` call needed
- JSONB columns: the model attribute is `opportunity_data` but the response key is `"opportunity"` to match the issue spec. The other two (`nonforecast_opportunity_summary`, `competition`) use the same name in both the model and response. All three are typed as `fields.Dict` rather than `fields.Nested` typed schemas because they are raw JSONB snapshots at audit time, not FK-linked objects
- Default sort is descending by `created_at`, matching the award recommendation audit endpoint

## Validation steps

**Run tests:**
```
make test args="tests/src/api/opportunities_grantors_v1/test_opportunity_audit_list.py -v"
```
All 10 tests should pass.

**Manual test via Swagger at `http://localhost:8080/docs` with `X-API-Key: one_agency_opp_edit_key`:**

1. Create an opportunity (`POST /v1/grantors/opportunities/`) to generate audit rows, or use an existing `opportunity_id` with audit history

2. Fetch all audit events (descending by default):
```
POST /v1/grantors/opportunities/{opportunity_id}/audit_history
{"pagination": {"page_offset": 1, "page_size": 25}}
```

> 200, rows in descending `created_at` order, each row has exactly one non-null JSONB column (`opportunity`, `nonforecast_opportunity_summary`, or `competition`)

3. Filter by event type:
```
POST /v1/grantors/opportunities/{opportunity_id}/audit_history
{
  "filters": {"opportunity_audit_event": {"one_of": ["opportunity_created", "opportunity_updated"]}},
  "pagination": {"page_offset": 1, "page_size": 25}
}
```

> 200, only rows matching the filter

4. Pagination: `"page_size": 2, "page_offset": 1` 

> 2 rows, correct `total_records` and `total_pages`

6. 404: random UUID as `opportunity_id` 

>  404

8. 403: use `X-API-Key: one_agency_opp_edit_key` against an opportunity belonging to USAID-SAF 

```
POST /v1/grantors/opportunities/{usaid_saf_opportunity_id}/audit_history
{"pagination": {"page_offset": 1, "page_size": 25}}
```
>  403 Forbidden

