### PR TITLE
[Issue #11886] Add legacy tracking number to logging

### DIFF
--- a/api/src/legacy_soap_api/legacy_soap_api_utils.py
+++ b/api/src/legacy_soap_api/legacy_soap_api_utils.py
@@ -12,6 +12,7 @@ import grants_shared.adapters.db as db
 import requests
 from defusedxml import minidom
 from grants_shared.adapters.aws import S3Config
+from grants_shared.logs.flask_logger import add_extra_data_to_current_request_logs
 from grants_shared.util import file_util
 from lxml import etree
 from sqlalchemy import exists, select
@@ -470,15 +471,7 @@ def get_alternate_proxy_response(soap_request: SOAPRequest) -> SOAPResponse | No
         return None
     if soap_request.operation_name in AlternateSoapOperation:
         tracking_number = get_gov_grants_tracking_number(xml_bytes)
-        logger.info(
-            "simpler_soap_api: tracking number check",
-            extra={
-                "tracking_number_length": len(tracking_number) if tracking_number else None,
-                "is_simpler_tracking_number": (
-                    tracking_number.startswith("GRANT8") if tracking_number else False
-                ),
-            },
-        )
+        add_extra_data_to_current_request_logs({"grants_gov_tracking_number": tracking_number})
         is_zip = soap_request.operation_name == AlternateSoapOperation.GET_APPLICATION_ZIP
         if tracking_number and (
             tracking_number.startswith("GRANT8") or tracking_number.startswith("GRANT9")

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -140,7 +140,7 @@ def test_successful_confirm_application_delivery_request(
 
 
 def test_successful_confirm_application_delivery_request_if_grants_gov_tracking_number_is_parsed_as_a_string(
-    db_session, client, enable_factory_create
+    db_session, client, enable_factory_create, caplog
 ) -> None:
     agency = AgencyFactory.create()
     opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
@@ -194,6 +194,9 @@ def test_successful_confirm_application_delivery_request_if_grants_gov_tracking_
         )
     )
     assert db_session.execute(count_query).scalar() == 1
+
+    end_message = next(record for record in caplog.records if record.message == "end request")
+    assert end_message.grants_gov_tracking_number == f"GRANT{submission.legacy_tracking_number}"
 
 
 @mock.patch("uuid.uuid4")


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11886  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Added logging for `GrantsGovTrackingNumber`
- Removed some logging that was confirming that the `GrantsGovTrackingNumber` was valid

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
For ease of troubleshooting we wanted to make the tracking number accessible in the logs.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [x] tests passing
After deploy
- [ ] tracking number appears in New Relic logs
