### PR TITLE
[Issue #10641] Store opportunity version at publish time to fix delayed grantee notifications

### DIFF
--- a/api/src/workflow/state_machine/opportunity_publish_state_machine.py
+++ b/api/src/workflow/state_machine/opportunity_publish_state_machine.py
@@ -15,6 +15,7 @@ from src.services.current_opportunity.determine_current_opportunity_summary impo
     determine_current_and_status,
     is_opportunity_changed,
 )
+from src.services.opportunities_v1.opportunity_version import save_opportunity_version
 from src.workflow.base_state_machine import BaseStateMachine
 from src.workflow.event.state_machine_event import StateMachineEvent
 from src.workflow.registry.workflow_client_registry import get_workflow_client_registry
@@ -32,6 +33,7 @@ class OpportunityPublishState(StrEnum):
     DRAFT_FLAG_FLIPPED = "draft_flag_flipped"
     CURRENT_OPPORTUNITY_SUMMARY_CALCULATED = "current_opportunity_summary_calculated"
     OPPORTUNITY_WRITTEN_TO_SEARCH = "opportunity_written_to_search"
+    OPPORTUNITY_VERSION_STORED = "opportunity_version_stored"
 
     END = "end"
 
@@ -51,6 +53,7 @@ class OpportunityPublishStateMachine(BaseStateMachine):
         OPP_PUBLISH_WRITTEN_TO_SEARCH_INDEX = "opp_publish_written_to_search_index"
         OPP_PUBLISH_NOT_WRITTEN_TO_SEARCH_INDEX = "opp_publish_not_written_to_search_index"
         OPP_PUBLISH_ERROR_WRITING_TO_SEARCH_INDEX = "opp_publish_error_writing_to_search_index"
+        OPP_PUBLISH_VERSION_STORED = "opp_publish_version_stored"
 
     ### States
     states = States.from_enum(
@@ -80,16 +83,25 @@ class OpportunityPublishStateMachine(BaseStateMachine):
     )
 
     # Write the opportunity to search and then
-    # do finish_publish
+    # do store_opportunity_version
     write_opportunity_to_search = Event(
         states.CURRENT_OPPORTUNITY_SUMMARY_CALCULATED.to(
-            states.OPPORTUNITY_WRITTEN_TO_SEARCH, after="finish_publish"
+            states.OPPORTUNITY_WRITTEN_TO_SEARCH, after="store_opportunity_version"
+        ),
+    )
+
+    # Store the opportunity's first version immediately at publish time
+    # (rather than waiting for the next hourly StoreOpportunityVersionTask
+    # run) and then do finish_publish
+    store_opportunity_version = Event(
+        states.OPPORTUNITY_WRITTEN_TO_SEARCH.to(
+            states.OPPORTUNITY_VERSION_STORED, after="finish_publish"
         ),
     )
 
     # End the publish workflow
     finish_publish = Event(
-        states.OPPORTUNITY_WRITTEN_TO_SEARCH.to(states.END),
+        states.OPPORTUNITY_VERSION_STORED.to(states.END),
     )
 
     def __init__(self, model: OpportunityPersistenceModel, **kwargs: Any):
@@ -216,3 +228,23 @@ class OpportunityPublishStateMachine(BaseStateMachine):
         except Exception:
             logger.exception("Failed to write opportunity to search index", extra=log_extra)
             state_machine_event.increment(self.Metrics.OPP_PUBLISH_ERROR_WRITING_TO_SEARCH_INDEX)
+
+    @store_opportunity_version.on
+    def handle_store_opportunity_version(self, state_machine_event: StateMachineEvent) -> None:
+        """Create the opportunity's first version snapshot immediately at publish time.
+
+        Without this, a grantee who saves the opportunity before the next hourly
+        StoreOpportunityVersionTask run has no prior version to diff against, and
+        never receives an edit-notification email for that opportunity.
+        """
+        log_extra = state_machine_event.get_log_extra() | {
+            "opportunity_id": self.opportunity.opportunity_id,
+        }
+
+        version_created = save_opportunity_version(self.db_session, self.opportunity)
+
+        logger.info(
+            "Stored opportunity version during publish",
+            extra=log_extra | {"version_created": version_created},
+        )
+        state_machine_event.increment(self.Metrics.OPP_PUBLISH_VERSION_STORED)

--- a/api/tests/src/workflow/state_machine/test_opportunity_publish_state_machine.py
+++ b/api/tests/src/workflow/state_machine/test_opportunity_publish_state_machine.py
@@ -2,8 +2,10 @@ from datetime import date
 
 import pytest
 from freezegun import freeze_time
+from sqlalchemy import select
 
 from src.constants.lookup_constants import OpportunityStatus, WorkflowType
+from src.db.models.opportunity_models import OpportunityVersion
 from src.workflow.handler.event_handler import EventHandler
 from src.workflow.state_machine.opportunity_publish_state_machine import OpportunityPublishState
 from src.workflow.workflow_errors import InvalidEventError
