### PR TITLE
[No ticket] Fix Opportunity Summary E2E failures after section-name updates

### DIFF
--- a/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
+++ b/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
@@ -325,6 +325,7 @@ export const ADDITIONAL_INFORMATION_FIELD_DEFINITIONS: OpportunityPageFieldDefin
       label: "Contact email",
       type: "email",
       valueKey: "contactEmail",
+      selector: "#agency_email_address",
       required: false,
       maxLength: 130,
       characterLimitValidationMessage: "1 character over limit",

--- a/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
+++ b/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
@@ -125,7 +125,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       label: "Funding type",
       type: "select",
       valueKey: "fundingType",
-      selector: "#funding-type-values",
+      selector: "#funding_instruments",
       required: true,
       requiredFieldMessage: "Select a funding type.",
     },
@@ -133,7 +133,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       label: "Category",
       type: "select",
       valueKey: "category",
-      selector: "#funding-category-values",
+      selector: "#funding_categories",
       required: true,
       requiredFieldMessage: "Select a funding category.",
     },
@@ -141,7 +141,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       label: "Expected number of awards",
       type: "text",
       valueKey: "expectedNumberOfAwards",
-      selector: "#expected-number-of-awards",
+      selector: "#expected_number_of_awards",
       required: false,
       // Un-comment after bug fixed
       // negativeNumberValidationMessage:
@@ -151,7 +151,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       label: "Estimated total program funding",
       type: "text",
       valueKey: "estimatedTotalProgramFunding",
-      selector: "#estimated-total-program-funding",
+      selector: "#estimated_total_program_funding",
       required: false,
       negativeNumberValidationMessage:
         "Estimated total program funding must be greater than or equal to zero and less than $1,000,000,000,000,000.",
@@ -160,7 +160,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       label: "Award minimum",
       type: "text",
       valueKey: "awardMinimum",
-      selector: "#award-minimum",
+      selector: "#award_floor",
       required: false,
       negativeNumberValidationMessage:
         "Award minimum must be greater than or equal to zero and less than $1,000,000,000,000,000.",
@@ -169,7 +169,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       label: "Award maximum",
       type: "text",
       valueKey: "awardMaximum",
-      selector: "#award-maximum",
+      selector: "#award_ceiling",
       required: false,
       negativeNumberValidationMessage:
         "Award maximum must be greater than or equal to zero and less than $1,000,000,000,000,000.",
@@ -178,7 +178,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       label: "Publish date",
       type: "date",
       valueKey: "publishDate",
-      selector: "#publish-date",
+      selector: "#post_date",
       required: true,
       requiredFieldMessage: "Enter a publish date.",
     },
@@ -197,13 +197,13 @@ export const CROSS_FIELD_VALIDATION_DEFINITIONS: CrossFieldValidationDefinition[
       name: "award min greater than award max",
       fieldsToSet: [
         {
-          selector: "#award-minimum",
+          selector: "#award_floor",
           valueKey: "awardMinimum",
           invalidValue: "100",
           expectedErrorMessage: "Award minimum cannot exceed Award maximum.",
         },
         {
-          selector: "#award-maximum",
+          selector: "#award_ceiling",
           valueKey: "awardMaximum",
           invalidValue: "50",
           expectedErrorMessage:
@@ -215,19 +215,19 @@ export const CROSS_FIELD_VALIDATION_DEFINITIONS: CrossFieldValidationDefinition[
       name: "award min and max greater than total funding",
       fieldsToSet: [
         {
-          selector: "#estimated-total-program-funding",
+          selector: "#estimated_total_program_funding",
           valueKey: "estimatedTotalProgramFunding",
           invalidValue: "100",
         },
         {
-          selector: "#award-minimum",
+          selector: "#award_floor",
           valueKey: "awardMinimum",
           invalidValue: "200",
           expectedErrorMessage:
             "Award minimum cannot exceed the Estimated Total Program Funding.",
         },
         {
-          selector: "#award-maximum",
+          selector: "#award_ceiling",
           valueKey: "awardMaximum",
           invalidValue: "300",
           expectedErrorMessage:

--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
@@ -133,7 +133,7 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
       });
 
       // [Bug] Draft opportunity summary save actions do not navigate #11665
-      
+
       // // And I click "Save and exit" button
       // await page.getByRole("button", { name: "Save and exit" }).click();
 
@@ -160,7 +160,7 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
 
       // // And the matching row should be visible.
       // await expect(matchingRow).toBeVisible();
-      
+
       //--------------Scenario steps end here----------------
     },
   );

--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
@@ -40,8 +40,8 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
 import { assertButtonEnabledDisabledStates } from "tests/e2e/utils/common/index";
-import { assertOverviewSectionStatus } from "tests/e2e/utils/opportunities/overview-status-utils";
-import { waitForOpportunityRowByStatus } from "tests/e2e/utils/opportunities/table-row-utils";
+// import { assertOverviewSectionStatus } from "tests/e2e/utils/opportunities/overview-status-utils";
+// import { waitForOpportunityRowByStatus } from "tests/e2e/utils/opportunities/table-row-utils";
 import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
 import { fillPageFields } from "tests/e2e/utils/pages/general-pages-filling";
 
@@ -76,7 +76,7 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
 
       // Define commonly used values for assertions and form filling at the beginning of the test for better readability of the scenario steps.
       const fillData = buildOpportunityHappyPathFillData(new Date());
-      const opportunityTitle = fillData.opportunityTitle;
+      // const opportunityTitle = fillData.opportunityTitle;
 
       //--------------Scenario steps start here----------------
 
@@ -132,33 +132,35 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
         "Save and continue": true,
       });
 
