### PR TITLE
[Issue #11613] Add logout endpoints to grants management API

### DIFF
--- a/backend/grants_management_api/local.env
+++ b/backend/grants_management_api/local.env
@@ -72,7 +72,7 @@ LOGIN_GOV_JWK_ENDPOINT=http://host.docker.internal:5008/issuer1/jwks
 LOGIN_GOV_AUTH_ENDPOINT=http://localhost:5008/issuer1/authorize
 LOGIN_GOV_TOKEN_ENDPOINT=http://host.docker.internal:5008/issuer1/token
 LOGIN_GOV_ENDPOINT=http://host.docker.internal:5008/issuer1
-LOGIN_GOV_LOGOUT_ENDPOINT=http://localhost:5001/issuer1/endsession
+LOGIN_GOV_LOGOUT_ENDPOINT=http://localhost:5008/issuer1/endsession
 
 # We'll need to determine what the final login destination will be for this API
 # with the frontend later. For now, send it to the internal login endpoint

--- a/backend/grants_management_api/local.env
+++ b/backend/grants_management_api/local.env
@@ -72,10 +72,12 @@ LOGIN_GOV_JWK_ENDPOINT=http://host.docker.internal:5008/issuer1/jwks
 LOGIN_GOV_AUTH_ENDPOINT=http://localhost:5008/issuer1/authorize
 LOGIN_GOV_TOKEN_ENDPOINT=http://host.docker.internal:5008/issuer1/token
 LOGIN_GOV_ENDPOINT=http://host.docker.internal:5008/issuer1
+LOGIN_GOV_LOGOUT_ENDPOINT=http://localhost:5001/issuer1/endsession
 
 # We'll need to determine what the final login destination will be for this API
 # with the frontend later. For now, send it to the internal login endpoint
 LOGIN_FINAL_DESTINATION=http://localhost:8089/v1/users/login/result
+LOGOUT_FINAL_DESTINATION=http://localhost:3000/logout
 
 # These should be set in your override.env file
 # which can be created by running `make setup-env-override-file`

--- a/backend/grants_management_api/pyproject.toml
+++ b/backend/grants_management_api/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "prettytable>=3.16.0,<4",
     "PyYAML>=6.0.3,<7",
     "python-statemachine>=3.0.0,<4",
-    "grants-shared==0.2.16",
+    "grants-shared==0.2.18",
 ]
 
 [dependency-groups]

--- a/backend/grants_management_api/src/api/users/user_routes.py
+++ b/backend/grants_management_api/src/api/users/user_routes.py
@@ -7,20 +7,29 @@ from grants_shared.adapters.db import flask_db
 from grants_shared.api import response
 from grants_shared.api.route_utils import raise_flask_error
 from grants_shared.auth.api_jwt_auth import refresh_token_expiration
-from grants_shared.auth.login_gov_jwt_auth import get_final_redirect_uri
+from grants_shared.auth.login_gov_jwt_auth import (
+    get_final_logout_redirect_uri,
+    get_final_redirect_uri,
+)
 from grants_shared.logs.flask_logger import add_extra_data_to_current_request_logs
 
 from src.api.users import user_schemas
 from src.api.users.user_blueprint import user_blueprint
 from src.api.users.user_schemas import UserTokenLogoutResponseSchema, UserTokenRefreshResponseSchema
 from src.auth.api_jwt_auth import api_jwt_auth
-from src.auth.auth_utils import get_login_gov_redirect_uri, with_login_redirect_error_handler
+from src.auth.auth_utils import (
+    get_login_gov_logout_redirect_uri,
+    get_login_gov_redirect_uri,
+    with_login_redirect_error_handler,
+    with_logout_redirect_error_handler,
+)
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
 from src.db.models.user_models import MgmtUserTokenSession
 from src.services.users.login_gov_callback_handler import (
     handle_login_gov_callback_request,
     handle_login_gov_token,
 )
+from src.services.users.logout_user import logout_user
 from src.services.users.user_can_access import check_user_can_access
 
 logger = logging.getLogger(__name__)
@@ -32,6 +41,12 @@ you to an OAuth provider where you can sign into an account.
 Do not try to use the execute option below as OpenAPI will not redirect your browser for you.
 
 The token you receive can then be set to the X-MGMT-Token header for authenticating with endpoints.
