### PR TITLE
[Issue #11272] Setup internal resource in grants management API

### DIFF
--- a/backend/grants_management_api/Makefile
+++ b/backend/grants_management_api/Makefile
@@ -176,7 +176,7 @@ lint-security: # https://bandit.readthedocs.io/en/latest/index.html
 
 # Docker starts the image for the DB but it's not quite
 # ready to accept connections so we add a brief wait script
-init-db: start-db setup-postgres-db db-migrate
+init-db: start-db setup-postgres-db db-migrate setup-internal-resource
 
 start-db:
 	docker compose -f ../docker-compose.db.yml up --detach grants-db
@@ -184,6 +184,9 @@ start-db:
 
 setup-postgres-db: ## Does any initial setup necessary for our local database to work
 	$(PY_RUN_CMD) setup-postgres-db
+
+setup-internal-resource: ## Create the statically defined internal resource record (runs after migrations)
+	$(PY_RUN_CMD) setup-internal-resource
 
 #########################
 # DB Migrations

--- a/backend/grants_management_api/local.env
+++ b/backend/grants_management_api/local.env
@@ -84,6 +84,15 @@ API_JWT_PUBLIC_KEY=
 LOGIN_GOV_CLIENT_ASSERTION_PRIVATE_KEY=
 
 ############################
+# Authorization
+############################
+
+# The primary key of the statically defined internal resource record that
+# internal roles are checked against. The record is created by `make init-db`
+# (see setup_local_postgres_db.py). Only set up locally for now.
+MGMT_INTERNAL_RESOURCE_ID=2a9c7e50-6b1e-4c8f-9d3a-5e7f1b2c4d6e
+
+############################
 # Deploy Metadata
 ############################
 

--- a/backend/grants_management_api/local.env
+++ b/backend/grants_management_api/local.env
@@ -89,7 +89,7 @@ LOGIN_GOV_CLIENT_ASSERTION_PRIVATE_KEY=
 
 # The primary key of the statically defined internal resource record that
 # internal roles are checked against. The record is created by `make init-db`
-# (see setup_local_postgres_db.py). Only set up locally for now.
+# (see setup_local_postgres_db.py).
 MGMT_INTERNAL_RESOURCE_ID=2a9c7e50-6b1e-4c8f-9d3a-5e7f1b2c4d6e
 
 ############################

--- a/backend/grants_management_api/pyproject.toml
+++ b/backend/grants_management_api/pyproject.toml
@@ -64,6 +64,7 @@ db-migrate-down-all = "src.db.migrations.run:downall"
 db-seed-local = "tests.lib.seed_local_db:seed_local_db"
 create-erds = "bin.create_erds:main"
 setup-postgres-db = "src.db.migrations.setup_local_postgres_db:setup_local_postgres_db"
+setup-internal-resource = "src.db.migrations.setup_local_postgres_db:setup_internal_resource"
 
 
 [tool.uv]

--- a/backend/grants_management_api/src/auth/internal_resource.py
+++ b/backend/grants_management_api/src/auth/internal_resource.py
@@ -1,0 +1,76 @@
+import logging
+import uuid
+
+from grants_shared.adapters import db
+from grants_shared.util.env_config import PydanticBaseEnvConfig
+from pydantic import Field
+from sqlalchemy import select
+
+from src.db.models.resource_models import MgmtInternalResource
+
+logger = logging.getLogger(__name__)
+
+INTERNAL_RESOURCE_NAME = "Internal"
+
+
+class InternalResourceConfig(PydanticBaseEnvConfig):
+    # The primary key of the statically defined internal resource record.
+    # This is only set up locally for now - there is no terraform/SSM for it yet - so the
+    # field is required and instantiated lazily (only when the internal resource is needed).
+    mgmt_internal_resource_id: uuid.UUID = Field(alias="MGMT_INTERNAL_RESOURCE_ID")
+
+
+def get_internal_resource(db_session: db.Session) -> MgmtInternalResource:
+    """Fetch the statically defined internal resource record.
+
+    Internal roles are checked against this singular resource rather than a null
+    resource. This makes internal roles work the same as any other role in that they
+    are always checked against a particular resource. Use it like::
+
+        verify_access(user, {MgmtPrivilege.XYZ}, get_internal_resource(db_session))
+    """
+    config = InternalResourceConfig()
+
+    internal_resource = db_session.execute(
+        select(MgmtInternalResource).where(
+            MgmtInternalResource.mgmt_internal_resource_id == config.mgmt_internal_resource_id
+        )
+    ).scalar_one_or_none()
+
+    if internal_resource is None:
+        raise ValueError(
+            f"Internal resource {config.mgmt_internal_resource_id} does not exist - it must be created before it can be used"
+        )
+
+    return internal_resource
+
+
+def create_internal_resource(db_session: db.Session) -> MgmtInternalResource:
+    """Create the statically defined internal resource record if it does not already exist.
+
+    This is idempotent - if a record with the configured ID already exists, it is returned
+    unchanged rather than recreated. Requires resource automation to be set up so the backing
+    ``mgmt_resource`` row is created alongside it.
+    """
+    config = InternalResourceConfig()
+
+    log_extra = {"mgmt_internal_resource_id": config.mgmt_internal_resource_id}
+
+    internal_resource = db_session.execute(
+        select(MgmtInternalResource).where(
+            MgmtInternalResource.mgmt_internal_resource_id == config.mgmt_internal_resource_id
+        )
+    ).scalar_one_or_none()
+
+    if internal_resource is not None:
+        logger.info("Internal resource already exists, skipping creation", extra=log_extra)
+        return internal_resource
+
+    internal_resource = MgmtInternalResource(
+        mgmt_internal_resource_id=config.mgmt_internal_resource_id,
+        internal_resource_name=INTERNAL_RESOURCE_NAME,
+    )
+    db_session.add(internal_resource)
+
+    logger.info("Created internal resource", extra=log_extra)
+    return internal_resource

--- a/backend/grants_management_api/src/auth/internal_resource.py
+++ b/backend/grants_management_api/src/auth/internal_resource.py
@@ -14,9 +14,8 @@ INTERNAL_RESOURCE_NAME = "Internal"
 
 
 class InternalResourceConfig(PydanticBaseEnvConfig):
-    # The primary key of the statically defined internal resource record.
-    # This is only set up locally for now - there is no terraform/SSM for it yet - so the
-    # field is required and instantiated lazily (only when the internal resource is needed).
+    # The primary key of the statically defined internal resource record. The field is
+    # required and the config is instantiated lazily (only when the internal resource is needed).
     mgmt_internal_resource_id: uuid.UUID = Field(alias="MGMT_INTERNAL_RESOURCE_ID")
 
 

--- a/backend/grants_management_api/src/db/migrations/setup_local_postgres_db.py
+++ b/backend/grants_management_api/src/db/migrations/setup_local_postgres_db.py
@@ -6,7 +6,9 @@ import sqlalchemy
 from grants_shared.adapters.db import PostgresDBClient
 from grants_shared.util.local import error_if_not_local
 
+from src.auth.internal_resource import create_internal_resource
 from src.constants.schema import Schemas
+from src.db.resource_automation.resource_automation import setup_resource_automation
 
 logger = logging.getLogger(__name__)
 
@@ -25,3 +27,20 @@ def setup_local_postgres_db() -> None:
 def _create_schema(conn: db.Connection, schema_name: str) -> None:
     logger.info("Creating schema %s if it does not already exist", schema_name)
     conn.execute(sqlalchemy.schema.CreateSchema(schema_name, if_not_exists=True))
+
+
+def setup_internal_resource() -> None:
+    """Create the statically defined internal resource record for local development.
+
+    This runs after migrations (unlike schema creation above, which must run before)
+    since it needs the resource tables to exist. It always runs as part of `make init-db`
+    and is idempotent, so an existing record is left untouched.
+    """
+    with grants_shared.logs.init(__package__):
+        error_if_not_local()
+
+        db_client = PostgresDBClient()
+        setup_resource_automation()
+
+        with db_client.get_session() as db_session, db_session.begin():
+            create_internal_resource(db_session)

--- a/backend/grants_management_api/tests/auth/test_internal_resource.py
+++ b/backend/grants_management_api/tests/auth/test_internal_resource.py
@@ -22,7 +22,8 @@ def internal_resource_id(monkeypatch):
 
 def test_create_internal_resource(db_session, internal_resource_id):
     internal_resource = create_internal_resource(db_session)
-    db_session.commit()
+    # Flush so the resource automation (before_flush) populates the backing resource row
+    db_session.flush()
 
     assert internal_resource.mgmt_internal_resource_id == internal_resource_id
     assert internal_resource.internal_resource_name == INTERNAL_RESOURCE_NAME
@@ -46,10 +47,7 @@ def test_create_internal_resource(db_session, internal_resource_id):
 
 def test_create_internal_resource_is_idempotent(db_session, internal_resource_id):
     first = create_internal_resource(db_session)
-    db_session.commit()
-
     second = create_internal_resource(db_session)
-    db_session.commit()
 
     assert (
         first.mgmt_internal_resource_id == second.mgmt_internal_resource_id == internal_resource_id
@@ -79,7 +77,6 @@ def test_create_internal_resource_is_idempotent(db_session, internal_resource_id
 
 def test_get_internal_resource(db_session, internal_resource_id):
     created = create_internal_resource(db_session)
-    db_session.commit()
 
     fetched = get_internal_resource(db_session)
 

--- a/backend/grants_management_api/tests/auth/test_internal_resource.py
+++ b/backend/grants_management_api/tests/auth/test_internal_resource.py
@@ -1,0 +1,93 @@
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from src.auth.internal_resource import (
+    INTERNAL_RESOURCE_NAME,
+    create_internal_resource,
+    get_internal_resource,
+)
+from src.constants.lookup_constants import MgmtResourceType
+from src.db.models.resource_models import MgmtInternalResource, MgmtResource
+
+
+@pytest.fixture
+def internal_resource_id(monkeypatch):
+    """Use a distinct configured internal resource ID per test so tests never collide."""
+    internal_resource_id = uuid.uuid4()
+    monkeypatch.setenv("MGMT_INTERNAL_RESOURCE_ID", str(internal_resource_id))
+    return internal_resource_id
+
+
+def test_create_internal_resource(db_session, internal_resource_id):
+    internal_resource = create_internal_resource(db_session)
+    db_session.commit()
+
+    assert internal_resource.mgmt_internal_resource_id == internal_resource_id
+    assert internal_resource.internal_resource_name == INTERNAL_RESOURCE_NAME
+
+    # The backing resource row is created via resource automation
+    assert internal_resource.resource.mgmt_resource_id == internal_resource_id
+    assert internal_resource.resource.mgmt_resource_type == MgmtResourceType.INTERNAL
+
+    # Only a single record exists in the DB for the configured ID
+    records = (
+        db_session.execute(
+            select(MgmtInternalResource).where(
+                MgmtInternalResource.mgmt_internal_resource_id == internal_resource_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(records) == 1
+
+
+def test_create_internal_resource_is_idempotent(db_session, internal_resource_id):
+    first = create_internal_resource(db_session)
+    db_session.commit()
+
+    second = create_internal_resource(db_session)
+    db_session.commit()
+
+    assert (
+        first.mgmt_internal_resource_id == second.mgmt_internal_resource_id == internal_resource_id
+    )
+
+    # Still exactly one internal resource and one backing resource row for the configured ID
+    internal_records = (
+        db_session.execute(
+            select(MgmtInternalResource).where(
+                MgmtInternalResource.mgmt_internal_resource_id == internal_resource_id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(internal_records) == 1
+
+    resource_records = (
+        db_session.execute(
+            select(MgmtResource).where(MgmtResource.mgmt_resource_id == internal_resource_id)
+        )
+        .scalars()
+        .all()
+    )
+    assert len(resource_records) == 1
+
+
+def test_get_internal_resource(db_session, internal_resource_id):
+    created = create_internal_resource(db_session)
+    db_session.commit()
+
+    fetched = get_internal_resource(db_session)
+
+    assert fetched.mgmt_internal_resource_id == created.mgmt_internal_resource_id
+    assert fetched.get_resource_id() == internal_resource_id
+    assert fetched.get_resource_type() == MgmtResourceType.INTERNAL
+
+
+def test_get_internal_resource_raises_when_missing(db_session, internal_resource_id):
+    with pytest.raises(ValueError, match="does not exist"):
+        get_internal_resource(db_session)

--- a/backend/grants_management_api/tests/conftest.py
+++ b/backend/grants_management_api/tests/conftest.py
@@ -17,6 +17,7 @@ from grants_shared.util.local import load_local_env_vars
 
 import src.app as app_entry
 import tests.db.models.factories as factories
+from src.auth.internal_resource import create_internal_resource
 from src.db import models
 from src.db.models.lookup.sync_lookup_values import sync_lookup_values
 from src.db.resource_automation.resource_automation import setup_resource_automation
@@ -146,6 +147,20 @@ def db_session(db_client: db.DBClient) -> db.Session:
     """
     with db_client.get_session() as session:
         yield session
+
+
+@pytest.fixture(scope="session")
+def internal_resource(monkeypatch_session, db_client):
+    """Create the statically defined internal resource for the test session.
+
+    Tests that need the internal resource to exist (e.g. checking internal-role access)
+    can depend on this fixture rather than creating one themselves. Scoped to the session
+    so we only create it once for the whole suite.
+    """
+    monkeypatch_session.setenv("MGMT_INTERNAL_RESOURCE_ID", "2a9c7e50-6b1e-4c8f-9d3a-5e7f1b2c4d6e")
+
+    with db_client.get_session() as db_session, db_session.begin():
+        create_internal_resource(db_session)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11272 

## Changes proposed

- Created `internal_resource.py` to add the `MGMT_INTERNAL_RESOURCE_ID` config, the `get_internal_resource(db_session)` utility, and `create_internal_resource(db_session)`
- Updated `setup_local_postgres_db.py` to add a `setup_internal_resource()` entry point that creates the internal resource record
- Updated `pyproject.toml` to register the `setup-internal-resource` script
- Updated `Makefile` to run `setup-internal-resource` as part of `init-db` (after migrations) and add the target
- Updated `local.env` to define `MGMT_INTERNAL_RESOURCE_ID`
- Created `test_internal_resource.py` to cover creation, idempotency, fetching, and the missing-record error

## Context for reviewers

Sets up the statically-defined internal resource so internal roles are checked against a real resource instead of `None`. Because `setup-postgres-db` runs before migrations (schema creation must precede them), the record creation is a separate `init-db` step that runs after `db-migrate`. This is local-only for now.

## Validation steps

Confirm tests pass.

Locally, rebuild using `make build` and run `make init-db` to add the internal resource (`setup-internal-resource` is run as part of `init-db`). The following query against the grants_management database should show one row:
```
SELECT
    ir.mgmt_internal_resource_id,
    ir.internal_resource_name,
    r.mgmt_resource_id,
    rt.description AS resource_type
FROM grantor.mgmt_internal_resource ir
JOIN grantor.mgmt_resource r
    ON r.mgmt_resource_id = ir.mgmt_internal_resource_id
JOIN grantor.lk_mgmt_resource_type rt
    ON rt.mgmt_resource_type_id = r.mgmt_resource_type_id
WHERE ir.mgmt_internal_resource_id = '2a9c7e50-6b1e-4c8f-9d3a-5e7f1b2c4d6e'; 
```

