### PR TITLE
[Issue #10817] Create JSON Schema and Rules Schema for SF-424 Short Organizational form

### DIFF
--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -156,6 +156,7 @@ class FormFamily(StrEnum):
 
 class FormType(StrEnum):
     SF424 = "SF424"
+    SF424_SHORT = "SF424Short"
     SF424A = "SF424A"
     SF424B = "SF424B"
     SF424C = "SF424C"

--- a/api/src/db/models/lookup_models.py
+++ b/api/src/db/models/lookup_models.py
@@ -206,6 +206,7 @@ FORM_TYPE_CONFIG: LookupConfig[FormType] = LookupConfig(
         LookupStr(FormType.PROJECT_PERFORMANCE_SITE_LOCATION, 17),
         LookupStr(FormType.KEY_CONTACTS, 18),
         LookupStr(FormType.SF424C, 19),
+        LookupStr(FormType.SF424_SHORT, 20),
     ]
 )
 

--- a/api/src/form_schema/forms/__init__.py
+++ b/api/src/form_schema/forms/__init__.py
@@ -16,6 +16,7 @@ from .project_abstract_summary import ProjectAbstractSummary_v2_0
 from .project_narrative_attachment import ProjectNarrativeAttachment_v1_2
 from .project_performance_site_location import ProjectPerformanceSiteLocation_v4_0
 from .sf424 import SF424_v4_0