+"""
+
+LOGOUT_DESCRIPTION = """
+To use this endpoint, click [this link](/v1/users/logout) which will redirect you
+to an OAuth provider where you can logout of your account in both our system and
+the OAuth system.
 """
 
 
@@ -78,6 +93,33 @@ def login_result() -> flask.Response:
 
     # Echo back the query args as JSON for some readability
     return flask.jsonify(flask.request.args)
+
+
+@user_blueprint.get("/logout")
+@user_blueprint.doc(responses=[302], description=LOGOUT_DESCRIPTION)
+@with_logout_redirect_error_handler()
+@flask_db.with_db_session()
+def user_logout(db_session: db.Session) -> flask.Response:
+    logger.info("GET /v1/users/logout")
+
+    with db_session.begin():
+        # This endpoint doesn't require any auth token, but
+        # if it's provided, we'll handle logging the user out of our system.
+        logout_user(db_session, flask.request.headers.get("X-MGMT-Token", None))
+
+    return response.redirect_response(get_login_gov_logout_redirect_uri())
+
+
+@user_blueprint.get("/logout/callback")
+@with_logout_redirect_error_handler()
+@user_blueprint.doc(hide=True)
+def user_logout_callback() -> flask.Response:
+    logger.info("GET /v1/users/logout/callback")
+
+    # We don't have any logic to run here,
+    # we just redirect to the final destination
+    # in our frontend
+    return response.redirect_response(get_final_logout_redirect_uri(message="success"))
 
 
 @user_blueprint.post("/token/logout")

--- a/backend/grants_management_api/src/auth/auth_utils.py
+++ b/backend/grants_management_api/src/auth/auth_utils.py
@@ -14,6 +14,7 @@ from grants_shared.auth.login_gov_jwt_auth import (
     LoginGovConfig,
     RedirectParams,
     get_config,
+    get_final_logout_redirect_uri,
     get_final_redirect_uri,
 )
 
@@ -92,6 +93,65 @@ def with_login_redirect_error_handler() -> Callable[..., Callable[P, flask.Respo
     return decorator
 
 
+def with_logout_redirect_error_handler() -> Callable[..., Callable[P, flask.Response]]:
+    """Wrapper function to handle catching errors and redirecting for our logout redirect endpoints
+
+    Because our logout functions don't have standard 2xx returns
+    and instead redirect the user, we also redirect in the case of errors
+    so that they stay on the frontend, but we pass errors along.
+
+    Usage::
+
+        @with_logout_redirect_error_handler()
+        def foo(...):
+            logger.info("hello")
+
+            if condition:
+                raise_flask_error(...) # this will get caught and a redirect will occur
+
+            return ...
+
+    """
+
+    def decorator(f: Callable[P, flask.Response]) -> Callable[P, flask.Response]:
+        @functools.wraps(f)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> flask.Response:
+            try:
+                return f(*args, **kwargs)
+            except HTTPError as e:
+                # HTTPError is what raise_flask_error raises
+                # and should encompass our "expected" errors
+                # that aren't a concern, as long as it isn't a 5xx
+                message = e.message
+                logger.info("Logout flow failed: %s", message)
+
+                # But we still don't expect 5xx errors
+                if e.status_code >= 500:
+                    message = INTERNAL_ERROR
+                    logger.exception(
+                        "Unexpected error occurred in logout flow via raise_flask_error",
+                        extra={"error.message": e.message},
+                    )
+
+                return response.redirect_response(
+                    get_final_logout_redirect_uri(
+                        "error",
+                        error_description=message,
+                    )
+                )
+            except Exception:
+                # Any other exception, we'll just use a generic error message to be safe
+                # but this means an unexpected error occurred and we should log an error
+                logger.exception("Unexpected error occurred in logout flow")
+                return response.redirect_response(
+                    get_final_logout_redirect_uri("error", error_description=INTERNAL_ERROR)
+                )
+
+        return wrapper
+
+    return decorator
+
+
 def get_login_gov_redirect_uri(
     query_data: dict, db_session: db.Session, config: LoginGovConfig | None = None
 ) -> str:
@@ -131,3 +191,28 @@ def get_login_gov_redirect_uri(
     MgmtAuthHandler(db_session).create_login_gov_state(state, nonce)
 
     return f"{config.login_gov_auth_endpoint}?{encoded_params}"
+
+
+def get_login_gov_logout_redirect_uri(config: LoginGovConfig | None = None) -> str:
+    if config is None:
+        config = get_config()
+
+    redirect_uri = flask.url_for(
+        ".user_logout_callback", _external=True, _scheme=config.login_gov_redirect_scheme
+    )
+
+    url_params = {
+        "client_id": config.client_id,
+        "post_logout_redirect_uri": redirect_uri,
+        # Note that we don't use the state in the logout callback
+        # but include it just for consistency. There's no replay attack
+        # we need to prevent in callback logic since that endpoint just
+        # does a redirect to our frontend and doesn't care about anything else.
+        "state": uuid.uuid4(),
+    }
+
+    # We want to redirect to the logout endpoint of login.gov
+    # See: https://developers.login.gov/oidc/logout/
+    encoded_params = urllib.parse.urlencode(url_params)
+
+    return f"{config.login_gov_logout_endpoint}?{encoded_params}"

--- a/backend/grants_management_api/src/services/users/logout_user.py
+++ b/backend/grants_management_api/src/services/users/logout_user.py
@@ -1,0 +1,28 @@
+import logging
+
+from grants_shared.adapters import db
+from grants_shared.auth.api_jwt_auth import JwtAuth
+from grants_shared.auth.auth_errors import JwtValidationError
+
+from src.auth.auth_handler import MgmtAuthHandler
+
+logger = logging.getLogger(__name__)
+
+
+def logout_user(db_session: db.Session, user_token: str | None) -> None:
+    if user_token is None:
+        logger.info("No token provided, no user to logout")
+        return
+
+    # Attempt to parse the JWT that was provided, same as we would for authN normally.
+    # If there are any JWT-specific issues, we'll just log them, and still proceed with
+    # the redirect logic that comes after this.
+    try:
+        user_token_session = JwtAuth(MgmtAuthHandler(db_session)).parse_jwt_for_user(user_token)
+    except JwtValidationError:
+        logger.info("Provided JWT was not valid, cannot logout of our system", exc_info=True)
+        return
+
+    user_token_session.is_valid = False
+
+    logger.info("Logged user out of simpler grants", extra=user_token_session.get_log_extra())

--- a/backend/grants_management_api/tests/api/users/test_user_route_logout.py
+++ b/backend/grants_management_api/tests/api/users/test_user_route_logout.py
@@ -1,0 +1,133 @@
+import urllib
+from datetime import datetime
+
+from grants_shared.api.route_utils import raise_flask_error
+from grants_shared.auth import login_gov_jwt_auth
+from grants_shared.auth.api_jwt_auth import JwtAuth
+
+from src.auth.api_jwt_auth import create_jwt_for_user
+from tests.db.models.factories import MgmtLinkExternalUserFactory
+
+
+def validate_redirects_occurred(resp):
+    login_gov_config = login_gov_jwt_auth.get_config()
+    # History contains each redirect, we redirected 3 times
+    assert len(resp.history) == 3
+
+    first_redirect, second_redirect, third_redirect = resp.history
+
+    # Redirect to the oauth-logout
+    first_redirect_url = urllib.parse.urlparse(first_redirect.headers["Location"])
+    assert first_redirect_url.path == "/test-endpoint/oauth-logout"
+
+    first_redirect_params = urllib.parse.parse_qs(first_redirect_url.query)
+    assert first_redirect_params["client_id"][0] == login_gov_config.client_id
+    assert first_redirect_params["state"][0] is not None
+    assert (
+        first_redirect_params["post_logout_redirect_uri"][0]
+        == "http://localhost/v1/users/logout/callback"
+    )
+
+    # Redirect back to our callback endpoint
+    assert second_redirect.status_code == 302
+    second_redirect_url = urllib.parse.urlparse(second_redirect.headers["Location"])
+    assert second_redirect_url.path == "/v1/users/logout/callback"
+
+    second_redirect_params = urllib.parse.parse_qs(second_redirect_url.query)
+    assert second_redirect_params["state"][0] == first_redirect_params["state"][0]
+
+    # Redirect to the final destination page
+    assert third_redirect.status_code == 302
+    third_redirect_url = urllib.parse.urlparse(third_redirect.headers["Location"])
+    assert third_redirect_url.path == "/test-endpoint/oauth-logout-result"
+
+    third_redirect_params = urllib.parse.parse_qs(third_redirect_url.query)
+    assert third_redirect_params["message"][0] == "success"
+
+
+def test_user_logout_without_token_302(client, db_session):
+    resp = client.get("v1/users/logout", follow_redirects=True)
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "success"
+
+    validate_redirects_occurred(resp)
+
+
+def test_user_logout_with_token_302(client, db_session, enable_factory_create):
+    external_user = MgmtLinkExternalUserFactory.create()
+    token, user_token_session = create_jwt_for_user(external_user.mgmt_user, db_session)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-MGMT-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "success"
+
+    db_session.refresh(user_token_session)
+    assert user_token_session.is_valid is False
+
+    validate_redirects_occurred(resp)
+
+
+def test_user_logout_with_invalid_token_302(client, db_session, enable_factory_create):
+    external_user = MgmtLinkExternalUserFactory.create()
+    token, user_token_session = create_jwt_for_user(external_user.mgmt_user, db_session)
+    user_token_session.expires_at = datetime(2020, 1, 1, 12, 0, 0)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-MGMT-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "success"
+
+    db_session.refresh(user_token_session)
+    # Still marked as True because the validation failed due to the expiration time
+    assert user_token_session.is_valid is True
+
+    validate_redirects_occurred(resp)
+
+
+def test_user_logout_with_internal_issue_4xx(
+    client, db_session, enable_factory_create, monkeypatch
+):
+
+    def err_func(*args):
+        raise_flask_error(422, "the eventual error message")
+
+    monkeypatch.setattr(JwtAuth, "parse_jwt_for_user", err_func)
+
+    external_user = MgmtLinkExternalUserFactory.create()
+    token, _ = create_jwt_for_user(external_user.mgmt_user, db_session)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-MGMT-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "error"
+    assert resp_json["error_description"] == "the eventual error message"
+
+
+def test_user_logout_with_internal_issue_500(
+    client, db_session, enable_factory_create, monkeypatch
+):
+
+    def err_func(*args):
+        raise_flask_error(500, "an error message we won't see")
+
+    monkeypatch.setattr(JwtAuth, "parse_jwt_for_user", err_func)
+
+    external_user = MgmtLinkExternalUserFactory.create()
+    token, _ = create_jwt_for_user(external_user.mgmt_user, db_session)
+    db_session.commit()
+
+    resp = client.get("v1/users/logout", follow_redirects=True, headers={"X-MGMT-Token": token})
+
+    assert resp.status_code == 200
+    resp_json = resp.get_json()
+    assert resp_json["message"] == "error"
+    assert resp_json["error_description"] == "internal error"

--- a/backend/grants_management_api/tests/conftest.py
+++ b/backend/grants_management_api/tests/conftest.py
@@ -22,7 +22,7 @@ from src.db import models
 from src.db.models.lookup.sync_lookup_values import sync_lookup_values
 from src.db.resource_automation.resource_automation import setup_resource_automation
 from tests.test_utils import db_testing
-from tests.test_utils.auth_test_utils import mock_oauth_endpoint
+from tests.test_utils.auth_test_utils import mock_oauth_endpoint, mock_oauth_logout_endpoint
 
 ####################
 # General test setup/utils
@@ -253,12 +253,19 @@ def app(
         "LOGIN_GOV_AUTH_ENDPOINT", "http://localhost:8089/test-endpoint/oauth-authorize"
     )
     monkeypatch_session.setenv(
+        "LOGIN_GOV_LOGOUT_ENDPOINT", "http://localhost:8089/test-endpoint/oauth-logout"
+    )  # setup in mock_oauth_logout_endpoint below
+    monkeypatch_session.setenv(
         "LOGIN_FINAL_DESTINATION", "http://localhost:8089/v1/users/login/result"
     )
+    monkeypatch_session.setenv(
+        "LOGOUT_FINAL_DESTINATION", "http://localhost:8089/test-endpoint/oauth-logout-result"
+    )  # setup in mock_oauth_logout_endpoint below
     app = app_entry.create_app()
 
     # Add endpoints and mocks for handling the external OAuth logic
     mock_oauth_endpoint(app, monkeypatch_session, private_rsa_key, mock_oauth_client)
+    mock_oauth_logout_endpoint(app)
 
     return app
 

--- a/backend/grants_management_api/tests/test_utils/auth_test_utils.py
+++ b/backend/grants_management_api/tests/test_utils/auth_test_utils.py
@@ -134,6 +134,35 @@ def mock_oauth_endpoint(app, monkeypatch, private_key, mock_oauth_client):
     )
 
 
+def mock_oauth_logout_endpoint(app):
+    """
+    Mock out the logout endpoint for oauth for unit tests.
+
+    Primarily just redirects back to our callback endpoint
+    as there's no actual state checked on the other side.
+    """
+
+    @app.get("/test-endpoint/oauth-logout")
+    def oauth_logout():
+        # This endpoint represents a mocked version of
+        # https://developers.login.gov/oidc/logout/
+        # and needs to return the state value back.
+        query_args = flask.request.args
+        params = {"state": query_args.get("state")}
+
+        encoded_params = urllib.parse.urlencode(params)
+        redirect_uri = f"{query_args['post_logout_redirect_uri']}?{encoded_params}"
+
+        return flask.redirect(redirect_uri)
+
+    @app.get("/test-endpoint/oauth-logout-result")
+    def logout_result() -> flask.Response:
+        """Dummy endpoint for easily displaying the results of the logout flow"""
+
+        # Echo back the query args as JSON
+        return flask.jsonify(flask.request.args)
+
+
 def setup_user_with_roles(
     db_session: db.Session,
     resources: list[AbstractResourceTableMixin],

--- a/backend/grants_management_api/uv.lock
+++ b/backend/grants_management_api/uv.lock
@@ -601,7 +601,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.28.62,<2" },
     { name = "botocore", specifier = ">=1.31.62,<2" },
     { name = "flask-cors", specifier = ">=6.0.0,<7" },
-    { name = "grants-shared", specifier = "==0.2.16" },
+    { name = "grants-shared", specifier = "==0.2.18" },
     { name = "gunicorn", specifier = ">=23.0.0,<24" },
     { name = "marshmallow", specifier = ">=3.20.1,<4" },
     { name = "newrelic", specifier = ">=12.1.0,<13" },
@@ -643,7 +643,7 @@ dev = [
 
 [[package]]
 name = "grants-shared"
-version = "0.2.16"
+version = "0.2.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apiflask" },
@@ -666,9 +666,9 @@ dependencies = [
     { name = "smart-open" },
     { name = "sqlalchemy", extra = ["mypy"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/7c/c63f2b98cbf593fd201568363c2a3cca65a7d557500c4ed709cf6d78a275/grants_shared-0.2.16.tar.gz", hash = "sha256:6d34299ba7e22708160d5d0922660bbd118c59f9586c687b311671a1648824bc", size = 70355, upload-time = "2026-07-09T17:19:19.147Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/fb/6f7cea3a82dbd4141680e0ed0766643152b6f3dbff97d421f459a10481cf/grants_shared-0.2.18.tar.gz", hash = "sha256:eb1f07f7aa2710574ddc0cb87139dacb9afcec9a8bfc2c6bd99628443ba5b8ed", size = 71842, upload-time = "2026-07-22T18:46:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/b0/a4cf73c1069156a620fa9d13d8164d824a2cb03dc0e937f43977cf2bf4d0/grants_shared-0.2.16-py3-none-any.whl", hash = "sha256:ff5796f118de69418e2e2e7012412ee407368d725e6a87fe2b8848bf6a8c6f8b", size = 91243, upload-time = "2026-07-09T17:19:17.836Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/85/73a24fefe7da8e72a000c479f7cb982b89579d81d102ced597772a1eb7ad/grants_shared-0.2.18-py3-none-any.whl", hash = "sha256:f86acc5f71fa935282c2a48aee7fe09fecb72abb1a27e72cbf0f777f8051c0b3", size = 93315, upload-time = "2026-07-22T18:46:46.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Fixes #11613

## Changes proposed
* Add logout endpoints to grants management API

## Context for reviewers
This is logic we recently added in on the simpler API side, it's basically copy-pasting with some minor renames, but otherwise works the same.

## Validation steps
Verified that it works with local mock oauth client. Go to localhost:8089/docs - under the logout endpoint there is a link you can click that'll send you through the redirect chain, including briefly at the mock oauth client that sends back to the callback.