### PR TITLE
[Issue #11267] Build a can_access endpoint in the grants management API

### DIFF
--- a/backend/grants_management_api/src/api/users/user_routes.py
+++ b/backend/grants_management_api/src/api/users/user_routes.py
@@ -1,11 +1,14 @@
 import logging
+from uuid import UUID
 
 import flask
 from grants_shared.adapters import db
 from grants_shared.adapters.db import flask_db
 from grants_shared.api import response
+from grants_shared.api.route_utils import raise_flask_error
 from grants_shared.auth.api_jwt_auth import refresh_token_expiration
 from grants_shared.auth.login_gov_jwt_auth import get_final_redirect_uri
+from grants_shared.logs.flask_logger import add_extra_data_to_current_request_logs
 
 from src.api.users import user_schemas
 from src.api.users.user_blueprint import user_blueprint
@@ -17,6 +20,7 @@ from src.services.users.login_gov_callback_handler import (
     handle_login_gov_callback_request,
     handle_login_gov_token,
 )
+from src.services.users.user_can_access import check_user_can_access
 
 logger = logging.getLogger(__name__)
 
@@ -114,5 +118,37 @@ def user_token_refresh(db_session: db.Session) -> response.ApiResponse:
         "Refreshed a user token",
         extra=user_token_session.get_log_extra(),
     )
+
+    return response.ApiResponse(message="Success")
+
+
+@user_blueprint.post("/<uuid:mgmt_user_id>/can_access")
+@user_blueprint.input(user_schemas.MgmtUserCanAccessRequestSchema, location="json")
+@user_blueprint.output(user_schemas.MgmtUserCanAccessResponseSchema)
+@user_blueprint.doc(responses=[200, 401, 403, 404])
+@user_blueprint.auth_required(api_jwt_auth)
+@flask_db.with_db_session()
+def user_can_access(
+    db_session: db.Session, mgmt_user_id: UUID, json_data: dict
+) -> response.ApiResponse:
+    """Check whether the calling user can access a resource with the given privileges."""
+    add_extra_data_to_current_request_logs({"mgmt_user_id": mgmt_user_id})
+    logger.info("POST /v1/users/:mgmt_user_id/can_access")
+
+    user_token_session: MgmtUserTokenSession = api_jwt_auth.get_user_token_session()
+
+    # A user may only check access for themselves
+    if user_token_session.mgmt_user_id != mgmt_user_id:
+        raise_flask_error(403, "Forbidden")
+
+    with db_session.begin():
+        db_session.add(user_token_session)
+        check_user_can_access(
+            db_session,
+            user_token_session.mgmt_user,
+            json_data["mgmt_resource_type"],
+            json_data["mgmt_resource_id"],
+            set(json_data["mgmt_privileges"]),
+        )
 
     return response.ApiResponse(message="Success")

--- a/backend/grants_management_api/src/api/users/user_routes.py
+++ b/backend/grants_management_api/src/api/users/user_routes.py
@@ -15,6 +15,7 @@ from src.api.users.user_blueprint import user_blueprint
 from src.api.users.user_schemas import UserTokenLogoutResponseSchema, UserTokenRefreshResponseSchema
 from src.auth.api_jwt_auth import api_jwt_auth
 from src.auth.auth_utils import get_login_gov_redirect_uri, with_login_redirect_error_handler
