### PR TITLE
fix status message mapping for file upload

### DIFF
--- a/frontend/src/app/api/file/handler.ts
+++ b/frontend/src/app/api/file/handler.ts
@@ -60,7 +60,7 @@ const orchestrateFileUpload = async (
   responseStreamController: ReadableStreamDefaultController,
   file: File,
 ) => {
-  responseStreamController.enqueue(JSON.stringify({ status: "queued" }));
+  responseStreamController.enqueue(JSON.stringify({ status: "starting" }));
   // call Simpler API to obtain details for S3 upload and pending file id
   const fileUploadDetails = await fetchFileUploadDetails(file.name, file.type);
   responseStreamController.enqueue(JSON.stringify({ status: "uploading" }));

--- a/frontend/src/app/api/file/route.test.ts
+++ b/frontend/src/app/api/file/route.test.ts
@@ -78,7 +78,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
     );
     expect(response.status).toEqual(400);
   });
-  it("calls fetchFileUploadDetails with uploaded file, and streams 'queued' status", async () => {
+  it("calls fetchFileUploadDetails with uploaded file, and streams 'starting' status", async () => {
     const testFile = new File(["file contents"], "file.txt", {
       type: "application/octet-stream",
     });
@@ -97,7 +97,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
     const firstChunk = await reader?.read();
-    expect(firstChunk?.value).toEqual('{"status":"queued"}');
+    expect(firstChunk?.value).toEqual('{"status":"starting"}');
 
     expect(mockFetchFileUploadDetails).toHaveBeenCalledTimes(1);
     expect(mockFetchFileUploadDetails).toHaveBeenCalledWith(
@@ -105,7 +105,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
       testFile.type,
     );
   });
-  it("sets queued status while fetching s3 details", async () => {
+  it("sets starting status while fetching s3 details", async () => {
     const testFile = new File(["file contents"], "file.txt");
     const testFormData = new FormData();
     testFormData.append("file_attachment", testFile);
@@ -122,7 +122,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
     const firstChunk = await reader?.read();
-    expect(firstChunk?.value).toEqual('{"status":"queued"}');
+    expect(firstChunk?.value).toEqual('{"status":"starting"}');
   });
   it("calls uploadFileToS3 with returned data from fetchFileUploadDetails and file, and streams 'uploading' status", async () => {
     const testFile = new File(["file contents"], "file.txt");
@@ -197,7 +197,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
     const reader =
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
-    // advance through queued, uploading, and starting-scan states
+    // advance through starting, uploading, and starting-scan states
     await reader?.read();
     await reader?.read();
     await reader?.read();
@@ -242,7 +242,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
     const reader =
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
-    // advance through queued, uploading, and starting-scan states
+    // advance through starting, uploading, and starting-scan states
     await reader?.read();
     await reader?.read();
     await reader?.read();
@@ -347,7 +347,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
     const reader =
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
-    // advance through queued, uploading, and starting-scan states
+    // advance through starting, uploading, and starting-scan states
     await reader?.read();
     await reader?.read();
     await reader?.read();
@@ -379,7 +379,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
     const reader =
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
-    // advance through queued, uploading, and starting-scan states
+    // advance through starting, uploading, and starting-scan states
     await reader?.read();
     await reader?.read();
     await reader?.read();
@@ -418,7 +418,7 @@ describe("POST request handler /api/file (handleFileUpload)", () => {
     const reader =
       response.body?.getReader() as ReadableStreamDefaultReader<FileUploadStatusUpdate>;
 
-    // advance through queued, uploading, and starting-scan states
+    // advance through starting, uploading, and starting-scan states
     await reader?.read();
     await reader?.read();
     await reader?.read();

--- a/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
+++ b/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
@@ -141,7 +141,7 @@ export const FileInputStatusDisplay = ({
   // this relies on some magic strings, it's not great!
   // refactor this to be more flexible in terms of tracking progress
   const messagesMap: { [key in FileUploadStatus]: string } = {
-    processing: t("queued"),
+    processing: t("processing"),
     starting: t("starting"),
     uploading: t("uploading"),
     "starting-scan": t("startingScan"),

--- a/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
+++ b/frontend/src/components/core/fileInput/FileInputStatusDisplay.tsx
@@ -12,10 +12,12 @@ import { USWDSIcon } from "src/components/core/USWDSIcon";
 
 // maps upload statuses to the error message to show if error occurs while in those statuses
 const errorStatuses = new Map([
-  ["queued", "pre-upload-error"],
+  ["processing", "pre-upload-error"],
+  ["starting", "pre-upload-error"],
   ["uploading", "upload-error"],
   ["infected", "infected"],
   ["pending", "scan-error"],
+  ["in_progress", "scan-error"],
   ["starting-scan", "scan-error"],
   ["complete", "file-id-error"], // assuming that any error in this state is due to a missing file id
   ["post-upload", "post-upload-error"],
@@ -139,10 +141,12 @@ export const FileInputStatusDisplay = ({
   // this relies on some magic strings, it's not great!
   // refactor this to be more flexible in terms of tracking progress
   const messagesMap: { [key in FileUploadStatus]: string } = {
-    queued: t("queued"),
+    processing: t("queued"),
+    starting: t("starting"),
     uploading: t("uploading"),
     "starting-scan": t("startingScan"),
-    pending: t("scanning"),
+    pending: t("startingScan"),
+    in_progress: t("scanning"),
     infected: t("infected"),
     complete: t("scanComplete"),
     "scan-complete": t("scanComplete"),

--- a/frontend/src/components/core/fileInput/FileUploadManager.test.tsx
+++ b/frontend/src/components/core/fileInput/FileUploadManager.test.tsx
@@ -20,7 +20,7 @@ jest.mock("src/hooks/useFileUpload", () => ({
 describe("FileUploadManager", () => {
   beforeEach(() => {
     mockUseFileUpload.mockImplementation(() => ({
-      currentStatus: "queued",
+      currentStatus: "processing",
       uploadFile: mockUploadFile,
       handleCancel: mockHandleCancel,
       dismissError: mockDismissError,
@@ -83,7 +83,7 @@ describe("FileUploadManager", () => {
   });
   it("calls both hook based and SimplerFileInput callbacks on dismiss", async () => {
     mockUseFileUpload.mockImplementation(() => ({
-      currentStatus: "queued",
+      currentStatus: "processing",
       uploadFile: mockUploadFile,
       handleCancel: mockHandleCancel,
       dismissError: mockDismissError,

--- a/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
@@ -187,7 +187,7 @@ describe("SimplerFileInput", () => {
       await waitFor(async () =>
         expect(
           await screen.findByTestId("file-upload-status-display"),
-        ).toHaveTextContent("scanning"),
+        ).toHaveTextContent("startingScan"),
       );
     });
 
@@ -663,7 +663,7 @@ describe("SimplerFileInput", () => {
       await waitFor(async () =>
         expect(
           await screen.findByTestId("file-upload-status-display"),
-        ).toHaveTextContent("scanning"),
+        ).toHaveTextContent("startingScan"),
       );
     });
   });

--- a/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
+++ b/frontend/src/components/core/fileInput/SimplerFileInput.test.tsx
@@ -109,7 +109,7 @@ describe("SimplerFileInput", () => {
         await screen.findByTestId("file-upload-status-display"),
       ).toBeInTheDocument();
     });
-    it("displays a 'queued' message when queued", async () => {
+    it("displays a 'processing' message when processing", async () => {
       const trigger = createAdvanceStreamTrigger();
       clientFetchMock.mockResolvedValue(
         new Response(
@@ -142,7 +142,7 @@ describe("SimplerFileInput", () => {
       );
       expect(
         await screen.findByTestId("file-upload-status-display"),
-      ).toHaveTextContent("queued");
+      ).toHaveTextContent("processing");
     });
 
     it("displays a sequential status messages as received from streaming response", async () => {
@@ -153,6 +153,7 @@ describe("SimplerFileInput", () => {
             [
               JSON.stringify({ status: "uploading" }),
               JSON.stringify({ status: "pending" }),
+              JSON.stringify({ status: "in_progress" }),
             ],
             trigger,
           ),
@@ -188,6 +189,13 @@ describe("SimplerFileInput", () => {
         expect(
           await screen.findByTestId("file-upload-status-display"),
         ).toHaveTextContent("startingScan"),
+      );
+
+      trigger.advance();
+      await waitFor(async () =>
+        expect(
+          await screen.findByTestId("file-upload-status-display"),
+        ).toHaveTextContent("scanning"),
       );
     });
 

--- a/frontend/src/hooks/useFIleUpload.test.ts
+++ b/frontend/src/hooks/useFIleUpload.test.ts
@@ -174,7 +174,7 @@ describe("useFileUpload", () => {
     act(() => {
       result.current.uploadFile(fakeFile);
     });
-    expect(result.current.currentStatus).toEqual("queued");
+    expect(result.current.currentStatus).toEqual("processing");
     // having a hard time managing state changes in this test, since
     // the state updates multiple times without any user action.
     // As a result, the state jumps directly from queued to success.

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -152,7 +152,7 @@ export const useFileUpload = ({
       const uploadAbortController = new AbortController();
 
       setFileName(fileName);
-      setCurrentStatus("queued");
+      setCurrentStatus("processing");
       setUploadController(uploadAbortController);
 
       try {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -2724,7 +2724,8 @@ export const messages = {
     statusDisplay: {
       cancel: "Cancel",
       dismiss: "Dismiss",
-      queued: "Queued",
+      processing: "Processing file",
+      starting: "Starting upload",
       uploading: "Uploading...",
       startingScan: "Upload complete. Starting security scan",
       scanning: "Upload complete. Running security scan...",

--- a/frontend/src/types/fileUploadTypes.ts
+++ b/frontend/src/types/fileUploadTypes.ts
@@ -1,8 +1,10 @@
 export const fileUploadProcessStatus = [
-  "queued",
-  "uploading",
-  "starting-scan",
-  "pending", // API supplied status while undergoing virus scan
+  "processing", // before receiving any update from backend, time spent reading file data on server
+  "starting", // fetching s3 upload metadata
+  "uploading", // uploading file to s3
+  "starting-scan", // making request for scan status, no status yet received from API
+  "pending", // received scan status from API but scan not yet started
+  "in_progress", // API supplied status while undergoing virus scan
   "scan-complete", // Synthetic status used for sending back pending file id, same visually as "complete"
   "complete", // API supplied status for complete virus scan
   "post-upload",


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
unticketed

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes two issues with file upload status display:

* `queued` status was being used for two distinct phases of the upload, neither of which really involve the file being queued. This was split into a `processing` phase where the file is being uploaded to the NextJS server and read into memory so that it can be sent to s3, and a `starting` phase where we are fetching metadata from the API needed to send the file to s3
* the file scan process has a third `in_progress` status that was not previously being tracked

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. `npm run local` on this branch
2. visit http://localhost:3000 and login as many_app_user
3. click the test application link in the user dropdown
4. click `attachment form`
5. upload a file
6. _VERIFY_: the file runs through `Processing file`, `Starting upload`, `Upload complete. Starting security scan` and `Upload complete. Running security scan...` phases

Locally things this run fast so you may need to add debuggers in the api/file handler in order to pause execution and inspect the status at each juncture