### PR TITLE
[Issue# 11691] Fix flaky E2E tests by isolating validation states and improving sector handling

### DIFF
--- a/frontend/tests/e2e/opportunity/specs/failure-path-create-opportunity.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-create-opportunity.spec.ts
@@ -118,11 +118,17 @@ test.describe("Opportunity failure path - create opportunity", () => {
       // When I reset to a fresh create form via UI.
       await openFreshCreateOpportunityForm(page);
 
+      // Use a fresh unique data set so required-field gating assertions are not
+      // affected by duplicate-number validation from earlier shards.
+      const postDuplicateFillData = buildOpportunityHappyPathFillData(
+        new Date(Date.now() + 1500),
+      );
+
       // Then I verify required-field gating of Save and continue.
       await fillRequiredFieldsAndAssertButtonState(
         page,
         CREATE_OPPORTUNITY_FIELD_DEFINITIONS,
-        fillData,
+        postDuplicateFillData,
         {
           triggerButtonName: "Save and continue",
           additionalButtonStates: {
@@ -142,7 +148,7 @@ test.describe("Opportunity failure path - create opportunity", () => {
           CREATE_OPPORTUNITY_FIELD_DEFINITIONS,
           buildOverLimitFillData(
             CREATE_OPPORTUNITY_FIELD_DEFINITIONS,
-            fillData,
+            postDuplicateFillData,
           ),
         ),
       );

--- a/frontend/tests/e2e/opportunity/specs/failure-path-create-opportunity.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-create-opportunity.spec.ts
@@ -153,7 +153,13 @@ test.describe("Opportunity failure path - create opportunity", () => {
         ),
       );
 
-      // When I click "Save and continue" button
+      // And "Save and continue" should remain enabled while over-limit values exist.
+      await assertButtonEnabledDisabledStates(page, {
+        "Save and continue": true,
+        Cancel: true,
+      });
+
+      // When I click "Save and continue" after field-level validation renders.
       await page.getByRole("button", { name: "Save and continue" }).click();
 
       // And I remain on the create opportunity page
@@ -166,7 +172,7 @@ test.describe("Opportunity failure path - create opportunity", () => {
         getCharacterLimitedFields(CREATE_OPPORTUNITY_FIELD_DEFINITIONS).length,
       );
 
-      // And "Save and continue" button should be enabled, "Cancel" button should remain enabled
+      // And "Save and continue" button should remain enabled, "Cancel" button should remain enabled
       await assertButtonEnabledDisabledStates(page, {
         "Save and continue": true,
         Cancel: true,

--- a/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-summary.spec.ts
@@ -43,6 +43,7 @@ import { assertButtonEnabledDisabledStates } from "tests/e2e/utils/common/index"
 import { assertNegativeNumberValidationsFromDefinitions } from "tests/e2e/utils/common/negative-number-validation-utils";
 import { assertRequiredFieldValidationsFromDefinitions } from "tests/e2e/utils/common/required-field-validation-utils";
 import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
+import { fillPageFields } from "tests/e2e/utils/pages/general-pages-filling";
 
 const { GRANTOR, CORE_REGRESSION } = VALID_TAGS;
 const { targetEnv } = playwrightEnv;
@@ -113,6 +114,16 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
       const testPage = authenticatedLifecycle.getPage();
       const fillData = await setupAndNavigateToOpportunitySummary(testPage);
 
+      // Prime required fields to isolate negative-number assertions from
+      // unrelated required-field gating errors.
+      await fillPageFields(
+        testPage,
+        buildPageFieldsFromDefinitions(
+          REQUIRED_FIELD_DEFINITIONS.filter((field) => field.required),
+          fillData,
+        ),
+      );
+
       //--------------Scenario steps start here----------------
       // When I click the configured trigger button
       // Then negative number validation errors are shown on the page.
@@ -123,7 +134,7 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
         fillData,
         {
           negativeValue: "-10",
-          triggerButtonNames: ["Save and exit"],
+          triggerValidationWithButtonClick: false,
           pageUrlPattern: EDIT_OPPORTUNITY_URL_PATTERN,
         },
       );

--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
@@ -139,9 +139,7 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
 
       // Fail fast if required validation is still present before submit.
       await expect(
-        page
-          .getByRole("alert")
-          .filter({ hasText: "Select a funding category." }),
+        page.getByRole("alert").filter({ hasText: "Select a funding category." }),
       ).toHaveCount(0);
 
       // And I click "Save and exit" button

--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
@@ -110,6 +110,11 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
         ),
       );
 
+      // Ensure select state is committed before submit to avoid flaky same-page re-submit.
+      await expect(
+        page.locator("#funding_categories option:checked").first(),
+      ).toHaveText(fillData.category);
+
       // Fill required Eligibility values.
       await fillPageFields(
         page,
@@ -131,6 +136,13 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
         "Save and go back": true,
         "Save and continue": true,
       });
+
+      // Fail fast if required validation is still present before submit.
+      await expect(
+        page
+          .getByRole("alert")
+          .filter({ hasText: "Select a funding category." }),
+      ).toHaveCount(0);
 
       // And I click "Save and exit" button
       await Promise.all([

--- a/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/happy-path-opportunity-summary.spec.ts
@@ -133,12 +133,12 @@ test.describe("Grantor Opportunity Summary Happy Path", () => {
       });
 
       // And I click "Save and exit" button
-      await page.getByRole("button", { name: "Save and exit" }).click();
-
-      // Then I should return to the "Opportunity Overview" page.
-      await expect(page).toHaveURL(
-        /\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/,
-      );
+      await Promise.all([
+        page.waitForURL(/\/grantor\/opportunity\/([a-z0-9-]+?)\/overview/, {
+          timeout: 15000,
+        }),
+        page.getByRole("button", { name: "Save and exit" }).click(),
+      ]);
 
       // And I should see overview statuses for key sections.
       await assertOverviewSectionStatus(page, {

--- a/frontend/tests/e2e/utils/common/select-field.ts
+++ b/frontend/tests/e2e/utils/common/select-field.ts
@@ -28,6 +28,15 @@ export const selectHandler: FieldHandler = async (
     );
   }
 
+  // Prefer explicit selector when provided because some pages contain
+  // similarly labeled controls and selector targeting is more deterministic.
+  if (field.selector) {
+    const select = page.locator(field.selector).first();
+    await select.waitFor({ state: "visible", timeout: 5000 });
+    await select.selectOption({ label: data });
+    return;
+  }
+
   const label = field.label ?? field.field;
   await selectOptionByLabel(page, label, data, field.labelExact);
 };


### PR DESCRIPTION
## Summary
This update reduces Opportunity E2E flakiness in staging by isolating validation scenarios, improving deterministic field interactions, and hardening navigation assertions.

**Reference issue:** https://github.com/HHS/simpler-grants-gov/actions/runs/30398679235

<img width="1520" height="772" alt="image" src="https://github.com/user-attachments/assets/1477de1b-ba20-4443-bb11-f5a6315fd15e" />


<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11691  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

- Stabilize create-opportunity failure-path shard sequencing in [failure-path-create-opportunity.spec.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- Use fresh post-duplicate fill data for later shards so duplicate-number validation does not leak into required-field/button-state checks.
- Add timestamp offset (Date.now() + 1500) to avoid same-second collisions.
- Isolate negative-number validation from unrelated required-field failures in [failure-path-opportunity-summary.spec.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- Prime required fields before negative-number assertions.
- Switch negative-number flow to blur-driven validation (no Save and exit trigger for this scenario).
- Harden happy-path save navigation in [happy-path-opportunity-summary.spec.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- Replace click-then-assert pattern with Promise.all(waitForURL + click) for Save and exit.
- Make select behavior deterministic in [select-field.ts](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/1b6a188127/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
- Prefer explicit selector when present, then fall back to label lookup.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

- Root issue: multiple flaky failures were caused by validation-state coupling across shards and timing-sensitive interactions (save navigation and ambiguous select targeting).
- Scope is test-only (E2E specs/helpers), no product runtime behavior changes.
- Main risk: select helper now prioritizes selector over label where selector exists. This is intentional and aligns with metadata-driven locators.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Reliability check: Re-run targeted specs multiple times (for example repeat-each 3) in staging Chrome to confirm flake reduction.
