### PR TITLE
[Issue 11642] Preserve CommonGrants funding fields

### DIFF
--- a/api/src/api/common_grants/schemas/marshmallow/custom_fields.py
+++ b/api/src/api/common_grants/schemas/marshmallow/custom_fields.py
@@ -160,6 +160,18 @@ class federalFundingSource(CustomField):
     )
 
 
+class federalFundingInstruments(CustomField):
+    """The federal funding instruments available for this opportunity."""
+
+    name = fields.String(required=True, metadata={"example": "federalFundingInstruments"})
+    fieldType = fields.String(required=True, metadata={"example": "array"})
+    value = fields.List(fields.String(), required=True)
+    description = fields.String(
+        allow_none=True,
+        metadata={"example": "Federal funding instruments available for this opportunity"},
+    )
+
+
 class AgencyContactValue(Schema):
     """Schema for populating the AgencyContact value field"""
 

--- a/api/src/api/common_grants/schemas/marshmallow/schemas.py
+++ b/api/src/api/common_grants/schemas/marshmallow/schemas.py
@@ -17,6 +17,7 @@ from src.api.common_grants.schemas.marshmallow.custom_fields import (
     attachments,
     contactInfo,
     costSharing,
+    federalFundingInstruments,
     federalFundingSource,
     federalOpportunityNumber,
     fiscalYear,
@@ -347,6 +348,7 @@ class OpportunityCustomFields(Schema):
     agency = fields.Nested(agency, allow_none=True)
     attachments = fields.Nested(attachments, allow_none=True)
     federalFundingSource = fields.Nested(federalFundingSource, allow_none=True)
+    federalFundingInstruments = fields.Nested(federalFundingInstruments, allow_none=True)
     fiscalYear = fields.Nested(fiscalYear, allow_none=True)
     costSharing = fields.Nested(costSharing, allow_none=True)
     additionalInfo = fields.Nested(additionalInfo, allow_none=True)

--- a/api/src/services/common_grants/transformation.py
+++ b/api/src/services/common_grants/transformation.py
@@ -336,8 +336,12 @@ def transform_opportunity_to_cg(v1_opportunity: Opportunity) -> OpportunityBase 
             "post_date": v1_opportunity.summary.post_date,
             "close_date": v1_opportunity.summary.close_date,
             "estimated_total_program_funding": v1_opportunity.summary.estimated_total_program_funding,
+            "expected_number_of_awards": getattr(
+                v1_opportunity.summary, "expected_number_of_awards", None
+            ),
             "award_ceiling": v1_opportunity.summary.award_ceiling,
             "award_floor": v1_opportunity.summary.award_floor,
+            "funding_instruments": list(getattr(v1_opportunity.summary, "funding_instruments", [])),
             "additional_info_url": v1_opportunity.summary.additional_info_url,
             "additional_info_url_description": v1_opportunity.summary.additional_info_url_description,
             "agency_contact_description": v1_opportunity.summary.agency_contact_description,
@@ -442,6 +446,7 @@ def transform_search_result_to_cg(opp_data: dict) -> OpportunityBase | None:
                 totalAmountAvailable=total_amount_money,
                 maxAwardAmount=max_award_money,
                 minAwardAmount=min_award_money,
+                estimatedAwardCount=summary.get("expected_number_of_awards"),
             ),
             source=validate_url(
                 summary.get("additional_info_url"),
@@ -591,6 +596,21 @@ def populate_custom_fields(opp_data: dict) -> dict[str, CustomField] | None:
         )
         if field:
             custom_fields["federalFundingSource"] = field
+
+    if summary:
+        funding_instruments = summary.get("funding_instruments")
+        if funding_instruments:
+            field = validate_custom_field(
+                CustomField,
+                opportunity_id=opportunity_id,
+                name="federalFundingInstruments",
+                fieldType="array",
+                schema="https://commongrants.org/custom-fields/federalFundingInstruments/",
+                value=funding_instruments,
+                description="Federal funding instruments available for this opportunity",
+            )
+            if field:
+                custom_fields["federalFundingInstruments"] = field
 
     agency = opp_data.get("agency_code")
     if agency is not None:

--- a/api/tests/src/services/common_grants/test_transformation.py
+++ b/api/tests/src/services/common_grants/test_transformation.py
@@ -119,8 +119,10 @@ class TestTransformation:
                                 "post_date": date(2024, 1, 1),
                                 "close_date": date(2024, 12, 31),
                                 "estimated_total_program_funding": 1000000,
