### PR TITLE
[Issue #11759]: add new infra-training environment

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -24,6 +24,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-training
           - grantee1
           - prod
       version:

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -24,6 +24,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-training
           - grantee1
           - grantee2
           - grantor1

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -24,6 +24,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-training
           - grantee1
           - grantee2
           - grantor1

--- a/.github/workflows/cd-metabase.yml
+++ b/.github/workflows/cd-metabase.yml
@@ -21,6 +21,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-training
           - grantee1
           - prod
       image_tag:

--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -21,6 +21,7 @@ on:
           - infra-dev
           - infra-staging
           - training
+          - infra-training
           - grantee1
           - prod
       version:

--- a/infra/analytics/app-config/infra-training.tf
+++ b/infra/analytics/app-config/infra-training.tf
@@ -1,5 +1,10 @@
 # analytics service for the infra-training environment (AWS account 049145893907, network_name "infra-training").
-
+#
+# infra-training mirrors the existing training environment's analytics service +
+# database. A few environment-specific settings are deferred for the initial
+# bring-up because they don't exist yet in the new account:
+#   - HTTPS/custom domains: no ACM certificate
+#   - New Relic entity GUIDs: will migrate existing training to it
 module "infra_training_config" {
   source         = "./env-config"
   project_name   = local.project_name
@@ -19,6 +24,9 @@ module "infra_training_config" {
     # Mirrors training, which posts results to the #z_bot-sprint-reporting channel in slack
     ACTION = "post-results"
   }
+  # Records the intended hostname for this environment; it does not create any DNS
+  # or ACM resources on its own (same as infra-dev/infra-staging). The ACM cert lookup
+  # is gated on enable_https
   domain_name                     = "data.training.simpler.grants.gov"
   enable_https                    = false # No ACM cert / hosted zone in the infra-training account yet
   has_database                    = local.has_database

--- a/infra/analytics/app-config/infra-training.tf
+++ b/infra/analytics/app-config/infra-training.tf
@@ -1,0 +1,38 @@
+# analytics service for the infra-training environment (AWS account 049145893907, network_name "infra-training").
+
+module "infra_training_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  account_name   = "training"
+  environment    = "infra-training"
+  network_name   = "infra-training"
+
+  database_newrelic_entity_guid = ""     # Populate once the New Relic entity for the infra-training analytics RDS cluster exists
+  database_engine_version       = "17.7" # Must be >= the source snapshot's engine version when restoring from a snapshot
+  database_instance_count       = 2
+  database_min_capacity         = 2
+  database_max_capacity         = 2
+
+  service_override_extra_environment_variables = {
+    # Mirrors training, which posts results to the #z_bot-sprint-reporting channel in slack
+    ACTION = "post-results"
+  }
+  domain_name                     = "data.training.simpler.grants.gov"
+  enable_https                    = false # No ACM cert / hosted zone in the infra-training account yet
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = local.enable_notifications
+
+  service_cpu                    = 1024
+  service_memory                 = 8192
+  service_desired_instance_count = 3
+
+  # Enables ECS Exec access for debugging or jump access.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  # Defaults to `false`. Uncomment the next line to enable.
+  # ⚠️ Warning! It is not recommended to enable this in a production environment.
+  # enable_command_execution = true
+}

--- a/infra/analytics/app-config/main.tf
+++ b/infra/analytics/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "infra-dev", "infra-staging"]
+  environments = ["dev", "staging", "prod", "training", "infra-dev", "infra-staging", "infra-training"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -59,6 +59,9 @@ locals {
     # infra-staging is a staging-like environment in the "staging" AWS account
     # (317380566348), running in the "infra-staging" VPC.
     infra-staging = module.infra_staging_config
+    # infra-training is a training-like environment in the "training" AWS account
+    # (049145893907), running in the "infra-training" VPC.
+    infra-training = module.infra_training_config
   }
 
   # Map from environment name to the account name for the AWS account that
@@ -91,13 +94,14 @@ locals {
   #     prod    = "prod"
   #   }
   account_names_by_environment = {
-    shared        = "simpler-grants-gov"
-    dev           = "simpler-grants-gov"
-    staging       = "simpler-grants-gov"
-    prod          = "simpler-grants-gov"
-    training      = "simpler-grants-gov"
-    infra-dev     = "dev"     # infra-dev environment lives in AWS account 061664787759
-    infra-staging = "staging" # infra-staging environment lives in AWS account 317380566348
+    shared         = "simpler-grants-gov"
+    dev            = "simpler-grants-gov"
+    staging        = "simpler-grants-gov"
+    prod           = "simpler-grants-gov"
+    training       = "simpler-grants-gov"
+    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
+    infra-training = "training" # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/analytics/build-repository/infra-training.s3.tfbackend
+++ b/infra/analytics/build-repository/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/analytics/build-repository/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/database/infra-training.s3.tfbackend
+++ b/infra/analytics/database/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/analytics/database/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/service/infra-training.s3.tfbackend
+++ b/infra/analytics/service/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/analytics/service/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -54,6 +54,16 @@ locals {
       "--set-current",
       "--store-version"
     ],
+    # Mirrors training.
+    "infra-training" = [
+      "flask",
+      "data-migration",
+      "load-transform",
+      "--load",
+      "--transform",
+      "--set-current",
+      "--store-version"
+    ],
     grantee1 = [
       "flask",
       "data-migration",
@@ -107,6 +117,11 @@ locals {
       ]
       */
     }
+
+    "infra-training" = {
+      cpu = 1024
+      mem = 4096
+    }
     prod = {
       cpu = 1024
       mem = 4096
@@ -114,81 +129,88 @@ locals {
   }
   sam-extract-args = {
     # In dev/staging we don't fetch extracts, but generate our own
-    dev             = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
-    "infra-dev"     = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
-    staging         = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
-    "infra-staging" = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
-    training        = ["flask", "task", "sam-extracts"]
-    grantee1        = ["flask", "task", "sam-extracts"]
-    grantee2        = ["flask", "task", "sam-extracts"]
-    grantor1        = ["flask", "task", "sam-extracts"]
-    prod            = ["flask", "task", "sam-extracts"]
+    dev              = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
+    "infra-dev"      = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
+    staging          = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
+    "infra-staging"  = ["flask", "task", "sam-extracts", "--no-fetch-extracts", "--setup-lower-env"]
+    training         = ["flask", "task", "sam-extracts"]
+    "infra-training" = ["flask", "task", "sam-extracts"]
+    grantee1         = ["flask", "task", "sam-extracts"]
+    grantee2         = ["flask", "task", "sam-extracts"]
+    grantor1         = ["flask", "task", "sam-extracts"]
+    prod             = ["flask", "task", "sam-extracts"]
   }
   setup-lower-env-agencies-state = {
-    dev             = "ENABLED"
-    "infra-dev"     = "ENABLED"
-    staging         = "ENABLED"
-    "infra-staging" = "ENABLED"
-    training        = "DISABLED"
-    grantee1        = "DISABLED"
-    grantee2        = "DISABLED"
-    grantor1        = "DISABLED"
-    prod            = "DISABLED"
+    dev              = "ENABLED"
+    "infra-dev"      = "ENABLED"
+    staging          = "ENABLED"
+    "infra-staging"  = "ENABLED"
+    training         = "DISABLED"
+    "infra-training" = "DISABLED"
+    grantee1         = "DISABLED"
+    grantee2         = "DISABLED"
+    grantor1         = "DISABLED"
+    prod             = "DISABLED"
   }
   build-automatic-opportunities-state = {
-    dev             = "ENABLED"
-    "infra-dev"     = "ENABLED"
-    staging         = "ENABLED"
-    "infra-staging" = "ENABLED"
-    training        = "ENABLED"
-    grantee1        = "DISABLED"
-    grantee2        = "DISABLED"
-    grantor1        = "DISABLED"
-    prod            = "DISABLED"
+    dev              = "ENABLED"
+    "infra-dev"      = "ENABLED"
+    staging          = "ENABLED"
+    "infra-staging"  = "ENABLED"
+    training         = "ENABLED"
+    "infra-training" = "ENABLED"
+    grantee1         = "DISABLED"
+    grantee2         = "DISABLED"
+    grantor1         = "DISABLED"
+    prod             = "DISABLED"
   }
   load-transform-state = {
-    dev             = "ENABLED"
-    "infra-dev"     = "ENABLED"
-    staging         = "ENABLED"
-    "infra-staging" = "ENABLED"
-    training        = "ENABLED"
-    grantee1        = "ENABLED"
-    grantee2        = "ENABLED"
-    grantor1        = "ENABLED"
-    prod            = "ENABLED"
+    dev              = "ENABLED"
+    "infra-dev"      = "ENABLED"
+    staging          = "ENABLED"
+    "infra-staging"  = "ENABLED"
+    training         = "ENABLED"
+    "infra-training" = "ENABLED"
+    grantee1         = "ENABLED"
+    grantee2         = "ENABLED"
+    grantor1         = "ENABLED"
+    prod             = "ENABLED"
   }
   sam-extracts-state = {
-    dev             = "ENABLED"
-    "infra-dev"     = "ENABLED"
-    staging         = "ENABLED"
-    "infra-staging" = "ENABLED"
-    training        = "ENABLED"
-    grantee1        = "ENABLED"
-    grantee2        = "ENABLED"
-    grantor1        = "ENABLED"
-    prod            = "ENABLED"
+    dev              = "ENABLED"
+    "infra-dev"      = "ENABLED"
+    staging          = "ENABLED"
+    "infra-staging"  = "ENABLED"
+    training         = "ENABLED"
+    "infra-training" = "ENABLED"
+    grantee1         = "ENABLED"
+    grantee2         = "ENABLED"
+    grantor1         = "ENABLED"
+    prod             = "ENABLED"
   }
   create-analytics-db-csvs-state = {
-    dev             = "ENABLED"
-    "infra-dev"     = "ENABLED"
-    staging         = "ENABLED"
-    "infra-staging" = "ENABLED"
-    training        = "ENABLED"
-    grantee1        = "ENABLED"
-    grantee2        = "ENABLED"
-    grantor1        = "ENABLED"
-    prod            = "ENABLED"
+    dev              = "ENABLED"
+    "infra-dev"      = "ENABLED"
+    staging          = "ENABLED"
+    "infra-staging"  = "ENABLED"
+    training         = "ENABLED"
+    "infra-training" = "ENABLED"
+    grantee1         = "ENABLED"
+    grantee2         = "ENABLED"
+    grantor1         = "ENABLED"
+    prod             = "ENABLED"
   }
   email-notification-opportunity-state = {
-    dev             = "ENABLED"
-    "infra-dev"     = "ENABLED"
-    staging         = "ENABLED"
-    "infra-staging" = "ENABLED"
-    training        = "ENABLED"
-    grantee1        = "DISABLED"
-    grantee2        = "DISABLED"
-    grantor1        = "DISABLED"
-    prod            = "ENABLED"
+    dev              = "ENABLED"
+    "infra-dev"      = "ENABLED"
+    staging          = "ENABLED"
+    "infra-staging"  = "ENABLED"
+    training         = "ENABLED"
+    "infra-training" = "ENABLED"
+    grantee1         = "DISABLED"
+    grantee2         = "DISABLED"
+    grantor1         = "DISABLED"
+    prod             = "ENABLED"
   }
   scheduled_jobs = {
     load-transform = {

--- a/infra/api/app-config/infra-training.tf
+++ b/infra/api/app-config/infra-training.tf
@@ -1,0 +1,75 @@
+# api service for the infra-training environment (AWS account 049145893907, network_name "infra-training").
+
+
+module "infra_training_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  environment    = "infra-training"
+  network_name   = "infra-training"
+
+  domain_name            = "api.training.simpler.grants.gov"
+  secondary_domain_names = ["alb.training.simpler.grants.gov"]
+  enable_https           = false
+  # s3_cdn_domain_name = "files.training.simpler.grants.gov" # Set once a hosted zone/ACM cert exists in 049145893907
+  # mtls_domain_name   = "soap.training.simpler.grants.gov"  # Set once a hosted zone/ACM cert exists in 049145893907
+
+  has_database                  = local.has_database
+  database_enable_http_endpoint = true
+  database_engine_version       = "17.7"
+  database_deletion_protection  = false # non-prod experimental environment
+  database_newrelic_entity_guid = ""    # Populate once the New Relic entity for the infra-training RDS cluster exists
+
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = false # Enable once an SES domain identity exists for infra-training
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-training primary ALB exists
+  service_newrelic_mtls_entity_guid = "" # Populate once the New Relic entity for the infra-training mTLS ALB exists
+  api_host_newrelic_entity_guid     = "" # Populate once the New Relic entity for the infra-training ECS service host exists
+
+  # Sizing mirrors training.
+  instance_desired_instance_count = 2
+  instance_scaling_min_capacity   = 2
+  instance_scaling_max_capacity   = 4
+
+  database_min_capacity   = 2
+  database_max_capacity   = 4
+  database_instance_count = 2
+
+  has_search            = true
+  search_engine_version = "OpenSearch_2.15"
+
+  # The reserved-SSO role suffix (AWSReservedSSO_<PermissionSet>_<suffix>) is generated
+  # per AWS account, so the env-config default (which matches the shared account) does not
+  # exist in 049145893907. null falls back to the account root principal; replace with this
+  # account's own AWSReservedSSO_* role name once IAM Identity Center is wired up.
+  search_sso_admin_role_name = null
+
+  service_override_extra_environment_variables = {
+    SAM_GOV_BASE_URL = "https://api.sam.gov"
+
+    # Email notification
+    RESET_EMAILS_WITHOUT_SENDING               = "false"
+    ENABLE_ORG_SAVED_OPPORTUNITY_NOTIFICATIONS = "true"
+    ENABLE_GRANTOR_OPPORTUNITY_ENDPOINTS       = 1
+
+    # Workflow. This is training's internal user id, reused because infra-training's database
+    # is restored from a training snapshot and therefore carries the same user row. The
+    # workflow service REQUIRES this row to exist: brought up against an empty database it
+    # will fail at runtime, not at apply time, so a non-snapshot bring-up must either seed
+    # this user or point this at one that exists. Same arrangement as infra-dev/infra-staging,
+    # which reuse dev's and staging's ids for the same reason.
+    WORKFLOW_SERVICE_INTERNAL_USER_ID = "00bcaf8e-dd04-4fd1-9fb3-ea872a93178d"
+    ENABLE_WORKFLOW_ENDPOINTS         = 1
+  }
+  # Enables ECS Exec access for debugging or jump access.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  # Defaults to `false`, matching training. Uncomment the next line to enable.
+  # enable_command_execution = true
+
+  enable_workflow_service = true
+
+  scanner_provisioned_concurrency = 1
+}

--- a/infra/api/app-config/main.tf
+++ b/infra/api/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -57,6 +57,8 @@ locals {
     infra-dev = module.infra_dev_config
 
     infra-staging = module.infra_staging_config
+
+    infra-training = module.infra_training_config
   }
 
   # Map from environment name to the account name for the AWS account that
@@ -89,15 +91,16 @@ locals {
   #     prod    = "prod"
   #   }
   account_names_by_environment = {
-    shared        = "simpler-grants-gov"
-    dev           = "simpler-grants-gov"
-    grantee1      = "simpler-grants-gov"
-    grantee2      = "simpler-grants-gov"
-    grantor1      = "simpler-grants-gov"
-    staging       = "simpler-grants-gov"
-    prod          = "simpler-grants-gov"
-    infra-dev     = "dev"     # infra-dev environment lives in AWS account 061664787759
-    infra-staging = "staging" # infra-staging environment lives in AWS account 317380566348
+    shared         = "simpler-grants-gov"
+    dev            = "simpler-grants-gov"
+    grantee1       = "simpler-grants-gov"
+    grantee2       = "simpler-grants-gov"
+    grantor1       = "simpler-grants-gov"
+    staging        = "simpler-grants-gov"
+    prod           = "simpler-grants-gov"
+    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
+    infra-training = "training" # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/api/build-repository/infra-training.s3.tfbackend
+++ b/infra/api/build-repository/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/api/build-repository/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/infra-training.s3.tfbackend
+++ b/infra/api/database/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/api/database/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/infra-training.s3.tfbackend
+++ b/infra/api/service/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/api/service/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/app-config/infra-training.tf
+++ b/infra/frontend/app-config/infra-training.tf
@@ -1,0 +1,30 @@
+# frontend service for the infra-training environment (AWS account 049145893907, network_name "infra-training").
+
+module "infra_training_config" {
+  source                          = "./env-config"
+  project_name                    = local.project_name
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "infra-training"
+  network_name                    = "infra-training"
+  domain_name                     = null # "infra-training.simpler.grants.gov" once DNS + certs exist
+  enable_https                    = false
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = local.enable_notifications
+
+  # Sizing mirrors training.
+  instance_desired_instance_count = 4
+  instance_scaling_min_capacity   = 4
+  instance_scaling_max_capacity   = 20
+  instance_cpu                    = 1024
+  instance_memory                 = 2048
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-training frontend ALB exists
+  service_host_newrelic_entity_guid = "" # Populate once the New Relic browser entity for the infra-training frontend exists
+
+  # Enables ECS Exec access for debugging or jump access.
+  # Defaults to `false`. Uncomment the next line to enable.
+  # enable_command_execution = true
+}

--- a/infra/frontend/app-config/main.tf
+++ b/infra/frontend/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -64,6 +64,8 @@ locals {
     infra-dev = module.infra_dev_config
 
     infra-staging = module.infra_staging_config
+
+    infra-training = module.infra_training_config
   }
   # Map from environment name to the account name for the AWS account that
   # contains the resources for that environment. Resources that are shared
@@ -95,15 +97,16 @@ locals {
   #     prod    = "prod"
   #   }
   account_names_by_environment = {
-    shared        = "simpler-grants-gov"
-    dev           = "simpler-grants-gov"
-    staging       = "simpler-grants-gov"
-    prod          = "simpler-grants-gov"
-    grantee1      = "simpler-grants-gov"
-    grantee2      = "simpler-grants-gov"
-    grantor1      = "simpler-grants-gov"
-    infra-dev     = "dev"     # infra-dev environment lives in AWS account 061664787759
-    infra-staging = "staging" # infra-staging environment lives in AWS account 317380566348
+    shared         = "simpler-grants-gov"
+    dev            = "simpler-grants-gov"
+    staging        = "simpler-grants-gov"
+    prod           = "simpler-grants-gov"
+    grantee1       = "simpler-grants-gov"
+    grantee2       = "simpler-grants-gov"
+    grantor1       = "simpler-grants-gov"
+    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
+    infra-training = "training" # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/frontend/build-repository/infra-training.s3.tfbackend
+++ b/infra/frontend/build-repository/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/frontend/build-repository/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/infra-training.s3.tfbackend
+++ b/infra/frontend/service/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/frontend/service/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/metabase/app-config/infra-training.tf
+++ b/infra/metabase/app-config/infra-training.tf
@@ -9,7 +9,9 @@ module "infra_training_config" {
   environment    = "infra-training"
   network_name   = "infra-training"
 
-  # Analytics database that Metabase connects to
+  # Analytics database that Metabase connects to. Must match the cluster name the
+  # analytics database module creates for this environment, which is
+  # "${app_name}-${environment}" (see analytics/app-config/env-config/database.tf).
   analytics_database_cluster_name = "analytics-infra-training"
 
   domain_name  = null

--- a/infra/metabase/app-config/infra-training.tf
+++ b/infra/metabase/app-config/infra-training.tf
@@ -1,0 +1,25 @@
+# Metabase service for the infra-training environment (AWS account 049145893907, network_name "infra-training").
+
+
+module "infra_training_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  environment    = "infra-training"
+  network_name   = "infra-training"
+
+  # Analytics database that Metabase connects to
+  analytics_database_cluster_name = "analytics-infra-training"
+
+  domain_name  = null
+  enable_https = false
+
+  # Same as the existing training environment
+  service_cpu    = 1024
+  service_memory = 2048
+
+  service_desired_instance_count = 1
+  instance_scaling_min_capacity  = 1
+  instance_scaling_max_capacity  = 2
+}

--- a/infra/metabase/app-config/main.tf
+++ b/infra/metabase/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging", "infra-training"]
   project_name = module.project_config.project_name
 
   # Metabase uses the analytics database instead of its own
@@ -31,19 +31,22 @@ locals {
     # infra-staging is a staging-like environment in the "staging" AWS account
     # (317380566348), running in the "infra-staging" VPC.
     infra-staging = module.infra_staging_config
+
+    infra-training = module.infra_training_config
   }
 
   # Map from environment name to the account name for the AWS account that
   # contains the resources for that environment
   account_names_by_environment = {
-    shared        = "simpler-grants-gov"
-    dev           = "simpler-grants-gov"
-    staging       = "simpler-grants-gov"
-    prod          = "simpler-grants-gov"
-    training      = "simpler-grants-gov"
-    grantee1      = "simpler-grants-gov"
-    infra-dev     = "dev"     # infra-dev environment lives in AWS account 061664787759
-    infra-staging = "staging" # infra-staging environment lives in AWS account 317380566348
+    shared         = "simpler-grants-gov"
+    dev            = "simpler-grants-gov"
+    staging        = "simpler-grants-gov"
+    prod           = "simpler-grants-gov"
+    training       = "simpler-grants-gov"
+    grantee1       = "simpler-grants-gov"
+    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
+    infra-training = "training" # infra-training environment lives in AWS account 049145893907
   }
 
   # Use the same shared network as analytics since metabase shares its database

--- a/infra/metabase/service/infra-training.s3.tfbackend
+++ b/infra/metabase/service/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/metabase/service/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/modules/database/role_manager.tf
+++ b/infra/modules/database/role_manager.tf
@@ -30,9 +30,9 @@ resource "aws_lambda_function" "role_manager" {
 
   environment {
     variables = {
-      DB_HOST                = aws_rds_cluster.db.endpoint
-      DB_PORT                = aws_rds_cluster.db.port
-      DB_USER                = local.master_username
+      DB_HOST = aws_rds_cluster.db.endpoint
+      DB_PORT = aws_rds_cluster.db.port
+      DB_USER                = aws_rds_cluster.db.master_username
       DB_NAME                = aws_rds_cluster.db.database_name
       DB_PASSWORD_PARAM_NAME = local.db_password_param_name
       DB_PASSWORD_SECRET_ARN = aws_rds_cluster.db.master_user_secret[0].secret_arn

--- a/infra/modules/database/role_manager.tf
+++ b/infra/modules/database/role_manager.tf
@@ -30,8 +30,8 @@ resource "aws_lambda_function" "role_manager" {
 
   environment {
     variables = {
-      DB_HOST = aws_rds_cluster.db.endpoint
-      DB_PORT = aws_rds_cluster.db.port
+      DB_HOST                = aws_rds_cluster.db.endpoint
+      DB_PORT                = aws_rds_cluster.db.port
       DB_USER                = aws_rds_cluster.db.master_username
       DB_NAME                = aws_rds_cluster.db.database_name
       DB_PASSWORD_PARAM_NAME = local.db_password_param_name

--- a/infra/modules/database/role_manager.tf
+++ b/infra/modules/database/role_manager.tf
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "role_manager" {
     variables = {
       DB_HOST                = aws_rds_cluster.db.endpoint
       DB_PORT                = aws_rds_cluster.db.port
-      DB_USER                = aws_rds_cluster.db.master_username
+      DB_USER                = local.master_username
       DB_NAME                = aws_rds_cluster.db.database_name
       DB_PASSWORD_PARAM_NAME = local.db_password_param_name
       DB_PASSWORD_SECRET_ARN = aws_rds_cluster.db.master_user_secret[0].secret_arn

--- a/infra/networks/infra-training.s3.tfbackend
+++ b/infra/networks/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/networks/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/app-config/infra-training.tf
+++ b/infra/nofos/app-config/infra-training.tf
@@ -1,0 +1,24 @@
+# nofos service for the infra-training environment (AWS account 049145893907, network_name "infra-training").
+
+module "infra_training_config" {
+  source                          = "./env-config"
+  project_name                    = local.project_name
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "infra-training"
+  network_name                    = "infra-training"
+  domain_name                     = null  # "nofos.training.simpler.grants.gov" once DNS + certs exist in the training account
+  enable_https                    = false # No ACM cert / hosted zone in the infra-training account yet
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_notifications            = local.enable_notifications
+  enable_identity_provider        = local.enable_identity_provider
+
+  database_newrelic_entity_guid = ""     # Populate once the New Relic entity for the infra-training nofos RDS cluster exists
+  database_engine_version       = "17.7" # Must be >= the source snapshot's engine version when restoring from a snapshot
+  database_min_capacity         = 1
+  database_max_capacity         = 1
+  database_instance_count       = 1
+
+  service_override_extra_environment_variables = {}
+}

--- a/infra/nofos/app-config/main.tf
+++ b/infra/nofos/app-config/main.tf
@@ -54,7 +54,7 @@ locals {
     infra-dev = module.infra_dev_config
     # infra-staging is a staging-like environment in the "staging" AWS account
     # (317380566348), running in the "infra-staging" VPC.
-    infra-staging = module.infra_staging_config
+    infra-staging  = module.infra_staging_config
     infra-training = module.infra_training_config
   }
 

--- a/infra/nofos/app-config/main.tf
+++ b/infra/nofos/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging", "infra-training"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -55,20 +55,22 @@ locals {
     # infra-staging is a staging-like environment in the "staging" AWS account
     # (317380566348), running in the "infra-staging" VPC.
     infra-staging = module.infra_staging_config
+    infra-training = module.infra_training_config
   }
 
   # Map from environment name to the account name for the AWS account that
   # contains the resources for that environment. Resources that are shared
   # across environments use the key "shared".
   account_names_by_environment = {
-    shared        = "simpler-grants-gov"
-    dev           = "simpler-grants-gov"
-    staging       = "simpler-grants-gov"
-    prod          = "simpler-grants-gov"
-    training      = "simpler-grants-gov"
-    grantee1      = "simpler-grants-gov"
-    infra-dev     = "dev"     # infra-dev environment lives in AWS account 061664787759
-    infra-staging = "staging" # infra-staging environment lives in AWS account 317380566348
+    shared         = "simpler-grants-gov"
+    dev            = "simpler-grants-gov"
+    staging        = "simpler-grants-gov"
+    prod           = "simpler-grants-gov"
+    training       = "simpler-grants-gov"
+    grantee1       = "simpler-grants-gov"
+    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
+    infra-training = "training" # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/nofos/build-repository/infra-training.s3.tfbackend
+++ b/infra/nofos/build-repository/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/nofos/build-repository/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/database/infra-training.s3.tfbackend
+++ b/infra/nofos/database/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/nofos/database/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/service/infra-training.s3.tfbackend
+++ b/infra/nofos/service/infra-training.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-049145893907-us-east-1-tf"
+key            = "infra/nofos/service/infra-training.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -175,5 +175,22 @@ locals {
         certificate_configs = {}
       }
     }
+
+    infra-training = {
+      account_name                 = "training" # AWS account 049145893907 (see infra/accounts/training.049145893907.s3.tfbackend)
+      database_subnet_group_name   = "infra-training"
+      vpc_name                     = "infra-training"
+      second_octet                 = 7               # The second octet of the VPC CIDR block (10.7.0.0/20)
+      grants_gov_oracle_cidr_block = "10.207.0.0/16" # MicroHealth managed CIDR block where the training origin Oracle database for Grants.gov is located
+
+      enable_dms = true
+
+      domain_config = {
+        manage_dns  = false
+        hosted_zone = null # DNS is managed externally; set once a Route53 hosted zone is created
+
+        certificate_configs = {}
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Added the new environment infra-training. 

## Validation steps

All scans should be passing below. 

Deployed to infra-training api: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30591602262)

Deployed to infra-training frontend: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30591790587)

Deployed to infra-training analytics: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30591585960/job/91035156679)

Deployed to infra-training nofos: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30592020734)

Deployed to infra-training metabase: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30591893728)