### PR TITLE
[Issue#11536]-Add roles for workflow state machine and seed users script

### DIFF
--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -325,6 +325,14 @@ class Privilege(StrEnum):
     PROGRAM_OFFICER_APPROVAL = "program_officer_approval"
     BUDGET_OFFICER_APPROVAL = "budget_officer_approval"
 
+    # Award recommendation workflow privileges
+    CONTENT_CREATOR = "content_creator"
+    PQC_REVIEWER = "pqc_reviewer"
+    GMS_REVIEWER = "gms_reviewer"
+    FMO_REVIEWER = "fmo_reviewer"
+    GMO_REVIEWER = "gmo_reviewer"
+    FINAL_AWARD_REC_REVIEWER = "final_award_rec_reviewer"
+
     INTERNAL_S3_SCAN = "internal_s3_scan"
 
     MANAGE_TEST_USER_TOKEN = "manage_test_user_token"

--- a/api/src/constants/lookup_constants.py
+++ b/api/src/constants/lookup_constants.py
@@ -326,12 +326,11 @@ class Privilege(StrEnum):
     BUDGET_OFFICER_APPROVAL = "budget_officer_approval"
 
     # Award recommendation workflow privileges
-    CONTENT_CREATOR = "content_creator"
     PQC_REVIEWER = "pqc_reviewer"
     GMS_REVIEWER = "gms_reviewer"
     FMO_REVIEWER = "fmo_reviewer"
     GMO_REVIEWER = "gmo_reviewer"
-    FINAL_AWARD_REC_REVIEWER = "final_award_rec_reviewer"
+    FINAL_AWARD_REC_APPROVER = "final_award_rec_approver"
 
     INTERNAL_S3_SCAN = "internal_s3_scan"
 

--- a/api/src/constants/static_role_values.py
+++ b/api/src/constants/static_role_values.py
@@ -212,6 +212,90 @@ GRANTOR_BUDGET_OFFICER = Role(
     ],
 )
 
+CONTENT_CREATOR_ID = uuid.UUID("7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d")
+CONTENT_CREATOR = Role(
+    role_id=CONTENT_CREATOR_ID,
+    role_name="Content Creator",
+    is_core=True,
+    link_privileges=get_link_privileges(
+        CONTENT_CREATOR_ID,
+        [Privilege.CONTENT_CREATOR],
+    ),
+    link_role_types=[
+        LinkRoleRoleType(role_id=CONTENT_CREATOR_ID, role_type=RoleType.AGENCY)
+    ],
+)
+
+PQC_REVIEWER_ID = uuid.UUID("8b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e")
+PQC_REVIEWER = Role(
+    role_id=PQC_REVIEWER_ID,
+    role_name="PQC Reviewer",
+    is_core=True,
+    link_privileges=get_link_privileges(
+        PQC_REVIEWER_ID,
+        [Privilege.PQC_REVIEWER],
+    ),
+    link_role_types=[
+        LinkRoleRoleType(role_id=PQC_REVIEWER_ID, role_type=RoleType.AGENCY)
+    ],
+)
+
+GMS_REVIEWER_ID = uuid.UUID("9c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f")
+GMS_REVIEWER = Role(
+    role_id=GMS_REVIEWER_ID,
+    role_name="GMS Reviewer",
+    is_core=True,
+    link_privileges=get_link_privileges(
+        GMS_REVIEWER_ID,
+        [Privilege.GMS_REVIEWER],
+    ),
+    link_role_types=[
+        LinkRoleRoleType(role_id=GMS_REVIEWER_ID, role_type=RoleType.AGENCY)
+    ],
+)
+
+FMO_REVIEWER_ID = uuid.UUID("0d4e5f6a-7b8c-9d0e-1f2a-3b4c5d6e7f8a")
+FMO_REVIEWER = Role(
+    role_id=FMO_REVIEWER_ID,
+    role_name="FMO Reviewer",
+    is_core=True,
+    link_privileges=get_link_privileges(
+        FMO_REVIEWER_ID,
+        [Privilege.FMO_REVIEWER],
+    ),
+    link_role_types=[
+        LinkRoleRoleType(role_id=FMO_REVIEWER_ID, role_type=RoleType.AGENCY)
+    ],
+)
+
+GMO_REVIEWER_ID = uuid.UUID("1e5f6a7b-8c9d-0e1f-2a3b-4c5d6e7f8a9b")
+GMO_REVIEWER = Role(
+    role_id=GMO_REVIEWER_ID,
+    role_name="GMO Reviewer",
+    is_core=True,
+    link_privileges=get_link_privileges(
+        GMO_REVIEWER_ID,
+        [Privilege.GMO_REVIEWER],
+    ),
+    link_role_types=[
+        LinkRoleRoleType(role_id=GMO_REVIEWER_ID, role_type=RoleType.AGENCY)
+    ],
+)
+
+FINAL_AWARD_REC_REVIEWER_ID = uuid.UUID("2f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c")
+FINAL_AWARD_REC_REVIEWER = Role(
+    role_id=FINAL_AWARD_REC_REVIEWER_ID,
+    role_name="Final Award Rec Reviewer",
+    is_core=True,
+    link_privileges=get_link_privileges(
+        FINAL_AWARD_REC_REVIEWER_ID,
+        [Privilege.FINAL_AWARD_REC_REVIEWER],
+    ),
+    link_role_types=[
+        LinkRoleRoleType(role_id=FINAL_AWARD_REC_REVIEWER_ID, role_type=RoleType.AGENCY)
+    ],
+)
+
 ############################
 # Core Internal Roles
 ############################
