### PR TITLE
[Issue #11837] disable delete button if simpler file input is disabled, adds story

### DIFF
--- a/frontend/src/components/core/fileInput/FileInputExistingFiles.test.tsx
+++ b/frontend/src/components/core/fileInput/FileInputExistingFiles.test.tsx
@@ -114,4 +114,32 @@ describe("FileInputExistingFiles", () => {
       updatedAt: testDateTwo.toString(),
     });
   });
+  it("disables delete button when input is disabled", async () => {
+    const onDeleteMock = jest.fn();
+    const fileOne = generateFile(testDateOne, 1);
+    const fileTwo = generateFile(testDateTwo, 2);
+    render(
+      <FileInputExistingFiles
+        existingFiles={[fileOne, fileTwo]}
+        onDelete={onDeleteMock}
+        disabled={true}
+      />,
+    );
+
+    const deleteButtons = await screen.findAllByRole("button", {
+      name: "delete",
+    });
+    expect(deleteButtons).toHaveLength(2);
+
+    const firstButton = deleteButtons[0];
+    const secondButton = deleteButtons[1];
+    expect(firstButton).toBeDisabled();
+    expect(secondButton).toBeDisabled();
+
+    await userEvent.click(firstButton);
+    expect(onDeleteMock).not.toHaveBeenCalled();
+
+    await userEvent.click(secondButton);
+    expect(onDeleteMock).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/components/core/fileInput/FileInputExistingFiles.tsx
+++ b/frontend/src/components/core/fileInput/FileInputExistingFiles.tsx
@@ -10,10 +10,12 @@ import { USWDSIcon } from "src/components/core/USWDSIcon";
 export const FileInputExistingFiles = ({
   existingFiles,
   onDelete,
+  disabled = false,
   filesWithDeleteError = [] as string[],
 }: {
   existingFiles?: UploadFileMetadata[];
   onDelete: (fileToDelete: UploadFileMetadata) => void;
+  disabled?: boolean;
   filesWithDeleteError?: string[];
 }) => {
   const t = useTranslations("FileInput.existingFiles");
@@ -51,6 +53,7 @@ export const FileInputExistingFiles = ({
             <Button
               type="button"
               unstyled
+              disabled={disabled}
               onClick={() => {
                 void onDelete(existingFile);
               }}

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -227,6 +227,7 @@ export const SimplerFileInput = ({
           deleteModalRef.current?.toggleModal();
         }}
         filesWithDeleteError={filesWithDeleteError}
+        disabled={disabled}
       />
       <DeleteFileModal
         // note that this only supports deleting one file at a time.

--- a/frontend/src/components/core/fileInput/SimplerFileInput.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.tsx
@@ -227,7 +227,7 @@ export const SimplerFileInput = ({
           deleteModalRef.current?.toggleModal();
         }}
         filesWithDeleteError={filesWithDeleteError}
-        disabled={disabled}
+        disabled={disabled || readOnly}
       />
       <DeleteFileModal
         // note that this only supports deleting one file at a time.

--- a/frontend/stories/core-components/SimplerFileInput.stories.tsx
+++ b/frontend/stories/core-components/SimplerFileInput.stories.tsx
@@ -1,0 +1,59 @@
+import { SimplerFileInput } from "src/components/core/fileInput/SimplerFileInput";
+
+const meta = {
+  title: "Core Components/SimplerFileInput",
+  component: SimplerFileInput,
+};
+export default meta;
+
+const defaultArgs = {
+  postUploadAction: () => Promise.resolve(),
+  postUploadActionProgressMessage: "Post upload action in progress",
+  postUploadActionSuccessMessage: "Upload success",
+  postUploadActionErrorMessage: "Upload error",
+  onDelete: (_fileId: string) => {
+    // eslint-disable-next-line no-console
+    console.log("Deleting file");
+    return Promise.resolve();
+  },
+  onError: (_err: Error) => console.error("Error!"),
+  // eslint-disable-next-line no-console
+  onSuccess: () => console.log("Success!"),
+  // eslint-disable-next-line no-console
+  onStart: () => console.log("Upload started!"),
+  // eslint-disable-next-line no-console
+  onComplete: () => console.log("Upload complete!"),
+  id: "1",
+  existingFiles: [],
+  required: false,
+  disabled: false,
+  readOnly: false,
+  labelId: "",
+  multiFile: false,
+};
+
+export const Default = {
+  args: defaultArgs,
+};
+
+export const Disabled = (): React.ReactElement => (
+  <SimplerFileInput {...defaultArgs} disabled={true} />
+);
+
+export const DisabledExistingFiles = (): React.ReactElement => (
+  <SimplerFileInput
+    {...defaultArgs}
+    disabled={true}
+    existingFiles={[
+      {
+        id: "1",
+        fileName: "file.txt",
+        updatedAt: new Date().toString(),
+      },
+    ]}
+  />
+);
+
+export const MultiFile = (): React.ReactElement => (
+  <SimplerFileInput {...defaultArgs} multiFile={true} />
+);

--- a/frontend/stories/core-components/SimplerFileInput.stories.tsx
+++ b/frontend/stories/core-components/SimplerFileInput.stories.tsx
@@ -54,6 +54,20 @@ export const DisabledExistingFiles = (): React.ReactElement => (
   />
 );
 
+export const ReadOnlyExistingFiles = (): React.ReactElement => (
+  <SimplerFileInput
+    {...defaultArgs}
+    readOnly={true}
+    existingFiles={[
+      {
+        id: "1",
+        fileName: "file.txt",
+        updatedAt: new Date().toString(),
+      },
+    ]}
+  />
+);
+
 export const MultiFile = (): React.ReactElement => (
   <SimplerFileInput {...defaultArgs} multiFile={true} />
 );


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11837 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

* whenever a SimplerFileInput is disabled, the "delete" button for any existing files passed in is also disabled.
* a very basic storybook story is created to make sure this works

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

The story is not part of the requirements but it is the easiest way outside of unit testing to make sure this change works.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. run `npm run storybook` on this branch
2. visit http://localhost:6006/?path=/story/core-components-simplerfileinput--disabled-existing-files
3. hover over and click on the delete button
4. _VERIFY_: nothing happens, button is disabled