### PR TITLE
[Issue #10543] Improve XML fetcher to auto discover XSD dependencies

### DIFF
--- a/api/src/cli/xml_generation_cli.py
+++ b/api/src/cli/xml_generation_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 
 from src.form_schema.forms import init_form_registry
-from src.services.xml_generation.config import _build_xml_form_map
+from src.services.xml_generation.config import _build_xml_form_map, _build_xml_form_xsd_url_map
 from src.services.xml_generation.models import XMLGenerationRequest
 from src.services.xml_generation.service import XMLGenerationService
 from src.services.xml_generation.validation.test_cases import (
@@ -16,7 +16,7 @@ from src.services.xml_generation.validation.test_cases import (
     get_test_cases_by_form,
 )
 from src.services.xml_generation.validation.test_runner import ValidationTestRunner
-from src.services.xml_generation.validation.xsd_fetcher import XSDFetcher, get_all_form_xsd_urls
+from src.services.xml_generation.validation.xsd_fetcher import XSDFetcher
 from src.task.task_blueprint import task_blueprint
 
 
@@ -312,7 +312,7 @@ def fetch_xsds_command(
         # Get the XSD URL(s) to fetch directly from each form's own
         # configuration (api/form_schema) instead of a hardcoded list.
         init_form_registry()
-        form_xsd_urls = get_all_form_xsd_urls()
+        form_xsd_urls = _build_xml_form_xsd_url_map()
 
         if form:
             xsd_url = form_xsd_urls.get(form.upper())

--- a/api/src/cli/xml_generation_cli.py
+++ b/api/src/cli/xml_generation_cli.py
@@ -16,7 +16,7 @@ from src.services.xml_generation.validation.test_cases import (
     get_test_cases_by_form,
 )
 from src.services.xml_generation.validation.test_runner import ValidationTestRunner
-from src.services.xml_generation.validation.xsd_fetcher import XSDFetcher
+from src.services.xml_generation.validation.xsd_fetcher import XSDFetcher, get_all_form_xsd_urls
 from src.task.task_blueprint import task_blueprint
 
 
@@ -309,35 +309,29 @@ def fetch_xsds_command(
         if not xsd_dir:
             xsd_dir = str(Path(__file__).resolve().parents[2] / "src/services/xml_generation/xsds")
 
-        # Get test cases to determine which XSDs we need
+        # Get the XSD URL(s) to fetch directly from each form's own
+        # configuration (api/form_schema) instead of a hardcoded list.
+        init_form_registry()
+        form_xsd_urls = get_all_form_xsd_urls()
+
         if form:
-            test_cases = get_test_cases_by_form(form)
-            if not test_cases:
-                click.echo(f"Error: No test cases found for form: {form}", err=True)
+            xsd_url = form_xsd_urls.get(form.upper())
+            if not xsd_url:
+                click.echo(f"Error: No XSD URL configured for form: {form}", err=True)
                 sys.exit(1)
+            xsd_urls = {xsd_url}
             click.echo(f"Fetching XSD for form: {form}")
         else:
-            test_cases = get_all_test_cases()
-            if not test_cases:
-                click.echo("Error: No test cases found", err=True)
+            xsd_urls = set(form_xsd_urls.values())
+            if not xsd_urls:
+                click.echo("Error: No forms with XSD URLs found", err=True)
                 sys.exit(1)
-            click.echo(f"Fetching XSDs for {len(test_cases)} test cases")
+            click.echo(f"Fetching XSDs for {len(xsd_urls)} form(s)")
 
         # Initialize fetcher with XSD directory
         fetcher = XSDFetcher(xsd_dir=xsd_dir)
         click.echo(f"XSD Directory: {fetcher.xsd_dir}")
         click.echo("")
-
-        # Track unique XSD URLs to avoid duplicate downloads
-        xsd_urls = set()
-        for test_case in test_cases:
-            xsd_url = test_case.get("xsd_url")
-            if xsd_url and xsd_url not in xsd_urls:
-                xsd_urls.add(xsd_url)
-
-        if not xsd_urls:
-            click.echo("Warning: No XSD URLs found in test cases", err=True)
-            sys.exit(0)
 
         click.echo(f"Found {len(xsd_urls)} unique XSD files to fetch")
         click.echo("")

--- a/api/src/services/xml_generation/config.py
+++ b/api/src/services/xml_generation/config.py
@@ -17,6 +17,24 @@ def _build_xml_form_map() -> dict[str, dict[str, Any]]:
     return xml_form_map
 
 
+def _build_xml_form_xsd_url_map() -> dict[str, str]:
+    """Build a map of form names (uppercase) to their configured XSD schema URL.
+
+    Reuses `_build_xml_form_map` so the form registry is only read in one
+    place. Forms without an ``xsd_url`` configured (e.g. no XML transform
+    config yet) are omitted.
+    """
+    xsd_urls: dict[str, str] = {}
+    for form_name, transform_config in _build_xml_form_map().items():
+        xml_config = (transform_config or {}).get("_xml_config", {})
+        xsd_url = xml_config.get("xsd_url")
+        if xsd_url:
+            xsd_urls[form_name] = xsd_url
+        else:
+            logger.debug(f"No xsd_url configured for form: {form_name}")
+    return xsd_urls
+
+
 def load_xml_transform_config(form_name: str) -> dict[str, Any]:
     """Load XML transformation rules for a given form."""
     try:

--- a/api/src/services/xml_generation/validation/xsd_fetcher.py
+++ b/api/src/services/xml_generation/validation/xsd_fetcher.py
@@ -46,6 +46,12 @@ def discover_xsd_dependencies(xsd_content: bytes, source_url: str) -> list[str]:
     except etree.XMLSyntaxError as e:
         raise XSDFetchError(f"Failed to parse XSD from {source_url}: {e}") from e
 
+    if root.tag != f"{{{XSD_NAMESPACE}}}schema":
+        raise XSDFetchError(f"Not an XSD schema document (root={root.tag}) from {source_url}")
+        root = etree.fromstring(xsd_content)
+    except etree.XMLSyntaxError as e:
+        raise XSDFetchError(f"Failed to parse XSD from {source_url}: {e}") from e
+
     dependency_urls = []
     for tag in DEPENDENCY_TAGS:
         for elem in root.findall(f"{{{XSD_NAMESPACE}}}{tag}"):

--- a/api/src/services/xml_generation/validation/xsd_fetcher.py
+++ b/api/src/services/xml_generation/validation/xsd_fetcher.py
@@ -35,6 +35,11 @@ def discover_xsd_dependencies(xsd_content: bytes, source_url: str) -> list[str]:
 
     Returns:
         A list of absolute URLs for the dependencies declared in the schema.
+
+    Raises:
+        XSDFetchError: If ``xsd_content`` is not well-formed XML. Callers
+            should treat this as a hard failure for the URL being processed
+            rather than caching or reporting it as fetched.
     """
     try:
         root = etree.fromstring(xsd_content)
@@ -86,6 +91,14 @@ class XSDFetcher:
         ``xs:redefine`` declarations, so nested (transitive) dependencies are
         followed automatically. Already-visited URLs (including circular
         references back to a schema earlier in the chain) are skipped.
+
+        A freshly downloaded response is always parsed *before* it is
+        written to disk or counted as fetched. Persisting first would let an
+        invalid or corrupted response get cached as if it were a good
+        schema — it would satisfy ``xsd_path.exists()`` on every later run
+        and be silently reused as "stored" forever. Validating first means a
+        bad response is never written and never reported as a success; it
+        surfaces in ``errors`` instead, and the retry stays possible next run.
         """
         if visited is None:
             visited = set()
@@ -100,26 +113,27 @@ class XSDFetcher:
 
         try:
             xsd_path = self._local_path_for(xsd_url)
+            is_freshly_downloaded = not xsd_path.exists()
 
-            if xsd_path.exists():
-                logger.debug(f"Using existing XSD: {xsd_path}")
-                result["stored"].append(xsd_url)
-                xsd_content = xsd_path.read_bytes()
-            else:
+            if is_freshly_downloaded:
                 logger.info(f"Downloading XSD: {xsd_url}")
                 response = requests.get(xsd_url, timeout=30)
                 response.raise_for_status()
                 xsd_content = response.content
+            else:
+                logger.debug(f"Using existing XSD: {xsd_path}")
+                xsd_content = xsd_path.read_bytes()
 
+            # Validate before persisting or reporting success (see docstring).
+            dependencies = discover_xsd_dependencies(xsd_content, xsd_url)
+
+            if is_freshly_downloaded:
                 with open(xsd_path, "wb") as f:
                     f.write(xsd_content)
-
                 logger.info(f"Downloaded and stored: {xsd_path}")
                 result["fetched"].append(xsd_url)
-
-            # Discover dependencies directly from the schema we just fetched
-            # (or already had), instead of a hardcoded lookup table.
-            dependencies = discover_xsd_dependencies(xsd_content, xsd_url)
+            else:
+                result["stored"].append(xsd_url)
 
             for dep_url in dependencies:
                 try:
@@ -138,52 +152,3 @@ class XSDFetcher:
             result["errors"].append({"url": xsd_url, "error": str(e)})
 
         return result
-
-    def fetch_all(self, xsd_urls: list[str]) -> dict[str, Any]:
-        """Fetch a list of top-level XSD URLs and all of their dependencies.
-
-        Args:
-            xsd_urls: Top-level XSD URLs to fetch (e.g. one per form).
-
-        Returns:
-            Combined fetched/stored/errors across all URLs, with duplicates
-            across URLs collapsed via a shared ``visited`` set.
-        """
-        visited: set[str] = set()
-        combined: dict[str, Any] = {"fetched": [], "stored": [], "errors": []}
-
-        for xsd_url in xsd_urls:
-            single_result = self.fetch_xsd_with_dependencies(xsd_url, visited)
-            combined["fetched"].extend(single_result["fetched"])
-            combined["stored"].extend(single_result["stored"])
-            combined["errors"].extend(single_result["errors"])
-
-        return combined
-
-
-def get_all_form_xsd_urls() -> dict[str, str]:
-    """Get the XSD schema URL for every registered form.
-
-    Reads each form's configuration directly from the form_schema registry
-    (api/form_schema) instead of a hardcoded list, so newly added forms are
-    picked up automatically.
-
-    Returns:
-        Mapping of form short name (uppercase) to its XSD schema URL. Forms
-        without an ``xsd_url`` configured (e.g. no XML transform config yet)
-        are omitted.
-    """
-    from src.form_schema.forms import get_active_forms, init_form_registry
-
-    init_form_registry()
-
-    xsd_urls: dict[str, str] = {}
-    for form in get_active_forms():
-        xml_config = (form.json_to_xml_schema or {}).get("_xml_config", {})
-        xsd_url = xml_config.get("xsd_url")
-        if xsd_url:
-            xsd_urls[form.short_form_name.upper()] = xsd_url
-        else:
-            logger.debug(f"No xsd_url configured for form: {form.short_form_name}")
-
-    return xsd_urls

--- a/api/src/services/xml_generation/validation/xsd_fetcher.py
+++ b/api/src/services/xml_generation/validation/xsd_fetcher.py
@@ -3,10 +3,16 @@
 import logging
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin, urlparse
 
 import requests
+from lxml import etree
 
 logger = logging.getLogger(__name__)
+
+XSD_NAMESPACE = "http://www.w3.org/2001/XMLSchema"
+# Tags that can reference another schema document.
+DEPENDENCY_TAGS = ("import", "include", "redefine")
 
 
 class XSDFetchError(Exception):
@@ -15,101 +21,46 @@ class XSDFetchError(Exception):
     pass
 
 
-KNOWN_XSD_DEPENDENCIES = {
-    "SF424_4_0-V4.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-    ],
-    "SF424_Short_3_0-V3.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-    ],
-    "SF424A-V1.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-    ],
-    "SF424C_2_0-V2.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-    "SF424B-V1.1.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-    "SF424D-V1.1.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-    "SFLLL_2_0-V2.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-    "Project_AbstractSummary_2_0-V2.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-    ],
-    "Project_Abstract_1_2-V1.2.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-    "BudgetNarrativeAttachments_1_2-V1.2.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-    ],
-    "ProjectNarrativeAttachments_1_2-V1.2.xsd": [],
-    "OtherNarrativeAttachments_1_2-V1.2.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-    ],
-    "AttachmentForm_1_2-V1.2.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-    ],
-    "CD511-V1.1.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-    "SupplementaryCoverSheetforNEHGrantPrograms_3_0-V3.0.xsd": [],
-    "GG_LobbyingForm-V1.1.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-    "EPA4700_4_5_0-V5.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
-    ],
-    "Key_Contacts_2_0-V2.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
-    ],
-    "EPA_KeyContacts_2_0-V2.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
-    ],
-    "PerformanceSite_4_0-V4.0.xsd": [
-        "https://apply07.grants.gov/apply/system/schemas/Attachments-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/UniversalCodes-V2.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/Global-V1.0.xsd",
-        "https://apply07.grants.gov/apply/system/schemas/GlobalLibrary-V2.0.xsd",
-    ],
-}
+def discover_xsd_dependencies(xsd_content: bytes, source_url: str) -> list[str]:
+    """Parse an XSD document and discover the schemas it depends on.
+
+    Looks for ``xs:import``, ``xs:include``, and ``xs:redefine`` elements and
+    resolves their ``schemaLocation`` attribute (which may be relative)
+    against the URL the schema was fetched from.
+
+    Args:
+        xsd_content: Raw bytes of the XSD document.
+        source_url: The URL the XSD document was downloaded from, used to
+            resolve relative ``schemaLocation`` references.
+
+    Returns:
+        A list of absolute URLs for the dependencies declared in the schema.
+    """
+    try:
+        root = etree.fromstring(xsd_content)
+    except etree.XMLSyntaxError as e:
+        raise XSDFetchError(f"Failed to parse XSD from {source_url}: {e}") from e
+
+    dependency_urls = []
+    for tag in DEPENDENCY_TAGS:
+        for elem in root.findall(f"{{{XSD_NAMESPACE}}}{tag}"):
+            schema_location = elem.get("schemaLocation")
+            if not schema_location:
+                # imports without a schemaLocation just declare a namespace
+                continue
+            dependency_urls.append(urljoin(source_url, schema_location))
+
+    return dependency_urls
 
 
 class XSDFetcher:
     """Fetches XSD files and their dependencies for offline validation.
 
-    This utility downloads XSD schema files and stores them
-    locally for use during validation testing.
+    This utility downloads XSD schema files and stores them locally for use
+    during validation testing. Dependencies (imports/includes/redefines) are
+    discovered dynamically by parsing each XSD as it is fetched, rather than
+    relying on a hardcoded dependency map, so new forms and schema drift are
+    picked up automatically.
     """
 
     def __init__(self, xsd_dir: str | Path):
