### PR TITLE
[unticketed]: add infra-grantor and infra-grantee environments

### DIFF
--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -28,6 +28,9 @@ on:
           - grantee1
           - grantee2
           - grantor1
+          - infra-grantee1
+          - infra-grantee2
+          - infra-grantor1
           - prod
       version:
         required: true

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -28,6 +28,9 @@ on:
           - grantee1
           - grantee2
           - grantor1
+          - infra-grantee1
+          - infra-grantee2
+          - infra-grantor1
           - prod
       version:
         required: true

--- a/.github/workflows/update-frontend-feature-flag.yml
+++ b/.github/workflows/update-frontend-feature-flag.yml
@@ -19,6 +19,9 @@ on:
           - dev
           - staging
           - grantee1
+          - infra-grantee1
+          - infra-grantee2
+          - infra-grantor1
       value:
         description: Feature flag value
         required: true

--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -73,6 +73,16 @@ locals {
       "--set-current",
       "--store-version"
     ],
+    # Mirrors grantee1.
+    "infra-grantee1" = [
+      "flask",
+      "data-migration",
+      "load-transform",
+      "--load",
+      "--transform",
+      "--set-current",
+      "--store-version"
+    ],
     grantee2 = [
       "flask",
       "data-migration",
@@ -82,7 +92,27 @@ locals {
       "--set-current",
       "--store-version"
     ],
+    # Mirrors grantee2.
+    "infra-grantee2" = [
+      "flask",
+      "data-migration",
+      "load-transform",
+      "--load",
+      "--transform",
+      "--set-current",
+      "--store-version"
+    ],
     grantor1 = [
+      "flask",
+      "data-migration",
+      "load-transform",
+      "--load",
+      "--transform",
+      "--set-current",
+      "--store-version"
+    ],
+    # Mirrors grantor1.
+    "infra-grantor1" = [
       "flask",
       "data-migration",
       "load-transform",
@@ -136,8 +166,11 @@ locals {
     training         = ["flask", "task", "sam-extracts"]
     "infra-training" = ["flask", "task", "sam-extracts"]
     grantee1         = ["flask", "task", "sam-extracts"]
+    "infra-grantee1" = ["flask", "task", "sam-extracts"]
     grantee2         = ["flask", "task", "sam-extracts"]
+    "infra-grantee2" = ["flask", "task", "sam-extracts"]
     grantor1         = ["flask", "task", "sam-extracts"]
+    "infra-grantor1" = ["flask", "task", "sam-extracts"]
     prod             = ["flask", "task", "sam-extracts"]
   }
   setup-lower-env-agencies-state = {
@@ -148,8 +181,11 @@ locals {
     training         = "DISABLED"
     "infra-training" = "DISABLED"
     grantee1         = "DISABLED"
+    "infra-grantee1" = "DISABLED"
     grantee2         = "DISABLED"
+    "infra-grantee2" = "DISABLED"
     grantor1         = "DISABLED"
+    "infra-grantor1" = "DISABLED"
     prod             = "DISABLED"
   }
   build-automatic-opportunities-state = {
@@ -160,8 +196,11 @@ locals {
     training         = "ENABLED"
     "infra-training" = "ENABLED"
     grantee1         = "DISABLED"
+    "infra-grantee1" = "DISABLED"
     grantee2         = "DISABLED"
+    "infra-grantee2" = "DISABLED"
     grantor1         = "DISABLED"
+    "infra-grantor1" = "DISABLED"
     prod             = "DISABLED"
   }
   load-transform-state = {
@@ -172,8 +211,11 @@ locals {
     training         = "ENABLED"
     "infra-training" = "ENABLED"
     grantee1         = "ENABLED"
+    "infra-grantee1" = "ENABLED"
     grantee2         = "ENABLED"
+    "infra-grantee2" = "ENABLED"
     grantor1         = "ENABLED"
+    "infra-grantor1" = "ENABLED"
     prod             = "ENABLED"
   }
   sam-extracts-state = {
@@ -184,8 +226,11 @@ locals {
     training         = "ENABLED"
     "infra-training" = "ENABLED"
     grantee1         = "ENABLED"
+    "infra-grantee1" = "ENABLED"
     grantee2         = "ENABLED"
+    "infra-grantee2" = "ENABLED"
     grantor1         = "ENABLED"
+    "infra-grantor1" = "ENABLED"
     prod             = "ENABLED"
   }
   create-analytics-db-csvs-state = {
@@ -196,8 +241,11 @@ locals {
     training         = "ENABLED"
     "infra-training" = "ENABLED"
     grantee1         = "ENABLED"
+    "infra-grantee1" = "ENABLED"
     grantee2         = "ENABLED"
+    "infra-grantee2" = "ENABLED"
     grantor1         = "ENABLED"
+    "infra-grantor1" = "ENABLED"
     prod             = "ENABLED"
   }
   email-notification-opportunity-state = {
@@ -208,8 +256,11 @@ locals {
     training         = "ENABLED"
     "infra-training" = "ENABLED"
     grantee1         = "DISABLED"
+    "infra-grantee1" = "DISABLED"
     grantee2         = "DISABLED"
+    "infra-grantee2" = "DISABLED"
     grantor1         = "DISABLED"
+    "infra-grantor1" = "DISABLED"
     prod             = "ENABLED"
   }
   scheduled_jobs = {

--- a/infra/api/app-config/infra-grantee1.tf
+++ b/infra/api/app-config/infra-grantee1.tf
@@ -1,0 +1,89 @@
+# api service for the infra-grantee1 environment (AWS account 061664787759, network_name "infra-grantee1").
+#
+# infra-grantee1 is the "dev" account's copy of the shared account's grantee1
+# environment. Config values below mirror infra/api/app-config/grantee1.tf 1:1,
+# except for the settings that cannot be carried over to a different account:
+#   - HTTPS: no ACM certificate or Route53 hosted zone in this account yet, so
+#     enable_https is false (see the domain block below).
+#   - Notifications: no SES domain identity yet.
+#   - New Relic entity GUIDs: create the infra-grantee1 entities, then fill these in.
+#   - search_sso_admin_role_name: the reserved-SSO role suffix is generated per
+#     AWS account, so it is overridden with the "dev" account's (same value
+#     infra-dev uses).
+module "infra_grantee1_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  environment    = "infra-grantee1"
+  network_name   = "infra-grantee1"
+
+  # Reuses grantee1's hostnames, the same way infra-dev reuses dev's. domain_name CANNOT
+  # be null here: modules/service/api_gateway.tf interpolates it into every integration
+  # URI and infra/api/service/clamav.tf:33 builds api_base_url from it, neither of which
+  # is gated on enable_https -- and enable_api_gateway is hardcoded true at
+  # infra/api/service/main.tf:256. A null fails the plan before anything is created.
+  # These names still resolve to grantee1's ALB in the shared account until
+  # infra-grantee1 gets DNS of its own; nothing here serves traffic yet.
+  domain_name            = "api.grantee1.teams.simpler.grants.gov"
+  secondary_domain_names = ["alb.grantee1.teams.simpler.grants.gov"]
+  # Off until ACM certificates are imported into the "dev" account. While false, the
+  # aws_acm_certificate lookups for domain_name and secondary_domain_names are count = 0.
+  enable_https = false
+  # s3_cdn_domain_name and mtls_domain_name must stay unset: their certificate lookups are
+  # gated on the domain being non-null, NOT on enable_https, so setting them now would
+  # fail the plan. Uncomment once the certs exist.
+  # s3_cdn_domain_name = "files.grantee1.teams.simpler.grants.gov"
+  # mtls_domain_name   = "soap.grantee1.teams.simpler.grants.gov"
+
+  has_database                  = local.has_database
+  database_enable_http_endpoint = true
+  database_engine_version       = "17.7"
+  database_newrelic_entity_guid = "" # Populate once the New Relic entity for the infra-grantee1 RDS cluster exists
+  database_deletion_protection  = false
+
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = false # Enable once an SES domain identity exists for infra-grantee1
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantee1 primary ALB exists
+  service_newrelic_mtls_entity_guid = "" # Populate once the New Relic entity for the infra-grantee1 mTLS ALB exists
+  api_host_newrelic_entity_guid     = "" # Populate once the New Relic entity for the infra-grantee1 ECS service host exists
+
+  # Sizing mirrors grantee1.
+  instance_desired_instance_count = 2
+  instance_scaling_min_capacity   = 2
+  instance_scaling_max_capacity   = 4
+
+  database_min_capacity   = 2
+  database_max_capacity   = 4
+  database_instance_count = 2
+
+  has_search            = true
+  search_engine_version = "OpenSearch_2.15"
+  # The "dev" AWS account has its own IAM Identity Center reserved-SSO suffix,
+  # different from the shared account default in env-config.
+  search_sso_admin_role_name = "AWSReservedSSO_AdministratorAccess_73856a8074e1d297"
+
+  service_override_extra_environment_variables = {
+    # Email notification
+    RESET_EMAILS_WITHOUT_SENDING = "true"
+
+    # PDF Generation
+    FRONTEND_URL             = "https://grantee1.teams.simpler.grants.gov" # grantee1's frontend; repoint once infra-grantee1 has DNS
+    DOCRAPTOR_TEST_MODE      = "true"
+    PDF_GENERATION_USE_MOCKS = "false"
+
+    # Reuse staging's login.gov sandbox app registration
+    LOGIN_GOV_CLIENT_ID = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-staging-simpler-grants-gov"
+
+    # Virus scanning endpoints
+    ENABLE_FILE_UPLOAD_ENDPOINTS = 1
+  }
+  # Enables ECS Exec access for debugging or jump access.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  # Defaults to `false`. Uncomment the next line to enable.
+  # enable_command_execution = true
+
+  enable_workflow_service = true
+}

--- a/infra/api/app-config/infra-grantee1.tf
+++ b/infra/api/app-config/infra-grantee1.tf
@@ -66,6 +66,9 @@ module "infra_grantee1_config" {
   search_sso_admin_role_name = "AWSReservedSSO_AdministratorAccess_73856a8074e1d297"
 
   service_override_extra_environment_variables = {
+
+    ENABLE_WORKFLOW_ENDPOINTS = 1
+
     # Email notification
     RESET_EMAILS_WITHOUT_SENDING = "true"
 

--- a/infra/api/app-config/infra-grantee2.tf
+++ b/infra/api/app-config/infra-grantee2.tf
@@ -53,6 +53,9 @@ module "infra_grantee2_config" {
   search_sso_admin_role_name = "AWSReservedSSO_AdministratorAccess_73856a8074e1d297"
 
   service_override_extra_environment_variables = {
+
+    ENABLE_WORKFLOW_ENDPOINTS = 1
+
     # Email notification
     RESET_EMAILS_WITHOUT_SENDING = "true"
 

--- a/infra/api/app-config/infra-grantee2.tf
+++ b/infra/api/app-config/infra-grantee2.tf
@@ -1,0 +1,76 @@
+# api service for the infra-grantee2 environment (AWS account 061664787759, network_name "infra-grantee2").
+#
+# infra-grantee2 is the "dev" account's copy of the shared account's grantee2
+# environment. Config values below mirror infra/api/app-config/grantee2.tf 1:1,
+# except for the settings that cannot be carried over to a different account.
+# See infra/api/app-config/infra-grantee1.tf for the full rationale.
+module "infra_grantee2_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  environment    = "infra-grantee2"
+  network_name   = "infra-grantee2"
+
+  # Reuses grantee2's hostnames. domain_name cannot be null -- see the comment in
+  # infra/api/app-config/infra-grantee1.tf for why the plan fails without it.
+  domain_name            = "api.grantee2.teams.simpler.grants.gov"
+  secondary_domain_names = ["alb.grantee2.teams.simpler.grants.gov"]
+  # Off until ACM certificates are imported into the "dev" account.
+  enable_https = false
+  # Must stay unset: their certificate lookups are gated on the domain being non-null,
+  # NOT on enable_https. Uncomment once the certs exist.
+  # s3_cdn_domain_name = "files.grantee2.teams.simpler.grants.gov"
+  # mtls_domain_name   = "soap.grantee2.teams.simpler.grants.gov"
+
+  has_database                  = local.has_database
+  database_enable_http_endpoint = true
+  database_engine_version       = "17.7"
+  database_newrelic_entity_guid = "" # Populate once the New Relic entity for the infra-grantee2 RDS cluster exists
+  database_deletion_protection  = false
+
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = false # Enable once an SES domain identity exists for infra-grantee2
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantee2 primary ALB exists
+  service_newrelic_mtls_entity_guid = "" # Populate once the New Relic entity for the infra-grantee2 mTLS ALB exists
+  api_host_newrelic_entity_guid     = "" # Populate once the New Relic entity for the infra-grantee2 ECS service host exists
+
+  # Sizing mirrors grantee2.
+  instance_desired_instance_count = 2
+  instance_scaling_min_capacity   = 2
+  instance_scaling_max_capacity   = 4
+
+  database_min_capacity   = 2
+  database_max_capacity   = 4
+  database_instance_count = 2
+
+  has_search            = true
+  search_engine_version = "OpenSearch_2.15"
+  # The "dev" AWS account has its own IAM Identity Center reserved-SSO suffix,
+  # different from the shared account default in env-config.
+  search_sso_admin_role_name = "AWSReservedSSO_AdministratorAccess_73856a8074e1d297"
+
+  service_override_extra_environment_variables = {
+    # Email notification
+    RESET_EMAILS_WITHOUT_SENDING = "true"
+
+    # PDF Generation
+    FRONTEND_URL             = "https://grantee2.teams.simpler.grants.gov" # grantee2's frontend; repoint once infra-grantee2 has DNS
+    DOCRAPTOR_TEST_MODE      = "true"
+    PDF_GENERATION_USE_MOCKS = "false"
+
+    # Reuse staging's login.gov sandbox app registration
+    LOGIN_GOV_CLIENT_ID = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-staging-simpler-grants-gov"
+
+    # Virus scanning endpoints
+    ENABLE_FILE_UPLOAD_ENDPOINTS = 1
+  }
+  # Enables ECS Exec access for debugging or jump access.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  # Defaults to `false`. Uncomment the next line to enable.
+  # enable_command_execution = true
+
+  enable_workflow_service = true
+}

--- a/infra/api/app-config/infra-grantor1.tf
+++ b/infra/api/app-config/infra-grantor1.tf
@@ -1,0 +1,79 @@
+# api service for the infra-grantor1 environment (AWS account 061664787759, network_name "infra-grantor1").
+#
+# infra-grantor1 is the "dev" account's copy of the shared account's grantor1
+# environment. Config values below mirror infra/api/app-config/grantor1.tf 1:1,
+# except for the settings that cannot be carried over to a different account.
+# See infra/api/app-config/infra-grantee1.tf for the full rationale.
+module "infra_grantor1_config" {
+  source         = "./env-config"
+  project_name   = local.project_name
+  app_name       = local.app_name
+  default_region = module.project_config.default_region
+  environment    = "infra-grantor1"
+  network_name   = "infra-grantor1"
+
+  # Reuses grantor1's hostnames. domain_name cannot be null -- see the comment in
+  # infra/api/app-config/infra-grantee1.tf for why the plan fails without it.
+  domain_name            = "api.grantor1.teams.simpler.grants.gov"
+  secondary_domain_names = ["alb.grantor1.teams.simpler.grants.gov"]
+  # Off until ACM certificates are imported into the "dev" account.
+  enable_https = false
+  # Must stay unset: their certificate lookups are gated on the domain being non-null,
+  # NOT on enable_https. Uncomment once the certs exist.
+  # s3_cdn_domain_name = "files.grantor1.teams.simpler.grants.gov"
+  # mtls_domain_name   = "soap.grantor1.teams.simpler.grants.gov"
+
+  has_database                  = local.has_database
+  database_enable_http_endpoint = true
+  database_engine_version       = "17.7"
+  database_newrelic_entity_guid = "" # Populate once the New Relic entity for the infra-grantor1 RDS cluster exists
+  database_deletion_protection  = false
+
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = false # Enable once an SES domain identity exists for infra-grantor1
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantor1 primary ALB exists
+  service_newrelic_mtls_entity_guid = "" # Populate once the New Relic entity for the infra-grantor1 mTLS ALB exists
+  api_host_newrelic_entity_guid     = "" # Populate once the New Relic entity for the infra-grantor1 ECS service host exists
+
+  # Sizing mirrors grantor1.
+  instance_desired_instance_count = 2
+  instance_scaling_min_capacity   = 2
+  instance_scaling_max_capacity   = 4
+
+  database_min_capacity   = 2
+  database_max_capacity   = 4
+  database_instance_count = 2
+
+  has_search            = true
+  search_engine_version = "OpenSearch_2.15"
+  # The "dev" AWS account has its own IAM Identity Center reserved-SSO suffix,
+  # different from the shared account default in env-config.
+  search_sso_admin_role_name = "AWSReservedSSO_AdministratorAccess_73856a8074e1d297"
+
+  service_override_extra_environment_variables = {
+
+    ENABLE_WORKFLOW_ENDPOINTS             = 1
+    ENABLE_AWARD_RECOMMENDATION_ENDPOINTS = 1
+    ENABLE_GRANTOR_OPPORTUNITY_ENDPOINTS  = 1
+    ENABLE_FILE_UPLOAD_ENDPOINTS          = 1
+
+    # Email notification
+    RESET_EMAILS_WITHOUT_SENDING = "true"
+
+    # PDF Generation
+    FRONTEND_URL             = "https://grantor1.teams.simpler.grants.gov" # grantor1's frontend; repoint once infra-grantor1 has DNS
+    DOCRAPTOR_TEST_MODE      = "true"
+    PDF_GENERATION_USE_MOCKS = "false"
+
+    # Reuse staging's login.gov sandbox app registration
+    LOGIN_GOV_CLIENT_ID = "urn:gov:gsa:openidconnect.profiles:sp:sso:hhs-staging-simpler-grants-gov"
+  }
+  # Enables ECS Exec access for debugging or jump access.
+  # See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html
+  # Defaults to `false`. Uncomment the next line to enable.
+  # enable_command_execution = true
+
+  enable_workflow_service = true
+}

--- a/infra/api/app-config/main.tf
+++ b/infra/api/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training", "infra-grantee1", "infra-grantee2", "infra-grantor1"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -59,6 +59,12 @@ locals {
     infra-staging = module.infra_staging_config
 
     infra-training = module.infra_training_config
+
+    # Team environments in the "dev" AWS account, 1:1 copies of the shared
+    # account's grantee1/grantee2/grantor1. They deploy only api + frontend.
+    infra-grantee1 = module.infra_grantee1_config
+    infra-grantee2 = module.infra_grantee2_config
+    infra-grantor1 = module.infra_grantor1_config
   }
 
   # Map from environment name to the account name for the AWS account that
@@ -101,6 +107,9 @@ locals {
     infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
     infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
     infra-training = "training" # infra-training environment lives in AWS account 049145893907
+    infra-grantee1 = "dev"      # infra-grantee1 environment lives in AWS account 061664787759, alongside infra-dev
+    infra-grantee2 = "dev"      # infra-grantee2 environment lives in AWS account 061664787759, alongside infra-dev
+    infra-grantor1 = "dev"      # infra-grantor1 environment lives in AWS account 061664787759, alongside infra-dev
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/api/database/infra-grantee1.s3.tfbackend
+++ b/infra/api/database/infra-grantee1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/api/database/infra-grantee1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/infra-grantee2.s3.tfbackend
+++ b/infra/api/database/infra-grantee2.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/api/database/infra-grantee2.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/database/infra-grantor1.s3.tfbackend
+++ b/infra/api/database/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/api/database/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/infra-grantee1.s3.tfbackend
+++ b/infra/api/service/infra-grantee1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/api/service/infra-grantee1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/infra-grantee2.s3.tfbackend
+++ b/infra/api/service/infra-grantee2.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/api/service/infra-grantee2.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/service/infra-grantor1.s3.tfbackend
+++ b/infra/api/service/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/api/service/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/app-config/.terraform.lock.hcl
+++ b/infra/frontend/app-config/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.4.0"
+  hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
+    "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
+    "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
+    "zh:32d8492b1bdcc956ca3c6d00c6392d0a83942ff11d4820c7ee63ca6796e06950",
+    "zh:3c0482e894429f528ce6655a76ab0d8a9f7c0dacc6c828865e1515d4a7dbb852",
+    "zh:61e68100b4db2f930b31491f23c602126382fd5e51252be1b551f0e17f8ddbee",
+    "zh:6d60f615a0ad85eb962c9eb94f25e3eba7a72684ce276ba5dfb23f36b295a8f8",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9ced2745eb5f1346203027d2dd7bf856ad1d279a25730ff7dbc6eec187aaca0c",
+    "zh:a8378558a177d43f55aa0d79d4fae91a704695122a1b109668c1daa8fb76f09d",
+    "zh:aadd98086133d3ebea67437d56512fdcc6dfb3bd34dfc23f276c0db9272e27b4",
+    "zh:beff701b653841e70441978137768f54e7dc6c27e7bf12a4589087f01f5bbcee",
+    "zh:c91c2223b29fdbc0044d20e1936ccc051d010727a13f2ff1e75e51f09bff33a3",
+    "zh:d491f9c2d32a39dc4031628469ae7c8aec0074312a7c1f0286b173cdcf854a54",
+  ]
+}

--- a/infra/frontend/app-config/infra-grantee1.tf
+++ b/infra/frontend/app-config/infra-grantee1.tf
@@ -1,0 +1,35 @@
+# frontend service for the infra-grantee1 environment (AWS account 061664787759, network_name "infra-grantee1").
+#
+# Mirrors infra/frontend/app-config/grantee1.tf 1:1. HTTPS/custom domain is
+# deferred until an ACM cert + Route53 hosted zone exist in the "dev" account;
+# the intended domain is shown in a comment below.
+module "infra_grantee1_config" {
+  source                          = "./env-config"
+  project_name                    = local.project_name
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "infra-grantee1"
+  network_name                    = "infra-grantee1"
+  domain_name                     = null # "infra-grantee1.teams.simpler.grants.gov" once DNS + certs exist
+  enable_https                    = false
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = local.enable_notifications
+
+  # Sizing mirrors grantee1.
+  instance_desired_instance_count = 4
+  instance_scaling_min_capacity   = 4
+  instance_scaling_max_capacity   = 20
+
+  instance_cpu    = 1024
+  instance_memory = 2048
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantee1 frontend ALB exists
+  service_host_newrelic_entity_guid = "" # Populate once the New Relic browser entity for the infra-grantee1 frontend exists
+
+  # Enables ECS Exec access for debugging or jump access.
+  # Defaults to `false`. Uncomment the next line to enable.
+  # ⚠️ Warning! It is not recommended to enable this in a production environment.
+  # enable_command_execution = true
+}

--- a/infra/frontend/app-config/infra-grantee2.tf
+++ b/infra/frontend/app-config/infra-grantee2.tf
@@ -1,0 +1,35 @@
+# frontend service for the infra-grantee2 environment (AWS account 061664787759, network_name "infra-grantee2").
+#
+# Mirrors infra/frontend/app-config/grantee2.tf 1:1. HTTPS/custom domain is
+# deferred until an ACM cert + Route53 hosted zone exist in the "dev" account;
+# the intended domain is shown in a comment below.
+module "infra_grantee2_config" {
+  source                          = "./env-config"
+  project_name                    = local.project_name
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "infra-grantee2"
+  network_name                    = "infra-grantee2"
+  domain_name                     = null # "infra-grantee2.teams.simpler.grants.gov" once DNS + certs exist
+  enable_https                    = false
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = local.enable_notifications
+
+  # Sizing mirrors grantee2.
+  instance_desired_instance_count = 4
+  instance_scaling_min_capacity   = 4
+  instance_scaling_max_capacity   = 20
+
+  instance_cpu    = 1024
+  instance_memory = 2048
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantee2 frontend ALB exists
+  service_host_newrelic_entity_guid = "" # Populate once the New Relic browser entity for the infra-grantee2 frontend exists
+
+  # Enables ECS Exec access for debugging or jump access.
+  # Defaults to `false`. Uncomment the next line to enable.
+  # ⚠️ Warning! It is not recommended to enable this in a production environment.
+  # enable_command_execution = true
+}

--- a/infra/frontend/app-config/infra-grantor1.tf
+++ b/infra/frontend/app-config/infra-grantor1.tf
@@ -1,0 +1,35 @@
+# frontend service for the infra-grantor1 environment (AWS account 061664787759, network_name "infra-grantor1").
+#
+# Mirrors infra/frontend/app-config/grantor1.tf 1:1. HTTPS/custom domain is
+# deferred until an ACM cert + Route53 hosted zone exist in the "dev" account;
+# the intended domain is shown in a comment below.
+module "infra_grantor1_config" {
+  source                          = "./env-config"
+  project_name                    = local.project_name
+  app_name                        = local.app_name
+  default_region                  = module.project_config.default_region
+  environment                     = "infra-grantor1"
+  network_name                    = "infra-grantor1"
+  domain_name                     = null # "infra-grantor1.teams.simpler.grants.gov" once DNS + certs exist
+  enable_https                    = false
+  has_database                    = local.has_database
+  has_incident_management_service = local.has_incident_management_service
+  enable_identity_provider        = local.enable_identity_provider
+  enable_notifications            = local.enable_notifications
+
+  # Sizing mirrors grantor1.
+  instance_desired_instance_count = 4
+  instance_scaling_min_capacity   = 4
+  instance_scaling_max_capacity   = 20
+
+  instance_cpu    = 1024
+  instance_memory = 2048
+
+  service_newrelic_entity_guid      = "" # Populate once the New Relic entity for the infra-grantor1 frontend ALB exists
+  service_host_newrelic_entity_guid = "" # Populate once the New Relic browser entity for the infra-grantor1 frontend exists
+
+  # Enables ECS Exec access for debugging or jump access.
+  # Defaults to `false`. Uncomment the next line to enable.
+  # ⚠️ Warning! It is not recommended to enable this in a production environment.
+  # enable_command_execution = true
+}

--- a/infra/frontend/app-config/main.tf
+++ b/infra/frontend/app-config/main.tf
@@ -3,7 +3,7 @@ locals {
   # the folder under /infra that corresponds to the application
   app_name = regex("/infra/([^/]+)/app-config$", abspath(path.module))[0]
 
-  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training"]
+  environments = ["dev", "staging", "prod", "training", "grantee1", "grantee2", "grantor1", "infra-dev", "infra-staging", "infra-training", "infra-grantee1", "infra-grantee2", "infra-grantor1"]
   project_name = module.project_config.project_name
 
   # Whether or not the application has a database
@@ -66,6 +66,12 @@ locals {
     infra-staging = module.infra_staging_config
 
     infra-training = module.infra_training_config
+
+    # Team environments in the "dev" AWS account, 1:1 copies of the shared
+    # account's grantee1/grantee2/grantor1. They deploy only api + frontend.
+    infra-grantee1 = module.infra_grantee1_config
+    infra-grantee2 = module.infra_grantee2_config
+    infra-grantor1 = module.infra_grantor1_config
   }
   # Map from environment name to the account name for the AWS account that
   # contains the resources for that environment. Resources that are shared
@@ -107,6 +113,9 @@ locals {
     infra-dev      = "dev"      # infra-dev environment lives in AWS account 061664787759
     infra-staging  = "staging"  # infra-staging environment lives in AWS account 317380566348
     infra-training = "training" # infra-training environment lives in AWS account 049145893907
+    infra-grantee1 = "dev"      # infra-grantee1 environment lives in AWS account 061664787759, alongside infra-dev
+    infra-grantee2 = "dev"      # infra-grantee2 environment lives in AWS account 061664787759, alongside infra-dev
+    infra-grantor1 = "dev"      # infra-grantor1 environment lives in AWS account 061664787759, alongside infra-dev
   }
 
   # The name of the network that contains the resources shared across all

--- a/infra/frontend/service/infra-grantee1.s3.tfbackend
+++ b/infra/frontend/service/infra-grantee1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/frontend/service/infra-grantee1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/infra-grantee2.s3.tfbackend
+++ b/infra/frontend/service/infra-grantee2.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/frontend/service/infra-grantee2.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/frontend/service/infra-grantor1.s3.tfbackend
+++ b/infra/frontend/service/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/frontend/service/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/infra-grantee1.s3.tfbackend
+++ b/infra/networks/infra-grantee1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/networks/infra-grantee1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/infra-grantee2.s3.tfbackend
+++ b/infra/networks/infra-grantee2.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/networks/infra-grantee2.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/networks/infra-grantor1.s3.tfbackend
+++ b/infra/networks/infra-grantor1.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/networks/infra-grantor1.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/project-config/networks.tf
+++ b/infra/project-config/networks.tf
@@ -192,5 +192,58 @@ locals {
         certificate_configs = {}
       }
     }
+
+    # ---------------------------------------------------------------------------
+    # infra-grantee1 / infra-grantee2 / infra-grantor1
+    #
+    # Team environments in the "dev" AWS account (061664787759) -- the same account
+    # that hosts infra-dev. Each mirrors its counterpart in the shared account 1:1:
+    #   grantee1 -> infra-grantee1
+    #   grantee2 -> infra-grantee2
+    #   grantor1 -> infra-grantor1
+    #
+    # ---------------------------------------------------------------------------
+    infra-grantee1 = {
+      account_name                 = "dev" # AWS account 061664787759 (see infra/accounts/dev.061664787759.s3.tfbackend)
+      database_subnet_group_name   = "infra-grantee1"
+      vpc_name                     = "infra-grantee1"
+      second_octet                 = 33              # The second octet of the VPC CIDR block (10.33.0.0/20)
+      grants_gov_oracle_cidr_block = "10.207.0.0/16" # Unused while enable_dms = false, but still read by the api/database layer
+      enable_dms                   = false           # does not peer with the Grants.gov Oracle DMS network
+      domain_config = {
+        manage_dns  = false
+        hosted_zone = null # DNS is managed externally; set once a Route53 hosted zone is created
+
+        certificate_configs = {}
+      }
+    }
+    infra-grantee2 = {
+      account_name                 = "dev" # AWS account 061664787759 (see infra/accounts/dev.061664787759.s3.tfbackend)
+      database_subnet_group_name   = "infra-grantee2"
+      vpc_name                     = "infra-grantee2"
+      second_octet                 = 34              # The second octet of the VPC CIDR block (10.34.0.0/20)
+      grants_gov_oracle_cidr_block = "10.207.0.0/16" # Unused while enable_dms = false, but still read by the api/database layer
+      enable_dms                   = false           # does not peer with the Grants.gov Oracle DMS network
+      domain_config = {
+        manage_dns  = false
+        hosted_zone = null # DNS is managed externally; set once a Route53 hosted zone is created
+
+        certificate_configs = {}
+      }
+    }
+    infra-grantor1 = {
+      account_name                 = "dev" # AWS account 061664787759 (see infra/accounts/dev.061664787759.s3.tfbackend)
+      database_subnet_group_name   = "infra-grantor1"
+      vpc_name                     = "infra-grantor1"
+      second_octet                 = 35              # The second octet of the VPC CIDR block (10.35.0.0/20)
+      grants_gov_oracle_cidr_block = "10.207.0.0/16" # Unused while enable_dms = false, but still read by the api/database layer
+      enable_dms                   = false           # does not peer with the Grants.gov Oracle DMS network
+      domain_config = {
+        manage_dns  = false
+        hosted_zone = null # DNS is managed externally; set once a Route53 hosted zone is created
+
+        certificate_configs = {}
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Added the following environments: 

1. infra-grantee1 
2. infra-grantee2
3. infra-grantor1

## Validation steps

All scans should be passing below. 

Deployed infra-grantee1 api: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30681550388/job/91319591610)
Deployed infra-grantee1 frontend: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30681605380)

Deployed infra-grantee2 api: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30681718264)
Deployed infra-grantee2 frontend: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30681771706)

Deployed infra-grantor1 api: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30681735712)
Deployed infra-grantor1 frontend: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/30681748774)