### PR TITLE
[Issue #11526] Add validator to GetApplciationZipRequest schema

### DIFF
--- a/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
@@ -1,8 +1,8 @@
 from typing import Any, Self
 
-from pydantic import BaseModel, Field, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
 
-from src.legacy_soap_api.applicants.fault_messages import OpportunityListRequestInvalidParams
+from src.legacy_soap_api.grantors.fault_messages import InvalidGrantsGovTrackingNumber
 from src.legacy_soap_api.legacy_soap_api_utils import SOAPFaultException
 
 GET_APPLICATION_ZIP_REQUEST_ERR = "No grants_gov_tracking_number provided."
@@ -50,6 +50,14 @@ class GetApplicationZipRequest(BaseModel):
         if not self.grants_gov_tracking_number:
             raise SOAPFaultException(
                 GET_APPLICATION_ZIP_REQUEST_ERR,
-                fault=OpportunityListRequestInvalidParams,
+                fault=InvalidGrantsGovTrackingNumber,
             )
         return self
+
+    @field_validator("grants_gov_tracking_number", mode="before")
+    @classmethod
+    def get_value_from_dict(cls, value: str | dict) -> str | None:
+        if isinstance(value, dict):
+            return value.get("#text")
+        else:
+            return value

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -155,7 +155,8 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
         )
 
     def test_get_application_zip_request_schema_handles_a_dict_for_the_grants_gov_tracking_number(
-        self, db_session,
+        self,
+        db_session,
     ):
         request_xml_bytes = (
             "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207\r\n"

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -149,3 +149,47 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
         with pytest.raises(SOAPFaultException) as exc_info:
             grantors_schemas.GetApplicationZipRequest(**soap_request_dict)
         assert exc_info.value.message == "No grants_gov_tracking_number provided."
+        assert (
+            exc_info.value.fault.faultstring
+            == "Failed to validate request. cvc-pattern-valid: Value is not facet-valid with respect to pattern 'GRANT[0-9]{8}' for type 'GrantsGovTrackingNumberType'."
+        )
+
+    def test_get_application_zip_request_schema_handles_a_dict_for_the_grants_gov_tracking_number(
+        db_session,
+    ):
+        request_xml_bytes = (
+            "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207\r\n"
+            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+            "Content-Transfer-Encoding: binary\r\n"
+            "Content-ID: <0.urn:uuid:9467EB4D41266EA2C91784229922208@apache.org>\r\n\r\n"
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<soapenv:Body><agen:GetApplicationZipRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">'
+            '<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT80000038</gran:GrantsGovTrackingNumber>'
+            "</agen:GetApplicationZipRequest>"
+            "</soapenv:Body>"
+            "</soapenv:Envelope>\r\n"
+            "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207--"
+        ).encode("utf-8")
+        soap_request = SOAPRequest(
+            data=SoapRequestStreamer(stream=io.BytesIO(request_xml_bytes)),
+            full_path="x",
+            headers={},
+            method="POST",
+            api_name=SimplerSoapAPI.GRANTORS,
+            operation_name="GetApplicationZipRequest",
+        )
+        client = SimplerGrantorsS2SClient(soap_request, db_session)
+        soap_request_dict = client.get_soap_request_dict()
+        expected = {
+            "@xmlns:agen": "http://apply.grants.gov/services/AgencyWebServices-V2.0",
+            "GrantsGovTrackingNumber": {
+                "@xmlns:gran": "http://apply.grants.gov/system/GrantsCommonElements-V1.0",
+                "#text": "GRANT80000038",
+            },
+        }
+        assert soap_request_dict == expected
+        get_application_zip_request_schema = grantors_schemas.GetApplicationZipRequest(
+            **soap_request_dict
+        )
+        assert get_application_zip_request_schema.grants_gov_tracking_number == "GRANT80000038"

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -155,7 +155,7 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
         )
 
     def test_get_application_zip_request_schema_handles_a_dict_for_the_grants_gov_tracking_number(
-        db_session,
+        self, db_session,
     ):
         request_xml_bytes = (
             "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207\r\n"

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -505,6 +505,93 @@ class TestSimplerSOAPGetApplicationZip:
                 "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{BOUNDARY_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
             }
 
