### PR TITLE
[Issue #11891] Add temporary pending-file opportunity attachment endpoint

### DIFF
--- a/api/openapi.generated.yml
+++ b/api/openapi.generated.yml
@@ -3923,6 +3923,64 @@ paths:
       summary: User Delete Saved Opportunity
       security:
       - ApiJwtAuth: []
+  /v1/grantors/opportunities/{opportunity_id}/attachments/temporary:
+    post:
+      parameters:
+      - in: path
+        name: opportunity_id
+        schema:
+          type: string
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpportunityAttachmentCreateFromPendingFileResponseV1Schema'
+          description: Successful response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseSchema'
+          description: Validation error
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseSchema'
+          description: Authentication error
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseSchema'
+          description: Not found
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseSchema'
+          description: Forbidden
+      tags:
+      - Opportunity v1 - for Grantors
+      summary: Create an opportunity attachment from a pending (virus-scanned) file.
+      description: 'TEMPORARY endpoint (#11891): lives at a separate address from
+        the existing
+
+        multipart POST /attachments while the frontend migration (#11890) is pending.
+
+        A follow-up ticket will remove the old multipart endpoint and move this
+
+        implementation onto the permanent /attachments address.'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpportunityAttachmentCreateFromPendingFileRequestV1Schema'
+      security:
+      - ApiJwtAuth: &id037 []
+      - ApiUserKeyAuth: *id037
   /alpha/award-recommendations/{award_recommendation_id}/risks/list:
     post:
       parameters:
@@ -3972,8 +4030,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationRiskListRequestSchema'
       security:
-      - ApiJwtAuth: &id037 []
-      - ApiUserKeyAuth: *id037
+      - ApiJwtAuth: &id038 []
+      - ApiUserKeyAuth: *id038
   /v1/users/{user_id}/invitations/{invitation_id}/organizations:
     post:
       parameters:
@@ -4078,8 +4136,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationAttachmentCreateRequestSchema'
       security:
-      - ApiJwtAuth: &id038 []
-      - ApiUserKeyAuth: *id038
+      - ApiJwtAuth: &id039 []
+      - ApiUserKeyAuth: *id039
   /v1/users/{user_id}/saved-opportunities/{legacy_opportunity_id}:
     delete:
       parameters:
@@ -4267,8 +4325,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationStartReviewRequestSchema'
       security:
-      - ApiJwtAuth: &id039 []
-      - ApiUserKeyAuth: *id039
+      - ApiJwtAuth: &id040 []
+      - ApiUserKeyAuth: *id040
   /alpha/award-recommendations/{award_recommendation_id}/audit_history:
     post:
       parameters:
@@ -4318,8 +4376,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationAuditRequestSchema'
       security:
-      - ApiJwtAuth: &id040 []
-      - ApiUserKeyAuth: *id040
+      - ApiJwtAuth: &id041 []
+      - ApiUserKeyAuth: *id041
   /alpha/award-recommendations/{award_recommendation_id}/submissions/list:
     post:
       parameters:
@@ -4369,8 +4427,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationSubmissionListRequestSchema'
       security:
-      - ApiJwtAuth: &id041 []
-      - ApiUserKeyAuth: *id041
+      - ApiJwtAuth: &id042 []
+      - ApiUserKeyAuth: *id042
   /alpha/applications/{application_id}/application_form/{app_form_id}:
     get:
       parameters:
@@ -4407,8 +4465,8 @@ paths:
       - Application Alpha
       summary: Get an application form by ID
       security:
-      - ApiJwtAuth: &id042 []
-      - InternalApiJwtAuth: *id042
+      - ApiJwtAuth: &id043 []
+      - InternalApiJwtAuth: *id043
   /alpha/applications/{application_id}/organizations/{organization_id}:
     put:
       parameters:
@@ -4514,8 +4572,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationSubmissionDetailsBatchUpdateRequestSchema'
       security:
-      - ApiJwtAuth: &id043 []
-      - ApiUserKeyAuth: *id043
+      - ApiJwtAuth: &id044 []
+      - ApiUserKeyAuth: *id044
   /v1/organizations/{organization_id}/saved-opportunities/{opportunity_id}:
     delete:
       parameters:
@@ -4618,8 +4676,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CompetitionUpdateRequestSchema'
       security:
-      - ApiJwtAuth: &id044 []
-      - ApiUserKeyAuth: *id044
+      - ApiJwtAuth: &id045 []
+      - ApiUserKeyAuth: *id045
   /alpha/applications/{application_id}/attachments/{application_attachment_id}:
     get:
       parameters:
@@ -4805,8 +4863,8 @@ paths:
             schema:
               $ref: '#/components/schemas/OpportunitySummaryUpdateRequestV1Schema'
       security:
-      - ApiJwtAuth: &id045 []
-      - ApiUserKeyAuth: *id045
+      - ApiJwtAuth: &id046 []
+      - ApiUserKeyAuth: *id046
   /v1/grantors/opportunities/{opportunity_id}/attachments/{opportunity_attachment_id}:
     delete:
       parameters:
@@ -4861,8 +4919,8 @@ paths:
       - Opportunity v1 - for Grantors
       summary: Delete an attachment from an opportunity
       security:
-      - ApiJwtAuth: &id046 []
-      - ApiUserKeyAuth: *id046
+      - ApiJwtAuth: &id047 []
+      - ApiUserKeyAuth: *id047
   /v1/grantors/opportunities/{opportunity_id}/competitions/{competition_id}/instructions:
     post:
       parameters:
@@ -4922,8 +4980,8 @@ paths:
             schema:
               $ref: '#/components/schemas/CompetitionInstructionUploadRequestV1Schema'
       security:
-      - ApiJwtAuth: &id047 []
-      - ApiUserKeyAuth: *id047
+      - ApiJwtAuth: &id048 []
+      - ApiUserKeyAuth: *id048
   /alpha/award-recommendations/{award_recommendation_id}/risks/{award_recommendation_risk_id}:
     put:
       parameters:
@@ -4979,8 +5037,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationRiskRequestSchema'
       security:
-      - ApiJwtAuth: &id048 []
-      - ApiUserKeyAuth: *id048
+      - ApiJwtAuth: &id049 []
+      - ApiUserKeyAuth: *id049
     delete:
       parameters:
       - in: path
@@ -5023,8 +5081,8 @@ paths:
       summary: Delete Award Recommendation Risk
       description: Soft delete a risk for an award recommendation.
       security:
-      - ApiJwtAuth: &id049 []
-      - ApiUserKeyAuth: *id049
+      - ApiJwtAuth: &id050 []
+      - ApiUserKeyAuth: *id050
   /alpha/award-recommendations/{award_recommendation_id}/reviews/{award_recommendation_review_id}:
     put:
       parameters:
@@ -5079,8 +5137,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AwardRecommendationReviewUpdateRequestSchema'
       security:
-      - ApiJwtAuth: &id050 []
-      - ApiUserKeyAuth: *id050
+      - ApiJwtAuth: &id051 []
+      - ApiUserKeyAuth: *id051
   /alpha/award-recommendations/{award_recommendation_id}/attachments/{award_recommendation_attachment_id}:
     delete:
       parameters:
@@ -5124,8 +5182,8 @@ paths:
       summary: Delete Award Recommendation Attachment
       description: Soft delete an attachment for an award recommendation.
       security:
-      - ApiJwtAuth: &id051 []
-      - ApiUserKeyAuth: *id051
+      - ApiJwtAuth: &id052 []
+      - ApiUserKeyAuth: *id052
   /v1/grantors/opportunities/{opportunity_id}/competitions/{competition_id}/instructions/{competition_instruction_id}:
     delete:
       parameters:
@@ -5185,8 +5243,8 @@ paths:
       - Opportunity v1 - for Grantors
       summary: Delete an instruction file from a competition
       security:
-      - ApiJwtAuth: &id052 []
-      - ApiUserKeyAuth: *id052
+      - ApiJwtAuth: &id053 []
+      - ApiUserKeyAuth: *id053
 openapi: 3.1.0
 components:
   schemas:
@@ -5446,7 +5504,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: &id053
+          type: &id054
           - object
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
@@ -5692,7 +5750,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -6139,17 +6197,17 @@ components:
         funding_instruments:
           type: array
           items:
-            enum: &id054
+            enum: &id055
             - cooperative_agreement
             - grant
             - procurement_contract
             - other
-            type: &id055
+            type: &id056
             - string
         funding_categories:
           type: array
           items:
-            enum: &id056
+            enum: &id057
             - recovery_act
             - agriculture
             - arts
@@ -6178,12 +6236,12 @@ components:
             - other
             - energy_infrastructure_and_critical_mineral_and_materials
             - recreation_and_tourism
-            type: &id057
+            type: &id058
             - string
         applicant_types:
           type: array
           items:
-            enum: &id058
+            enum: &id059
             - state_governments
             - county_governments
             - city_or_township_governments
@@ -6201,7 +6259,7 @@ components:
             - small_businesses
             - other
             - unrestricted
-            type: &id059
+            type: &id060
             - string
         created_at:
           type: string
@@ -6265,7 +6323,7 @@ components:
           description: The opportunity category
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategory
           - discretionary
-          enum: &id060
+          enum: &id061
           - discretionary
           - mandatory
           - continuation
@@ -6284,23 +6342,23 @@ components:
         opportunity_assistance_listings:
           type: array
           items:
-            type: &id061
+            type: &id062
             - object
             $ref: '#/components/schemas/OpportunityAssistanceListingV1Schema'
         summary:
-          type: &id062
+          type: &id063
           - object
           $ref: '#/components/schemas/OpportunitySummaryV1Schema'
         opportunity_status:
           description: The current status of the opportunity
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityStatus
           - posted
-          enum: &id063
+          enum: &id064
           - forecasted
           - posted
           - closed
           - archived
-          type: &id064
+          type: &id065
           - string
         top_level_agency_code:
           type:
@@ -6384,7 +6442,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -7095,18 +7153,18 @@ components:
         funding_instruments:
           type: array
           items:
-            enum: *id054
-            type: *id055
+            enum: *id055
+            type: *id056
         funding_categories:
           type: array
           items:
-            enum: *id056
-            type: *id057
+            enum: *id057
+            type: *id058
         applicant_types:
           type: array
           items:
-            enum: *id058
-            type: *id059
+            enum: *id059
+            type: *id060
         created_at:
           type: string
           format: date-time
@@ -7482,7 +7540,7 @@ components:
           description: The opportunity category
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategory
           - discretionary
-          enum: *id060
+          enum: *id061
           type:
           - string
           - 'null'
@@ -7496,17 +7554,17 @@ components:
         opportunity_assistance_listings:
           type: array
           items:
-            type: *id061
+            type: *id062
             $ref: '#/components/schemas/OpportunityAssistanceListingV1Schema'
         summary:
-          type: *id062
+          type: *id063
           $ref: '#/components/schemas/OpportunitySummaryV1Schema'
         opportunity_status:
           description: The current status of the opportunity
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityStatus
           - posted
-          enum: *id063
-          type: *id064
+          enum: *id064
+          type: *id065
         top_level_agency_code:
           type:
           - string
@@ -7644,7 +7702,7 @@ components:
           description: A list of warnings - indicating something you may want to be
             aware of, but did not prevent handling of the request
           items:
-            type: &id071
+            type: &id072
             - object
             $ref: '#/components/schemas/ValidationIssueSchema'
     OpportunitySearchCSVRequestV1Schema:
@@ -7835,18 +7893,18 @@ components:
           example: AR-26-0001
         award_recommendation_status:
           description: The status of the award recommendation
-          enum: &id065
+          enum: &id066
           - draft
           - in_review
           - approved
           - submitted
           - revision_requested
           - in_revision
-          type: &id066
+          type: &id067
           - string
         award_selection_method:
           description: The method used to select the award
-          enum: &id067
+          enum: &id068
           - merit_review_ranking_only
           - merit_review_ranking_with_other_factors
           - formula
@@ -7894,19 +7952,19 @@ components:
           example: 123e4567-e89b-12d3-a456-426614174000
         opportunity:
           description: The associated opportunity
-          type: &id068
+          type: &id069
           - object
           $ref: '#/components/schemas/AwardRecommendationOpportunitySchema'
         award_recommendation_reviews:
           type: array
           description: Reviews associated with the award recommendation
           items:
-            type: &id069
+            type: &id070
             - object
             $ref: '#/components/schemas/AwardRecommendationReviewSchema'
         award_recommendation_summary:
           description: Aggregated submission recommendation summary
-          type: &id070
+          type: &id071
           - object
           $ref: '#/components/schemas/AwardRecommendationSummarySchema'
         award_recommendation_attachments:
@@ -8716,7 +8774,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -9304,11 +9362,11 @@ components:
           example: AR-26-0001
         award_recommendation_status:
           description: The status of the award recommendation
-          enum: *id065
-          type: *id066
+          enum: *id066
+          type: *id067
         award_selection_method:
           description: The method used to select the award
-          enum: *id067
+          enum: *id068
           type:
           - string
           - 'null'
@@ -9350,24 +9408,24 @@ components:
           example: 123e4567-e89b-12d3-a456-426614174000
         opportunity:
           description: The associated opportunity
-          type: *id068
+          type: *id069
           $ref: '#/components/schemas/AwardRecommendationOpportunitySchema'
         award_recommendation_reviews:
           type: array
           description: Reviews associated with the award recommendation
           items:
-            type: *id069
+            type: *id070
             $ref: '#/components/schemas/AwardRecommendationReviewSchema'
         award_recommendation_summary:
           description: Aggregated submission recommendation summary
-          type: *id070
+          type: *id071
           $ref: '#/components/schemas/AwardRecommendationSummarySchema'
     AwardRecommendationListResponseSchema:
       type: object
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -10376,7 +10434,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -10503,7 +10561,7 @@ components:
           description: The opportunity category
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityCategory
           - discretionary
-          enum: *id060
+          enum: *id061
           type:
           - string
           - 'null'
@@ -10517,17 +10575,17 @@ components:
         opportunity_assistance_listings:
           type: array
           items:
-            type: *id061
+            type: *id062
             $ref: '#/components/schemas/OpportunityAssistanceListingV1Schema'
         summary:
-          type: *id062
+          type: *id063
           $ref: '#/components/schemas/OpportunitySummaryV1Schema'
         opportunity_status:
           description: The current status of the opportunity
           example: !!python/object/apply:src.constants.lookup_constants.OpportunityStatus
           - posted
-          enum: *id063
-          type: *id064
+          enum: *id064
+          type: *id065
         top_level_agency_code:
           type:
           - string
@@ -11111,7 +11169,7 @@ components:
           description: A list of warnings - indicating something you may want to be
             aware of, but did not prevent handling of the request
           items:
-            type: *id071
+            type: *id072
             $ref: '#/components/schemas/ValidationIssueSchema'
         message:
           type: string
@@ -11359,7 +11417,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -12094,7 +12152,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -12262,7 +12320,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -12425,7 +12483,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -12668,7 +12726,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -12926,11 +12984,11 @@ components:
           type: array
           minItems: 1
           description: Categories of funding for this opportunity
-          example: &id075
+          example: &id076
           - education
           - health
           items:
-            enum: &id076
+            enum: &id077
             - recovery_act
             - agriculture
             - arts
@@ -12959,7 +13017,7 @@ components:
             - other
             - energy_infrastructure_and_critical_mineral_and_materials
             - recreation_and_tourism
-            type: &id077
+            type: &id078
             - string
         funding_category_description:
           type:
@@ -12972,26 +13030,26 @@ components:
           type: array
           minItems: 1
           description: Types of funding instruments used for this opportunity
-          example: &id078
+          example: &id079
           - cooperative_agreement
           - grant
           items:
-            enum: &id079
+            enum: &id080
             - cooperative_agreement
             - grant
             - procurement_contract
             - other
-            type: &id080
+            type: &id081
             - string
         applicant_types:
           type: array
           minItems: 1
           description: Types of applicants eligible for this opportunity
-          example: &id081
+          example: &id082
           - state_governments
           - county_governments
           items:
-            enum: &id082
+            enum: &id083
             - state_governments
             - county_governments
             - city_or_township_governments
@@ -13009,7 +13067,7 @@ components:
             - small_businesses
             - other
             - unrestricted
-            type: &id083
+            type: &id084
             - string
         applicant_eligibility_description:
           type:
@@ -13330,16 +13388,16 @@ components:
           type: array
           minItems: 1
           description: List of applicant types eligible for this competition
-          example: &id072
+          example: &id073
           - !!python/object/apply:src.constants.lookup_constants.CompetitionOpenToApplicant
             - individual
           - !!python/object/apply:src.constants.lookup_constants.CompetitionOpenToApplicant
             - organization
           items:
-            enum: &id073
+            enum: &id074
             - individual
             - organization
-            type: &id074
+            type: &id075
             - string
       required:
       - closing_date
@@ -13439,7 +13497,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -13586,7 +13644,7 @@ components:
           description: A list of warnings - indicating something you may want to be
             aware of, but did not prevent handling of the request
           items:
-            type: *id071
+            type: *id072
             $ref: '#/components/schemas/ValidationIssueSchema'
         message:
           type: string
@@ -13729,12 +13787,37 @@ components:
           type: integer
           description: The HTTP status code
           example: 200
+    OpportunityAttachmentCreateFromPendingFileResponseV1Schema:
+      type: object
+      properties:
+        message:
+          type: string
+          description: The message to return
+          example: Success
+        data:
+          type:
+          - object
+          $ref: '#/components/schemas/OpportunityAttachmentV1Schema'
+        status_code:
+          type: integer
+          description: The HTTP status code
+          example: 200
+    OpportunityAttachmentCreateFromPendingFileRequestV1Schema:
+      type: object
+      properties:
+        pending_file_id:
+          type: string
+          format: uuid
+          description: The ID of the pending (virus-scanned) file to attach
+          example: 123e4567-e89b-12d3-a456-426614174000
+      required:
+      - pending_file_id
     AwardRecommendationRiskListResponseSchema:
       type: object
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -14203,7 +14286,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -14454,7 +14537,7 @@ components:
       properties:
         pagination_info:
           description: The pagination information for paginated endpoints
-          type: *id053
+          type: *id054
           $ref: '#/components/schemas/PaginationInfoSchema'
         message:
           type: string
@@ -14572,7 +14655,7 @@ components:
           description: A list of warnings - indicating something you may want to be
             aware of, but did not prevent handling of the request
           items:
-            type: *id071
+            type: *id072
             $ref: '#/components/schemas/ValidationIssueSchema'
         message:
           type: string
@@ -14738,10 +14821,10 @@ components:
           type: array
           minItems: 1
           description: List of applicant types eligible for this competition
-          example: *id072
+          example: *id073
           items:
-            enum: *id073
-            type: *id074
+            enum: *id074
+            type: *id075
       required:
       - closing_date
       - competition_title
@@ -14981,10 +15064,10 @@ components:
           type: array
           minItems: 1
           description: Categories of funding for this opportunity
-          example: *id075
+          example: *id076
           items:
-            enum: *id076
-            type: *id077
+            enum: *id077
+            type: *id078
         funding_category_description:
           type:
           - string
@@ -14996,18 +15079,18 @@ components:
           type: array
           minItems: 1
           description: Types of funding instruments used for this opportunity
-          example: *id078
+          example: *id079
           items:
-            enum: *id079
-            type: *id080
+            enum: *id080
+            type: *id081
         applicant_types:
           type: array
           minItems: 1
           description: Types of applicants eligible for this opportunity
-          example: *id081
+          example: *id082
           items:
-            enum: *id082
-            type: *id083
+            enum: *id083
+            type: *id084
         applicant_eligibility_description:
           type:
           - string

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py
@@ -23,6 +23,9 @@ from src.services.opportunities_grantor_v1.get_opportunity_list import (
     get_opportunity_list_for_user,
 )
 from src.services.opportunities_grantor_v1.list_opportunity_audit import list_opportunity_audit
+from src.services.opportunities_grantor_v1.opportunity_attachment_from_pending_file import (
+    create_opportunity_attachment_from_pending_file,
+)
 from src.services.opportunities_grantor_v1.opportunity_creation import create_opportunity
 from src.services.opportunities_grantor_v1.opportunity_summaries import (
     create_opportunity_summary,
@@ -244,6 +247,44 @@ def opportunity_upload_attachments(
         message="Attachment uploaded successfully",
         data={"opportunity_attachment_id": attachment_id, "file_description": file_description},
     )
+
+
+@opportunity_grantor_blueprint.post("/opportunities/<uuid:opportunity_id>/attachments/temporary")
+@opportunity_grantor_blueprint.input(
+    opportunity_grantor_schemas.OpportunityAttachmentCreateFromPendingFileRequestV1Schema(),
+    location="json",
+)
+@opportunity_grantor_blueprint.output(
+    opportunity_grantor_schemas.OpportunityAttachmentCreateFromPendingFileResponseV1Schema()
+)
+@opportunity_grantor_blueprint.auth_required(jwt_or_api_user_key_multi_auth)
+@opportunity_grantor_blueprint.doc(responses=[200, 401, 403, 404, 422])
+@flask_db.with_db_session()
+def opportunity_upload_attachment_temporary(
+    db_session: db.Session, opportunity_id: UUID, json_data: dict
+) -> response.ApiResponse:
+    """Create an opportunity attachment from a pending (virus-scanned) file.
+
+    TEMPORARY endpoint (#11891): lives at a separate address from the existing
+    multipart POST /attachments while the frontend migration (#11890) is pending.
+    A follow-up ticket will remove the old multipart endpoint and move this
+    implementation onto the permanent /attachments address.
+    """
+    add_extra_data_to_current_request_logs({"opportunity_id": opportunity_id})
+    logger.info("POST /v1/grantors/opportunities/:opportunity_id/attachments/temporary")
+
+    with db_session.begin():
+        user = jwt_or_api_user_key_multi_auth.get_user()
+        db_session.add(user)
+
+        attachment = create_opportunity_attachment_from_pending_file(
+            db_session=db_session,
+            user=user,
+            opportunity_id=opportunity_id,
+            pending_file_id=json_data["pending_file_id"],
+        )
+
+    return response.ApiResponse(message="Success", data=attachment)
 
 
 @opportunity_grantor_blueprint.delete(

--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
@@ -631,6 +631,19 @@ class DeleteAttachmentResponseV1Schema(ResponseWithErrorsSchema):
     pass
 
 
+class OpportunityAttachmentCreateFromPendingFileRequestV1Schema(Schema):
+    pending_file_id = fields.UUID(
+        required=True,
+        metadata={"description": "The ID of the pending (virus-scanned) file to attach"},
+    )
+
+
+class OpportunityAttachmentCreateFromPendingFileResponseV1Schema(AbstractResponseSchema):
+    """Response Schema for the temporary pending-file Upload Attachment Endpoint"""
+
+    data = fields.Nested(OpportunityAttachmentV1Schema())
+
+
 class OpportunityPublishResponseV1Schema(AbstractResponseSchema):
     data = fields.Nested(OpportunityGrantorSchema())
 

--- a/api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py
+++ b/api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py
@@ -1,0 +1,81 @@
+import logging
+import uuid
+
+import grants_shared.adapters.db as db
+from grants_shared.adapters.aws import S3Config
+from grants_shared.util import file_util
+
+from src.auth.endpoint_access_util import verify_access
+from src.constants.lookup_constants import Privilege
+from src.db.models.opportunity_models import OpportunityAttachment
+from src.db.models.user_models import User
+from src.services.files.pending_file_handling_domain_specific import (
+    fetch_and_validate_scan_complete_file,
+    move_pending_file_to_destination,
+)
+from src.services.opportunities_grantor_v1.get_opportunity import get_opportunity_for_grantors
+from src.services.opportunities_grantor_v1.opportunity_utils import (
+    validate_opportunity_created_in_simpler_grants,
+)
+from src.services.opportunity_attachments.attachment_util import (
+    adjust_legacy_file_name,
+    get_s3_attachment_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def create_opportunity_attachment_from_pending_file(
+    db_session: db.Session,
+    user: User,
+    opportunity_id: uuid.UUID,
+    pending_file_id: uuid.UUID,
+) -> OpportunityAttachment:
+    """Create an opportunity attachment from a pending (virus-scanned) file.
+
+    Order matters: validate the pending file, create+add the DB record,
+    then move the S3 object - so a failed DB write leaves the pending file untouched.
+    """
+    opportunity = get_opportunity_for_grantors(db_session, user, opportunity_id)
+    verify_access(user, {Privilege.UPDATE_OPPORTUNITY}, opportunity.agency_record)
+    validate_opportunity_created_in_simpler_grants(opportunity)
+
+    pending_file = fetch_and_validate_scan_complete_file(db_session, pending_file_id, user)
+
+    attachment_id = uuid.uuid4()
+    file_name = adjust_legacy_file_name(pending_file.file_name)
+
+    s3_config = S3Config()
+    s3_file_location = get_s3_attachment_path(
+        file_name=file_name,
+        opportunity_attachment_id=attachment_id,
+        opportunity=opportunity,
+        s3_config=s3_config,
+    )
+    file_size_bytes = file_util.get_file_length_bytes(pending_file.file_location)
+
+    attachment = OpportunityAttachment(
+        attachment_id=attachment_id,
+        opportunity_id=opportunity_id,
+        file_location=s3_file_location,
+        mime_type=pending_file.mime_type,
+        file_name=file_name,
+        file_description="",
+        file_size_bytes=file_size_bytes,
+        legacy_attachment_id=None,
+    )
+    db_session.add(attachment)
+
+    # Move after db_session.add - a failed DB write must leave the pending file alone
+    move_pending_file_to_destination(pending_file, s3_file_location)
+
+    logger.info(
+        "Created opportunity attachment from pending file",
+        extra={
+            "opportunity_id": opportunity_id,
+            "attachment_id": attachment_id,
+            "pending_file_id": pending_file_id,
+        },
+    )
+
+    return attachment

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_attachments_temporary.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_attachments_temporary.py
@@ -1,0 +1,207 @@
+import uuid
+
+import pytest
+from grants_shared.util import file_util
+
+from src.constants.lookup_constants import FileScanStatus, Privilege
+from src.db.models import opportunity_models
+from tests.lib.agency_test_utils import create_user_in_agency_with_jwt_and_api_key
+from tests.src.db.models.factories import OpportunityFactory, PendingFileFactory, UserFactory
+
+
+@pytest.fixture
+def grantor_auth_data(db_session, enable_factory_create):
+    """Create a user with UPDATE_OPPORTUNITY permission and return auth data"""
+    user, agency, token, api_key_id = create_user_in_agency_with_jwt_and_api_key(
+        db_session=db_session,
+        privileges=[Privilege.VIEW_OPPORTUNITY, Privilege.UPDATE_OPPORTUNITY],
+    )
+    return user, agency, token, api_key_id
+
+
+@pytest.fixture
+def existing_opportunity(grantor_auth_data, enable_factory_create):
+    """Create an opportunity belonging to the grantor's agency"""
+    user, agency, _, _ = grantor_auth_data
+    return OpportunityFactory.create(
+        agency_code=agency.agency_code, is_draft=True, is_simpler_grants_opportunity=True
+    )
+
+
+def make_pending_file(
+    user, s3_config, file_scan_status=FileScanStatus.COMPLETE, mime_type="application/pdf"
+):
+    """Create a PendingFile backed by a real S3 file."""
+    file_name = "test-attachment.pdf"
+    source_location = f"{s3_config.file_scan_bucket_path}/scan_complete/{uuid.uuid4()}/{file_name}"
+    file_util.write_to_file(source_location, "test file content")
+    return PendingFileFactory.create(
+        user=user,
+        file_name=file_name,
+        file_location=source_location,
+        file_scan_status=file_scan_status,
+        mime_type=mime_type,
+    )
+
+
+ROUTE = "/v1/grantors/opportunities/{opportunity_id}/attachments/temporary"
+
+
+def test_create_from_pending_file_200(
+    client, db_session, enable_factory_create, grantor_auth_data, existing_opportunity, s3_config
+):
+    user, _, token, _ = grantor_auth_data
+    pending_file = make_pending_file(user, s3_config)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=existing_opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+
+    assert resp.status_code == 200, resp.get_json()
+    data = resp.get_json()["data"]
+    assert data["opportunity_attachment_id"] is not None
+    assert data["file_name"] == "test-attachment.pdf"
+    assert data["mime_type"] == "application/pdf"
+
+    attachment = (
+        db_session.query(opportunity_models.OpportunityAttachment)
+        .filter_by(attachment_id=data["opportunity_attachment_id"])
+        .one()
+    )
+    assert file_util.file_exists(attachment.file_location) is True
+    assert file_util.file_exists(pending_file.file_location) is False
+    db_session.refresh(pending_file)
+    assert pending_file.file_scan_status == FileScanStatus.PROCESSED
+
+
+def test_create_from_pending_file_403_missing_privilege(
+    client, db_session, enable_factory_create, existing_opportunity, s3_config
+):
+    user, agency, token, _ = create_user_in_agency_with_jwt_and_api_key(
+        db_session=db_session, privileges=[Privilege.VIEW_OPPORTUNITY]
+    )
+    pending_file = make_pending_file(user, s3_config)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=existing_opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+    assert resp.status_code == 403
+
+
+def test_create_from_pending_file_403_other_users_file(
+    client, db_session, enable_factory_create, grantor_auth_data, existing_opportunity, s3_config
+):
+    _, _, token, _ = grantor_auth_data
+    other_user = UserFactory.create()
+    pending_file = make_pending_file(other_user, s3_config)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=existing_opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+    assert resp.status_code == 403
+
+
+def test_create_from_pending_file_404_opportunity_not_found(
+    client, db_session, enable_factory_create, grantor_auth_data, s3_config
+):
+    user, _, token, _ = grantor_auth_data
+    pending_file = make_pending_file(user, s3_config)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=uuid.uuid4()),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+    assert resp.status_code == 404
+
+
+def test_create_from_pending_file_404_pending_file_not_found(
+    client, db_session, enable_factory_create, grantor_auth_data, existing_opportunity
+):
+    _, _, token, _ = grantor_auth_data
+    resp = client.post(
+        ROUTE.format(opportunity_id=existing_opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(uuid.uuid4())},
+    )
+    assert resp.status_code == 404
+
+
+def test_create_from_pending_file_422_missing_pending_file_id(
+    client, db_session, enable_factory_create, grantor_auth_data, existing_opportunity
+):
+    _, _, token, _ = grantor_auth_data
+    resp = client.post(
+        ROUTE.format(opportunity_id=existing_opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_from_pending_file_422_scan_not_complete(
+    client, db_session, enable_factory_create, grantor_auth_data, existing_opportunity, s3_config
+):
+    user, _, token, _ = grantor_auth_data
+    pending_file = make_pending_file(user, s3_config, file_scan_status=FileScanStatus.PENDING)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=existing_opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_from_pending_file_422_scan_infected(
+    client, db_session, enable_factory_create, grantor_auth_data, existing_opportunity, s3_config
+):
+    user, _, token, _ = grantor_auth_data
+    pending_file = make_pending_file(user, s3_config, file_scan_status=FileScanStatus.INFECTED)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=existing_opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_from_pending_file_422_published_non_sgm_opportunity(
+    client, db_session, enable_factory_create, grantor_auth_data, s3_config
+):
+    user, agency, token, _ = grantor_auth_data
+    opportunity = OpportunityFactory.create(
+        agency_code=agency.agency_code, is_draft=False, is_simpler_grants_opportunity=False
+    )
+    pending_file = make_pending_file(user, s3_config)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_from_pending_file_200_published_sgm_opportunity(
+    client, db_session, enable_factory_create, grantor_auth_data, s3_config
+):
+    user, agency, token, _ = grantor_auth_data
+    opportunity = OpportunityFactory.create(
+        agency_code=agency.agency_code, is_draft=False, is_simpler_grants_opportunity=True
+    )
+    pending_file = make_pending_file(user, s3_config)
+
+    resp = client.post(
+        ROUTE.format(opportunity_id=opportunity.opportunity_id),
+        headers={"X-SGG-Token": token},
+        json={"pending_file_id": str(pending_file.pending_file_id)},
+    )
+    assert resp.status_code == 200, resp.get_json()


### PR DESCRIPTION
## Summary

Fixes #11891

## Changes proposed

- New route `POST /v1/grantors/opportunities/:opportunity_id/attachments/temporary`, accepting a `pending_file_id` (UUID) instead of a raw multipart file upload
- New service `create_opportunity_attachment_from_pending_file` (`api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py`), which validates the pending file is scan-complete, creates the `OpportunityAttachment` DB record, then moves the file from its temporary S3 location to its permanent one - in that order, so a failed DB write leaves the pending file untouched
- New request/response schemas (`OpportunityAttachmentCreateFromPendingFileRequestV1Schema`, `OpportunityAttachmentCreateFromPendingFileResponseV1Schema`) in the existing `opportunity_grantor_schemas.py`
- New test file covering success, auth, ownership, not-found, and scan-status cases (`test_opportunity_attachments_temporary.py`)
- The existing `POST /opportunities/:opportunity_id/attachments` (multipart) and `DELETE /opportunities/:opportunity_id/attachments/:opportunity_attachment_id` endpoints are untouched and continue working exactly as before - this is a purely additive change at a separate, temporary address, per the ticket's own framing. A follow-up ticket (once #11890 ships) will remove the old endpoint and move this implementation onto the permanent `/attachments` address.

## Context for reviewers

**Reference implementation.** This follows the same pending-file pattern the Apply team already implemented and had reviewed in PR #11425, reusing the same shared helpers (`fetch_and_validate_scan_complete_file`, `move_pending_file_to_destination` from `pending_file_handling_domain_specific.py`) rather than duplicating that logic. File-by-file comparison, in case it's useful for review:

| Opportunity (this PR) | Application (reference, PR #11425) |
|---|---|
| `api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py` | `api/src/services/applications/create_application_attachment_from_pending_file.py` |
| `api/src/api/opportunities_grantor_v1/opportunity_grantor_routes.py` (new route added) | `api/src/api/application_v1/application_route.py` |
| `api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py` (new schemas added) | `api/src/api/application_v1/application_schemas.py` |
| `api/tests/src/api/opportunities_grantors_v1/test_opportunity_attachments_temporary.py` | `api/tests/src/api/application_v1/test_create_application_attachment.py` |

Note the left-side route/schema files are much larger because they're the existing, shared grantor route/schema files with our endpoint added in - Application's are dedicated files since that was a new blueprint. The comparison is about whether the *added* code follows the same pattern, not file-for-file size parity.

`download_path` was descoped from this ticket's AC (see #11891 for the full note).

## Validation steps

**Automated tests** (from `api/`):
```
make test args="tests/src/api/opportunities_grantors_v1/ -v"
```
Expect 136 passed, including the new endpoint's 10 tests and all pre-existing sibling tests (multipart upload, delete, and everything else in this directory) unchanged.

```
make lint-mypy && make format-check
```
Both should pass clean.

**Manual verification** (against local Docker containers):
1. From `api/`, run `make db-migrate` then `make db-seed-local-with-agencies` (creates agency USAID-ETH, `agency_id = 9293aa4d-101b-4507-9725-6a180df2facd`, and user `one_agency_opp_edit` with API key `one_agency_opp_edit_key`).
2. In Swagger (`http://localhost:8080/docs#/`), authorize with `one_agency_opp_edit_key` under `ApiUserKeyAuth`.
3. `POST /v1/grantors/opportunities` to create a draft opportunity for that agency; note `opportunity_id`.
4. `POST /v1/files` with a file name/mime type to get a presigned upload URL and `pending_file_id`.
5. Upload the actual file to the returned presigned URL (via curl/Postman - S3 presigned POST, not one of our endpoints).
6. `GET /v1/files/{pending_file_id}/results` until `status: "complete"`.
7. `POST /opportunities/{opportunity_id}/attachments/temporary` with `{"pending_file_id": ...}` - expect 200 with the created attachment.
8. Confirm the old `POST /opportunities/{opportunity_id}/attachments` (multipart) and `DELETE .../attachments/{id}` still work unchanged.
