### PR TITLE
[Issue #11974] Allow DAP Analytics via CSP

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -23,7 +23,7 @@ const cspHeader = `
     base-uri 'self';
     media-src 'self';
     style-src-elem 'self' 'unsafe-inline' https://fonts.googleapis.com/;
-    script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com/ https://fonts.googleapis.com/ https://js-agent.newrelic.com/;
+    script-src-elem 'self' 'unsafe-inline' https://www.googletagmanager.com/ https://fonts.googleapis.com/ https://js-agent.newrelic.com/ https://dap.digitalgov.gov/;
     form-action 'self';
     frame-ancestors 'none';
     upgrade-insecure-requests;


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11974 

## Changes proposed

Add Fed's DAP Analytics URL to our CSP allow list

## Context for reviewers

We made a decision long ago in an ADR to support DAP Analytics on Simpler since it's a public gov site. However it was injected via GTM but never allow listed in our CSP settings so browsers have been blocking the script.

## Validation steps

- Checks pass
- Test once deployed and validate that Developer Console does not flag CSP violation for DAP
