### PR TITLE
[Issue #11967]: Update clamav max file size to 2gb. 

### DIFF
--- a/infra/modules/clamav/scanner.tf
+++ b/infra/modules/clamav/scanner.tf
@@ -143,6 +143,11 @@ resource "aws_lambda_function" "scanner" {
   memory_size = var.scanner_memory_size
   timeout     = var.scanner_timeout
 
+
+  ephemeral_storage {
+    size = var.scanner_ephemeral_storage_size
+  }
+
   publish = true
 
   # Bound parallel scans so a burst of uploads can't exhaust the account

--- a/infra/modules/clamav/src/scan.py
+++ b/infra/modules/clamav/src/scan.py
@@ -60,7 +60,7 @@ UNSCANNED_PREFIX = os.environ.get("UNSCANNED_PREFIX", "unscanned/")
 SCANNED_PREFIX = os.environ.get("SCANNED_PREFIX", "scanned/")
 INFECTED_PREFIX = os.environ.get("INFECTED_PREFIX", "infected/")
 CLAMAV_DB_DIR = os.environ.get("CLAMAV_DB_DIR", "/mnt/clamav")
-MAX_FILE_SIZE_BYTES = int(os.environ.get("MAX_FILE_SIZE_BYTES", "471859200"))
+MAX_FILE_SIZE_BYTES = int(os.environ.get("MAX_FILE_SIZE_BYTES", "2147483648"))
 
 # File-scan callback API. FILE_SCAN_API_KEY authenticates as the internal
 # scanner user (INTERNAL_S3_SCAN privilege) via the X-API-Key header.

--- a/infra/modules/clamav/variables.tf
+++ b/infra/modules/clamav/variables.tf
@@ -99,9 +99,15 @@ variable "scanner_provisioned_concurrency" {
 }
 
 variable "scanner_max_file_size_bytes" {
-  description = "Maximum object size the scanner will download to /tmp. Files above this threshold are moved to the failed prefix with an explicit reason rather than failing with a confusing disk-space error. Default is 450 MiB to leave headroom under Lambda's 512 MiB /tmp limit."
+  description = "Maximum object size the scanner will scan."
   type        = number
-  default     = 471859200
+  default     = 2147483648
+}
+
+variable "scanner_ephemeral_storage_size" {
+  description = "Scanner Lambda /tmp size in MB."
+  type        = number
+  default     = 10240
 }
 
 variable "alert_email_subscriptions" {


### PR DESCRIPTION
## Summary

Updated the clamav max file size to 2gb. 

## Validation steps

Deployed to dev: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/31638274631)