### PR TITLE
[Issue #11601] Change debug_identifier in s3 soap logging

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterator
 from enum import StrEnum
 from typing import Any
 
+import flask
 import grants_shared.adapters.db as db
 import requests
 from defusedxml import minidom
@@ -551,14 +552,14 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
     if get_soap_config().save_soap_messages_to_s3:
         try:
             s3_config = S3Config()
-            debug_identifier = uuid.uuid4()
+            internal_request_id = get_internal_request_id()
             base_path = file_util.join(
                 s3_config.draft_files_bucket_path,
                 # Not "soap": in virtual-hosted S3 URLs the object key becomes the URL path,
                 # and a WAF rule blocks paths starting with /soap -- which breaks both the
                 # upload here and downloading these files from the S3 console.
                 "soap-debug",
-                str(debug_identifier),
+                internal_request_id,
             )
             # Store as plain text so the debug files preview in the browser / S3 console
             # instead of downloading as binary/octet-stream.
@@ -605,10 +606,16 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
             )
             logger.info(
                 "soap_client: debug info uploaded to s3",
-                extra={"debug_identifier": debug_identifier},
             )
         except Exception:
             logger.exception(
                 "soap_client: failed to upload debug info to s3",
                 extra={"soap_api_event": LegacySoapApiEvent.ERROR_UPLOADING_DEBUG_DATA},
             )
+
+
+def get_internal_request_id() -> str:
+    if flask.has_request_context():
+        return str(getattr(flask.g, "internal_request_id", uuid.uuid4()))
+    else:
+        return str(uuid.uuid4())

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -617,5 +617,4 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
 def get_internal_request_id() -> str:
     if flask.has_request_context():
         return str(getattr(flask.g, "internal_request_id", uuid.uuid4()))
-    else:
-        return str(uuid.uuid4())
+    return str(uuid.uuid4())

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -273,10 +273,10 @@ def test_request_and_response_data_uploaded_to_s3_if_save_soap_messages_flag_is_
     )
     assert record
     request_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{TEST_UUID}/request.txt"
     )
     response_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{TEST_UUID}/response.txt"
     )
     assert request_contents.replace("\n", "") == mock_data.decode().replace("\n", "")
     assert response_contents.replace("\r", "") == expected_response.decode().replace("\r", "")
@@ -507,7 +507,9 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
     assert len(records) == 1
 
 
+@mock.patch("uuid.uuid4")
 def test_if_soap_request_errors_on_creation_the_s3_handling_records_just_the_response(
+    mock_uuid,
     db_session,
     client,
     enable_factory_create,
@@ -517,6 +519,8 @@ def test_if_soap_request_errors_on_creation_the_s3_handling_records_just_the_res
     mock_s3,
     s3_config,
 ) -> None:
+    TEST_UUID_1 = "99999999-aaaa-0000-bbbb-000000000000"
+    mock_uuid.return_value = TEST_UUID_1
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
     agency = AgencyFactory.create()
@@ -566,16 +570,15 @@ def test_if_soap_request_errors_on_creation_the_s3_handling_records_just_the_res
                 },
             )
         assert response.status_code == 500
-        records = [
+        record = next(
             r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
-        ]
-        assert len(records) == 1
-    record = records[0]
+        )
+    assert getattr(record, "request.internal_id") == TEST_UUID_1
     assert not file_util.file_exists(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{TEST_UUID_1}/request.txt"
     )
     assert file_util.file_exists(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{TEST_UUID_1}/response.txt"
     )
 
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import uuid
-from unittest import mock
 
 import boto3
 import flask
@@ -108,9 +107,8 @@ def test_write_debug_data_to_s3(
     )
 
 
