### PR TITLE
[Issue #11811] Stop s3 logging GetApplicationZip response

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -590,11 +590,18 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
                 base_path,
                 "response.txt",
             )
-            file_util.write_to_file(
-                response_s3_path,
-                soap_response.to_bytes().decode("utf-8"),
-                content_type=text_content_type,
-            )
+            if soap_request and soap_request.operation_name == "GetApplicationZipRequest":
+                file_util.write_to_file(
+                    response_s3_path,
+                    "GetApplicationZip response not currently logged",
+                    content_type=text_content_type,
+                )
+            else:
+                file_util.write_to_file(
+                    response_s3_path,
+                    soap_response.to_bytes().decode("utf-8"),
+                    content_type=text_content_type,
+                )
             response_headers_s3_path = file_util.join(
                 base_path,
                 "response_headers.txt",

--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -591,10 +591,8 @@ def write_debug_data_to_s3(soap_request: SOAPRequest | None, soap_response: SOAP
                 "response.txt",
             )
             if soap_request and soap_request.operation_name == "GetApplicationZipRequest":
-                file_util.write_to_file(
-                    response_s3_path,
-                    "GetApplicationZip response not currently logged",
-                    content_type=text_content_type,
+                logger.info(
+                    "soap_client: response is not currently being logged to s3",
                 )
             else:
                 file_util.write_to_file(

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -107,6 +107,47 @@ def test_write_debug_data_to_s3(
     )
 
 
+def test_write_debug_data_to_s3_does_not_write_get_application_zip_response(
+    app,
+    db_session,
+    enable_factory_create,
+    monkeypatch,
+    mock_s3_bucket,
+    s3_config,
+) -> None:
+    test_uuid = uuid.uuid4()
+    soap_api_config.get_soap_config.cache_clear()
+    monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    soap_legacy_response = SOAPResponse(
+        data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={"xyz": "abc"}
+    )
+    soap_request = create_soap_request(SOAP_PAYLOAD, operation_name="GetApplicationZipRequest")
+    with app.test_request_context("/"):
+        flask.g.internal_request_id = test_uuid
+        write_debug_data_to_s3(soap_request, soap_legacy_response)
+    request_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request.txt"
+    )
+    response_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response.txt"
+    )
+    response_headers_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response_headers.txt"
+    )
+    request_headers_contents = file_util.read_file(
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request_headers.txt"
+    )
+    assert request_contents.replace("\n", "") == SOAP_PAYLOAD.decode().replace("\n", "")
+    assert response_contents.replace("\r", "") == "GetApplicationZip response not currently logged"
+    assert response_headers_contents.replace("\r", "") == json.dumps({"xyz": "abc"})
+    assert request_headers_contents.replace("\r", "") == json.dumps(
+        {
+            "X-Gg-S2S-Uri": "https://google.com/xyz",
+            "Soapaction": f"{GRANTOR_SOAP_ACTION_PATH}/GetApplicationZip",
+        }
+    )
+
+
 def test_write_debug_data_to_s3_handles_a_null_soap_request(
     app,
     caplog,

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_write_debug_data_to_s3.py
@@ -109,6 +109,7 @@ def test_write_debug_data_to_s3(
 
 def test_write_debug_data_to_s3_does_not_write_get_application_zip_response(
     app,
+    caplog,
     db_session,
     enable_factory_create,
     monkeypatch,
@@ -118,6 +119,7 @@ def test_write_debug_data_to_s3_does_not_write_get_application_zip_response(
     test_uuid = uuid.uuid4()
     soap_api_config.get_soap_config.cache_clear()
     monkeypatch.setenv("SAVE_SOAP_MESSAGES_TO_S3", "true")
+    caplog.set_level(logging.INFO)
     soap_legacy_response = SOAPResponse(
         data=SOAP_LEGACY_RESPONSE_PAYLOAD, status_code=200, headers={"xyz": "abc"}
     )
@@ -128,9 +130,6 @@ def test_write_debug_data_to_s3_does_not_write_get_application_zip_response(
     request_contents = file_util.read_file(
         f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request.txt"
     )
-    response_contents = file_util.read_file(
-        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response.txt"
-    )
     response_headers_contents = file_util.read_file(
         f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response_headers.txt"
     )
@@ -138,7 +137,15 @@ def test_write_debug_data_to_s3_does_not_write_get_application_zip_response(
         f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/request_headers.txt"
     )
     assert request_contents.replace("\n", "") == SOAP_PAYLOAD.decode().replace("\n", "")
-    assert response_contents.replace("\r", "") == "GetApplicationZip response not currently logged"
+    assert not file_util.file_exists(
+        f"s3://local-mock-draft-bucket/soap-debug/{test_uuid}/response.txt"
+    )
+    record = next(
+        r
+        for r in caplog.records
+        if r.message == "soap_client: response is not currently being logged to s3"
+    )
+    assert record
     assert response_headers_contents.replace("\r", "") == json.dumps({"xyz": "abc"})
     assert request_headers_contents.replace("\r", "") == json.dumps(
         {
@@ -217,6 +224,7 @@ def test_write_debug_data_to_s3_runs_on_any_endpoint(
         create_soap_request(SOAP_PAYLOAD, operation_name="GetSubmissionListRequest"),
         soap_legacy_response,
     )
+    # Note: Response will not be written for GetApplicationZip
     write_debug_data_to_s3(
         create_soap_request(SOAP_PAYLOAD, operation_name="GetApplicationZipRequest"),
         soap_legacy_response,
@@ -236,7 +244,7 @@ def test_write_debug_data_to_s3_runs_on_any_endpoint(
         create_soap_request(SOAP_PAYLOAD, operation_name="Y"), soap_legacy_response
     )
     objects = s3_client.list_objects_v2(Bucket="local-mock-draft-bucket")
-    assert len(objects.get("Contents")) == 28
+    assert len(objects.get("Contents")) == 27
 
 
 def test_get_internal_request_id_returns_flask_internal_request_id_if_in_context(app):


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11811 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Added a check for `GetApplicationZipRequest` in the `write_debug_to_s3` method and if it's true to just put a placeholder message instead of trying to write the response

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Currently the attempt to write to s3 is throwing an `UnicodeDecodeError` when trying to write the response to s3:
```
["<class 'UnicodeDecodeError'>", "'utf-8' codec can't decode byte 0xf1 in position 1592: invalid continuation byte", "<traceback object at 0x7f4d7ce8cb00>"]
```
So we're currently going to skip on writing it to s3.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
once deployed
- [ ] errors should stop being logged
