### PR TITLE
[Issue #10398] (2/2) Add logout for login.gov to simpler API

### DIFF
--- a/api/local.env
+++ b/api/local.env
@@ -46,8 +46,10 @@ LOGIN_GOV_JWK_ENDPOINT=http://host.docker.internal:5001/issuer1/jwks
 LOGIN_GOV_AUTH_ENDPOINT=http://localhost:5001/issuer1/authorize
 LOGIN_GOV_TOKEN_ENDPOINT=http://host.docker.internal:5001/issuer1/token
 LOGIN_GOV_ENDPOINT=http://host.docker.internal:5001/issuer1
+LOGIN_GOV_LOGOUT_ENDPOINT=http://localhost:5001/issuer1/endsession
 
 LOGIN_FINAL_DESTINATION=http://localhost:3000/api/auth/callback
+LOGOUT_FINAL_DESTINATION=http://localhost:3000/logout
 
 FRONTEND_BASE_URL=http://localhost:8080
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "urllib3>=2.7.0,<3",
     "python-statemachine>=3.0.0,<4",
     "beautifulsoup4>=4.14.3,<5",
-    "grants-shared==0.2.17",
+    "grants-shared==0.2.18",
 ]
 
 [project.scripts]

--- a/api/src/api/users/user_routes.py
+++ b/api/src/api/users/user_routes.py
@@ -7,7 +7,10 @@ from grants_shared.adapters.db import flask_db
 from grants_shared.api import response
 from grants_shared.api.route_utils import raise_flask_error
 from grants_shared.auth.api_jwt_auth import refresh_token_expiration
-from grants_shared.auth.login_gov_jwt_auth import get_final_redirect_uri
+from grants_shared.auth.login_gov_jwt_auth import (
+    get_final_logout_redirect_uri,
+    get_final_redirect_uri,
+)
 from grants_shared.logs.flask_logger import add_extra_data_to_current_request_logs
 from grants_shared.util.dict_util import flatten_dict
 
@@ -56,8 +59,14 @@ from src.api.users.user_schemas import (
     UserUpdateSavedSearchResponseSchema,
 )
 from src.auth.api_jwt_auth import api_jwt_auth
-from src.auth.auth_utils import with_login_redirect_error_handler
-from src.auth.login_gov_jwt_auth import get_login_gov_redirect_uri
+from src.auth.auth_utils import (
+    with_login_redirect_error_handler,
+    with_logout_redirect_error_handler,
+)
+from src.auth.login_gov_jwt_auth import (
+    get_login_gov_logout_redirect_uri,
+    get_login_gov_redirect_uri,
+)
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.db.models.user_models import UserTokenSession
 from src.services.users.create_api_key import create_api_key
@@ -82,6 +91,7 @@ from src.services.users.login_gov_callback_handler import (
     handle_login_gov_callback_request,
     handle_login_gov_token,
 )