@@ -121,42 +72,54 @@ class XSDFetcher:
         self.xsd_dir = Path(xsd_dir)
         self.xsd_dir.mkdir(parents=True, exist_ok=True)
 
+    def _local_path_for(self, xsd_url: str) -> Path:
+        filename = urlparse(xsd_url).path.rsplit("/", 1)[-1]
+        return self.xsd_dir / filename
+
     def fetch_xsd_with_dependencies(
         self, xsd_url: str, visited: set[str] | None = None
     ) -> dict[str, Any]:
-        """Fetch an XSD file and all its known dependencies."""
+        """Fetch an XSD file and recursively fetch every schema it depends on.
+
+        Dependencies are not looked up from a static map; they're discovered
+        by parsing the XSD's own ``xs:import`` / ``xs:include`` /
+        ``xs:redefine`` declarations, so nested (transitive) dependencies are
+        followed automatically. Already-visited URLs (including circular
+        references back to a schema earlier in the chain) are skipped.
+        """
         if visited is None:
             visited = set()
 
         result: dict[str, Any] = {"fetched": [], "stored": [], "errors": []}
 
-        # Skip if already processed
+        # Skip if already processed (also guards against circular imports)
         if xsd_url in visited:
             return result
 
         visited.add(xsd_url)
 
         try:
