### PR TITLE
[Issue #11983] limit next js payloads to 200mb

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -154,7 +154,7 @@ const nextConfig = {
   // warning about unrecognized key can be ignored
   api: {
     bodyParser: {
-      sizeLimit: "2000mb",
+      sizeLimit: "200mb",
     },
   },
   basePath,
@@ -188,9 +188,9 @@ const nextConfig = {
   },
   experimental: {
     testProxy: true,
-    proxyClientMaxBodySize: "2000mb",
+    proxyClientMaxBodySize: "200mb",
     serverActions: {
-      bodySizeLimit: "2000mb",
+      bodySizeLimit: "200mb",
     },
   },
   async redirects() {


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11983 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Reduces the max payload size for next js request payloads to 200mb from 2gb.


## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Note that the error for an oversized file comes through as a "pre-upload error", and the error appears as a `
TypeError: Failed to parse body as FormData.`, because the way Next implements this is to truncate the payload rather than erroring at that point. NextJS does log a separate warning in the middleware when it encounters the payload, but that's not usable from an error handling perspective.

The better way to handle this is to check client side for the file size within the component before even making the request, but that'd be a bigger change that we'd want to implement flexibly to handle customizable max file sizes.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. run `npm run local` on this branch
2. log in as many_app_user
3. click the `test application` link under the user dropdown
4. click `attachment form`
5. upload a file larger than 200mb
6. _VERIFY_: upload fails with a `pre-upload error`