### PR TITLE
[Issue #9135] Add endpoint to create award recommendation attachments

### DIFF
--- a/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_routes.py
@@ -10,6 +10,8 @@ from src.api.award_recommendations_alpha.award_recommendation_blueprint import (
     award_recommendation_blueprint,
 )
 from src.api.award_recommendations_alpha.award_recommendation_schemas import (
+    AwardRecommendationAttachmentCreateRequestSchema,
+    AwardRecommendationAttachmentCreateResponseSchema,
     AwardRecommendationAttachmentDeleteResponseSchema,
     AwardRecommendationAuditRequestSchema,
     AwardRecommendationAuditResponseSchema,
@@ -39,6 +41,9 @@ from src.services.award_recommendations.bulk_update_submission_details import (
 )
 from src.services.award_recommendations.create_award_recommendation import (
     create_award_recommendation,
+)
+from src.services.award_recommendations.create_award_recommendation_attachment import (
+    create_award_recommendation_attachment,
 )
 from src.services.award_recommendations.create_award_recommendation_risk import (
     create_award_recommendation_risk,
@@ -488,6 +493,45 @@ def award_recommendation_risk_delete(
         )
 
     return response.ApiResponse(message="Success", data=None)
+
+
+@award_recommendation_blueprint.post(
+    "/award-recommendations/<uuid:award_recommendation_id>/attachments"
+)
+@award_recommendation_blueprint.input(
+    AwardRecommendationAttachmentCreateRequestSchema(), location="json"
+)
+@award_recommendation_blueprint.output(AwardRecommendationAttachmentCreateResponseSchema())
+@award_recommendation_blueprint.doc(
+    summary="Create Award Recommendation Attachment",
+    description=(
+        "Attach a virus-scanned pending file to an award recommendation. "
+        "Upload the file first via POST /v1/files and wait for scan completion."
+    ),
+    responses=[200, 401, 403, 404, 422],
+)
+@award_recommendation_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@flask_db.with_db_session()
+def award_recommendation_attachment_create(
+    db_session: db.Session,
+    award_recommendation_id: uuid.UUID,
+    json_data: dict,
+) -> response.ApiResponse:
+    add_extra_data_to_current_request_logs({"award_recommendation_id": award_recommendation_id})
+    logger.info("POST /alpha/award-recommendations/:award_recommendation_id/attachments")
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        attachment = create_award_recommendation_attachment(
+            db_session,
+            user,
+            award_recommendation_id,
+            json_data,
+        )
+
+    return response.ApiResponse(message="Success", data=attachment)
 
 
 @award_recommendation_blueprint.delete(

--- a/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
+++ b/api/src/api/award_recommendations_alpha/award_recommendation_schemas.py
@@ -568,6 +568,40 @@ class AwardRecommendationAttachmentDeleteResponseSchema(AbstractResponseSchema):
     data = fields.MixinField(metadata={"example": None})
 
 
+class AwardRecommendationAttachmentCreateRequestSchema(Schema):
+    """Schema for POST award recommendation attachment from a scanned pending file"""
+
+    pending_file_id = fields.UUID(
+        required=True,
+        metadata={
+            "description": "The ID of the pending (virus-scanned) file to attach",
+        },
+    )
+    award_recommendation_attachment_type = fields.Enum(
+        AwardRecommendationAttachmentType,
+        required=True,
+        metadata={"description": "The type of the attachment"},
+    )
+    file_name = fields.String(
+        required=False,
+        allow_none=True,
+        metadata={
+            "description": "Optional override for the uploaded file name",
+            "example": "terms_and_conditions.pdf",
+        },
+    )
+
+
+class AwardRecommendationAttachmentCreateSchema(Schema):
+    award_recommendation_attachment_id = fields.UUID(
+        metadata={"description": "The ID of the created award recommendation attachment"}
+    )
+
+
+class AwardRecommendationAttachmentCreateResponseSchema(AbstractResponseSchema):
+    data = fields.Nested(AwardRecommendationAttachmentCreateSchema())
+
+
 class AwardRecommendationDeleteResponseSchema(AbstractResponseSchema):
     data = fields.MixinField(metadata={"example": None})
 

--- a/api/src/services/award_recommendations/create_award_recommendation_attachment.py
+++ b/api/src/services/award_recommendations/create_award_recommendation_attachment.py
@@ -1,0 +1,120 @@
+import logging
+import uuid
+
+import grants_shared.adapters.db as db
+import grants_shared.util.file_util as file_util
+from grants_shared.adapters.aws import S3Config
+
+from src.constants.lookup_constants import (
+    AwardRecommendationAttachmentType,
+    AwardRecommendationAuditEvent,
+)
+from src.db.models.award_recommendation_models import (
+    AwardRecommendationAttachment,
+    AwardRecommendationAudit,
+)
+from src.db.models.user_models import User
+from src.services.award_recommendations.get_award_recommendation import (
+    get_award_recommendation_for_update,
+)
+from src.services.files.pending_file_handling_domain_specific import (
+    fetch_and_validate_scan_complete_file,
+    move_pending_file_to_destination,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_award_recommendation_attachment(
+    db_session: db.Session,
+    user: User,
+    award_recommendation_id: uuid.UUID,
+    request_data: dict,
+) -> AwardRecommendationAttachment:
+    """Create an award recommendation attachment from a virus-scanned pending file.
+
+    Accepts a ``pending_file_id`` referencing a file uploaded via ``POST /v1/files``
+    that has cleared the virus scanner (``FileScanStatus.COMPLETE``). The pending
+    file is moved (not copied) into the award recommendation attachments path.
+    """
+    award_recommendation = get_award_recommendation_for_update(
+        db_session, user, award_recommendation_id
+    )
+
+    pending_file_id: uuid.UUID = request_data["pending_file_id"]
+    attachment_type: AwardRecommendationAttachmentType = request_data[
+        "award_recommendation_attachment_type"
+    ]
+    # Optional override for the pending file's display / path name
+    file_name_override: str | None = request_data.get("file_name")
+
+    pending_file = fetch_and_validate_scan_complete_file(db_session, pending_file_id, user)
+
+    raw_file_name = file_name_override or pending_file.file_name
+    secure_file_name = file_util.get_secure_file_name(raw_file_name)
+
+    award_recommendation_attachment_id = uuid.uuid4()
+    s3_file_location = build_s3_award_recommendation_attachment_path(
+        secure_file_name, award_recommendation_id, award_recommendation_attachment_id
+    )
+
+    # Persist attachment before moving the file so a DB failure leaves the
+    # pending file in its original scanned location.
+    user = db_session.merge(user)
+
+    attachment = AwardRecommendationAttachment(
+        award_recommendation_attachment_id=award_recommendation_attachment_id,
+        award_recommendation=award_recommendation,
+        file_location=s3_file_location,
+        file_name=file_util.get_file_name(raw_file_name),
+        award_recommendation_attachment_type=attachment_type,
+        uploading_user=user,
+    )
+    db_session.add(attachment)
+
+    award_recommendation.award_recommendation_audit_events.append(
+        AwardRecommendationAudit(
+            user=user,
+            award_recommendation_audit_event=AwardRecommendationAuditEvent.ATTACHMENT_CREATED,
+            award_recommendation_attachment=attachment,
+        )
+    )
+
+    # Move (not copy) after DB writes — pending file is consumed and marked PROCESSED.
+    move_pending_file_to_destination(pending_file, s3_file_location)
+
+    logger.info(
+        "Created award recommendation attachment",
+        extra={
+            "award_recommendation_id": award_recommendation_id,
+            "award_recommendation_attachment_id": award_recommendation_attachment_id,
+            "pending_file_id": pending_file_id,
+        },
+    )
+    return attachment
+
+
+def build_s3_award_recommendation_attachment_path(
+    file_name: str,
+    award_recommendation_id: uuid.UUID,
+    award_recommendation_attachment_id: uuid.UUID,
+) -> str:
+    """Construct a path to the award recommendation attachments on s3
+
+    Will be formatted like:
+
+        s3://<bucket>/award-recommendations/<award_recommendation_id>/attachments/<attachment_id>/<file_name>
+
+    We store each file in a separate folder as we don't require file names to be unique.
+    """
+    s3_config = S3Config()
+    base_path = s3_config.draft_files_bucket_path
+
+    return file_util.join(
+        base_path,
+        "award-recommendations",
+        str(award_recommendation_id),
+        "attachments",
+        str(award_recommendation_attachment_id),
+        file_name,
+    )

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_attachment_create.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_attachment_create.py
@@ -1,0 +1,455 @@
+import uuid
+
+import grants_shared.util.file_util as file_util
+import pytest
+from sqlalchemy import select
+
+from src.constants.lookup_constants import (
+    AwardRecommendationAttachmentType,
+    AwardRecommendationAuditEvent,
+    AwardRecommendationStatus,
+    FileScanStatus,
+    Privilege,
+)
+from src.db.models.award_recommendation_models import (
+    AwardRecommendationAttachment,
+    AwardRecommendationAudit,
+)
+from src.db.models.opportunity_models import Opportunity
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt
+from tests.src.db.models.factories import (
+    AgencyFactory,
+    AwardRecommendationFactory,
+    OpportunityFactory,
+    PendingFileFactory,
+    UserFactory,
+)
+
+API_URL = "/alpha/award-recommendations"
+
+
+####################################
+# Helpers / Fixtures
+####################################
+
+
+def make_pending_file(
+    user, s3_config, file_scan_status=FileScanStatus.COMPLETE, mime_type="application/pdf"
+):
+    """Create a PendingFile backed by a real S3 file."""
+    file_name = "test-attachment.pdf"
+    source_location = f"{s3_config.file_scan_bucket_path}/scan_complete/{uuid.uuid4()}/{file_name}"
+    file_util.write_to_file(source_location, "test file content")
+    return PendingFileFactory.create(
+        user=user,
+        file_name=file_name,
+        file_location=source_location,
+        file_scan_status=file_scan_status,
+        mime_type=mime_type,
+    )
+
+
+@pytest.fixture
+def agency(enable_factory_create):
+    return AgencyFactory.create()
+
+
+@pytest.fixture
+def opportunity(agency) -> Opportunity:
+    return OpportunityFactory.create(agency_code=agency.agency_code)
+
+
+@pytest.fixture
+def award_recommendation(opportunity):
+    return AwardRecommendationFactory.create(
+        opportunity=opportunity,
+        award_recommendation_status=AwardRecommendationStatus.DRAFT,
+        is_deleted=False,
+        review_workflow=None,
+        review_workflow_id=None,
+    )
+
+
+####################################
+# 200 Tests
+####################################
+
+
+class TestCreateAwardRecommendationAttachment200:
+
+    def test_create_attachment_200(
+        self,
+        client,
+        db_session,
+        agency,
+        award_recommendation,
+        s3_config,
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        pending_file = make_pending_file(user, s3_config)
+        original_location = pending_file.file_location
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 200, resp.json
+        assert resp.json["message"] == "Success"
+
+        attachment_id = resp.json["data"]["award_recommendation_attachment_id"]
+        assert attachment_id is not None
+
+        db_session.expire_all()
+        attachment = db_session.execute(
+            select(AwardRecommendationAttachment).where(
+                AwardRecommendationAttachment.award_recommendation_attachment_id == attachment_id
+            )
+        ).scalar_one()
+
+        assert attachment.file_name == "test-attachment.pdf"
+        assert (
+            attachment.award_recommendation_attachment_type
+            == AwardRecommendationAttachmentType.OTHER
+        )
+        assert attachment.award_recommendation_id == award_recommendation.award_recommendation_id
+        assert attachment.is_deleted is False
+        assert file_util.file_exists(attachment.file_location) is True
+        assert file_util.file_exists(original_location) is False
+        assert (
+            f"award-recommendations/{award_recommendation.award_recommendation_id}/attachments/"
+            f"{attachment_id}/"
+        ) in attachment.file_location
+
+        db_session.refresh(pending_file)
+        assert pending_file.file_scan_status == FileScanStatus.PROCESSED
+
+        audit_event = db_session.execute(
+            select(AwardRecommendationAudit).where(
+                AwardRecommendationAudit.award_recommendation_id
+                == award_recommendation.award_recommendation_id,
+                AwardRecommendationAudit.award_recommendation_audit_event
+                == AwardRecommendationAuditEvent.ATTACHMENT_CREATED,
+            )
+        ).scalar_one()
+        assert audit_event.award_recommendation_attachment_id == uuid.UUID(attachment_id)
+
+    def test_create_attachment_with_file_name_override_200(
+        self,
+        client,
+        db_session,
+        agency,
+        award_recommendation,
+        s3_config,
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        pending_file = make_pending_file(user, s3_config)
+        override_name = "custom_override_name.pdf"
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": (
+                    AwardRecommendationAttachmentType.STANDARD_TERMS
+                ),
+                "file_name": override_name,
+            },
+        )
+
+        assert resp.status_code == 200, resp.json
+
+        attachment_id = resp.json["data"]["award_recommendation_attachment_id"]
+        db_session.expire_all()
+        attachment = db_session.execute(
+            select(AwardRecommendationAttachment).where(
+                AwardRecommendationAttachment.award_recommendation_attachment_id == attachment_id
+            )
+        ).scalar_one()
+
+        assert attachment.file_name == override_name
+        assert (
+            attachment.award_recommendation_attachment_type
+            == AwardRecommendationAttachmentType.STANDARD_TERMS
+        )
+        assert attachment.file_location.endswith(f"/{override_name}")
+        assert file_util.file_exists(attachment.file_location) is True
+
+
+####################################
+# 404 Tests
+####################################
+
+
+class TestCreateAwardRecommendationAttachment404:
+
+    def test_create_attachment_award_recommendation_not_found_404(
+        self, client, db_session, agency, s3_config
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        pending_file = make_pending_file(user, s3_config)
+        missing_id = uuid.uuid4()
+
+        resp = client.post(
+            f"{API_URL}/{missing_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 404
+        assert resp.json["message"] == f"Could not find Award Recommendation with ID {missing_id}"
+
+    def test_create_attachment_pending_file_not_found_404(
+        self, client, db_session, agency, award_recommendation
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        missing_id = uuid.uuid4()
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(missing_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 404
+        assert resp.json["message"] == "Pending file not found"
+
+
+####################################
+# 401 Tests
+####################################
+
+
+class TestCreateAwardRecommendationAttachment401:
+
+    def test_create_attachment_no_token_401(self, client, award_recommendation):
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            json={
+                "pending_file_id": str(uuid.uuid4()),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 401
+
+    def test_create_attachment_invalid_token_401(self, client, award_recommendation):
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": "invalid-token"},
+            json={
+                "pending_file_id": str(uuid.uuid4()),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 401
+
+
+####################################
+# 403 Tests
+####################################
+
+
+class TestCreateAwardRecommendationAttachment403:
+
+    def test_create_attachment_wrong_agency_403(
+        self, client, db_session, award_recommendation, s3_config
+    ):
+        other_agency = AgencyFactory.create()
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=other_agency,
+            privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION],
+        )
+        pending_file = make_pending_file(user, s3_config)
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+    def test_create_attachment_wrong_privilege_403(
+        self, client, db_session, agency, award_recommendation, s3_config
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session,
+            agency=agency,
+            privileges=[Privilege.VIEW_AWARD_RECOMMENDATION],
+        )
+        pending_file = make_pending_file(user, s3_config)
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "Forbidden"
+
+    def test_create_attachment_pending_file_belongs_to_other_user_403(
+        self, client, db_session, agency, award_recommendation, s3_config
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        other_user = UserFactory.create()
+        pending_file = make_pending_file(other_user, s3_config)
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 403
+        assert resp.json["message"] == "You do not have permission to access this file"
+
+
+####################################
+# 422 Tests
+####################################
+
+
+class TestCreateAwardRecommendationAttachment422:
+
+    def test_create_attachment_file_scan_not_complete_422(
+        self, client, db_session, agency, award_recommendation, s3_config
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        pending_file = make_pending_file(
+            user, s3_config, file_scan_status=FileScanStatus.PENDING
+        )
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 422
+        assert resp.json["message"] == "File cannot be used, status must be complete"
+
+    def test_create_attachment_file_scan_infected_422(
+        self, client, db_session, agency, award_recommendation, s3_config
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        pending_file = make_pending_file(
+            user, s3_config, file_scan_status=FileScanStatus.INFECTED
+        )
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 422
+        assert resp.json["message"] == "File cannot be used, status must be complete"
+
+    def test_create_attachment_missing_type_422(
+        self, client, db_session, agency, award_recommendation, s3_config
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        pending_file = make_pending_file(user, s3_config)
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+            },
+        )
+
+        assert resp.status_code == 422
+        assert resp.json["message"] == "Validation error"
+        assert any(
+            error["field"] == "award_recommendation_attachment_type" for error in resp.json["errors"]
+        )
+
+    def test_create_attachment_invalid_type_422(
+        self, client, db_session, agency, award_recommendation, s3_config
+    ):
+        user, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+        pending_file = make_pending_file(user, s3_config)
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "pending_file_id": str(pending_file.pending_file_id),
+                "award_recommendation_attachment_type": "not_a_valid_type",
+            },
+        )
+
+        assert resp.status_code == 422
+        assert resp.json["message"] == "Validation error"
+        assert any(
+            error["field"] == "award_recommendation_attachment_type" for error in resp.json["errors"]
+        )
+
+    def test_create_attachment_missing_pending_file_id_422(
+        self, client, db_session, agency, award_recommendation
+    ):
+        _, _, token = create_user_in_agency_with_jwt(
+            db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
+        )
+
+        resp = client.post(
+            f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
+            headers={"X-SGG-Token": token},
+            json={
+                "award_recommendation_attachment_type": AwardRecommendationAttachmentType.OTHER,
+            },
+        )
+
+        assert resp.status_code == 422
+        assert resp.json["message"] == "Validation error"
+        assert any(error["field"] == "pending_file_id" for error in resp.json["errors"])

--- a/api/tests/src/api/award_recommendations/test_award_recommendation_attachment_create.py
+++ b/api/tests/src/api/award_recommendations/test_award_recommendation_attachment_create.py
@@ -352,9 +352,7 @@ class TestCreateAwardRecommendationAttachment422:
         user, _, token = create_user_in_agency_with_jwt(
             db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
         )
-        pending_file = make_pending_file(
-            user, s3_config, file_scan_status=FileScanStatus.PENDING
-        )
+        pending_file = make_pending_file(user, s3_config, file_scan_status=FileScanStatus.PENDING)
 
         resp = client.post(
             f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
@@ -374,9 +372,7 @@ class TestCreateAwardRecommendationAttachment422:
         user, _, token = create_user_in_agency_with_jwt(
             db_session, agency=agency, privileges=[Privilege.UPDATE_AWARD_RECOMMENDATION]
         )
-        pending_file = make_pending_file(
-            user, s3_config, file_scan_status=FileScanStatus.INFECTED
-        )
+        pending_file = make_pending_file(user, s3_config, file_scan_status=FileScanStatus.INFECTED)
 
         resp = client.post(
             f"{API_URL}/{award_recommendation.award_recommendation_id}/attachments",
@@ -409,7 +405,8 @@ class TestCreateAwardRecommendationAttachment422:
         assert resp.status_code == 422
         assert resp.json["message"] == "Validation error"
         assert any(
-            error["field"] == "award_recommendation_attachment_type" for error in resp.json["errors"]
+            error["field"] == "award_recommendation_attachment_type"
+            for error in resp.json["errors"]
         )
 
     def test_create_attachment_invalid_type_422(
@@ -432,7 +429,8 @@ class TestCreateAwardRecommendationAttachment422:
         assert resp.status_code == 422
         assert resp.json["message"] == "Validation error"
         assert any(
-            error["field"] == "award_recommendation_attachment_type" for error in resp.json["errors"]
+            error["field"] == "award_recommendation_attachment_type"
+            for error in resp.json["errors"]
         )
 
     def test_create_attachment_missing_pending_file_id_422(


### PR DESCRIPTION
## Summary

Work for #9135 

## Changes proposed

- Added `POST /alpha/award-recommendations/:id/attachments` to attach a virus-scanned pending file to an award recommendation
- Accepts `pending_file_id`, required `award_recommendation_attachment_type`, and optional `file_name`
- Moves the scanned file into draft S3 and emits `ATTACHMENT_CREATED`

## Context for reviewers

Follows the pending-file / virus-scan flow in `documentation/api/file-upload-and-scanning.md`, same pattern as `POST /v1/applications/:id/attachments`. Aligns with frontend `SimplerFileInput`

## Validation steps

- [ ] Ensure API is running and AR seed data exists
- [ ] Use seeded auth, e.g. X-API-Key: ar_rec_user1_key
- [ ] Get an award rec id
- [ ] Put a small test file (for example example.pdf) in your working directory, then follow the [example script](https://github.com/HHS/simpler-grants-gov/blob/main/documentation/api/file-upload-and-scanning.md#example-script) to upload a file (point it at http://localhost:8080 and use `X-API-Key: ar_rec_user1_key`)
- [ ] Create the award recommendation attachment by calling (replace `{ar_id}` and `{pending_file_id}`):
```bash
curl -s -X POST "http://localhost:8080/alpha/award-recommendations/{ar_id}/attachments" \
  -H "X-API-Key: ar_rec_user1_key" \
  -H "Content-Type: application/json" \
  -d '{
    "pending_file_id": "{pending_file_id}",
    "award_recommendation_attachment_type": "other"
  }'
```
- [ ] Confirm 200 with `award_recommendation_attachment_id`, then GET the award rec and verify the attachment appears