+from .sf424_short import SF424Short_v3_0
 from .sf424a import SF424a_v1_0
 from .sf424b import SF424b_v1_1
 from .sf424c import SF424c_v2_0
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 _ALL_FORMS: list[Form] = [
     SF424_v4_0,
+    SF424Short_v3_0,
     SF424a_v1_0,
     SF424b_v1_1,
     SF424c_v2_0,

--- a/api/src/form_schema/forms/sf424_short/1/0/form_json.py
+++ b/api/src/form_schema/forms/sf424_short/1/0/form_json.py
@@ -1,0 +1,649 @@
+import uuid
+
+from src.constants.lookup_constants import FormType
+from src.db.models.competition_models import Form
+from src.form_schema.shared import ADDRESS_SHARED_V1, COMMON_SHARED_V1
+
+# Applicant type codes shared by the SF-424 family (globLib:ApplicantTypeCodeDataType).
+APPLICANT_TYPE_CODES = [
+    "A: State Government",
+    "B: County Government",
+    "C: City or Township Government",
+    "D: Special District Government",
+    "E: Regional Organization",
+    "F: U.S. Territory or Possession",
+    "G: Independent School District",
+    "H: Public/state Controlled Institution of Higher Education",
+    "I: Indian/Native American Tribal Government (Federally Recognized)",
+    "J: Indian/Native American Tribal Government (Other than Federally Recognized)",
+    "K: Indian/Native American Tribally Designated Organization",
+    "L: Public/Indian Housing Authority",
+    "M: Nonprofit with 501C3 IRS Status (Other than Institution of Higher Education)",
+    "N: Nonprofit without 501C3 IRS Status (Other than Institution of Higher Education)",
+    "O: Private Institution of Higher Education",
+    "P: Individual",
+    "Q: For-Profit Organization (Other than Small Business)",
+    "R: Small Business",
+    "S: Hispanic-serving Institution",
+    "T: Historically Black Colleges and Universities (HBCUs)",
+    "U: Tribally Controlled Colleges and Universities (TCCUs)",
+    "V: Alaska Native and Native Hawaiian Serving Institutions",
+    "W: Non-domestic (non-US) Entity",
+    "X: Other (specify)",
+]
+
+FORM_JSON_SCHEMA = {
+    "type": "object",
+    "required": [
+        "agency_name",
+        "funding_opportunity_number",
+        "funding_opportunity_title",
+        "organization_name",
+        "applicant",
+        "applicant_type_code",
+        "employer_taxpayer_identification_number",
+        "sam_uei",
+        "congressional_district_applicant",
+        "project_title",
+        "project_description",
+        "project_start_date",
+        "project_end_date",
+        "project_director",
+        "application_certification",
+        "authorized_representative",
+        "authorized_representative_title",
+        "authorized_representative_email",
+        "authorized_representative_phone_number",
+    ],
+    # Conditional validation rules for SF-424 Short
+    "allOf": [
+        # If one of the applicant_type_code values is X: Other, applicant_type_other_specify is required
+        {
+            "if": {
+                "properties": {
+                    "applicant_type_code": {"contains": {"const": "X: Other (specify)"}}
+                },
+                "required": ["applicant_type_code"],  # Only run rule if applicant_type_code is set
+            },
+            "then": {"required": ["applicant_type_other_specify"]},
+        },
+        # Item 8 (Primary Contact / Grants Administrator) - "Same as Project Director".
+        # When the applicant marks the contact as the same as the project director, the
+        # separate contact_person block must be empty (the applicant skips item 8).
+        {
+            "if": {
+                "properties": {"same_as_project_director": {"const": True}},
+                "required": ["same_as_project_director"],
+            },
+            # contact_person must be empty (no populated sub-fields) when the contact is the
+            # same as the project director. maxProperties: 0 targets the error at the field.
+            "then": {"properties": {"contact_person": {"maxProperties": 0}}},
+        },
+        # Otherwise the primary contact (item 8) must be provided.
+        {
+            "if": {
+                "not": {
+                    "properties": {"same_as_project_director": {"const": True}},
+                    "required": ["same_as_project_director"],
+                }
+            },
+            "then": {"required": ["contact_person"]},
+        },
+    ],
+    "$defs": {
+        # globLib:ContactPersonDataTypeV3 - reused by the project director (item 7) and the
+        # primary contact / grants administrator (item 8). Name and Address are required per
+        # the XSD; the form additionally marks Title, Email and Telephone Number as required.
+        "contact_person_group": {
+            "type": "object",
+            "required": ["name", "title", "address", "phone_number", "email"],
+            "properties": {
+                "name": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
+                    "title": "Name",
+                    "description": "Enter the name.",
+                },
+                "title": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_person_title")}],
+                    "title": "Title",
+                    "description": "Enter the position title.",
+                },
+                "address": {
+                    "allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("address")}],
+                    "title": "Address",
+                    "description": "Enter the address.",
+                },
+                "phone_number": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
+                    "title": "Telephone Number",
+                    "description": "Enter the daytime Telephone Number.",
+                },
+                "fax": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
+                    "title": "Fax Number",
+                    "description": "Enter the Fax Number.",
+                },
+                "email": {
+                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_email")}],
+                    "title": "Email",
+                    "description": "Enter a valid email Address.",
+                },
+            },
+        },
+    },
+    "properties": {
+        "agency_name": {
+            "type": "string",
+            "title": "Name of Federal Agency",
+            "description": "Pre-populated from the Application cover sheet.",
+            "minLength": 1,
+            "maxLength": 60,
+        },
+        "assistance_listing_number": {
+            "type": "string",
+            "title": "Assistance Listing Number",
+            "description": "Pre-populated from the Application cover sheet.",
+            "minLength": 1,
+            "maxLength": 15,
+        },
+        "assistance_listing_program_title": {
+            "type": "string",
+            "title": "Assistance Listing Title",
+            "description": "Pre-populated from the Application cover sheet.",
+            "minLength": 1,
+            "maxLength": 120,
+        },
+        "date_received": {
+            "type": "string",
+            "title": "Date Received",
+            "description": "Completed by Grants.gov upon submission.",
+            "format": "date",
+            "readOnly": True,
+        },
+        "funding_opportunity_number": {
+            "type": "string",
+            "title": "Funding Opportunity Number",
+            "description": "Pre-populated from the Application cover sheet.",
+            "minLength": 1,
+            "maxLength": 40,
+        },
+        "funding_opportunity_title": {
+            "type": "string",
+            "title": "Funding Opportunity Title",
+            "description": "Pre-populated from the Application cover sheet.",
+            "minLength": 1,
+            "maxLength": 255,
+        },
+        "organization_name": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("organization_name")}],
+            "title": "Legal Name",
+            "description": "Enter the legal name of the applicant that will undertake the assistance activity. This is the organization that has registered with the System for Award Management (SAM). Information on registering with SAM may be obtained by visiting SAM.gov.",
+        },
+        "applicant": {
+            "allOf": [{"$ref": ADDRESS_SHARED_V1.field_ref("address")}],
+            "title": "Address",
+            "description": "Enter the address of the applicant.",
+        },
+        "applicant_web_address": {
+            "type": "string",
+            "title": "Web Address",
+            "description": "Enter the applicant's web address, if applicable.",
+            "minLength": 1,
+            # The XSD models this as an unbounded anyURI; we cap the length as a safeguard.
+            "maxLength": 250,
+        },
+        "applicant_type_code": {
+            # In the XML model this is 3 separate fields (ApplicantTypeCode1-3); we join them
+            # together into a single array value.
+            "type": "array",
+            "title": "Type of Applicant",
+            "description": "Select the appropriate applicant types.",
+            "minItems": 1,
+            "maxItems": 3,
+            "items": {
+                "type": "string",
+                "enum": APPLICANT_TYPE_CODES,
+            },
+        },
+        "applicant_type_other_specify": {
+            "type": "string",
+            "title": "Type of Applicant Other Explanation",
+            "description": 'Enter the applicant type here if you selected "Other (specify)" for Type of applicant.',
+            "minLength": 0,
+            "maxLength": 30,
+        },
+        "employer_taxpayer_identification_number": {
+            "type": "string",
+            "title": "EIN/TIN",
+            "description": "Enter either TIN or EIN as assigned by the Internal Revenue Service.  If your organization is not in the US, enter 44-4444444.",
+            "minLength": 9,
+            "maxLength": 30,
+        },
+        "sam_uei": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("sam_uei")}],
+            "title": "SAM UEI",
+            "description": "UEI of the applicant organization. This field is pre-populated from the Application cover sheet.",
+        },
+        "congressional_district_applicant": {
+            "type": "string",
+            "title": "Congressional District of Applicant",
+            "description": "Enter the Congressional District in the format: 2 character state Abbreviation - 3 character District Number. Examples: CA-005 for California's 5th district, CA-012 for California's 12th district.If outside the US, enter 00-000.",
+            "minLength": 1,
+            "maxLength": 6,
+        },
+        "project_title": {
+            "type": "string",
+            "title": "Project Title",
+            "description": "Enter a brief, descriptive title of the project.",
+            "minLength": 1,
+            "maxLength": 200,
+        },
+        "project_description": {
+            "type": "string",
+            "title": "Project Description",
+            "description": "Enter a brief description of the project.",
+            "minLength": 1,
+            "maxLength": 1000,
+        },
+        "project_start_date": {
+            "type": "string",
+            "title": "Project Start Date",
+            "description": "Enter the date in the format MM/DD/YYYY.",
+            "format": "date",
+        },
+        "project_end_date": {
+            "type": "string",
+            "title": "Project End Date",
+            "description": "Enter the date in the format MM/DD/YYYY.",
+            "format": "date",
+        },
+        "project_director": {
+            "allOf": [{"$ref": "#/$defs/contact_person_group"}],
+            "title": "Project Director",
+            "description": "Enter information about the project director.",
+        },
+        "same_as_project_director": {
+            "type": "boolean",
+            "title": "Same as Project Director",
+            "description": "Check if the primary contact / grants administrator is the same as the project director.",
+        },
+        "contact_person": {
+            "allOf": [{"$ref": "#/$defs/contact_person_group"}],
+            "title": "Primary Contact/Grants Administrator",
+            "description": "Enter information about the primary contact. Leave blank if the primary contact is the same as the project director.",
+        },
+        "application_certification": {
+            "type": "boolean",
+            "title": "Certification",
+            "description": "By signing this application, I certify (1) to the statements contained in the list of certifications and (2) that the statements herein are true, complete and accurate to the best of my knowledge. I also provide the required assurances and agree to comply with any resulting terms if I accept an award. I am aware that any false, fictitious, or fraudulent statements or claims may subject me to criminal, civil, or administrative penalties. (U.S. Code, Title 18, Section 1001)",
+        },
+        "authorized_representative": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("person_name")}],
+            "title": "Authorized Representative",
+            "description": "Enter the name of the authorized representative.",
+        },
+        "authorized_representative_title": {
+            "type": "string",
+            "title": "Title",
+            "description": "Enter the position title.",
+            "minLength": 1,
+            "maxLength": 45,
+        },
+        "authorized_representative_email": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("contact_email")}],
+            "title": "Email",
+            "description": "Enter a valid email Address.",
+        },
+        "authorized_representative_phone_number": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
+            "title": "Telephone Number",
+            "description": "Enter the daytime Telephone Number.",
+        },
+        "authorized_representative_fax": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("phone_number")}],
+            "title": "Fax Number",
+            "description": "Enter the Fax Number.",
+        },
+        "aor_signature": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("signature")}],
+            "title": "Signature of Authorized Representative",
+            "description": "Completed by Grants.gov upon submission.",
+            "readOnly": True,
+        },
+        "authorized_representative_date_signed": {
+            "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("submitted_date")}],
+            "title": "Date Signed",
+            "description": "Completed by Grants.gov upon submission.",
+            "readOnly": True,
+        },
+    },
+}
+
+_CONTACT_PERSON_GROUP_UI_CHILDREN = [
+    {"type": "field", "definition": "{base}/properties/name/properties/prefix"},
+    {"type": "field", "definition": "{base}/properties/name/properties/first_name"},
+    {"type": "field", "definition": "{base}/properties/name/properties/middle_name"},
+    {"type": "field", "definition": "{base}/properties/name/properties/last_name"},
+    {"type": "field", "definition": "{base}/properties/name/properties/suffix"},
+    {"type": "field", "definition": "{base}/properties/title"},
+    {"type": "field", "definition": "{base}/properties/email"},
+    {"type": "field", "definition": "{base}/properties/phone_number"},
+    {"type": "field", "definition": "{base}/properties/fax"},
+    {"type": "field", "definition": "{base}/properties/address/properties/street1"},
+    {"type": "field", "definition": "{base}/properties/address/properties/street2"},
+    {"type": "field", "definition": "{base}/properties/address/properties/city"},
+    {"type": "field", "definition": "{base}/properties/address/properties/county"},
+    {"type": "field", "definition": "{base}/properties/address/properties/state"},
+    {"type": "field", "definition": "{base}/properties/address/properties/province"},
+    {"type": "field", "definition": "{base}/properties/address/properties/country"},
+    {"type": "field", "definition": "{base}/properties/address/properties/zip_code"},
+]
+
+
+def _contact_person_ui_children(base: str) -> list[dict]:
+    return [
+        {"type": child["type"], "definition": child["definition"].format(base=base)}
+        for child in _CONTACT_PERSON_GROUP_UI_CHILDREN
+    ]
+
+
+FORM_UI_SCHEMA = [
+    {
+        "type": "section",
+        "name": "federal_agency",
+        "label": "1. Name of Federal Agency",
+        "children": [{"type": "field", "definition": "/properties/agency_name"}],
+    },
+    {
+        "type": "section",
+        "name": "assistance_listing",
+        "label": "2. Assistance Listing Number/Title",
+        "children": [
+            {"type": "field", "definition": "/properties/assistance_listing_number"},
+            {"type": "field", "definition": "/properties/assistance_listing_program_title"},
+        ],
+    },
+    {
+        "type": "section",
+        "name": "date_received",
+        "label": "3. Date Received",
+        "children": [{"type": "null", "definition": "/properties/date_received"}],
+    },
+    {
+        "type": "section",
+        "name": "funding_opportunity",
+        "label": "4. Funding Opportunity Number/Title",
+        "children": [
+            {"type": "field", "definition": "/properties/funding_opportunity_number"},
+            {"type": "field", "definition": "/properties/funding_opportunity_title"},
+        ],
+    },
+    {
+        "type": "section",
+        "name": "applicant_information",
+        "label": "5. Applicant Information",
+        "children": [
+            {"type": "field", "definition": "/properties/organization_name"},
+            {"type": "field", "definition": "/properties/applicant/properties/street1"},
+            {"type": "field", "definition": "/properties/applicant/properties/street2"},
+            {"type": "field", "definition": "/properties/applicant/properties/city"},
+            {"type": "field", "definition": "/properties/applicant/properties/county"},
+            {"type": "field", "definition": "/properties/applicant/properties/state"},
+            {"type": "field", "definition": "/properties/applicant/properties/province"},
+            {"type": "field", "definition": "/properties/applicant/properties/country"},
+            {"type": "field", "definition": "/properties/applicant/properties/zip_code"},
+            {"type": "field", "definition": "/properties/applicant_web_address"},
+            {"type": "field", "definition": "/properties/applicant_type_code"},
+            {"type": "field", "definition": "/properties/applicant_type_other_specify"},
+            {"type": "field", "definition": "/properties/employer_taxpayer_identification_number"},
+            {"type": "field", "definition": "/properties/sam_uei"},
+            {"type": "field", "definition": "/properties/congressional_district_applicant"},
+        ],
+    },
+    {
+        "type": "section",
+        "name": "project_information",
+        "label": "6. Project Information",
+        "children": [
+            {"type": "field", "definition": "/properties/project_title"},
+            {"type": "field", "definition": "/properties/project_description"},
+            {"type": "field", "definition": "/properties/project_start_date"},
+            {"type": "field", "definition": "/properties/project_end_date"},
+        ],
+    },
+    {
+        "type": "section",
+        "name": "project_director",
+        "label": "7. Project Director",
+        "children": _contact_person_ui_children("/properties/project_director"),
+    },
+    {
+        "type": "section",
+        "name": "contact_person",
+        "label": "8. Primary Contact/Grants Administrator",
+        "children": [
+            {"type": "field", "definition": "/properties/same_as_project_director"},
+            *_contact_person_ui_children("/properties/contact_person"),
+        ],
+    },
+    {
+        "type": "section",
+        "name": "authorized_representative",
+        "label": "9. Authorized Representative",
+        "children": [
+            {"type": "field", "definition": "/properties/application_certification"},
+            {
+                "type": "field",
+                "definition": "/properties/authorized_representative/properties/prefix",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/authorized_representative/properties/first_name",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/authorized_representative/properties/middle_name",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/authorized_representative/properties/last_name",
+            },
+            {
+                "type": "field",
+                "definition": "/properties/authorized_representative/properties/suffix",
+            },
+            {"type": "field", "definition": "/properties/authorized_representative_title"},
+            {"type": "field", "definition": "/properties/authorized_representative_email"},
+            {"type": "field", "definition": "/properties/authorized_representative_phone_number"},
+            {"type": "field", "definition": "/properties/authorized_representative_fax"},
+            {"type": "null", "definition": "/properties/aor_signature"},
+            {"type": "null", "definition": "/properties/authorized_representative_date_signed"},
+        ],
+    },
+]
+
+
+FORM_RULE_SCHEMA = {
+    ##### PRE-POPULATION RULES
+    "agency_name": {"gg_pre_population": {"rule": "agency_name"}},
+    "assistance_listing_number": {"gg_pre_population": {"rule": "assistance_listing_number"}},
+    "assistance_listing_program_title": {
+        "gg_pre_population": {"rule": "assistance_listing_program_title"}
+    },
+    "funding_opportunity_number": {"gg_pre_population": {"rule": "opportunity_number"}},
+    "funding_opportunity_title": {"gg_pre_population": {"rule": "opportunity_title"}},
+    "sam_uei": {"gg_pre_population": {"rule": "uei"}},
+    ##### POST-POPULATION RULES
+    "date_received": {"gg_post_population": {"rule": "current_date"}},
+    "aor_signature": {"gg_post_population": {"rule": "signature"}},
+    "authorized_representative_date_signed": {"gg_post_population": {"rule": "current_date"}},
+}
+
+
+# The nested name/address groups shared by the project director and contact person.
+_CONTACT_PERSON_GROUP_XML_TRANSFORM = {
+    "xml_transform": {"target": "PLACEHOLDER", "type": "nested_object"},
+    "name": {
+        "xml_transform": {"target": "Name", "namespace": "globLib", "type": "nested_object"},
+        "prefix": {"xml_transform": {"target": "PrefixName", "namespace": "globLib"}},
+        "first_name": {"xml_transform": {"target": "FirstName", "namespace": "globLib"}},
+        "middle_name": {"xml_transform": {"target": "MiddleName", "namespace": "globLib"}},
+        "last_name": {"xml_transform": {"target": "LastName", "namespace": "globLib"}},
+        "suffix": {"xml_transform": {"target": "SuffixName", "namespace": "globLib"}},
+    },
+    "title": {"xml_transform": {"target": "Title", "namespace": "globLib"}},
+    "address": {
+        "xml_transform": {"target": "Address", "namespace": "globLib", "type": "nested_object"},
+        "street1": {"xml_transform": {"target": "Street1", "namespace": "globLib"}},
+        "street2": {"xml_transform": {"target": "Street2", "namespace": "globLib"}},
+        "city": {"xml_transform": {"target": "City", "namespace": "globLib"}},
+        "county": {"xml_transform": {"target": "County", "namespace": "globLib"}},
+        "state": {"xml_transform": {"target": "State", "namespace": "globLib"}},
+        "province": {"xml_transform": {"target": "Province", "namespace": "globLib"}},
+        "zip_code": {"xml_transform": {"target": "ZipPostalCode", "namespace": "globLib"}},
+        "country": {"xml_transform": {"target": "Country", "namespace": "globLib"}},
+    },
+    "phone_number": {"xml_transform": {"target": "Phone", "namespace": "globLib"}},
+    "fax": {"xml_transform": {"target": "Fax", "namespace": "globLib"}},
+    "email": {"xml_transform": {"target": "Email", "namespace": "globLib"}},
+}
+
+
+def _contact_person_group_xml(target: str) -> dict:
+    group = {key: value for key, value in _CONTACT_PERSON_GROUP_XML_TRANSFORM.items()}
+    group["xml_transform"] = {"target": target, "type": "nested_object"}
+    return group
+
+
+# XML Transformation Rules for SF-424 Short Organizational 3.0
+FORM_XML_TRANSFORM_RULES = {
+    # Metadata
+    "_xml_config": {
+        "description": "XML transformation rules for converting Simpler SF-424 Short JSON to Grants.gov XML format",
+        # NOTE: the top-level applicant Address element is in the form namespace per the XSD,
+        # while the Name/Address groups inside ProjectDirectorGroup/ContactPersonGroup are in the
+        # globLib namespace. The XML transformer currently keys namespaces by element name, so
+        # the shared "Address"/"Street1"/... names resolve to a single namespace. Full XSD-valid
+        # output (and its validation test) is handled with the SF-424 Short XML generation work.
+        "version": "1.0",
+        "form_name": "SF424_Short_3_0",
+        "namespaces": {
+            "default": "http://apply.grants.gov/forms/SF424_Short_3_0-V3.0",
+            "globLib": "http://apply.grants.gov/system/GlobalLibrary-V2.0",
+        },
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/SF424_Short_3_0-V3.0.xsd",
+        "xml_structure": {"root_element": "SF424_Short_3_0", "version": "3.0"},
+        "null_handling_options": {
+            "exclude": "Default - exclude field entirely from XML (recommended)",
+            "include_null": "Include empty XML element: <Field></Field>",
+            "default_value": "Use configured default value when field is None",
+        },
+    },
+    # Opportunity information - order matches XSD sequence
+    "agency_name": {"xml_transform": {"target": "AgencyName"}},
+    "assistance_listing_number": {"xml_transform": {"target": "CFDANumber"}},
+    "assistance_listing_program_title": {"xml_transform": {"target": "CFDAProgramTitle"}},
+    "date_received": {"xml_transform": {"target": "DateReceived", "null_handling": "include_null"}},
+    "funding_opportunity_number": {"xml_transform": {"target": "FundingOpportunityNumber"}},
+    "funding_opportunity_title": {"xml_transform": {"target": "FundingOpportunityTitle"}},
+    # Applicant information
+    "organization_name": {"xml_transform": {"target": "OrganizationName"}},
+    "applicant": {
+        "xml_transform": {"target": "Address", "type": "nested_object"},
+        "street1": {"xml_transform": {"target": "Street1", "namespace": "globLib"}},
+        "street2": {"xml_transform": {"target": "Street2", "namespace": "globLib"}},
+        "city": {"xml_transform": {"target": "City", "namespace": "globLib"}},
+        "county": {"xml_transform": {"target": "County", "namespace": "globLib"}},
+        "state": {"xml_transform": {"target": "State", "namespace": "globLib"}},
+        "province": {"xml_transform": {"target": "Province", "namespace": "globLib"}},
+        "zip_code": {"xml_transform": {"target": "ZipPostalCode", "namespace": "globLib"}},
+        "country": {"xml_transform": {"target": "Country", "namespace": "globLib"}},
+    },
+    "applicant_web_address": {"xml_transform": {"target": "ApplicantWebAddress"}},
+    # One-to-many mapping - applicant type codes (must come before other fields per XSD)
+    "applicant_type_code_mapping": {
+        "xml_transform": {
+            "target": "ApplicantTypeCode",  # Not used for one-to-many
+            "type": "conditional",
+            "conditional_transform": {
+                "type": "one_to_many",
+                "source_field": "applicant_type_code",
+                "target_pattern": "ApplicantTypeCode{index}",
+                "max_count": 3,  # SF-424 Short supports up to 3 applicant type codes
+            },
+        }
+    },
+    "applicant_type_other_specify": {"xml_transform": {"target": "ApplicantTypeOtherSpecify"}},
+    "employer_taxpayer_identification_number": {
+        "xml_transform": {"target": "EmployerTaxpayerIdentificationNumber"}
+    },
+    "sam_uei": {"xml_transform": {"target": "SAMUEI"}},
+    "congressional_district_applicant": {
+        "xml_transform": {"target": "CongressionalDistrictApplicant"}
+    },
+    # Project information
+    "project_title": {"xml_transform": {"target": "ProjectTitle"}},
+    "project_description": {"xml_transform": {"target": "ProjectDescription"}},
+    "project_start_date": {"xml_transform": {"target": "ProjectStartDate"}},
+    "project_end_date": {"xml_transform": {"target": "ProjectEndDate"}},
+    # Project director (item 7) and primary contact (item 8) - ContactPersonDataTypeV3
+    "project_director": _contact_person_group_xml("ProjectDirectorGroup"),
+    "same_as_project_director": {
+        "xml_transform": {
+            "target": "SameAsProjectDirector",
+            "value_transform": {"type": "boolean_to_yes_no"},
+        }
+    },
+    "contact_person": _contact_person_group_xml("ContactPersonGroup"),
+    # Certification and authorized representative
+    "application_certification": {
+        "xml_transform": {
+            "target": "ApplicationCertification",
+            "value_transform": {"type": "boolean_to_yes_no"},
+        }
+    },
+    "authorized_representative": {
+        "xml_transform": {"target": "AuthorizedRepresentative", "type": "nested_object"},
+        "prefix": {"xml_transform": {"target": "PrefixName", "namespace": "globLib"}},
+        "first_name": {"xml_transform": {"target": "FirstName", "namespace": "globLib"}},
+        "middle_name": {"xml_transform": {"target": "MiddleName", "namespace": "globLib"}},
+        "last_name": {"xml_transform": {"target": "LastName", "namespace": "globLib"}},
+        "suffix": {"xml_transform": {"target": "SuffixName", "namespace": "globLib"}},
+    },
+    "authorized_representative_title": {
+        "xml_transform": {"target": "AuthorizedRepresentativeTitle"}
+    },
+    "authorized_representative_email": {
+        "xml_transform": {"target": "AuthorizedRepresentativeEmail"}
+    },
+    "authorized_representative_phone_number": {
+        "xml_transform": {"target": "AuthorizedRepresentativePhoneNumber"}
+    },
+    "authorized_representative_fax": {
+        "xml_transform": {"target": "AuthorizedRepresentativeFaxNumber"}
+    },
+    "aor_signature": {"xml_transform": {"target": "AuthorizedRepresentativeSignature"}},
+    "authorized_representative_date_signed": {
+        "xml_transform": {"target": "AuthorizedRepresentativeDateSigned"}
+    },
+}
+
+
+SF424Short_v3_0 = Form(
+    # https://www.grants.gov/forms/form-items-description/fid/711
+    form_id=uuid.UUID("cf355a4d-d840-43fd-a78f-729edf41ab4c"),
+    legacy_form_id=711,
+    form_name="Application for Federal Domestic Assistance - Short Organizational (SF-424 Short)",
+    short_form_name="SF424_Short_3_0",
+    form_version="3.0",
+    agency_code="SGG",
+    omb_number="4040-0003",
+    form_json_schema=FORM_JSON_SCHEMA,
+    form_ui_schema=FORM_UI_SCHEMA,
+    form_rule_schema=FORM_RULE_SCHEMA,
+    json_to_xml_schema=FORM_XML_TRANSFORM_RULES,
+    # SF-424 Short does not currently have instructions loaded
+    form_type=FormType.SF424_SHORT,
+    sgg_version="1.0",
+    is_deprecated=False,
+)

