### PR TITLE
[Issue #10934] Backend - Enhance List Award Recommendations Endpoint

### DIFF
--- a/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
@@ -696,7 +696,14 @@ class AwardRecommendationListRequestSchema(Schema):
     pagination = fields.Nested(
         generate_pagination_schema(
             "AwardRecommendationListPaginationSchema",
-            ["created_at"],
+            [
+                "award_recommendation_number",
+                "opportunity_name",
+                "opportunity_number",
+                "total_received_count",
+                "award_recommendation_status",
+                "created_at",
+            ],
             default_sort_order=[{"order_by": "created_at", "sort_direction": "descending"}],
         ),
         required=True,

--- a/api/src/services/award_recommendations/list_award_recommendations.py
+++ b/api/src/services/award_recommendations/list_award_recommendations.py
@@ -1,5 +1,6 @@
 import uuid
 from collections.abc import Sequence
+from typing import Any, cast
 
 import grants_shared.adapters.db as db
 from grants_shared.api.response import ValidationErrorDetail
@@ -22,10 +23,6 @@ from src.db.models.opportunity_models import CurrentOpportunitySummary, Opportun
 from src.db.models.user_models import User
 from src.search.search_models import UuidSearchFilter
 from src.validation.validation_constants import ValidationErrorType
-
-COLUMN_MAPPING = {
-    "created_at": AwardRecommendation.created_at,
-}
 
 
 class AwardRecommendationListFilters(BaseModel):
@@ -80,9 +77,26 @@ def list_award_recommendations(
     agencies = verify_agencies_access(db_session, user, agency_ids)
     agency_codes = [a.agency_code for a in agencies]
 
+    # Create subquery for total_received_count to enable sorting
+    total_received_count_subquery = (
+        select(
+            AwardRecommendationApplicationSubmission.award_recommendation_id,
+            func.count(
+                AwardRecommendationApplicationSubmission.award_recommendation_application_submission_id
+            ).label("total_received_count"),
+        )
+        .group_by(AwardRecommendationApplicationSubmission.award_recommendation_id)
+        .subquery()
+    )
+
     stmt = (
         select(AwardRecommendation)
         .join(Opportunity, Opportunity.opportunity_id == AwardRecommendation.opportunity_id)
+        .outerjoin(
+            total_received_count_subquery,
+            total_received_count_subquery.c.award_recommendation_id
+            == AwardRecommendation.award_recommendation_id,
+        )
         .where(
             AwardRecommendation.is_deleted.isnot(True),
             Opportunity.agency_code.in_(agency_codes),
@@ -95,7 +109,20 @@ def list_award_recommendations(
             selectinload(AwardRecommendation.award_recommendation_reviews),
         )
     )
-    stmt = apply_sorting(stmt, params.pagination.sort_order, COLUMN_MAPPING, nulls_last=True)
+
+    # Column mapping for sorting
+    column_mapping = {
+        "award_recommendation_number": AwardRecommendation.award_recommendation_number,
+        "opportunity_name": Opportunity.opportunity_title,
+        "opportunity_number": Opportunity.opportunity_number,
+        "total_received_count": total_received_count_subquery.c.total_received_count,
+        "award_recommendation_status": AwardRecommendation.award_recommendation_status,
+        "created_at": AwardRecommendation.created_at,
+    }
+
+    stmt = apply_sorting(
+        stmt, params.pagination.sort_order, cast(Any, column_mapping), nulls_last=True
+    )
 
     paginator: Paginator[AwardRecommendation] = Paginator(
         AwardRecommendation,

--- a/api/src/services/award_recommendations/list_award_recommendations.py
+++ b/api/src/services/award_recommendations/list_award_recommendations.py
@@ -115,7 +115,9 @@ def list_award_recommendations(
         "award_recommendation_number": AwardRecommendation.award_recommendation_number,
         "opportunity_name": Opportunity.opportunity_title,
         "opportunity_number": Opportunity.opportunity_number,
-        "total_received_count": total_received_count_subquery.c.total_received_count,
+        "total_received_count": func.coalesce(
+            total_received_count_subquery.c.total_received_count, 0
+        ),
         "award_recommendation_status": AwardRecommendation.award_recommendation_status,
         "created_at": AwardRecommendation.created_at,
     }

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
@@ -529,6 +529,55 @@ class TestListAwardRecommendations200:
             str(ar2.award_recommendation_id),  # OPP-999
         ]
 
+    def test_list_award_recommendations_sort_by_total_received_count_ascending_with_zero(
+        self, client, db_session, agency, opportunity
+    ):
+        """Test that ARs with 0 submissions sort correctly at the start in ascending order"""
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        ar1 = AwardRecommendationFactory.create(
+            opportunity=opportunity, review_workflow=None, review_workflow_id=None
+        )
+        ar2 = AwardRecommendationFactory.create(
+            opportunity=opportunity, review_workflow=None, review_workflow_id=None
+        )
+        ar3 = AwardRecommendationFactory.create(
+            opportunity=opportunity, review_workflow=None, review_workflow_id=None
+        )
+
+        # ar1 has 0 submissions
+        # ar2 has 2 submissions
+        for _ in range(2):
+            AwardRecommendationApplicationSubmissionFactory.create(award_recommendation=ar2)
+        # ar3 has 5 submissions
+        for _ in range(5):
+            AwardRecommendationApplicationSubmissionFactory.create(award_recommendation=ar3)
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [
+                        {"order_by": "total_received_count", "sort_direction": "ascending"}
+                    ],
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        returned_ids = [d["award_recommendation_id"] for d in resp.json["data"]]
+        assert returned_ids == [
+            str(ar1.award_recommendation_id),  # 0 submissions
+            str(ar2.award_recommendation_id),  # 2 submissions
+            str(ar3.award_recommendation_id),  # 5 submissions
+        ]
+
 
 ####################################
 # 404 Tests

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
@@ -289,6 +289,196 @@ class TestListAwardRecommendations200:
         assert counts_by_id[str(ar_with_submissions.award_recommendation_id)] == 2
         assert counts_by_id[str(ar_without_submissions.award_recommendation_id)] == 0
 
+    def test_list_award_recommendations_sort_by_award_recommendation_number(
+        self, client, db_session, agency, opportunity
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        ar1 = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_number="AR-AAA",
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        ar2 = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_number="AR-ZZZ",
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        ar3 = AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_number="AR-MMM",
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [
+                        {"order_by": "award_recommendation_number", "sort_direction": "ascending"}
+                    ],
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        returned_ids = [d["award_recommendation_id"] for d in resp.json["data"]]
+        assert returned_ids == [
+            str(ar1.award_recommendation_id),
+            str(ar3.award_recommendation_id),
+            str(ar2.award_recommendation_id),
+        ]
+
+    def test_list_award_recommendations_sort_by_opportunity_name(self, client, db_session, agency):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        opp1 = OpportunityFactory.create(
+            agency_code=agency.agency_code, opportunity_title="Alpha Opportunity"
+        )
+        opp2 = OpportunityFactory.create(
+            agency_code=agency.agency_code, opportunity_title="Zulu Opportunity"
+        )
+        opp3 = OpportunityFactory.create(
+            agency_code=agency.agency_code, opportunity_title="Bravo Opportunity"
+        )
+
+        ar1 = AwardRecommendationFactory.create(
+            opportunity=opp1, review_workflow=None, review_workflow_id=None
+        )
+        ar2 = AwardRecommendationFactory.create(
+            opportunity=opp2, review_workflow=None, review_workflow_id=None
+        )
+        ar3 = AwardRecommendationFactory.create(
+            opportunity=opp3, review_workflow=None, review_workflow_id=None
+        )
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [{"order_by": "opportunity_name", "sort_direction": "ascending"}],
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        returned_ids = [d["award_recommendation_id"] for d in resp.json["data"]]
+        assert returned_ids == [
+            str(ar1.award_recommendation_id),
+            str(ar3.award_recommendation_id),
+            str(ar2.award_recommendation_id),
+        ]
+
+    def test_list_award_recommendations_sort_by_total_received_count(
+        self, client, db_session, agency, opportunity
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        ar1 = AwardRecommendationFactory.create(
+            opportunity=opportunity, review_workflow=None, review_workflow_id=None
+        )
+        ar2 = AwardRecommendationFactory.create(
+            opportunity=opportunity, review_workflow=None, review_workflow_id=None
+        )
+        ar3 = AwardRecommendationFactory.create(
+            opportunity=opportunity, review_workflow=None, review_workflow_id=None
+        )
+
+        # ar1 has 5 submissions
+        for _ in range(5):
+            AwardRecommendationApplicationSubmissionFactory.create(award_recommendation=ar1)
+
+        # ar2 has 2 submissions
+        for _ in range(2):
+            AwardRecommendationApplicationSubmissionFactory.create(award_recommendation=ar2)
+
+        # ar3 has 0 submissions
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [
+                        {"order_by": "total_received_count", "sort_direction": "descending"}
+                    ],
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        returned_ids = [d["award_recommendation_id"] for d in resp.json["data"]]
+        assert returned_ids == [
+            str(ar1.award_recommendation_id),
+            str(ar2.award_recommendation_id),
+            str(ar3.award_recommendation_id),
+        ]
+
+    def test_list_award_recommendations_sort_by_status(
+        self, client, db_session, agency, opportunity
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_status=AwardRecommendationStatus.APPROVED,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_status=AwardRecommendationStatus.DRAFT,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+        AwardRecommendationFactory.create(
+            opportunity=opportunity,
+            award_recommendation_status=AwardRecommendationStatus.IN_REVIEW,
+            review_workflow=None,
+            review_workflow_id=None,
+        )
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [
+                        {"order_by": "award_recommendation_status", "sort_direction": "ascending"}
+                    ],
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        statuses = [d["award_recommendation_status"] for d in resp.json["data"]]
+        assert statuses == ["draft", "in_review", "approved"]
+
 
 ####################################
 # 404 Tests
@@ -477,6 +667,48 @@ class TestListAwardRecommendations422:
             API_URL,
             headers={"X-SGG-Token": token},
             json=_build_request([]),
+        )
+
+        assert resp.status_code == 422
+
+    def test_list_award_recommendations_invalid_sort_field_422(self, client, db_session, agency):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [{"order_by": "invalid_field", "sort_direction": "ascending"}],
+                },
+            },
+        )
+
+        assert resp.status_code == 422
+
+    def test_list_award_recommendations_invalid_sort_direction_422(
+        self, client, db_session, agency
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [{"order_by": "created_at", "sort_direction": "invalid"}],
+                },
+            },
         )
 
         assert resp.status_code == 422

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_list.py
@@ -479,6 +479,56 @@ class TestListAwardRecommendations200:
         statuses = [d["award_recommendation_status"] for d in resp.json["data"]]
         assert statuses == ["draft", "in_review", "approved"]
 
+    def test_list_award_recommendations_sort_by_opportunity_number(
+        self, client, db_session, agency
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.VIEW_AWARD_RECOMMENDATION]
+        )
+
+        opp1 = OpportunityFactory.create(
+            agency_code=agency.agency_code, opportunity_number="OPP-001"
+        )
+        opp2 = OpportunityFactory.create(
+            agency_code=agency.agency_code, opportunity_number="OPP-999"
+        )
+        opp3 = OpportunityFactory.create(
+            agency_code=agency.agency_code, opportunity_number="OPP-500"
+        )
+
+        ar1 = AwardRecommendationFactory.create(
+            opportunity=opp1, review_workflow=None, review_workflow_id=None
+        )
+        ar2 = AwardRecommendationFactory.create(
+            opportunity=opp2, review_workflow=None, review_workflow_id=None
+        )
+        ar3 = AwardRecommendationFactory.create(
+            opportunity=opp3, review_workflow=None, review_workflow_id=None
+        )
+
+        resp = client.post(
+            API_URL,
+            headers={"X-SGG-Token": token},
+            json={
+                "filters": {"agency_id": {"one_of": [str(agency.agency_id)]}},
+                "pagination": {
+                    "page_offset": 1,
+                    "page_size": 25,
+                    "sort_order": [
+                        {"order_by": "opportunity_number", "sort_direction": "ascending"}
+                    ],
+                },
+            },
+        )
+
+        assert resp.status_code == 200
+        returned_ids = [d["award_recommendation_id"] for d in resp.json["data"]]
+        assert returned_ids == [
+            str(ar1.award_recommendation_id),  # OPP-001
+            str(ar3.award_recommendation_id),  # OPP-500
+            str(ar2.award_recommendation_id),  # OPP-999
+        ]
+
 
 ####################################
 # 404 Tests


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10934 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Enhance POST /alpha/award-recommendations/list to support sorting by the fields shown in the Award Recommendation list view.
* `award_recommendation_number`
* `opportunity_name`
* `opportunity_number`
* `total_received_count`
* `award_recommendation_status`
* `created_at`

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The endpoint currently only supports sorting by `created_at`. The UI displays additional fields that users may reasonably expect to sort by.
This is to enhance `POST /alpha/award-recommendations/list` to support sorting by the fields shown in the Award Recommendation list view.

Dev note - Because `total_received_count` is not a direct column on the `AwardRecommendation` table but is instead a calculated value, removed the original `COLUMN_MAPPING` on `created_at` and replaced it with a subquery that can calculate that field at runtime.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] Added unit tests to verify the expected sort output for each new option
- [x] Verified correct output on local testing in Swagger UI
