### PR TITLE
[Issue #11658] Relax CommonGrants URL pre-validation from strict to lax pydantic HttpUrl

### DIFF
--- a/api/src/services/common_grants/url_utils.py
+++ b/api/src/services/common_grants/url_utils.py
@@ -20,9 +20,7 @@ class _UrlValidator(BaseModel):
     """Pydantic HttpUrl validator.
 
     Mirrors the HttpUrl field in OpportunityBase and other CommonGrants models.
-    Deliberately not strict: the SDK models dropped model-level strict mode in
-    0.6.x, so strict here would drop URLs (e.g. unencoded ``{}`` in a query
-    string) that the response pipeline accepts and serves fine.
+    Not strict: strict drops URLs (e.g. raw ``{}`` in a query) the pipeline serves fine.
     """
 
     url: HttpUrl

--- a/api/src/services/common_grants/url_utils.py
+++ b/api/src/services/common_grants/url_utils.py
@@ -13,16 +13,19 @@ Background and reproduction: https://github.com/HHS/simpler-grants-gov/issues/99
 
 from marshmallow import ValidationError as MarshmallowValidationError
 from marshmallow import fields as marshmallow_fields
-from pydantic import BaseModel, Field, HttpUrl, ValidationError
+from pydantic import BaseModel, HttpUrl, ValidationError
 
 
 class _UrlValidator(BaseModel):
-    """Pydantic strict HttpUrl validator.
+    """Pydantic HttpUrl validator.
 
     Mirrors the HttpUrl field in OpportunityBase and other CommonGrants models.
+    Deliberately not strict: the SDK models dropped model-level strict mode in
+    0.6.x, so strict here would drop URLs (e.g. unencoded ``{}`` in a query
+    string) that the response pipeline accepts and serves fine.
     """
 
-    url: HttpUrl = Field(strict=True)
+    url: HttpUrl
 
 
 _marshmallow_url_field = marshmallow_fields.URL()

--- a/api/tests/src/services/common_grants/test_transformation.py
+++ b/api/tests/src/services/common_grants/test_transformation.py
@@ -1,6 +1,7 @@
 """Tests for the transformation utility."""
 
 from datetime import date, datetime, timezone
+from http import HTTPStatus
 from uuid import uuid4
 
 from common_grants_sdk.schemas.pydantic import (
@@ -11,15 +12,21 @@ from common_grants_sdk.schemas.pydantic import (
     MoneyRange,
     MoneyRangeFilter,
     OppFilters,
+    OpportunitiesSearchResponse,
     OppSortBy,
     OppSorting,
     OppStatusOptions,
     PaginatedBodyParams,
+    PaginatedResultsInfo,
     RangeOperator,
+    SortedResultsInfo,
     StringArrayFilter,
 )
 from freezegun import freeze_time
 
+from src.api.common_grants.schemas.marshmallow.schemas import (
+    OpportunitiesSearchResponse as OpportunitiesSearchResponseSchema,
+)
 from src.api.common_grants.schemas.marshmallow.schemas import OpportunityCustomFields
 from src.api.common_grants.schemas.pydantic.custom_fields import (
     AgencyField,
@@ -44,6 +51,45 @@ from src.services.common_grants.transformation import (
     validate_custom_field,
     validate_url,
 )
+
+
+def _opp_data_with_info_url(url: str, description: str) -> dict:
+    """Minimal search-result payload whose summary.additional_info_url is `url`."""
+    return {
+        "opportunity_id": uuid4(),
+        "opportunity_title": "Test Opportunity",
+        "opportunity_status": OpportunityStatus.POSTED,
+        "created_at": datetime(2024, 1, 1, 12, 0, 0),
+        "updated_at": datetime(2024, 1, 2, 12, 0, 0),
+        "summary": {
+            "summary_description": "Test description",
+            "post_date": date(2024, 1, 1),
+            "close_date": date(2024, 12, 31),
+            "additional_info_url": url,
+            "additional_info_url_description": description,
+            "created_at": datetime(2024, 1, 1, 12, 0, 0),
+            "updated_at": datetime(2024, 1, 2, 12, 0, 0),
+        },
+    }
+
+
+def _load_through_response_schema(cg_opportunity) -> dict:
+    """Run one CG opportunity down the route's response path: pydantic response model
+    -> model_dump -> marshmallow load. The load is what 500s on a divergent URL."""
+    response = OpportunitiesSearchResponse(
+        status=HTTPStatus.OK,
+        message="ok",
+        items=[cg_opportunity],
+        pagination_info=PaginatedResultsInfo(page=1, page_size=1, totalItems=1, totalPages=1),
+        sort_info=SortedResultsInfo(
+            sort_by=OppSortBy.LAST_MODIFIED_AT.value,
+            sort_order="desc",
+            errors=[],
+        ),
+        filter_info=build_filter_info(None),
+    )
+    return OpportunitiesSearchResponseSchema().load(response.model_dump(by_alias=True, mode="json"))
+
 
 DEFAULT_MOCK_OPP_FIELDS = {
     "legacy_opportunity_id": 67890,
@@ -673,71 +719,21 @@ class TestTransformation:
         assert result is None
 
     def test_validate_url_nasa_url_round_trips_through_response_pipeline(self):
-        """Guard: URLs that survive validate_url() must round-trip through the full
-        response pipeline — pydantic OpportunityBase construction AND the marshmallow
-        response load. The NASA URL (raw {} in the query string) is RFC-invalid but
-        accepted by both, so it must be served, not dropped.
-
-        History: validate_url() once pre-screened with strict-mode HttpUrl because
-        SDK <=0.5.x ran model_validate() with model_config strict=True, which rejected
-        this URL and crashed the transformation. The SDK dropped model-level strict
-        in 0.6.x, so validate_url() is lax again. If a future SDK version re-tightens
-        URL validation, this test fails in CI instead of the URL 500ing (or being
-        silently dropped) in prod.
+        """A URL that survives validate_url() must survive the whole response path.
+        Fails if a future SDK re-tightens URL validation, which would otherwise drop
+        the field (or 500) in prod instead of here.
         """
-        from http import HTTPStatus
-
-        from common_grants_sdk.schemas.pydantic import (
-            OpportunitiesSearchResponse,
-            PaginatedResultsInfo,
-            SortedResultsInfo,
-        )
-
-        from src.api.common_grants.schemas.marshmallow.schemas import (
-            OpportunitiesSearchResponse as OpportunitiesSearchResponseSchema,
-        )
-
         nasa_url = "https://nspires.nasaprs.com/external/solicitations/summary!init.do?solId={D8604BE7-CAB6-C1C0-B668-423042C43AA6}&path=&method=init"
 
-        result = validate_url(nasa_url)
-        assert result == nasa_url, "validate_url() must accept the NASA URL unchanged"
+        assert validate_url(nasa_url) == nasa_url
 
-        opp_data = {
-            "opportunity_id": uuid4(),
-            "opportunity_title": "Test Opportunity",
-            "opportunity_status": OpportunityStatus.POSTED,
-            "created_at": datetime(2024, 1, 1, 12, 0, 0),
-            "updated_at": datetime(2024, 1, 2, 12, 0, 0),
-            "summary": {
-                "summary_description": "Test description",
-                "post_date": date(2024, 1, 1),
-                "close_date": date(2024, 12, 31),
-                "additional_info_url": nasa_url,
-                "additional_info_url_description": "NSPIRES solicitation",
-                "created_at": datetime(2024, 1, 1, 12, 0, 0),
-                "updated_at": datetime(2024, 1, 2, 12, 0, 0),
-            },
-        }
-
-        cg_opportunity = transform_search_result_to_cg(opp_data)
+        cg_opportunity = transform_search_result_to_cg(
+            _opp_data_with_info_url(nasa_url, "NSPIRES solicitation")
+        )
         assert cg_opportunity is not None
         assert str(cg_opportunity.source) == nasa_url
 
-        response = OpportunitiesSearchResponse(
-            status=HTTPStatus.OK,
-            message="ok",
-            items=[cg_opportunity],
-            pagination_info=PaginatedResultsInfo(page=1, page_size=1, totalItems=1, totalPages=1),
-            sort_info=SortedResultsInfo(
-                sort_by=OppSortBy.LAST_MODIFIED_AT.value,
-                sort_order="desc",
-                errors=[],
-            ),
-            filter_info=build_filter_info(None),
-        )
-        response_json = response.model_dump(by_alias=True, mode="json")
-
-        validated = OpportunitiesSearchResponseSchema().load(response_json)
+        validated = _load_through_response_schema(cg_opportunity)
         assert validated["items"][0]["source"] == nasa_url
 
     def test_validate_url_rejects_urls_that_marshmallow_url_field_rejects(self):
@@ -776,55 +772,15 @@ class TestTransformation:
         items[0].customFields.additionalInfo.value.url. After the fix the record loads
         cleanly with additionalInfo absent (because validate_url returned None).
         """
-        from http import HTTPStatus
-
-        from common_grants_sdk.schemas.pydantic import (
-            OpportunitiesSearchResponse,
-            PaginatedResultsInfo,
-            SortedResultsInfo,
-        )
-
-        from src.api.common_grants.schemas.marshmallow.schemas import (
-            OpportunitiesSearchResponse as OpportunitiesSearchResponseSchema,
-        )
-
         problematic_url = "https://www.grants.gov,https://other.example"
-        opp_data = {
-            "opportunity_id": uuid4(),
-            "opportunity_title": "Test Opportunity",
-            "opportunity_status": OpportunityStatus.POSTED,
-            "created_at": datetime(2024, 1, 1, 12, 0, 0),
-            "updated_at": datetime(2024, 1, 2, 12, 0, 0),
-            "summary": {
-                "summary_description": "Test description",
-                "post_date": date(2024, 1, 1),
-                "close_date": date(2024, 12, 31),
-                "additional_info_url": problematic_url,
-                "additional_info_url_description": "Multiple links",
-                "created_at": datetime(2024, 1, 1, 12, 0, 0),
-                "updated_at": datetime(2024, 1, 2, 12, 0, 0),
-            },
-        }
 
-        cg_opportunity = transform_search_result_to_cg(opp_data)
+        cg_opportunity = transform_search_result_to_cg(
+            _opp_data_with_info_url(problematic_url, "Multiple links")
+        )
         assert cg_opportunity is not None, "transform itself must not drop the record"
 
-        response = OpportunitiesSearchResponse(
-            status=HTTPStatus.OK,
-            message="ok",
-            items=[cg_opportunity],
-            pagination_info=PaginatedResultsInfo(page=1, page_size=1, totalItems=1, totalPages=1),
-            sort_info=SortedResultsInfo(
-                sort_by=OppSortBy.LAST_MODIFIED_AT.value,
-                sort_order="desc",
-                errors=[],
-            ),
-            filter_info=build_filter_info(None),
-        )
-        response_json = response.model_dump(by_alias=True, mode="json")
-
-        # This is the line that raises marshmallow.ValidationError in prod.
-        validated = OpportunitiesSearchResponseSchema().load(response_json)
+        # The load inside is the line that raises marshmallow.ValidationError in prod.
+        validated = _load_through_response_schema(cg_opportunity)
 
         assert len(validated["items"]) == 1
         # Once validate_url filters the bad URL, additionalInfo is absent; that's the
@@ -917,33 +873,6 @@ class TestTransformation:
         for r in drop_records:
             assert getattr(r, "opportunity_id", None) == opp_id
             assert r.levelname == "WARNING"
-
-    def test_transform_search_result_to_cg_with_nasa_url(self):
-        """RFC-invalid but pipeline-safe URLs (raw {} in query) must survive the
-        transformation into `source` rather than being dropped."""
-        nasa_url = "https://nspires.nasaprs.com/external/solicitations/summary!init.do?solId={D8604BE7-CAB6-C1C0-B668-423042C43AA6}&path=&method=init"
-
-        opp_data = {
-            "opportunity_id": uuid4(),
-            "opportunity_title": "Test Opportunity",
-            "opportunity_status": OpportunityStatus.POSTED,
-            "created_at": datetime(2024, 1, 1, 12, 0, 0),
-            "updated_at": datetime(2024, 1, 2, 12, 0, 0),
-            "summary": {
-                "summary_description": "Test description",
-                "post_date": date(2024, 1, 1),
-                "close_date": date(2024, 12, 31),
-                "estimated_total_program_funding": 1000000,
-                "award_ceiling": 500000,
-                "award_floor": 10000,
-                "additional_info_url": nasa_url,
-            },
-        }
-
-        result = transform_search_result_to_cg(opp_data)
-
-        assert result is not None
-        assert str(result.source) == nasa_url
 
     def test_build_money_range_filter(self):
         """Test building money range filters."""
@@ -1175,7 +1104,6 @@ class TestTransformation:
         # a data-suppression event, not a routine validation observation.
         caplog.set_level(logging.WARNING)
 
-        # Create opportunity data with an invalid URL (dual-check drops comma-URLs)
         invalid_url = "https://example.com,https://other.example"
         opp_data = {
             "opportunity_id": uuid4(),

--- a/api/tests/src/services/common_grants/test_transformation.py
+++ b/api/tests/src/services/common_grants/test_transformation.py
@@ -1,7 +1,6 @@
 """Tests for the transformation utility."""
 
 from datetime import date, datetime, timezone
-from urllib.parse import urlparse
 from uuid import uuid4
 
 from common_grants_sdk.schemas.pydantic import (
@@ -45,31 +44,6 @@ from src.services.common_grants.transformation import (
     validate_custom_field,
     validate_url,
 )
-
-
-def _legacy_validate_url(value: str | None) -> str | None:
-    """
-    Validate a URL string.
-
-    Args:
-        value: The string to validate
-
-    Returns:
-        A valid URL string or None
-    """
-    # Parse the string
-    parsed = urlparse(value)
-
-    # Check for scheme and netloc (i.e. it's a complete url)
-    if parsed.scheme and parsed.netloc:
-        return value
-
-    # Check for netloc only (i.e. it's a domain name)
-    if not parsed.scheme and parsed.netloc:
-        return f"https://{value}"
-
-    return None
-
 
 DEFAULT_MOCK_OPP_FIELDS = {
     "legacy_opportunity_id": 67890,
@@ -698,25 +672,73 @@ class TestTransformation:
         # Should return None for invalid data
         assert result is None
 
-    def test_validate_url_with_nasa_url_bug(self):
-        """Test that validate_url() properly rejects URLs that Pydantic HttpUrl rejects.
+    def test_validate_url_nasa_url_round_trips_through_response_pipeline(self):
+        """Guard: URLs that survive validate_url() must round-trip through the full
+        response pipeline — pydantic OpportunityBase construction AND the marshmallow
+        response load. The NASA URL (raw {} in the query string) is RFC-invalid but
+        accepted by both, so it must be served, not dropped.
 
-        This test reproduces a bug where validate_url() lets through URLs
-        that Pydantic's HttpUrl validation rejects, causing transformations to fail.
-
-        The NASA URL has curly braces or other characters that urlparse accepts but
-        Pydantic's strict HttpUrl validation rejects.
+        History: validate_url() once pre-screened with strict-mode HttpUrl because
+        SDK <=0.5.x ran model_validate() with model_config strict=True, which rejected
+        this URL and crashed the transformation. The SDK dropped model-level strict
+        in 0.6.x, so validate_url() is lax again. If a future SDK version re-tightens
+        URL validation, this test fails in CI instead of the URL 500ing (or being
+        silently dropped) in prod.
         """
-        # This URL has characters that urlparse accepts but Pydantic HttpUrl rejects
-        # Based on error: "non-URL code point" - likely curly braces or other invalid chars
+        from http import HTTPStatus
+
+        from common_grants_sdk.schemas.pydantic import (
+            OpportunitiesSearchResponse,
+            PaginatedResultsInfo,
+            SortedResultsInfo,
+        )
+
+        from src.api.common_grants.schemas.marshmallow.schemas import (
+            OpportunitiesSearchResponse as OpportunitiesSearchResponseSchema,
+        )
+
         nasa_url = "https://nspires.nasaprs.com/external/solicitations/summary!init.do?solId={D8604BE7-CAB6-C1C0-B668-423042C43AA6}&path=&method=init"
 
-        # Old implementation used urlparse, new implementation uses Pydantic HttpUrl
-        old_result = _legacy_validate_url(nasa_url)
-        new_result = validate_url(nasa_url)
+        result = validate_url(nasa_url)
+        assert result == nasa_url, "validate_url() must accept the NASA URL unchanged"
 
-        assert old_result is not None, "_legacy_validate_url() should accept NASA URL"
-        assert new_result is None, "validate_url() should reject NASA URL"
+        opp_data = {
+            "opportunity_id": uuid4(),
+            "opportunity_title": "Test Opportunity",
+            "opportunity_status": OpportunityStatus.POSTED,
+            "created_at": datetime(2024, 1, 1, 12, 0, 0),
+            "updated_at": datetime(2024, 1, 2, 12, 0, 0),
+            "summary": {
+                "summary_description": "Test description",
+                "post_date": date(2024, 1, 1),
+                "close_date": date(2024, 12, 31),
+                "additional_info_url": nasa_url,
+                "additional_info_url_description": "NSPIRES solicitation",
+                "created_at": datetime(2024, 1, 1, 12, 0, 0),
+                "updated_at": datetime(2024, 1, 2, 12, 0, 0),
+            },
+        }
+
+        cg_opportunity = transform_search_result_to_cg(opp_data)
+        assert cg_opportunity is not None
+        assert str(cg_opportunity.source) == nasa_url
+
+        response = OpportunitiesSearchResponse(
+            status=HTTPStatus.OK,
+            message="ok",
+            items=[cg_opportunity],
+            pagination_info=PaginatedResultsInfo(page=1, page_size=1, totalItems=1, totalPages=1),
+            sort_info=SortedResultsInfo(
+                sort_by=OppSortBy.LAST_MODIFIED_AT.value,
+                sort_order="desc",
+                errors=[],
+            ),
+            filter_info=build_filter_info(None),
+        )
+        response_json = response.model_dump(by_alias=True, mode="json")
+
+        validated = OpportunitiesSearchResponseSchema().load(response_json)
+        assert validated["items"][0]["source"] == nasa_url
 
     def test_validate_url_rejects_urls_that_marshmallow_url_field_rejects(self):
         """validate_url() must also reject URLs that pass Pydantic's HttpUrl but fail
@@ -896,17 +918,10 @@ class TestTransformation:
             assert getattr(r, "opportunity_id", None) == opp_id
             assert r.levelname == "WARNING"
 
-    def test_transform_search_result_to_cg_with_nasa_url_bug(self):
-        """Test that transformation works correctly with NASA URL that Pydantic rejects.
-
-        This test ensures that when validate_url() properly rejects invalid URLs,
-        the transformation still succeeds (with source=None) rather than failing.
-        """
-        # This URL has characters that urlparse accepts but Pydantic HttpUrl rejects
+    def test_transform_search_result_to_cg_with_nasa_url(self):
+        """RFC-invalid but pipeline-safe URLs (raw {} in query) must survive the
+        transformation into `source` rather than being dropped."""
         nasa_url = "https://nspires.nasaprs.com/external/solicitations/summary!init.do?solId={D8604BE7-CAB6-C1C0-B668-423042C43AA6}&path=&method=init"
-        assert (
-            _legacy_validate_url(nasa_url) is not None
-        ), "_legacy_validate_url() should accept NASA URL"
 
         opp_data = {
             "opportunity_id": uuid4(),
@@ -925,13 +940,10 @@ class TestTransformation:
             },
         }
 
-        # The transformation should succeed without raising a Pydantic validation error
         result = transform_search_result_to_cg(opp_data)
 
-        # After fix: validate_url() should reject the URL, so source should be None
-        # but transformation should still succeed
-        assert result is not None, "Transformation should succeed even with invalid URL"
-        assert result.source is None, "Invalid URL should result in source=None"
+        assert result is not None
+        assert str(result.source) == nasa_url
 
     def test_build_money_range_filter(self):
         """Test building money range filters."""
@@ -1087,8 +1099,9 @@ class TestTransformation:
         # Set up logging to capture info level logs
         caplog.set_level(logging.INFO)
 
-        # Test with an invalid URL that should trigger the logging
-        invalid_url = "https://example.com/path/{invalid-chars}"
+        # Comma-separated URL: pydantic accepts it, marshmallow rejects it, so the
+        # dual-check drops it and logs.
+        invalid_url = "https://example.com,https://other.example"
 
         result = validate_url(invalid_url)
 
@@ -1162,8 +1175,8 @@ class TestTransformation:
         # a data-suppression event, not a routine validation observation.
         caplog.set_level(logging.WARNING)
 
-        # Create opportunity data with an invalid URL
-        invalid_url = "https://example.com/path/{invalid}"
+        # Create opportunity data with an invalid URL (dual-check drops comma-URLs)
+        invalid_url = "https://example.com,https://other.example"
         opp_data = {
             "opportunity_id": uuid4(),
             "opportunity_title": "Test Opportunity",

--- a/api/tests/src/services/common_grants/test_url_utils.py
+++ b/api/tests/src/services/common_grants/test_url_utils.py
@@ -3,7 +3,7 @@
 import pytest
 from marshmallow import ValidationError as MarshmallowValidationError
 from marshmallow import fields as marshmallow_fields
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, HttpUrl
 
 from src.services.common_grants.url_utils import validate_url_compatible
 
@@ -11,7 +11,7 @@ from src.services.common_grants.url_utils import validate_url_compatible
 class _PydanticHttpUrl(BaseModel):
     """Minimal pydantic HttpUrl validator used to demonstrate the divergence."""
 
-    url: HttpUrl = Field(strict=True)
+    url: HttpUrl
 
 
 class TestValidateUrlCompatible:
@@ -35,6 +35,18 @@ class TestValidateUrlCompatible:
     def test_rejects_garbage(self):
         assert validate_url_compatible("not-a-url") is None
         assert validate_url_compatible("sam.gov") is None  # missing scheme
+
+    def test_accepts_unencoded_braces_in_query(self):
+        """Agency URLs with raw {} in query strings (e.g. NASA NSPIRES solId GUIDs)
+        are RFC-invalid but accepted by every validator in the response pipeline;
+        they must be served, not dropped."""
+        url = "https://nspires.nasaprs.com/x/summary.do?solId={9455D565-3411-0574}&method=init"
+        assert validate_url_compatible(url) == url
+
+    def test_rejects_non_http_schemes(self):
+        # HttpUrl restricts scheme to http/https regardless of strictness.
+        assert validate_url_compatible("javascript:alert(1)") is None
+        assert validate_url_compatible("ftp://example.gov/file") is None
 
     @pytest.mark.parametrize(
         "bad_url",

--- a/api/tests/src/services/common_grants/test_url_utils.py
+++ b/api/tests/src/services/common_grants/test_url_utils.py
@@ -37,9 +37,7 @@ class TestValidateUrlCompatible:
         assert validate_url_compatible("sam.gov") is None  # missing scheme
 
     def test_accepts_unencoded_braces_in_query(self):
-        """Agency URLs with raw {} in query strings (e.g. NASA NSPIRES solId GUIDs)
-        are RFC-invalid but accepted by every validator in the response pipeline;
-        they must be served, not dropped."""
+        """Raw {} in a query is RFC-invalid but the whole pipeline accepts it."""
         url = "https://nspires.nasaprs.com/x/summary.do?solId={9455D565-3411-0574}&method=init"
         assert validate_url_compatible(url) == url
 


### PR DESCRIPTION
## Summary

Fixes HHS/simpler-grants-protocol#1068

Prod logs a steady stream of `Dropping URL field from CG response: failed dual validation` for URLs the response pipeline serves fine, e.g. NASA NSPIRES links with raw `{}` in the query string. The strict-mode pre-check that drops them mirrors SDK behavior that no longer exists: the SDK dropped model-level `strict=True` in 0.6.x (HHS/simpler-grants-protocol#555), leaving the pre-check stricter than every validator in the actual egress path. `_UrlValidator` now uses lax `HttpUrl`, matching `OpportunityBase.source`.

The HHS/simpler-grants-gov#9904 search-500 protection is untouched. The dual-check's marshmallow leg still drops comma-separated URLs and TLD-less hosts, and `HttpUrl` still restricts schemes to http/https regardless of strictness (new test covers that).

The old NASA-rejection test becomes a round-trip guard: URLs surviving `validate_url()` must construct `OpportunityBase` and load through the marshmallow response schema, so a future SDK that re-tightens URL validation fails CI instead of dropping fields in prod.

## Measured impact on real data

`additional_info_url` comes from legacy `fd_link_url` (`transform_util.py:252`), so I ran every `AdditionalInformationURL` in the public grants.gov daily extract (`GrantsDBExtract20260727v2`, 32,170 distinct values across 82,975 records) through the dual-check both ways:

|  | distinct | occurrences |
|---|---|---|
| accepted before and after | 30,454 | 50,154 |
| newly served (was dropped and warned) | 778 | 1,469 |
| still dropped | 938 | 2,638 |

The 778 are mostly trailing whitespace (497 distinct) and NSPIRES braces (245). Nothing in the corpus contains a tab, newline, or carriage return, so no URL gets silently rewritten by control-character stripping. The 938 still dropped are not links at all: `www.grants.gov`, `askcsid@fema.dhs.gov`, `See Invitation Letter`, `N/A`. Remaining `cg_event=url_validation_error` warnings become upstream data-quality signal.

## Behavior notes

- Consumers may now receive RFC-3986-invalid characters (`{}`, `|`, `^`) in query strings. Both SDK response validators accept them: the Python SDK's lax `HttpUrl` and the TS SDK's `z.string().url()`.
- `AttachmentValue.downloadUrl` shares the helper, so attachments relax the same way, restoring the pre-#9911 behavior that HHS/simpler-grants-gov#9911 flagged as an unintended tightening.
- 244 of the newly-served URLs carry a literal `&amp;` from HTML-escaped legacy data, so `source` can be populated with a link that mis-targets. Roughly 1,480 such URLs already pass strict and are served today; this adds 244 to that count.

## Validation steps

```bash
make test args="tests/src/services/common_grants tests/src/api/common_grants"
```

All 110 pass locally with Postgres + OpenSearch up. `make format-check`, `make lint`, `make lint-security`, and `make db-check` are clean.

After deploy, confirm the NSPIRES record's `source` is populated and no `cg_event=url_validation_error` WARNING is logged for it:

```bash
curl -X POST 'https://api.simpler.grants.gov/common-grants/opportunities/search' \
  -H 'X-API-Key: <KEY>' -H 'Content-Type: application/json' \
  -d '{"search":"NSPIRES","pagination":{"page":1,"pageSize":10}}'
```
