### PR TITLE
[Issue #10570] Key Contact form add instructions

### DIFF
--- a/api/src/form_schema/forms/key_contacts/1/0/form_json.py
+++ b/api/src/form_schema/forms/key_contacts/1/0/form_json.py
@@ -359,7 +359,7 @@ KeyContacts_v2_0 = Form(
     # No rule schema needed — no conditional fields, attachments, or pre/post-population
     form_rule_schema=None,
     json_to_xml_schema=FORM_XML_TRANSFORM_RULES,
-    form_instruction_id=None,
+    form_instruction_id=uuid.UUID("f47ac10b-58cc-4372-a567-0e02b2c3d479"),
     form_type=FormType.KEY_CONTACTS,
     sgg_version="1.0",
     is_deprecated=False,


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes  for #10570  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Set form_instruction_id on the KeyContacts_v2_0 form definition so the API resolves and returns the form instruction when fetching application/competition data.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
The form instruction PDF was manually downloaded and uploaded to S3, and a form_instruction record was inserted directly into the DB with ID `f47ac10b-58cc-4372-a567-0e02b2c3d479`. The form registry definition had form_instruction_id=None, which meant the API never looked up the instruction — the UI would never display it. This one-line change wires the registry to the existing DB record.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Verify the following query yields a row in all environments `select * from api.form_instruction where form_instruction_id='f47ac10b-58cc-4372-a567-0e02b2c3d479';`