+from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.db.models.user_models import MgmtUserTokenSession
 from src.services.users.login_gov_callback_handler import (
     handle_login_gov_callback_request,
@@ -126,7 +127,7 @@ def user_token_refresh(db_session: db.Session) -> response.ApiResponse:
 @user_blueprint.input(user_schemas.MgmtUserCanAccessRequestSchema, location="json")
 @user_blueprint.output(user_schemas.MgmtUserCanAccessResponseSchema)
 @user_blueprint.doc(responses=[200, 401, 403, 404])
-@user_blueprint.auth_required(api_jwt_auth)
+@user_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
 @flask_db.with_db_session()
 def user_can_access(
     db_session: db.Session, mgmt_user_id: UUID, json_data: dict
@@ -135,20 +136,21 @@ def user_can_access(
     add_extra_data_to_current_request_logs({"mgmt_user_id": mgmt_user_id})
     logger.info("POST /v1/users/:mgmt_user_id/can_access")
 
-    user_token_session: MgmtUserTokenSession = api_jwt_auth.get_user_token_session()
+    # Get the user from multi-auth (supports both JWT and User API Key)
+    user = jwt_or_api_user_key_multi_auth.get_user()
 
     # A user may only check access for themselves
-    if user_token_session.mgmt_user_id != mgmt_user_id:
+    if user.mgmt_user_id != mgmt_user_id:
         raise_flask_error(403, "Forbidden")
 
     with db_session.begin():
-        db_session.add(user_token_session)
+        db_session.add(user)
         check_user_can_access(
             db_session,
-            user_token_session.mgmt_user,
-            json_data["mgmt_resource_type"],
-            json_data["mgmt_resource_id"],
-            set(json_data["mgmt_privileges"]),
+            user=user,
+            resource_type=json_data["mgmt_resource_type"],
+            resource_id=json_data["mgmt_resource_id"],
+            privileges=set(json_data["mgmt_privileges"]),
         )
 
     return response.ApiResponse(message="Success")

--- a/backend/grants_management_api/src/api/users/user_schemas.py
+++ b/backend/grants_management_api/src/api/users/user_schemas.py
@@ -1,5 +1,7 @@
-from grants_shared.api.schemas.extension import Schema, fields
+from grants_shared.api.schemas.extension import Schema, fields, validators
 from grants_shared.api.schemas.response_schema import AbstractResponseSchema
+
+from src.constants.lookup_constants import MgmtPrivilege, MgmtResourceType
 
 
 class UserLoginGovCallbackSchema(Schema):
@@ -40,4 +42,28 @@ class UserTokenRefreshResponseSchema(AbstractResponseSchema):
 
 class UserTokenLogoutResponseSchema(AbstractResponseSchema):
     # No data returned
+    data = fields.MixinField(metadata={"example": None})
+
+
+class MgmtUserCanAccessRequestSchema(Schema):
+    mgmt_resource_id = fields.UUID(
+        required=True, metadata={"description": "The ID of the resource to check access against"}
+    )
+    mgmt_resource_type = fields.Enum(
+        MgmtResourceType,
+        required=True,
+        metadata={"description": "The type of the resource to check access against"},
+    )
+    mgmt_privileges = fields.List(
+        fields.Enum(MgmtPrivilege),
+        required=True,
+        validate=[validators.Length(min=1)],
+        metadata={
+            "description": "The privileges the user must have against the resource. The user must have all of them."
+        },
+    )
+
+
+class MgmtUserCanAccessResponseSchema(AbstractResponseSchema):
+    # No data returned - a 200 indicates the user has access
     data = fields.MixinField(metadata={"example": None})

--- a/backend/grants_management_api/src/auth/multi_auth.py
+++ b/backend/grants_management_api/src/auth/multi_auth.py
@@ -1,0 +1,40 @@
+from apiflask import MultiAuth
+from apiflask.types import HTTPAuthType
+
+from src.auth.api_jwt_auth import api_jwt_auth
+from src.auth.api_user_key_auth import api_user_key_auth
+from src.db.models.user_models import MgmtUser, MgmtUserApiKey, MgmtUserTokenSession
+
+
+class MgmtMultiHttpTokenAuth(MultiAuth):
+    def get_user(self) -> MgmtUser:
+        current_user = self.current_user
+
+        if isinstance(current_user, (MgmtUserTokenSession, MgmtUserApiKey)):
+            return current_user.mgmt_user
+
+        raise Exception(f"Unsupported user type: {type(current_user)}")
+
+    @property
+    def _auths(self) -> list[HTTPAuthType]:
+        # Override the parent _auths because it assumes the field it wants
+        # is additional_auth and that was recently renamed to additional_auths
+        # This just grabs both. Once APIFlask fixes this, we can remove this.
+        return (
+            [self.main_auth]
+            + list(getattr(self, "additional_auth", []))
+            + list(getattr(self, "additional_auths", []))
+        )
+
+
+# Define the multi auth that supports
+# * User JWT auth
+# * API User Key Auth
+#
+# Note that the order defined matters - earlier ones will take precedence in
+# the event a user provides us with multiple auth approaches at once, only the first
+# relevant one will be used.
+# We define the JWT auth first as the frontend will pass us a users JWT
+# and the frontend's API key for all user-based requests in order to validate
+# with our API gateway that handles rate limiting.
+jwt_or_api_user_key_multi_auth = MgmtMultiHttpTokenAuth(api_jwt_auth, api_user_key_auth)

--- a/backend/grants_management_api/src/auth/multi_auth.py
+++ b/backend/grants_management_api/src/auth/multi_auth.py
@@ -1,5 +1,4 @@
 from apiflask import MultiAuth
-from apiflask.types import HTTPAuthType
 
 from src.auth.api_jwt_auth import api_jwt_auth
 from src.auth.api_user_key_auth import api_user_key_auth
@@ -14,17 +13,6 @@ class MgmtMultiHttpTokenAuth(MultiAuth):
             return current_user.mgmt_user
 
         raise Exception(f"Unsupported user type: {type(current_user)}")
-
-    @property
-    def _auths(self) -> list[HTTPAuthType]:
-        # Override the parent _auths because it assumes the field it wants
-        # is additional_auth and that was recently renamed to additional_auths
-        # This just grabs both. Once APIFlask fixes this, we can remove this.
-        return (
-            [self.main_auth]
-            + list(getattr(self, "additional_auth", []))
-            + list(getattr(self, "additional_auths", []))
-        )
 
 
 # Define the multi auth that supports

--- a/backend/grants_management_api/src/services/users/user_can_access.py
+++ b/backend/grants_management_api/src/services/users/user_can_access.py
@@ -1,0 +1,53 @@
+import uuid
+
+from grants_shared.adapters import db
+from grants_shared.api.route_utils import raise_flask_error
+from sqlalchemy import select
+from sqlalchemy.orm import InstrumentedAttribute
+
+from src.auth.authorization_enforcer import AuthorizationEnforcer
+from src.constants.lookup_constants import MgmtPrivilege, MgmtResourceType
+from src.db.models.resource_models import AbstractResourceTableMixin, Department, Subagency, Team
+from src.db.models.user_models import MgmtUser
+
+# Each resource type we support needs its own getter that fetches the resource by its ID.
+RESOURCE_MAP: dict[
+    MgmtResourceType, tuple[type[AbstractResourceTableMixin], InstrumentedAttribute]
+] = {
+    MgmtResourceType.DEPARTMENT: (Department, Department.department_id),
+    MgmtResourceType.SUBAGENCY: (Subagency, Subagency.subagency_id),
+    MgmtResourceType.TEAM: (Team, Team.team_id),
+}
+
+
+def get_resource(
+    db_session: db.Session, resource_type: MgmtResourceType, resource_id: uuid.UUID
+) -> AbstractResourceTableMixin:
+    # An unsupported (or mismatched) type is treated the same as a missing resource so we
+    # don't reveal that a resource with that ID exists as a different type.
+    if resource_type not in RESOURCE_MAP:
+        raise_flask_error(404, f"Resource {resource_id} of type {resource_type} not found")
+
+    model, id_field = RESOURCE_MAP[resource_type]
+    resource = db_session.execute(select(model).where(id_field == resource_id)).scalar_one_or_none()
+
+    if resource is None:
+        raise_flask_error(404, f"Resource {resource_id} of type {resource_type} not found")
+
+    return resource
+
+
+def check_user_can_access(
+    db_session: db.Session,
+    user: MgmtUser,
+    resource_type: MgmtResourceType,
+    resource_id: uuid.UUID,
+    privileges: set[MgmtPrivilege],
+) -> None:
+    resource = get_resource(db_session, resource_type, resource_id)
+
+    AuthorizationEnforcer(db_session).verify_access(
+        user=user,
+        required_privileges=privileges,
+        resource=resource,
+    )

--- a/backend/grants_management_api/tests/api/users/test_user_route_can_access.py
+++ b/backend/grants_management_api/tests/api/users/test_user_route_can_access.py
@@ -7,6 +7,7 @@ from src.constants.lookup_constants import MgmtPrivilege, MgmtResourceType
 from tests.db.models.factories import (
     DepartmentFactory,
     MgmtInternalResourceFactory,
+    MgmtUserApiKeyFactory,
     MgmtUserFactory,
     SubagencyFactory,
     TeamFactory,
@@ -245,6 +246,48 @@ def test_can_access_empty_privileges_422(user_and_token, client, db_session):
     resp = _post(client, user.mgmt_user_id, token, MgmtResourceType.TEAM, team.team_id, [])
 
     assert resp.status_code == 422
+
+
+def test_can_access_via_api_key_200(enable_factory_create, client, db_session):
+    """The endpoint also authenticates via an API key (X-API-Key)."""
+    user = MgmtUserFactory.create()
+    api_key = MgmtUserApiKeyFactory.create(mgmt_user=user, key_id="can-access-key", is_active=True)
+    team = TeamFactory.create()
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    resp = client.post(
+        f"v1/users/{user.mgmt_user_id}/can_access",
+        headers={"X-API-Key": api_key.key_id},
+        json={
+            "mgmt_resource_type": MgmtResourceType.TEAM,
+            "mgmt_resource_id": str(team.team_id),
+            "mgmt_privileges": ["view_team"],
+        },
+    )
+
+    assert resp.status_code == 200
+
+
+def test_can_access_via_api_key_other_user_403(enable_factory_create, client, db_session):
+    """An API-key-authenticated user may only check access for their own user ID."""
+    user = MgmtUserFactory.create()
+    api_key = MgmtUserApiKeyFactory.create(
+        mgmt_user=user, key_id="can-access-key-2", is_active=True
+    )
+    team = TeamFactory.create()
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    resp = client.post(
+        f"v1/users/{uuid.uuid4()}/can_access",
+        headers={"X-API-Key": api_key.key_id},
+        json={
+            "mgmt_resource_type": MgmtResourceType.TEAM,
+            "mgmt_resource_id": str(team.team_id),
+            "mgmt_privileges": ["view_team"],
+        },
+    )
+
+    assert resp.status_code == 403
 
 
 def test_can_access_no_token_401(client, enable_factory_create, db_session):

--- a/backend/grants_management_api/tests/api/users/test_user_route_can_access.py
+++ b/backend/grants_management_api/tests/api/users/test_user_route_can_access.py
@@ -1,0 +1,262 @@
+import uuid
+
+import pytest
+
+from src.auth.api_jwt_auth import create_jwt_for_user
+from src.constants.lookup_constants import MgmtPrivilege, MgmtResourceType
+from tests.db.models.factories import (
+    DepartmentFactory,
+    MgmtInternalResourceFactory,
+    MgmtUserFactory,
+    SubagencyFactory,
+    TeamFactory,
+)
+from tests.test_utils.auth_test_utils import setup_user_with_roles
+
+
+@pytest.fixture
+def user_and_token(enable_factory_create, db_session, app):
+    """Create a user and a valid JWT token for them."""
+    user = MgmtUserFactory.create()
+    token, _ = create_jwt_for_user(user, db_session)
+    db_session.commit()
+    return user, token
+
+
+def _post(client, user_id, token, resource_type, resource_id, privileges):
+    return client.post(
+        f"v1/users/{user_id}/can_access",
+        headers={"X-MGMT-Token": token},
+        json={
+            "mgmt_resource_type": resource_type,
+            "mgmt_resource_id": str(resource_id),
+            "mgmt_privileges": privileges,
+        },
+    )
+
+
+def test_can_access_direct_grant_200(user_and_token, client, db_session):
+    user, token = user_and_token
+    team = TeamFactory.create()
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    resp = _post(
+        client, user.mgmt_user_id, token, MgmtResourceType.TEAM, team.team_id, ["view_team"]
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["message"] == "Success"
+
+
+def test_can_access_department_200(user_and_token, client, db_session):
+    user, token = user_and_token
+    department = DepartmentFactory.create()
+    setup_user_with_roles(
+        db_session, [department], user=user, privileges=[MgmtPrivilege.VIEW_DEPARTMENT]
+    )
+
+    resp = _post(
+        client,
+        user.mgmt_user_id,
+        token,
+        MgmtResourceType.DEPARTMENT,
+        department.department_id,
+        ["view_department"],
+    )
+
+    assert resp.status_code == 200
+
+
+def test_can_access_subagency_200(user_and_token, client, db_session):
+    user, token = user_and_token
+    subagency = SubagencyFactory.create()
+    setup_user_with_roles(
+        db_session, [subagency], user=user, privileges=[MgmtPrivilege.VIEW_SUBAGENCY]
+    )
+
+    resp = _post(
+        client,
+        user.mgmt_user_id,
+        token,
+        MgmtResourceType.SUBAGENCY,
+        subagency.subagency_id,
+        ["view_subagency"],
+    )
+
+    assert resp.status_code == 200
+
+
+def test_can_access_inherited_from_parent_department_200(user_and_token, client, db_session):
+    """A role granted on the parent department should allow access to a team beneath it."""
+    user, token = user_and_token
+    team = TeamFactory.create()
+    department = team.subagency.department
+
+    # Grant the privilege on the department, then check access against the team
+    setup_user_with_roles(db_session, [department], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    resp = _post(
+        client, user.mgmt_user_id, token, MgmtResourceType.TEAM, team.team_id, ["view_team"]
+    )
+
+    assert resp.status_code == 200
+
+
+def test_can_access_multiple_privileges_requires_all_403(user_and_token, client, db_session):
+    """When multiple privileges are requested, the user must have all of them."""
+    user, token = user_and_token
+    team = TeamFactory.create()
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    resp = _post(
+        client,
+        user.mgmt_user_id,
+        token,
+        MgmtResourceType.TEAM,
+        team.team_id,
+        ["view_team", "update_team"],
+    )
+
+    assert resp.status_code == 403
+
+
+def test_can_access_missing_privilege_403(user_and_token, client, db_session):
+    user, token = user_and_token
+    team = TeamFactory.create()
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    resp = _post(
+        client, user.mgmt_user_id, token, MgmtResourceType.TEAM, team.team_id, ["update_team"]
+    )
+
+    assert resp.status_code == 403
+    assert resp.get_json()["message"] == "Forbidden"
+
+
+def test_can_access_no_roles_403(user_and_token, client, db_session):
+    """A user with no roles at all against the resource is denied."""
+    user, token = user_and_token
+    team = TeamFactory.create()
+
+    resp = _post(
+        client, user.mgmt_user_id, token, MgmtResourceType.TEAM, team.team_id, ["view_team"]
+    )
+
+    assert resp.status_code == 403
+
+
+def test_can_access_child_grant_does_not_reach_parent_403(user_and_token, client, db_session):
+    """A grant on a child team must not authorize access to the parent department."""
+    user, token = user_and_token
+    team = TeamFactory.create()
+    department = team.subagency.department
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_DEPARTMENT])
+
+    resp = _post(
+        client,
+        user.mgmt_user_id,
+        token,
+        MgmtResourceType.DEPARTMENT,
+        department.department_id,
+        ["view_department"],
+    )
+
+    assert resp.status_code == 403
+
+
+def test_can_access_other_user_403(user_and_token, client, db_session):
+    """A user may only check access for their own user ID."""
+    user, token = user_and_token
+    team = TeamFactory.create()
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    other_user_id = uuid.uuid4()
+    resp = _post(client, other_user_id, token, MgmtResourceType.TEAM, team.team_id, ["view_team"])
+
+    assert resp.status_code == 403
+
+
+def test_can_access_resource_not_found_404(user_and_token, client):
+    user, token = user_and_token
+
+    resp = _post(
+        client, user.mgmt_user_id, token, MgmtResourceType.TEAM, uuid.uuid4(), ["view_team"]
+    )
+
+    assert resp.status_code == 404
+
+
+def test_can_access_resource_type_mismatch_404(user_and_token, client, db_session):
+    """A real resource ID checked under the wrong type returns 404, not extra info."""
+    user, token = user_and_token
+    team = TeamFactory.create()
+    setup_user_with_roles(db_session, [team], user=user, privileges=[MgmtPrivilege.VIEW_TEAM])
+
+    # team.team_id is a real resource, but we ask for it as a department
+    resp = _post(
+        client,
+        user.mgmt_user_id,
+        token,
+        MgmtResourceType.DEPARTMENT,
+        team.team_id,
+        ["view_department"],
+    )
+
+    assert resp.status_code == 404
+
+
+def test_can_access_unsupported_resource_type_404(user_and_token, client):
+    """Resource types without a getter (e.g. opportunity) are not supported yet."""
+    user, token = user_and_token
+
+    resp = _post(
+        client,
+        user.mgmt_user_id,
+        token,
+        MgmtResourceType.OPPORTUNITY,
+        uuid.uuid4(),
+        ["view_team"],
+    )
+
+    assert resp.status_code == 404
+
+
+def test_can_access_internal_resource_type_404(user_and_token, client, db_session):
+    """The internal resource type is not exposed through this endpoint."""
+    user, token = user_and_token
+    internal_resource = MgmtInternalResourceFactory.create()
+
+    resp = _post(
+        client,
+        user.mgmt_user_id,
+        token,
+        MgmtResourceType.INTERNAL,
+        internal_resource.mgmt_internal_resource_id,
+        ["view_team"],
+    )
+
+    assert resp.status_code == 404
+
+
+def test_can_access_empty_privileges_422(user_and_token, client, db_session):
+    user, token = user_and_token
+    team = TeamFactory.create()
+
+    resp = _post(client, user.mgmt_user_id, token, MgmtResourceType.TEAM, team.team_id, [])
+
+    assert resp.status_code == 422
+
+
+def test_can_access_no_token_401(client, enable_factory_create, db_session):
+    team = TeamFactory.create()
+
+    resp = client.post(
+        f"v1/users/{uuid.uuid4()}/can_access",
+        json={
+            "mgmt_resource_type": MgmtResourceType.TEAM,
+            "mgmt_resource_id": str(team.team_id),
+            "mgmt_privileges": ["view_team"],
+        },
+    )
+
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11267  

## Changes proposed

- Created `user_can_access.py` to house the service logic. A `RESOURCE_MAP` of supported resource types to their getters, a `get_resource` helper that 404s on missing/unsupported/mismatched types, and `check_user_can_access` which runs the fetched resource through the `AuthorizationEnforcer`.
- Created `multi_auth.py` to add a `jwt_or_api_user_key_multi_auth` so endpoints can authenticate via either a user JWT or an API key.
- Updated `user_routes.py` to add the `POST /v1/users/{mgmt_user_id}/can_access` endpoint, which authenticates via JWT or API key, enforces that a user can only check their own access, and delegates to the service.
- Updated `user_schemas.py` to add `MgmtUserCanAccessRequestSchema` and the empty `MgmtUserCanAccessResponseSchema`.
- Created `test_user_route_can_access.py` to cover the endpoint across direct grants, hierarchy inheritance, both auth methods, and the various 403/404/422/401 paths, and the all-privileges-required semantics.

## Context for reviewers

This exposes the grants management `AuthorizationEnforcer` as an endpoint the frontend uses to gate functionality on pages, mirroring the existing `can_access` endpoint on the simpler API but against the new resource schema. Only department, subagency, and team resource types are supported for now - types without a concrete resource table + enforcer support (opportunity, internal) return a 404.

## Validation steps

Confirm tests pass.