### PR TITLE
[Unticketed] Fix ERD uid permission

### DIFF
--- a/.github/workflows/ci-openapi-grants-management-api.yml
+++ b/.github/workflows/ci-openapi-grants-management-api.yml
@@ -21,11 +21,10 @@ jobs:
           fetch-depth: 0  # fetch full history so we can create branches properly
 
       # Generate artifacts on the triggering ref before switching branches.
-      # Only the docs-generation image is needed (it reads SQLAlchemy metadata,
-      # so no DB is required). It's profile-gated, so build it by name.
-      - name: Build the OpenAPI/ERD tooling image
-        run: docker compose build openapi-tools
-
+      # The make targets build the profile-gated openapi-tools image on first
+      # use via `docker compose run`, which bakes in RUN_UID=$(id -u) so the
+      # container can write generated files back to the mounted checkout. (No DB
+      # is needed -- doc generation only reads SQLAlchemy metadata.)
       - name: Create ERD diagram
         run: make create-erds
 


### PR DESCRIPTION
## Summary

## Changes proposed

- Updated `ci-openapi-grants-management-api.yml` to remove the out-of-band `docker compose build openapi-tools` step, letting `make create-erds` build the image on first use so it's built with the runner's `RUN_UID`.

## Context for reviewers

Fixes a permission error on the workflow's first live run: building the image outside `make` defaulted `RUN_UID` to `4000`, so the container couldn't write into the runner-owned checkout. The make targets export `RUN_UID=$(id -u)`, matching the checkout owner.

## Validation steps

Confirm `make create-erds` run locally from `backend/grants_management_api` still works. 

The real test will be confirming no errors on the next live run after merge. 