### PR TITLE
[Issue #11869] Remove debug logging flag for gunicorn

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -141,4 +141,4 @@ USER ${RUN_USER}
 # from the WORKDIR (/api) when the file is present. We pass it explicitly as a guardrail --
 # if the config is ever dropped from the image again, gunicorn fails fast at startup
 # instead of silently falling back to its defaults (1 sync worker, 1 thread).
-CMD ["gunicorn", "-c", "gunicorn.conf.py", "--worker-tmp-dir=/dev/shm", "src.app:create_app()", "--log-level", "debug"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "--worker-tmp-dir=/dev/shm", "src.app:create_app()"]


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11869 

## Changes proposed

Remove command line arg to gunicorn that was enabling debug logging
## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
We needed this for GS integration troubleshooting but we solved that problem and can turn this back off.

## Validation steps
- [ ] Checks pass
- [ ] Debug logs no longer happen once deployed.