### PR TITLE
[Issue #9540] remove nextJS preloading links for auth behavior

### DIFF
--- a/frontend/src/components/core/header/Header.tsx
+++ b/frontend/src/components/core/header/Header.tsx
@@ -39,6 +39,39 @@ type PrimaryLink = {
 
 const homeRegexp = /^\/(?:e[ns])?$/;
 
+/*
+  nav links going to external sites need to:
+  - not be preloaded
+  - include an "external link" icon
+  - open in a new tab
+*/
+const ExternalNavLink = ({
+  href = "",
+  classes,
+  onClick,
+  text,
+}: {
+  href?: string;
+  classes?: string;
+  onClick: () => void;
+  text: string;
+}) => {
+  return (
+    <a
+      href={href}
+      key={href}
+      className={classes}
+      target="_blank"
+      onClick={onClick}
+    >
+      <span className="icon-btn">
+        {text}
+        <USWDSIcon name="launch" className="usa-icon--size-2" />
+      </span>
+    </a>
+  );
+};
+
 const NavLink = ({
   href = "",
   classes,
@@ -50,27 +83,20 @@ const NavLink = ({
   onClick: () => void;
   text: string;
 }) => {
-  let iconBtnClass, linkTarget;
-
   if (isExternalLink(href)) {
-    iconBtnClass = "icon-btn";
-    linkTarget = "_blank";
+    return (
+      <ExternalNavLink
+        href={href}
+        classes={classes}
+        onClick={onClick}
+        text={text}
+      />
+    );
   }
 
   return (
-    <Link
-      href={href}
-      key={href}
-      className={classes}
-      target={linkTarget}
-      onClick={onClick}
-    >
-      <span className={iconBtnClass}>
-        {text}
-        {isExternalLink(href) && (
-          <USWDSIcon name="launch" className="usa-icon--size-2" />
-        )}
-      </span>
+    <Link href={href} key={href} className={classes} onClick={onClick}>
+      {text}
     </Link>
   );
 };
@@ -249,22 +275,23 @@ const NavLinks = ({
       );
     });
 
-    // add user account nav  depending on login status
+    // add user account nav depending on login status
     if (!user?.token) {
       items.push(
-        <NavLink
-          key="sign-in"
+        <a
           href={LOGIN_URL}
+          key="sign-in"
+          className={clsx({
+            "usa-nav__link": true,
+            "text-normal": true,
+          })}
           onClick={() => {
             storeCurrentPage(location.pathname, location.search);
             closeDropdownAndMobileNav();
           }}
-          text={t("login")}
-          classes={clsx({
-            "usa-nav__link": true,
-            "text-normal": true,
-          })}
-        />,
+        >
+          {t("login")}
+        </a>,
       );
     } else {
       const accountIndex = navLinkList.length;

--- a/frontend/src/components/core/header/SignOutNavLink.tsx
+++ b/frontend/src/components/core/header/SignOutNavLink.tsx
@@ -1,7 +1,6 @@
 import { useUser } from "src/services/auth/useUser";
 
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
 
@@ -19,7 +18,7 @@ export const SignOutNavLink = ({ onClick }: { onClick: () => void }) => {
   }, [logoutLocalUser, router, onClick]);
 
   return (
-    <Link
+    <a
       href="#"
       onClick={(e) => {
         e.preventDefault();
@@ -27,6 +26,6 @@ export const SignOutNavLink = ({ onClick }: { onClick: () => void }) => {
       }}
     >
       {t("logout")}
-    </Link>
+    </a>
   );
 };


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #9540 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Currently we use nextJS `<Link>` components that attempt to preload pages for both login and logout links. Since neither of these links can be preloaded, they should use regular `<a>` tags instead.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

This also does a slight refactor to create and `ExternalNavLink` component since I originally thought that'd be useful. It's not directly related to this change, since the needs of an external nav link (opening in a new tab, including an external link icon) are not relevant to the login and logout links, but kept it in any case since it does make things cleaner and removes the preload link from other external links that also should not be preloaded.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. `npm run dev` on this branch
2. visit http://localhost:3000
3. _VERIFY_: no csp errors for `/login` route appear in the console
4. log in
3. _VERIFY_: no csp errors for `/logout` route appear in the console