### PR TITLE
[Issue #11891] Fix filename handling and query style per PR #11959 review feedback

### DIFF
--- a/api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py
+++ b/api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py
@@ -17,10 +17,7 @@ from src.services.opportunities_grantor_v1.get_opportunity import get_opportunit
 from src.services.opportunities_grantor_v1.opportunity_utils import (
     validate_opportunity_created_in_simpler_grants,
 )
-from src.services.opportunity_attachments.attachment_util import (
-    adjust_legacy_file_name,
-    get_s3_attachment_path,
-)
+from src.services.opportunity_attachments.attachment_util import get_s3_attachment_path
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +40,15 @@ def create_opportunity_attachment_from_pending_file(
     pending_file = fetch_and_validate_scan_complete_file(db_session, pending_file_id, user)
 
     attachment_id = uuid.uuid4()
-    file_name = adjust_legacy_file_name(pending_file.file_name)
+    # secure_filename makes the file safe for path operations and strips
+    # non-ascii characters before we hand it to s3 - matches the pending-file
+    # pattern in create_application_attachment_from_pending_file.py. The raw
+    # name is kept for the DB record's display file_name below.
+    secure_file_name = file_util.get_secure_file_name(pending_file.file_name)
 
     s3_config = S3Config()
     s3_file_location = get_s3_attachment_path(
-        file_name=file_name,
+        file_name=secure_file_name,
         opportunity_attachment_id=attachment_id,
         opportunity=opportunity,
         s3_config=s3_config,
@@ -59,7 +60,7 @@ def create_opportunity_attachment_from_pending_file(
         opportunity_id=opportunity_id,
         file_location=s3_file_location,
         mime_type=pending_file.mime_type,
-        file_name=file_name,
+        file_name=pending_file.file_name,
         file_description="",
         file_size_bytes=file_size_bytes,
         legacy_attachment_id=None,

--- a/api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py
+++ b/api/src/services/opportunities_grantor_v1/opportunity_attachment_from_pending_file.py
@@ -40,11 +40,11 @@ def create_opportunity_attachment_from_pending_file(
     pending_file = fetch_and_validate_scan_complete_file(db_session, pending_file_id, user)
 
     attachment_id = uuid.uuid4()
-    # secure_filename makes the file safe for path operations and strips
-    # non-ascii characters before we hand it to s3 - matches the pending-file
-    # pattern in create_application_attachment_from_pending_file.py. The raw
-    # name is kept for the DB record's display file_name below.
-    secure_file_name = file_util.get_secure_file_name(pending_file.file_name)
+    # pending_file.file_location already ends in a secure_filename-sanitized
+    # name (applied once at presign time) - reuse it instead of re-sanitizing
+    # pending_file.file_name from scratch. The raw name is kept for the DB
+    # record's display file_name below.
+    secure_file_name = file_util.get_file_name(pending_file.file_location)
 
     s3_config = S3Config()
     s3_file_location = get_s3_attachment_path(

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_attachments_temporary.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_attachments_temporary.py
@@ -2,6 +2,7 @@ import uuid
 
 import pytest
 from grants_shared.util import file_util
+from sqlalchemy import select
 
 from src.constants.lookup_constants import FileScanStatus, Privilege
 from src.db.models import opportunity_models
@@ -65,11 +66,12 @@ def test_create_from_pending_file_200(
     assert data["file_name"] == "test-attachment.pdf"
     assert data["mime_type"] == "application/pdf"
 
-    attachment = (
-        db_session.query(opportunity_models.OpportunityAttachment)
-        .filter_by(attachment_id=data["opportunity_attachment_id"])
-        .one()
-    )
+    attachment = db_session.execute(
+        select(opportunity_models.OpportunityAttachment).where(
+            opportunity_models.OpportunityAttachment.attachment_id
+            == data["opportunity_attachment_id"]
+        )
+    ).scalar_one()
     assert file_util.file_exists(attachment.file_location) is True
     assert file_util.file_exists(pending_file.file_location) is False
     db_session.refresh(pending_file)


### PR DESCRIPTION
## Summary

Fixes #11891

## Changes proposed

Two changes, both from review comments on PR #11959 (left after that PR was already merged):

- Filename handling in the pending-file attachment service - replaced `adjust_legacy_file_name()` with `get_secure_file_name()` for the S3 path, matching the pattern already used in Apply's pending-file flow (`create_application_attachment_from_pending_file.py`). The database record's `file_name` field now keeps the original, unmodified filename instead of a sanitized one.
- Query style in the test - replaced the legacy `db_session.query(...)` with `db_session.execute(select(...))`.

## Context for reviewers

- Filename comment: https://github.com/HHS/simpler-grants-gov/pull/11959#discussion_r3776395265
- Query style comment: https://github.com/HHS/simpler-grants-gov/pull/11959#discussion_r3776424709


## Validation steps

1. Run the affected test file directly: `pytest tests/src/api/opportunities_grantors_v1/test_opportunity_attachments_temporary.py -v` - expect 10 passed.
2. Run the full domain suite: `pytest tests/src/api/opportunities_grantors_v1/ -q` - expect 136 passed, no regressions.
3. Format, lint, security lint, and migration checks all pass via `make format-check && make lint && make lint-security && make db-check-migrations`.