### PR TITLE
[Issue #11595] Fix ConfirmApplicationDelivery ValidatonError

### DIFF
--- a/api/src/legacy_soap_api/grantors/fault_messages.py
+++ b/api/src/legacy_soap_api/grantors/fault_messages.py
@@ -6,7 +6,7 @@ InvalidGrantsGovTrackingNumber = FaultMessage(
 )
 
 MissingGrantsGovTrackingNumber = FaultMessage(
-    faultstring="Failed to validate request.\ncvc-complex-type.2.4.b: The content of element UpdateApplicationInfoRequest is not complete. One of {https://apply.grants.gov/system/GrantsCommonElements-V1.0:GrantsGovTrackingNumber} is expected.",
+    faultstring="Failed to validate request. cvc-complex-type.2.4.b: The content of element is not complete. One of {https://apply.grants.gov/system/GrantsCommonElements-V1.0:GrantsGovTrackingNumber} is expected.",
     faultcode="soap:Server",
 )
 

--- a/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
@@ -1,9 +1,10 @@
-from typing import Any, Self
+from typing import Any
 
-from pydantic import BaseModel, Field, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, Field, PrivateAttr
 
-from src.legacy_soap_api.grantors.fault_messages import InvalidGrantsGovTrackingNumber
-from src.legacy_soap_api.legacy_soap_api_utils import SOAPFaultException
+from src.legacy_soap_api.grantors.schemas.grants_gov_tracking_number_schema import (
+    GrantsGovTrackingNumberRequiredSchema,
+)
 
 GET_APPLICATION_ZIP_REQUEST_ERR = "No grants_gov_tracking_number provided."
 
@@ -42,22 +43,5 @@ class GetApplicationZipResponseSOAPEnvelope(BaseModel):
         return envelope_dict
 
 
-class GetApplicationZipRequest(BaseModel):
-    grants_gov_tracking_number: str | None = Field(default=None, alias="GrantsGovTrackingNumber")
-
-    @model_validator(mode="after")
-    def validate_required_properties(self) -> Self:
-        if not self.grants_gov_tracking_number:
-            raise SOAPFaultException(
-                GET_APPLICATION_ZIP_REQUEST_ERR,
-                fault=InvalidGrantsGovTrackingNumber,
-            )
-        return self
-
-    @field_validator("grants_gov_tracking_number", mode="before")
-    @classmethod
-    def get_value_from_dict(cls, value: str | dict) -> str | None:
-        if isinstance(value, dict):
-            return value.get("#text")
-        else:
-            return value
+class GetApplicationZipRequest(GrantsGovTrackingNumberRequiredSchema):
+    pass

--- a/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/get_application_zip_schemas.py
@@ -6,8 +6,6 @@ from src.legacy_soap_api.grantors.schemas.grants_gov_tracking_number_schema impo
     GrantsGovTrackingNumberRequiredSchema,
 )
 
-GET_APPLICATION_ZIP_REQUEST_ERR = "No grants_gov_tracking_number provided."
-
 
 class XOPIncludeData(BaseModel):
     href: str = Field(alias="@href")

--- a/api/src/legacy_soap_api/grantors/schemas/grants_gov_tracking_number_schema.py
+++ b/api/src/legacy_soap_api/grantors/schemas/grants_gov_tracking_number_schema.py
@@ -29,3 +29,11 @@ class GrantsGovTrackingNumberRequiredSchema(BaseSOAPSchema):
                 message=INVALID_TRACKING_NUMBER_ERR, fault=InvalidGrantsGovTrackingNumber
             )
         return value
+
+    @field_validator("grants_gov_tracking_number", mode="before")
+    @classmethod
+    def get_value_from_dict(cls, value: str | dict) -> str | None:
+        if isinstance(value, dict):
+            return value.get("#text")
+        else:
+            return value

--- a/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
+++ b/api/tests/src/legacy_soap_api/grantors/schemas/test_legacy_soap_grantor_get_application_zip_schema.py
@@ -148,10 +148,10 @@ class TestLegacySoapGrantorGetApplicationZipSchema:
         soap_request_dict = client.get_soap_request_dict()
         with pytest.raises(SOAPFaultException) as exc_info:
             grantors_schemas.GetApplicationZipRequest(**soap_request_dict)