-            # Download the main XSD if needed
-            xsd_filename = xsd_url.split("/")[-1]
-            xsd_path = self.xsd_dir / xsd_filename
+            xsd_path = self._local_path_for(xsd_url)
 
             if xsd_path.exists():
                 logger.debug(f"Using existing XSD: {xsd_path}")
                 result["stored"].append(xsd_url)
+                xsd_content = xsd_path.read_bytes()
             else:
                 logger.info(f"Downloading XSD: {xsd_url}")
                 response = requests.get(xsd_url, timeout=30)
                 response.raise_for_status()
+                xsd_content = response.content
 
                 with open(xsd_path, "wb") as f:
-                    f.write(response.content)
+                    f.write(xsd_content)
 
                 logger.info(f"Downloaded and stored: {xsd_path}")
                 result["fetched"].append(xsd_url)
 
-            # Fetch known dependencies
-            dependencies = KNOWN_XSD_DEPENDENCIES.get(xsd_filename, [])
+            # Discover dependencies directly from the schema we just fetched
+            # (or already had), instead of a hardcoded lookup table.
+            dependencies = discover_xsd_dependencies(xsd_content, xsd_url)
 
             for dep_url in dependencies:
                 try:
@@ -175,3 +138,52 @@ class XSDFetcher:
             result["errors"].append({"url": xsd_url, "error": str(e)})
 
         return result
