### PR TITLE
[Issue #9132] XML differences for Simpler Project Abstract Summary form (ID: 591)

### DIFF
--- a/api/src/services/xml_generation/validation/test_cases.py
+++ b/api/src/services/xml_generation/validation/test_cases.py
@@ -1651,6 +1651,20 @@ PROJECT_ABSTRACT_SUMMARY_TEST_CASES = [
         "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/Project_AbstractSummary_2_0-V2.0.xsd",
         "pretty_print": True,
     },
+    {
+        # Mirrors the legacy Grants.gov submission captured for issue #9132 (legacy form ID 591).
+        "name": "project_abstract_summary_legacy_parity",
+        "json_input": {
+            "funding_opportunity_number": "SIMP-PROJABSTRACTSUMMARY-07282026",
+            "assistance_listing_number": "00.000",
+            "applicant_name": "m h",
+            "project_title": "adsf",
+            "project_abstract": "asdfsdf",
+        },
+        "form_name": "Project_AbstractSummary_2_0",
+        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/Project_AbstractSummary_2_0-V2.0.xsd",
+        "pretty_print": True,
+    },
 ]
 
 # Sample test cases for EPA Key Contacts validation
@@ -1828,7 +1842,6 @@ OTHER_NARRATIVE_ATTACHMENTS_TEST_CASES = [
         },
     }
 ]
-
 
 # Sample test cases for Project/Performance Site Location v4.0 validation
 PERFORMANCE_SITE_TEST_CASES = [

--- a/api/tests/src/services/xml_generation/test_project_abstract_summary_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_project_abstract_summary_xml_generation.py
@@ -178,6 +178,51 @@ class TestProjectAbstractSummaryXMLGeneration:
         # All elements should exist and be in order
         assert fon_pos < cfda_pos < org_pos < title_pos < abstract_pos
 
+    def test_generate_project_abstract_summary_xml_matches_legacy_grants_gov_structure(self):
+        """Generated XML matches the legacy Grants.gov output for issue #9132.
+
+        Reproduces the submission captured from legacy Grants.gov (legacy form ID 591)
+        and asserts every element, value, and the FormVersion attribute match. The only
+        difference between Simpler and legacy output is namespace-declaration placement
+        (legacy redeclares xmlns on every element; Simpler declares once at the root) and
+        which unused system namespaces are declared on the root, both semantically inert.
+        """
+        application_data = {
+            "funding_opportunity_number": "SIMP-PROJABSTRACTSUMMARY-07282026",
+            "assistance_listing_number": "00.000",
+            "applicant_name": "m h",
+            "project_title": "adsf",
+            "project_abstract": "asdfsdf",
+        }
+
+        service = XMLGenerationService()
+        request = XMLGenerationRequest(
+            application_data=application_data,
+            transform_config=PROJECT_ABSTRACT_SUMMARY_TRANSFORM_RULES,
+        )
+
+        response = service.generate_xml(request)
+        assert response.success is True
+        assert response.xml_data is not None
+
+        pas_ns = "http://apply.grants.gov/forms/Project_AbstractSummary_2_0-V2.0"
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(response.xml_data.encode("utf-8"), parser=parser)
+
+        assert root.tag == f"{{{pas_ns}}}Project_AbstractSummary_2_0"
+        assert root.get(f"{{{pas_ns}}}FormVersion") == "2.0"
+
+        # Every child element, in XSD sequence order, matches the legacy submission.
+        expected_children = [
+            ("FundingOpportunityNumber", "SIMP-PROJABSTRACTSUMMARY-07282026"),
+            ("CFDANumber", "00.000"),
+            ("OrganizationName", "m h"),
+            ("ProjectTitle", "adsf"),
+            ("ProjectAbstract", "asdfsdf"),
+        ]
+        actual_children = [(lxml_etree.QName(child).localname, child.text) for child in root]
+        assert actual_children == expected_children
+
     def test_generate_project_abstract_summary_xml_long_abstract(self):
         """Test Project Abstract Summary XML generation with a long abstract (up to 4000 chars)."""
         long_abstract = (


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #9132

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Add a legacy-parity unit test in test_project_abstract_summary_xml_generation.py (test_generate_project_abstract_summary_xml_matches_legacy_grants_gov_structure) that reproduces the exact legacy submission, parses the generated XML, and asserts the root element, the FormVersion="2.0" attribute, and every child element (name + value, in XSD sequence order) against the legacy output.
- Add an XSD-validation test case (project_abstract_summary_legacy_parity) to PROJECT_ABSTRACT_SUMMARY_TEST_CASES in validation/test_cases.py, using the same legacy submission data, so flask task validate-xml-generation --form Project_AbstractSummary_2_0 exercises the real-world payload against the Grants.gov XSD.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
No XML changes are needed for Simpler to match Legacy. We added some tests to assert the behavior based on generated Legacy XML.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
`make test args="tests/src/services/xml_generation/test_project_abstract_summary_xml_generation.py"`
`make test-xml-validation form=Project_AbstractSummary_2_0`
`make generate-xml form=Project_AbstractSummary_2_0 json='{"funding_opportunity_number":"SIMP-PROJABSTRACTSUMMARY-07282026","assistance_listing_number":"00.000","applicant_name":"m h","project_title":"adsf","project_abstract":"asdfsdf"}'

Compare to:
[GrantApplication.xml](https://github.com/user-attachments/files/30507559/GrantApplication.xml)
