### PR TITLE
File upload debugging

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -188,7 +188,7 @@ const nextConfig = {
   },
   experimental: {
     testProxy: true,
-    proxyClientMaxBodySize: "2000mb",
+    proxyClientMaxBodySize: "10mb",
     serverActions: {
       bodySizeLimit: "2000mb",
     },

--- a/frontend/src/app/api/file/handler.ts
+++ b/frontend/src/app/api/file/handler.ts
@@ -60,6 +60,7 @@ const orchestrateFileUpload = async (
   responseStreamController: ReadableStreamDefaultController,
   file: File,
 ) => {
+  console.warn("~~~ processUploadInStream: orchestrating file upload ~~~");
   responseStreamController.enqueue(JSON.stringify({ status: "starting" }));
   // call Simpler API to obtain details for S3 upload and pending file id
   const fileUploadDetails = await fetchFileUploadDetails(file.name, file.type);
@@ -95,7 +96,11 @@ const processUploadInStream = (file: File): ReadableStream<string> => {
   const responseStream = new ReadableStream<string>({
     start: async (responseStreamController) => {
       try {
+        console.warn(
+          "~~~ processUploadInStream: orchestrating file upload ~~~",
+        );
         await orchestrateFileUpload(responseStreamController, file);
+        console.warn("~~~ processUploadInStream: closing response stream ~~~");
         responseStreamController.close();
       } catch (e) {
         console.error("Error in file upload orchestration stream", e);
@@ -115,7 +120,9 @@ const processUploadInStream = (file: File): ReadableStream<string> => {
 // uploads file to S3 and sends the client updates about upload and virus scan progress
 export const handleFileUpload = async (request: NextRequest) => {
   try {
+    console.warn("~~~ handleFileUpload: gathering form data ~~~");
     const formData = await request.formData();
+    console.warn("~~~ handleFileUpload: pulling file attachment ~~~");
     const file = formData.get("file_attachment") as File;
 
     if (!file) {
@@ -126,8 +133,10 @@ export const handleFileUpload = async (request: NextRequest) => {
       );
     }
 
+    console.warn("~~~ handleFileUpload: opening response stream ~~~");
     // all calls to manage upload are made within the streaming process
     const responseStream = processUploadInStream(file);
+    console.warn("~~~ handleFileUpload: sending response ~~~");
     const responseToClient = new NextResponse(responseStream);
 
     return responseToClient;

--- a/frontend/src/app/api/file/handler.ts
+++ b/frontend/src/app/api/file/handler.ts
@@ -60,7 +60,7 @@ const orchestrateFileUpload = async (
   responseStreamController: ReadableStreamDefaultController,
   file: File,
 ) => {
-  responseStreamController.enqueue(JSON.stringify({ status: "queued" }));
+  responseStreamController.enqueue(JSON.stringify({ status: "starting" }));
   // call Simpler API to obtain details for S3 upload and pending file id
   const fileUploadDetails = await fetchFileUploadDetails(file.name, file.type);
   responseStreamController.enqueue(JSON.stringify({ status: "uploading" }));

--- a/frontend/src/app/api/file/route.test.ts
+++ b/frontend/src/app/api/file/route.test.ts
@@ -78,7 +78,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
     );
     expect(response.status).toEqual(400);
   });
-  it("calls fetchFileUploadDetails with uploaded file, and streams 'queued' status", async () => {
+  it("calls fetchFileUploadDetails with uploaded file, and streams 'starting' status", async () => {
     const testFile = new File(["file contents"], "file.txt", {
       type: "application/octet-stream",
     });
@@ -97,7 +97,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
     const firstChunk = await reader?.read();
-    expect(firstChunk?.value).toEqual('{"status":"queued"}');
+    expect(firstChunk?.value).toEqual('{"status":"starting"}');
 
     expect(mockFetchFileUploadDetails).toHaveBeenCalledTimes(1);
     expect(mockFetchFileUploadDetails).toHaveBeenCalledWith(
@@ -105,7 +105,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
       testFile.type,
     );
   });
-  it("sets queued status while fetching s3 details", async () => {
+  it("sets starting status while fetching s3 details", async () => {
     const testFile = new File(["file contents"], "file.txt");
     const testFormData = new FormData();
     testFormData.append("file_attachment", testFile);
@@ -122,7 +122,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
     const firstChunk = await reader?.read();
-    expect(firstChunk?.value).toEqual('{"status":"queued"}');
+    expect(firstChunk?.value).toEqual('{"status":"starting"}');
   });
   it("calls uploadFileToS3 with returned data from fetchFileUploadDetails and file, and streams 'uploading' status", async () => {
     const testFile = new File(["file contents"], "file.txt");

--- a/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
+++ b/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
@@ -162,6 +162,10 @@ export const FileInputStatusDisplay = ({
     ? (errorStatuses.get(status) as FileUploadStatus) || "error"
     : status;
   const statusMessageForDisplay = messagesMap[adjustedStatus];
+
+  console.log(
+    `~~~ fileInputStatusDisplay render:${status} --- ${statusMessageForDisplay} ~~~`,
+  );
   return (
     <div className="margin-x-3">
       <Grid

--- a/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
+++ b/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
@@ -16,6 +16,7 @@ const errorStatuses = new Map([
   ["starting", "pre-upload-error"],
   ["uploading", "upload-error"],
   ["starting-scan", "scan-error"],
+  ["pending", "scan-error"],
   ["in_progress", "scan-error"],
   ["infected", "infected"],
   ["complete", "file-id-error"], // assuming that any error in this state is due to a missing file id
@@ -144,6 +145,7 @@ export const FileInputStatusDisplay = ({
     starting: t("starting"),
     uploading: t("uploading"),
     "starting-scan": t("startingScan"),
+    pending: t("startingScan"),
     in_progress: t("scanning"),
     infected: t("infected"),
     complete: t("scanComplete"),

--- a/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
+++ b/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
@@ -15,9 +15,9 @@ const errorStatuses = new Map([
   ["queued", "pre-upload-error"],
   ["starting", "pre-upload-error"],
   ["uploading", "upload-error"],
-  ["infected", "infected"],
-  ["pending", "scan-error"],
   ["starting-scan", "scan-error"],
+  ["in_progress", "scan-error"],
+  ["infected", "infected"],
   ["complete", "file-id-error"], // assuming that any error in this state is due to a missing file id
   ["post-upload", "post-upload-error"],
 ]);
@@ -144,7 +144,7 @@ export const FileInputStatusDisplay = ({
     starting: t("starting"),
     uploading: t("uploading"),
     "starting-scan": t("startingScan"),
-    pending: t("scanning"),
+    in_progress: t("scanning"),
     infected: t("infected"),
     complete: t("scanComplete"),
     "scan-complete": t("scanComplete"),

--- a/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
+++ b/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
@@ -13,6 +13,7 @@ import { USWDSIcon } from "src/components/core/USWDSIcon";
 // maps upload statuses to the error message to show if error occurs while in those statuses
 const errorStatuses = new Map([
   ["queued", "pre-upload-error"],
+  ["starting", "pre-upload-error"],
   ["uploading", "upload-error"],
   ["infected", "infected"],
   ["pending", "scan-error"],
@@ -140,6 +141,7 @@ export const FileInputStatusDisplay = ({
   // refactor this to be more flexible in terms of tracking progress
   const messagesMap: { [key in FileUploadStatus]: string } = {
     queued: t("queued"),
+    starting: t("starting"),
     uploading: t("uploading"),
     "starting-scan": t("startingScan"),
     pending: t("scanning"),

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -189,6 +189,7 @@ export const useFileUpload = ({
           }
           const postUploadAbortController = new AbortController();
           setCurrentStatus("post-upload");
+          console.log(`~~~ set post upload status ~~~`);
           setPostUploadController(postUploadAbortController);
           return postUploadAction(
             pendingFileId,
@@ -242,5 +243,6 @@ export const useFileUpload = ({
     ],
   );
 
+  console.log(`~~~ useFileUpload render: ${currentStatus} ~~~`);
   return useFileUploadInterface;
 };

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2725,6 +2725,7 @@ export const messages = {
       cancel: "Cancel",
       dismiss: "Dismiss",
       queued: "Queued",
+      starting: "Starting upload process",
       uploading: "Uploading...",
       startingScan: "Upload complete. Starting security scan",
       scanning: "Upload complete. Running security scan...",

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -18,12 +18,11 @@ export const config = {
   matcher: [
     /*
      * Run Middleware on all request paths except these:
-     * - Api routes
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - images (static files in public/images/ directory)
      */
-    "/((?!_next/static|_next/image|sitemap|public|img|uswds|images|robots.txt|site.webmanifest|favicon.ico).*)",
+    "/((?!_next/static|_next/image|sitemap|public|img|uswds|images|robots.txt|site.webmanifest|favicon.ico|api/file).*)",
     /**
      * Fix issue where the pattern above was causing middleware
      * to not run on the homepage:

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -82,7 +82,6 @@ export default function proxy(request: NextRequest): NextResponse {
   const cacheControl: string[] = [];
 
   // only allow for cdn testing/troubleshooting in lower envs
-
   if (isACdnTestRequest(request)) {
     const testResponse = applyCorrelationId(request, handleCdnTest(request));
     logRequest(request, testResponse);

--- a/frontend/src/types/fileUploadTypes.ts
+++ b/frontend/src/types/fileUploadTypes.ts
@@ -1,7 +1,8 @@
 export const fileUploadProcessStatus = [
-  "queued",
-  "uploading",
-  "starting-scan",
+  "starting", // before receiving any response from the backend
+  "queued", // fetching s3 upload metadata
+  "uploading", // uploading file to s3
+  "starting-scan", // making request for scan status, no status yet received from API
   "pending", // API supplied status while undergoing virus scan
   "scan-complete", // Synthetic status used for sending back pending file id, same visually as "complete"
   "complete", // API supplied status for complete virus scan

--- a/frontend/src/types/fileUploadTypes.ts
+++ b/frontend/src/types/fileUploadTypes.ts
@@ -3,6 +3,7 @@ export const fileUploadProcessStatus = [
   "queued", // fetching s3 upload metadata
   "uploading", // uploading file to s3
   "starting-scan", // making request for scan status, no status yet received from API
+  "pending", // recieved scan status from API but scan not yet started
   "in_progress", // API supplied status while undergoing virus scan
   "scan-complete", // Synthetic status used for sending back pending file id, same visually as "complete"
   "complete", // API supplied status for complete virus scan

--- a/frontend/src/types/fileUploadTypes.ts
+++ b/frontend/src/types/fileUploadTypes.ts
@@ -3,7 +3,7 @@ export const fileUploadProcessStatus = [
   "queued", // fetching s3 upload metadata
   "uploading", // uploading file to s3
   "starting-scan", // making request for scan status, no status yet received from API
-  "pending", // API supplied status while undergoing virus scan
+  "in_progress", // API supplied status while undergoing virus scan
   "scan-complete", // Synthetic status used for sending back pending file id, same visually as "complete"
   "complete", // API supplied status for complete virus scan
   "post-upload",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes two issues with file upload status display:

* `queued` status was being used for two distinct phases of the upload, neither of which really involve the file being queued. This was split into a `processing` phase where the file is being uploaded to the NextJS server and read into memory so that it can be sent to s3, and a `starting` phase where we are fetching metadata from the API needed to send the file to s3
* the file scan process has a third `in_progress` status that was not previously being tracked

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. `npm run local` on this branch
2. visit http://localhost:3000 and login as many_app_user
3. click the test application link in the user dropdown
4. click `attachment form`
5. upload a file
6. _VERIFY_: the file runs through `Processing file`, `Starting upload`, `Upload complete. Starting security scan` and `Upload complete. Running security scan...` phases

Locally things this run fast so you may need to add debuggers in the api/file handler in order to pause execution and inspect the status at each juncture