### PR TITLE
[Issue #11704] set playwright base url and api url explicitly per env

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -127,6 +127,13 @@ runs:
       run: |
         npx playwright install --with-deps webkit
 
+    - name: Set target urls for environment
+      shell: bash
+      run: |
+        if [[ ${{ inputs.target }} = "staging" ]]; then
+          echo "base_url=https://staging.simpler.grants.gov" >> "$GITHUB_ENV"
+          echo "api_url=https://api.staging.simpler.grants.gov" >> "$GITHUB_ENV"
+        fi
     - name: Run all e2e tests (Shard ${{ inputs.current_shard }}/${{ inputs.total_shards }})
       if: ${{ inputs.playwright_tags == '' }}
       working-directory: ./frontend
@@ -135,6 +142,8 @@ runs:
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
+        PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
+        PLAYWRIGHT_API_URL: ${{ env.api_url }}
         PLAYWRIGHT_WORKERS: ${{ inputs.workers }}
         STAGING_TEST_USER_EMAIL: ${{ inputs.staging_test_user_email }}
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
@@ -154,6 +163,8 @@ runs:
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
+        PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
+        PLAYWRIGHT_API_URL: ${{ env.api_url }}
         PLAYWRIGHT_WORKERS: ${{ inputs.workers }}
         STAGING_TEST_USER_EMAIL: ${{ inputs.staging_test_user_email }}
         STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}

--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -4,6 +4,25 @@
 
 E2E tests are run using Playwright. See [development.md](/DEVELOPMENT.md) for more general info!
 
+### Running against deployed environments
+
+Playwright tests can be directed at any deployed environment by adjusting environment variables set in your `.env.local` file. For example, when running against staging:
+
+```
+PLAYWRIGHT_TARGET_ENV=staging
+PLAYWRIGHT_BASE_URL=https://staging.simpler.grants.gov
+PLAYWRIGHT_API_URL=https://api.staging.simpler.grants.gov
+TEST_USER_EMAIL=<from 1password>
+TEST_USER_PASSWORD=<from 1password>
+TEST_USER_MFA_KEY=<from 1password>
+SESSION_SECRET=<from 1password>
+TEST_USER_MANAGER_API_KEY=<from 1password>
+```
+
+Note that tests will still run without having secret env vars set, but tests involving login will fail.
+
+The correct values for secrets can be found in 1Password, AWS SSM, or ask a team member.
+
 ### Spoofing logins
 
 There are situations where we want to be able to test a "logged in" experience without having to script the test through the full login flow. In order to support this we have built a system to spoof the user login by placing a session cookie into the browser context. This system works by creating a client side cookie on the browser context within Playwright that will function the same as the session cookie produced as the output of the real login process.
