### PR TITLE
Fix burnup queries copied from burndown, add missing burndown query indexes

### DIFF
--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0014_add_burndown_query_indexes.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0014_add_burndown_query_indexes.sql
@@ -1,0 +1,13 @@
+-- gh_issue.parent_issue_ghid drives the recursive epic->issue tree walk used
+-- by the Deliverable_Burndowns/Deliverable_Burnup/Deliverable_Data queries;
+-- it previously had no index at all, forcing a full table scan per
+-- recursion level per query.
+CREATE INDEX IF NOT EXISTS gh_issue_i2 ON gh_issue(parent_issue_ghid);
+
+-- gh_deliverable_quad_map/gh_epic_deliverable_map are day-keyed SCD tables;
+-- "latest row per deliverable/epic" is resolved via a ROW_NUMBER()/DISTINCT
+-- ON ordered (id, d_effective DESC), but the existing indexes on these
+-- tables are ascending on d_effective, so that ordering can't be served
+-- from an index and falls back to a full sort.
+CREATE INDEX IF NOT EXISTS gh_dqm_i2 ON gh_deliverable_quad_map(deliverable_id, d_effective DESC);
+CREATE INDEX IF NOT EXISTS gh_edm_i2 ON gh_epic_deliverable_map(epic_id, d_effective DESC);

--- a/analytics/src/analytics/integrations/metabase/sql/67-Sprint_Metrics/155-Sprint_Burnup_by_points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/67-Sprint_Metrics/155-Sprint_Burnup_by_points.sql
@@ -10,20 +10,20 @@ WITH -- get project_id
    FROM project_data,
         gh_sprint
    WHERE gh_sprint.project_id = project_data.project_id
-     AND {{sprint_name}}), -- calculate points opened in the sprint
- opened AS
+     AND {{sprint_name}}), -- calculate total sprint scope (points tracked) by day
+ SCOPE AS
   (SELECT gh_issue_history.d_effective AS DAY,
-          sum(gh_issue_history.points) AS total_opened
+          sum(gh_issue_history.points) AS total_scope
    FROM gh_issue_history,
         sprint_data
    WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
      AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
           AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
    GROUP BY DAY
-   ORDER BY DAY), -- calculate points closed in the sprint
- closed AS
+   ORDER BY DAY), -- calculate points completed in the sprint by day
+ completed AS
   (SELECT gh_issue_history.d_effective AS DAY,
-          sum(gh_issue_history.points) AS total_closed
+          sum(gh_issue_history.points) AS total_completed
    FROM gh_issue_history,
         sprint_data
    WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
@@ -31,15 +31,14 @@ WITH -- get project_id
      AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
           AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
    GROUP BY DAY
-   ORDER BY DAY), -- aggregate points opened and closed by day
+   ORDER BY DAY), -- aggregate scope and completed work by day (both climb toward total scope)
  totals AS
-  (SELECT opened.day AS DAY,
-          opened.total_opened,
-          closed.total_closed,
-          opened.total_opened - closed.total_closed AS total_remaining
-   FROM opened,
-        closed
-   WHERE opened.day = closed.day
+  (SELECT scope.day AS DAY,
+          scope.total_scope,
+          completed.total_completed
+   FROM SCOPE,
+        completed
+   WHERE scope.day = completed.day
    ORDER BY DAY)
 SELECT *
 FROM totals

--- a/analytics/src/analytics/integrations/metabase/sql/67-Sprint_Metrics/156-Sprint_Burnup_by_issues.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/67-Sprint_Metrics/156-Sprint_Burnup_by_issues.sql
@@ -10,20 +10,20 @@ WITH -- get project_id
    FROM project_data,
         gh_sprint
    WHERE gh_sprint.project_id = project_data.project_id
-     AND {{sprint_name}}), -- calculate issues opened in the sprint identified by sprint_id
- opened AS
+     AND {{sprint_name}}), -- calculate total sprint scope (issues tracked) by day
+ SCOPE AS
   (SELECT gh_issue_history.d_effective AS DAY,
-          count(*) AS total_opened
+          count(*) AS total_scope
    FROM gh_issue_history,
         sprint_data
    WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
      AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
           AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
    GROUP BY DAY
-   ORDER BY DAY), -- calculate issues closed in the sprint
- closed AS
+   ORDER BY DAY), -- calculate issues completed in the sprint by day
+ completed AS
   (SELECT gh_issue_history.d_effective AS DAY,
-          count(*) AS total_closed
+          count(*) AS total_completed
    FROM gh_issue_history,
         sprint_data
    WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
@@ -31,15 +31,14 @@ WITH -- get project_id
      AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
           AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
    GROUP BY DAY
-   ORDER BY DAY), -- aggregate issues opened and closed by day
+   ORDER BY DAY), -- aggregate scope and completed work by day (both climb toward total scope)
  totals AS