-        assert exc_info.value.message == "No grants_gov_tracking_number provided."
+        assert exc_info.value.message == "GrantsGovTrackingNumber is a required value."
         assert (
             exc_info.value.fault.faultstring
-            == "Failed to validate request. cvc-pattern-valid: Value is not facet-valid with respect to pattern 'GRANT[0-9]{8}' for type 'GrantsGovTrackingNumberType'."
+            == "Failed to validate request. cvc-complex-type.2.4.b: The content of element is not complete. One of {https://apply.grants.gov/system/GrantsCommonElements-V1.0:GrantsGovTrackingNumber} is expected."
         )
 
     def test_get_application_zip_request_schema_handles_a_dict_for_the_grants_gov_tracking_number(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -444,7 +444,7 @@ class TestSimplerSOAPGetApplicationZip:
             "<soapenv:Header/>"
             "<soapenv:Body>"
             "<agen:GetApplicationZipRequest>"
-            f"<gran:GrantsGovTrackingNumber>{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+            f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
             "</soapenv:Envelope>"
@@ -530,7 +530,7 @@ class TestSimplerSOAPGetApplicationZip:
             "<soapenv:Header/>"
             "<soapenv:Body>"
             "<agen:GetApplicationZipRequest>"
-            f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>'
+            f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>'
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
             "</soapenv:Envelope>\r\n"
@@ -610,7 +610,7 @@ class TestSimplerSOAPGetApplicationZip:
             "<soapenv:Header/>"
             "<soapenv:Body>"
             "<agen:GetApplicationZipRequest>"
-            f"<gran:GrantsGovTrackingNumber>{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+            f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
             "</soapenv:Envelope>"
@@ -653,7 +653,7 @@ class TestSimplerSOAPGetApplicationZip:
             "<soapenv:Header/>"
             "<soapenv:Body>"
             "<agen:GetApplicationZipRequest>"
-            f"<gran:GrantsGovTrackingNumber>{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+            f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
             "</soapenv:Envelope>"
@@ -694,7 +694,7 @@ class TestSimplerSOAPGetApplicationZip:
             "<soapenv:Header/>"
             "<soapenv:Body>"
             "<agen:GetApplicationZipRequest>"
-            f"<gran:GrantsGovTrackingNumber>{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+            f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
             "</soapenv:Envelope>"
@@ -734,7 +734,7 @@ class TestSimplerSOAPGetApplicationZip:
             "<soapenv:Header/>"
             "<soapenv:Body>"
             "<agen:GetApplicationZipRequest>"
-            f"<gran:GrantsGovTrackingNumber>{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+            f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
             "</agen:GetApplicationZipRequest>"
             "</soapenv:Body>"
             "</soapenv:Envelope>"
@@ -756,7 +756,7 @@ class TestSimplerSOAPGetApplicationZip:
                 "GetObject",
             )
             response = client.get_simpler_soap_response(mock_proxy_response)
-            msg = f"Unable to retrieve file legacy_tracking_number {submission.legacy_tracking_number} from s3 file location."
+            msg = f"Unable to retrieve file legacy_tracking_number GRANT{submission.legacy_tracking_number} from s3 file location."
             assert msg in caplog.messages
             assert response.data == mock_proxy_response.data
             assert response.status_code == mock_proxy_response.status_code

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from grants_shared.util import file_util
 from lxml import etree
+from sqlalchemy import func, select
 
 from src.constants.lookup_constants import ApplicationStatus, Privilege
 from src.db.models.competition_models import ApplicationSubmissionRetrieved
@@ -127,12 +128,15 @@ def test_successful_confirm_application_delivery_request(
             },
         )
     assert response.status_code == 200
