### PR TITLE
[Issue #10398] (1/2) Add logout support to grants_shared

### DIFF
--- a/backend/grants_shared/pyproject.toml
+++ b/backend/grants_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grants-shared"
-version = "0.2.17"
+version = "0.2.18"
 description = "Shared code used by the Simpler Grants.gov repo"
 readme = "README.md"
 license = "CC0-1.0"

--- a/backend/grants_shared/src/grants_shared/auth/login_gov_jwt_auth.py
+++ b/backend/grants_shared/src/grants_shared/auth/login_gov_jwt_auth.py
@@ -47,10 +47,14 @@ class LoginGovConfig(PydanticBaseEnvConfig):
     login_gov_jwk_endpoint: str = Field(alias="LOGIN_GOV_JWK_ENDPOINT")
     login_gov_auth_endpoint: str = Field(alias="LOGIN_GOV_AUTH_ENDPOINT")
     login_gov_token_endpoint: str = Field(alias="LOGIN_GOV_TOKEN_ENDPOINT")
+    login_gov_logout_endpoint: str = Field(alias="LOGIN_GOV_LOGOUT_ENDPOINT")
 
     # Where we send a user after they have successfully logged in
     # for now we'll always send them to the same place (a frontend page)
     login_final_destination: str = Field(alias="LOGIN_FINAL_DESTINATION")
+
+    # Where we sent users after they have successfully logged out
+    logout_final_destination: str = Field(alias="LOGOUT_FINAL_DESTINATION")
 
     # The private key we gave login.gov for private_key_jwt validation in the token endpoint
     # See: https://developers.login.gov/oidc/token/#client_assertion
@@ -179,6 +183,29 @@ def get_final_redirect_uri(
     encoded_params = urllib.parse.urlencode(params)
 
     return f"{config.login_final_destination}?{encoded_params}"
+
+
+def get_final_logout_redirect_uri(
+    message: str,
+    error_description: str | None = None,
+    config: LoginGovConfig | None = None,
+) -> str:
+    """
+    Get the destination where we should redirect to after the full logout flow has completed.
+
+    Generally will be a defined page in our frontend website that handles post-logout UX.
+    """
+    if config is None:
+        config = get_config()
+
+    params: dict = {"message": message}
+
+    if error_description is not None:
+        params["error_description"] = error_description
+
+    encoded_params = urllib.parse.urlencode(params)
+
+    return f"{config.logout_final_destination}?{encoded_params}"
 
 
 def validate_token(token: str, nonce: str, config: LoginGovConfig | None = None) -> LoginGovUser:

--- a/backend/grants_shared/tests/grants_shared/auth/test_login_gov_jwt_auth.py
+++ b/backend/grants_shared/tests/grants_shared/auth/test_login_gov_jwt_auth.py
@@ -252,3 +252,17 @@ def test_validate_token_invalid_nonce(login_gov_config, private_rsa_key):
 
     with pytest.raises(JwtValidationError, match="Nonce does not match expected"):
         validate_token(token, nonce=DEFAULT_NONCE, config=login_gov_config)
+
+
+def test_get_final_logout_redirect_uri(login_gov_config):
+
+    assert (
+        login_gov_jwt_auth.get_final_logout_redirect_uri("example message", config=login_gov_config)
+        == "http://localhost:3000/final-logout?message=example+message"
+    )
+    assert (
+        login_gov_jwt_auth.get_final_logout_redirect_uri(
+            "bad message", error_description="it errored", config=login_gov_config
+        )
+        == "http://localhost:3000/final-logout?message=bad+message&error_description=it+errored"
+    )

--- a/backend/grants_shared/tests/grants_shared/conftest.py
+++ b/backend/grants_shared/tests/grants_shared/conftest.py
@@ -302,7 +302,9 @@ def login_gov_config(public_rsa_key, private_rsa_key):
         LOGIN_GOV_CLIENT_ASSERTION_PRIVATE_KEY=private_rsa_key,
         LOGIN_GOV_AUTH_ENDPOINT="http://localhost:3000/auth",
         LOGIN_GOV_TOKEN_ENDPOINT="http://localhost:3000/token",
+        LOGIN_GOV_LOGOUT_ENDPOINT="http://localhost:3000/logout",
         LOGIN_FINAL_DESTINATION="http://localhost:3000/final",
+        LOGOUT_FINAL_DESTINATION="http://localhost:3000/final-logout",
     )
 
 

--- a/backend/grants_shared/uv.lock
+++ b/backend/grants_shared/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.17"
+version = "0.2.18"
 source = { virtual = "." }
 dependencies = [
     { name = "apiflask" },


### PR DESCRIPTION
## Summary
Work for #10398 

## Changes proposed
* Add logout support to grants_shared

## Context for reviewers
To support logout, we need to add a few common utils/config values to the shared code. I've already setup a lot of the implementation mostly on the API side, and this was the portion that needed to go into grants_shared. The rest of the implementation will come later.

Really just two env vars and a function that uses one of those to create a final redirect location - the general pattern here matches what we do for login, it'll just be much simpler in scope.

## Validation steps
Just tests, will test much more thoroughly once the API portion is added.