### PR TITLE
[Issue #9927] Clean up CI after multi user implementation

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -60,9 +60,6 @@ inputs:
   do-webkit-install:
     description: "install webkit for playwright"
     default: "false"
-  staging_test_user_api_key:
-    description: "test user API key used in spoofing staging user logins"
-    default: ""
   staging_client_session_secret:
     description: "encode key for client side JWTs, used in spoofing staging user logins"
     default: ""
@@ -142,7 +139,6 @@ runs:
         STAGING_TEST_USER_EMAIL: ${{ inputs.staging_test_user_email }}
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
-        STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
         SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
         TEST_USER_MANAGER_API_KEY: ${{ inputs.test_user_manager_api_key }}
 
@@ -162,7 +158,6 @@ runs:
         STAGING_TEST_USER_EMAIL: ${{ inputs.staging_test_user_email }}
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
         STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
-        STAGING_TEST_USER_API_KEY: ${{ inputs.staging_test_user_api_key }}
         SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
         TEST_USER_MANAGER_API_KEY: ${{ inputs.test_user_manager_api_key }}
 

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -63,7 +63,6 @@ jobs:
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}
           staging_test_user_password: ${{ secrets.STAGING_TEST_USER_PASSWORD }}
           staging_test_user_mfa_key: ${{ secrets.STAGING_TEST_USER_MFA_KEY }}
-          staging_test_user_api_key: ${{ secrets.STAGING_TEST_USER_API_KEY }}
           staging_client_session_secret: ${{ secrets.STAGING_CLIENT_SESSION_SECRET }}
           test_user_manager_api_key: ${{ secrets.STAGING_TEST_USER_MANAGER_API_KEY }}
           do-chrome-install: "true"

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -72,7 +72,6 @@ const playwrightEnv = {
   testUserEmail: process.env.STAGING_TEST_USER_EMAIL || "",
   testUserPassword: process.env.STAGING_TEST_USER_PASSWORD || "",
   testUserAuthKey: process.env.STAGING_TEST_USER_MFA_KEY || "",
-  stagingTestUserApiKey: process.env.STAGING_TEST_USER_API_KEY || "",
   testUserManagerApiKey,
 };
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #9927  

## Changes proposed

- Updated `e2e-staging.yml` to stop passing the `staging_test_user_api_key` secret into the e2e action invocation.
- Updated `action.yml` to remove the `staging_test_user_api_key` input and its two `STAGING_TEST_USER_API_KEY` env var mappings.
- Updated `playwright-env.ts` to remove the unused `stagingTestUserApiKey` field.

## Context for reviewers

Cleanup after the multi-user test system was fully enabled. The old `STAGING_TEST_USER_API_KEY` flow is dead now that test-user auth tokens are fetched via `POST /v1/internal/e2e-token` with the manager API key. The "cat of e2e_token into env" item from the ticket was already removed in #11445, so this PR covers the remaining references. This removes an unused authentication input/secret from the e2e path; no active auth behavior changes, and the `STAGING_TEST_USER_API_KEY` GitHub secret will be deleted from repo settings separately.

## Validation steps

Confirm updated actions have unchanged behavior. 