### PR TITLE
[Issue #11533] Mark `first_name` and `last_name` as `required=True`

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -8794,6 +8794,9 @@ components:
           type: string
           description: The last name of the user
           example: Smith
+      required:
+      - first_name
+      - last_name
     WorkflowUserSchema:
       type: object
       properties:

--- a/api/src/api/users/user_schemas.py
+++ b/api/src/api/users/user_schemas.py
@@ -515,7 +515,22 @@ class UserApiKeyListResponseSchema(AbstractResponseSchema):
 
 
 class UserUpdateProfileRequestSchema(UserProfile):
-    pass
+    first_name = fields.String(
+        required=True,
+        allow_none=False,
+        metadata={
+            "description": "The first name of the user",
+            "example": "John",
+        },
+    )
+    last_name = fields.String(
+        required=True,
+        allow_none=False,
+        metadata={
+            "description": "The last name of the user",
+            "example": "Smith",
+        },
+    )
 
 
 class UserUpdateProfileResponseSchema(AbstractResponseSchema):

--- a/api/tests/src/api/users/test_user_profile_put.py
+++ b/api/tests/src/api/users/test_user_profile_put.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+import pytest
+
 from src.db.models.user_models import UserProfile
 from tests.src.db.models.factories import UserProfileFactory
 
@@ -48,7 +50,7 @@ def test_user_update_profile_unauthorized(client, db_session, user_auth_token, u
     response = client.put(
         f"/v1/users/{user_id}/profile",
         headers={"X-SGG-Token": user_auth_token},
-        json={"first_name": "Henry"},
+        json={"first_name": "Henry", "last_name": "Ford"},
     )
 
     assert response.status_code == 403
@@ -56,4 +58,33 @@ def test_user_update_profile_unauthorized(client, db_session, user_auth_token, u
 
     # Verify no record created
     res = db_session.query(UserProfile).filter(UserProfile.user_id == user_id).first()
+    assert not res
+
+
+@pytest.mark.parametrize(
+    "request_json,expected_missing_fields",
+    [
+        ({}, {"first_name", "last_name"}),
+        ({"last_name": "Ford"}, {"first_name"}),
+        ({"first_name": "Henry"}, {"last_name"}),
+        ({"middle_name": "Jane"}, {"first_name", "last_name"}),
+    ],
+)
+def test_user_update_profile_missing_required_fields(
+    client, db_session, user_auth_token, user, request_json, expected_missing_fields
+):
+    response = client.put(
+        f"/v1/users/{user.user_id}/profile",
+        headers={"X-SGG-Token": user_auth_token},
+        json=request_json,
+    )
+
+    assert response.status_code == 422
+
+    errors = response.json["errors"]
+    assert {error["field"] for error in errors} == expected_missing_fields
+    for error in errors:
+        assert error["type"] == "required"
+
+    res = db_session.query(UserProfile).filter(UserProfile.user_id == user.user_id).first()
     assert not res


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11533 

## Changes proposed
- Mark `first_name` and `last_name` as `required=True` on `UserUpdateProfileRequestSchema`, so `PUT /v1/users/:user_id/profile` returns a 422
- Add tests covering empty `{}` body, missing `first_name`, missing `last_name`, and middle-name-only.

## Context for reviewers
The fields are overridden on the request subclass rather than on the base `UserProfile` schema, since that base is also used for responses (`UserSchema.profile` and `UserUpdateProfileResponseSchema`).`UserProfile` is subclassed nowhere else, so this affects exactly one endpoint.

## Validation steps
See updated unit test demonstrating 422.