@@ -18,13 +37,9 @@ The system is defined in [Login Utils](https://github.com/HHS/simpler-grants-gov
 - set `SESSION_SECRET` and `TEST_USER_MANAGER_API_KEY` in your frontend `.env.local`. `TEST_USER_MANAGER_API_KEY` must match `LOCAL_TEST_USER_MANAGER_API_KEY` in `api/local.env` (default: `local-manager-key`).
 - that's it! Running e2e tests using spoofing should now work.
 
-#### Staging setup
+#### Switching between local and deployed environments
 
-Staging runs on a deployed server, so Playwright requests the session token from the same staging-only internal endpoint. To run spoofed logins against staging, set `PLAYWRIGHT_TARGET_ENV=staging`, `SESSION_SECRET`, and `TEST_USER_MANAGER_API_KEY` in `.env.local`. The staging values for `SESSION_SECRET` and `TEST_USER_MANAGER_API_KEY` (the staging test-user-manager's API key) can be found in 1Password, AWS SSM, or ask a team member.
-
-#### Switching between local and staging
-
-Both targets read the **same** env var, `TEST_USER_MANAGER_API_KEY` — only its value differs (the local `make db-seed-local` default `local-manager-key` vs. the staging manager key). So to switch targets on your machine, change `PLAYWRIGHT_TARGET_ENV` and swap the `TEST_USER_MANAGER_API_KEY` (and `SESSION_SECRET`) value to match. In CI this is handled automatically: the local workflow passes `local-manager-key` and the staging workflow injects the staging key, both into `TEST_USER_MANAGER_API_KEY`.
+Whether running against a local or deployed environment, Playwright reads the **same** env var, `TEST_USER_MANAGER_API_KEY` — only its value differs (the local `make db-seed-local` default `local-manager-key` vs. the key for the deployed environment). So to switch targets on your machine, change `PLAYWRIGHT_TARGET_ENV` and swap the `TEST_USER_MANAGER_API_KEY` (and `SESSION_SECRET`) value to match. In CI this is handled automatically: the local workflow passes `local-manager-key` and the deployed workflow injects the key for the deployed environment, both into `TEST_USER_MANAGER_API_KEY`.
 
 ### Test groups
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -128,8 +128,11 @@ CI=
 # Only needed if running end-to-end tests with Playwright
 # See: frontend/tests/e2e/playwright-env.ts
 
-# Target environment for playwright tests (local or staging)
-PLAYWRIGHT_TARGET_ENV=local
+# Target environment inro for playwright tests
+# Defaults to local, set to staging, or grantor/grantee environment to run tests there instead
+PLAYWRIGHT_TARGET_ENV=
+PLAYWRIGHT_API_URL=
+PLAYWRIGHT_BASE_URL=
 
 # Base URL for local Playwright tests (override if running on different host/port)
 LOCAL_BASE_URL=http://127.0.0.1:3000

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -101,9 +101,9 @@ USE_SEARCH_MOCK_DATA=false
 
 NEW_RELIC_ENABLED=false
 NEW_RELIC_APP_NAME=
-NEW_RELIC_LICENSE_KEY= 
+NEW_RELIC_LICENSE_KEY=
 
-# See documentation/frontend/development.md (line 245). 
+# See documentation/frontend/development.md (line 245).
 
 # ============================================================================
 # BUILD AND RUNTIME SETTINGS
@@ -119,7 +119,7 @@ NEXT_RUNTIME=
 # See: frontend/tests/e2e/playwright-env.ts
 CI=
 # IMPORTANT!!
-# CI=false is unsafe!! In frontend/next.config.js, Boolean(process.env.CI) (line 141) treats "false" as truthy that results in adding security headers locally to be skipped. It is recommended to leave CI as blank. 
+# CI=false is unsafe!! In frontend/next.config.js, Boolean(process.env.CI) (line 141) treats "false" as truthy that results in adding security headers locally to be skipped. It is recommended to leave CI as blank.
 
 
 # ============================================================================
@@ -128,17 +128,11 @@ CI=
 # Only needed if running end-to-end tests with Playwright
 # See: frontend/tests/e2e/playwright-env.ts
 
-# Target environment inro for playwright tests
+# Target environment info for playwright tests
 # Defaults to local, set to staging, or grantor/grantee environment to run tests there instead
 PLAYWRIGHT_TARGET_ENV=
 PLAYWRIGHT_API_URL=
 PLAYWRIGHT_BASE_URL=
-
-# Base URL for local Playwright tests (override if running on different host/port)
-LOCAL_BASE_URL=http://127.0.0.1:3000
-
-# Base URL for staging Playwright tests
-STAGING_BASE_URL=https://staging.simpler.grants.gov
 
 # Test user credentials for staging E2E tests (only needed if testing against staging)
 STAGING_TEST_USER_EMAIL=

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -21,6 +21,19 @@ const TEST_ORG_LABELS: Record<string, string> = {
 const targetEnv = process.env.PLAYWRIGHT_TARGET_ENV || "local";
 const testOrgLabel = TEST_ORG_LABELS[targetEnv];
 
+const isLocal = targetEnv === "local";
+const baseUrl =
+  process.env.PLAYWRIGHT_BASE_URL || (isLocal ? "http://127.0.0.1:3000" : "");
+const apiUrl =
+  process.env.PLAYWRIGHT_API_URL || (isLocal ? "http://127.0.0.1:8080" : "");
+
+// this does what it can to prevent the app from starting with mismatched target env and url variable assignments
+if (!baseUrl || !apiUrl) {
+  throw new Error(
+    `PLAYWRIGHT_BASE_URL and PLAYWRIGHT_API_URL must be set when PLAYWRIGHT_TARGET_ENV=${targetEnv}`,
+  );
+}
+
 if (SUPPORTED_ENVS.indexOf(targetEnv as SupportedEnvs) === -1) {
   throw new Error(
     `Unsupported PLAYWRIGHT_TARGET_ENV: ${targetEnv}. Allowed values: ${SUPPORTED_ENVS.join(", ")}`,
@@ -37,8 +50,8 @@ const webServerEnv: Record<string, string> = Object.fromEntries(
 
 const playwrightEnv = {
   webServerEnv,
-  baseUrl: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
-  apiUrl: process.env.PLAYWRIGHT_API_URL || "http://127.0.0.1:8080",
+  baseUrl,
+  apiUrl,
   targetEnv,
   testOrgLabel,
   isCi: process.env.CI,

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -8,32 +8,8 @@ if (fs.existsSync(envPath)) {
   dotenv.config({ path: envPath, quiet: true });
 }
 
-const SUPPORTED_ENVS = ["local", "staging"];
-
-// Base URLs for each environment, read from .env.local if present, else fallback to defaults
-const BASE_URLS: Record<string, string> = {
-  local: process.env.LOCAL_BASE_URL || "http://127.0.0.1:3000",
-  staging: process.env.STAGING_BASE_URL || "https://staging.simpler.grants.gov",
-};
-
-// API URLs for each environment, read from .env.local if present, else fallback to defaults
-const API_URLS: Record<string, string> = {
-  local: process.env.LOCAL_API_URL || "http://127.0.0.1:8080",
-  staging:
-    process.env.STAGING_API_URL || "https://api.staging.simpler.grants.gov",
-};
-
-const targetEnv = process.env.PLAYWRIGHT_TARGET_ENV || "local";
-
-if (SUPPORTED_ENVS.indexOf(targetEnv) === -1) {
-  throw new Error(
-    `Unsupported PLAYWRIGHT_TARGET_ENV: ${targetEnv}. Allowed values: ${SUPPORTED_ENVS.join(", ")}`,
-  );
-}
-
-const baseUrl = BASE_URLS[targetEnv];
-
-const apiUrl = API_URLS[targetEnv];
+const SUPPORTED_ENVS = ["local", "staging"] as const;
+export type SupportedEnvs = (typeof SUPPORTED_ENVS)[number];
 
 // Organization label shown in the "Start new application" modal dropdown.
 // Must match the legal_business_name in seed_orgs_and_users.py.
@@ -42,13 +18,14 @@ const TEST_ORG_LABELS: Record<string, string> = {
   staging: "Automatic staging Organization for UEI AUTOHQDCCHBY",
 };
 
+const targetEnv = process.env.PLAYWRIGHT_TARGET_ENV || "local";
 const testOrgLabel = TEST_ORG_LABELS[targetEnv];
 
-// API key for the "test user manager" whose credentials authorize
-// POST /v1/internal/e2e-token. A single variable set per environment by the
-// e2e composite action (local uses the committed local-manager-key; staging
-// injects its own secret value).
-const testUserManagerApiKey = process.env.TEST_USER_MANAGER_API_KEY || "";
+if (SUPPORTED_ENVS.indexOf(targetEnv as SupportedEnvs) === -1) {
+  throw new Error(
+    `Unsupported PLAYWRIGHT_TARGET_ENV: ${targetEnv}. Allowed values: ${SUPPORTED_ENVS.join(", ")}`,
+  );
+}
 
 // Environment for web server
 const webServerEnv: Record<string, string> = Object.fromEntries(
@@ -60,8 +37,8 @@ const webServerEnv: Record<string, string> = Object.fromEntries(
 
 const playwrightEnv = {
   webServerEnv,
-  baseUrl,
-  apiUrl,
+  baseUrl: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
+  apiUrl: process.env.PLAYWRIGHT_API_URL || "http://127.0.0.1:8080",
   targetEnv,
   testOrgLabel,
   isCi: process.env.CI,
@@ -72,7 +49,7 @@ const playwrightEnv = {
   testUserEmail: process.env.STAGING_TEST_USER_EMAIL || "",
   testUserPassword: process.env.STAGING_TEST_USER_PASSWORD || "",
   testUserAuthKey: process.env.STAGING_TEST_USER_MFA_KEY || "",
-  testUserManagerApiKey,
+  testUserManagerApiKey: process.env.TEST_USER_MANAGER_API_KEY || "",
 };
 
 export default playwrightEnv;


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11704 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Introduces `PLAYWRIGHT_API_URL` and `PLAYWRIGHT_BASE_URL` environment variables into the playwright system and CI to allow for directly setting these values without any hard coding. This change is needed to support running tests from the mgmt repo after splitting code.

This piece of the work does not address the parts of the ticket oriented towards supporting grantee / grantor test environments. Those pieces are in https://github.com/HHS/simpler-grants-gov/pull/11804

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

There should be no change to functionality in this PR.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. _VERIFY_: e2e tests pass in CI