--- a/api/src/form_schema/forms/sf424_short/1/0/form_json.py
+++ b/api/src/form_schema/forms/sf424_short/1/0/form_json.py
@@ -633,7 +633,7 @@ SF424Short_v3_0 = Form(
     # https://www.grants.gov/forms/form-items-description/fid/711
     form_id=uuid.UUID("cf355a4d-d840-43fd-a78f-729edf41ab4c"),
     legacy_form_id=711,
-    form_name="Application for Federal Domestic Assistance - Short Organizational (SF-424 Short)",
+    form_name="Application for Federal Domestic Assistance - Short Organizational",
     short_form_name="SF424_Short_3_0",
     form_version="3.0",
     agency_code="SGG",

--- a/api/src/form_schema/forms/sf424_short/__init__.py
+++ b/api/src/form_schema/forms/sf424_short/__init__.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from src.form_schema.forms._loader import load_versioned_form
+
+_mod = load_versioned_form(Path(__file__).parent, "1.0")
+FORM_JSON_SCHEMA = _mod.FORM_JSON_SCHEMA
+FORM_UI_SCHEMA = _mod.FORM_UI_SCHEMA
+FORM_RULE_SCHEMA = _mod.FORM_RULE_SCHEMA
+FORM_XML_TRANSFORM_RULES = _mod.FORM_XML_TRANSFORM_RULES
+SF424Short_v3_0 = _mod.SF424Short_v3_0
+del _mod

--- a/api/src/form_schema/forms/sf424_short/config.py
+++ b/api/src/form_schema/forms/sf424_short/config.py
@@ -1,0 +1,5 @@
+import uuid
+
+# Stable identifiers for this form — do not change across versions.
+FORM_ID = uuid.UUID("cf355a4d-d840-43fd-a78f-729edf41ab4c")
+SHORT_FORM_NAME = "SF424_Short_3_0"

--- a/api/tests/src/form_schema/forms/conftest.py
+++ b/api/tests/src/form_schema/forms/conftest.py
@@ -17,6 +17,7 @@ from src.form_schema.forms import (
     ProjectNarrativeAttachment_v1_2,
     ProjectPerformanceSiteLocation_v4_0,
     SF424_v4_0,
+    SF424Short_v3_0,
     SF424a_v1_0,
     SF424b_v1_1,
     SF424c_v2_0,
@@ -67,6 +68,11 @@ def validate_max_length(data, expected_fields_to_error: list[str], form: Form):
 @pytest.fixture(scope="session")
 def sf424_v4_0():
     return setup_resolved_form(SF424_v4_0)
+
+
+@pytest.fixture(scope="session")
+def sf424_short_v3_0():
+    return setup_resolved_form(SF424Short_v3_0)
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/src/form_schema/forms/conftest.py
+++ b/api/tests/src/form_schema/forms/conftest.py
@@ -17,11 +17,11 @@ from src.form_schema.forms import (
     ProjectNarrativeAttachment_v1_2,
     ProjectPerformanceSiteLocation_v4_0,
     SF424_v4_0,
-    SF424Short_v3_0,
     SF424a_v1_0,
     SF424b_v1_1,
     SF424c_v2_0,
     SF424d_v1_1,
+    SF424Short_v3_0,
     SFLLL_v2_0,
     SupplementaryNEHCoverSheet_v3_0,
 )

--- a/api/tests/src/form_schema/forms/test_sf424_short.py
+++ b/api/tests/src/form_schema/forms/test_sf424_short.py
@@ -1,0 +1,391 @@
+import freezegun
+import pytest
+
+from src.form_schema.jsonschema_validator import validate_json_schema_for_form
+from src.services.applications.application_validation import (
+    ApplicationAction,
+    validate_application_form,
+)
+from tests.lib.data_factories import setup_application_for_form_validation
+
+
+@pytest.fixture
+def contact_person_group():
+    return {
+        "name": {
+            "first_name": "Jane",
+            "last_name": "Doe",
+        },
+        "title": "Project Director",
+        "email": "jane@example.com",
+        "phone_number": "123-456-7890",
+        "address": {
+            "street1": "123 Main St",
+            "city": "Exampleburg",
+            "state": "NY: New York",
+            "country": "USA: UNITED STATES",
+            "zip_code": "12345",
+        },
+    }
+
+
+@pytest.fixture
+def valid_json_v3_0(contact_person_group):
+    # Minimal valid response - the primary contact is the same as the project director,
+    # so the contact_person block is intentionally omitted.
+    return {
+        "agency_name": "Department of Research",
+        "funding_opportunity_number": "ABC-123",
+        "funding_opportunity_title": "My Example Opportunity",
+        "organization_name": "Example Org",
+        "applicant": {
+            "street1": "123 Main St",
+            "city": "Exampleburg",
+            "state": "NY: New York",
+            "country": "USA: UNITED STATES",
+            "zip_code": "12345",
+        },
+        "applicant_type_code": ["P: Individual"],
+        "employer_taxpayer_identification_number": "123-456-7890",
+        "sam_uei": "UEI123123123",
+        "congressional_district_applicant": "NY-001",
+        "project_title": "My Project",
+        "project_description": "A short description of my project.",
+        "project_start_date": "2026-01-01",
+        "project_end_date": "2026-12-31",
+        "project_director": contact_person_group,
+        "same_as_project_director": True,
+        "application_certification": True,
+        "authorized_representative": {
+            "first_name": "Bob",
+            "last_name": "Smith",
+        },
+        "authorized_representative_title": "Doctor",
+        "authorized_representative_email": "example@mail.com",
+        "authorized_representative_phone_number": "123-456-7890",
+    }
+
+
+@pytest.fixture
+def full_valid_json_v3_0(valid_json_v3_0, contact_person_group):
+    # All optional fields set and the primary contact provided separately from the
+    # project director (same_as_project_director is False).
+    contact = contact_person_group | {
+        "name": {
+            "prefix": "Mrs",
+            "first_name": "Sally",
+            "middle_name": "Anne",
+            "last_name": "Jones",
+            "suffix": "III",
+        },
+        "title": "Grants Administrator",
+        "email": "sally@example.com",
+        "fax": "222-222-2222",
+    }
+    return valid_json_v3_0 | {
+        "assistance_listing_number": "12.345",
+        "assistance_listing_program_title": "Secret Research",
+        "date_received": "2025-01-01",
+        "applicant_web_address": "https://example.org",
+        "applicant_type_code": ["P: Individual", "X: Other (specify)"],
+        "applicant_type_other_specify": "Secret Development",
+        "same_as_project_director": False,
+        "contact_person": contact,
+        "authorized_representative": {
+            "prefix": "Mr",
+            "first_name": "Bob",
+            "middle_name": "Frank",
+            "last_name": "Smith",
+            "suffix": "Jr",
+        },
+        "authorized_representative_fax": "333-333-3333",
+        "aor_signature": "Bob Smith",
+        "authorized_representative_date_signed": "2025-06-01",
+    }
+
+
+def test_sf424_short_v3_0_valid_json(sf424_short_v3_0, valid_json_v3_0):
+    validation_issues = validate_json_schema_for_form(valid_json_v3_0, sf424_short_v3_0)
+    assert len(validation_issues) == 0
+
+
+def test_sf424_short_v3_0_full_valid_json(sf424_short_v3_0, full_valid_json_v3_0):
+    validation_issues = validate_json_schema_for_form(full_valid_json_v3_0, sf424_short_v3_0)
+    assert len(validation_issues) == 0
+
+
+def test_sf424_short_v3_0_empty_json(sf424_short_v3_0):
+    validation_issues = validate_json_schema_for_form({}, sf424_short_v3_0)
+
+    EXPECTED_REQUIRED_FIELDS = {
+        "$.agency_name",
+        "$.funding_opportunity_number",
+        "$.funding_opportunity_title",
+        "$.organization_name",
+        "$.applicant",
+        "$.applicant_type_code",
+        "$.employer_taxpayer_identification_number",
+        "$.sam_uei",
+        "$.congressional_district_applicant",
+        "$.project_title",
+        "$.project_description",
+        "$.project_start_date",
+        "$.project_end_date",
+        "$.project_director",
+        # contact_person is required because same_as_project_director is not True
+        "$.contact_person",
+        "$.application_certification",
+        "$.authorized_representative",
+        "$.authorized_representative_title",
+        "$.authorized_representative_email",
+        "$.authorized_representative_phone_number",
+    }
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+def test_sf424_short_v3_0_empty_nested(sf424_short_v3_0, valid_json_v3_0):
+    data = valid_json_v3_0
+    data["applicant"] = {}
+    data["project_director"] = {}
+    data["authorized_representative"] = {}
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+
+    EXPECTED_REQUIRED_FIELDS = {
+        "$.applicant.street1",
+        "$.applicant.city",
+        "$.applicant.country",
+        "$.project_director.name",
+        "$.project_director.title",
+        "$.project_director.address",
+        "$.project_director.phone_number",
+        "$.project_director.email",
+        "$.authorized_representative.first_name",
+        "$.authorized_representative.last_name",
+    }
+
+    assert len(validation_issues) == len(EXPECTED_REQUIRED_FIELDS)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ["X: Other (specify)"],
+        ["X: Other (specify)", "A: State Government"],
+        ["E: Regional Organization", "X: Other (specify)", "G: Independent School District"],
+    ],
+)
+def test_sf424_short_v3_0_applicant_type_other(sf424_short_v3_0, valid_json_v3_0, value):
+    """An applicant type of Other makes applicant_type_other_specify required."""
+    data = valid_json_v3_0
+    data["applicant_type_code"] = value
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].message == "'applicant_type_other_specify' is a required property"
+
+
+@pytest.mark.parametrize(
+    "value,expected_error",
+    [
+        ([], "[] should be non-empty"),
+        (
+            [
+                "A: State Government",
+                "B: County Government",
+                "C: City or Township Government",
+                "D: Special District Government",
+            ],
+            "The array is too long, expected a maximum length of 3",
+        ),
+    ],
+)
+def test_sf424_short_v3_0_applicant_type_length(
+    sf424_short_v3_0, valid_json_v3_0, value, expected_error
+):
+    """Applicant type must have 1-3 values."""
+    data = valid_json_v3_0
+    data["applicant_type_code"] = value
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].message == expected_error
+
+
+@pytest.mark.parametrize(
+    "data,required_fields",
+    [
+        # Same as project director -> contact person must be empty
+        (
+            {"same_as_project_director": False},
+            ["$.contact_person"],
+        ),
+        # Address in the US requires state and zip
+        (
+            {
+                "applicant": {
+                    "street1": "123 Main St",
+                    "city": "New York",
+                    "country": "USA: UNITED STATES",
+                }
+            },
+            ["$.applicant.state", "$.applicant.zip_code"],
+        ),
+    ],
+)
+def test_sf424_short_v3_0_conditionally_required_fields(
+    sf424_short_v3_0, valid_json_v3_0, data, required_fields
+):
+    data = valid_json_v3_0 | data
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == len(required_fields)
+    for validation_issue in validation_issues:
+        assert validation_issue.type == "required"
+        assert validation_issue.field in required_fields
+
+
+def test_sf424_short_v3_0_contact_person_required_when_not_same(sf424_short_v3_0, valid_json_v3_0):
+    """When same_as_project_director is not True, the primary contact is required."""
+    data = valid_json_v3_0
+    del data["same_as_project_director"]
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "required"
+    assert validation_issues[0].field == "$.contact_person"
+
+
+def test_sf424_short_v3_0_contact_person_must_be_empty_when_same(
+    sf424_short_v3_0, valid_json_v3_0, contact_person_group
+):
+    """When same_as_project_director is True, providing a populated contact fails validation."""
+    data = valid_json_v3_0 | {
+        "same_as_project_director": True,
+        "contact_person": contact_person_group,
+    }
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxProperties"
+    assert validation_issues[0].field == "$.contact_person"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # Date fields
+        {"date_received": "not-a-date"},
+        {"project_start_date": "nope"},
+        {"project_end_date": "Jan 1st, 2025"},
+        {"authorized_representative_date_signed": "words"},
+        # Email fields
+        {"authorized_representative_email": "bob at mail.com"},
+    ],
+)
+def test_sf424_short_v3_0_formats(sf424_short_v3_0, valid_json_v3_0, data):
+    data = valid_json_v3_0 | data
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "format"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"employer_taxpayer_identification_number": "12345678"},
+        {"sam_uei": "xyz123"},
+        {"congressional_district_applicant": ""},
+        {"authorized_representative": {"first_name": "", "last_name": "Smith"}},
+        {"authorized_representative_fax": ""},
+    ],
+)
+def test_sf424_short_v3_0_min_length(sf424_short_v3_0, valid_json_v3_0, data):
+    """Test some field length requirements - does not check every single field."""
+    data = valid_json_v3_0 | data
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "minLength"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"employer_taxpayer_identification_number": "1" * 31},
+        {"sam_uei": "xyz123xyz123xyz"},
+        {"congressional_district_applicant": "1234567"},
+        {"project_title": "a" * 201},
+        {"project_description": "a" * 1001},
+        {"authorized_representative_title": "a" * 46},
+    ],
+)
+def test_sf424_short_v3_0_max_length(sf424_short_v3_0, valid_json_v3_0, data):
+    """Test some field length requirements - does not check every single field."""
+    data = valid_json_v3_0 | data
+
+    validation_issues = validate_json_schema_for_form(data, sf424_short_v3_0)
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "maxLength"
+
+
+def test_sf424_short_v3_0_pre_population_with_all_non_null_values(
+    enable_factory_create, valid_json_v3_0, sf424_short_v3_0, verify_no_warning_error_logs
+):
+    application_form = setup_application_for_form_validation(
+        valid_json_v3_0,
+        json_schema=sf424_short_v3_0.form_json_schema,
+        rule_schema=sf424_short_v3_0.form_rule_schema,
+        opportunity_number="ABC-123-XYZ",
+        opportunity_title="My Example Opportunity",
+        has_agency=True,
+        agency_name="Example Agency XYZ",
+        agency_code="ABC-XYZ-123-456-789",
+        has_organization=True,
+        uei="TESTUEI98765",
+        has_assistance_listing_number=True,
+        assistance_listing_number="12.345",
+        assistance_listing_program_title="Example Program Title",
+    )
+
+    issues = validate_application_form(application_form, ApplicationAction.MODIFY)
+
+    assert len(issues) == 0
+    app_json = application_form.application_response
+    assert app_json["sam_uei"] == "TESTUEI98765"
+    assert app_json["agency_name"] == "Example Agency XYZ"
+    assert app_json["assistance_listing_number"] == "12.345"
+    assert app_json["assistance_listing_program_title"] == "Example Program Title"
+    assert app_json["funding_opportunity_number"] == "ABC-123-XYZ"
+    assert app_json["funding_opportunity_title"] == "My Example Opportunity"
+    # Post-populated fields not present on a modify
+    assert "date_received" not in app_json
+    assert "aor_signature" not in app_json
+    assert "authorized_representative_date_signed" not in app_json
+
+
+@freezegun.freeze_time("2023-02-20 12:00:00", tz_offset=0)
+def test_sf424_short_v3_0_post_population(
+    enable_factory_create, valid_json_v3_0, sf424_short_v3_0, verify_no_warning_error_logs
+):
+    application_form = setup_application_for_form_validation(
+        valid_json_v3_0,
+        json_schema=sf424_short_v3_0.form_json_schema,
+        rule_schema=sf424_short_v3_0.form_rule_schema,
+        user_email="mynewmail@example.com",
+    )
+
+    issues = validate_application_form(application_form, ApplicationAction.SUBMIT)
+    assert len(issues) == 0
+    app_json = application_form.application_response
+    assert app_json["date_received"] == "2023-02-20"
+    assert app_json["authorized_representative_date_signed"] == "2023-02-20"
+    assert app_json["aor_signature"] == "mynewmail@example.com"