+from src.services.users.logout_user import logout_user
 from src.services.users.org_invitation_response import org_invitation_response
 from src.services.users.rename_api_key import rename_api_key
 from src.services.users.set_saved_opportunity_notification_settings import (
@@ -100,6 +110,12 @@ you to an OAuth provider where you can sign into an account.
 Do not try to use the execute option below as OpenAPI will not redirect your browser for you.
 
 The token you receive can then be set to the X-SGG-Token header for authenticating with endpoints.
+"""
+
+LOGOUT_DESCRIPTION = """
+To use this endpoint, click [this link](/v1/users/logout) which will redirect you
+to an OAuth provider where you can logout of your account in both our system and
+the OAuth system.
 """
 
 
@@ -146,6 +162,33 @@ def login_result() -> flask.Response:
 
     # Echo back the query args as JSON for some readability
     return flask.jsonify(flask.request.args)
+
+
+@user_blueprint.get("/logout")
+@user_blueprint.doc(responses=[302], description=LOGOUT_DESCRIPTION)
+@with_logout_redirect_error_handler()
+@flask_db.with_db_session()
+def user_logout(db_session: db.Session) -> flask.Response:
+    logger.info("GET /v1/users/logout")
+
+    with db_session.begin():
+        # This endpoint doesn't require any auth token, but
+        # if it's provided, we'll handle logging the user out of our system.
+        logout_user(db_session, flask.request.headers.get("X-SGG-Token", None))
+
+    return response.redirect_response(get_login_gov_logout_redirect_uri())
+
+
+@user_blueprint.get("/logout/callback")
+@with_logout_redirect_error_handler()
+@user_blueprint.doc(hide=True)
+def user_logout_callback() -> flask.Response:
+    logger.info("GET /v1/users/logout/callback")
+
+    # We don't have any logic to run here,
+    # we just redirect to the final destination
+    # in our frontend
+    return response.redirect_response(get_final_logout_redirect_uri(message="success"))
 
 
 @user_blueprint.post("/token/logout")

--- a/api/src/api/users/user_schemas.py
+++ b/api/src/api/users/user_schemas.py
@@ -130,6 +130,20 @@ class UserLoginSchema(Schema):
     )
 
 
+class UserLoginGovLogoutCallbackSchema(Schema):
+    # This is defining the inputs we receive on the callback from login.gov's
+    # logout endpoint and must match:
+    # https://developers.login.gov/oidc/logout/
+    state = fields.String(
+        metadata={
+            "description": "The state value originally provided by us when calling login.gov"
+        },
+        # We don't use the state, but it can be passed, so allow it to be missing/null.
+        required=False,
+        allow_none=True,
+    )
+
+
 class UserTokenRefreshResponseSchema(AbstractResponseSchema):
     # No data returned
     data = fields.MixinField(metadata={"example": None})

--- a/api/src/auth/auth_utils.py
+++ b/api/src/auth/auth_utils.py
@@ -84,8 +84,22 @@ def with_login_redirect_error_handler() -> Callable[..., Callable[P, flask.Respo
 
 
 def with_logout_redirect_error_handler() -> Callable[..., Callable[P, flask.Response]]:
-    """
-    Wrapper function TODO
+    """Wrapper function to handle catching errors and redirecting for our logout redirect endpoints
+
+    Because our logout functions don't have standard 2xx returns
+    and instead redirect the user, we also redirect in the case of errors
+    so that they stay on the frontend, but we pass errors along.
+
+    Usage::
+
+        @with_logout_redirect_error_handler()
+        def foo(...):
+            logger.info("hello")
+
+            if condition:
+                raise_flask_error(...) # this will get caught and a redirect will occur
+
+            return ...
 
     """
 

--- a/api/src/auth/auth_utils.py
+++ b/api/src/auth/auth_utils.py
@@ -1,13 +1,15 @@
 import functools
 import logging
-import urllib
 from collections.abc import Callable
 from typing import Any, ParamSpec
 
 import flask
 from apiflask.exceptions import HTTPError
 from grants_shared.api import response
-from grants_shared.auth.login_gov_jwt_auth import LoginGovConfig, get_config, get_final_redirect_uri
+from grants_shared.auth.login_gov_jwt_auth import (
+    get_final_logout_redirect_uri,
+    get_final_redirect_uri,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +126,7 @@ def with_logout_redirect_error_handler() -> Callable[..., Callable[P, flask.Resp
                     )
 
                 return response.redirect_response(
-                    get_final_redirect_uri(
+                    get_final_logout_redirect_uri(
                         "error",
                         error_description=message,
                     )
@@ -140,24 +142,3 @@ def with_logout_redirect_error_handler() -> Callable[..., Callable[P, flask.Resp
         return wrapper
 
     return decorator
-
-
-# TODO - move the below function to grants_shared
-
-
-def get_final_logout_redirect_uri(
-    message: str,
-    error_description: str | None = None,
-    config: LoginGovConfig | None = None,
-) -> str:
-    if config is None:
-        config = get_config()
-
-    params: dict = {"message": message}
-
-    if error_description is not None:
-        params["error_description"] = error_description
-
-    encoded_params = urllib.parse.urlencode(params)
-
-    return f"{config.logout_final_destination}?{encoded_params}"

--- a/api/src/auth/auth_utils.py
+++ b/api/src/auth/auth_utils.py
@@ -61,8 +61,8 @@ def with_login_redirect_error_handler() -> Callable[..., Callable[P, flask.Respo
                 if e.status_code >= 500:
                     message = INTERNAL_ERROR
                     logger.exception(
-                        "Unexpected error occurred in login flow via raise_flask_error: %s",
-                        e.message,
+                        "Unexpected error occurred in login flow via raise_flask_error",
+                        extra={"error.message": e.message},
                     )
 
                 return response.redirect_response(
@@ -121,8 +121,8 @@ def with_logout_redirect_error_handler() -> Callable[..., Callable[P, flask.Resp
                 if e.status_code >= 500:
                     message = INTERNAL_ERROR
                     logger.exception(
-                        "Unexpected error occurred in logout flow via raise_flask_error: %s",
-                        e.message,
+                        "Unexpected error occurred in logout flow via raise_flask_error",
+                        extra={"error.message": e.message},
                     )
 
                 return response.redirect_response(

--- a/api/src/auth/auth_utils.py
+++ b/api/src/auth/auth_utils.py
@@ -1,12 +1,13 @@
 import functools
 import logging
+import urllib
 from collections.abc import Callable
 from typing import Any, ParamSpec
 
 import flask
 from apiflask.exceptions import HTTPError
 from grants_shared.api import response
-from grants_shared.auth.login_gov_jwt_auth import get_final_redirect_uri
+from grants_shared.auth.login_gov_jwt_auth import LoginGovConfig, get_config, get_final_redirect_uri
 
 logger = logging.getLogger(__name__)
 
@@ -80,3 +81,69 @@ def with_login_redirect_error_handler() -> Callable[..., Callable[P, flask.Respo
         return wrapper
 
     return decorator
+
+
+def with_logout_redirect_error_handler() -> Callable[..., Callable[P, flask.Response]]:
+    """
+    Wrapper function TODO
+
+    """
+
+    def decorator(f: Callable[P, flask.Response]) -> Callable[P, flask.Response]:
+        @functools.wraps(f)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> flask.Response:
+            try:
+                return f(*args, **kwargs)
+            except HTTPError as e:
+                # HTTPError is what raise_flask_error raises
+                # and should encompass our "expected" errors
+                # that aren't a concern, as long as it isn't a 5xx
+                message = e.message
+                logger.info("Logout flow failed: %s", message)
+
+                # But we still don't expect 5xx errors
+                if e.status_code >= 500:
+                    message = INTERNAL_ERROR
+                    logger.exception(
+                        "Unexpected error occurred in logout flow via raise_flask_error: %s",
+                        e.message,
+                    )
+
+                return response.redirect_response(
+                    get_final_redirect_uri(
+                        "error",
+                        error_description=message,
+                    )
+                )
+            except Exception:
+                # Any other exception, we'll just use a generic error message to be safe
+                # but this means an unexpected error occurred and we should log an error
+                logger.exception("Unexpected error occurred in logout flow")
+                return response.redirect_response(
+                    get_final_logout_redirect_uri("error", error_description=INTERNAL_ERROR)
+                )
+
+        return wrapper
+
+    return decorator
+
+
+# TODO - move the below function to grants_shared
+
+
+def get_final_logout_redirect_uri(
+    message: str,
+    error_description: str | None = None,
+    config: LoginGovConfig | None = None,
+) -> str:
+    if config is None:
+        config = get_config()
+
+    params: dict = {"message": message}
+
+    if error_description is not None:
+        params["error_description"] = error_description
+
+    encoded_params = urllib.parse.urlencode(params)
+
+    return f"{config.logout_final_destination}?{encoded_params}"

--- a/api/src/auth/login_gov_jwt_auth.py
+++ b/api/src/auth/login_gov_jwt_auth.py
@@ -55,3 +55,28 @@ def get_login_gov_redirect_uri(
     AuthHandler(db_session).create_login_gov_state(state, nonce)
 
     return f"{config.login_gov_auth_endpoint}?{encoded_params}"
+
+
+def get_login_gov_logout_redirect_uri(config: LoginGovConfig | None = None) -> str:
+    if config is None:
+        config = get_config()
+
+    redirect_uri = flask.url_for(
+        ".user_logout_callback", _external=True, _scheme=config.login_gov_redirect_scheme
+    )
+
+    url_params = {
+        "client_id": config.client_id,
+        "post_logout_redirect_uri": redirect_uri,
+        # Note that we don't use the state in the logout callback
+        # but include it just for consistency. There's no replay attack
+        # we need to prevent in callback logic since that endpoint just
+        # does a redirect to our frontend and doesn't care about anything else.
+        "state": uuid.uuid4(),
+    }
+
+    # We want to redirect to the logout endpoint of login.gov
+    # See: https://developers.login.gov/oidc/logout/
+    encoded_params = urllib.parse.urlencode(url_params)
+
+    return f"{config.login_gov_logout_endpoint}?{encoded_params}"

--- a/api/src/services/users/logout_user.py
+++ b/api/src/services/users/logout_user.py
@@ -1,0 +1,28 @@
+import logging
+
+from grants_shared.adapters import db
+from grants_shared.auth.api_jwt_auth import JwtAuth
+from grants_shared.auth.auth_errors import JwtValidationError
+
+from src.auth.auth_handler import AuthHandler
+
+logger = logging.getLogger(__name__)
+
+
+def logout_user(db_session: db.Session, user_token: str | None) -> None:
+    if user_token is None:
+        logger.info("No token provided, no user to logout")
+        return
+
+    # Attempt to parse the JWT that was provided, same as we would for authN normally.
+    # If there are any JWT-specific issues, we'll just log them, and still proceed with
+    # the redirect logic that comes after this.
+    try:
+        user_token_session = JwtAuth(AuthHandler(db_session)).parse_jwt_for_user(user_token)
+    except JwtValidationError:
+        logger.info("Provided JWT was not valid, cannot logout of our system", exc_info=True)
+        return
+
+    user_token_session.is_valid = False
+
+    logger.info("Logged user out of simpler grants", extra=user_token_session.get_log_extra())

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -423,16 +423,16 @@ def app(
     # Override the OAuth endpoint path before creating the app which loads the config at startup
     monkeypatch_session.setenv(
         "LOGIN_GOV_AUTH_ENDPOINT", "http://localhost:8080/test-endpoint/oauth-authorize"
-    )
+    )  # setup in mock_oauth_endpoint
     monkeypatch_session.setenv(
         "LOGIN_GOV_LOGOUT_ENDPOINT", "http://localhost:8080/test-endpoint/oauth-logout"
-    )
+    )  # setup in mock_oauth_logout_endpoint below
     monkeypatch_session.setenv(
         "LOGIN_FINAL_DESTINATION", "http://localhost:8080/v1/users/login/result"
     )
     monkeypatch_session.setenv(
-        "LOGOUT_FINAL_DESTINATION", "http://localhost:8080/v1/users/login/result"
-    )  # We reuse the login result endpoint for logout result rather than make another endpoint for the same purpose
+        "LOGOUT_FINAL_DESTINATION", "http://localhost:8080/test-endpoint/oauth-logout-result"
+    )  # setup in mock_oauth_logout_endpoint below
     app = app_entry.create_app()
 
     # Add endpoints and mocks for handling the external OAuth logic

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -47,7 +47,7 @@ from src.workflow.registry.workflow_client_registry import (
 )
 from src.workflow.workflow_background_task import _init_newrelic_app
 from tests.lib import db_testing
-from tests.lib.auth_test_utils import mock_oauth_endpoint
+from tests.lib.auth_test_utils import mock_oauth_endpoint, mock_oauth_logout_endpoint
 from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.db.models.factories import (
     InternalUserRoleFactory,
@@ -425,12 +425,19 @@ def app(
         "LOGIN_GOV_AUTH_ENDPOINT", "http://localhost:8080/test-endpoint/oauth-authorize"
     )
     monkeypatch_session.setenv(
+        "LOGIN_GOV_LOGOUT_ENDPOINT", "http://localhost:8080/test-endpoint/oauth-logout"
+    )
+    monkeypatch_session.setenv(
         "LOGIN_FINAL_DESTINATION", "http://localhost:8080/v1/users/login/result"
     )
+    monkeypatch_session.setenv(
+        "LOGOUT_FINAL_DESTINATION", "http://localhost:8080/v1/users/login/result"
+    )  # We reuse the login result endpoint for logout result rather than make another endpoint for the same purpose
     app = app_entry.create_app()
 
     # Add endpoints and mocks for handling the external OAuth logic
     mock_oauth_endpoint(app, monkeypatch_session, private_rsa_key, mock_oauth_client)
+    mock_oauth_logout_endpoint(app)
 
     return app
 

--- a/api/tests/lib/auth_test_utils.py
+++ b/api/tests/lib/auth_test_utils.py
@@ -122,3 +122,25 @@ def mock_oauth_endpoint(app, monkeypatch, private_key, mock_oauth_client):
         "grants_shared.services.users.login_gov_callback_handler.get_login_gov_client",
         override_get_client,
     )
+
+
+def mock_oauth_logout_endpoint(app):
+    """
+    Mock out the logout endpoint for oauth for unit tests.
+
+    Primarily just redirects back to our callback endpoint
+    as there's no actual state checked on the other side.
+    """
+
+    @app.get("/test-endpoint/oauth-logout")
+    def oauth_logout():
+        # This endpoint represents a mocked version of
+        # https://developers.login.gov/oidc/logout/
+        # and needs to return the state value back.
+        query_args = flask.request.args
+        params = {"state": query_args.get("state")}
+
+        encoded_params = urllib.parse.urlencode(params)
+        redirect_uri = f"{query_args['post_logout_redirect_uri']}?{encoded_params}"
+
+        return flask.redirect(redirect_uri)

--- a/api/tests/lib/auth_test_utils.py
+++ b/api/tests/lib/auth_test_utils.py
@@ -146,7 +146,7 @@ def mock_oauth_logout_endpoint(app):
         return flask.redirect(redirect_uri)
 
     @app.get("/test-endpoint/oauth-logout-result")
-    def login_result() -> flask.Response:
+    def logout_result() -> flask.Response:
         """Dummy endpoint for easily displaying the results of the logout flow"""
 
         # Echo back the query args as JSON

--- a/api/tests/lib/auth_test_utils.py
+++ b/api/tests/lib/auth_test_utils.py
@@ -144,3 +144,10 @@ def mock_oauth_logout_endpoint(app):
         redirect_uri = f"{query_args['post_logout_redirect_uri']}?{encoded_params}"
 
         return flask.redirect(redirect_uri)
+
+    @app.get("/test-endpoint/oauth-logout-result")
+    def login_result() -> flask.Response:
+        """Dummy endpoint for easily displaying the results of the logout flow"""
+
+        # Echo back the query args as JSON
+        return flask.jsonify(flask.request.args)

--- a/api/tests/src/api/users/test_user_route_login.py
+++ b/api/tests/src/api/users/test_user_route_login.py
@@ -379,10 +379,13 @@ def test_user_callback_error_in_token_302(client, enable_factory_create, caplog)
     assert resp_json["error_description"] == "internal error"
 
     # Verify it errored because of the response from token Oauth
-    assert (
-        "Unexpected error occurred in login flow via raise_flask_error: default mock error description"
-        in caplog.messages
+    log_record = next(
+        record
+        for record in caplog.records
+        if getattr(record, "message", None)
+        == "Unexpected error occurred in login flow via raise_flask_error"
     )
+    assert getattr(log_record, "error.message", None) == "default mock error description"
 
 
 @pytest.mark.parametrize(

--- a/api/tests/src/api/users/test_user_route_logout.py
+++ b/api/tests/src/api/users/test_user_route_logout.py
@@ -1,0 +1,133 @@
+import urllib
+from datetime import datetime
+
+from grants_shared.api.route_utils import raise_flask_error
+from grants_shared.auth import login_gov_jwt_auth
+from grants_shared.auth.api_jwt_auth import JwtAuth
+
+from src.auth.api_jwt_auth import create_jwt_for_user
+from tests.src.db.models.factories import LinkExternalUserFactory
+
+
+def validate_redirects_occurred(resp):
+    login_gov_config = login_gov_jwt_auth.get_config()
+    # History contains each redirect, we redirected 3 times
+    assert len(resp.history) == 3
+
+    first_redirect, second_redirect, third_redirect = resp.history
+
+    # Redirect to the oauth-logout
+    first_redirect_url = urllib.parse.urlparse(first_redirect.headers["Location"])
+    assert first_redirect_url.path == "/test-endpoint/oauth-logout"
+
+    first_redirect_params = urllib.parse.parse_qs(first_redirect_url.query)
+    assert first_redirect_params["client_id"][0] == login_gov_config.client_id
+    assert first_redirect_params["state"][0] is not None
+    assert (
+        first_redirect_params["post_logout_redirect_uri"][0]
+        == "http://localhost/v1/users/logout/callback"
+    )
+
+    # Redirect back to our callback endpoint
+    assert second_redirect.status_code == 302
+    second_redirect_url = urllib.parse.urlparse(second_redirect.headers["Location"])
+    assert second_redirect_url.path == "/v1/users/logout/callback"
+
+    second_redirect_params = urllib.parse.parse_qs(second_redirect_url.query)
+    assert second_redirect_params["state"][0] == first_redirect_params["state"][0]
+
+    # Redirect to the final destination page
+    assert third_redirect.status_code == 302
+    third_redirect_url = urllib.parse.urlparse(third_redirect.headers["Location"])
+    assert third_redirect_url.path == "/v1/users/login/result"
+
+    third_redirect_params = urllib.parse.parse_qs(third_redirect_url.query)
+    assert third_redirect_params["message"][0] == "success"
+
+
+def test_user_logout_without_token_302(client, db_session):
+    resp = client.get("v1/users/logout", follow_redirects=True)
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "success"
+
+    validate_redirects_occurred(resp)
+
+
+def test_user_logout_with_token_302(client, db_session, enable_factory_create):
+    external_user = LinkExternalUserFactory.create()
+    token, user_token_session = create_jwt_for_user(external_user.user, db_session)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "success"
+
+    db_session.refresh(user_token_session)
+    assert user_token_session.is_valid is False
+
+    validate_redirects_occurred(resp)
+
+
+def test_user_logout_with_invalid_token_302(client, db_session, enable_factory_create):
+    external_user = LinkExternalUserFactory.create()
+    token, user_token_session = create_jwt_for_user(external_user.user, db_session)
+    user_token_session.expires_at = datetime(2020, 1, 1, 12, 0, 0)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "success"
+
+    db_session.refresh(user_token_session)
+    # Still marked as True because the validation failed due to the expiration time
+    assert user_token_session.is_valid is True
+
+    validate_redirects_occurred(resp)
+
+
+def test_user_logout_with_internal_issue_4xx(
+    client, db_session, enable_factory_create, monkeypatch
+):
+
+    def err_func(*args):
+        raise_flask_error(422, "the eventual error message")
+
+    monkeypatch.setattr(JwtAuth, "parse_jwt_for_user", err_func)
+
+    external_user = LinkExternalUserFactory.create()
+    token, _ = create_jwt_for_user(external_user.user, db_session)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "error"
+    assert resp_json["error_description"] == "the eventual error message"
+
+
+def test_user_logout_with_internal_issue_500(
+    client, db_session, enable_factory_create, monkeypatch
+):
+
+    def err_func(*args):
+        raise_flask_error(500, "an error message we won't see")
+
+    monkeypatch.setattr(JwtAuth, "parse_jwt_for_user", err_func)
+
+    external_user = LinkExternalUserFactory.create()
+    token, _ = create_jwt_for_user(external_user.user, db_session)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-SGG-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "error"
+    assert resp_json["error_description"] == "internal error"

--- a/api/tests/src/api/users/test_user_route_logout.py
+++ b/api/tests/src/api/users/test_user_route_logout.py
@@ -39,7 +39,7 @@ def validate_redirects_occurred(resp):
     # Redirect to the final destination page
     assert third_redirect.status_code == 302
     third_redirect_url = urllib.parse.urlparse(third_redirect.headers["Location"])
-    assert third_redirect_url.path == "/v1/users/login/result"
+    assert third_redirect_url.path == "/test-endpoint/oauth-logout-result"
 
     third_redirect_params = urllib.parse.parse_qs(third_redirect_url.query)
     assert third_redirect_params["message"][0] == "success"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -613,7 +613,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.17"
+version = "0.2.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apiflask" },
@@ -636,9 +636,9 @@ dependencies = [
     { name = "smart-open" },
     { name = "sqlalchemy", extra = ["mypy"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/d0/e3f0cb5d6b3105346365635dee463c5a5adaf401b2b19c9b755c932013c6/grants_shared-0.2.17.tar.gz", hash = "sha256:ebe15ccfedc499a913900fd64cc4fb6b415d85fa5193e5460a9e026e5811316a", size = 71701, upload-time = "2026-07-14T13:25:34.049Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fb/6f7cea3a82dbd4141680e0ed0766643152b6f3dbff97d421f459a10481cf/grants_shared-0.2.18.tar.gz", hash = "sha256:eb1f07f7aa2710574ddc0cb87139dacb9afcec9a8bfc2c6bd99628443ba5b8ed", size = 71842, upload-time = "2026-07-22T18:46:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/33/78c573f315385258b461fb216aa65d729a4c5556574db71f69e31d4f0822/grants_shared-0.2.17-py3-none-any.whl", hash = "sha256:f0c059c2d3e47a03e7c87a3191532b78590cd09262b8547dd531ef95734a876a", size = 93166, upload-time = "2026-07-14T13:25:32.624Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/85/73a24fefe7da8e72a000c479f7cb982b89579d81d102ced597772a1eb7ad/grants_shared-0.2.18-py3-none-any.whl", hash = "sha256:f86acc5f71fa935282c2a48aee7fe09fecb72abb1a27e72cbf0f777f8051c0b3", size = 93315, upload-time = "2026-07-22T18:46:46.019Z" },
 ]
 
 [[package]]
@@ -1801,7 +1801,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1,<0.8" },
     { name = "docraptor", specifier = ">=3.0.0,<4" },
     { name = "flask-cors", specifier = ">=6.0.0,<7" },
-    { name = "grants-shared", specifier = "==0.2.17" },
+    { name = "grants-shared", specifier = "==0.2.18" },
     { name = "gunicorn", specifier = ">=23.0.0,<24" },
     { name = "jinja2", specifier = ">=3.1.5" },
     { name = "jsonpath-ng", specifier = ">=1.7.0,<2" },

--- a/documentation/api/authentication.md
+++ b/documentation/api/authentication.md
@@ -200,3 +200,42 @@ def my_example_endpoint(db_session: db.Session) -> response.ApiResponse:
     return response.ApiResponse(message="Success", data=result)
 ```
 
+## Logout
+
+Logout will log you out of both our system by invalidating your
+JWT token obtained during login, as well as logging you out of
+login.gov. Our logout process works even if you provide no
+token, or your current token is invalid in order to ensure that
+if you want to logout, we'll always try to do as much as we can
+and log you out of login.gov.
+
+If a user is already fully logged out of both systems, logout
+will still work, and a user will be redirected through the flow
+although nothing will happen.
+
+### Logout Flow
+```mermaid
+sequenceDiagram
+    autonumber
+    participant frontend
+    participant api
+    participant login.gov
+
+    frontend->>+api: user clicks logout
+    Note over api: /users/logout
+
+    opt If token provided
+        Note over api: Invalidate JWT token
+    end
+
+    api->>-login.gov: redirect
+    activate login.gov
+    Note over login.gov: /logout
+    login.gov->>+api: redirect
+    deactivate login.gov
+
+    Note over api: /users/logout/callback
+
+    api->>-frontend: redirect
+    Note over frontend: /logout
+  ```

--- a/infra/api/app-config/env-config/environment_variables.tf
+++ b/infra/api/app-config/env-config/environment_variables.tf
@@ -17,6 +17,7 @@ locals {
     LOGIN_GOV_JWK_ENDPOINT           = "https://idp.int.identitysandbox.gov/api/openid_connect/certs"
     LOGIN_GOV_AUTH_ENDPOINT          = "https://idp.int.identitysandbox.gov/openid_connect/authorize"
     LOGIN_GOV_TOKEN_ENDPOINT         = "https://idp.int.identitysandbox.gov/api/openid_connect/token"
+    LOGIN_GOV_LOGOUT_ENDPOINT        = "https://idp.int.identitysandbox.gov/openid_connect/logout"
     LOGIN_GOV_REDIRECT_SCHEME        = var.enable_https ? "https" : "http"
     API_JWT_ISSUER                   = "simpler-grants-api-${var.environment}"
     API_JWT_AUDIENCE                 = "simpler-grants-api-${var.environment}"
@@ -79,6 +80,11 @@ locals {
     LOGIN_FINAL_DESTINATION = {
       manage_method     = "manual"
       secret_store_name = "/api/${var.environment}/frontend-login-redirect-url"
+    }
+
+    LOGOUT_FINAL_DESTINATION = {
+      manage_method     = "manual"
+      secret_store_name = "/api/${var.environment}/frontend-logout-redirect-url"
     }
 
     FRONTEND_BASE_URL = {

--- a/infra/api/app-config/prod.tf
+++ b/infra/api/app-config/prod.tf
@@ -74,10 +74,11 @@ module "prod_config" {
     LOAD_AGENCY_SEARCH_REPLICA_COUNT = 2
 
     # Login.gov OAuth
-    LOGIN_GOV_ENDPOINT       = "https://secure.login.gov/"
-    LOGIN_GOV_JWK_ENDPOINT   = "https://secure.login.gov/api/openid_connect/certs"
-    LOGIN_GOV_AUTH_ENDPOINT  = "https://secure.login.gov/openid_connect/authorize"
-    LOGIN_GOV_TOKEN_ENDPOINT = "https://secure.login.gov/api/openid_connect/token"
+    LOGIN_GOV_ENDPOINT        = "https://secure.login.gov/"
+    LOGIN_GOV_JWK_ENDPOINT    = "https://secure.login.gov/api/openid_connect/certs"
+    LOGIN_GOV_AUTH_ENDPOINT   = "https://secure.login.gov/openid_connect/authorize"
+    LOGIN_GOV_TOKEN_ENDPOINT  = "https://secure.login.gov/api/openid_connect/token"
+    LOGIN_GOV_LOGOUT_ENDPOINT = "https://secure.login.gov/openid_connect/logout"
 
 
     # CommonGrants Protocol


### PR DESCRIPTION
## Summary
Fixes #10398

## Changes proposed
* Add new logout endpoints to logout of Simpler grants & login.gov
* Added configurations for env vars, including those in parameter store

## Context for reviewers
Our current logout endpoint just logs you out of Simpler Grants, but keeps your session active with login.gov. To actually support logging out of login.gov, we need to instead do a series of redirects which I added a sequence diagram to the docs to illustrate, but boils down to:
* A logout endpoint that we first handle invalidating the token if provided, and is okay with bad tokens (just won't invalidate them) which redirects to login.gov's logout endpoint
* Login.gov's logout where it'll ask if you're sure you want to logout - if a user never says yes, it'll never redirect further which redirects to a second endpoint we've added for logout callback
* Our logout callback that just redirects to the final location, which will be the frontend

## Validation steps
Verified that you can use this locally with the mock oauth client. The oauth client doesn't maintain any meaningful state, so "logout" doesn't really do anything, but it at least can handle redirects back to our callback.

This is a lot more complex to test, but if you setup every env var, and grab the private key we use for talking to login.gov, you can make your local API interact with real login.gov. Verified that this works with actual login.gov regardless of being logged in or not. 
