### PR TITLE
[Issue #10831] Add environment variable kill-switch to @ecs_background_task decorator

### DIFF
--- a/backend/grants_shared/pyproject.toml
+++ b/backend/grants_shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grants-shared"
-version = "0.2.18"
+version = "0.2.19"
 description = "Shared code used by the Simpler Grants.gov repo"
 readme = "README.md"
 license = "CC0-1.0"

--- a/backend/grants_shared/src/grants_shared/api/maintenance_mode.py
+++ b/backend/grants_shared/src/grants_shared/api/maintenance_mode.py
@@ -17,6 +17,7 @@ class MaintenanceModeLogEvent(StrEnum):
     """Distinct, queryable event types for maintenance-mode log records."""
 
     REQUEST_REJECTED = "maintenance_mode_request_rejected"
+    TASK_SKIPPED = "maintenance_mode_task_skipped"
 
 
 class MaintenanceModeConfig(PydanticBaseEnvConfig):

--- a/backend/grants_shared/src/grants_shared/task/ecs_background_task.py
+++ b/backend/grants_shared/src/grants_shared/task/ecs_background_task.py
@@ -5,11 +5,12 @@ import time
 import uuid
 from collections.abc import Callable, Generator
 from functools import wraps
-from typing import ParamSpec, TypeVar
+from typing import ParamSpec, TypeVar, cast
 
 import newrelic.agent
 import requests
 
+from grants_shared.api.maintenance_mode import MaintenanceModeLogEvent, is_maintenance_mode_enabled
 from grants_shared.logs.flask_logger import add_extra_data_to_global_logs
 
 logger = logging.getLogger(__name__)
@@ -49,6 +50,17 @@ def ecs_background_task(task_name: str) -> Callable[[Callable[P, T]], Callable[P
     def decorator(f: Callable[P, T]) -> Callable[P, T]:
         @wraps(f)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            # During a maintenance window the DB is unavailable, so skip the task
+            # entirely rather than letting it fail mid-run. The task still fires on
+            # its cron schedule; it just logs the skip and exits cleanly.
+            if is_maintenance_mode_enabled():
+                _add_log_metadata(task_name)
+                logger.info(
+                    "Skipping ECS task due to maintenance mode",
+                    extra={"maintenance_mode_event": MaintenanceModeLogEvent.TASK_SKIPPED},
+                )
+                return cast(T, None)
+
             # Wrap with New Relic instrumentation
             application = newrelic.agent.register_application(timeout=10.0)
             with newrelic.agent.BackgroundTask(application, name=task_name, group="Python/ECSTask"):

--- a/backend/grants_shared/src/grants_shared/task/ecs_background_task.py
+++ b/backend/grants_shared/src/grants_shared/task/ecs_background_task.py
@@ -50,22 +50,22 @@ def ecs_background_task(task_name: str) -> Callable[[Callable[P, T]], Callable[P
     def decorator(f: Callable[P, T]) -> Callable[P, T]:
         @wraps(f)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            # During a maintenance window the DB is unavailable, so skip the task
-            # entirely rather than letting it fail mid-run. The task still fires on
-            # its cron schedule; it just logs the skip and exits cleanly.
-            if is_maintenance_mode_enabled():
-                _add_log_metadata(task_name)
-                logger.info(
-                    "Skipping ECS task due to maintenance mode",
-                    extra={"maintenance_mode_event": MaintenanceModeLogEvent.TASK_SKIPPED},
-                )
-                return cast(T, None)
-
             # Wrap with New Relic instrumentation
             application = newrelic.agent.register_application(timeout=10.0)
             with newrelic.agent.BackgroundTask(application, name=task_name, group="Python/ECSTask"):
                 # Wrap with our own logging (timing/general logs)
                 with _ecs_background_task_impl(task_name):
+                    # During a maintenance window the DB is unavailable, so skip the
+                    # task body rather than letting it fail mid-run. The task still
+                    # fires on its cron schedule; it just logs the skip and exits
+                    # cleanly. This runs inside the New Relic / logging wrapping so
+                    # the skip is still recorded — nothing above touches the DB.
+                    if is_maintenance_mode_enabled():
+                        logger.info(
+                            "Skipping ECS task due to maintenance mode",
+                            extra={"maintenance_mode_event": MaintenanceModeLogEvent.TASK_SKIPPED},
+                        )
+                        return cast(T, None)
                     # Finally actually run the task
                     return f(*args, **kwargs)
 

--- a/backend/grants_shared/tests/grants_shared/task/test_ecs_background_task.py
+++ b/backend/grants_shared/tests/grants_shared/task/test_ecs_background_task.py
@@ -12,10 +12,8 @@ from grants_shared.task.ecs_background_task import ecs_background_task
 
 @pytest.fixture(autouse=True)
 def clear_maintenance_config_cache():
-    # The maintenance-mode config is @cache'd, so clear it around every test to
+    # The maintenance-mode config is @cache'd, so clear it before every test to
     # keep the ENABLE_MAINTENANCE_MODE env var from leaking across tests.
-    get_maintenance_mode_config.cache_clear()
-    yield
     get_maintenance_mode_config.cache_clear()
 
 

--- a/backend/grants_shared/tests/grants_shared/task/test_ecs_background_task.py
+++ b/backend/grants_shared/tests/grants_shared/task/test_ecs_background_task.py
@@ -5,8 +5,18 @@ import time
 import pytest
 from flask import Flask
 
+from grants_shared.api.maintenance_mode import MaintenanceModeLogEvent, get_maintenance_mode_config
 from grants_shared.logs.flask_logger import add_extra_data_to_global_logs, init_app
 from grants_shared.task.ecs_background_task import ecs_background_task
+
+
+@pytest.fixture(autouse=True)
+def clear_maintenance_config_cache():
+    # The maintenance-mode config is @cache'd, so clear it around every test to
+    # keep the ENABLE_MAINTENANCE_MODE env var from leaking across tests.
+    get_maintenance_mode_config.cache_clear()
+    yield
+    get_maintenance_mode_config.cache_clear()
 
 
 @pytest.fixture
@@ -98,3 +108,50 @@ def test_ecs_background_task_when_erroring(app, caplog, monkeypatch_session):
     assert last_record["levelname"] == "ERROR"
     assert last_record["message"] == "ECS task failed"
     assert last_record["exc_info_short"] == "ValueError('I am an error')"
+
+
+def test_ecs_background_task_skipped_during_maintenance_mode(app, caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("ENABLE_MAINTENANCE_MODE", "true")
+    get_maintenance_mode_config.cache_clear()
+
+    was_called = False
+
+    @ecs_background_task(task_name="my_maintenance_task")
+    def my_test_func():
+        nonlocal was_called
+        was_called = True
+        return "ran"
+
+    # The task exits cleanly without running its wrapped (DB-touching) body.
+    assert my_test_func() is None
+    assert was_called is False
+
+    skip_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "maintenance_mode_event", None) == MaintenanceModeLogEvent.TASK_SKIPPED
+    ]
+    assert len(skip_records) == 1
+    assert skip_records[0].message == "Skipping ECS task due to maintenance mode"
+    assert skip_records[0].task_name == "my_maintenance_task"
+
+
+def test_ecs_background_task_runs_normally_when_maintenance_mode_off(app, caplog, monkeypatch):
+    caplog.set_level(logging.INFO)
+    monkeypatch.setenv("ENABLE_MAINTENANCE_MODE", "false")
+    get_maintenance_mode_config.cache_clear()
+
+    @ecs_background_task(task_name="my_non_maintenance_task")
+    def my_test_func(param1, param2):
+        return param1 + param2
+
+    # With maintenance off, the wrapped function runs and its return value is preserved.
+    assert my_test_func(2, 3) == 5
+
+    skip_records = [
+        record
+        for record in caplog.records
+        if getattr(record, "maintenance_mode_event", None) == MaintenanceModeLogEvent.TASK_SKIPPED
+    ]
+    assert len(skip_records) == 0

--- a/backend/grants_shared/uv.lock
+++ b/backend/grants_shared/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.18"
+version = "0.2.19"
 source = { virtual = "." }
 dependencies = [
     { name = "apiflask" },


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10831 

## Changes proposed

- Updated `ecs_background_task.py` to skip the wrapped task body when maintenance mode is enabled.
- Updated `maintenance_mode.py` to add a `TASK_SKIPPED` value to `MaintenanceModeLogEvent` so scheduled-task skips are filterable in New Relic.
- Updated `test_ecs_background_task.py` to cover the skip path and the maintenance-off path, plus an autouse fixture clearing the `@cache`d config between tests
- Updated `pyproject.toml` and `uv.lock` to bump the grants_shared version to `0.2.19`

## Context for reviewers

This is the first of two PRs: this releases grants_shared 0.2.19; a follow-up api PR bumps the pin to `==0.2.19` and adds a smoke test once published. The decorator reuses the existing shared `is_maintenance_mode_enabled()` helper (reads `ENABLE_MAINTENANCE_MODE`), since the config now lives in grants_shared.

## Validation steps

Confirm tests pass.