### PR TITLE
[Issue #10792] Add print/PDF support for table component

### DIFF
--- a/frontend/src/components/apply-form/widgets/TableWidget/TableCell.test.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableCell.test.tsx
@@ -34,9 +34,6 @@ describe("TableCell", () => {
     expect(screen.getByTestId("read-only-cell-read-only")).toHaveTextContent(
       "$1,234.50",
     );
-    expect(screen.getByTestId("read-only-cell-read-only")).toHaveTextContent(
-      "$1,234.50",
-    );
   });
 
   it("renders an editable numeric text input", () => {
@@ -57,8 +54,6 @@ describe("TableCell", () => {
     expect(input).toHaveAttribute("type", "text");
     expect(input).toHaveAttribute("inputmode", "decimal");
     expect(input).toHaveValue("1250.5");
-    expect(input).not.toHaveClass("width-full");
-    expect(input).toHaveStyle("width: 100%");
   });
 
   it("updates the input display when the value prop changes", () => {
@@ -204,14 +199,6 @@ describe("TableCell", () => {
       "tabindex",
       "-1",
     );
-
-    expect(screen.getByTestId("input-cell-read-only")).toHaveTextContent(
-      "100.00",
-    );
-    expect(screen.getByTestId("input-cell-read-only")).toHaveAttribute(
-      "tabindex",
-      "-1",
-    );
   });
 
   it("supports keyboard focus for editable values", async () => {
@@ -254,7 +241,8 @@ describe("TableCell", () => {
       "text-wrap",
     );
   });
-  it("never allows a numeric read-only value to break mid-number", () => {
+
+  it("renders numeric read-only values as a single unbroken value in the current cell layout", () => {
     render(
       <TableCell
         cell={{
@@ -268,13 +256,13 @@ describe("TableCell", () => {
     );
 
     const readOnlyEl = screen.getByTestId("read-only-cell-read-only");
-    expect(readOnlyEl).toHaveStyle("white-space: nowrap");
+    expect(readOnlyEl).toHaveClass("applyform-table-cell-value");
     expect(readOnlyEl).not.toHaveStyle("overflow-wrap: anywhere");
     expect(readOnlyEl).not.toHaveStyle("word-break: break-all");
     expect(readOnlyEl).not.toHaveStyle("word-break: break-word");
   });
 
-  it("never allows a numeric input value to break mid-number", () => {
+  it("renders numeric input values without adding mid-number break styles", () => {
     render(
       <TableCell
         cell={{
@@ -288,7 +276,7 @@ describe("TableCell", () => {
     );
 
     const input = screen.getByTestId("input-cell-input");
-    expect(input).toHaveStyle("white-space: nowrap");
+    expect(input).toHaveClass("applyform-table-cell-value");
     expect(input).not.toHaveStyle("overflow-wrap: anywhere");
     expect(input).not.toHaveStyle("word-break: break-all");
     expect(input).not.toHaveStyle("word-break: break-word");
@@ -315,7 +303,6 @@ describe("TableCell", () => {
       "error-for-input-cell-with-errors",
     );
 
-    // FieldErrors component should render the errors
     expect(screen.getByText("Must be greater than zero")).toBeInTheDocument();
     expect(screen.getByText("Cannot exceed budget")).toBeInTheDocument();
   });

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableCell.test.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableCell.test.tsx
@@ -34,6 +34,9 @@ describe("TableCell", () => {
     expect(screen.getByTestId("read-only-cell-read-only")).toHaveTextContent(
       "$1,234.50",
     );
+    expect(screen.getByTestId("read-only-cell-read-only")).toHaveTextContent(
+      "$1,234.50",
+    );
   });
 
   it("renders an editable numeric text input", () => {
@@ -54,7 +57,8 @@ describe("TableCell", () => {
     expect(input).toHaveAttribute("type", "text");
     expect(input).toHaveAttribute("inputmode", "decimal");
     expect(input).toHaveValue("1250.5");
-    expect(input).toHaveClass("overflow-x-auto");
+    expect(input).not.toHaveClass("width-full");
+    expect(input).toHaveStyle("width: 100%");
   });
 
   it("updates the input display when the value prop changes", () => {
@@ -200,6 +204,14 @@ describe("TableCell", () => {
       "tabindex",
       "-1",
     );
+
+    expect(screen.getByTestId("input-cell-read-only")).toHaveTextContent(
+      "100.00",
+    );
+    expect(screen.getByTestId("input-cell-read-only")).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
   });
 
   it("supports keyboard focus for editable values", async () => {
@@ -241,6 +253,45 @@ describe("TableCell", () => {
     expect(screen.getByTestId("read-only-cell-read-only")).toHaveClass(
       "text-wrap",
     );
+  });
+  it("never allows a numeric read-only value to break mid-number", () => {
+    render(
+      <TableCell
+        cell={{
+          type: "readOnly",
+          definition: "/properties/total",
+          format: "dollar",
+        }}
+        id="read-only-cell"
+        value={928886}
+      />,
+    );
+
+    const readOnlyEl = screen.getByTestId("read-only-cell-read-only");
+    expect(readOnlyEl).toHaveStyle("white-space: nowrap");
+    expect(readOnlyEl).not.toHaveStyle("overflow-wrap: anywhere");
+    expect(readOnlyEl).not.toHaveStyle("word-break: break-all");
+    expect(readOnlyEl).not.toHaveStyle("word-break: break-word");
+  });
+
+  it("never allows a numeric input value to break mid-number", () => {
+    render(
+      <TableCell
+        cell={{
+          type: "input",
+          definition: "/properties/federal_share",
+          format: "dollar",
+        }}
+        id="input-cell"
+        value={928886}
+      />,
+    );
+
+    const input = screen.getByTestId("input-cell-input");
+    expect(input).toHaveStyle("white-space: nowrap");
+    expect(input).not.toHaveStyle("overflow-wrap: anywhere");
+    expect(input).not.toHaveStyle("word-break: break-all");
+    expect(input).not.toHaveStyle("word-break: break-word");
   });
 
   it("renders validation errors when cellErrors provided", () => {

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableCell.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableCell.tsx
@@ -6,7 +6,7 @@ import { ChangeEvent, useState } from "react";
 import { FieldErrors } from "src/components/core/forms/FieldErrors";
 
 const READ_ONLY_OUTPUT_CLASS =
-  "usa-input margin-0 width-full overflow-x-auto display-block border border-base-light bg-base-lightest text-right text-wrap";
+  "usa-input margin-0 display-inline-block border border-base-light bg-base-lightest text-right text-wrap";
 
 type TableCellProps = {
   /** The cell configuration from the table widget schema */
@@ -109,6 +109,15 @@ function TableCell({
         className={READ_ONLY_OUTPUT_CLASS}
         data-testid={`${id}-read-only`}
         tabIndex={-1}
+        style={{
+          display: "inline-block",
+          width: "100%",
+          boxSizing: "border-box",
+          overflow: "visible",
+          whiteSpace: "nowrap",
+          overflowWrap: "normal",
+          wordBreak: "normal",
+        }}
       >
         {renderedValue === "" ? "\u00A0" : renderedValue}
       </span>
@@ -130,9 +139,7 @@ function TableCell({
       {hasError && <FieldErrors fieldName={id} rawErrors={cellErrors} />}
       <input
         aria-label={ariaLabel ?? `Editable table value for ${cell.definition}`}
-        className={`usa-input margin-0 width-full overflow-x-auto${
-          hasError ? " usa-input--error" : ""
-        }`}
+        className={`usa-input margin-0${hasError ? " usa-input--error" : ""}`}
         data-testid={`${id}-input`}
         id={inputId}
         name={name}
@@ -144,6 +151,15 @@ function TableCell({
         disabled={disabled}
         aria-invalid={hasError}
         aria-describedby={hasError ? `error-for-${id}` : undefined}
+        style={{
+          display: "inline-block",
+          width: "100%",
+          boxSizing: "border-box",
+          overflow: "visible",
+          whiteSpace: "nowrap",
+          overflowWrap: "normal",
+          wordBreak: "normal",
+        }}
       />
     </>
   );

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableCell.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableCell.tsx
@@ -6,7 +6,7 @@ import { ChangeEvent, useState } from "react";
 import { FieldErrors } from "src/components/core/forms/FieldErrors";
 
 const READ_ONLY_OUTPUT_CLASS =
-  "usa-input margin-0 display-inline-block border border-base-light bg-base-lightest text-right text-wrap";
+  "usa-input margin-0 width-full overflow-x-auto display-block border border-base-light bg-base-lightest text-right text-wrap applyform-table-cell-value";
 
 type TableCellProps = {
   /** The cell configuration from the table widget schema */
@@ -109,15 +109,6 @@ function TableCell({
         className={READ_ONLY_OUTPUT_CLASS}
         data-testid={`${id}-read-only`}
         tabIndex={-1}
-        style={{
-          display: "inline-block",
-          width: "100%",
-          boxSizing: "border-box",
-          overflow: "visible",
-          whiteSpace: "nowrap",
-          overflowWrap: "normal",
-          wordBreak: "normal",
-        }}
       >
         {renderedValue === "" ? "\u00A0" : renderedValue}
       </span>
@@ -139,7 +130,9 @@ function TableCell({
       {hasError && <FieldErrors fieldName={id} rawErrors={cellErrors} />}
       <input
         aria-label={ariaLabel ?? `Editable table value for ${cell.definition}`}
-        className={`usa-input margin-0${hasError ? " usa-input--error" : ""}`}
+        className={`usa-input margin-0 width-full overflow-x-auto applyform-table-cell-value${
+          hasError ? " usa-input--error" : ""
+        }`}
         data-testid={`${id}-input`}
         id={inputId}
         name={name}
@@ -151,15 +144,6 @@ function TableCell({
         disabled={disabled}
         aria-invalid={hasError}
         aria-describedby={hasError ? `error-for-${id}` : undefined}
-        style={{
-          display: "inline-block",
-          width: "100%",
-          boxSizing: "border-box",
-          overflow: "visible",
-          whiteSpace: "nowrap",
-          overflowWrap: "normal",
-          wordBreak: "normal",
-        }}
       />
     </>
   );

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.test.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.test.tsx
@@ -1,8 +1,16 @@
+import { readFileSync } from "fs";
+import path from "path";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { TableWidgetProps } from "src/types/applyForm/types";
 import { wrapForExpectedError } from "src/utils/testing/commonTestUtils";
 
 import TableWidget from "./TableWidget";
+
+const printStylesPath = path.resolve(
+  __dirname,
+  "../../../../styles/_uswds-theme-custom-styles.scss",
+);
+const printStylesCss = readFileSync(printStylesPath, "utf8");
 
 describe("TableWidget", () => {
   const props: TableWidgetProps = {
@@ -600,7 +608,7 @@ describe("TableWidget", () => {
       expect(numeric).not.toEqual([50, 25, 25]);
     });
 
-    it("prevents a table row from splitting across a page when printed", () => {
+    it("does not inline print styles in the component; they live in the shared print stylesheet", () => {
       render(
         <TableWidget
           {...props}
@@ -611,21 +619,24 @@ describe("TableWidget", () => {
         />,
       );
 
-      const stylesheet = Array.from(document.styleSheets).find((sheet) =>
-        Array.from(sheet.cssRules).some((rule) =>
-          rule.cssText.includes(".applyform-budget-table tr"),
-        ),
-      );
-      expect(stylesheet).toBeDefined();
-      const cssText = Array.from(stylesheet!.cssRules)
-        .map((rule) => rule.cssText)
-        .join("\n");
+      expect(screen.getByTestId("table")).not.toHaveAttribute("style");
+      expect(printStylesCss).toMatch(/\.applyform-budget-table/);
+    });
 
-      expect(cssText).toMatch(
-        /\.applyform-budget-table tr\s*{[^}]*break-inside:\s*avoid;/,
+    it("prevents a table row from splitting across a page when printed", () => {
+      const tableBlockMatch = printStylesCss.match(
+        /\.applyform-budget-table\s*{[\s\S]*?\r?\n {2}}\r?\n/,
       );
-      expect(cssText).toMatch(
-        /\.applyform-budget-table tr\s*{[^}]*page-break-inside:\s*avoid;/,
+      expect(tableBlockMatch).not.toBeNull();
+      const tableBlock = tableBlockMatch![0];
+
+      expect(tableBlock).toMatch(/tr\s*{[^}]*break-inside:\s*avoid;/);
+      expect(tableBlock).toMatch(/tr\s*{[^}]*page-break-inside:\s*avoid;/);
+    });
+
+    it("resets overflow and max-height on the USWDS scrollable table wrapper during print so the table can paginate across pages", () => {
+      expect(printStylesCss).toMatch(
+        /\.usa-table-container--scrollable\s*{\s*overflow:\s*visible\s*!important;\s*max-height:\s*none\s*!important;/,
       );
     });
 
@@ -640,14 +651,12 @@ describe("TableWidget", () => {
         />,
       );
 
-      const stylesheet = Array.from(document.styleSheets).find(
-        (sheet) =>
-          sheet.cssRules.length > 0 &&
-          Array.from(sheet.cssRules).some((rule) =>
-            rule.cssText.startsWith("@media print"),
-          ),
-      );
-      expect(stylesheet).toBeDefined();
+      // The print rules for .applyform-budget-table live inside an
+      // @media print block in the shared stylesheet.
+      const printBlockStart = printStylesCss.indexOf("@media print");
+      expect(printBlockStart).toBeGreaterThan(-1);
+      const printBlock = printStylesCss.slice(printBlockStart);
+      expect(printBlock.indexOf(".applyform-budget-table")).toBeGreaterThan(-1);
 
       // No inline width leaks onto the table itself outside print.
       expect(screen.getByTestId("table")).not.toHaveAttribute("style");

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.test.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.test.tsx
@@ -49,6 +49,21 @@ describe("TableWidget", () => {
     },
   };
 
+  it("applies the fixed table-layout class so colgroup widths are respected", () => {
+    render(
+      <TableWidget
+        {...props}
+        schema={{}}
+        rawErrors={[]}
+        value={{}}
+        options={{}}
+      />,
+    );
+    expect(screen.getByTestId("table")).toHaveClass(
+      "applyform-table-fixed-layout",
+    );
+  });
+
   it("renders configured table headers and cells", () => {
     render(
       <TableWidget

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.test.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.test.tsx
@@ -49,7 +49,7 @@ describe("TableWidget", () => {
     },
   };
 
-  it("applies the fixed table-layout class so colgroup widths are respected", () => {
+  it("applies the print-scoped table class used to force fixed table-layout in print", () => {
     render(
       <TableWidget
         {...props}
@@ -59,9 +59,7 @@ describe("TableWidget", () => {
         options={{}}
       />,
     );
-    expect(screen.getByTestId("table")).toHaveClass(
-      "applyform-table-fixed-layout",
-    );
+    expect(screen.getByTestId("table")).toHaveClass("applyform-budget-table");
   });
 
   it("renders configured table headers and cells", () => {
@@ -523,5 +521,187 @@ describe("TableWidget", () => {
     );
 
     expect(screen.queryByText("Total cost error")).not.toBeInTheDocument();
+  });
+
+  describe("print layout behavior", () => {
+    it("keeps the interactive on-screen header widths driven by configured column.width", () => {
+      const widthProps: TableWidgetProps = {
+        ...props,
+        uiSchemaField: {
+          ...props.uiSchemaField,
+          children: {
+            columns: [
+              { columnHeader: "Item", width: 50 },
+              { columnHeader: "First Value", width: 25 },
+              { columnHeader: "Second Value", width: 25 },
+            ],
+            rows: props.uiSchemaField.children.rows,
+          },
+        },
+      };
+
+      render(
+        <TableWidget
+          {...widthProps}
+          schema={{}}
+          rawErrors={[]}
+          value={{ first_value: 100, second_value: 200 }}
+          options={{}}
+        />,
+      );
+
+      const headers = screen.getAllByRole("columnheader");
+      expect(headers[0]).toHaveStyle("width: 50%");
+      expect(headers[1]).toHaveStyle("width: 25%");
+      expect(headers[2]).toHaveStyle("width: 25%");
+    });
+
+    it("computes print-only column widths from content, independent of configured column.width", () => {
+      const widthProps: TableWidgetProps = {
+        ...props,
+        uiSchemaField: {
+          ...props.uiSchemaField,
+          children: {
+            columns: [
+              { columnHeader: "Item", width: 50 },
+              { columnHeader: "First Value", width: 25 },
+              { columnHeader: "Second Value", width: 25 },
+            ],
+            rows: props.uiSchemaField.children.rows,
+          },
+        },
+      };
+
+      render(
+        <TableWidget
+          {...widthProps}
+          schema={{}}
+          rawErrors={[]}
+          value={{ first_value: 100, second_value: 200 }}
+          options={{}}
+        />,
+      );
+
+      const tableHtml = screen.getByTestId("table").innerHTML;
+      const colStyles = Array.from(
+        tableHtml.matchAll(/<col[^>]*style="([^"]*)"/g),
+      ).map((match) => match[1]);
+      const printWidths = colStyles.map((style) => {
+        const match = /--applyform-print-col-width:\s*([\d.]+)%/.exec(style);
+        return match ? `${match[1]}%` : "";
+      });
+
+      // Widths should sum to 100% but NOT equal the configured 50/25/25 split —
+      // proving print sizing is content-derived, not copied from column.width.
+      const numeric = printWidths.map((w) => parseFloat(w));
+      const total = numeric.reduce((sum, w) => sum + w, 0);
+
+      expect(total).toBeCloseTo(100, 1);
+      expect(numeric).not.toEqual([50, 25, 25]);
+    });
+
+    it("prevents a table row from splitting across a page when printed", () => {
+      render(
+        <TableWidget
+          {...props}
+          schema={{}}
+          rawErrors={[]}
+          value={{}}
+          options={{}}
+        />,
+      );
+
+      const stylesheet = Array.from(document.styleSheets).find((sheet) =>
+        Array.from(sheet.cssRules).some((rule) =>
+          rule.cssText.includes(".applyform-budget-table tr"),
+        ),
+      );
+      expect(stylesheet).toBeDefined();
+      const cssText = Array.from(stylesheet!.cssRules)
+        .map((rule) => rule.cssText)
+        .join("\n");
+
+      expect(cssText).toMatch(
+        /\.applyform-budget-table tr\s*{[^}]*break-inside:\s*avoid;/,
+      );
+      expect(cssText).toMatch(
+        /\.applyform-budget-table tr\s*{[^}]*page-break-inside:\s*avoid;/,
+      );
+    });
+
+    it("scopes print-only layout changes to @media print, leaving the interactive form untouched", () => {
+      render(
+        <TableWidget
+          {...props}
+          schema={{}}
+          rawErrors={[]}
+          value={{}}
+          options={{}}
+        />,
+      );
+
+      const stylesheet = Array.from(document.styleSheets).find(
+        (sheet) =>
+          sheet.cssRules.length > 0 &&
+          Array.from(sheet.cssRules).some((rule) =>
+            rule.cssText.startsWith("@media print"),
+          ),
+      );
+      expect(stylesheet).toBeDefined();
+
+      // No inline width leaks onto the table itself outside print.
+      expect(screen.getByTestId("table")).not.toHaveAttribute("style");
+
+      const tableHtml = screen.getByTestId("table").innerHTML;
+      const colStyleStrings = Array.from(
+        tableHtml.matchAll(/<col[^>]*style="([^"]*)"/g),
+      ).map((match) => match[1]);
+      expect(colStyleStrings).not.toHaveLength(0);
+      colStyleStrings.forEach((style) => {
+        expect(style).toContain("--applyform-print-col-width");
+      });
+    });
+
+    it("assigns distinct print widths based on content for text and long numeric columns", () => {
+      const longValueProps: TableWidgetProps = {
+        ...props,
+        uiSchemaField: {
+          ...props.uiSchemaField,
+          children: {
+            columns: [
+              { columnHeader: "Item" },
+              { columnHeader: "First Value" },
+              { columnHeader: "Second Value" },
+            ],
+            rows: props.uiSchemaField.children.rows,
+          },
+        },
+      };
+
+      render(
+        <TableWidget
+          {...longValueProps}
+          schema={{}}
+          rawErrors={[]}
+          value={{ first_value: 100, second_value: 987654321 }}
+          options={{}}
+        />,
+      );
+
+      const tableHtml = screen.getByTestId("table").innerHTML;
+      const colStyleStrings = Array.from(
+        tableHtml.matchAll(/<col[^>]*style="([^"]*)"/g),
+      ).map((match) => match[1]);
+      const widths = colStyleStrings.map((style) => {
+        const match = /--applyform-print-col-width:\s*([\d.]+)%/.exec(style);
+        return match ? parseFloat(match[1]) : 0;
+      });
+      const textColWidth = widths[0];
+      const longNumberColWidth = widths[2];
+
+      expect(textColWidth).toBeGreaterThan(0);
+      expect(longNumberColWidth).toBeGreaterThan(0);
+      expect(textColWidth).not.toBe(longNumberColWidth);
+    });
   });
 });

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.tsx
@@ -52,16 +52,15 @@ function getRenderValue(
     : undefined;
 }
 
-const TEXT_COLUMN_UNIT = 16;
-
-const MIN_COLUMN_WIDTH_PERCENT = 10;
-
-const NUMERIC_UNIT_PADDING = 2;
+const PRINT_TEXT_COLUMN_UNIT = 16;
+// Floor so no column collapses to an unusable sliver in print.
+const PRINT_MIN_COLUMN_WIDTH_PERCENT = 10;
 
 /**
  * Determine whether a column is a "text" column (i.e. every populated cell
  * in that column is plainText). Text columns can wrap, so they're sized
- * differently from numeric input/readOnly columns, which must stay on one line.
+ * differently from numeric input/readOnly columns, which must stay on one
+ * line when printed.
  */
 function isPlainTextColumn(
   rows: UiSchemaTableRow[],
@@ -74,8 +73,9 @@ function isPlainTextColumn(
 }
 
 /**
- * Estimate how many "character units" a numeric (input/readOnly) column
- * needs by finding the longest formatted value across all rows.
+ * Find the longest formatted value in a numeric (input/readOnly) column,
+ * across all rows — including computed subtotal/total rows, whose values
+ * can run a digit or two longer than any single input row.
  */
 function getMaxFormattedLength(
   rows: UiSchemaTableRow[],
@@ -96,23 +96,25 @@ function getMaxFormattedLength(
 }
 
 /**
- * Compute column widths (as percentages summing to 100) based on the actual
- * content each column needs to display, rather than a fixed width from the
- * schema. Numeric columns get width proportional to their longest formatted
- * value (since numbers can't wrap onto multiple lines); plainText columns get
- * a fixed, smaller allotment since text can wrap. This keeps values from
- * overflowing their cells both on screen and when printed.
+ * Compute print-only column widths (as percentages summing to 100) based on
+ * the actual content each column needs to display. Numeric columns get width
+ * proportional to their longest formatted value, with a safety buffer that
+ * scales with length (subtotal/total rows tend to be a digit or two longer
+ * than regular rows, and need enough breathing room not to overflow).
+ * plainText columns get a fixed, smaller allotment since text can wrap.
  */
-function computeColumnWidths(
+function computePrintColumnWidths(
   columns: UiSchemaTableColumn[],
   rows: UiSchemaTableRow[],
   value: unknown,
 ): number[] {
   const units = columns.map((_, colIndex) => {
     if (isPlainTextColumn(rows, colIndex)) {
-      return TEXT_COLUMN_UNIT;
+      return PRINT_TEXT_COLUMN_UNIT;
     }
-    return getMaxFormattedLength(rows, colIndex, value) + NUMERIC_UNIT_PADDING;
+    const maxLen = getMaxFormattedLength(rows, colIndex, value);
+    const buffer = Math.max(2, Math.ceil(maxLen * 0.15));
+    return maxLen + buffer;
   });
 
   const total = units.reduce((sum, unit) => sum + unit, 0) || 1;
@@ -120,7 +122,7 @@ function computeColumnWidths(
 
   // Enforce a minimum width so no column collapses, then renormalize to 100%.
   const clamped = rawPercentages.map((pct) =>
-    Math.max(pct, MIN_COLUMN_WIDTH_PERCENT),
+    Math.max(pct, PRINT_MIN_COLUMN_WIDTH_PERCENT),
   );
   const clampedTotal = clamped.reduce((sum, pct) => sum + pct, 0);
 
@@ -231,8 +233,9 @@ function TableWidget({
     (uiSchemaField as UiSchemaTableMultiField | undefined)?.children?.rows ??
     [];
 
-  const columnWidths = useMemo(
-    () => computeColumnWidths(columns, rows, value),
+  // Only used by the print stylesheet below — does not affect on-screen widths.
+  const printColumnWidths = useMemo(
+    () => computePrintColumnWidths(columns, rows, value),
     [columns, rows, value],
   );
 
@@ -386,17 +389,35 @@ function TableWidget({
   return (
     <>
       {/*
-        @trussworks/react-uswds's TableProps intentionally omits `style`, so
-        table-layout: fixed (needed for the colgroup percentages below to be
-        respected instead of overridden by content width) is applied via this
-        class instead of an inline style.
+        Print-only overrides. On screen this changes nothing — table-layout
+        stays at its default (auto) and the colgroup widths below are inert
+        until @media print switches the table to a fixed layout and applies
+        them. This also stops a row's cells from splitting across a page
+        break, which the browser's default table pagination allows otherwise.
       */}
-      <style>{`.applyform-table-fixed-layout { table-layout: fixed; }`}</style>
+      <style>{`
+        @media print {
+          .applyform-budget-table {
+            table-layout: fixed;
+          }
+          .applyform-budget-table col {
+            width: var(--applyform-print-col-width) !important;
+          }
+          .applyform-budget-table tr {
+            break-inside: avoid;
+            page-break-inside: avoid;
+          }
+          .applyform-budget-table .applyform-table-cell-value {
+            white-space: nowrap !important;
+            overflow: visible !important;
+          }
+        }
+      `}</style>
       <Table
         bordered
         fullWidth
         scrollable
-        className="width-full overflow-wrap applyform-table-fixed-layout"
+        className="applyform-budget-table"
         data-testid="table"
         data-table-name={uiSchemaField.name}
         data-table-column-count={columns.length}
@@ -409,7 +430,11 @@ function TableWidget({
           {columns.map((column, index) => (
             <col
               key={column.columnHeader}
-              style={{ width: `${columnWidths[index]}%` }}
+              style={
+                {
+                  "--applyform-print-col-width": `${printColumnWidths[index]}%`,
+                } as React.CSSProperties
+              }
             />
           ))}
         </colgroup>
@@ -419,10 +444,7 @@ function TableWidget({
               <th
                 key={column.columnHeader}
                 scope="col"
-                style={{
-                  whiteSpace: "normal",
-                  overflowWrap: "anywhere",
-                }}
+                style={column.width ? { width: `${column.width}%` } : undefined}
               >
                 {column.columnHeader}
               </th>
@@ -445,11 +467,6 @@ function TableWidget({
                     <td
                       key={`table-row-${rowIndex}-cell-${cellIndex}`}
                       data-table-cell-type={cell.type}
-                      style={{
-                        whiteSpace: "normal",
-                        overflowWrap: "anywhere",
-                        verticalAlign: "top",
-                      }}
                     >
                       <TableCell
                         cell={cell}

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.tsx
@@ -52,9 +52,9 @@ function getRenderValue(
     : undefined;
 }
 
-const PRINT_TEXT_COLUMN_UNIT = 16;
+const PRINT_TEXT_COLUMN_UNIT = 8;
 // Floor so no column collapses to an unusable sliver in print.
-const PRINT_MIN_COLUMN_WIDTH_PERCENT = 10;
+const PRINT_MIN_COLUMN_WIDTH_PERCENT = 6;
 
 /**
  * Determine whether a column is a "text" column (i.e. every populated cell
@@ -388,31 +388,6 @@ function TableWidget({
 
   return (
     <>
-      {/*
-        Print-only overrides. On screen this changes nothing — table-layout
-        stays at its default (auto) and the colgroup widths below are inert
-        until @media print switches the table to a fixed layout and applies
-        them. This also stops a row's cells from splitting across a page
-        break, which the browser's default table pagination allows otherwise.
-      */}
-      <style>{`
-        @media print {
-          .applyform-budget-table {
-            table-layout: fixed;
-          }
-          .applyform-budget-table col {
-            width: var(--applyform-print-col-width) !important;
-          }
-          .applyform-budget-table tr {
-            break-inside: avoid;
-            page-break-inside: avoid;
-          }
-          .applyform-budget-table .applyform-table-cell-value {
-            white-space: nowrap !important;
-            overflow: visible !important;
-          }
-        }
-      `}</style>
       <Table
         bordered
         fullWidth

--- a/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/TableWidget/TableWidget.tsx
@@ -10,6 +10,7 @@ import {
   getFieldNameForHtml,
   jsonSchemaPointerToPath,
 } from "src/utils/applyForm/applyFormUtils";
+import { formatTableCellValue } from "src/utils/applyForm/formatTableCellValue";
 
 import { useCallback, useMemo } from "react";
 import { Table } from "@trussworks/react-uswds";
@@ -49,6 +50,81 @@ function getRenderValue(
   return typeof renderValue === "string" || typeof renderValue === "number"
     ? renderValue
     : undefined;
+}
+
+const TEXT_COLUMN_UNIT = 16;
+
+const MIN_COLUMN_WIDTH_PERCENT = 10;
+
+const NUMERIC_UNIT_PADDING = 2;
+
+/**
+ * Determine whether a column is a "text" column (i.e. every populated cell
+ * in that column is plainText). Text columns can wrap, so they're sized
+ * differently from numeric input/readOnly columns, which must stay on one line.
+ */
+function isPlainTextColumn(
+  rows: UiSchemaTableRow[],
+  colIndex: number,
+): boolean {
+  const cell = rows
+    .map((row) => row.cells[colIndex])
+    .find((candidate) => candidate !== undefined);
+  return !cell || cell.type === "plainText";
+}
+
+/**
+ * Estimate how many "character units" a numeric (input/readOnly) column
+ * needs by finding the longest formatted value across all rows.
+ */
+function getMaxFormattedLength(
+  rows: UiSchemaTableRow[],
+  colIndex: number,
+  value: unknown,
+): number {
+  let maxLen = 0;
+  rows.forEach((row) => {
+    const cell = row.cells[colIndex];
+    if (!cell || cell.type === "plainText") return;
+    const renderValue = getRenderValue(cell.definition, value);
+    const formatted = formatTableCellValue(renderValue, cell.format);
+    if (formatted.length > maxLen) {
+      maxLen = formatted.length;
+    }
+  });
+  return maxLen;
+}
+
+/**
+ * Compute column widths (as percentages summing to 100) based on the actual
+ * content each column needs to display, rather than a fixed width from the
+ * schema. Numeric columns get width proportional to their longest formatted
+ * value (since numbers can't wrap onto multiple lines); plainText columns get
+ * a fixed, smaller allotment since text can wrap. This keeps values from
+ * overflowing their cells both on screen and when printed.
+ */
+function computeColumnWidths(
+  columns: UiSchemaTableColumn[],
+  rows: UiSchemaTableRow[],
+  value: unknown,
+): number[] {
+  const units = columns.map((_, colIndex) => {
+    if (isPlainTextColumn(rows, colIndex)) {
+      return TEXT_COLUMN_UNIT;
+    }
+    return getMaxFormattedLength(rows, colIndex, value) + NUMERIC_UNIT_PADDING;
+  });
+
+  const total = units.reduce((sum, unit) => sum + unit, 0) || 1;
+  const rawPercentages = units.map((unit) => (unit / total) * 100);
+
+  // Enforce a minimum width so no column collapses, then renormalize to 100%.
+  const clamped = rawPercentages.map((pct) =>
+    Math.max(pct, MIN_COLUMN_WIDTH_PERCENT),
+  );
+  const clampedTotal = clamped.reduce((sum, pct) => sum + pct, 0);
+
+  return clamped.map((pct) => (pct / clampedTotal) * 100);
 }
 
 /**
@@ -154,6 +230,11 @@ function TableWidget({
   const rows: UiSchemaTableRow[] =
     (uiSchemaField as UiSchemaTableMultiField | undefined)?.children?.rows ??
     [];
+
+  const columnWidths = useMemo(
+    () => computeColumnWidths(columns, rows, value),
+    [columns, rows, value],
+  );
 
   const cellChangeHandlers = useMemo(
     () =>
@@ -303,84 +384,110 @@ function TableWidget({
   });
 
   return (
-    <Table
-      bordered
-      fullWidth
-      scrollable
-      data-testid="table"
-      data-table-name={uiSchemaField.name}
-      data-table-column-count={columns.length}
-      data-table-row-count={rows.length}
-      caption={
-        <span className="usa-sr-only">{label ?? uiSchemaField.name}</span>
-      }
-    >
-      <thead>
-        <tr>
-          {columns.map((column) => (
-            <th
+    <>
+      {/*
+        @trussworks/react-uswds's TableProps intentionally omits `style`, so
+        table-layout: fixed (needed for the colgroup percentages below to be
+        respected instead of overridden by content width) is applied via this
+        class instead of an inline style.
+      */}
+      <style>{`.applyform-table-fixed-layout { table-layout: fixed; }`}</style>
+      <Table
+        bordered
+        fullWidth
+        scrollable
+        className="width-full overflow-wrap applyform-table-fixed-layout"
+        data-testid="table"
+        data-table-name={uiSchemaField.name}
+        data-table-column-count={columns.length}
+        data-table-row-count={rows.length}
+        caption={
+          <span className="usa-sr-only">{label ?? uiSchemaField.name}</span>
+        }
+      >
+        <colgroup>
+          {columns.map((column, index) => (
+            <col
               key={column.columnHeader}
-              scope="col"
-              style={column.width ? { width: `${column.width}%` } : undefined}
-            >
-              {column.columnHeader}
-            </th>
+              style={{ width: `${columnWidths[index]}%` }}
+            />
           ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, rowIndex) => {
-          const rowLabel =
-            row.cells[0]?.type === "plainText"
-              ? row.cells[0].staticContent
-              : undefined;
+        </colgroup>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th
+                key={column.columnHeader}
+                scope="col"
+                style={{
+                  whiteSpace: "normal",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {column.columnHeader}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => {
+            const rowLabel =
+              row.cells[0]?.type === "plainText"
+                ? row.cells[0].staticContent
+                : undefined;
 
-          return (
-            <tr key={`table-row-${rowIndex}`}>
-              {row.cells.map((cell, cellIndex) => {
-                const cellId = `${uiSchemaField.name}-${rowIndex}-${cellIndex}`;
+            return (
+              <tr key={`table-row-${rowIndex}`}>
+                {row.cells.map((cell, cellIndex) => {
+                  const cellId = `${uiSchemaField.name}-${rowIndex}-${cellIndex}`;
 
-                return (
-                  <td
-                    key={`table-row-${rowIndex}-cell-${cellIndex}`}
-                    data-table-cell-type={cell.type}
-                  >
-                    <TableCell
-                      cell={cell}
-                      cellErrors={getCellErrors(
-                        buildCellName(cell.definition, rowIndex),
-                      )}
-                      disabled={
-                        cell.type === "input" ? isInteractionDisabled : false
-                      }
-                      id={cellId}
-                      name={buildCellName(cell.definition, rowIndex)}
-                      ariaLabel={
-                        cell.type === "input"
-                          ? [rowLabel, columns[cellIndex]?.columnHeader]
-                              .filter(Boolean)
-                              .join(", ")
-                          : undefined
-                      }
-                      onChange={
-                        cell.type === "input" && cell.definition
-                          ? cellChangeHandlers[cell.definition]
-                          : undefined
-                      }
-                      value={
-                        cell.type === "plainText"
-                          ? undefined
-                          : getRenderValue(cell.definition, value)
-                      }
-                    />
-                  </td>
-                );
-              })}
-            </tr>
-          );
-        })}
-      </tbody>
-    </Table>
+                  return (
+                    <td
+                      key={`table-row-${rowIndex}-cell-${cellIndex}`}
+                      data-table-cell-type={cell.type}
+                      style={{
+                        whiteSpace: "normal",
+                        overflowWrap: "anywhere",
+                        verticalAlign: "top",
+                      }}
+                    >
+                      <TableCell
+                        cell={cell}
+                        cellErrors={getCellErrors(
+                          buildCellName(cell.definition, rowIndex),
+                        )}
+                        disabled={
+                          cell.type === "input" ? isInteractionDisabled : false
+                        }
+                        id={cellId}
+                        name={buildCellName(cell.definition, rowIndex)}
+                        ariaLabel={
+                          cell.type === "input"
+                            ? [rowLabel, columns[cellIndex]?.columnHeader]
+                                .filter(Boolean)
+                                .join(", ")
+                            : undefined
+                        }
+                        onChange={
+                          cell.type === "input" && cell.definition
+                            ? cellChangeHandlers[cell.definition]
+                            : undefined
+                        }
+                        value={
+                          cell.type === "plainText"
+                            ? undefined
+                            : getRenderValue(cell.definition, value)
+                        }
+                      />
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    </>
   );
 }
 

--- a/frontend/src/styles/_uswds-theme-custom-styles.scss
+++ b/frontend/src/styles/_uswds-theme-custom-styles.scss
@@ -943,6 +943,33 @@ dl {
     word-break: break-word !important;
     line-height: 1.2 !important;
   }
+
+  // TableWidget (apply-form budget/summary tables)
+  // Forces a fixed table-layout and applies the content-derived column
+  // widths TableWidget computes at render time (--applyform-print-col-width
+  // custom properties on each <col>). On screen this table stays at its
+  // default auto layout; these rules only take effect at print time.
+  .applyform-budget-table {
+    table-layout: fixed;
+
+    col {
+      width: var(--applyform-print-col-width) !important;
+    }
+
+    tr {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
+
+    .applyform-table-cell-value {
+      white-space: nowrap !important;
+      overflow: visible !important;
+    }
+  }
+  .usa-table-container--scrollable {
+    overflow: visible !important;
+    max-height: none !important;
+  }
 }
 
 #user-control {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10792 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

- Added print-specific rendering support for Table widget output.
- Ensured all table cell types are included in print/PDF:
  - editable/input values
  - read-only values
  - calculated values
  - plain-text/static cells
- Updated print styles to reduce clipping/truncation risks.
- Added/wired wrapping behavior for long content in table cells.
- Improved table readability in print/PDF layout (column/row behavior and spacing).
- Addressed multi-page print behavior for longer tables (page-break handling).
- Used SF424-C table schema as the primary development/testing playground.
- Added/updated documentation for Table print/PDF behavior and known limitations.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This PR addresses a gap where interactive Table widget content did not reliably appear (or appeared incorrectly) in generated PDFs/print views.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- [ ] Run the app and navigate to the SF424-C development form/table flow.
- [ ] Enter a mix of values:
  - [ ] short text/numbers
  - [ ] long text values
  - [ ] monetary/numeric values
  - [ ] rows/fields that produce calculated and read-only outputs
- [ ] Generate print preview and PDF output.
- [ ] Verify:
  - [ ] table content appears in output,
  - [ ] editable/read-only/calculated/plain-text values are all present,
  - [ ] no unintended clipping/truncation,
  - [ ] long values wrap or are fully visible,
- [ ] formatting remains readable.
- [ ] Test with enough data to force multi-page output and verify page-break behavior.

How to:

- Replace the code in form SF424C: api/src/form_schema/forms/sf424c/1/0/form_json.py
- navigate to search
- search for all forms / Test Opportunity for SF424C 2.0

### SF424-C schema
```


import uuid

from src.constants.lookup_constants import FormType
from src.db.models.competition_models import Form
from src.form_schema.shared import COMMON_SHARED_V1

FORM_JSON_SCHEMA = {
    "type": "object",
    "required": [],
    "properties": {
        "budget_information": {
            # Table 1 — Budget Information for Construction Programs
            "type": "object",
            "required": [],
            "properties": {
                "administrative_and_legal_expenses": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "land_structures_rights_of_way": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "relocation_expenses": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "architectural_engineering_fees": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "other_architectural_engineering_fees": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "project_inspection_fees": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "site_work": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "demolition_and_removal": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "construction": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                    "required": ["total_cost"],
                },
                "equipment": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "miscellaneous": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "subtotal_1": {
                    # Row 12 — Subtotal (sum of rows 1–11)
                    "allOf": [{"$ref": "#/$defs/budget_calculated_row"}],
                },
                "contingencies": {
                    # Row 13
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "subtotal_2": {
                    # Row 14 — Subtotal (rows 12 + 13)
                    "allOf": [{"$ref": "#/$defs/budget_calculated_row"}],
                },
                "project_income": {
                    "allOf": [{"$ref": "#/$defs/budget_row"}],
                },
                "total_project_costs": {
                    # Row 16 — Total project costs (row 14 - row 15)
                    "allOf": [{"$ref": "#/$defs/budget_calculated_row"}],
                    
                },
            },
        },
        "federal_funding": {
            # Section 17 — Federal Funding
            "type": "object",
            "required": ["federal_percentage_share"],
            "properties": {
                "total_project_costs": {
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_total_non_negative")}
                    ],
                },
                "federal_percentage_share": {
                    "allOf": [{"$ref": COMMON_SHARED_V1.field_ref("percentage")}],
                },
                "federal_funding_share": {
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_total_non_negative")}
                    ],
                },
            },
        },
    },
    "$defs": {
        "budget_row": {
            "type": "object",
            "required": [],
            "properties": {
                "total_cost": {
                    # Column A — Total Cost
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount_non_negative")}
                    ],
                },
                "non_allowable_cost": {
                    # Column B — Costs Not Allowable
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_amount_non_negative")}
                    ],
                },
                "total_allowable_cost": {
                    # Column C — Total Allowable Costs
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_total_non_negative")}
                    ],
                },
            },
        },
        "budget_calculated_row": {
            "type": "object",
            "required": [],
            "properties": {
                "total_cost": {
                    # Column A — Total Cost
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_total_non_negative")}
                    ],
                },
                "non_allowable_cost": {
                    # Column B — Costs Not Allowable
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_total_non_negative")}
                    ],
                },
                "total_allowable_cost": {
                    # Column C — Total Allowable Costs
                    "allOf": [
                        {"$ref": COMMON_SHARED_V1.field_ref("budget_monetary_total_non_negative")}
                    ],
                },
            },
        },
    },
}

FORM_UI_SCHEMA = [
    {
        "name": "Table1",
        "type": "section",
        "label": "Budget Information for Construction Programs",
        "description": "NOTE: Certain Federal assistance programs require additional computations to arrive at the Federal share of project costs eligible for participation. If such is the case, you will be notified.",
        "children": [
            {
                "type": "multiField",
                "name": "budget_424c_table_1",
                "widget": "Table",
                "definition": ["/properties/budget_information"],
                "children": {
                    "columns": [
                        {
                            "columnHeader": "COST CLASSIFICATION",
                            "width": 40,
                        },
                        {
                            "columnHeader": "a. Total Cost",
                            "width": 20,
                        },
                        {
                            "columnHeader": "b. Costs Not Allowable \nfor Participation",
                            "width": 20,
                        },
                        {
                            "columnHeader": "Total Allowable Costs \n(Columns a - b)",
                            "width": 20,
                        },
                    ],
                    "rows": [
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "1. Administrative and legal expenses",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/administrative_and_legal_expenses/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/administrative_and_legal_expenses/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/administrative_and_legal_expenses/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "2. Land, structures, rights-of-way, appraisals, etc.",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/land_structures_rights_of_way/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/land_structures_rights_of_way/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/land_structures_rights_of_way/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "3. Relocation expenses and payments",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/relocation_expenses/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/relocation_expenses/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/relocation_expenses/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "4. Architectural and engineering fees",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/architectural_engineering_fees/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/architectural_engineering_fees/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/architectural_engineering_fees/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "5. Other architectural and engineering fees",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/other_architectural_engineering_fees/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/other_architectural_engineering_fees/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/other_architectural_engineering_fees/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "6. Project inspection fees",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/project_inspection_fees/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/project_inspection_fees/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/project_inspection_fees/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "7. Site work",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/site_work/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/site_work/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/site_work/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "8. Demolition and removal",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/demolition_and_removal/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/demolition_and_removal/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/demolition_and_removal/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "9. Construction",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/construction/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/construction/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/construction/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "10. Equipment",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/equipment/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/equipment/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/equipment/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "11. Miscellaneous",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/miscellaneous/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/miscellaneous/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/miscellaneous/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "12. SUBTOTAL (sum of lines 1-11)",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/subtotal_1/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/subtotal_1/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/subtotal_1/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "13. Contingencies",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/contingencies/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/contingencies/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/contingencies/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "14. SUBTOTAL",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/subtotal_2/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/subtotal_2/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/subtotal_2/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "15. Project (program) income",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/project_income/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "input",
                                    "definition": "/properties/project_income/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/project_income/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "16.  TOTAL PROJECT COSTS (subtract 15 from 14)",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/total_project_costs/properties/total_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/total_project_costs/properties/non_allowable_cost",
                                    "format": "dollar",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/total_project_costs/properties/total_allowable_cost",
                                    "format": "dollar",
                                },
                            ],
                        },
                    ],
                },
            }
        ],
    },
    {
        "name": "Table2",
        "type": "section",
        "label": "Federal Funding",
        "description": "Federal assistance requested, calculate as follows.",
        "children": [
            {
                "type": "multiField",
                "name": "budget_424c_table_2",
                "widget": "Table",
                "definition": ["/properties/federal_funding"],
                "children": {
                    "columns": [
                        {
                            "columnHeader": "Field",
                            "width": 60,
                        },
                        {
                            "columnHeader": "Value",
                            "width": 40,
                        },
                    ],
                    "rows": [
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "Total project costs",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/total_project_costs",
                                    "format": "dollar",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "Federal percentage share \n(Consult Federal agency for Federal percentage share.)",
                                },
                                { 
                                    "type": "input",
                                    "definition": "/properties/federal_percentage_share",
                                    "format": "percentage",
                                },
                            ],
                        },
                        {
                            "cells": [
                                {
                                    "type": "plainText",
                                    "staticContent": "Federal funding share",
                                },
                                {
                                    "type": "readOnly",
                                    "definition": "/properties/federal_funding_share",
                                    "format": "dollar",
                                },
                            ],
                        },
                    ],
                },
            }
        ],
    },
]
FORM_RULE_SCHEMA = {
    ##### PRE-POPULATION RULES
    "budget_information": {
        # Rows 1-11 — total_allowable_cost = total_cost - non_allowable_cost
        "administrative_and_legal_expenses": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.administrative_and_legal_expenses.total_cost",
                        "budget_information.administrative_and_legal_expenses.non_allowable_cost",
                    ],
                }
            }
        },
        "land_structures_rights_of_way": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.land_structures_rights_of_way.total_cost",
                        "budget_information.land_structures_rights_of_way.non_allowable_cost",
                    ],
                }
            }
        },
        "relocation_expenses": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.relocation_expenses.total_cost",
                        "budget_information.relocation_expenses.non_allowable_cost",
                    ],
                }
            }
        },
        "architectural_engineering_fees": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.architectural_engineering_fees.total_cost",
                        "budget_information.architectural_engineering_fees.non_allowable_cost",
                    ],
                }
            }
        },
        "other_architectural_engineering_fees": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.other_architectural_engineering_fees.total_cost",
                        "budget_information.other_architectural_engineering_fees.non_allowable_cost",
                    ],
                }
            }
        },
        "project_inspection_fees": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.project_inspection_fees.total_cost",
                        "budget_information.project_inspection_fees.non_allowable_cost",
                    ],
                }
            }
        },
        "site_work": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.site_work.total_cost",
                        "budget_information.site_work.non_allowable_cost",
                    ],
                }
            }
        },
        "demolition_and_removal": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.demolition_and_removal.total_cost",
                        "budget_information.demolition_and_removal.non_allowable_cost",
                    ],
                }
            }
        },
        "construction": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.construction.total_cost",
                        "budget_information.construction.non_allowable_cost",
                    ],
                }
            }
        },
        "equipment": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.equipment.total_cost",
                        "budget_information.equipment.non_allowable_cost",
                    ],
                }
            }
        },
        "miscellaneous": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.miscellaneous.total_cost",
                        "budget_information.miscellaneous.non_allowable_cost",
                    ],
                }
            }
        },
        # Row 12 — Subtotal 1 (sum of rows 1-11)
        "subtotal_1": {
            "total_cost": {
                "gg_pre_population": {
                    "rule": "sum_monetary",
                    "fields": [
                        "budget_information.administrative_and_legal_expenses.total_cost",
                        "budget_information.land_structures_rights_of_way.total_cost",
                        "budget_information.relocation_expenses.total_cost",
                        "budget_information.architectural_engineering_fees.total_cost",
                        "budget_information.other_architectural_engineering_fees.total_cost",
                        "budget_information.project_inspection_fees.total_cost",
                        "budget_information.site_work.total_cost",
                        "budget_information.demolition_and_removal.total_cost",
                        "budget_information.construction.total_cost",
                        "budget_information.equipment.total_cost",
                        "budget_information.miscellaneous.total_cost",
                    ],
                }
            },
            "non_allowable_cost": {
                "gg_pre_population": {
                    "rule": "sum_monetary",
                    "fields": [
                        "budget_information.administrative_and_legal_expenses.non_allowable_cost",
                        "budget_information.land_structures_rights_of_way.non_allowable_cost",
                        "budget_information.relocation_expenses.non_allowable_cost",
                        "budget_information.architectural_engineering_fees.non_allowable_cost",
                        "budget_information.other_architectural_engineering_fees.non_allowable_cost",
                        "budget_information.project_inspection_fees.non_allowable_cost",
                        "budget_information.site_work.non_allowable_cost",
                        "budget_information.demolition_and_removal.non_allowable_cost",
                        "budget_information.construction.non_allowable_cost",
                        "budget_information.equipment.non_allowable_cost",
                        "budget_information.miscellaneous.non_allowable_cost",
                    ],
                }
            },
            "total_allowable_cost": {
                # Runs after total_cost and non_allowable_cost are set (order 2)
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.subtotal_1.total_cost",
                        "budget_information.subtotal_1.non_allowable_cost",
                    ],
                    "order": 2,
                }
            },
        },
        # Row 13 — Contingencies
        "contingencies": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.contingencies.total_cost",
                        "budget_information.contingencies.non_allowable_cost",
                    ],
                }
            }
        },
        # Row 14 — Subtotal 2 (subtotal_1 + contingencies)
        "subtotal_2": {
            "total_cost": {
                "gg_pre_population": {
                    "rule": "sum_monetary",
                    "fields": [
                        "budget_information.subtotal_1.total_cost",
                        "budget_information.contingencies.total_cost",
                    ],
                    "order": 3,
                }
            },
            "non_allowable_cost": {
                "gg_pre_population": {
                    "rule": "sum_monetary",
                    "fields": [
                        "budget_information.subtotal_1.non_allowable_cost",
                        "budget_information.contingencies.non_allowable_cost",
                    ],
                    "order": 3,
                }
            },
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.subtotal_2.total_cost",
                        "budget_information.subtotal_2.non_allowable_cost",
                    ],
                    "order": 4,
                }
            },
        },
        # Row 15 — Project income
        "project_income": {
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.project_income.total_cost",
                        "budget_information.project_income.non_allowable_cost",
                    ],
                }
            }
        },
        # Row 16 — Total project costs (subtotal_2 - project_income)
        "total_project_costs": {
            "total_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.subtotal_2.total_cost",
                        "budget_information.project_income.total_cost",
                    ],
                    "order": 4,
                }
            },
            "non_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.subtotal_2.non_allowable_cost",
                        "budget_information.project_income.non_allowable_cost",
                    ],
                    "order": 4,
                }
            },
            "total_allowable_cost": {
                "gg_pre_population": {
                    "rule": "subtract_monetary",
                    "fields": [
                        "budget_information.subtotal_2.total_allowable_cost",
                        "budget_information.project_income.total_allowable_cost",
                    ],
                    "order": 5,
                }
            },
        },
    },
    # Section 17 — Federal Funding
    "federal_funding": {
        # Total project costs — copied from Table 1 Row 16 Column C (total_allowable_cost)
        "total_project_costs": {
            "gg_pre_population": {
                "rule": "sum_monetary",
                "fields": ["budget_information.total_project_costs.total_allowable_cost"],
                "order": 6,
            }
        },
        # Federal funding share = total_project_costs * federal_percentage_share / 100
        "federal_funding_share": {
            "gg_pre_population": {
                "rule": "multiply_by_percentage",
                "amount": "federal_funding.total_project_costs",
                "percentage": "federal_funding.federal_percentage_share",
                "order": 7,
            }
        },
    },
}

# XML Transformation Rules for SF-424C v2.0
FORM_XML_TRANSFORM_RULES = {
    # Metadata
    "_xml_config": {
        "description": "XML transformation rules for converting Simpler SF-424C JSON to XML",
        "version": "2.0",
        "form_name": "SF424C",
        "namespaces": {
            "SF424C_2_0": "http://apply.grants.gov/forms/SF424C_2_0-V2.0",
            "default": "http://apply.grants.gov/forms/SF424C_2_0-V2.0",
        },
        "xsd_url": "https://apply07.grants.gov/apply/forms/schemas/SF424C_2_0-V2.0.xsd",
        "xml_structure": {
            "root_element": "SF424C_2_0",
            "root_namespace_prefix": "SF424C_2_0",
            "root_attributes": {
                "programType": "Construction",
                "FormVersion": "2.0",
            },
        },
        "null_handling_options": {
            "exclude": "Default - exclude field entirely from XML (recommended)",
            "include_null": "Include empty XML element: <Field></Field>",
            "default_value": "Use configured default value when field is None",
        },
    },
    # Table 1 - Budget Information for Construction Programs field mappings
    # Each row maps to a ProjectCosts child element in the XSD.
    # Each row has three columns: total_cost (A), non_allowable_cost (B), total_allowable_cost (C).
    "budget_information": {
        "xml_transform": {
            "target": "ProjectCosts",
            "type": "nested_object",
        },
        "administrative_and_legal_expenses": {
            "xml_transform": {"target": "AdministrationCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "land_structures_rights_of_way": {
            "xml_transform": {"target": "LandCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "relocation_expenses": {
            "xml_transform": {"target": "RelocationCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "architectural_engineering_fees": {
            "xml_transform": {"target": "ArchitecturalCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "other_architectural_engineering_fees": {
            "xml_transform": {"target": "OtherArchitecturalCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "project_inspection_fees": {
            "xml_transform": {"target": "InspectionFeesCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "site_work": {
            "xml_transform": {"target": "SiteWorkCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "demolition_and_removal": {
            "xml_transform": {"target": "DemolitionCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "construction": {
            "xml_transform": {"target": "ConstructionCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "equipment": {
            "xml_transform": {"target": "EquipmentCost", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "miscellaneous": {
            "xml_transform": {"target": "Miscellaneous", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        # Subtotal rows — calculated by rules engine; same column structure as user-input rows
        "subtotal_1": {
            "xml_transform": {
                "target": "CostSubtotalBeforeContingencies",
                "type": "nested_object",
            },
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "contingencies": {
            "xml_transform": {"target": "Contingencies", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "subtotal_2": {
            "xml_transform": {
                "target": "CostSubtotalAfterContingencies",
                "type": "nested_object",
            },
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "project_income": {
            "xml_transform": {"target": "ProgramIncome", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
        "total_project_costs": {
            "xml_transform": {"target": "TotalProjectCosts", "type": "nested_object"},
            "total_cost": {"xml_transform": {"target": "BudgetEstimatedCostAmount"}},
            "non_allowable_cost": {"xml_transform": {"target": "BudgetNonAllowableCostAmount"}},
            "total_allowable_cost": {"xml_transform": {"target": "BudgetTotalAllowableCostAmount"}},
        },
    },
    # Section 17 - Federal Funding field mappings
    # Note: No xml_transform on federal_funding itself so its children bubble up to root level,
    # matching the XSD where these are direct children of SF424C_2_0.
    # Note: federal_funding.total_project_costs is UI-only; no XSD element.
    "federal_funding": {
        "federal_percentage_share": {
            "xml_transform": {"target": "FederalFundingPercentageShareValue"}
        },
        "federal_funding_share": {"xml_transform": {"target": "FederalFundingShareValue"}},
    },
}

SF424c_v2_0 = Form(
    # https://www.grants.gov/forms/form-items-description/fid/408
    form_id=uuid.UUID("b98c72d0-4dd4-425f-bb9c-a7b72dc6972b"),
    legacy_form_id=408,
    form_name="Budget Information for Construction Programs (SF-424C)",
    short_form_name="SF424C",
    form_version="2.0",
    agency_code="SGG",
    omb_number="4040-0008",
    form_json_schema=FORM_JSON_SCHEMA,
    form_ui_schema=FORM_UI_SCHEMA,
    form_rule_schema=FORM_RULE_SCHEMA,
    json_to_xml_schema=FORM_XML_TRANSFORM_RULES,
    form_instruction_id=None,
    form_type=FormType.SF424C,
    sgg_version="1.0",
    is_deprecated=False,
)





```