@@ -310,6 +394,12 @@ CORE_ROLES = [
     AWARD_RECOMMENDATION_USER,
     GRANTOR_PROGRAM_OFFICER,
     GRANTOR_BUDGET_OFFICER,
+    CONTENT_CREATOR,
+    PQC_REVIEWER,
+    GMS_REVIEWER,
+    FMO_REVIEWER,
+    GMO_REVIEWER,
+    FINAL_AWARD_REC_REVIEWER,
     INTERNAL_S3_SCANNER_ROLE,
     E2E_TEST_USER_MANAGER_ROLE,
 ]

--- a/api/src/constants/static_role_values.py
+++ b/api/src/constants/static_role_values.py
@@ -221,9 +221,7 @@ CONTENT_CREATOR = Role(
         CONTENT_CREATOR_ID,
         [Privilege.CONTENT_CREATOR],
     ),
-    link_role_types=[
-        LinkRoleRoleType(role_id=CONTENT_CREATOR_ID, role_type=RoleType.AGENCY)
-    ],
+    link_role_types=[LinkRoleRoleType(role_id=CONTENT_CREATOR_ID, role_type=RoleType.AGENCY)],
 )
 
 PQC_REVIEWER_ID = uuid.UUID("8b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e")
@@ -235,9 +233,7 @@ PQC_REVIEWER = Role(
         PQC_REVIEWER_ID,
         [Privilege.PQC_REVIEWER],
     ),
-    link_role_types=[
-        LinkRoleRoleType(role_id=PQC_REVIEWER_ID, role_type=RoleType.AGENCY)
-    ],
+    link_role_types=[LinkRoleRoleType(role_id=PQC_REVIEWER_ID, role_type=RoleType.AGENCY)],
 )
 
 GMS_REVIEWER_ID = uuid.UUID("9c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f")
@@ -249,9 +245,7 @@ GMS_REVIEWER = Role(
         GMS_REVIEWER_ID,
         [Privilege.GMS_REVIEWER],
     ),
-    link_role_types=[
-        LinkRoleRoleType(role_id=GMS_REVIEWER_ID, role_type=RoleType.AGENCY)
-    ],
+    link_role_types=[LinkRoleRoleType(role_id=GMS_REVIEWER_ID, role_type=RoleType.AGENCY)],
 )
 
 FMO_REVIEWER_ID = uuid.UUID("0d4e5f6a-7b8c-9d0e-1f2a-3b4c5d6e7f8a")