+    def test_get_simpler_soap_response_returns_mtom_xml_handles_alternate_reqest_body(
+        self, db_session, enable_factory_create, mock_s3_bucket
+    ):
+        agency = AgencyFactory.create()
+        user, role, soap_client_certificate, _ = setup_cert_user(
+            agency, {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+        )
+        opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+        competition = CompetitionFactory.create(
+            opportunity=opportunity, public_competition_id="CDE-123"
+        )
+        application = ApplicationFactory.create(competition=competition)
+        submission = ApplicationSubmissionFactory.create(application=application)
+        response = requests.get(submission.download_path, timeout=10)
+        submission_text = response.content.decode()
+        request_xml_bytes = (
+            "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207\r\n"
+            'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+            "Content-Transfer-Encoding: binary\r\n"
+            "Content-ID: <0.urn:uuid:9467EB4D41266EA2C91784229922208@apache.org>\r\n\r\n"
+            "<?xml version='1.0' encoding='UTF-8'?>"
+            '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+            'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+            'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+            "<soapenv:Header/>"
+            "<soapenv:Body>"
+            "<agen:GetApplicationZipRequest>"
+            f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>'
+            "</agen:GetApplicationZipRequest>"
+            "</soapenv:Body>"
+            "</soapenv:Envelope>/r/n"
+            "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207--"
+        ).encode("utf-8")
+        soap_request = SOAPRequest(
+            data=SoapRequestStreamer(stream=io.BytesIO(request_xml_bytes)),
+            full_path="x",
+            headers={},
+            method="POST",
+            api_name=SimplerSoapAPI.GRANTORS,
+            operation_name="GetApplicationZipRequest",
+            auth=SOAPAuth(certificate=soap_client_certificate),
+        )
+        mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
+        with patch.object(uuid, "uuid4") as mock_uuid4:
+            mock_uuid4.side_effect = [ADDITIONAL_UUID, BOUNDARY_UUID]
+            client = SimplerGrantorsS2SClient(soap_request, db_session)
+            result = client.get_simpler_soap_response(mock_proxy_response)
+            expected = (
+                "--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\n"
+                'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+                "Content-Transfer-Encoding: binary\r\n"
+                "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+                '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+                "<soap:Body>"
+                "<ns2:GetApplicationZipResponse "
+                'xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" '
+                'xmlns:ns11="http://schemas.xmlsoap.org/wsdl/" '
+                'xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" '
+                'xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" '
+                'xmlns:ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" '
+                'xmlns:ns6="http://apply.grants.gov/system/GrantsPackage-V1.0" '
+                'xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" '
+                'xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" '
+                'xmlns:ns3="http://apply.grants.gov/system/GrantsTemplate-V1.0" '
+                'xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+                'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+                "<ns2:FileDataHandler>"
+                f'<xop:Include xmlns:xop="http://www.w3.org/2004/08/xop/include" href="cid:{submission.application_submission_id}-1@apply.grants.gov"/>'
+                "</ns2:FileDataHandler>"
+                "</ns2:GetApplicationZipResponse>"
+                "</soap:Body>"
+                "</soap:Envelope>\r\n"
+                "--uuid:cccccccc-1111-2222-3333-dddddddddddd\r\n"
+                "Content-Type: application/octet-stream\r\n"
+                "Content-Transfer-Encoding: binary\r\n"
+                f"Content-ID: <{submission.application_submission_id}-1@apply.grants.gov>\r\n"
+                'Content-Disposition: attachment;name="AgencyApplicationDownload.zip"\r\n\r\n'
+                f"{submission_text}\r\n"
+                "--uuid:cccccccc-1111-2222-3333-dddddddddddd--"
+            ).encode("utf-8")
+            assert isinstance(result.data, Iterator)
+            assert b"".join(list(result.data)) == expected
+            assert result.status_code == 200
+            assert result.headers == {
+                "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{BOUNDARY_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
+            }
+
     def test_get_simpler_soap_response_returns_soap_action_in_header(
         self, db_session, enable_factory_create, mock_s3_bucket
     ):

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -505,7 +505,7 @@ class TestSimplerSOAPGetApplicationZip:
                 "Content-Type": f'multipart/related; type="application/xop+xml"; boundary="uuid:{BOUNDARY_UUID}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"',
             }
 
-    def test_get_simpler_soap_response_returns_mtom_xml_handles_alternate_reqest_body(
+    def test_get_simpler_soap_response_returns_mtom_xml_handles_alternate_request_body(
         self, db_session, enable_factory_create, mock_s3_bucket
     ):
         agency = AgencyFactory.create()
@@ -535,7 +535,7 @@ class TestSimplerSOAPGetApplicationZip:
             f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>'
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
-            "</soapenv:Envelope>/r/n"
+            "</soapenv:Envelope>\r\n"
             "--MIMEBoundaryurn_uuid_9467EB4D41266EA2C91784229922207--"
         ).encode("utf-8")
         soap_request = SOAPRequest(


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11526  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Add field_validator to `GetApplicationZipRequest` schema
- Add test

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
There's incoming requests that have the `GrantsGovTrackingNumber` get parsed as a dict and this causes a ValidationError in the Pydantic schema. This fix allows for that case.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- tests pass
- Calls with the incoming request with a GrantsGovTrackingNumber that get parsed as a dict do not raise a ValidationError and are processed correctly