-  (SELECT opened.day AS DAY,
-          opened.total_opened,
-          closed.total_closed,
-          opened.total_opened - closed.total_closed AS total_remaining
-   FROM opened,
-        closed
-   WHERE opened.day = closed.day
+  (SELECT scope.day AS DAY,
+          scope.total_scope,
+          completed.total_completed
+   FROM SCOPE,
+        completed
+   WHERE scope.day = completed.day
    ORDER BY DAY)
 SELECT *
 FROM totals

--- a/analytics/src/analytics/integrations/metabase/sql/69-Delivery_Metrics/212-Deliverable_Burnup_Issue_Count.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/69-Delivery_Metrics/212-Deliverable_Burnup_Issue_Count.sql
@@ -65,33 +65,32 @@ WITH RECURSIVE -- 1. Get reporting period dynamically
   (SELECT *
    FROM epic_issue_tree
    UNION ALL SELECT *
-   FROM direct_issues), -- 9. Calculate issues opened in the given time period
- opened AS
+   FROM direct_issues), -- 9. Calculate total issue scope (issues tracked) in the given time period
+ scope AS
   (SELECT h.d_effective AS issue_day,
-          COUNT(DISTINCT h.issue_id) AS total_opened
+          COUNT(DISTINCT h.issue_id) AS total_scope
    FROM gh_issue_history h
    JOIN combined_issues ci ON h.issue_id = ci.issue_id
    CROSS JOIN reporting_period
    WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
    GROUP BY h.d_effective
-   ORDER BY h.d_effective), -- 10. Calculate issues closed in the given time period
- closed AS
+   ORDER BY h.d_effective), -- 10. Calculate issues completed in the given time period
+ completed AS
   (SELECT h.d_effective AS issue_day,
-          COUNT(DISTINCT h.issue_id) AS total_closed
+          COUNT(DISTINCT h.issue_id) AS total_completed
    FROM gh_issue_history h
    JOIN combined_issues ci ON h.issue_id = ci.issue_id
    CROSS JOIN reporting_period
    WHERE h.is_closed::BOOLEAN = TRUE
      AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
    GROUP BY h.d_effective
-   ORDER BY h.d_effective), -- 11. Aggregate issues opened and closed by day
+   ORDER BY h.d_effective), -- 11. Aggregate scope and completed work by day (both climb toward total scope)
  totals AS
-  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
-          COALESCE(o.total_opened, 0) AS total_opened,
-          COALESCE(c.total_closed, 0) AS total_closed,
-          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
-   FROM opened o
-   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
+  (SELECT COALESCE(s.issue_day, c.issue_day) AS issue_day,
+          COALESCE(s.total_scope, 0) AS total_scope,
+          COALESCE(c.total_completed, 0) AS total_completed
+   FROM scope s
+   FULL OUTER JOIN completed c ON s.issue_day = c.issue_day
    ORDER BY issue_day)
 SELECT *
 FROM totals;