@@ -63,7 +65,7 @@ def test_opportunity_publish_happy_path(
     assert workflow.workflow_event_history[0].is_successfully_processed is True
 
     # Several event transitions automatically fire in sequence
-    assert len(workflow.workflow_audits) == 5
+    assert len(workflow.workflow_audits) == 6
     audits = sorted(workflow.workflow_audits, key=lambda audit: audit.created_at)
 
     assert audits[0].source_state == OpportunityPublishState.START
@@ -79,13 +81,26 @@ def test_opportunity_publish_happy_path(
     assert audits[3].target_state == OpportunityPublishState.OPPORTUNITY_WRITTEN_TO_SEARCH
 
     assert audits[4].source_state == OpportunityPublishState.OPPORTUNITY_WRITTEN_TO_SEARCH
-    assert audits[4].target_state == OpportunityPublishState.END
+    assert audits[4].target_state == OpportunityPublishState.OPPORTUNITY_VERSION_STORED
+
+    assert audits[5].source_state == OpportunityPublishState.OPPORTUNITY_VERSION_STORED
+    assert audits[5].target_state == OpportunityPublishState.END
 
     # Verify the opportunity is in the search index
     result = search_client.get(opportunity_index_alias, opportunity.opportunity_id)
     assert result is not None
     assert result["opportunity_id"] == str(opportunity.opportunity_id)
     assert result["opportunity_title"] == opportunity.opportunity_title
+
+    # Verify a version was created immediately at publish time 
+    # a grantee saving the opportunity right now already has a version to
+    # diff against, rather than waiting for the next hourly batch run.
+    versions = db_session.scalars(
+        select(OpportunityVersion).where(
+            OpportunityVersion.opportunity_id == opportunity.opportunity_id
+        )
+    ).all()
+    assert len(versions) == 1
 
 
 @pytest.mark.parametrize(

--- a/api/tests/src/workflow/state_machine/test_opportunity_publish_state_machine.py
+++ b/api/tests/src/workflow/state_machine/test_opportunity_publish_state_machine.py
@@ -92,7 +92,7 @@ def test_opportunity_publish_happy_path(
     assert result["opportunity_id"] == str(opportunity.opportunity_id)
     assert result["opportunity_title"] == opportunity.opportunity_title
 
-    # Verify a version was created immediately at publish time 
+    # Verify a version was created immediately at publish time
     # a grantee saving the opportunity right now already has a version to
     # diff against, rather than waiting for the next hourly batch run.
     versions = db_session.scalars(


### PR DESCRIPTION
## Summary

Work for #10641

## Changes proposed

Add a new step to `OpportunityPublishStateMachine` (`api/src/workflow/state_machine/opportunity_publish_state_machine.py`) that creates the opportunity's first version snapshot synchronously during publish, instead of waiting for the next hourly `StoreOpportunityVersionTask` batch run.

- New state `OPPORTUNITY_VERSION_STORED`, inserted between `OPPORTUNITY_WRITTEN_TO_SEARCH` and `END`
- New `store_opportunity_version` event/handler calling the existing `save_opportunity_version()` service function
- New metric `OPP_PUBLISH_VERSION_STORED`
- Updated `test_opportunity_publish_state_machine.py`: bumped the expected workflow-audit count from 5 to 6, added the new transition assertion, and added a new assertion confirming exactly one `OpportunityVersion` row exists immediately after publish

## Context for reviewers

A grantee who saves a freshly-published opportunity before the next hourly versioning job runs ends up with a `last_notified_at` bookmark that predates the opportunity's very first version. The notification job's diff logic (`OpportunityNotificationTask._get_last_notified_versions` in `api/src/task/notifications/opportunity_notifcation.py`) can only compare against a version *older* than that bookmark - since none exists, it hits the "no previous version found" branch, silently advances the bookmark, and never sends an email for that grantee, for any edit made before the bookmark catches up. This can silently swallow multiple real edits' worth of notifications in a single day.

## Validation steps

Automated:
```
cd api && make test args="tests/src/workflow/state_machine/test_opportunity_publish_state_machine.py -v"
```
All 13 tests should pass, including the new assertion that a version exists immediately after publish.

Manual (local):
1. Create a draft opportunity with valid summary data and publish it.
2. Immediately query `api.opportunity_version` for that opportunity's ID (`SELECT * FROM api.opportunity_version WHERE opportunity_id = '<id>'`) - **without** running the hourly `load-transform --store-version` job. Expect exactly 1 row, timestamped at publish time.
3. Save the opportunity as a grantee, then edit a tracked field (e.g. `close_date`, funding amounts, status) as grantor.
4. Manually trigger the versioning and notification jobs:
   ```
   docker exec grants-api sh -c "/opt/venv/bin/flask data-migration load-transform --no-load --no-transform --no-set-current --store-version"
   docker exec grants-api sh -c "/opt/venv/bin/flask task email-notifications"
   ```
5. Confirm a `user_notification_log` row exists for the grantee with `notification_reason = 'opportunity_updates'`.