### PR TITLE
[unticketed] Remove duplicate application attachment audit logging event

### DIFF
--- a/api/src/services/applications/create_application_attachment_from_pending_file.py
+++ b/api/src/services/applications/create_application_attachment_from_pending_file.py
@@ -8,10 +8,9 @@ from sqlalchemy import func, select
 
 from src.app_config import AppConfig
 from src.auth.endpoint_access_util import check_user_access
-from src.constants.lookup_constants import ApplicationAuditEvent, Privilege, SubmissionIssue
+from src.constants.lookup_constants import Privilege, SubmissionIssue
 from src.db.models.competition_models import ApplicationAttachment
 from src.db.models.user_models import User
-from src.services.applications.application_audit import add_audit_event
 from src.services.applications.create_application_attachment import (
     build_s3_application_attachment_path,
 )
@@ -97,14 +96,6 @@ def create_application_attachment_from_pending_file(
     application_attachment.file_size_bytes = file_size_bytes
     application_attachment.user = user
     db_session.add(application_attachment)
-
-    add_audit_event(
-        db_session=db_session,
-        application=application,
-        user=user,
-        audit_event=ApplicationAuditEvent.ATTACHMENT_ADDED,
-        target_attachment=application_attachment,
-    )
 
     # Move (not copy) after all DB operations — pending file is consumed and
     # its status is set to PROCESSED.

--- a/api/tests/src/api/application_v1/test_create_application_attachment.py
+++ b/api/tests/src/api/application_v1/test_create_application_attachment.py
@@ -3,7 +3,7 @@ import uuid
 import grants_shared.util.file_util as file_util
 from sqlalchemy import select
 
-from src.constants.lookup_constants import ApplicationAuditEvent, FileScanStatus, Privilege
+from src.constants.lookup_constants import FileScanStatus, Privilege
 from src.db.models.competition_models import ApplicationAttachment
 from tests.lib.application_test_utils import create_user_in_app
 from tests.src.db.models.factories import (

--- a/api/tests/src/api/application_v1/test_create_application_attachment.py
+++ b/api/tests/src/api/application_v1/test_create_application_attachment.py
@@ -75,11 +75,7 @@ def test_create_application_attachment_200(db_session, enable_factory_create, cl
 
     # Audit event recorded
     db_session.refresh(application)
-    assert len(application.application_audits) == 1
-    audit = application.application_audits[0]
-    assert audit.application_audit_event == ApplicationAuditEvent.ATTACHMENT_ADDED
-    assert audit.user_id == user.user_id
-    assert str(audit.target_attachment_id) == attachment_id
+    assert len(application.application_audits) == 0
 
 
 def test_create_application_attachment_401_missing_token(db_session, enable_factory_create, client):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
This pr removes the functionality to insert an entry into the application audit log table. This audit event should only be captured upon the saving of an application form.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Audit logging for attachments being added to an application are processed in the form save endpoint. See [this](https://github.com/HHS/simpler-grants-gov/blob/6a354998ae0a692a5acfd94a6f3fd924b01e2c4f/api/src/services/applications/process_application_attachment_changes.py#L90) method.

This will ensure that the application audit history table in the frontend does not render duplicate entries for attachment creations.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Ensure unit test pass for audit logging on api route