### PR TITLE
[Issue #10923] Add test opportunity for SF424C

### DIFF
--- a/api/src/task/opportunities/build_automatic_opportunities.py
+++ b/api/src/task/opportunities/build_automatic_opportunities.py
@@ -657,6 +657,12 @@ class BuildAutomaticOpportunitiesTask(Task):
                 "dbd8b2c4-0d6b-48b6-9427-32ee7795f4d6",
             ),
             (
+                "E2E-SF424C",
+                "Budget Information for Construction Programs (SF-424C)",
+                SF424c_v2_0.form_id,
+                "a4c8e1f2-3b6d-4e91-8a2c-7f5b9d3e6a18",
+            ),
+            (
                 "E2E-SF424D",
                 "Assurances for Construction Programs (SF-424D)",
                 SF424d_v1_1.form_id,

--- a/api/src/task/opportunities/build_automatic_opportunities.py
+++ b/api/src/task/opportunities/build_automatic_opportunities.py
@@ -46,6 +46,7 @@ from src.form_schema.forms import (
     SF424_v4_0,
     SF424a_v1_0,
     SF424b_v1_1,
+    SF424c_v2_0,
     SF424d_v1_1,
     SF424Short_v3_0,
     SFLLL_v2_0,

--- a/api/tests/lib/seed_local_db.py
+++ b/api/tests/lib/seed_local_db.py
@@ -606,6 +606,13 @@ def _build_custom_test_competitions(forms: dict[str, Form]) -> None:
             "15d10405-d81b-4b8e-ae56-8ac1bd4c5560",
         ),
         (
+            "SF424C",
+            "E2E-SF424C",
+            "Budget Information for Construction Programs (SF-424C)",
+            "a4c8e1f2-3b6d-4e91-8a2c-7f5b9d3e6a18",
+            "d9f2b6e4-1c8a-4b73-9e6f-2a5d8c4b7f19",
+        ),
+        (
             "SF424D",
             "E2E-SF424D",
             "Assurances for Construction Programs (SF-424D)",

--- a/api/tests/src/task/opportunities/test_build_automatic_opportunities.py
+++ b/api/tests/src/task/opportunities/test_build_automatic_opportunities.py
@@ -57,7 +57,7 @@ def test_build_automatic_opportunities(enable_factory_create, db_session, forms)
 
     # Grab the opportunities created from the task itself
     opportunities = task.opportunities
-    assert len(opportunities) == 40
+    assert len(opportunities) == 41
 
     # Figure out the forms we added to each opportunity
     opp_form_ids_for_opps = set()
@@ -74,7 +74,7 @@ def test_build_automatic_opportunities(enable_factory_create, db_session, forms)
     # There should also be one opportunity with every form
     assert all_form_ids in opp_form_ids_for_opps
 
-    assert task.metrics[task.Metrics.OPPORTUNITY_CREATED_COUNT] == 40
+    assert task.metrics[task.Metrics.OPPORTUNITY_CREATED_COUNT] == 41
     assert task.metrics[task.Metrics.OPPORTUNITY_ALREADY_EXIST_COUNT] == 0
 
     # If we rerun the task, all opportunities should be skipped (including ALL-forms)
@@ -84,7 +84,7 @@ def test_build_automatic_opportunities(enable_factory_create, db_session, forms)
     assert len(task.opportunities) == 0
 
     assert task.metrics[task.Metrics.OPPORTUNITY_CREATED_COUNT] == 0
-    assert task.metrics[task.Metrics.OPPORTUNITY_ALREADY_EXIST_COUNT] == 40
+    assert task.metrics[task.Metrics.OPPORTUNITY_ALREADY_EXIST_COUNT] == 41
 
 
 def test_opportunity_ids_are_consistent_across_runs(enable_factory_create, db_session, forms):
@@ -143,6 +143,7 @@ def test_opportunity_ids_are_consistent_across_runs(enable_factory_create, db_se
         "E2E-SF424SHORT-ORG-IND-01": uuid.UUID("425c2ffe-6fbd-4852-ab72-b64467fe3df0"),
         "E2E-SF424A-ORG-IND-01": uuid.UUID("6c25cd41-660e-473f-abff-654083b7795d"),
         "E2E-SF424B-ORG-IND-01": uuid.UUID("dbd8b2c4-0d6b-48b6-9427-32ee7795f4d6"),
+        "E2E-SF424C-ORG-IND-01": uuid.UUID("a4c8e1f2-3b6d-4e91-8a2c-7f5b9d3e6a18"),
         "E2E-SF424D-ORG-IND-01": uuid.UUID("abd9bce9-2b9b-46b8-b814-2c5cb7c5e88b"),
         "E2E-SFLLL-ORG-IND-01": uuid.UUID("f3e438ee-ff4c-475b-a058-8049aee9abda"),
         "E2E-NEHCS-ORG-IND-01": uuid.UUID("b88287e2-7e2a-4c99-8ffe-30ab50c388ef"),


### PR DESCRIPTION
## Summary
Work for: Task #10923 

## Changes proposed
Create test opportunity for SF424C Form

## Context for reviewers
This change enables testing and validation of SF424C Form testing work.

## Validation steps
Verify the above opportunity exist in local by running the make command : make db-seed-local populate-search-opportunities for data population and search for the data in the logs.

For the Staging and Training environments, the change must first be merged into main and then deployed (deployments usually happens on Wednesdays).