@@ -263,9 +257,7 @@ FMO_REVIEWER = Role(
         FMO_REVIEWER_ID,
         [Privilege.FMO_REVIEWER],
     ),
-    link_role_types=[
-        LinkRoleRoleType(role_id=FMO_REVIEWER_ID, role_type=RoleType.AGENCY)
-    ],
+    link_role_types=[LinkRoleRoleType(role_id=FMO_REVIEWER_ID, role_type=RoleType.AGENCY)],
 )
 
 GMO_REVIEWER_ID = uuid.UUID("1e5f6a7b-8c9d-0e1f-2a3b-4c5d6e7f8a9b")
@@ -277,9 +269,7 @@ GMO_REVIEWER = Role(
         GMO_REVIEWER_ID,
         [Privilege.GMO_REVIEWER],
     ),
-    link_role_types=[
-        LinkRoleRoleType(role_id=GMO_REVIEWER_ID, role_type=RoleType.AGENCY)
-    ],
+    link_role_types=[LinkRoleRoleType(role_id=GMO_REVIEWER_ID, role_type=RoleType.AGENCY)],
 )
 
 FINAL_AWARD_REC_REVIEWER_ID = uuid.UUID("2f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c")

--- a/api/src/constants/static_role_values.py
+++ b/api/src/constants/static_role_values.py
@@ -212,18 +212,6 @@ GRANTOR_BUDGET_OFFICER = Role(
     ],
 )
 
-CONTENT_CREATOR_ID = uuid.UUID("7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d")
-CONTENT_CREATOR = Role(
-    role_id=CONTENT_CREATOR_ID,
-    role_name="Content Creator",
-    is_core=True,
-    link_privileges=get_link_privileges(
-        CONTENT_CREATOR_ID,
-        [Privilege.CONTENT_CREATOR],
-    ),
-    link_role_types=[LinkRoleRoleType(role_id=CONTENT_CREATOR_ID, role_type=RoleType.AGENCY)],
-)
-
 PQC_REVIEWER_ID = uuid.UUID("8b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e")
 PQC_REVIEWER = Role(
     role_id=PQC_REVIEWER_ID,
@@ -272,17 +260,17 @@ GMO_REVIEWER = Role(
     link_role_types=[LinkRoleRoleType(role_id=GMO_REVIEWER_ID, role_type=RoleType.AGENCY)],
 )
 
-FINAL_AWARD_REC_REVIEWER_ID = uuid.UUID("2f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c")
-FINAL_AWARD_REC_REVIEWER = Role(
-    role_id=FINAL_AWARD_REC_REVIEWER_ID,
-    role_name="Final Award Rec Reviewer",
+FINAL_AWARD_REC_APPROVER_ID = uuid.UUID("2f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c")
+FINAL_AWARD_REC_APPROVER = Role(
+    role_id=FINAL_AWARD_REC_APPROVER_ID,
+    role_name="Final Award Rec Approver",
     is_core=True,
     link_privileges=get_link_privileges(
-        FINAL_AWARD_REC_REVIEWER_ID,
-        [Privilege.FINAL_AWARD_REC_REVIEWER],
+        FINAL_AWARD_REC_APPROVER_ID,
+        [Privilege.FINAL_AWARD_REC_APPROVER],
     ),
     link_role_types=[
-        LinkRoleRoleType(role_id=FINAL_AWARD_REC_REVIEWER_ID, role_type=RoleType.AGENCY)
+        LinkRoleRoleType(role_id=FINAL_AWARD_REC_APPROVER_ID, role_type=RoleType.AGENCY)
     ],
 )
 
@@ -384,12 +372,11 @@ CORE_ROLES = [
     AWARD_RECOMMENDATION_USER,
     GRANTOR_PROGRAM_OFFICER,
     GRANTOR_BUDGET_OFFICER,
-    CONTENT_CREATOR,
     PQC_REVIEWER,
     GMS_REVIEWER,
     FMO_REVIEWER,
     GMO_REVIEWER,
-    FINAL_AWARD_REC_REVIEWER,
+    FINAL_AWARD_REC_APPROVER,
     INTERNAL_S3_SCANNER_ROLE,
     E2E_TEST_USER_MANAGER_ROLE,
 ]

--- a/api/src/db/models/lookup_models.py
+++ b/api/src/db/models/lookup_models.py
@@ -349,6 +349,12 @@ PRIVILEGE_CONFIG: LookupConfig[Privilege] = LookupConfig(
         LookupStr(Privilege.SUBMIT_AWARD_RECOMMENDATION, 31),
         LookupStr(Privilege.INTERNAL_S3_SCAN, 32),
         LookupStr(Privilege.MANAGE_TEST_USER_TOKEN, 33),
+        LookupStr(Privilege.CONTENT_CREATOR, 34),
+        LookupStr(Privilege.PQC_REVIEWER, 35),
+        LookupStr(Privilege.GMS_REVIEWER, 36),
+        LookupStr(Privilege.FMO_REVIEWER, 37),
+        LookupStr(Privilege.GMO_REVIEWER, 38),
+        LookupStr(Privilege.FINAL_AWARD_REC_REVIEWER, 39),
     ]
 )
 

--- a/api/src/db/models/lookup_models.py
+++ b/api/src/db/models/lookup_models.py
@@ -349,12 +349,11 @@ PRIVILEGE_CONFIG: LookupConfig[Privilege] = LookupConfig(
         LookupStr(Privilege.SUBMIT_AWARD_RECOMMENDATION, 31),
         LookupStr(Privilege.INTERNAL_S3_SCAN, 32),
         LookupStr(Privilege.MANAGE_TEST_USER_TOKEN, 33),
-        LookupStr(Privilege.CONTENT_CREATOR, 34),
-        LookupStr(Privilege.PQC_REVIEWER, 35),
-        LookupStr(Privilege.GMS_REVIEWER, 36),
-        LookupStr(Privilege.FMO_REVIEWER, 37),
-        LookupStr(Privilege.GMO_REVIEWER, 38),
-        LookupStr(Privilege.FINAL_AWARD_REC_REVIEWER, 39),
+        LookupStr(Privilege.PQC_REVIEWER, 34),
+        LookupStr(Privilege.GMS_REVIEWER, 35),
+        LookupStr(Privilege.FMO_REVIEWER, 36),
+        LookupStr(Privilege.GMO_REVIEWER, 37),
+        LookupStr(Privilege.FINAL_AWARD_REC_APPROVER, 38),
     ]
 )
 

