### PR TITLE
[Issue #11724] Modify presigned file upload in preparation of moving it to grants-shared

### DIFF
--- a/api/src/api/files_v1/file_routes.py
+++ b/api/src/api/files_v1/file_routes.py
@@ -13,7 +13,7 @@ import src.api.files_v1.file_schemas as file_schemas
 from src.api.files_v1.file_blueprint import file_blueprint
 from src.auth.api_user_key_auth import api_user_key_auth
 from src.auth.multi_auth import jwt_or_api_user_key_multi_auth
-from src.services.files.create_presigned_upload import create_presigned_upload
+from src.services.files.create_presigned_upload import SimplerPresignFileUploadService
 from src.services.files.stream_file_scan_results import stream_file_scan_results
 from src.services.files.update_pending_file_scan_status import update_pending_file_scan_status
 
@@ -42,10 +42,8 @@ def create_presigned_upload_route(db_session: db.Session, json_data: dict) -> re
 
     with db_session.begin():
         db_session.add(user)
-        result = create_presigned_upload(
-            db_session=db_session,
-            user=user,
-            request_data=json_data,
+        result = SimplerPresignFileUploadService(db_session).create_presigned_upload(
+            user=user, file_name=json_data["file_name"], mime_type=json_data["mime_type"]
         )
 
     add_extra_data_to_current_request_logs({"pending_file_id": result.pending_file_id})

--- a/api/src/services/files/create_presigned_upload.py
+++ b/api/src/services/files/create_presigned_upload.py
@@ -1,3 +1,4 @@
+import abc
 import logging
 import uuid
 from dataclasses import dataclass
@@ -10,6 +11,7 @@ from grants_shared.adapters.aws import S3Config
 from grants_shared.adapters.aws.dynamodb_adapter import DynamoDBClient, DynamoDBConfig
 from grants_shared.api.response import ValidationErrorDetail
 from grants_shared.api.route_utils import raise_flask_error
+from grants_shared.db.models.auth_base_models import BaseUser
 from grants_shared.util import datetime_util
 from pydantic import Field
 from sqlalchemy import func, select
@@ -37,16 +39,113 @@ class PresignedUploadResult:
     body: dict[str, Any]
 
 
-def _count_recent_pending_files(
-    db_session: db.Session, user_id: uuid.UUID, window_hours: int
-) -> int:
-    cutoff = datetime_util.utcnow() - timedelta(hours=window_hours)
-    stmt = (
-        select(func.count())
-        .select_from(PendingFile)
-        .where(PendingFile.user_id == user_id, PendingFile.created_at >= cutoff)
-    )
-    return db_session.execute(stmt).scalar_one()
+class BasePresignFileUploadService[USER: BaseUser](abc.ABC, metaclass=abc.ABCMeta):
+    """
+    Base class for setting up a presigned URL to work with our file upload approach.
+
+    This handles:
+    * Validating anything about the user before they upload the file.
+    * Creating a pending record in the DB.
+    * Create a presigned URL with metadata expected.
+    * Create a record in DynamoDB about the pending file.
+    """
+
+    def __init__(
+        self,
+        db_session: db.Session,
+        s3_config: S3Config | None = None,
+        dynamodb_client: DynamoDBClient | None = None,
+        dynamodb_config: DynamoDBConfig | None = None,
+        config: PresignedUploadConfig | None = None,
+    ):
+        self.db_session = db_session
+        if s3_config is None:
+            s3_config = S3Config()
+        self.s3_config = s3_config
+
+        if dynamodb_client is None:
+            dynamodb_client = DynamoDBClient()
+        self.dynamodb_client = dynamodb_client
+
+        if dynamodb_config is None:
+            dynamodb_config = DynamoDBConfig()
+        self.dynamodb_config = dynamodb_config
+
+        if config is None:
+            config = PresignedUploadConfig()
+        self.config = config
+
+    def create_presigned_upload(
+        self, user: USER, file_name: str, mime_type: str
+    ) -> PresignedUploadResult:
+
+        # Verify that the user can presign the URL
+        self.validate_user_can_presign(user)
+        user_id = user.get_user_id()
+
+        # secure_filename makes the file safe for path operations and strips
+        # non-ascii characters before we hand it to s3.
+        secure_file_name = file_util.get_secure_file_name(file_name)
+
+        pending_file_id = uuid.uuid4()
+        s3_file_location = _build_s3_file_location(
+            self.s3_config, pending_file_id, secure_file_name
+        )
+
+        self.create_pending_file_in_db(
+            pending_file_id=pending_file_id,
+            user=user,
+            file_name=file_name,
+            s3_file_location=s3_file_location,
+            mime_type=mime_type,
+        )
+
+        presigned = file_util.pre_sign_upload(
+            file_path=s3_file_location,
+            content_type=mime_type,
+            metadata={
+                "file-id": str(pending_file_id),
+                "user-id": str(user_id),
+            },
+            s3_config=self.s3_config,
+        )
+
+        _write_scan_record(
+            dynamodb_client=self.dynamodb_client,
+            dynamodb_config=self.dynamodb_config,
+            pending_file_id=pending_file_id,
+            user_id=user.get_user_id(),
+        )
+
+        logger.info(
+            "Created presigned upload for pending file",
+            extra={
+                "pending_file_id": pending_file_id,
+                "user_id": user_id,
+                "file_scan_status": FileScanStatus.PENDING,
+            },
+        )
+
+        return PresignedUploadResult(
+            pending_file_id=pending_file_id,
+            url=presigned["url"],
+            body=presigned["fields"],
+        )
+
+    @abc.abstractmethod
+    def validate_user_can_presign(self, user: USER) -> None:
+        pass
+
+    @abc.abstractmethod
+    def create_pending_file_in_db(
+        self,
+        pending_file_id: uuid.UUID,
+        user: USER,
+        file_name: str,
+        s3_file_location: str,
+        mime_type: str,
+    ) -> None:
+        pass
 
 
 def _build_s3_file_location(s3_config: S3Config, pending_file_id: uuid.UUID, file_name: str) -> str:
@@ -74,102 +173,68 @@ def _write_scan_record(
     )
 
 
-def create_presigned_upload(
-    db_session: db.Session,
-    user: User,
-    request_data: dict,
-    s3_config: S3Config | None = None,
-    dynamodb_client: DynamoDBClient | None = None,
-    dynamodb_config: DynamoDBConfig | None = None,
-    config: PresignedUploadConfig | None = None,
-) -> PresignedUploadResult:
-    if s3_config is None:
-        s3_config = S3Config()
-    if dynamodb_client is None:
-        dynamodb_client = DynamoDBClient()
-    if dynamodb_config is None:
-        dynamodb_config = DynamoDBConfig()
-    if config is None:
-        config = PresignedUploadConfig()
+# Everything under here will stay in Simpler, everything above will go to grant-shared.
 
-    file_name = request_data["file_name"]
-    mime_type = request_data["mime_type"]
 
-    recent_count = _count_recent_pending_files(
-        db_session, user.user_id, config.pending_file_upload_rate_window_hours
-    )
-    if recent_count >= config.pending_file_upload_rate_limit:
-        logger.info(
-            "User exceeded pending file upload rate limit",
-            extra={
-                "user_id": user.user_id,
-                "recent_pending_file_count": recent_count,
-                "pending_file_upload_rate_limit": config.pending_file_upload_rate_limit,
-                "pending_file_upload_rate_window_hours": (
-                    config.pending_file_upload_rate_window_hours
-                ),
-            },
+class SimplerPresignFileUploadService(BasePresignFileUploadService[User]):
+
+    def validate_user_can_presign(self, user: User) -> None:
+        recent_count = _count_recent_pending_files(
+            self.db_session, user.user_id, self.config.pending_file_upload_rate_window_hours
         )
-        raise_flask_error(
-            429,
-            message="Too many pending file uploads",
-            validation_issues=[
-                ValidationErrorDetail(
-                    type=ValidationErrorType.PENDING_FILE_UPLOAD_LIMIT_EXCEEDED,
-                    message=(
-                        f"User has uploaded more than "
-                        f"{config.pending_file_upload_rate_limit} files in the past "
-                        f"{config.pending_file_upload_rate_window_hours} hour(s)"
+        if recent_count >= self.config.pending_file_upload_rate_limit:
+            logger.info(
+                "User exceeded pending file upload rate limit",
+                extra={
+                    "user_id": user.user_id,
+                    "recent_pending_file_count": recent_count,
+                    "pending_file_upload_rate_limit": self.config.pending_file_upload_rate_limit,
+                    "pending_file_upload_rate_window_hours": (
+                        self.config.pending_file_upload_rate_window_hours
                     ),
-                )
-            ],
+                },
+            )
+            raise_flask_error(
+                429,
+                message="Too many pending file uploads",
+                validation_issues=[
+                    ValidationErrorDetail(
+                        type=ValidationErrorType.PENDING_FILE_UPLOAD_LIMIT_EXCEEDED,
+                        message=(
+                            f"User has uploaded more than "
+                            f"{self.config.pending_file_upload_rate_limit} files in the past "
+                            f"{self.config.pending_file_upload_rate_window_hours} hour(s)"
+                        ),
+                    )
+                ],
+            )
+
+    def create_pending_file_in_db(
+        self,
+        pending_file_id: uuid.UUID,
+        user: User,
+        file_name: str,
+        s3_file_location: str,
+        mime_type: str,
+    ) -> None:
+        pending_file = PendingFile(
+            pending_file_id=pending_file_id,
+            user=user,
+            file_name=file_name,
+            file_location=s3_file_location,
+            mime_type=mime_type,
+            file_scan_status=FileScanStatus.PENDING,
         )
+        self.db_session.add(pending_file)
 
-    # secure_filename makes the file safe for path operations and strips
-    # non-ascii characters before we hand it to s3.
-    secure_file_name = file_util.get_secure_file_name(file_name)
 
-    pending_file_id = uuid.uuid4()
-    s3_file_location = _build_s3_file_location(s3_config, pending_file_id, secure_file_name)
-
-    pending_file = PendingFile(
-        pending_file_id=pending_file_id,
-        user=user,
-        file_name=file_name,
-        file_location=s3_file_location,
-        mime_type=mime_type,
-        file_scan_status=FileScanStatus.PENDING,
+def _count_recent_pending_files(
+    db_session: db.Session, user_id: uuid.UUID, window_hours: int
+) -> int:
+    cutoff = datetime_util.utcnow() - timedelta(hours=window_hours)
+    stmt = (
+        select(func.count())
+        .select_from(PendingFile)
+        .where(PendingFile.user_id == user_id, PendingFile.created_at >= cutoff)
     )
-    db_session.add(pending_file)
-
-    presigned = file_util.pre_sign_upload(
-        file_path=s3_file_location,
-        content_type=mime_type,
-        metadata={
-            "file-id": str(pending_file_id),
-            "user-id": str(user.user_id),
-        },
-        s3_config=s3_config,
-    )
-
-    _write_scan_record(
-        dynamodb_client=dynamodb_client,
-        dynamodb_config=dynamodb_config,
-        pending_file_id=pending_file_id,
-        user_id=user.user_id,
-    )
-
-    logger.info(
-        "Created presigned upload for pending file",
-        extra={
-            "pending_file_id": pending_file_id,
-            "user_id": user.user_id,
-            "file_scan_status": FileScanStatus.PENDING,
-        },
-    )
-
-    return PresignedUploadResult(
-        pending_file_id=pending_file_id,
-        url=presigned["url"],
-        body=presigned["fields"],
-    )
+    return db_session.execute(stmt).scalar_one()

--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -10,13 +10,13 @@ import grants_shared.adapters.db.flask_db as flask_db
 import grants_shared.util.file_util as file_util
 from grants_shared.adapters.aws.dynamodb_adapter import DynamoDBClient, DynamoDBConfig
 from grants_shared.api.route_utils import raise_flask_error
+from grants_shared.db.models.auth_base_models import BaseUser
 from grants_shared.util import datetime_util
 from pydantic import Field
 from sqlalchemy import select
 
 from src.constants.lookup_constants import FileScanStatus
 from src.db.models.file_upload_models import PendingFile
-from src.db.models.user_models import User
 from src.util.env_config import PydanticBaseEnvConfig
 
 logger = logging.getLogger(__name__)
@@ -186,7 +186,7 @@ def _metadata_for_status(status: FileScanStatus, pending_file_id: uuid.UUID) -> 
 
 def stream_file_scan_results(
     pending_file_id: uuid.UUID,
-    user: User,
+    user: BaseUser,
     dynamodb_client: DynamoDBClient,
     config: FileScanStreamConfig | None = None,
     dynamodb_config: DynamoDBConfig | None = None,
@@ -209,6 +209,7 @@ def stream_file_scan_results(
         dynamodb_config = DynamoDBConfig()
 
     table_name = dynamodb_config.file_scan_cache_table_name
+    user_id = user.get_user_id()
 
     # First lookup happens outside the generator so that 404/403/500 results in
     # a proper HTTP status code rather than a truncated stream. A malformed
@@ -218,12 +219,12 @@ def stream_file_scan_results(
     if record is None:
         raise_flask_error(404, "File scan record not found")
 
-    if record.user_id != str(user.user_id):
+    if record.user_id != str(user_id):
         logger.warning(
             "User attempted to access another user's file scan results",
             extra={
                 "pending_file_id": pending_file_id,
-                "user_id": user.user_id,
+                "user_id": user_id,
                 "record_user_id": record.user_id,
             },
         )
@@ -252,7 +253,7 @@ def stream_file_scan_results(
                     "File scan results stream reached terminal status",
                     extra={
                         "pending_file_id": pending_file_id,
-                        "user_id": user.user_id,
+                        "user_id": user_id,
                         "file_scan_status": status,
                         "stream_duration_seconds": elapsed,
                     },
@@ -264,7 +265,7 @@ def stream_file_scan_results(
                     "File scan results stream reached max duration",
                     extra={
                         "pending_file_id": pending_file_id,
-                        "user_id": user.user_id,
+                        "user_id": user_id,
                         "last_file_scan_status": status,
                         "stream_duration_seconds": elapsed,
                     },
@@ -275,7 +276,7 @@ def stream_file_scan_results(
 
             try:
                 next_record = _fetch_next_record(
-                    dynamodb_client, table_name, pending_file_id, user.user_id
+                    dynamodb_client, table_name, pending_file_id, user_id
                 )
             except InvalidFileScanRecordError:
                 # Streaming has already started so we can't change the HTTP
@@ -285,7 +286,7 @@ def stream_file_scan_results(
                     "Invalid file scan record encountered mid-stream, aborting",
                     extra={
                         "pending_file_id": pending_file_id,
-                        "user_id": user.user_id,
+                        "user_id": user_id,
                         "stream_duration_seconds": elapsed,
                     },
                 )


### PR DESCRIPTION
## Summary
Fixes #11724

## Changes proposed
* Adjust how we do the presigned URL logic to abstract away the database functionality so we can move this to grants shared
* Slight modification to the file stream logic to work with a user ID from either system.

## Context for reviewers
This should not meaningfully change the behavior, it just prepares us to move this code to grants-shared so it can be reused in the grants management system.

I did not move the logic for the local file scanning as that's going to be a lot more coupled to the app itself, and I think it makes sense to be able to adjust the scenarios right there.

## Validation steps
Tests continue working, didn't change any meaningful implementation, just reorganized to be more reusable.