+                                "expected_number_of_awards": 12,
                                 "award_ceiling": 500000,
                                 "award_floor": 10000,
+                                "funding_instruments": ["grant", "cooperative_agreement"],
                                 "additional_info_url": "https://example.com/opportunity",
                                 "additional_info_url_description": "Additional opportunity information",
                                 "agency_contact_description": "Contact the grants office for questions",
@@ -180,6 +182,7 @@ class TestTransformation:
         assert result.funding.max_award_amount.currency == "USD"
         assert result.funding.min_award_amount.amount == "10000"
         assert result.funding.min_award_amount.currency == "USD"
+        assert result.funding.estimated_award_count == 12
 
         # Check source URL
         assert str(result.source) == "https://example.com/opportunity"
@@ -195,6 +198,18 @@ class TestTransformation:
 
         assert "federalFundingSource" in result.custom_fields
         assert result.custom_fields["federalFundingSource"].value == "Mandatory"
+
+        assert result.custom_fields["federalFundingInstruments"].value == [
+            "grant",
+            "cooperative_agreement",
+        ]
+        serialized_custom_fields = result.model_dump(by_alias=True, mode="json")["customFields"]
+        validated_custom_fields = OpportunityCustomFields().load(serialized_custom_fields)
+        assert isinstance(validated_custom_fields, dict)
+        assert validated_custom_fields["federalFundingInstruments"]["value"] == [
+            "grant",
+            "cooperative_agreement",
+        ]
 
         assert "agency" in result.custom_fields
         assert result.custom_fields["agency"].value.code == "A2345"
@@ -633,8 +648,10 @@ class TestTransformation:
                 "post_date": date(2024, 1, 1),
                 "close_date": date(2024, 12, 31),
                 "estimated_total_program_funding": 1000000,
+                "expected_number_of_awards": 12,
                 "award_ceiling": 500000,
                 "award_floor": 10000,
+                "funding_instruments": ["grant", "cooperative_agreement"],
                 "additional_info_url": "https://example.com/opportunity",
                 "created_at": datetime(2024, 1, 3, 12, 0, 0),
                 "updated_at": datetime(2024, 1, 4, 12, 0, 0),
@@ -645,6 +662,8 @@ class TestTransformation:
 
         # The transformation should succeed and return a valid OpportunityBase object
         assert result is not None
+        assert result.funding is not None
+        assert result.custom_fields is not None
         assert result.title == "Test Opportunity"
         assert result.description == "Test description"
         assert result.id == opp_data["opportunity_id"]
@@ -652,6 +671,11 @@ class TestTransformation:
         assert result.funding.total_amount_available.amount == "1000000"
         assert result.funding.max_award_amount.amount == "500000"
         assert result.funding.min_award_amount.amount == "10000"
+        assert result.funding.estimated_award_count == 12
+        assert result.custom_fields["federalFundingInstruments"].value == [
+            "grant",
+            "cooperative_agreement",
+        ]
         assert result.key_dates.post_date.date == date(2024, 1, 1)
         assert result.key_dates.close_date.date == date(2024, 12, 31)
         assert str(result.source) == "https://example.com/opportunity"
@@ -679,6 +703,7 @@ class TestTransformation:
         assert result.status.value == "open"
         assert result.created_at == datetime(2024, 1, 3, 12, 0, 0, tzinfo=timezone.utc)
         assert result.last_modified_at == datetime(2024, 1, 3, 12, 0, 0, tzinfo=timezone.utc)
+        assert result.funding is not None
 
         # Check that timeline and funding are None when summary is empty
         assert result.key_dates.post_date is None
@@ -686,6 +711,8 @@ class TestTransformation:
         assert result.funding.total_amount_available is None
         assert result.funding.max_award_amount is None
         assert result.funding.min_award_amount is None
+        assert result.funding.estimated_award_count is None
+        assert result.custom_fields is None
         assert result.source is None
 
     def test_transform_search_result_to_cg_with_invalid_data(self):


### PR DESCRIPTION
## Summary

Fixes #11642

## Changes proposed

Preserve expected award counts and federal funding instruments in CommonGrants search and detail responses. Missing values remain optional.

## Context for reviewers

The native summary fields were omitted from the intermediate transformation dictionary, so the existing CommonGrants destinations were never populated.

## Validation steps

- `pytest -q tests/src/services/common_grants/test_transformation.py` (66 passed)
- `ruff check` on all four changed files
- Regression verified failing before the source fix and passing after it