--- a/api/tests/src/form_schema/forms/test_sf424_short.py
+++ b/api/tests/src/form_schema/forms/test_sf424_short.py
@@ -350,7 +350,7 @@ def test_sf424_short_v3_0_pre_population_with_all_non_null_values(
         agency_name="Example Agency XYZ",
         agency_code="ABC-XYZ-123-456-789",
         has_organization=True,
-        uei="TESTUEI98765",
+        uei="SHORTUEI9876",
         has_assistance_listing_number=True,
         assistance_listing_number="12.345",
         assistance_listing_program_title="Example Program Title",
@@ -360,7 +360,7 @@ def test_sf424_short_v3_0_pre_population_with_all_non_null_values(
 
     assert len(issues) == 0
     app_json = application_form.application_response
-    assert app_json["sam_uei"] == "TESTUEI98765"
+    assert app_json["sam_uei"] == "SHORTUEI9876"
     assert app_json["agency_name"] == "Example Agency XYZ"
     assert app_json["assistance_listing_number"] == "12.345"
     assert app_json["assistance_listing_program_title"] == "Example Program Title"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10817 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Added the `sf424_short` form package (`config.py`, `__init__.py`, `1/0/form_json.py`) defining `SF424Short_v3_0`
- Registered `FormType.SF424_SHORT` in `lookup_constants.py` and `FORM_TYPE_CONFIG`.
- Registered the form in `forms/__init__.py` and added a conftest fixture.
- Added `test_sf424_short.py` covering valid/empty/nested cases, conditional requireds, the empty-if-true rule, formats, length bounds, and pre/post-population.


## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
This ticket is to complete the backend work for the SF-424 Short Organization form.

Form information: https://www.grants.gov/forms/form-items-description/fid/711

Readme: https://github.com/HHS/simpler-grants-gov/tree/main/api/src/form_schema/forms

Form metadata: https://docs.google.com/spreadsheets/d/1nGolGAVMPgDQ3kaDwE9CtRPqfR6Eh40LG2WZyGAM8O8/edit?gid=1515759995#gid=1515759995

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
See new unit tests. (`make test args="tests/src/form_schema/"`)