### PR TITLE
[Issue #8342] Implement XML differences for Simpler EPA 4700-4 form (ID: 773) to match legacy Grants.gov

### DIFF
--- a/api/src/form_schema/forms/epa_form_4700_4/1/0/form_json.py
+++ b/api/src/form_schema/forms/epa_form_4700_4/1/0/form_json.py
@@ -339,6 +339,7 @@ FORM_XML_TRANSFORM_RULES = {
             "EPA4700_4_5_0": "http://apply.grants.gov/forms/EPA4700_4_5_0-V5.0",
             "globLib": "http://apply.grants.gov/system/GlobalLibrary-V2.0",
             "glob": "http://apply.grants.gov/system/Global-V1.0",
+            "att": "http://apply.grants.gov/system/Attachments-V1.0",
         },
         "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/EPA4700_4_5_0-V5.0.xsd",
         "xml_structure": {

--- a/api/tests/src/services/xml_generation/test_epa_form_4700_4_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_epa_form_4700_4_xml_generation.py
@@ -1,0 +1,98 @@
+"""Tests for EPA Form 4700-4 XML generation.
+
+Ensures generated XML matches the legacy Grants.gov output for this form.
+
+XSD Reference: https://apply07.grants.gov/apply/forms/schemas/EPA4700_4_5_0-V5.0.xsd
+"""
+
+from lxml import etree as lxml_etree
+
+from src.form_schema.forms.epa_form_4700_4 import FORM_XML_TRANSFORM_RULES
+from src.services.xml_generation.models import XMLGenerationRequest
+from src.services.xml_generation.service import XMLGenerationService
+
+FORM_NS = "http://apply.grants.gov/forms/EPA4700_4_5_0-V5.0"
+
+
+def _full_application_data() -> dict:
+    return {
+        "applicant_name": "MH",
+        "applicant_address": {
+            "address": "123 foo st",
+            "city": "Foo",
+            "state": "AL: Alabama",
+            "zip_code": "123451234",
+        },
+        "sam_uei": "00000000INDV",
+        "point_of_contact_name": "MH",
+        "point_of_contact_phone_number": "123-123-1234",
+        "point_of_contact_email": "mike.huneke@focusconsulting.io",
+        "point_of_contact_title": "MH",
+        "federal_financial_assistance": False,
+        "civil_rights_lawsuit_question1": "asdf",
+        "civil_rights_lawsuit_question2": "adsf",
+        "civil_rights_lawsuit_question3": "asdf",
+        "construction_federal_assistance": True,
+        "construction_new_facilities": True,
+        "construction_new_facilities_explanation": "adsf",
+        "notice1": True,
+        "notice2": True,
+        "notice3": True,
+        "notice4": True,
+        "demographic_data": True,
+        "policy": True,
+        "policy_explanation": "asdf",
+        "program_explanation": "asdf",
+        "applicant_signature": {
+            "aor_signature": "Mike  Huneke",
+            "aor_title": "MH",
+            "submitted_date": "2026-07-23",
+        },
+    }
+
+
+def _generate(application_data: dict) -> str:
+    response = XMLGenerationService().generate_xml(
+        XMLGenerationRequest(
+            application_data=application_data,
+            transform_config=FORM_XML_TRANSFORM_RULES,
+        )
+    )
+    assert response.success is True, response.error_message
+    assert response.xml_data is not None
+    return response.xml_data
+
+
+def test_epa_form_4700_4_xml_matches_legacy_structure():
+    root = lxml_etree.fromstring(_generate(_full_application_data()).encode())
+
+    assert lxml_etree.QName(root).localname == "EPA4700_4_5_0"
+    assert root.get(f"{{{FORM_NS}}}FormVersion") == "5.0"
+
+    # applicant_name + applicant_address are grouped under a single ApplicantInfo element
+    applicant_info = root.find(f"{{{FORM_NS}}}ApplicantInfo")
+    assert applicant_info.find(f"{{{FORM_NS}}}ApplicantName").text == "MH"
+    address = applicant_info.find(f"{{{FORM_NS}}}ApplicantAddress")
+    assert [lxml_etree.QName(c).localname for c in address] == [
+        "Address",
+        "City",
+        "State",
+        "ZipCode",
+    ]
+
+    # booleans render as the legacy "Y: Yes" / "N: No" encoding
+    assert root.find(f"{{{FORM_NS}}}FederalFinancialAssistanceQuestion").text == "N: No"
+    assert root.find(f"{{{FORM_NS}}}Construction").text == "Y: Yes"
+
+    signature = root.find(f"{{{FORM_NS}}}ApplicantSignature")
+    assert [lxml_etree.QName(c).localname for c in signature] == [
+        "AORSignature",
+        "PersonTitle",
+        "SubmittedDate",
+    ]
+
+
+def test_epa_form_4700_4_declares_attachments_namespace():
+    """The att namespace is declared to match legacy output even though the body omits it."""
+    root = lxml_etree.fromstring(_generate(_full_application_data()).encode())
+    assert root.nsmap.get("att") == "http://apply.grants.gov/system/Attachments-V1.0"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #8342

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add `att` namespace, the only difference from legacy to simpler XML.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Compared a real Grants.gov S2S submission (tracking number `GRANT00853851`) against Simpler's generated output for the EPA 4700-4 form.

### The only difference: root namespace declarations

**Legacy Grants.gov** declares four namespaces on the form's root element:
```
xml
<EPA4700_4_5_0:EPA4700_4_5_0
    xmlns:att="http://apply.grants.gov/system/Attachments-V1.0"
    xmlns:glob="http://apply.grants.gov/system/Global-V1.0"
    xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0"
    xmlns:EPA4700_4_5_0="http://apply.grants.gov/forms/EPA4700_4_5_0-V5.0"
    EPA4700_4_5_0:FormVersion="5.0">
Simpler (before this PR) declared only three — it was missing att:


<EPA4700_4_5_0:EPA4700_4_5_0
    xmlns:EPA4700_4_5_0="http://apply.grants.gov/forms/EPA4700_4_5_0-V5.0"
    xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0"
    xmlns:glob="http://apply.grants.gov/system/Global-V1.0"
    EPA4700_4_5_0:FormVersion="5.0"> 
```
The att namespace is declared but unused in this form's body — the EPA 4700-4 has no attachment fields, and no att:-prefixed element appears anywhere in either document. Grants.gov emits it unconditionally from a shared template. Because it's unused, its absence had no functional impact on XSD validation or data equivalence, but declaring it gives byte-level parity with the legacy system and avoids surprising diffs for anyone comparing outputs downstream.

Note on declaration order: XML treats namespace declaration order as insignificant, so the differing order between the two outputs (e.g. att first in legacy vs. last in Simpler) is not a real difference and is not something we normalize.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

`make generate-xml form=EPA4700_4 json="$(cat epa4700-sample.json)"`

Compare XML and JSON:
[GrantApplication.xml](https://github.com/user-attachments/files/30318211/GrantApplication.xml)
[epa4700-sample.json](https://github.com/user-attachments/files/30318332/epa4700-sample.json)


[epa4700-sample (1).json](https://github.com/user-attachments/files/30428573/epa4700-sample.1.json)
[GrantApplication.xml](https://github.com/user-attachments/files/30428576/GrantApplication.xml)
