### PR TITLE
[Issue #10419] Add validation to award recommendation submission edit page

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { identity } from "lodash";
 import { RecommendationDetailForm } from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
 import { AwardRecommendationSubmission } from "src/types/awardRecommendationTypes";
@@ -307,38 +307,79 @@ describe("RecommendationDetailForm", () => {
     });
   });
 
-  describe("required fields", () => {
-    it("marks recommendation type as required", () => {
-      render(<RecommendationDetailForm submission={mockSubmission} />);
+  describe("validation", () => {
+    it("shows recommendation and amount errors when validate is called with empty values", async () => {
+      const ref = { current: null as null | { validate: () => boolean } };
+      render(
+        <RecommendationDetailForm
+          ref={(instance) => {
+            ref.current = instance;
+          }}
+          submission={{
+            ...mockSubmission,
+            submission_detail: undefined,
+          }}
+        />,
+      );
 
-      const select = screen.getByRole("combobox", {
-        name: /recommendationLabel/i,
+      act(() => {
+        expect(ref.current?.validate()).toBe(false);
       });
-      expect(select).toBeRequired();
+      expect(
+        await screen.findByText("validationErrorHeading"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getAllByText("recommendationRequired").length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.getAllByText("amountRecommendedRequired").length,
+      ).toBeGreaterThanOrEqual(1);
     });
 
-    it("marks recommended amount as required", () => {
-      render(<RecommendationDetailForm submission={mockSubmission} />);
+    it("shows exception detail error when exception is checked and reason is empty", async () => {
+      const ref = { current: null as null | { validate: () => boolean } };
+      render(
+        <RecommendationDetailForm
+          ref={(instance) => {
+            ref.current = instance;
+          }}
+          submission={{
+            ...mockSubmission,
+            submission_detail: {
+              award_recommendation_type: "recommended_without_funding",
+              recommended_amount: "75000.00",
+              has_exception: true,
+              exception_detail: "",
+            },
+          }}
+        />,
+      );
 
-      const input = screen.getByDisplayValue("$75,000");
-      expect(input).toBeRequired();
+      act(() => {
+        expect(ref.current?.validate()).toBe(false);
+      });
+      expect(
+        await screen.findAllByText("exceptionDetailRequired"),
+      ).not.toHaveLength(0);
     });
 
-    it("marks exception detail as required when shown", () => {
-      const submissionWithException: AwardRecommendationSubmission = {
-        ...mockSubmission,
-        submission_detail: {
-          award_recommendation_type: "recommended_without_funding",
-          recommended_amount: "75000.00",
-          has_exception: true,
-          exception_detail: "Test exception",
-        },
-      };
+    it("passes validation when required fields are filled", () => {
+      const ref = { current: null as null | { validate: () => boolean } };
+      render(
+        <RecommendationDetailForm
+          ref={(instance) => {
+            ref.current = instance;
+          }}
+          submission={mockSubmission}
+        />,
+      );
 
-      render(<RecommendationDetailForm submission={submissionWithException} />);
-
-      const textarea = screen.getByTestId("exception-detail-textarea");
-      expect(textarea).toBeRequired();
+      act(() => {
+        expect(ref.current?.validate()).toBe(true);
+      });
+      expect(
+        screen.queryByText("validationErrorHeading"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection.tsx
@@ -8,13 +8,23 @@ import {
   formatCurrency,
   formatCurrencyString,
   getNumericAmountFromString,
+  sanitizeCurrencyInput,
 } from "src/utils/formatCurrencyUtil";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
 import {
+  ChangeEvent,
+  ForwardedRef,
+  forwardRef,
+  useImperativeHandle,
+  useState,
+} from "react";
+import {
+  Alert,
   CharacterCount,
   Checkbox,
+  ErrorMessage,
+  FormGroup,
   Grid,
   Label,
   Select,
@@ -37,6 +47,20 @@ const defaultHasExceptionByRecommendationType: Record<
   not_recommended: false,
 };
 
+const isAmountEmpty = (value: string) =>
+  (value ?? "").replace(/[$,\s]/g, "") === "";
+
+export type RecommendationFieldErrors = {
+  recommendation?: string;
+  exceptionDetail?: string;
+  recommendedAmount?: string;
+  recommendedAmounts?: Record<string, string>;
+};
+
+export type RecommendationDetailFormHandle = {
+  validate: () => boolean;
+};
+
 type RecommendationDetailFormProps = {
   submission?: AwardRecommendationSubmission;
   submissions?: AwardRecommendationSubmission[];
@@ -47,30 +71,37 @@ type RecommendationFieldsProps = {
   namePrefix: string;
   generalCommentDefaultValue?: string;
   exceptionDetailDefaultValue?: string;
-  initialRecommendationType?: AwardRecommendationType;
-  initialHasException?: boolean;
+  recommendationType: AwardRecommendationType | "";
+  hasException: boolean;
+  exceptionDetail: string;
+  onRecommendationTypeChange: (value: AwardRecommendationType | "") => void;
+  onHasExceptionChange: (value: boolean) => void;
+  onExceptionDetailChange: (value: string) => void;
+  errors: RecommendationFieldErrors;
 };
 
 const RecommendationFields = ({
   submissionId,
   namePrefix,
   generalCommentDefaultValue,
-  exceptionDetailDefaultValue,
-  initialRecommendationType = "recommended_for_funding",
-  initialHasException = false,
+  recommendationType,
+  hasException,
+  exceptionDetail,
+  onRecommendationTypeChange,
+  onHasExceptionChange,
+  onExceptionDetailChange,
+  errors,
 }: RecommendationFieldsProps) => {
   const t = useTranslations("AwardRecommendation.recommendationDetails");
-  const [recommendationType, setRecommendationType] =
-    useState<AwardRecommendationType>(initialRecommendationType);
-  const [hasException, setHasException] = useState(initialHasException);
 
   const canHaveException =
+    recommendationType !== "" &&
     exceptionEligibleRecommendationTypes.includes(recommendationType);
   const showExceptionDetail = canHaveException && hasException;
 
   return (
     <>
-      <div className="margin-bottom-3">
+      <FormGroup error={!!errors.recommendation} className="margin-bottom-3">
         <Label
           htmlFor={`award_recommendation_type_${submissionId}`}
           className="text-bold margin-bottom-1"
@@ -78,21 +109,28 @@ const RecommendationFields = ({
           <span>{t("recommendationLabel")}</span>
           <RequiredFieldIndicator> *</RequiredFieldIndicator>
         </Label>
+        {errors.recommendation && (
+          <ErrorMessage>{errors.recommendation}</ErrorMessage>
+        )}
         <Select
           id={`award_recommendation_type_${submissionId}`}
           name={`${namePrefix}[award_recommendation_type]`}
           value={recommendationType}
           onChange={(event) => {
-            const nextRecommendationType = event.target
-              .value as AwardRecommendationType;
-            setRecommendationType(nextRecommendationType);
-            setHasException(
-              defaultHasExceptionByRecommendationType[nextRecommendationType],
+            const nextValue = event.target.value as
+              AwardRecommendationType | "";
+            onRecommendationTypeChange(nextValue);
+            if (nextValue === "") {
+              onHasExceptionChange(false);
+              return;
+            }
+            onHasExceptionChange(
+              defaultHasExceptionByRecommendationType[nextValue],
             );
           }}
           className="maxw-card-lg"
-          required
         >
+          <option value="">{t("selectOnePlaceholder")}</option>
           <option value="recommended_for_funding">
             {t("recommendationOptions.recommended")}
           </option>
@@ -103,7 +141,7 @@ const RecommendationFields = ({
             {t("recommendationOptions.notRecommended")}
           </option>
         </Select>
-      </div>
+      </FormGroup>
 
       {canHaveException && (
         <Checkbox
@@ -111,7 +149,7 @@ const RecommendationFields = ({
           name={`${namePrefix}[has_exception]`}
           label={t("hasExceptionLabel")}
           checked={hasException}
-          onChange={(event) => setHasException(event.target.checked)}
+          onChange={(event) => onHasExceptionChange(event.target.checked)}
         />
       )}
 
@@ -135,26 +173,34 @@ const RecommendationFields = ({
       </div>
 
       {showExceptionDetail && (
-        <div className="margin-bottom-3">
-          <p className="text-bold margin-bottom-1 font-sans-sm">
+        <FormGroup error={!!errors.exceptionDetail} className="margin-bottom-3">
+          <Label
+            htmlFor={`exception_detail_${submissionId}`}
+            className="text-bold margin-bottom-1"
+          >
             <span>{t("exceptionDetailLabel")}</span>
             <RequiredFieldIndicator> *</RequiredFieldIndicator>
-          </p>
+          </Label>
           <p className="text-base margin-top-1 margin-bottom-2">
             {t("exceptionDetailDescription")}
           </p>
+          {errors.exceptionDetail && (
+            <ErrorMessage>{errors.exceptionDetail}</ErrorMessage>
+          )}
           <CharacterCount
             id={`exception_detail_${submissionId}`}
             name={`${namePrefix}[exception_detail]`}
             maxLength={1000}
             isTextArea
-            defaultValue={exceptionDetailDefaultValue || ""}
+            value={exceptionDetail}
+            onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+              onExceptionDetailChange(event.target.value)
+            }
             rows={6}
             className="maxw-full"
             data-testid="exception-detail-textarea"
-            required
           />
-        </div>
+        </FormGroup>
       )}
     </>
   );
@@ -164,10 +210,12 @@ const FundingRecommendationRow = ({
   submission,
   recommendedAmount,
   onRecommendedAmountChange,
+  error,
 }: {
   submission: AwardRecommendationSubmission;
   recommendedAmount: string;
   onRecommendedAmountChange: (value: string) => void;
+  error?: string;
 }) => {
   const submissionId =
     submission.award_recommendation_application_submission_id;
@@ -181,17 +229,27 @@ const FundingRecommendationRow = ({
         )}
       </td>
       <td>
-        <TextInput
-          id={`recommended_amount_${submissionId}`}
-          name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
-          type="text"
-          value={recommendedAmount}
-          onChange={(event) => onRecommendedAmountChange(event.target.value)}
-          onBlur={(event) =>
-            onRecommendedAmountChange(formatCurrencyString(event.target.value))
-          }
-          required
-        />
+        <FormGroup error={!!error} className="margin-0">
+          {error && <ErrorMessage>{error}</ErrorMessage>}
+          <TextInput
+            id={`recommended_amount_${submissionId}`}
+            name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
+            type="text"
+            inputMode="decimal"
+            value={recommendedAmount}
+            onChange={(event) =>
+              onRecommendedAmountChange(
+                sanitizeCurrencyInput(event.target.value),
+              )
+            }
+            onBlur={(event) =>
+              onRecommendedAmountChange(
+                formatCurrencyString(event.target.value),
+              )
+            }
+            validationStatus={error ? "error" : undefined}
+          />
+        </FormGroup>
       </td>
     </tr>
   );
@@ -199,28 +257,16 @@ const FundingRecommendationRow = ({
 
 const FundingSectionMultiple = ({
   submissions,
+  recommendedAmounts,
+  onRecommendedAmountChange,
+  amountErrors,
 }: {
   submissions: AwardRecommendationSubmission[];
+  recommendedAmounts: Record<string, string>;
+  onRecommendedAmountChange: (submissionId: string, value: string) => void;
+  amountErrors?: Record<string, string>;
 }) => {
   const t = useTranslations("AwardRecommendation.recommendationDetails");
-
-  const [recommendedAmounts, setRecommendedAmounts] = useState<
-    Record<string, string>
-  >(() => {
-    const initial: Record<string, string> = {};
-    submissions.forEach((sub) => {
-      initial[sub.award_recommendation_application_submission_id] =
-        formatCurrencyString(sub.submission_detail?.recommended_amount);
-    });
-    return initial;
-  });
-
-  const handleAmountChange = (submissionId: string, value: string) => {
-    setRecommendedAmounts((prev) => ({
-      ...prev,
-      [submissionId]: value,
-    }));
-  };
 
   const totalRequested = submissions.reduce(
     (sum, s) =>
@@ -277,10 +323,15 @@ const FundingSectionMultiple = ({
                   ]
                 }
                 onRecommendedAmountChange={(value) =>
-                  handleAmountChange(
+                  onRecommendedAmountChange(
                     sub.award_recommendation_application_submission_id,
                     value,
                   )
+                }
+                error={
+                  amountErrors?.[
+                    sub.award_recommendation_application_submission_id
+                  ]
                 }
               />
             ))}
@@ -298,15 +349,18 @@ const FundingSectionMultiple = ({
 
 const FundingSectionSingle = ({
   submission,
+  recommendedAmount,
+  onRecommendedAmountChange,
+  error,
 }: {
   submission: AwardRecommendationSubmission;
+  recommendedAmount: string;
+  onRecommendedAmountChange: (value: string) => void;
+  error?: string;
 }) => {
   const t = useTranslations("AwardRecommendation.recommendationDetails");
   const submissionId =
     submission.award_recommendation_application_submission_id;
-  const [recommendedAmount, setRecommendedAmount] = useState(
-    formatCurrencyString(submission.submission_detail?.recommended_amount),
-  );
 
   return (
     <div className="margin-top-4">
@@ -325,90 +379,217 @@ const FundingSectionSingle = ({
           </p>
         </Grid>
         <Grid col={12} tablet={{ col: 6 }}>
-          <Label
-            htmlFor={`recommended_amount_${submissionId}`}
-            className="text-bold margin-top-0 margin-bottom-1"
-          >
-            <span>{t("amountRecommendedLabel")}</span>
-            <RequiredFieldIndicator> *</RequiredFieldIndicator>
-          </Label>
-          <TextInput
-            id={`recommended_amount_${submissionId}`}
-            name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
-            type="text"
-            value={recommendedAmount}
-            onChange={(event) => setRecommendedAmount(event.target.value)}
-            onBlur={(event) =>
-              setRecommendedAmount(formatCurrencyString(event.target.value))
-            }
-            required
-          />
+          <FormGroup error={!!error}>
+            <Label
+              htmlFor={`recommended_amount_${submissionId}`}
+              className="text-bold margin-top-0 margin-bottom-1"
+            >
+              <span>{t("amountRecommendedLabel")}</span>
+              <RequiredFieldIndicator> *</RequiredFieldIndicator>
+            </Label>
+            {error && <ErrorMessage>{error}</ErrorMessage>}
+            <TextInput
+              id={`recommended_amount_${submissionId}`}
+              name={`award_recommendation_submissions[${submissionId}][recommended_amount]`}
+              type="text"
+              inputMode="decimal"
+              value={recommendedAmount}
+              onChange={(event) =>
+                onRecommendedAmountChange(
+                  sanitizeCurrencyInput(event.target.value),
+                )
+              }
+              onBlur={(event) =>
+                onRecommendedAmountChange(
+                  formatCurrencyString(event.target.value),
+                )
+              }
+              validationStatus={error ? "error" : undefined}
+            />
+          </FormGroup>
         </Grid>
       </Grid>
     </div>
   );
 };
 
-export const RecommendationDetailForm = ({
-  submission,
-  submissions,
-}: RecommendationDetailFormProps) => {
-  const isMultipleSubmissions = submissions && submissions.length > 1;
-  const singleSubmission =
-    submission ||
-    (submissions && submissions.length === 1 ? submissions[0] : null);
+export const RecommendationDetailForm = forwardRef(
+  function RecommendationDetailForm(
+    { submission, submissions }: RecommendationDetailFormProps,
+    ref: ForwardedRef<RecommendationDetailFormHandle>,
+  ) {
+    const t = useTranslations("AwardRecommendation.recommendationDetails");
+    const isMultipleSubmissions = submissions && submissions.length > 1;
+    const singleSubmission =
+      submission ||
+      (submissions && submissions.length === 1 ? submissions[0] : null);
 
-  if (!singleSubmission && !isMultipleSubmissions) {
-    return null;
-  }
+    const initialDetail = singleSubmission?.submission_detail;
+    const [recommendationType, setRecommendationType] = useState<
+      AwardRecommendationType | ""
+    >(initialDetail?.award_recommendation_type ?? "");
+    const [hasException, setHasException] = useState(
+      Boolean(initialDetail?.has_exception),
+    );
+    const [exceptionDetail, setExceptionDetail] = useState(
+      initialDetail?.exception_detail ?? "",
+    );
+    const [errors, setErrors] = useState<RecommendationFieldErrors>({});
 
-  if (isMultipleSubmissions) {
+    const [singleRecommendedAmount, setSingleRecommendedAmount] = useState(
+      formatCurrencyString(initialDetail?.recommended_amount),
+    );
+    const [recommendedAmounts, setRecommendedAmounts] = useState<
+      Record<string, string>
+    >(() => {
+      const initial: Record<string, string> = {};
+      (submissions ?? []).forEach((sub) => {
+        initial[sub.award_recommendation_application_submission_id] =
+          formatCurrencyString(sub.submission_detail?.recommended_amount);
+      });
+      return initial;
+    });
+
+    const validate = (): boolean => {
+      const nextErrors: RecommendationFieldErrors = {};
+
+      if (!recommendationType) {
+        nextErrors.recommendation = t("recommendationRequired");
+      }
+
+      const canHaveException =
+        recommendationType !== "" &&
+        exceptionEligibleRecommendationTypes.includes(recommendationType);
+      if (canHaveException && hasException && !exceptionDetail.trim()) {
+        nextErrors.exceptionDetail = t("exceptionDetailRequired");
+      }
+
+      if (isMultipleSubmissions && submissions) {
+        const amountErrors: Record<string, string> = {};
+        submissions.forEach((sub) => {
+          const id = sub.award_recommendation_application_submission_id;
+          if (isAmountEmpty(recommendedAmounts[id] ?? "")) {
+            amountErrors[id] = t("amountRecommendedRequired");
+          }
+        });
+        if (Object.keys(amountErrors).length > 0) {
+          nextErrors.recommendedAmounts = amountErrors;
+          // Also surface a single amount message in the top alert
+          nextErrors.recommendedAmount = t("amountRecommendedRequired");
+        }
+      } else if (isAmountEmpty(singleRecommendedAmount)) {
+        nextErrors.recommendedAmount = t("amountRecommendedRequired");
+      }
+
+      setErrors(nextErrors);
+      return Object.keys(nextErrors).length === 0;
+    };
+
+    useImperativeHandle(ref, () => ({ validate }), [
+      recommendationType,
+      hasException,
+      exceptionDetail,
+      singleRecommendedAmount,
+      recommendedAmounts,
+      isMultipleSubmissions,
+      submissions,
+      t,
+    ]);
+
+    if (!singleSubmission && !isMultipleSubmissions) {
+      return null;
+    }
+
+    const alertMessages = [
+      errors.recommendation,
+      errors.exceptionDetail,
+      errors.recommendedAmount,
+    ].filter(Boolean) as string[];
+
+    const submissionId = isMultipleSubmissions
+      ? "bulk"
+      : singleSubmission!.award_recommendation_application_submission_id;
+    const namePrefix = isMultipleSubmissions
+      ? "bulk_edit"
+      : `award_recommendation_submissions[${submissionId}]`;
+
     return (
       <div className="margin-bottom-4" data-testid="recommendation-detail-form">
-        <RecommendationFields submissionId="bulk" namePrefix="bulk_edit[" />
-        <FundingSectionMultiple submissions={submissions} />
+        {alertMessages.length > 0 && (
+          <Alert
+            type="error"
+            heading={t("validationErrorHeading")}
+            headingLevel="h3"
+            validation
+            className="margin-bottom-3"
+          >
+            <ul className="usa-list margin-top-1 margin-bottom-0">
+              {alertMessages.map((message) => (
+                <li key={message}>{message}</li>
+              ))}
+            </ul>
+          </Alert>
+        )}
+
+        <RecommendationFields
+          submissionId={submissionId}
+          namePrefix={namePrefix}
+          generalCommentDefaultValue={
+            isMultipleSubmissions ? undefined : initialDetail?.general_comment
+          }
+          recommendationType={recommendationType}
+          hasException={hasException}
+          exceptionDetail={exceptionDetail}
+          onRecommendationTypeChange={setRecommendationType}
+          onHasExceptionChange={setHasException}
+          onExceptionDetailChange={setExceptionDetail}
+          errors={errors}
+        />
+
+        {isMultipleSubmissions ? (
+          <FundingSectionMultiple
+            submissions={submissions}
+            recommendedAmounts={recommendedAmounts}
+            onRecommendedAmountChange={(id, value) =>
+              setRecommendedAmounts((prev) => ({ ...prev, [id]: value }))
+            }
+            amountErrors={errors.recommendedAmounts}
+          />
+        ) : (
+          <FundingSectionSingle
+            submission={singleSubmission!}
+            recommendedAmount={singleRecommendedAmount}
+            onRecommendedAmountChange={setSingleRecommendedAmount}
+            error={errors.recommendedAmount}
+          />
+        )}
       </div>
     );
-  }
+  },
+);
 
-  const detail = singleSubmission!.submission_detail;
-  const submissionId =
-    singleSubmission!.award_recommendation_application_submission_id;
+export const RecommendationDetailsSection = forwardRef(
+  function RecommendationDetailsSection(
+    {
+      submission,
+    }: {
+      submission: AwardRecommendationSubmission;
+    },
+    ref: ForwardedRef<RecommendationDetailFormHandle>,
+  ) {
+    const t = useTranslations("AwardRecommendation.recommendationDetails");
 
-  return (
-    <div className="margin-bottom-4" data-testid="recommendation-detail-form">
-      <RecommendationFields
-        submissionId={submissionId}
-        namePrefix={`award_recommendation_submissions[${submissionId}]`}
-        generalCommentDefaultValue={detail?.general_comment}
-        exceptionDetailDefaultValue={detail?.exception_detail}
-        initialRecommendationType={
-          detail?.award_recommendation_type ?? "recommended_for_funding"
-        }
-        initialHasException={Boolean(detail?.has_exception)}
-      />
-      <FundingSectionSingle submission={singleSubmission!} />
-    </div>
-  );
-};
-
-export const RecommendationDetailsSection = ({
-  submission,
-}: {
-  submission: AwardRecommendationSubmission;
-}) => {
-  const t = useTranslations("AwardRecommendation.recommendationDetails");
-
-  return (
-    <div>
-      <Grid row className="grid-gap">
-        <Grid col={9} tablet={{ col: 9 }}>
-          <div className="margin-top-3 margin-bottom-3">
-            <h2 className="margin-top-0 margin-bottom-2">{t("heading")}</h2>
-            <RecommendationDetailForm submission={submission} />
-          </div>
+    return (
+      <div>
+        <Grid row className="grid-gap">
+          <Grid col={9} tablet={{ col: 9 }}>
+            <div className="margin-top-3 margin-bottom-3">
+              <h2 className="margin-top-0 margin-bottom-2">{t("heading")}</h2>
+              <RecommendationDetailForm submission={submission} ref={ref} />
+            </div>
+          </Grid>
         </Grid>
-      </Grid>
-    </div>
-  );
-};
+      </div>
+    );
+  },
+);

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationSubmissionEditForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationSubmissionEditForm.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {
+  RecommendationDetailsSection,
+  type RecommendationDetailFormHandle,
+} from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
+import { AwardRecommendationSubmission } from "src/types/awardRecommendationTypes";
+
+import { FormEvent, ReactNode, useRef } from "react";
+import { GridContainer } from "@trussworks/react-uswds";
+
+type RecommendationSubmissionEditFormProps = {
+  action: (formData: FormData) => void | Promise<void>;
+  awardRecommendationId: string;
+  applicationSubmissionId: string;
+  submission: AwardRecommendationSubmission;
+  hero: ReactNode;
+};
+
+export default function RecommendationSubmissionEditForm({
+  action,
+  awardRecommendationId,
+  applicationSubmissionId,
+  submission,
+  hero,
+}: RecommendationSubmissionEditFormProps) {
+  const formRef = useRef<RecommendationDetailFormHandle>(null);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (!formRef.current?.validate()) {
+      event.preventDefault();
+    }
+  };
+
+  return (
+    <form action={action} onSubmit={handleSubmit}>
+      {hero}
+      <GridContainer>
+        <input
+          type="hidden"
+          name="award_recommendation_id"
+          value={awardRecommendationId}
+        />
+        <input
+          type="hidden"
+          name="award_recommendation_application_submission_id"
+          value={applicationSubmissionId}
+        />
+        <RecommendationDetailsSection submission={submission} ref={formRef} />
+      </GridContainer>
+    </form>
+  );
+}

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import { saveAwardRecommendationSubmissionDetails } from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/actions";
-import { RecommendationDetailsSection } from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
+import RecommendationSubmissionEditForm from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationSubmissionEditForm";
 import { ApiRequestError, parseErrorStatus } from "src/errors";
 import withFeatureFlag from "src/services/featureFlags/withFeatureFlag";
 import {
@@ -13,7 +13,7 @@ import { WithFeatureFlagProps } from "src/types/uiTypes";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
-import { Alert, GridContainer } from "@trussworks/react-uswds";
+import { Alert } from "@trussworks/react-uswds";
 
 import AwardRecommendationHero from "src/components/award-recommendation/AwardRecommendationHero";
 
@@ -138,46 +138,39 @@ async function AwardRecommendationSubmissionEditPageContent({
   };
 
   return (
-    <form action={saveAwardRecommendationSubmissionDetails}>
-      <Suspense
-        fallback={
-          <span data-testid="award-recommendation-hero-fallback"></span>
-        }
-      >
-        <AwardRecommendationHero
-          heading={editTitle}
-          showDateAndStatus={false}
-          buttons={heroButtons}
-          externalLink={externalLink}
-          additionalBreadcrumbs={[
-            {
-              title: t("awardRecs"),
-              path: "/",
-            },
-            {
-              title: `${t("heroTitle")}: ${awardRecommendationNumber}`,
-              path: editPageHref,
-            },
-            {
-              title: editTitle,
-            },
-          ]}
-        />
-      </Suspense>
-      <GridContainer>
-        <input
-          type="hidden"
-          name="award_recommendation_id"
-          value={awardRecommendationId}
-        />
-        <input
-          type="hidden"
-          name="award_recommendation_application_submission_id"
-          value={applicationSubmissionId}
-        />
-        <RecommendationDetailsSection submission={submission} />
-      </GridContainer>
-    </form>
+    <RecommendationSubmissionEditForm
+      action={saveAwardRecommendationSubmissionDetails}
+      awardRecommendationId={awardRecommendationId}
+      applicationSubmissionId={applicationSubmissionId}
+      submission={submission}
+      hero={
+        <Suspense
+          fallback={
+            <span data-testid="award-recommendation-hero-fallback"></span>
+          }
+        >
+          <AwardRecommendationHero
+            heading={editTitle}
+            showDateAndStatus={false}
+            buttons={heroButtons}
+            externalLink={externalLink}
+            additionalBreadcrumbs={[
+              {
+                title: t("awardRecs"),
+                path: "/",
+              },
+              {
+                title: `${t("heroTitle")}: ${awardRecommendationNumber}`,
+                path: editPageHref,
+              },
+              {
+                title: editTitle,
+              },
+            ]}
+          />
+        </Suspense>
+      }
+    />
   );
 }
 

--- a/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/edit/bulk/_components/EditRecommendationsForm.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { RecommendationDetailForm } from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
+import {
+  RecommendationDetailForm,
+  RecommendationDetailFormHandle,
+} from "src/app/[locale]/(base)/grantor/award-recommendation/[id]/application-submissions/[applicationSubmissionId]/edit/_components/RecommendationDetailsSection";
 import { useSelectedSubmissions } from "src/hooks/useSelectedSubmissions";
 
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button, ButtonGroup } from "@trussworks/react-uswds";
 
 import SelectedApplicationsTable from "src/components/award-recommendation/SelectedApplicationsTable";
@@ -22,6 +25,7 @@ export default function EditRecommendationsForm({
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const formRef = useRef<RecommendationDetailFormHandle>(null);
 
   const { selectedSubmissions, hasSelections } = useSelectedSubmissions(
     awardRecommendationId,
@@ -37,6 +41,10 @@ export default function EditRecommendationsForm({
   };
 
   const handleSave = () => {
+    if (!formRef.current?.validate()) {
+      return;
+    }
+
     setIsSubmitting(true);
     setError(null);
 
@@ -96,6 +104,7 @@ export default function EditRecommendationsForm({
 
       <div className="margin-top-4">
         <RecommendationDetailForm
+          ref={formRef}
           submission={isSingleSubmission ? selectedSubmissions[0] : undefined}
           submissions={isMultipleSubmissions ? selectedSubmissions : undefined}
         />

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2207,11 +2207,12 @@ export const messages = {
         recommendedWithoutFunding: "Recommended but not funded",
         notRecommended: "Not recommended",
       },
+      selectOnePlaceholder: "Select one",
       hasExceptionLabel: "Contains exceptions to selection method",
       commentsLabel: "Recommendation comments",
       commentsDescription:
         "Add any needed context for your recommendations for any selected group or single application.",
-      exceptionDetailLabel: "Exceptions to selection method",
+      exceptionDetailLabel: "Reason for exception",
       exceptionDetailDescription:
         "Select one or more applications and explain any exceptions to the general selection method. For example, the reasons for any applications skipped on the merit review ranking or other similar exceptions.",
       fundingHeading: "Funding recommendations",
@@ -2221,6 +2222,10 @@ export const messages = {
       amountRequestedLabel: "Amount Requested",
       amountRecommendedLabel: "Amount Recommended",
       totalLabel: "Total",
+      validationErrorHeading: "There is a problem with your recommendation",
+      recommendationRequired: "Select your recommendation",
+      exceptionDetailRequired: "Enter a reason for this exception",
+      amountRecommendedRequired: "Enter an amount recommended",
     },
     errorHeadingAwardRecommendation:
       "Error fetching award recommendation details",

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2212,7 +2212,7 @@ export const messages = {
       commentsLabel: "Recommendation comments",
       commentsDescription:
         "Add any needed context for your recommendations for any selected group or single application.",
-      exceptionDetailLabel: "Reason for exception",
+      exceptionDetailLabel: "Exceptions to selection method",
       exceptionDetailDescription:
         "Select one or more applications and explain any exceptions to the general selection method. For example, the reasons for any applications skipped on the merit review ranking or other similar exceptions.",
       fundingHeading: "Funding recommendations",

--- a/frontend/src/utils/formatCurrencyUtil.test.ts
+++ b/frontend/src/utils/formatCurrencyUtil.test.ts
@@ -2,6 +2,7 @@ import {
   formatCurrency,
   formatCurrencyString,
   getNumericAmountFromString,
+  sanitizeCurrencyInput,
 } from "src/utils/formatCurrencyUtil";
 
 describe("formatCurrency", () => {
@@ -87,5 +88,26 @@ describe("getNumericAmountFromString", () => {
 
   it("parses large formatted amounts", () => {
     expect(getNumericAmountFromString("$1,234,567.89")).toBe(1234567.89);
+  });
+});
+
+describe("sanitizeCurrencyInput", () => {
+  it("strips letters and other non-numeric characters", () => {
+    expect(sanitizeCurrencyInput("12a3b")).toBe("123");
+    expect(sanitizeCurrencyInput("$1,234")).toBe("1234");
+  });
+
+  it("allows a single decimal point and at most two decimal places", () => {
+    expect(sanitizeCurrencyInput("12.345")).toBe("12.34");
+    expect(sanitizeCurrencyInput("12.3.4")).toBe("12.34");
+  });
+
+  it("allows only a leading minus sign", () => {
+    expect(sanitizeCurrencyInput("-12.5")).toBe("-12.5");
+    expect(sanitizeCurrencyInput("12-5")).toBe("125");
+  });
+
+  it("returns an empty string when there are no numeric characters", () => {
+    expect(sanitizeCurrencyInput("abc")).toBe("");
   });
 });

--- a/frontend/src/utils/formatCurrencyUtil.ts
+++ b/frontend/src/utils/formatCurrencyUtil.ts
@@ -25,3 +25,21 @@ export const getNumericAmountFromString = (
   const raw = (value ?? "").replace(/[$,\s]/g, "");
   return Number(raw) || 0;
 };
+
+/**
+ * Strips non-numeric characters from a currency input while typing.
+ * Matches the budget amount input behavior: digits, optional leading minus,
+ * a single decimal point, and at most two decimal places.
+ */
+export const sanitizeCurrencyInput = (value: string): string => {
+  let next = value.replace(/[^0-9.-]/g, "");
+  next = next.replace(/(?!^)-/g, "");
+  const parts = next.split(".");
+  if (parts.length > 2) {
+    next = `${parts[0]}.${parts.slice(1).join("")}`;
+  }
+  if (parts[1]?.length > 2) {
+    next = `${parts[0]}.${parts[1].slice(0, 2)}`;
+  }
+  return next;
+};


### PR DESCRIPTION
## Summary

Work for #10419 

## Changes proposed

- Add required-field validation on the award recommendation submission edit form (single and bulk), with a top USWDS alert and per-field error messages for Recommendation, Reason for exception (when the exception checkbox is checked), and Amount recommended
- Replace native select required with a “Select one” placeholder and custom validation
- Strip non-numeric characters from Amount recommended while typing (same approach as budget amount inputs), via new `sanitizeCurrencyInput` helper

## Context for reviewers

Validation lives in `RecommendationDetailForm` and is wired through `RecommendationSubmissionEditForm` (single) and EditRecommendationsForm (bulk). Amount recommended is still formatted as currency on blur; sanitization only restricts input while typing.

## Validation steps

- [ ] Submit single and bulk edit with Recommendation, exception reason (when checked), and/or Amount recommended empty 
   - [ ] validate presence of top alert + field errors block submit
- [ ] Fill required fields 
   - [ ] validate that submit succeeds
- [ ] Type letters in Amount recommended
   - [ ] validate that non-numeric characters are rejected; blur still formats currency