+
+    def fetch_all(self, xsd_urls: list[str]) -> dict[str, Any]:
+        """Fetch a list of top-level XSD URLs and all of their dependencies.
+
+        Args:
+            xsd_urls: Top-level XSD URLs to fetch (e.g. one per form).
+
+        Returns:
+            Combined fetched/stored/errors across all URLs, with duplicates
+            across URLs collapsed via a shared ``visited`` set.
+        """
+        visited: set[str] = set()
+        combined: dict[str, Any] = {"fetched": [], "stored": [], "errors": []}
+
+        for xsd_url in xsd_urls:
+            single_result = self.fetch_xsd_with_dependencies(xsd_url, visited)
+            combined["fetched"].extend(single_result["fetched"])
+            combined["stored"].extend(single_result["stored"])
+            combined["errors"].extend(single_result["errors"])
+
+        return combined
+
+
+def get_all_form_xsd_urls() -> dict[str, str]:
+    """Get the XSD schema URL for every registered form.
+
+    Reads each form's configuration directly from the form_schema registry
+    (api/form_schema) instead of a hardcoded list, so newly added forms are
+    picked up automatically.
+
+    Returns:
+        Mapping of form short name (uppercase) to its XSD schema URL. Forms
+        without an ``xsd_url`` configured (e.g. no XML transform config yet)
+        are omitted.
+    """
+    from src.form_schema.forms import get_active_forms, init_form_registry
+
+    init_form_registry()
+
+    xsd_urls: dict[str, str] = {}
+    for form in get_active_forms():
+        xml_config = (form.json_to_xml_schema or {}).get("_xml_config", {})
+        xsd_url = xml_config.get("xsd_url")
+        if xsd_url:
+            xsd_urls[form.short_form_name.upper()] = xsd_url
+        else:
+            logger.debug(f"No xsd_url configured for form: {form.short_form_name}")
+
+    return xsd_urls