--- a/api/tests/lib/seed_award_recommendations.py
+++ b/api/tests/lib/seed_award_recommendations.py
@@ -15,8 +15,14 @@ from src.constants.lookup_constants import (
 )
 from src.constants.static_role_values import (
     AWARD_RECOMMENDATION_USER,
+    CONTENT_CREATOR,
+    FINAL_AWARD_REC_REVIEWER,
+    FMO_REVIEWER,
+    GMS_REVIEWER,
+    GMO_REVIEWER,
     GRANTOR_BUDGET_OFFICER,
     GRANTOR_PROGRAM_OFFICER,
+    PQC_REVIEWER,
 )
 from src.db.models.agency_models import Agency
 from src.db.models.award_recommendation_models import AwardRecommendation
@@ -169,7 +175,31 @@ def _setup_agency_and_users(db_session: db.Session) -> Agency:
     ).build()
     logger.info("Created user: ar_budget_officer (Grantor Budget Officer)")
 
-    logger.info("✓ Created 1 agency and 4 users with different AR roles")
+    # Create 5 users for each new role
+    roles_config = [
+        (CONTENT_CREATOR, "content_creator", "Content Creator"),
+        (PQC_REVIEWER, "pqc_reviewer", "PQC Reviewer"),
+        (GMS_REVIEWER, "gms_reviewer", "GMS Reviewer"),
+        (FMO_REVIEWER, "fmo_reviewer", "FMO Reviewer"),
+        (GMO_REVIEWER, "gmo_reviewer", "GMO Reviewer"),
+        (FINAL_AWARD_REC_REVIEWER, "final_award_rec_reviewer", "Final Award Rec Reviewer"),
+    ]
+
+    user_counter = 4
+    for role, role_slug, role_name in roles_config:
+        for i in range(1, 6):
+            user_counter += 1
+            user_id = uuid.UUID(f"660e8400-e29b-41d4-a716-4466554400{user_counter:02d}")
+            username = f"{role_slug}_{i}"
+            display_name = f"AR User - {role_name} {i}"
+            UserBuilder(user_id, db_session, display_name).with_oauth_login(
+                username
+            ).with_api_key(f"{username}_key").with_jwt_auth().with_agency(
+                agency, roles=[role]
+            ).build()
+            logger.info(f"Created user: {username} ({role_name})")
+
+    logger.info(f"✓ Created 1 agency and {user_counter} users with different AR roles")
     logger.info("")
 
     return agency