-@mock.patch("uuid.uuid4")
 def test_write_debug_data_to_s3_handles_a_null_soap_request(
-    mock_uuid,
+    app,
     caplog,
     db_session,
     enable_factory_create,
@@ -120,14 +118,15 @@ def test_write_debug_data_to_s3_handles_a_null_soap_request(
     mock_s3,
 ) -> None:
     test_uuid = uuid.uuid4()
-    mock_uuid.return_value = str(test_uuid)
     caplog.set_level(logging.INFO)
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
     soap_legacy_response = SOAPResponse(
         data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={}
     )
-    write_debug_data_to_s3(None, soap_legacy_response)
+    with app.test_request_context("/"):
+        flask.g.internal_request_id = test_uuid
+        write_debug_data_to_s3(None, soap_legacy_response)
     record = next(
         r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
     )

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -63,20 +63,15 @@ SOAP_LEGACY_RESPONSE_PAYLOAD = (
 ).encode("utf-8")
 
 
-@mock.patch("src.legacy_soap_api.legacy_soap_api_utils.get_internal_request_id")
 def test_write_debug_data_to_s3(
-    mock_internal_id,
-    caplog,
+    app,
     db_session,
     enable_factory_create,
     monkeypatch,
     mock_s3_bucket,
     s3_config,
-    mock_s3,
 ) -> None:
     test_uuid = uuid.uuid4()
-    mock_internal_id.return_value = str(test_uuid)
-    caplog.set_level(logging.INFO)
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
     soap_legacy_response = SOAPResponse(
@@ -85,7 +80,9 @@ def test_write_debug_data_to_s3(
     soap_request = create_soap_request(
         SOAP_PAYLOAD, operation_name="GetSubmissionListExpandedRequest"
     )
-    write_debug_data_to_s3(soap_request, soap_legacy_response)
+    with app.test_request_context("/"):
+        flask.g.internal_request_id = test_uuid
+        write_debug_data_to_s3(soap_request, soap_legacy_response)
     request_contents = file_util.read_file(
         f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request.txt"
     )

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -1,13 +1,19 @@
 import json
 import logging
+import uuid
+from unittest import mock
 
 import boto3
+import flask
 from grants_shared.util import file_util
 
 from src.legacy_soap_api import legacy_soap_api_config as soap_api_config
 from src.legacy_soap_api.legacy_soap_api_config import GRANTOR_SOAP_ACTION_PATH
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
-from src.legacy_soap_api.legacy_soap_api_utils import write_debug_data_to_s3
+from src.legacy_soap_api.legacy_soap_api_utils import (
+    get_internal_request_id,
+    write_debug_data_to_s3,
+)
 from tests.lib.data_factories import create_soap_request
 
 NSMAP = {
@@ -57,9 +63,19 @@ SOAP_LEGACY_RESPONSE_PAYLOAD = (
 ).encode("utf-8")
 
 
+@mock.patch("src.legacy_soap_api.legacy_soap_api_utils.get_internal_request_id")
 def test_write_debug_data_to_s3(
-    caplog, db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
+    mock_internal_id,
+    caplog,
+    db_session,
+    enable_factory_create,
+    monkeypatch,
+    mock_s3_bucket,
+    s3_config,
+    mock_s3,
 ) -> None:
+    test_uuid = uuid.uuid4()
+    mock_internal_id.return_value = str(test_uuid)
     caplog.set_level(logging.INFO)
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
@@ -70,20 +86,17 @@ def test_write_debug_data_to_s3(
         SOAP_PAYLOAD, operation_name="GetSubmissionListExpandedRequest"
     )
     write_debug_data_to_s3(soap_request, soap_legacy_response)
-    record = next(
-        r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
-    )
     request_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request.txt"
     )
     response_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response.txt"
     )
     response_headers_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response_headers.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response_headers.txt"
     )
     request_headers_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request_headers.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request_headers.txt"
     )
     assert request_contents.replace("\n", "") == SOAP_PAYLOAD.decode().replace("\n", "")
     assert response_contents.replace("\r", "") == SOAP_LEGACY_RESPONSE_PAYLOAD.decode().replace(
@@ -98,9 +111,19 @@ def test_write_debug_data_to_s3(
     )
 
 
+@mock.patch("uuid.uuid4")
 def test_write_debug_data_to_s3_handles_a_null_soap_request(
-    caplog, db_session, enable_factory_create, monkeypatch, mock_s3_bucket, s3_config, mock_s3
+    mock_uuid,
+    caplog,
+    db_session,
+    enable_factory_create,
+    monkeypatch,
+    mock_s3_bucket,
+    s3_config,
+    mock_s3,
 ) -> None:
+    test_uuid = uuid.uuid4()
+    mock_uuid.return_value = str(test_uuid)
     caplog.set_level(logging.INFO)
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
@@ -111,11 +134,12 @@ def test_write_debug_data_to_s3_handles_a_null_soap_request(
     record = next(
         r for r in caplog.records if r.message == "soap_client: debug info uploaded to s3"
     )
+    assert record
     assert not file_util.file_exists(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/request.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request.txt"
     )
     response_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{record.debug_identifier}/response.txt"
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response.txt"
     )
     assert response_contents.replace("\r", "") == SOAP_LEGACY_RESPONSE_PAYLOAD.decode().replace(
         "\r", ""
@@ -176,3 +200,16 @@ def test_write_debug_data_to_s3_runs_on_any_endpoint(
     )
     objects = s3_client.list_objects_v2(Bucket="local-mock-draft-bucket")
     assert len(objects.get("Contents")) == 28
+
+
+def test_get_internal_request_id_returns_flask_internal_request_id_if_in_context(app):
+    with app.test_request_context("/"):
+        TEST_UUID = "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb"
+        flask.g.internal_request_id = TEST_UUID
+        # The internal id is consistent and not recalculated after every call if in context
+        result_1 = get_internal_request_id()
+        assert result_1 == TEST_UUID
+        result_2 = get_internal_request_id()
+        assert result_2 == TEST_UUID
+    result_3 = get_internal_request_id()
+    assert result_3 != TEST_UUID


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11601  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Remove debug_identifier on log
- Get and use the `request.internal_id` on the s3 path for soap logging
- added test to check context check
- update tests to check for internal id

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The `debug_identifier` only really appeared on one log and made it difficult to find the s3 logs. This way you can locate the s3 files from any new relic log.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests pass
After deploy
- [ ] Can use the `request.internal_id` to correctly find s3 log
