### PR TITLE
[unticketed]:  resolve anchore cve's in the python base image

### DIFF
--- a/analytics/Dockerfile
+++ b/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:64ba00d@sha256:084381646234074fa58d963269cc49d7042941ecebab1cd8878c600becfac22c AS base
+FROM ghcr.io/hhs/python-base-image:9d1e227@sha256:45a6c0735a62abad927e5a5b1f223c41001817af6254f0786cd4c863a89e1b5b AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hhs/python-base-image:64ba00d@sha256:084381646234074fa58d963269cc49d7042941ecebab1cd8878c600becfac22c AS base
+FROM ghcr.io/hhs/python-base-image:9d1e227@sha256:45a6c0735a62abad927e5a5b1f223c41001817af6254f0786cd4c863a89e1b5b AS base
 
 ARG RUN_UID
 ARG RUN_USER

--- a/api/docker-python-base
+++ b/api/docker-python-base
@@ -1,7 +1,7 @@
 #==============================================
 # Stage 0: UV binary source
 #==============================================
-ARG UV_VERSION=0.11.15
+ARG UV_VERSION=0.11.33
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
 
 #==============================================
@@ -181,12 +181,12 @@ RUN dnf install -y \
       libsmartcols-2.37.4-1.amzn2023.0.5 \
       libuuid-2.37.4-1.amzn2023.0.5 && \
     # July ALAS batch: glib2 (1942), krb5-libs (1939), rust-toolset-srpm-macros (1951),
-    # kernel6.18-headers (1969), libacl (1986)
-    dnf update -y --releasever=2023.12.20260720 \
+    # kernel6.18-headers (ALAS2023-2026-2003), libacl (1986)
+    dnf update -y --releasever=2023.12.20260727 \
       glib2-2.82.2-770.amzn2023 \
       krb5-libs-1.21.3-8.amzn2023.0.1 \
       rust-toolset-srpm-macros-1.97.0-1.amzn2023.0.1 \
-      kernel6.18-headers-6.18.38-73.137.amzn2023 \
+      kernel6.18-headers-6.18.38-76.139.amzn2023 \
       libacl-2.4.0-1.amzn2023.0.1 && \
     dnf clean all && \
     # Remove the system Python RPMs


### PR DESCRIPTION
## Summary

Resolve anchore cve's in the base image. 

```
NAME                INSTALLED                  FIXED IN                 TYPE        VULNERABILITY        SEVERITY  EPSS         RISK  
kernel6.18-headers  1:6.18.38-73.137.amzn2023  6.18.38-76.139.amzn2023  rpm         ALAS2023-2026-2003   High      0.5% (39th)  0.4   
quinn-proto         0.11.14                    0.11.15                  rust-crate  GHSA-4w2j-m93h-cj5j  High      N/A          N/A  
```

Failing anchore scan: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30359564673/job/90276307984)

## Validation steps

All scans should be passing below. 

Deployed to api dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30364657249)