--- a/api/tests/lib/seed_award_recommendations.py
+++ b/api/tests/lib/seed_award_recommendations.py
@@ -18,8 +18,8 @@ from src.constants.static_role_values import (
     CONTENT_CREATOR,
     FINAL_AWARD_REC_REVIEWER,
     FMO_REVIEWER,
-    GMS_REVIEWER,
     GMO_REVIEWER,
+    GMS_REVIEWER,
     GRANTOR_BUDGET_OFFICER,
     GRANTOR_PROGRAM_OFFICER,
     PQC_REVIEWER,
@@ -192,11 +192,9 @@ def _setup_agency_and_users(db_session: db.Session) -> Agency:
             user_id = uuid.UUID(f"660e8400-e29b-41d4-a716-4466554400{user_counter:02d}")
             username = f"{role_slug}_{i}"
             display_name = f"AR User - {role_name} {i}"
-            UserBuilder(user_id, db_session, display_name).with_oauth_login(
-                username
-            ).with_api_key(f"{username}_key").with_jwt_auth().with_agency(
-                agency, roles=[role]
-            ).build()
+            UserBuilder(user_id, db_session, display_name).with_oauth_login(username).with_api_key(
+                f"{username}_key"
+            ).with_jwt_auth().with_agency(agency, roles=[role]).build()
             logger.info(f"Created user: {username} ({role_name})")
 
     logger.info(f"✓ Created 1 agency and {user_counter} users with different AR roles")

--- a/api/tests/lib/seed_award_recommendations.py
+++ b/api/tests/lib/seed_award_recommendations.py
@@ -15,8 +15,7 @@ from src.constants.lookup_constants import (
 )
 from src.constants.static_role_values import (
     AWARD_RECOMMENDATION_USER,
-    CONTENT_CREATOR,
-    FINAL_AWARD_REC_REVIEWER,
+    FINAL_AWARD_REC_APPROVER,
     FMO_REVIEWER,
     GMO_REVIEWER,
     GMS_REVIEWER,
@@ -177,12 +176,11 @@ def _setup_agency_and_users(db_session: db.Session) -> Agency:
 
     # Create 5 users for each new role
     roles_config = [
-        (CONTENT_CREATOR, "content_creator", "Content Creator"),
         (PQC_REVIEWER, "pqc_reviewer", "PQC Reviewer"),
         (GMS_REVIEWER, "gms_reviewer", "GMS Reviewer"),
         (FMO_REVIEWER, "fmo_reviewer", "FMO Reviewer"),
         (GMO_REVIEWER, "gmo_reviewer", "GMO Reviewer"),
-        (FINAL_AWARD_REC_REVIEWER, "final_award_rec_reviewer", "Final Award Rec Reviewer"),
+        (FINAL_AWARD_REC_APPROVER, "final_award_rec_approver", "Final Award Rec Approver"),
     ]
 
     user_counter = 4


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11536  

## Changes proposed

Add Roles required for workflow state machine
## Context for reviewers

Add Roles required for workflow state machine
seed script to add 5 users to each role created
## Validation steps

- Fetch new changes and run make init on api folder observe roles, privileges  are created from database.
- run  make setup-api-data command to see seeded data(role specific users)