--- a/api/src/services/xml_generation/validation/xsd_fetcher.py
+++ b/api/src/services/xml_generation/validation/xsd_fetcher.py
@@ -48,9 +48,6 @@ def discover_xsd_dependencies(xsd_content: bytes, source_url: str) -> list[str]:
 
     if root.tag != f"{{{XSD_NAMESPACE}}}schema":
         raise XSDFetchError(f"Not an XSD schema document (root={root.tag}) from {source_url}")
-        root = etree.fromstring(xsd_content)
-    except etree.XMLSyntaxError as e:
-        raise XSDFetchError(f"Failed to parse XSD from {source_url}: {e}") from e
 
     dependency_urls = []
     for tag in DEPENDENCY_TAGS:

--- a/api/tests/src/services/xml_generation/test_xsd_fetcher.py
+++ b/api/tests/src/services/xml_generation/test_xsd_fetcher.py
@@ -174,21 +174,35 @@ class TestFetchXsdWithDependencies:
         assert len(result["errors"]) == 1
         assert result["errors"][0]["url"] == url_b
 
-    def test_fetch_all_collapses_shared_dependencies_across_top_level_urls(self, tmp_path):
-        """Two top-level forms sharing a common dependency should only fetch it once."""
+    def test_invalid_response_is_not_persisted_or_marked_fetched(self, tmp_path):
+        """A corrupt/invalid downloaded response must not be written to disk
+        or counted as fetched -- otherwise it would satisfy
+        ``xsd_path.exists()`` and get silently reused as "stored" forever.
+        """
         url_a = "https://example.com/a.xsd"
