### PR TITLE
[unticketed]: fix new relic logging

### DIFF
--- a/infra/frontend/service/main.tf
+++ b/infra/frontend/service/main.tf
@@ -48,6 +48,10 @@ locals {
 
   service_name = "${local.prefix}${module.app_config.app_name}-${var.environment_name}"
 
+  # Name this service reports to New Relic. Matches service_name unless the environment sets
+  # app_environment_name to stand in for another (infra-staging reports as frontend-staging).
+  newrelic_service_name = "${local.prefix}${module.app_config.app_name}-${local.service_config.app_environment_name}"
+
   # Include project name in bucket name since buckets need to be globally unique across AWS
   bucket_name  = "${local.prefix}${module.project_config.project_name}-${module.app_config.app_name}-${var.environment_name}"
   is_temporary = terraform.workspace != "default"
@@ -250,6 +254,7 @@ module "service" {
 
   newrelic_entity_guid      = local.service_config.newrelic_entity_guid
   newrelic_host_entity_guid = local.service_config.newrelic_host_entity_guid
+  newrelic_service_name     = local.newrelic_service_name
 
   is_temporary = local.is_temporary
 }

--- a/infra/modules/service/alb_log_forwarding.tf
+++ b/infra/modules/service/alb_log_forwarding.tf
@@ -51,6 +51,8 @@ resource "aws_lambda_function" "nr_alb_log_forwarder" {
       AWS_ACCOUNT_ID          = data.aws_caller_identity.current.account_id
       ALB_NAME                = var.service_name
       MTLS_ALB_NAME           = "${var.service_name}-mtls"
+      NR_ENTITY_NAME          = local.newrelic_service_name
+      NR_MTLS_ENTITY_NAME     = "${local.newrelic_service_name}-mtls"
       NR_ENTITY_GUID          = var.newrelic_entity_guid != null ? var.newrelic_entity_guid : ""
       NR_MTLS_ENTITY_GUID     = var.newrelic_mtls_entity_guid != null ? var.newrelic_mtls_entity_guid : ""
     }

--- a/infra/modules/service/host_log_forwarding.tf
+++ b/infra/modules/service/host_log_forwarding.tf
@@ -4,6 +4,10 @@
 
 locals {
   nr_host_log_forwarder_name = "${var.service_name}-nr-host-log-forwarder"
+
+  # New Relic reporting identity, which may differ from the AWS resource name when an
+  # environment stands in for another (e.g. infra-staging reports as frontend-staging).
+  newrelic_service_name = coalesce(var.newrelic_service_name, var.service_name)
 }
 
 data "aws_ssm_parameter" "newrelic_license_key_host" {
@@ -47,6 +51,7 @@ resource "aws_lambda_function" "nr_host_log_forwarder" {
       AWS_ACCOUNT_ID          = data.aws_caller_identity.current.account_id
       ECS_SERVICE_NAME        = var.service_name
       ECS_CLUSTER_NAME        = var.service_name
+      NR_ENTITY_NAME          = local.newrelic_service_name
       NR_ENTITY_GUID          = var.newrelic_host_entity_guid != null ? var.newrelic_host_entity_guid : ""
     }
   }

--- a/infra/modules/service/lambda/newrelic_alb_log_forwarder.py
+++ b/infra/modules/service/lambda/newrelic_alb_log_forwarder.py
@@ -24,6 +24,12 @@ MTLS_ALB_NAME = os.environ.get("MTLS_ALB_NAME", "")
 NR_ENTITY_GUID = os.environ.get("NR_ENTITY_GUID", "")
 NR_MTLS_ENTITY_GUID = os.environ.get("NR_MTLS_ENTITY_GUID", "")
 
+# New Relic reporting names. Differ from the ALB names when an environment stands in for
+# another (e.g. infra-staging reports as frontend-staging so it lands on the same entity
+# as the environment it replaces). The aws.alb.name attribute stays truthful.
+NR_ENTITY_NAME = os.environ.get("NR_ENTITY_NAME", "")
+NR_MTLS_ENTITY_NAME = os.environ.get("NR_MTLS_ENTITY_NAME", "")
+
 # Max log entries per New Relic Logs API request
 BATCH_SIZE = 1000
 
@@ -106,6 +112,15 @@ def get_entity_guid(alb_name):
     if MTLS_ALB_NAME and alb_name == MTLS_ALB_NAME and NR_MTLS_ENTITY_GUID:
         return NR_MTLS_ENTITY_GUID
     return ""
+
+
+def get_entity_name(alb_name):
+    """Return the New Relic reporting name for the given ALB name."""
+    if alb_name == ALB_NAME and NR_ENTITY_NAME:
+        return NR_ENTITY_NAME
+    if MTLS_ALB_NAME and alb_name == MTLS_ALB_NAME and NR_MTLS_ENTITY_NAME:
+        return NR_MTLS_ENTITY_NAME
+    return alb_name
 
 
 def send_to_newrelic(nr_payload, nr_license_key):
@@ -198,6 +213,7 @@ def process_log_file(bucket, key):
     total = 0
     for alb_name, entries in entries_by_alb.items():
         entity_guid = get_entity_guid(alb_name)
+        entity_name = get_entity_name(alb_name)
         common_attributes = {
             "logtype": "alb-access-logs",
             "plugin": "s3-lambda-forwarder",
@@ -206,8 +222,8 @@ def process_log_file(bucket, key):
             "aws.accountId": AWS_ACCOUNT_ID,
             "aws.region": region,
             "aws.alb.name": alb_name,
-            "hostname": alb_name,
-            "entity.name": alb_name,
+            "hostname": entity_name,
+            "entity.name": entity_name,
             "entity.type": "AWSALB",
             "provider": "Alb",
         }

--- a/infra/modules/service/lambda/newrelic_host_log_forwarder.py
+++ b/infra/modules/service/lambda/newrelic_host_log_forwarder.py
@@ -21,6 +21,11 @@ ECS_SERVICE_NAME = os.environ.get("ECS_SERVICE_NAME", "")
 ECS_CLUSTER_NAME = os.environ.get("ECS_CLUSTER_NAME", "")
 NR_ENTITY_GUID = os.environ.get("NR_ENTITY_GUID", "")
 
+# New Relic reporting name. Differs from ECS_SERVICE_NAME when an environment stands in
+# for another (e.g. infra-staging reports as frontend-staging so it lands on the same
+# entity as the environment it replaces). The aws.ecs.* attributes stay truthful.
+NR_ENTITY_NAME = os.environ.get("NR_ENTITY_NAME", "") or ECS_SERVICE_NAME
+
 # Max log entries per New Relic Logs API request
 BATCH_SIZE = 1000
 
@@ -240,8 +245,8 @@ def handler(event, context):
         "aws.region": AWS_REGION,
         "aws.ecs.serviceName": ECS_SERVICE_NAME,
         "aws.ecs.clusterName": ECS_CLUSTER_NAME,
-        "hostname": ECS_SERVICE_NAME,
-        "entity.name": ECS_SERVICE_NAME,
+        "hostname": NR_ENTITY_NAME,
+        "entity.name": NR_ENTITY_NAME,
         "entity.type": "AWSECSSERVICE",
         "provider": "EcsService",
     }

--- a/infra/modules/service/variables.tf
+++ b/infra/modules/service/variables.tf
@@ -423,3 +423,9 @@ variable "newrelic_host_entity_guid" {
   description = "New Relic entity GUID for the ECS service, used to correlate container logs with the infrastructure entity in New Relic."
   default     = null
 }
+
+variable "newrelic_service_name" {
+  type        = string
+  description = "Name reported to New Relic as entity.name/hostname in forwarded logs; defaults to service_name."
+  default     = null
+}


### PR DESCRIPTION
## Summary

Updated new relic logging to forward entity names from the new aws accounts. 

## Validation steps

Deployed to frontend staging: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/31725537248/job/94533182758)