### PR TITLE
[Issue #11790]: add new infra-grantor1 environment

### DIFF
--- a/.github/workflows/cd-analytics.yml
+++ b/.github/workflows/cd-analytics.yml
@@ -24,6 +24,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-grantor1
           - infra-training
           - grantee1
           - prod

--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -24,6 +24,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-grantor1
           - infra-training
           - grantee1
           - grantee2

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -24,6 +24,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-grantor1
           - infra-training
           - grantee1
           - grantee2

--- a/.github/workflows/cd-metabase.yml
+++ b/.github/workflows/cd-metabase.yml
@@ -21,6 +21,7 @@ on:
           - staging
           - infra-staging
           - training
+          - infra-grantor1
           - infra-training
           - grantee1
           - prod

--- a/.github/workflows/cd-nofos.yml
+++ b/.github/workflows/cd-nofos.yml
@@ -21,6 +21,7 @@ on:
           - infra-dev
           - infra-staging
           - training
+          - infra-grantor1
           - infra-training
           - grantee1
           - prod

--- a/infra/analytics/app-config/infra-grantor1.tf
+++ b/infra/analytics/app-config/infra-grantor1.tf
@@ -1,0 +1,46 @@
+# analytics service for the infra-grantor1 environment (AWS account 315341936575, network_name "infra-grantor1").
+#
+# infra-grantor1 mirrors the existing training environment's analytics service +
+# database. A few environment-specific settings are deferred for the initial
+# bring-up because they don't exist yet in the new account:
+#   - HTTPS/custom domains: no ACM certificate
+#   - New Relic entity GUIDs: will migrate existing training to it
+module "infra_grantor1_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  account_name   = "simpler-grants-gov"
+  environment    = "infra-grantor1"
+  network_name   = "infra-grantor1"
+
+  database_newrelic_entity_guid = ""     # Populate once the New Relic entity for the infra-grantor1 analytics RDS cluster exists
+  database_engine_version       = "17.7" # Must be >= the source snapshot's engine version when restoring from a snapshot
+  database_instance_count       = 2
+  database_min_capacity         = 2
+  database_max_capacity         = 2
+
+  service_override_extra_environment_variables = {
+    # Mirrors training, which posts results to the #z_bot-sprint-reporting channel in slack
+    ACTION = "post-results"
+  }
+  # Records the intended hostname for this environment; it does not create any DNS
+  # or ACM resources on its own (same as infra-dev/infra-staging). The ACM cert lookup
+  # is gated on enable_https
+  domain_name                     = null  # set once DNS + ACM exist in this env
+  enable_https                    = false # No ACM cert / hosted zone in the infra-grantor1 account yet
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = local.enable_notifications
+
+  service_cpu                    = 1024
+  service_memory                 = 8192
+  service_desired_instance_count = 3
+
+  # Enables ECS Exec access for debugging or jump access.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  # Defaults to `false`. Uncomment the next line to enable.
+  # ⚠️ Warning! It is not recommended to enable this in a production environment.
+  # enable_command_execution = true
+}

