### PR TITLE
[Issue #11547] Refactor few shared behaviors into reusable helpers + resolve E2E run failures

### DIFF
--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-budget-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-budget-narrative-attachment.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -39,12 +40,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-cd511.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-cd511.spec.ts
@@ -29,7 +29,7 @@ import {
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-cd511.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-cd511.spec.ts
@@ -19,6 +19,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -33,12 +34,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-epa-keycontacts.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-epa-keycontacts.spec.ts
@@ -20,6 +20,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { fillFormPartial } from "tests/e2e/utils/forms/general-forms-filling";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
@@ -42,12 +43,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-epa4700-4.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-epa4700-4.spec.ts
@@ -29,7 +29,7 @@ import {
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-epa4700-4.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-epa4700-4.spec.ts
@@ -19,6 +19,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -33,12 +34,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-grantsgov-lobbying.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-grantsgov-lobbying.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -39,12 +40,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-other-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-other-narrative-attachment.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -39,12 +40,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-abstract-summary.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-abstract-summary.spec.ts
@@ -28,7 +28,7 @@ import {
 } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-abstract-summary.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-abstract-summary.spec.ts
@@ -19,6 +19,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -32,12 +33,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-abstract.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-abstract.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -39,12 +40,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-project-narrative-attachment.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -39,12 +40,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424.spec.ts
@@ -29,7 +29,7 @@ import {
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424.spec.ts
@@ -19,6 +19,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -33,12 +34,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424a.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424a.spec.ts
@@ -23,6 +23,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -41,12 +42,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424b.spec.ts
@@ -28,7 +28,7 @@ import {
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_ID = "f7a1c2b3-4d5e-6789-8abc-1234567890ab"; // TEST-APPLY-ORG-IND-ON01
 const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424b.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -33,12 +34,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424d.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424d.spec.ts
@@ -28,7 +28,7 @@ import {
 } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424d.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sf424d.spec.ts
@@ -19,6 +19,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -32,12 +33,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sflll.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-sflll.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -39,12 +40,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-suppcoversheet-neh-grantsprogram.spec.ts
+++ b/frontend/tests/e2e/apply/forms/failure-path/specs/failure-path-suppcoversheet-neh-grantsprogram.spec.ts
@@ -18,6 +18,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
 import {
@@ -39,12 +40,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-budget-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-budget-narrative-attachment.spec.ts
@@ -16,6 +16,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -33,12 +34,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-cd511.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-cd511.spec.ts
@@ -22,7 +22,7 @@ import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-cd511.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-cd511.spec.ts
@@ -17,6 +17,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -26,12 +27,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa-keycontacts.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa-keycontacts.spec.ts
@@ -17,6 +17,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -26,12 +27,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging to avoid OTP rate-limiting
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa-keycontacts.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa-keycontacts.spec.ts
@@ -22,7 +22,7 @@ import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging to avoid OTP rate-limiting

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa4700-4.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa4700-4.spec.ts
@@ -17,6 +17,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -27,12 +28,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa4700-4.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-epa4700-4.spec.ts
@@ -23,7 +23,7 @@ import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-sta
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-grantsgov-lobbying.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-grantsgov-lobbying.spec.ts
@@ -17,12 +17,18 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
 const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
+
+// Skip non-Chrome browsers in staging
+test.beforeEach(({ page: _ }, testInfo) => {
+  skipNonChromeOnStaging(testInfo);
+});
 
 test(
   "Application form completion happy path - Grants.gov Lobbying",

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-other-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-other-narrative-attachment.spec.ts
@@ -16,6 +16,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -34,12 +35,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-project-abstract.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-project-abstract.spec.ts
@@ -16,6 +16,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -33,12 +34,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-project-narrative-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-project-narrative-attachment.spec.ts
@@ -16,6 +16,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -34,12 +35,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424b.spec.ts
@@ -21,7 +21,7 @@ import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_ID = "f7a1c2b3-4d5e-6789-8abc-1234567890ab"; // TEST-APPLY-ORG-IND-ON01
 const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424b.spec.ts
@@ -16,6 +16,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -26,12 +27,7 @@ const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424d.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424d.spec.ts
@@ -16,6 +16,7 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { getOpportunityId } from "tests/e2e/utils/application/get-opportunityId-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
@@ -25,12 +26,7 @@ const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424d.spec.ts
+++ b/frontend/tests/e2e/apply/forms/happy-path/specs/happy-path-sf424d.spec.ts
@@ -21,7 +21,7 @@ import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { verifyFormStatusAfterSave } from "tests/e2e/utils/forms/verify-form-status-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION } = VALID_TAGS;
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_URL = `/opportunity/${getOpportunityId()}`;
 
 // Skip non-Chrome browsers in staging

--- a/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
@@ -23,6 +23,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { selectFormInclusionOption } from "tests/e2e/utils/forms/select-form-inclusion-utils";
 import {
@@ -52,12 +53,7 @@ const applicantScenarios = [
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 for (const { testName, orgLabel } of applicantScenarios) {

--- a/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/happy-path-submission-required-conditional.spec.ts
@@ -34,7 +34,7 @@ import { submitApplicationAndVerify } from "tests/e2e/utils/submission/submit-ap
 
 const { APPLY, SMOKE, GRANTEE } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_ID = "f7a1c2b3-4d5e-6789-8abc-1234567890ab"; // TEST-APPLY-ORG-IND-ON01
 const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 

--- a/frontend/tests/e2e/apply/submission/specs/submission-printview-attachment.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-printview-attachment.spec.ts
@@ -14,6 +14,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import {
   verifyFormStatusAfterSave,
@@ -28,11 +29,14 @@ import {
   validateAttachmentPrintViewSection,
   validatePrintViewField,
 } from "tests/e2e/utils/submission/print-view-utils";
-import { submitApplicationAndVerify } from "tests/e2e/utils/submission/submit-application-utils";
+import {
+  submitApplicationAndVerify,
+  verifySubmissionConfirmation,
+} from "tests/e2e/utils/submission/submit-application-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION, SMOKE, GRANTEE } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 
 // Only the opportunity number is declared here.
 // All opportunity/form details are resolved from the per-form data files via load-opportunity-config.ts.
@@ -53,12 +57,7 @@ const applicantScenarios = [
 
 // Skip non-Chrome browsers in staging to avoid MFA OTP rate-limiting.
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 for (const { testName, orgLabel } of applicantScenarios) {
@@ -90,11 +89,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       const filledForms: FilledFormEntry[] = [];
 
       for (const [index, form] of opportunityConfig.forms.entries()) {
-        const testData = buildHappyPathTestData(
-          form.buildTestData,
-          baseSuffix + index,
-          form.formConfig,
-        );
+        const testData = buildHappyPathTestData(form, baseSuffix + index);
 
         await fillForm(testInfo, page, form.formConfig, testData, false);
 
@@ -131,15 +126,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       await submitApplicationAndVerify(page, "success");
 
       // --- Confirmation Page Validation ---
-      await expect(
-        page.getByRole("heading", {
-          name: /your application has been submitted/i,
-        }),
-      ).toBeVisible();
-
-      await expect(page.getByTestId("summary-box")).toContainText(
-        "Your application has been submitted",
-      );
+      await verifySubmissionConfirmation(page);
 
       // --- Print View Validation (one page per form) ---
       for (const {

--- a/frontend/tests/e2e/apply/submission/specs/submission-printview-project-abstract-summary.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-printview-project-abstract-summary.spec.ts
@@ -19,6 +19,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import {
   verifyFormStatusAfterSave,
@@ -32,11 +33,14 @@ import {
   navigateToPrintView,
   validatePrintViewField,
 } from "tests/e2e/utils/submission/print-view-utils";
-import { submitApplicationAndVerify } from "tests/e2e/utils/submission/submit-application-utils";
+import {
+  submitApplicationAndVerify,
+  verifySubmissionConfirmation,
+} from "tests/e2e/utils/submission/submit-application-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION, SMOKE, GRANTEE } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 
 // Only the opportunity number is declared here.
 // All opportunity/form details are resolved from form specific fixtures.
@@ -56,12 +60,7 @@ const applicantScenarios = [
 
 // Skip non-Chrome browsers in staging to avoid MFA OTP rate-limiting.
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 for (const { testName, orgLabel } of applicantScenarios) {
@@ -89,11 +88,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
 
       // --- Generate this form's happy-path test data ---
       for (const [index, form] of opportunityConfig.forms.entries()) {
-        const testData = buildHappyPathTestData(
-          form.buildTestData,
-          baseSuffix + index,
-          form.formConfig,
-        );
+        const testData = buildHappyPathTestData(form, baseSuffix + index);
 
         // --- Fill the form with generated unique data ---
         await fillForm(testInfo, page, form.formConfig, testData, false);
@@ -131,16 +126,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       await submitApplicationAndVerify(page, "success");
 
       // --- Confirmation Page Validation ---
-      await expect(
-        page.getByRole("heading", {
-          name: /your application has been submitted/i,
-        }),
-      ).toBeVisible();
-
-      // --- Summary box contains submission confirmation message ---
-      await expect(page.getByTestId("summary-box")).toContainText(
-        "Your application has been submitted",
-      );
+      await verifySubmissionConfirmation(page);
 
       // --- Print View Validation (one print url per form) ---
       for (const {

--- a/frontend/tests/e2e/apply/submission/specs/submission-printview-sf424.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-printview-sf424.spec.ts
@@ -14,6 +14,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import {
   verifyFormStatusAfterSave,
@@ -28,11 +29,14 @@ import {
   validateAttachmentPrintViewSection,
   validatePrintViewField,
 } from "tests/e2e/utils/submission/print-view-utils";
-import { submitApplicationAndVerify } from "tests/e2e/utils/submission/submit-application-utils";
+import {
+  submitApplicationAndVerify,
+  verifySubmissionConfirmation,
+} from "tests/e2e/utils/submission/submit-application-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION, SMOKE, GRANTEE } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 
 // Only the opportunity number is declared here.
 // All opportunity/form details are resolved from the per-form data files via load-opportunity-config.ts.
@@ -53,12 +57,7 @@ const applicantScenarios = [
 
 // Skip non-Chrome browsers in staging to avoid MFA OTP rate-limiting.
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 for (const { testName, orgLabel } of applicantScenarios) {
@@ -90,11 +89,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       const filledForms: FilledFormEntry[] = [];
 
       for (const [index, form] of opportunityConfig.forms.entries()) {
-        const testData = buildHappyPathTestData(
-          form.buildTestData,
-          baseSuffix + index,
-          form.formConfig,
-        );
+        const testData = buildHappyPathTestData(form, baseSuffix + index);
 
         await fillForm(testInfo, page, form.formConfig, testData, false);
 
@@ -131,15 +126,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       await submitApplicationAndVerify(page, "success");
 
       // --- Confirmation Page Validation ---
-      await expect(
-        page.getByRole("heading", {
-          name: /your application has been submitted/i,
-        }),
-      ).toBeVisible();
-
-      await expect(page.getByTestId("summary-box")).toContainText(
-        "Your application has been submitted",
-      );
+      await verifySubmissionConfirmation(page);
 
       // --- Print View Validation (one page per form) ---
       for (const {

--- a/frontend/tests/e2e/apply/submission/specs/submission-printview-sf424a.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-printview-sf424a.spec.ts
@@ -14,6 +14,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import {
   verifyFormStatusAfterSave,
@@ -27,14 +28,17 @@ import {
   navigateToPrintView,
   validatePrintViewField,
 } from "tests/e2e/utils/submission/print-view-utils";
-import { submitApplicationAndVerify } from "tests/e2e/utils/submission/submit-application-utils";
+import {
+  submitApplicationAndVerify,
+  verifySubmissionConfirmation,
+} from "tests/e2e/utils/submission/submit-application-utils";
 
 // TODO: Uncomment when bug #11223 is fixed (row totals and grand total)
 // import { validateSF424ARowTotals } from "tests/e2e/utils/forms/validate-form-totals-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION, SMOKE, GRANTEE } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 
 // Only the opportunity number is declared here.
 // All opportunity/form details are resolved from the per-form data files via load-opportunity-config.ts.
@@ -55,12 +59,7 @@ const applicantScenarios = [
 
 // Skip non-Chrome browsers in staging to avoid MFA OTP rate-limiting.
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 for (const { testName, orgLabel } of applicantScenarios) {
@@ -92,11 +91,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       const filledForms: FilledFormEntry[] = [];
 
       for (const [index, form] of opportunityConfig.forms.entries()) {
-        const testData = buildHappyPathTestData(
-          form.buildTestData,
-          baseSuffix + index,
-          form.formConfig,
-        );
+        const testData = buildHappyPathTestData(form, baseSuffix + index);
 
         await fillForm(testInfo, page, form.formConfig, testData, false);
 
@@ -156,15 +151,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       await page.waitForLoadState("domcontentloaded");
 
       // --- Confirmation Page Validation ---
-      await expect(
-        page.getByRole("heading", {
-          name: /your application has been submitted/i,
-        }),
-      ).toBeVisible();
-
-      await expect(page.getByTestId("summary-box")).toContainText(
-        "Your application has been submitted",
-      );
+      await verifySubmissionConfirmation(page);
 
       // --- Print View Validation (one page per form) ---
       for (const {

--- a/frontend/tests/e2e/apply/submission/specs/submission-printview-sflll.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-printview-sflll.spec.ts
@@ -14,6 +14,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import {
   verifyFormStatusAfterSave,
@@ -27,11 +28,14 @@ import {
   navigateToPrintView,
   validatePrintViewField,
 } from "tests/e2e/utils/submission/print-view-utils";
-import { submitApplicationAndVerify } from "tests/e2e/utils/submission/submit-application-utils";
+import {
+  submitApplicationAndVerify,
+  verifySubmissionConfirmation,
+} from "tests/e2e/utils/submission/submit-application-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION, SMOKE, GRANTEE } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 
 // Only the opportunity number is declared here.
 // All opportunity/form details are resolved from the per-form data files via load-opportunity-config.ts.
@@ -52,12 +56,7 @@ const applicantScenarios = [
 
 // Skip non-Chrome browsers in staging to avoid MFA OTP rate-limiting.
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 for (const { testName, orgLabel } of applicantScenarios) {
@@ -89,11 +88,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       const filledForms: FilledFormEntry[] = [];
 
       for (const [index, form] of opportunityConfig.forms.entries()) {
-        const testData = buildHappyPathTestData(
-          form.buildTestData,
-          baseSuffix + index,
-          form.formConfig,
-        );
+        const testData = buildHappyPathTestData(form, baseSuffix + index);
 
         await fillForm(testInfo, page, form.formConfig, testData, false);
 
@@ -130,15 +125,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       await submitApplicationAndVerify(page, "success");
 
       // --- Confirmation Page Validation ---
-      await expect(
-        page.getByRole("heading", {
-          name: /your application has been submitted/i,
-        }),
-      ).toBeVisible();
-
-      await expect(page.getByTestId("summary-box")).toContainText(
-        "Your application has been submitted",
-      );
+      await verifySubmissionConfirmation(page);
 
       // --- Print View Validation (one page per form) ---
       for (const {

--- a/frontend/tests/e2e/apply/submission/specs/submission-printview-supp-cover-sheet-neh.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-printview-supp-cover-sheet-neh.spec.ts
@@ -14,6 +14,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import {
   verifyFormStatusAfterSave,
@@ -27,11 +28,14 @@ import {
   navigateToPrintView,
   validatePrintViewField,
 } from "tests/e2e/utils/submission/print-view-utils";
-import { submitApplicationAndVerify } from "tests/e2e/utils/submission/submit-application-utils";
+import {
+  submitApplicationAndVerify,
+  verifySubmissionConfirmation,
+} from "tests/e2e/utils/submission/submit-application-utils";
 
 const { APPLY, APPLY_FORMS, CORE_REGRESSION, SMOKE, GRANTEE } = VALID_TAGS;
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 
 // Only the opportunity number is declared here.
 // All opportunity/form details are resolved from the per-form data files via load-opportunity-config.ts.
@@ -52,12 +56,7 @@ const applicantScenarios = [
 
 // Skip non-Chrome browsers in staging to avoid MFA OTP rate-limiting.
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 for (const { testName, orgLabel } of applicantScenarios) {
@@ -89,11 +88,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       const filledForms: FilledFormEntry[] = [];
 
       for (const [index, form] of opportunityConfig.forms.entries()) {
-        const testData = buildHappyPathTestData(
-          form.buildTestData,
-          baseSuffix + index,
-          form.formConfig,
-        );
+        const testData = buildHappyPathTestData(form, baseSuffix + index);
 
         await fillForm(testInfo, page, form.formConfig, testData, false);
 
@@ -130,15 +125,7 @@ for (const { testName, orgLabel } of applicantScenarios) {
       await submitApplicationAndVerify(page, "success");
 
       // --- Confirmation Page Validation ---
-      await expect(
-        page.getByRole("heading", {
-          name: /your application has been submitted/i,
-        }),
-      ).toBeVisible();
-
-      await expect(page.getByTestId("summary-box")).toContainText(
-        "Your application has been submitted",
-      );
+      await verifySubmissionConfirmation(page);
 
       // --- Print View Validation (one page per form) ---
       for (const {

--- a/frontend/tests/e2e/apply/submission/specs/submission-state-history-validation.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-state-history-validation.spec.ts
@@ -17,6 +17,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { createApplication } from "tests/e2e/utils/application/create-application-utils";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { openForm } from "tests/e2e/utils/forms/form-navigation-utils";
 import { fillForm } from "tests/e2e/utils/forms/general-forms-filling";
 import { saveForm } from "tests/e2e/utils/forms/save-form-utils";
@@ -63,12 +64,7 @@ const EXPECTED_HISTORY_ENTRIES = [
 
 // Skip non-Chrome browsers in staging
 test.beforeEach(({ page: _ }, testInfo) => {
-  if (targetEnv === "staging") {
-    test.skip(
-      testInfo.project.name !== "Chrome",
-      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-    );
-  }
+  skipNonChromeOnStaging(testInfo);
 });
 
 test(

--- a/frontend/tests/e2e/apply/submission/specs/submission-state-history-validation.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-state-history-validation.spec.ts
@@ -35,7 +35,7 @@ import {
   type SubmitOutcome,
 } from "tests/e2e/utils/submission/submit-application-utils";
 
-const { testOrgLabel, targetEnv } = playwrightEnv;
+const { testOrgLabel } = playwrightEnv;
 const OPPORTUNITY_ID = "f7a1c2b3-4d5e-6789-8abc-1234567890ab"; // TEST-APPLY-ORG-IND-ON01
 const OPPORTUNITY_URL = `/opportunity/${OPPORTUNITY_ID}`;
 

--- a/frontend/tests/e2e/login/specs/login-with-login-gov.spec.ts
+++ b/frontend/tests/e2e/login/specs/login-with-login-gov.spec.ts
@@ -11,6 +11,7 @@ import {
   findSignOutButton,
   performStagingLogin,
 } from "tests/e2e/utils/auth/perform-login-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 
 const { SMOKE, AUTH } = VALID_TAGS;
 
@@ -22,12 +23,7 @@ const TIMEOUT_REDIRECT = 90000;
 test.describe("Login.gov based authentication tests", () => {
   // Skip non-Chrome browsers in staging
   test.beforeEach(({ page: _ }, testInfo) => {
-    if (targetEnv === "staging") {
-      test.skip(
-        testInfo.project.name !== "Chrome",
-        "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-      );
-    }
+    skipNonChromeOnStaging(testInfo);
   });
 
   // Skip test if env missing

--- a/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
+++ b/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "@playwright/test";
-import playwrightEnv from "tests/e2e/playwright-env";
 import { openMobileNav, waitForURLChange } from "tests/e2e/playwrightUtils";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";

--- a/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
+++ b/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
@@ -8,8 +8,6 @@ import { ensureOpportunityIsSaved } from "tests/e2e/utils/saved-opportunities/sa
 
 const { GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION } = VALID_TAGS;
 
-const { targetEnv } = playwrightEnv;
-
 const SAVED_OPPORTUNITY = {
   title: "TEST-APPLY-ORG-IND-OT01",
   opportunityNumber: "TEST-APPLY-ORG-IND-ON01",
@@ -34,12 +32,7 @@ const CARD_FIELD_LABELS = [
 test.describe("Saved Opportunities", () => {
   // Skip non-Chrome browsers in staging
   test.beforeEach(({ page: _ }, testInfo) => {
-    if (targetEnv === "staging") {
-      test.skip(
-        testInfo.project.name !== "Chrome",
-        "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
-      );
-    }
+    skipNonChromeOnStaging(testInfo);
   });
 
   /**

--- a/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
+++ b/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
@@ -4,8 +4,11 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
 import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { ensureOpportunityIsSaved } from "tests/e2e/utils/saved-opportunities/save-opportunity-utils";
+import playwrightEnv from "tests/e2e/playwright-env";
 
 const { GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION } = VALID_TAGS;
+
+const { targetEnv } = playwrightEnv;
 
 const SAVED_OPPORTUNITY = {
   title: "TEST-APPLY-ORG-IND-OT01",

--- a/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
+++ b/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
+import playwrightEnv from "tests/e2e/playwright-env";
 import { openMobileNav, waitForURLChange } from "tests/e2e/playwrightUtils";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
 import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { ensureOpportunityIsSaved } from "tests/e2e/utils/saved-opportunities/save-opportunity-utils";
-import playwrightEnv from "tests/e2e/playwright-env";
 
 const { GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION } = VALID_TAGS;
 

--- a/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
+++ b/frontend/tests/e2e/saved-opportunities/specs/saved-opportunities.spec.ts
@@ -3,6 +3,7 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { openMobileNav, waitForURLChange } from "tests/e2e/playwrightUtils";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
 import { ensureOpportunityIsSaved } from "tests/e2e/utils/saved-opportunities/save-opportunity-utils";
 
 const { GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION } = VALID_TAGS;

--- a/frontend/tests/e2e/search/search-core/specs/search.spec.ts
+++ b/frontend/tests/e2e/search/search-core/specs/search.spec.ts
@@ -42,7 +42,7 @@ test.describe("Search page tests", () => {
       let currentPageButton = page
         .locator(".usa-pagination__button.usa-current")
         .first();
-      await expect(currentPageButton).toHaveAttribute("aria-label", "Page 2");
+      await expect(currentPageButton).toHaveAttribute("aria-label", /page 2/i);
 
       // And I check the "Closed" opportunity status filter
       const statusCheckboxes = {
@@ -66,7 +66,7 @@ test.describe("Search page tests", () => {
       currentPageButton = page
         .locator(".usa-pagination__button.usa-current")
         .first();
-      await expect(currentPageButton).toHaveAttribute("aria-label", "Page 1");
+      await expect(currentPageButton).toHaveAttribute("aria-label", /page 1/i);
 
       // And the URL should include "status=closed"
       await page.waitForURL("search?status=closed");

--- a/frontend/tests/e2e/utils/auth/skip-non-chrome-staging-utils.ts
+++ b/frontend/tests/e2e/utils/auth/skip-non-chrome-staging-utils.ts
@@ -1,0 +1,15 @@
+import { test, TestInfo } from "@playwright/test";
+import playwrightEnv from "tests/e2e/playwright-env";
+
+/**
+ * Staging MFA login is limited to Chrome to avoid OTP rate-limiting.
+ * Call inside a test.beforeEach in any spec that authenticates against staging.
+ */
+export function skipNonChromeOnStaging(testInfo: TestInfo): void {
+  if (playwrightEnv.targetEnv === "staging") {
+    test.skip(
+      testInfo.project.name !== "Chrome",
+      "Staging MFA login is limited to Chrome to avoid OTP rate-limiting",
+    );
+  }
+}

--- a/frontend/tests/e2e/utils/submission/print-view-utils.ts
+++ b/frontend/tests/e2e/utils/submission/print-view-utils.ts
@@ -1,6 +1,8 @@
 import { expect, type Page } from "@playwright/test";
 import type { FillFormConfig } from "tests/e2e/utils/common/types";
 
+import type { ResolvedPrintViewForm } from "./opportunity-print-view.types";
+
 /**
  * Converts a workspace application form URL to its corresponding print view URL.
  *
@@ -58,21 +60,19 @@ function truncateToMaxLength(value: string, maxLength: number): string {
  * Keys in the returned Record match the fill-data field keys
  * so the spec can resolve print testIds generically.
  *
- * @param builder    - The form's test data builder function.
- * @param suffix     - A numeric suffix appended to each value (e.g. Date.now()).
- * @param formConfig - The form's FillFormConfig, used for completeness + maxLength checks.
+ * @param form   - The ResolvedPrintViewForm containing buildTestData and formConfig.
+ * @param suffix - A numeric suffix appended to each value (e.g. Date.now()).
  */
 export function buildHappyPathTestData(
-  builder: (suffix: number) => Record<string, string>,
+  form: ResolvedPrintViewForm,
   suffix: number,
-  formConfig: FillFormConfig,
 ): Record<string, string> {
-  const rawData = builder(suffix);
+  const rawData = form.buildTestData(suffix);
 
   // Completeness check: every non-attachment, non-conditional field in the form
   // definition must have a value in the test data. This ensures the builder stays
   // in sync with field definition changes automatically — no manual list to maintain.
-  const missingKeys = Object.entries(formConfig.fields)
+  const missingKeys = Object.entries(form.formConfig.fields)
     .filter(
       ([key, def]) =>
         def.type !== "file" && !def.dependsOn && rawData[key] === undefined,
@@ -88,7 +88,7 @@ export function buildHappyPathTestData(
   // Truncate each value to its field's maxLength to prevent validation failures.
   return Object.fromEntries(
     Object.entries(rawData).map(([key, value]) => {
-      const maxLength = formConfig.fields[key]?.maxLength;
+      const maxLength = form.formConfig.fields[key]?.maxLength;
       return [
         key,
         maxLength !== undefined ? truncateToMaxLength(value, maxLength) : value,

--- a/frontend/tests/e2e/utils/submission/print-view-utils.ts
+++ b/frontend/tests/e2e/utils/submission/print-view-utils.ts
@@ -1,5 +1,4 @@
 import { expect, type Page } from "@playwright/test";
-import type { FillFormConfig } from "tests/e2e/utils/common/types";
 
 import type { ResolvedPrintViewForm } from "./opportunity-print-view.types";
 

--- a/frontend/tests/e2e/utils/submission/submit-application-utils.ts
+++ b/frontend/tests/e2e/utils/submission/submit-application-utils.ts
@@ -156,3 +156,16 @@ export async function submitApplicationAndVerify(
 
   return appIdMatch[1];
 }
+
+// --- Confirmation Page Validation ---
+export async function verifySubmissionConfirmation(page: Page): Promise<void> {
+  await expect(
+    page.getByRole("heading", {
+      name: /your application has been submitted/i,
+    }),
+  ).toBeVisible();
+
+  await expect(page.getByTestId("summary-box")).toContainText(
+    "Your application has been submitted",
+  );
+}


### PR DESCRIPTION
## Summary
Work for: Task #11547 

## Changes proposed
- Extracted the staging browser restriction logic into a reusable skipNonChromeOnStaging utility
- Centralized submission confirmation page validation into a shared verifySubmissionConfirmation helper
- Updated buildHappyPathTestData to accept the resolved form configuration object instead of separate buildTestData and formConfig arguments.
- Updated specs to use the new shared utilities.
- Relaxed search pagination assertions to match the aria-label value case-insensitively, making the tests less brittle while still validating the expected page navigation behavior. (This is not specific to Apply Form changes, but for stabilizing the E2E daily run failures)

## Context for reviewers
This PR consolidates shared behaviors into reusable helpers and stabilizes the E2E runs

## Validation steps
Run the E2E test suite in Local and Staging CI and confirm that all tests pass