-        url_b = "https://example.com/b.xsd"
-        url_shared = "https://example.com/shared.xsd"
+        content_map = {url_a: b"this is not valid xml <<<"}
 
-        content_map = {
-            url_a: _xsd("urn:a", deps=[("import", "shared.xsd")]),
-            url_b: _xsd("urn:b", deps=[("import", "shared.xsd")]),
-            url_shared: _xsd("urn:shared"),
-        }
+        fetcher = XSDFetcher(xsd_dir=tmp_path)
+        with patch("requests.get", side_effect=self._mock_get(content_map)):
+            result = fetcher.fetch_xsd_with_dependencies(url_a)
+
+        assert result["fetched"] == []
+        assert result["stored"] == []
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["url"] == url_a
+        # The bad response must never be written to disk.
+        assert not (tmp_path / "a.xsd").exists()
+
+    def test_invalid_response_is_retried_on_next_run(self, tmp_path):
+        """Since a bad response is never persisted, a second run should
+        attempt the download again instead of finding a cached bad file.
+        """
+        url_a = "https://example.com/a.xsd"
+        content_map = {url_a: b"this is not valid xml <<<"}
 
         fetcher = XSDFetcher(xsd_dir=tmp_path)
         with patch("requests.get", side_effect=self._mock_get(content_map)) as mock_get:
-            result = fetcher.fetch_all([url_a, url_b])
+            fetcher.fetch_xsd_with_dependencies(url_a)
+            fetcher.fetch_xsd_with_dependencies(url_a)
 
-        assert set(result["fetched"]) == {url_a, url_b, url_shared}
-        assert mock_get.call_count == 3
+        assert mock_get.call_count == 2