--- a/infra/analytics/app-config/main.tf
+++ b/infra/analytics/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "infra-dev", "infra-staging", "infra-training"]
+  environments = ["dev", "staging", "prod", "training", "infra-dev", "infra-staging", "infra-training", "infra-grantor1"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -58,7 +58,8 @@ locals {
     infra-dev = module.infra_dev_config
     # infra-staging is a staging-like environment in the "staging" AWS account
     # (317380566348), running in the "infra-staging" VPC.
-    infra-staging = module.infra_staging_config
+    infra-staging  = module.infra_staging_config
+    infra-grantor1 = module.infra_grantor1_config
     # infra-training is a training-like environment in the "training" AWS account
     # (049145893907), running in the "infra-training" VPC.
     infra-training = module.infra_training_config
@@ -99,9 +100,10 @@ locals {
     staging        = "simpler-grants-gov"
     prod           = "simpler-grants-gov"
     training       = "simpler-grants-gov"
-    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
-    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
-    infra-training = "training" # infra-training environment lives in AWS account 049145893907
+    infra-dev      = "dev"                # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"            # infra-staging environment lives in AWS account 317380566348
+    infra-grantor1 = "simpler-grants-gov" # reuses the main simpler-grants-gov account (315341936575) with its own VPC
+    infra-training = "training"           # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/analytics/build-repository/infra-grantor1.s3.tfbackend
+++ b/infra/analytics/build-repository/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/analytics/build-repository/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/database/infra-grantor1.s3.tfbackend
+++ b/infra/analytics/database/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/analytics/database/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/analytics/service/infra-grantor1.s3.tfbackend
+++ b/infra/analytics/service/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/analytics/service/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/app-config/infra-grantor1.tf
+++ b/infra/api/app-config/infra-grantor1.tf
@@ -1,0 +1,75 @@
+# api service for the infra-grantor1 environment (AWS account 315341936575, network_name "infra-grantor1").
+
+
+module "infra_grantor1_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  environment    = "infra-grantor1"
+  network_name   = "infra-grantor1"
+
+  domain_name            = null # set once DNS + ACM exist in this env
+  secondary_domain_names = []   # set once DNS + ACM exist in this env
+  enable_https           = false
+  # s3_cdn_domain_name = "files.training.simpler.grants.gov" # Set once a hosted zone/ACM cert exists in 315341936575
+  # mtls_domain_name   = "soap.training.simpler.grants.gov"  # Set once a hosted zone/ACM cert exists in 315341936575
+
+  has_database                  = local.has_database
+  database_enable_http_endpoint = true
+  database_engine_version       = "17.7"
+  database_deletion_protection  = false # non-prod experimental environment
+  database_newrelic_entity_guid = ""    # Populate once the New Relic entity for the infra-grantor1 RDS cluster exists
+
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = false # Enable once an SES domain identity exists for infra-grantor1
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantor1 primary ALB exists
+  service_newrelic_mtls_entity_guid = "" # Populate once the New Relic entity for the infra-grantor1 mTLS ALB exists
+  api_host_newrelic_entity_guid     = "" # Populate once the New Relic entity for the infra-grantor1 ECS service host exists
+
+  # Sizing mirrors training.
+  instance_desired_instance_count = 2
+  instance_scaling_min_capacity   = 2
+  instance_scaling_max_capacity   = 4
+
+  database_min_capacity   = 2
+  database_max_capacity   = 4
+  database_instance_count = 2
+
+  has_search            = true
+  search_engine_version = "OpenSearch_2.15"
+
+  # The reserved-SSO role suffix (AWSReservedSSO_<PermissionSet>_<suffix>) is generated
+  # per AWS account, so the env-config default (which matches the shared account) does not
+  # exist in 315341936575. null falls back to the account root principal; replace with this
+  # account's own AWSReservedSSO_* role name once IAM Identity Center is wired up.
+  search_sso_admin_role_name = null
+
+  service_override_extra_environment_variables = {
+    SAM_GOV_BASE_URL = "https://api.sam.gov"
+
+    # Email notification
+    RESET_EMAILS_WITHOUT_SENDING               = "false"
+    ENABLE_ORG_SAVED_OPPORTUNITY_NOTIFICATIONS = "true"
+    ENABLE_GRANTOR_OPPORTUNITY_ENDPOINTS       = 1
+
+    # Workflow. This is training's internal user id, reused because infra-grantor1's database
+    # is restored from a training snapshot and therefore carries the same user row. The
+    # workflow service REQUIRES this row to exist: brought up against an empty database it
+    # will fail at runtime, not at apply time, so a non-snapshot bring-up must either seed
+    # this user or point this at one that exists. Same arrangement as infra-dev/infra-staging,
+    # which reuse dev's and staging's ids for the same reason.
+    WORKFLOW_SERVICE_INTERNAL_USER_ID = "00bcaf8e-dd04-4fd1-9fb3-ea872a93178d"
+    ENABLE_WORKFLOW_ENDPOINTS         = 1
+  }
+  # Enables ECS Exec access for debugging or jump access.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  # Defaults to `false`, matching training. Uncomment the next line to enable.
+  # enable_command_execution = true
+
+  enable_workflow_service = true
+
+  scanner_provisioned_concurrency = 1
+}

--- a/infra/api/app-config/main.tf
+++ b/infra/api/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training", "infra-grantor1"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -56,7 +56,8 @@ locals {
     # (see infra/sgm/service).
     infra-dev = module.infra_dev_config
 
-    infra-staging = module.infra_staging_config
+    infra-staging  = module.infra_staging_config
+    infra-grantor1 = module.infra_grantor1_config
 
     infra-training = module.infra_training_config
   }
@@ -98,9 +99,10 @@ locals {
     grantor1       = "simpler-grants-gov"
     staging        = "simpler-grants-gov"
     prod           = "simpler-grants-gov"
-    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
-    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
-    infra-training = "training" # infra-training environment lives in AWS account 049145893907
+    infra-dev      = "dev"                # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"            # infra-staging environment lives in AWS account 317380566348
+    infra-grantor1 = "simpler-grants-gov" # reuses the main simpler-grants-gov account (315341936575) with its own VPC
+    infra-training = "training"           # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/api/build-repository/infra-grantor1.s3.tfbackend
+++ b/infra/api/build-repository/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/api/build-repository/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/infra-grantor1.s3.tfbackend
+++ b/infra/api/database/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/api/database/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/infra-grantor1.s3.tfbackend
+++ b/infra/api/service/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/api/service/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/app-config/infra-grantor1.tf
+++ b/infra/frontend/app-config/infra-grantor1.tf
@@ -1,0 +1,30 @@
+# frontend service for the infra-grantor1 environment (AWS account 315341936575, network_name "infra-grantor1").
+
+module "infra_grantor1_config" {
+  source                          = "./env-config"
+  project_name                    = local.project_name
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "infra-grantor1"
+  network_name                    = "infra-grantor1"
+  domain_name                     = null # "infra-grantor1.simpler.grants.gov" once DNS + certs exist
+  enable_https                    = false
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = local.enable_notifications
+
+  # Sizing mirrors training.
+  instance_desired_instance_count = 4
+  instance_scaling_min_capacity   = 4
+  instance_scaling_max_capacity   = 20
+  instance_cpu                    = 1024
+  instance_memory                 = 2048
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantor1 frontend ALB exists
+  service_host_newrelic_entity_guid = "" # Populate once the New Relic browser entity for the infra-grantor1 frontend exists
+
+  # Enables ECS Exec access for debugging or jump access.
+  # Defaults to `false`. Uncomment the next line to enable.
+  # enable_command_execution = true
+}

--- a/infra/frontend/app-config/main.tf
+++ b/infra/frontend/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training", "infra-grantor1"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -63,7 +63,8 @@ locals {
     # (see infra/sgm/service).
     infra-dev = module.infra_dev_config
 
-    infra-staging = module.infra_staging_config
+    infra-staging  = module.infra_staging_config
+    infra-grantor1 = module.infra_grantor1_config
 
     infra-training = module.infra_training_config
   }
@@ -104,9 +105,10 @@ locals {
     grantee1       = "simpler-grants-gov"
     grantee2       = "simpler-grants-gov"
     grantor1       = "simpler-grants-gov"
-    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
-    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
-    infra-training = "training" # infra-training environment lives in AWS account 049145893907
+    infra-dev      = "dev"                # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"            # infra-staging environment lives in AWS account 317380566348
+    infra-grantor1 = "simpler-grants-gov" # reuses the main simpler-grants-gov account (315341936575) with its own VPC
+    infra-training = "training"           # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/frontend/build-repository/infra-grantor1.s3.tfbackend
+++ b/infra/frontend/build-repository/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/frontend/build-repository/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/infra-grantor1.s3.tfbackend
+++ b/infra/frontend/service/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/frontend/service/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/metabase/app-config/infra-grantor1.tf
+++ b/infra/metabase/app-config/infra-grantor1.tf
@@ -1,0 +1,27 @@
+# Metabase service for the infra-grantor1 environment (AWS account 315341936575, network_name "infra-grantor1").
+
+
+module "infra_grantor1_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  environment    = "infra-grantor1"
+  network_name   = "infra-grantor1"
+
+  # Analytics database that Metabase connects to. Must match the cluster name the
+  # analytics database module creates for this environment, which is
+  # "${app_name}-${environment}" (see analytics/app-config/env-config/database.tf).
+  analytics_database_cluster_name = "analytics-infra-grantor1"
+
+  domain_name  = null
+  enable_https = false
+
+  # Same as the existing training environment
+  service_cpu    = 1024
+  service_memory = 2048
+
+  service_desired_instance_count = 1
+  instance_scaling_min_capacity  = 1
+  instance_scaling_max_capacity  = 2
+}

--- a/infra/metabase/app-config/main.tf
+++ b/infra/metabase/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging", "infra-training"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging", "infra-training", "infra-grantor1"]
   project_name = module.project_config.project_name
 
   # Metabase uses the analytics database instead of its own