-      // And I click "Save and exit" button
-      await page.getByRole("button", { name: "Save and exit" }).click();
+      // [Bug] Draft opportunity summary save actions do not navigate #11665
+      
+      // // And I click "Save and exit" button
+      // await page.getByRole("button", { name: "Save and exit" }).click();
 
-      // Then I should return to the "Opportunity Overview" page.
-      await expect(page).toHaveURL(
-        /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
-      );
+      // // Then I should return to the "Opportunity Overview" page.
+      // await expect(page).toHaveURL(
+      //   /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
+      // );
 
-      // And I should see overview statuses for key sections.
-      await assertOverviewSectionStatus(page, {
-        "Opportunity Summary": "Complete",
-        "Application Package": "Not started",
-      });
+      // // And I should see overview statuses for key sections.
+      // await assertOverviewSectionStatus(page, {
+      //   "Opportunity Summary": "Complete",
+      //   "Application Package": "Not started",
+      // });
 
-      // When I navigate directly to opportunity list page
-      await page.goto("/grantor/opportunities");
+      // // When I navigate directly to opportunity list page
+      // await page.goto("/grantor/opportunities");
 
-      // Then I should see "Draft" status for the created opportunity row.
-      const matchingRow = await waitForOpportunityRowByStatus(page, {
-        title: opportunityTitle,
-        status: "Draft",
-        message: 'Waiting for "Draft" opportunity row to appear on list',
-      });
+      // // Then I should see "Draft" status for the created opportunity row.
+      // const matchingRow = await waitForOpportunityRowByStatus(page, {
+      //   title: opportunityTitle,
+      //   status: "Draft",
+      //   message: 'Waiting for "Draft" opportunity row to appear on list',
+      // });
 
-      // And the matching row should be visible.
-      await expect(matchingRow).toBeVisible();
-
+      // // And the matching row should be visible.
+      // await expect(matchingRow).toBeVisible();
+      
       //--------------Scenario steps end here----------------
     },
   );

--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
@@ -40,8 +40,8 @@ import playwrightEnv from "tests/e2e/playwright-env";
 import { VALID_TAGS } from "tests/e2e/tags";
 import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
 import { assertButtonEnabledDisabledStates } from "tests/e2e/utils/common/index";
-// import { assertOverviewSectionStatus } from "tests/e2e/utils/opportunities/overview-status-utils";
-// import { waitForOpportunityRowByStatus } from "tests/e2e/utils/opportunities/table-row-utils";
+import { assertOverviewSectionStatus } from "tests/e2e/utils/opportunities/overview-status-utils";
+import { waitForOpportunityRowByStatus } from "tests/e2e/utils/opportunities/table-row-utils";
 import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
 import { fillPageFields } from "tests/e2e/utils/pages/general-pages-filling";
 
@@ -76,7 +76,7 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
 
       // Define commonly used values for assertions and form filling at the beginning of the test for better readability of the scenario steps.
       const fillData = buildOpportunityHappyPathFillData(new Date());
-      // const opportunityTitle = fillData.opportunityTitle;
+      const opportunityTitle = fillData.opportunityTitle;
 
       //--------------Scenario steps start here----------------
 
@@ -132,34 +132,32 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
         "Save and continue": true,
       });
 
-      // [Bug] Draft opportunity summary save actions do not navigate #11665
+      // And I click "Save and exit" button
+      await page.getByRole("button", { name: "Save and exit" }).click();
 
-      // // And I click "Save and exit" button
-      // await page.getByRole("button", { name: "Save and exit" }).click();
+      // Then I should return to the "Opportunity Overview" page.
+      await expect(page).toHaveURL(
+        /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
+      );
 
-      // // Then I should return to the "Opportunity Overview" page.
-      // await expect(page).toHaveURL(
-      //   /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
-      // );
+      // And I should see overview statuses for key sections.
+      await assertOverviewSectionStatus(page, {
+        "Opportunity Summary": "Complete",
+        "Application Package": "Not started",
+      });
 
-      // // And I should see overview statuses for key sections.
-      // await assertOverviewSectionStatus(page, {
-      //   "Opportunity Summary": "Complete",
-      //   "Application Package": "Not started",
-      // });
+      // When I navigate directly to opportunity list page
+      await page.goto("/grantor/opportunities");
 
-      // // When I navigate directly to opportunity list page
-      // await page.goto("/grantor/opportunities");
+      // Then I should see "Draft" status for the created opportunity row.
+      const matchingRow = await waitForOpportunityRowByStatus(page, {
+        title: opportunityTitle,
+        status: "Draft",
+        message: 'Waiting for "Draft" opportunity row to appear on list',
+      });
 
-      // // Then I should see "Draft" status for the created opportunity row.
-      // const matchingRow = await waitForOpportunityRowByStatus(page, {
-      //   title: opportunityTitle,
-      //   status: "Draft",
-      //   message: 'Waiting for "Draft" opportunity row to appear on list',
-      // });
-
-      // // And the matching row should be visible.
-      // await expect(matchingRow).toBeVisible();
+      // And the matching row should be visible.
+      await expect(matchingRow).toBeVisible();
 
       //--------------Scenario steps end here----------------
     },


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #ISSUE 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->


1. Update Opportunity Summary E2E field metadata to align with current platform section names. 
          Ref:[Issue #9602] form data to json opportunity edit (#11499) #[12289](https://github.com/HHS/simpler-grants-gov/actions/runs/30274748684/job/90006341873)

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

Opportunity Summary E2E no longer fails from stale section metadata.

Test passed:
E2E Tests (Deployed Target) #[1080](https://github.com/HHS/simpler-grants-gov/actions/runs/30382995187)
E2E Tests (Local Github Target) #[12467](https://github.com/HHS/simpler-grants-gov/actions/runs/30383740743)