### PR TITLE
Update watchLinks for Big Demos

### DIFF
--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -76,6 +76,10 @@ export const messages = {
       watch: "Watch recordings of past Big Demos",
       watchLinks: [
         {
+          text: "June 30, 2026",
+          link: "https://youtu.be/AeHXvMamcnc?si=3dikqd4MU7zNZ5-q",
+        },
+        {
           text: "January 29, 2026",
           link: "https://youtu.be/LBIqOTKOFf0?si=O0Ec4PaNuAByeHA9",
         },


### PR DESCRIPTION
## Summary

n/a, no issue

## Changes proposed

- Add the June 30, 2026 Big Demo video link to the events page

## Context for reviewers

We need this added to the site so the newsletter can go out asap (this Thursday). 

## Validation steps

- Go to the Events page
- Scroll down to the "Simpler.Grants.gov Big Demo" section
- In the list under "Watch recordings…" there should be a link to the latest youtube video
- The linked video should be the "June 2026 COFFA Community Meeting" 