@@ -30,7 +30,8 @@ locals {
     infra-dev = module.infra_dev_config
     # infra-staging is a staging-like environment in the "staging" AWS account
     # (317380566348), running in the "infra-staging" VPC.
-    infra-staging = module.infra_staging_config
+    infra-staging  = module.infra_staging_config
+    infra-grantor1 = module.infra_grantor1_config
 
     infra-training = module.infra_training_config
   }
@@ -44,9 +45,10 @@ locals {
     prod           = "simpler-grants-gov"
     training       = "simpler-grants-gov"
     grantee1       = "simpler-grants-gov"
-    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
-    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
-    infra-training = "training" # infra-training environment lives in AWS account 049145893907
+    infra-dev      = "dev"                # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"            # infra-staging environment lives in AWS account 317380566348
+    infra-grantor1 = "simpler-grants-gov" # reuses the main simpler-grants-gov account (315341936575) with its own VPC
+    infra-training = "training"           # infra-training environment lives in AWS account 049145893907
   }
 
   # Use the same shared network as analytics since metabase shares its database

--- a/infra/metabase/service/infra-grantor1.s3.tfbackend
+++ b/infra/metabase/service/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/metabase/service/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/infra-grantor1.s3.tfbackend
+++ b/infra/networks/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/networks/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/app-config/infra-grantor1.tf
+++ b/infra/nofos/app-config/infra-grantor1.tf
@@ -1,0 +1,24 @@
+# nofos service for the infra-grantor1 environment (AWS account 315341936575, network_name "infra-grantor1").
+
+module "infra_grantor1_config" {
+  source                          = "./env-config"
+  project_name                    = local.project_name
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "infra-grantor1"
+  network_name                    = "infra-grantor1"
+  domain_name                     = null  # "nofos.training.simpler.grants.gov" once DNS + certs exist in the training account
+  enable_https                    = false # No ACM cert / hosted zone in the infra-grantor1 account yet
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_notifications            = local.enable_notifications
+  enable_identity_provider        = local.enable_identity_provider
+
+  database_newrelic_entity_guid = ""     # Populate once the New Relic entity for the infra-grantor1 nofos RDS cluster exists
+  database_engine_version       = "17.7" # Must be >= the source snapshot's engine version when restoring from a snapshot
+  database_min_capacity         = 1
+  database_max_capacity         = 1
+  database_instance_count       = 1
+
+  service_override_extra_environment_variables = {}
+}