-    retrieved = (
-        db_session.query(ApplicationSubmissionRetrieved)
-        .filter_by(application_submission_id=submission.application_submission_id)
-        .all()
+    count_query = (
+        select(func.count())
+        .select_from(ApplicationSubmissionRetrieved)
+        .where(
+            ApplicationSubmissionRetrieved.application_submission_id
+            == submission.application_submission_id
+        )
     )
-    assert len(retrieved) == 1
+    assert db_session.execute(count_query).scalar() == 1
 
 
 def test_successful_confirm_application_delivery_request_if_grants_gov_tracking_number_is_parsed_as_a_string(
@@ -181,12 +185,15 @@ def test_successful_confirm_application_delivery_request_if_grants_gov_tracking_
             },
         )
     assert response.status_code == 200
-    retrieved = (
-        db_session.query(ApplicationSubmissionRetrieved)
-        .filter_by(application_submission_id=submission.application_submission_id)
-        .all()
+    count_query = (
+        select(func.count())
+        .select_from(ApplicationSubmissionRetrieved)
+        .where(
+            ApplicationSubmissionRetrieved.application_submission_id
+            == submission.application_submission_id
+        )
     )
-    assert len(retrieved) == 1
+    assert db_session.execute(count_query).scalar() == 1
 
 
 @mock.patch("uuid.uuid4")

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -104,6 +104,60 @@ def test_successful_confirm_application_delivery_request(
         "<soapenv:Header/>"
         "<soapenv:Body>"
         "<agen:ConfirmApplicationDeliveryRequest>"
+        f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>'
+        "</agen:ConfirmApplicationDeliveryRequest>"
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    ).encode()
+    mock_client_cert = SOAPClientCertificate(
+        cert=MOCK_CERT_STR,
+        fingerprint=MOCK_FINGERPRINT,
+        serial_number="1235",
+        legacy_certificate=soap_client_certificate.legacy_certificate,
+        cert_id=soap_client_certificate.legacy_certificate.cert_id,
+    )
+    with mock.patch("src.legacy_soap_api.simpler_soap_api.get_soap_auth") as mock_get_auth:
+        mock_get_auth.return_value = SOAPAuth(certificate=mock_client_cert)
+        response = client.post(
+            full_path,
+            data=mock_data,
+            headers={
+                "Use-Simpler-Override": "1",
+                MTLS_CERT_HEADER_KEY: mtls_cert,
+            },
+        )
+    assert response.status_code == 200
+    retrieved = (
+        db_session.query(ApplicationSubmissionRetrieved)
+        .filter_by(application_submission_id=submission.application_submission_id)
+        .all()
+    )
+    assert len(retrieved) == 1
+
+
+def test_successful_confirm_application_delivery_request_if_grants_gov_tracking_number_is_parsed_as_a_string(
+    db_session, client, enable_factory_create
+) -> None:
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_GRANT_RETRIEVER}
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.ACCEPTED
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    mock_data = (
+        "<soapenv:Envelope "
+        'xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
+        'xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        "<soapenv:Header/>"
+        "<soapenv:Body>"
+        "<agen:ConfirmApplicationDeliveryRequest>"
         f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
         "</agen:ConfirmApplicationDeliveryRequest>"
         "</soapenv:Body>"
@@ -173,7 +227,7 @@ def test_request_and_response_data_uploaded_to_s3_if_save_soap_messages_flag_is_
         "<soapenv:Header/>"
         "<soapenv:Body>"
         "<agen:ConfirmApplicationDeliveryRequest>"
-        f"<gran:GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>"
+        f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>'
         "</agen:ConfirmApplicationDeliveryRequest>"
         "</soapenv:Body>"
         "</soapenv:Envelope>"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11595  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Moved GetApplicationZipRequest Schema to inherit from the `GrantsGovTrackingNumberRequiredSchema` instead of `BaseSchema`
- Updated GetApplicationZip tests to handle the validation requirements and responses
- Update `GrantsGovTrackingNumberRequiredSchema` to have the validator that can translate `GrantsGovTrackingNumber` from dict to a str.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
`ConfirmApplicationDelivery` calls were failing because they were formatting their xml such that `GrantsGovTrackingNumber` parsed as a dict and so we were getting a ValidationError. This change fixes that and should handle the case if this happens for UpdateApplicationInfo.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
After deploy
- [ ] can successfully pass in their alternate request xml and get parsed without validation error
