### PR TITLE
[issue #11903] Send Slack notification on failures

### DIFF
--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -21,3 +21,10 @@ jobs:
     secrets: inherit
     with:
       playwright_tags: "@smoke|@core-regression|@full-regression"
+  send-slack-notification:
+    if: failure()
+    needs: [daily-e2e-tests-deployed, daily-e2e-tests-local]
+    uses: ./.github/workflows/send-slack-notification.yml
+    with:
+      "channel_id": "alerts-e2e"
+    secrets: inherit


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11903 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Add the Slack Notification step from E2E Weekly to E2E Daily

## Validation steps

- Checks pass
- Merge to main and observe if failures start notifying