--- a/infra/nofos/app-config/main.tf
+++ b/infra/nofos/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging", "infra-training"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "infra-dev", "infra-staging", "infra-training", "infra-grantor1"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -55,6 +55,7 @@ locals {
     # infra-staging is a staging-like environment in the "staging" AWS account
     # (317380566348), running in the "infra-staging" VPC.
     infra-staging  = module.infra_staging_config
+    infra-grantor1 = module.infra_grantor1_config
     infra-training = module.infra_training_config
   }
 
@@ -68,9 +69,10 @@ locals {
     prod           = "simpler-grants-gov"
     training       = "simpler-grants-gov"
     grantee1       = "simpler-grants-gov"
-    infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
-    infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
-    infra-training = "training" # infra-training environment lives in AWS account 049145893907
+    infra-dev      = "dev"                # infra-dev environment lives in AWS account 061664787759
+    infra-staging  = "staging"            # infra-staging environment lives in AWS account 317380566348
+    infra-grantor1 = "simpler-grants-gov" # reuses the main simpler-grants-gov account (315341936575) with its own VPC
+    infra-training = "training"           # infra-training environment lives in AWS account 049145893907
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/nofos/build-repository/infra-grantor1.s3.tfbackend
+++ b/infra/nofos/build-repository/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/nofos/build-repository/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/database/infra-grantor1.s3.tfbackend
+++ b/infra/nofos/database/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/nofos/database/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/nofos/service/infra-grantor1.s3.tfbackend
+++ b/infra/nofos/service/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-315341936575-us-east-1-tf"
+key            = "infra/nofos/service/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -192,5 +192,21 @@ locals {
         certificate_configs = {}
       }
     }
+    infra-grantor1 = {
+      account_name                 = "simpler-grants-gov" # AWS account 315341936575 (reuses the main account with its own VPC)
+      database_subnet_group_name   = "infra-grantor1"
+      vpc_name                     = "infra-grantor1"
+      second_octet                 = 11              # The second octet of the VPC CIDR block (10.11.0.0/20)
+      grants_gov_oracle_cidr_block = "10.207.0.0/16" # MicroHealth managed CIDR block (unused; DMS peering is disabled for this env)
+
+      enable_dms = false
+
+      domain_config = {
+        manage_dns  = false
+        hosted_zone = null # DNS is managed externally; set once a Route53 hosted zone is created
+
+        certificate_configs = {}
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Added the new `infra-grantor1` environment across all apps (api, frontend, analytics, metabase, nofos), following the `infra-training` pattern from #11760.

Closes #11790.

## Details
- Reuses the **simpler-grants-gov** account (`315341936575`) with its own VPC — `10.11.0.0/20` (`second_octet = 11`), mirroring how `infra-training` reused the training account.
- **DMS / VPC peering disabled** (`enable_dms = false`) — this environment gets refreshed data via the DB restore pipeline, not DMS. (Per project guidance for these envs.)
- Domains left `null` pending DNS + ACM in this environment; `enable_https = false`.
- Wired into each app's `app-config/main.tf` (`environments`, `configs`, `account_names_by_environment`), `project-config/networks.tf`, and the `cd-*.yml` workflow environment dropdowns.

## Validation
- `terraform fmt -recursive` clean.
- `terraform validate` passes for all five app-configs and `project-config`.