--- a/analytics/src/analytics/integrations/metabase/sql/69-Delivery_Metrics/213-Deliverable_Burnup_Points.sql
+++ b/analytics/src/analytics/integrations/metabase/sql/69-Delivery_Metrics/213-Deliverable_Burnup_Points.sql
@@ -65,33 +65,32 @@ WITH RECURSIVE -- 1. Get reporting period dynamically
   (SELECT *
    FROM epic_issue_tree
    UNION ALL SELECT *
-   FROM direct_issues), -- 9. Calculate points opened in the given time period
- opened AS
+   FROM direct_issues), -- 9. Calculate total points scope (points tracked) in the given time period
+ scope AS
   (SELECT h.d_effective AS issue_day,
-          SUM(h.points) AS total_opened
+          SUM(h.points) AS total_scope
    FROM gh_issue_history h
    JOIN combined_issues ci ON h.issue_id = ci.issue_id
    CROSS JOIN reporting_period
    WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
    GROUP BY h.d_effective
-   ORDER BY h.d_effective), -- 10. Calculate points closed in the given time period
- closed AS
+   ORDER BY h.d_effective), -- 10. Calculate points completed in the given time period
+ completed AS
   (SELECT h.d_effective AS issue_day,
-          SUM(h.points) AS total_closed
+          SUM(h.points) AS total_completed
    FROM gh_issue_history h
    JOIN combined_issues ci ON h.issue_id = ci.issue_id
    CROSS JOIN reporting_period
    WHERE h.is_closed::BOOLEAN = TRUE
      AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
    GROUP BY h.d_effective
-   ORDER BY h.d_effective), -- 11. Aggregate points opened and closed by day
+   ORDER BY h.d_effective), -- 11. Aggregate scope and completed work by day (both climb toward total scope)
  totals AS
-  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
-          COALESCE(o.total_opened, 0) AS total_opened,
-          COALESCE(c.total_closed, 0) AS total_closed,
-          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
-   FROM opened o
-   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
+  (SELECT COALESCE(s.issue_day, c.issue_day) AS issue_day,
+          COALESCE(s.total_scope, 0) AS total_scope,
+          COALESCE(c.total_completed, 0) AS total_completed
+   FROM scope s
+   FULL OUTER JOIN completed c ON s.issue_day = c.issue_day
    ORDER BY issue_day)
 SELECT *
 FROM totals;


### PR DESCRIPTION
## Summary

**1. Fix burnup queries that were copies of burndown queries**

`155-Sprint_Burnup_by_points.sql`, `156-Sprint_Burnup_by_issues.sql`, `212-Deliverable_Burnup_Issue_Count.sql`, and `213-Deliverable_Burnup_Points.sql` all computed `total_remaining = opened - closed` -- the burndown formula, byte-for-byte identical to their burndown counterparts in the issue/sprint-level cases. A burnup chart should show two independent series that both climb toward total scope (`total_scope`, `total_completed`), never subtracted. Renamed the underlying CTEs (`opened`/`closed` -> `scope`/`completed`) and dropped the subtraction in all four.

**2. Add missing indexes for the deliverable burndown/burnup/rollup queries**

`gh_issue.parent_issue_ghid` (drives the recursive epic->issue tree walk used by every `Deliverable_Burndowns`/`Deliverable_Burnup`/`Deliverable_Data` question) and the "latest row per deliverable/epic" lookups on `gh_deliverable_quad_map`/`gh_epic_deliverable_map` had no supporting index, so each fell back to a full table scan or sort on every query execution. Added migration `0014_add_burndown_query_indexes.sql`.

## Why draft

This repo's analytics pipeline doesn't have seed/backup tooling yet to apply saved-question changes automatically, so these are raw SQL/migration file changes only -- someone with access to the live Metabase instance still needs to manually paste the updated query text into the corresponding saved questions, and run the new migration against the database. Opening as a draft until that manual verification happens.

## Test plan
- [x] Verified the burnup/burndown pairs were exact duplicates before this change (`diff`).
- [x] Verified via `EXPLAIN ANALYZE` against a copy of this schema that the three affected joins/window functions switch from `Seq Scan`+`Sort` to `Index Scan` after adding the equivalent indexes.
- [ ] Manually apply the 4 updated queries to the live Metabase instance and confirm the burnup charts now show two climbing series instead of a declining one.
- [ ] Run the new migration against the live database.