--- a/api/tests/src/services/xml_generation/test_xsd_fetcher.py
+++ b/api/tests/src/services/xml_generation/test_xsd_fetcher.py
@@ -1,0 +1,196 @@
+"""Tests for XSD dependency discovery and fetching."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.services.xml_generation.validation.xsd_fetcher import XSDFetcher, discover_xsd_dependencies
+
+XSD_NS = "http://www.w3.org/2001/XMLSchema"
+
+
+def _xsd(target_ns: str, deps: list[tuple[str, str]] | None = None) -> bytes:
+    """Build a minimal XSD document with optional import/include/redefine deps.
+
+    Args:
+        target_ns: targetNamespace for this schema.
+        deps: list of (tag, schemaLocation) tuples, e.g. [("import", "b.xsd")].
+    """
+    dep_elements = ""
+    if deps:
+        for tag, location in deps:
+            dep_elements += f'  <xs:{tag} schemaLocation="{location}"/>\n'
+
+    return f"""<?xml version="1.0"?>
+<xs:schema xmlns:xs="{XSD_NS}" targetNamespace="{target_ns}">
+{dep_elements}</xs:schema>""".encode()
+
+
+class TestDiscoverXsdDependencies:
+    """Tests for discover_xsd_dependencies()."""
+
+    def test_no_dependencies(self):
+        content = _xsd("urn:a")
+        deps = discover_xsd_dependencies(content, "https://example.com/a.xsd")
+        assert deps == []
+
+    def test_single_import(self):
+        content = _xsd("urn:a", deps=[("import", "b.xsd")])
+        deps = discover_xsd_dependencies(content, "https://example.com/a.xsd")
+        assert deps == ["https://example.com/b.xsd"]
+
+    def test_include_and_redefine(self):
+        content = _xsd(
+            "urn:a",
+            deps=[("include", "b.xsd"), ("redefine", "c.xsd")],
+        )
+        deps = discover_xsd_dependencies(content, "https://example.com/a.xsd")
+        assert deps == [
+            "https://example.com/b.xsd",
+            "https://example.com/c.xsd",
+        ]
+
+    def test_import_without_schema_location_is_skipped(self):
+        content = f"""<?xml version="1.0"?>
+<xs:schema xmlns:xs="{XSD_NS}" targetNamespace="urn:a">
+  <xs:import namespace="urn:b"/>
+</xs:schema>""".encode()
+        deps = discover_xsd_dependencies(content, "https://example.com/a.xsd")
+        assert deps == []
+
+    def test_relative_schema_location_resolved_against_source_url(self):
+        content = _xsd("urn:a", deps=[("import", "../shared/b.xsd")])
+        deps = discover_xsd_dependencies(content, "https://example.com/forms/a.xsd")
+        assert deps == ["https://example.com/shared/b.xsd"]
+
+
+class TestFetchXsdWithDependencies:
+    """Tests for XSDFetcher.fetch_xsd_with_dependencies()."""
+
+    def _mock_get(self, url_to_content: dict[str, bytes]):
+        def fake_get(url, timeout=30):
+            response = Mock()
+            response.content = url_to_content[url]
+            response.raise_for_status = Mock()
+            return response
+
+        return fake_get
+
+    def test_nested_transitive_imports(self, tmp_path):
+        """a imports b, b imports c: fetching a should pull b and c."""
+        url_a = "https://example.com/a.xsd"
+        url_b = "https://example.com/b.xsd"
+        url_c = "https://example.com/c.xsd"
+
+        content_map = {
+            url_a: _xsd("urn:a", deps=[("import", "b.xsd")]),
+            url_b: _xsd("urn:b", deps=[("import", "c.xsd")]),
+            url_c: _xsd("urn:c"),
+        }
+
+        fetcher = XSDFetcher(xsd_dir=tmp_path)
+        with patch("requests.get", side_effect=self._mock_get(content_map)):
+            result = fetcher.fetch_xsd_with_dependencies(url_a)
+
+        assert set(result["fetched"]) == {url_a, url_b, url_c}
+        assert result["errors"] == []
+        assert (tmp_path / "a.xsd").exists()
+        assert (tmp_path / "b.xsd").exists()
+        assert (tmp_path / "c.xsd").exists()
+
+    def test_absolute_schema_location_is_preserved(self, tmp_path):
+        content = _xsd("urn:a", deps=[("import", "https://example.com/shared/b.xsd")])
+        deps = discover_xsd_dependencies(content, "https://example.com/a.xsd")
+        assert deps == ["https://example.com/shared/b.xsd"]
+
+    def test_duplicate_dependency_only_fetched_once(self, tmp_path):
+        url_a = "https://example.com/a.xsd"
+        url_b = "https://example.com/b.xsd"
+
+        content_map = {
+            url_a: _xsd("urn:a", deps=[("import", "b.xsd"), ("include", "b.xsd")]),
+            url_b: _xsd("urn:b"),
+        }
+
+        fetcher = XSDFetcher(xsd_dir=tmp_path)
+        with patch("requests.get", side_effect=self._mock_get(content_map)) as mock_get:
+            result = fetcher.fetch_xsd_with_dependencies(url_a)
+
+        assert set(result["fetched"]) == {url_a, url_b}
+        assert mock_get.call_count == 2
+
+    def test_circular_imports_do_not_infinite_loop(self, tmp_path):
+        """a imports b, b imports a back: fetch must terminate and fetch both once."""
+        url_a = "https://example.com/a.xsd"
+        url_b = "https://example.com/b.xsd"
+
+        content_map = {
+            url_a: _xsd("urn:a", deps=[("import", "b.xsd")]),
+            url_b: _xsd("urn:b", deps=[("import", "a.xsd")]),
+        }
+
+        fetcher = XSDFetcher(xsd_dir=tmp_path)
+        fake_get = self._mock_get(content_map)
+        with patch("requests.get", side_effect=fake_get) as mock_get:
+            result = fetcher.fetch_xsd_with_dependencies(url_a)
+
+        assert set(result["fetched"]) == {url_a, url_b}
+        assert result["errors"] == []
+        # Each URL should only be downloaded once despite the circular reference.
+        assert mock_get.call_count == 2
+
+    def test_already_downloaded_dependency_is_marked_stored(self, tmp_path):
+        """If a dependency file already exists on disk, it's reused, not re-downloaded."""
+        url_a = "https://example.com/a.xsd"
+        url_b = "https://example.com/b.xsd"
+
+        (tmp_path / "b.xsd").write_bytes(_xsd("urn:b"))
+
+        content_map = {url_a: _xsd("urn:a", deps=[("import", "b.xsd")])}
+
+        fetcher = XSDFetcher(xsd_dir=tmp_path)
+        with patch("requests.get", side_effect=self._mock_get(content_map)) as mock_get:
+            result = fetcher.fetch_xsd_with_dependencies(url_a)
+
+        assert result["fetched"] == [url_a]
+        assert result["stored"] == [url_b]
+        mock_get.assert_called_once_with(url_a, timeout=30)
+
+    def test_fetch_error_on_dependency_is_recorded_not_raised(self, tmp_path):
+        url_a = "https://example.com/a.xsd"
+        url_b = "https://example.com/b.xsd"
+
+        def fake_get(url, timeout=30):
+            if url == url_a:
+                response = Mock()
+                response.content = _xsd("urn:a", deps=[("import", "b.xsd")])
+                response.raise_for_status = Mock()
+                return response
+            raise ConnectionError("boom")
+
+        fetcher = XSDFetcher(xsd_dir=tmp_path)
+        with patch("requests.get", side_effect=fake_get):
+            result = fetcher.fetch_xsd_with_dependencies(url_a)
+
+        assert result["fetched"] == [url_a]
+        assert len(result["errors"]) == 1
+        assert result["errors"][0]["url"] == url_b
+
+    def test_fetch_all_collapses_shared_dependencies_across_top_level_urls(self, tmp_path):
+        """Two top-level forms sharing a common dependency should only fetch it once."""
+        url_a = "https://example.com/a.xsd"
+        url_b = "https://example.com/b.xsd"
+        url_shared = "https://example.com/shared.xsd"
+
+        content_map = {
+            url_a: _xsd("urn:a", deps=[("import", "shared.xsd")]),
+            url_b: _xsd("urn:b", deps=[("import", "shared.xsd")]),
+            url_shared: _xsd("urn:shared"),
+        }
+
+        fetcher = XSDFetcher(xsd_dir=tmp_path)
+        with patch("requests.get", side_effect=self._mock_get(content_map)) as mock_get:
+            result = fetcher.fetch_all([url_a, url_b])
+
+        assert set(result["fetched"]) == {url_a, url_b, url_shared}
+        assert mock_get.call_count == 3

--- a/api/tests/src/services/xml_generation/test_xsd_fetcher.py
+++ b/api/tests/src/services/xml_generation/test_xsd_fetcher.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import Mock, patch
 
-import pytest
-
 from src.services.xml_generation.validation.xsd_fetcher import XSDFetcher, discover_xsd_dependencies
 
 XSD_NS = "http://www.w3.org/2001/XMLSchema"


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #10543 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Replaced hardcoded XSD dependency map with dynamic discovery:

- Removed KNOWN_XSD_DEPENDENCIES static map
- Added discover_xsd_dependencies() to parse XSD files and extract imports/includes/redefines
- Updated XSDFetcher to recursively fetch all transitive dependencies
- Updated CLI to use form registry instead of test cases

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Previous implementation only had dependencies hardcoded for one form and missed transitive imports for others. Now the fetcher parses each XSD to discover its own dependencies, automatically handling all forms and new schema changes without code updates.


## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
Run `make fetch-xsds`  should fetch all XSDs with transitive dependencies
