### PR TITLE
[Issue #11478] Handle not GetApplicationZip not found with exc

### DIFF
--- a/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
@@ -79,6 +79,7 @@ def get_application_zip_response(
         extra={
             "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
             "response_operation_name": "GetApplicationZipResponse",
+            "legacy_tracking_number": legacy_tracking_number,
         },
     )
     fault_message = FaultMessage(

--- a/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
@@ -5,11 +5,14 @@ from botocore.exceptions import ClientError
 from grants_shared.util import file_util
 
 from src.legacy_soap_api.grantors import schemas as grantor_schemas
+from src.legacy_soap_api.grantors.fault_messages import MissingGrantsGovTrackingNumber
 from src.legacy_soap_api.legacy_soap_api_auth import validate_certificate, verify_certificate_access
 from src.legacy_soap_api.legacy_soap_api_config import SOAPOperationConfig
 from src.legacy_soap_api.legacy_soap_api_constants import LegacySoapApiEvent
+from src.legacy_soap_api.legacy_soap_api_schemas import FaultMessage
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest
 from src.legacy_soap_api.legacy_soap_api_utils import (
+    SOAPFaultException,
     get_application_submission_by_legacy_tracking_number,
 )
 
@@ -41,11 +44,14 @@ def get_application_zip_response(
     schema = build_schema()
     legacy_tracking_number = get_application_zip_request.grants_gov_tracking_number
     if not legacy_tracking_number:
-        return schema
+        raise SOAPFaultException(
+            "legacy_tracking_number cannot be None.",
+            fault=MissingGrantsGovTrackingNumber,
+        )
     application_submission = get_application_submission_by_legacy_tracking_number(
         db_session, legacy_tracking_number
     )
-    if application_submission:
+    if application_submission is not None:
         content_id = f"{application_submission.application_submission_id}-1@apply.grants.gov"
         schema = build_schema(content_id)
         certificate = validate_certificate(
@@ -67,12 +73,19 @@ def get_application_zip_response(
                     "response_operation_name": "GetApplicationZipResponse",
                 },
             )
-    else:
-        logger.info(
-            f"Unable to find submission legacy_tracking_number {legacy_tracking_number}.",
-            extra={
-                "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
-                "response_operation_name": "GetApplicationZipResponse",
-            },
-        )
-    return schema
+        return schema
+    logger.info(
+        "Unable to find submission.",
+        extra={
+            "soap_api_event": LegacySoapApiEvent.ERROR_CALLING_SIMPLER,
+            "response_operation_name": "GetApplicationZipResponse",
+        },
+    )
+    fault_message = FaultMessage(
+        faultstring=f"Failed to get application zip.(Grant Application not found for tracking number:{legacy_tracking_number})",
+        faultcode="soap:Server",
+    )
+    raise SOAPFaultException(
+        "ApplicationSubmission not found",
+        fault=fault_message,
+    )

--- a/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
+++ b/api/src/legacy_soap_api/grantors/services/get_application_zip_response.py
@@ -41,7 +41,6 @@ def get_application_zip_response(
     get_application_zip_request: grantor_schemas.GetApplicationZipRequest,
     soap_config: SOAPOperationConfig,
 ) -> grantor_schemas.GetApplicationZipResponseSOAPEnvelope:
-    schema = build_schema()
     legacy_tracking_number = get_application_zip_request.grants_gov_tracking_number
     if not legacy_tracking_number:
         raise SOAPFaultException(

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -217,16 +217,16 @@ def get_soap_error_response(
     faultstring: str = "Server error has occurred",
     headers: dict | None = None,
 ) -> SOAPResponse:
-    err = f"""
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-    <soap:Body>
-        <soap:Fault>
-            <faultcode>{faultcode}</faultcode>
-            <faultstring>{faultstring}</faultstring>
-        </soap:Fault>
-    </soap:Body>
-</soap:Envelope>
-""".encode()
+    err = (
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        f"<faultcode>{faultcode}</faultcode>"
+        f"<faultstring>{faultstring}</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    ).encode()
     return get_soap_response(data=err, status_code=500, headers=headers)
 
 
@@ -235,16 +235,16 @@ def get_soap_fault_error_response(
     faultstring: str = "Server error has occurred",
     headers: dict | None = None,
 ) -> SOAPResponse:
-    err = f"""
-    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-        <soap:Body>
-            <soap:Fault>
-                <faultcode>{faultcode}</faultcode>
-                <faultstring>{faultstring}</faultstring>
-            </soap:Fault>
-        </soap:Body>
-    </soap:Envelope>
-    """.strip()
+    err = (
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        f"<faultcode>{faultcode}</faultcode>"
+        f"<faultstring>{faultstring}</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    )
     boundary_id = str(uuid.uuid4())
     mtom_response = (
         f"--uuid:{boundary_id}\r\n"
@@ -252,7 +252,7 @@ def get_soap_fault_error_response(
         f"Content-Transfer-Encoding: binary\r\n"
         f"Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
         f"{err}\r\n"
-        f"--uuid:{boundary_id}--\r\n"
+        f"--uuid:{boundary_id}--"
     ).encode()
     response_headers = {
         "Content-Type": (

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -789,7 +789,7 @@ class TestSimplerSOAPGetApplicationZip:
         )
         mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
         client = SimplerGrantorsS2SClient(soap_request, db_session)
-        with pytest.raises(SOAPFaultException, match="ApplicationSubmission not found."):
+        with pytest.raises(SOAPFaultException, match="ApplicationSubmission not found"):
             client.get_simpler_soap_response(mock_proxy_response)
         assert "Unable to find submission." in caplog.messages
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_client.py
@@ -34,6 +34,7 @@ from src.legacy_soap_api.legacy_soap_api_config import (
 )
 from src.legacy_soap_api.legacy_soap_api_schemas import SOAPResponse
 from src.legacy_soap_api.legacy_soap_api_schemas.base import SOAPRequest, SoapRequestStreamer
+from src.legacy_soap_api.legacy_soap_api_utils import SOAPFaultException
 from tests.lib.data_factories import setup_cert_user
 from tests.lib.db_testing import cascade_delete_from_db_table
 from tests.src.db.models.factories import (
@@ -788,12 +789,9 @@ class TestSimplerSOAPGetApplicationZip:
         )
         mock_proxy_response = SOAPResponse(data=b"", status_code=500, headers={})
         client = SimplerGrantorsS2SClient(soap_request, db_session)
-        response = client.get_simpler_soap_response(mock_proxy_response)
-        grants_gov_tracking_number = FAKE_GRANTS_GOV_TRACKING_NUMBER
-        msg = f"Unable to find submission legacy_tracking_number {grants_gov_tracking_number}."
-        assert msg in caplog.messages
-        assert response.data == mock_proxy_response.data
-        assert response.status_code == mock_proxy_response.status_code
+        with pytest.raises(SOAPFaultException, match="ApplicationSubmission not found."):
+            client.get_simpler_soap_response(mock_proxy_response)
+        assert "Unable to find submission." in caplog.messages
 
 
 class TestSimplerSOAPGetSubmissionListExpanded:

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -481,17 +481,17 @@ def test_successful_confirm_application_delivery_request_when_in_received_by_age
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
         "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "        <soap:Body>\n"
-        "            <soap:Fault>\n"
-        "                <faultcode>soap:Server</faultcode>\n"
-        "                <faultstring>Failed to confirm application delivery."
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Failed to confirm application delivery."
         "(Expected an Application status of:'Validated' , but found a status of "
-        f"'Received by Agency' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
-        "            </soap:Fault>\n"
-        "        </soap:Body>\n"
-        "    </soap:Envelope>\r\n"
-        f"--uuid:{TEST_UUID}--\r\n"
+        f"'Received by Agency' for GRANT{submission.legacy_tracking_number})</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--"
     )
     assert response.data.decode() == expected
     assert (
@@ -637,17 +637,17 @@ def test_successful_confirm_application_delivery_request_when_in_tracking_number
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
         "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "        <soap:Body>\n"
-        "            <soap:Fault>\n"
-        "                <faultcode>soap:Server</faultcode>\n"
-        "                <faultstring>Failed to confirm application delivery."
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Failed to confirm application delivery."
         "(Expected an Application status of:'Validated' , but found a status of "
-        f"'Agency Tracking Number Assigned' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
-        "            </soap:Fault>\n"
-        "        </soap:Body>\n"
-        "    </soap:Envelope>\r\n"
-        f"--uuid:{TEST_UUID}--\r\n"
+        f"'Agency Tracking Number Assigned' for GRANT{submission.legacy_tracking_number})</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--"
     )
     assert response.data.decode() == expected
     log = next(r for r in caplog.records if r.message == "Soap Fault Exception raised")
@@ -713,15 +713,15 @@ def test_confirm_application_delivery_when_application_has_no_status(
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
         "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "        <soap:Body>\n"
-        "            <soap:Fault>\n"
-        "                <faultcode>soap:Server</faultcode>\n"
-        "                <faultstring>Application has no application_status</faultstring>\n"
-        "            </soap:Fault>\n"
-        "        </soap:Body>\n"
-        "    </soap:Envelope>\r\n"
-        f"--uuid:{TEST_UUID}--\r\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Application has no application_status</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--"
     )
     assert response.data.decode() == expected
 
@@ -778,15 +778,15 @@ def test_if_soap_fault_exception_raised_return_correct_response_if_proxy_respons
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
         "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
-        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n'
-        "        <soap:Body>\n"
-        "            <soap:Fault>\n"
-        "                <faultcode>soap:Server</faultcode>\n"
-        f"                <faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received' for GRANT{submission.legacy_tracking_number})</faultstring>\n"
-        "            </soap:Fault>\n"
-        "        </soap:Body>\n"
-        "    </soap:Envelope>\r\n"
-        f"--uuid:{TEST_UUID}--\r\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        f"<faultstring>Failed to confirm application delivery.(Expected an Application status of:'Validated' , but found a status of 'Received' for GRANT{submission.legacy_tracking_number})</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--"
     )
     assert response.data.decode() == expected
 
@@ -943,7 +943,7 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
         "<soapenv:Header/>"
         "<soapenv:Body>"
         "<agen:GetApplicationZipRequest>"
-        f'<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">{SIMPLER_TRACKING_NUMBER}</gran:GrantsGovTrackingNumber>'
+        '<gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT99999999</gran:GrantsGovTrackingNumber>'
         "</agen:GetApplicationZipRequest>"
         "</soapenv:Body>"
         "</soapenv:Envelope>/r/n"
@@ -965,7 +965,7 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
         '\r\n\r\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
         "<soap:Body><soap:Fault>"
         "<faultcode>soap:Server</faultcode>"
-        f"<faultstring>Failed to get application zip.(Grant Application not found for tracking number:{SIMPLER_TRACKING_NUMBER})"
+        f"<faultstring>Failed to get application zip.(Grant Application not found for tracking number:GRANT99999999)"
         "</faultstring></soap:Fault></soap:Body></soap:Envelope>\r\n"
         f"--uuid:{test_uuid}--"
     ).encode("utf-8")
@@ -976,7 +976,6 @@ def test_getapplicationzip_operation_returns_not_found_response_if_simpler_id_is
         response.headers["Content-Type"]
         == f'multipart/related; type="application/xop+xml"; boundary="uuid:{test_uuid}"; start="<root.message@cxf.apache.org>"; start-info="text/xml"'
     )
-    assert response.headers["Set-Cookie"] == "None; Path=/grantsws-agency; Secure; HttpOnly"
 
 
 @mock.patch("src.legacy_soap_api.legacy_soap_api_proxy._get_soap_response")
@@ -1213,14 +1212,14 @@ def test_request_fails_if_no_mtls_cert_is_attached(
     )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
-        "<soap:Body>\n        "
-        "<soap:Fault>\n            "
-        "<faultcode>soap:Server</faultcode>\n            "
-        "<faultstring>Missing certificate. (Authorization Failure)</faultstring>\n        "
-        "</soap:Fault>\n    "
-        "</soap:Body>\n"
-        "</soap:Envelope>\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Missing certificate. (Authorization Failure)</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
     )
     assert response.data.decode() == expected
 
@@ -1248,14 +1247,14 @@ def test_request_fails_if_no_tcertificate(db_session, client, enable_factory_cre
     )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
-        "<soap:Body>\n        "
-        "<soap:Fault>\n            "
-        "<faultcode>soap:Server</faultcode>\n            "
-        "<faultstring>No tcertificate found. (Authorization Failure)</faultstring>\n        "
-        "</soap:Fault>\n    "
-        "</soap:Body>\n"
-        "</soap:Envelope>\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>No tcertificate found. (Authorization Failure)</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
     )
     assert response.data.decode() == expected
 
@@ -1288,14 +1287,14 @@ def test_request_fails_if_tcertificate_is_expired(
     )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
-        "<soap:Body>\n        "
-        "<soap:Fault>\n            "
-        "<faultcode>soap:Server</faultcode>\n            "
-        "<faultstring>Certificate is expired. (Authorization Failure)</faultstring>\n        "
-        "</soap:Fault>\n    "
-        "</soap:Body>\n"
-        "</soap:Envelope>\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Certificate is expired. (Authorization Failure)</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
     )
     assert response.data.decode() == expected
 
@@ -1404,14 +1403,14 @@ def test_request_fails_if_legacy_certificate_is_expired(
     )
     assert response.status_code == 500
     expected = (
-        '\n<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">\n    '
-        "<soap:Body>\n        "
-        "<soap:Fault>\n            "
-        "<faultcode>soap:Server</faultcode>\n            "
-        "<faultstring>Certificate is expired. (Authorization Failure)</faultstring>\n        "
-        "</soap:Fault>\n    "
-        "</soap:Body>\n"
-        "</soap:Envelope>\n"
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Certificate is expired. (Authorization Failure)</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
     )
     assert response.data.decode() == expected
 

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_utils.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_utils.py
@@ -29,16 +29,16 @@ def test_format_local_soap_response() -> None:
 
 def test_get_auth_error_response() -> None:
     err_response = get_auth_error_response()
-    err = b"""
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-    <soap:Body>
-        <soap:Fault>
-            <faultcode>soap:Server</faultcode>
-            <faultstring>Authorization error</faultstring>
-        </soap:Fault>
-    </soap:Body>
-</soap:Envelope>
-"""
+    err = (
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<soap:Fault>"
+        "<faultcode>soap:Server</faultcode>"
+        "<faultstring>Authorization error</faultstring>"
+        "</soap:Fault>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    ).encode("utf-8")
     assert err in err_response.data
     assert err_response.status_code == 500
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11478  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Have the get_application_zip response method throw an exception when submission not found.
- Removed some formatting in error responses 
- Update some tests

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The submission not found scenario was being handled by checking to see if a returned schema had an mtom_file_stream attached to it. This was working correctly but made it very unclear what was going on. Instead we now raise an exception when a submission is not found.

The formatting in error response fixes were because it turns out that testing revealed that those error responses don't actually have the formatting we were putting in.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
- [ ] nothing should really change performance-wise but hopefully it's easier to understand how it handles this scenario
