### PR TITLE
[Issue #11986] SOAP/Proxy handle dict AssignAgencyTrackingNumber

### DIFF
--- a/api/src/legacy_soap_api/grantors/schemas/update_application_info_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/update_application_info_schemas.py
@@ -6,7 +6,7 @@ Training: https://trainingapply.grants.gov/apply/system/schemas/AgencyUpdateAppl
 Production: https://apply07.grants.gov/apply/system/schemas/AgencyUpdateApplicationInfo-V1.0.xsd
 """
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from src.legacy_soap_api.grantors.schemas.grants_gov_tracking_number_schema import (
     GrantsGovTrackingNumberRequiredSchema,
@@ -19,6 +19,13 @@ class UpdateApplicationInfoRequest(GrantsGovTrackingNumberRequiredSchema):
         default=None, alias="AssignAgencyTrackingNumber"
     )
     save_agency_notes: str | None = Field(default=None, alias="SaveAgencyNotes", min_length=1)
+
+    @field_validator("assign_agency_tracking_number", mode="before")
+    @classmethod
+    def get_agency_tracking_number_value_from_dict(cls, value: str | dict) -> str | None:
+        if isinstance(value, dict):
+            return value.get("#text")
+        return value
 
 
 class SaveAgencyNotesResult(BaseSOAPSchema):

--- a/api/src/legacy_soap_api/grantors/schemas/update_application_info_schemas.py
+++ b/api/src/legacy_soap_api/grantors/schemas/update_application_info_schemas.py
@@ -27,6 +27,13 @@ class UpdateApplicationInfoRequest(GrantsGovTrackingNumberRequiredSchema):
             return value.get("#text")
         return value
 
+    @field_validator("save_agency_notes", mode="before")
+    @classmethod
+    def get_save_agency_notes_value_from_dict(cls, value: str | dict) -> str | None:
+        if isinstance(value, dict):
+            return value.get("#text")
+        return value
+
 
 class SaveAgencyNotesResult(BaseSOAPSchema):
     success: str | None = Field(default=None, alias="ns9:Success")

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1761,7 +1761,8 @@ def test_update_application_info_successfully_handles_alternate_request_body(
         <soapenv:Body>
         <agen:UpdateApplicationInfoRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">
         <gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>
-        <agen1:AssignAgencyTrackingNumber xmlns:agen1="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0">test 1</agen1:AssignAgencyTrackingNumber>
+        <agen1:AssignAgencyTrackingNumber xmlns:agen1="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0">test agency number</agen1:AssignAgencyTrackingNumber>
+        <agen1:SaveAgencyNotes xmlns:agen1="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0">your note text</agen1:SaveAgencyNotes>
         </agen:UpdateApplicationInfoRequest>
         </soapenv:Body>
         </soapenv:Envelope>
@@ -1771,14 +1772,14 @@ def test_update_application_info_successfully_handles_alternate_request_body(
         data=mock_data,
         headers={MTLS_CERT_HEADER_KEY: mtls_cert, "Use-Simpler-Override": "1"},
     )
-    assert response.status_code == 200
     expected = (
         f"--uuid:{TEST_UUID}\r\n"
         'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
         "Content-Transfer-Encoding: binary\r\n"
         "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
-        "<soap:Envelope "
-        'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:UpdateApplicationInfoResponse '
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+        "<soap:Body>"
+        "<ns2:UpdateApplicationInfoResponse "
         'xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" '
         'xmlns:ns11="http://schemas.xmlsoap.org/wsdl/" '
         'xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" '
@@ -1793,12 +1794,10 @@ def test_update_application_info_successfully_handles_alternate_request_body(
         'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
         f"<GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</GrantsGovTrackingNumber>"
         "<ns2:Success>true</ns2:Success>"
-        "<ns9:AssignAgencyTrackingNumberResult>"
-        "<ns9:Success>true</ns9:Success>"
-        "</ns9:AssignAgencyTrackingNumberResult>"
+        "<ns9:AssignAgencyTrackingNumberResult><ns9:Success>true</ns9:Success></ns9:AssignAgencyTrackingNumberResult>"
+        "<ns9:SaveAgencyNotesResult><ns9:Success>true</ns9:Success></ns9:SaveAgencyNotesResult>"
         "</ns2:UpdateApplicationInfoResponse>"
-        "</soap:Body>"
-        "</soap:Envelope>\r\n"
+        "</soap:Body></soap:Envelope>\r\n"
         f"--uuid:{TEST_UUID}--"
     ).encode("utf-8")
     assert response.data == expected

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1730,6 +1730,80 @@ def test_calls_simpler_if_using_simpler_tracking_number(
     mock_get_simpler_soap_response.assert_called_once()
 
 
+@mock.patch("uuid.uuid4")
+def test_calls_simpler_if_using_simpler_tracking_number_handles_alternate_request(
+    mock_uuid,
+    db_session,
+    client,
+    enable_factory_create,
+) -> None:
+    mock_uuid.return_value = TEST_UUID
+    full_path = "/grantsws-agency/services/v2/AgencyWebServicesSoapPort"
+    agency = AgencyFactory.create()
+    opportunity = OpportunityFactory.create(agency_code=agency.agency_code)
+    competition = CompetitionFactory(
+        opportunity=opportunity,
+    )
+    privileges = {Privilege.LEGACY_AGENCY_ASSIGNER}
+    user, role, soap_client_certificate, mtls_cert = setup_cert_user(agency, privileges)
+    application = ApplicationFactory.create(
+        competition=competition, application_status=ApplicationStatus.ACCEPTED
+    )
+    submission = ApplicationSubmissionFactory.create(application=application)
+    ApplicationSubmissionRetrievedFactory.create(
+        application_submission=submission,
+        created_by_user=user,
+        modified_by_user=user,
+    )
+    mock_data = f"""
+        <?xml version='1.0' encoding='UTF-8'?>
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+        <soapenv:Body>
+        <agen:UpdateApplicationInfoRequest xmlns:agen="http://apply.grants.gov/services/AgencyWebServices-V2.0">
+        <gran:GrantsGovTrackingNumber xmlns:gran="http://apply.grants.gov/system/GrantsCommonElements-V1.0">GRANT{submission.legacy_tracking_number}</gran:GrantsGovTrackingNumber>
+        <agen1:AssignAgencyTrackingNumber xmlns:agen1="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0">test 1</agen1:AssignAgencyTrackingNumber>
+        </agen:UpdateApplicationInfoRequest>
+        </soapenv:Body>
+        </soapenv:Envelope>
+    """.encode("utf-8")
+    response = client.post(
+        full_path,
+        data=mock_data,
+        headers={MTLS_CERT_HEADER_KEY: mtls_cert, "Use-Simpler-Override": "1"},
+    )
+    assert response.status_code == 200
+    expected = (
+        f"--uuid:{TEST_UUID}\r\n"
+        'Content-Type: application/xop+xml; charset=UTF-8; type="text/xml"\r\n'
+        "Content-Transfer-Encoding: binary\r\n"
+        "Content-ID: <root.message@cxf.apache.org>\r\n\r\n"
+        "<soap:Envelope "
+        'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:UpdateApplicationInfoResponse '
+        'xmlns:ns12="http://schemas.xmlsoap.org/wsdl/soap/" '
+        'xmlns:ns11="http://schemas.xmlsoap.org/wsdl/" '
+        'xmlns:ns10="http://apply.grants.gov/system/GrantsFundingSynopsis-V2.0" '
+        'xmlns:ns9="http://apply.grants.gov/system/AgencyUpdateApplicationInfo-V1.0" '
+        'xmlns:ns8="http://apply.grants.gov/system/GrantsForecastSynopsis-V1.0" '
+        'xmlns:ns7="http://apply.grants.gov/system/AgencyManagePackage-V1.0" '
+        'xmlns:ns6="http://apply.grants.gov/system/GrantsPackage-V1.0" '
+        'xmlns:ns5="http://apply.grants.gov/system/GrantsOpportunity-V1.0" '
+        'xmlns:ns4="http://apply.grants.gov/system/GrantsRelatedDocument-V1.0" '
+        'xmlns:ns3="http://apply.grants.gov/system/GrantsTemplate-V1.0" '
+        'xmlns:ns2="http://apply.grants.gov/services/AgencyWebServices-V2.0" '
+        'xmlns="http://apply.grants.gov/system/GrantsCommonElements-V1.0">'
+        f"<GrantsGovTrackingNumber>GRANT{submission.legacy_tracking_number}</GrantsGovTrackingNumber>"
+        "<ns2:Success>true</ns2:Success>"
+        "<ns9:AssignAgencyTrackingNumberResult>"
+        "<ns9:Success>true</ns9:Success>"
+        "</ns9:AssignAgencyTrackingNumberResult>"
+        "</ns2:UpdateApplicationInfoResponse>"
+        "</soap:Body>"
+        "</soap:Envelope>\r\n"
+        f"--uuid:{TEST_UUID}--"
+    ).encode("utf-8")
+    assert response.data == expected
+
+
 def post_get_submission_list_expanded(client, add_to_headers=None):
     mtls_cert, serial_number = get_mtls_urlencoded_str_and_serial_number()
     tcertificate = StagingTcertificatesFactory.create(serial_num=serial_number)

--- a/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
+++ b/api/tests/src/legacy_soap_api/test_legacy_soap_api_routes.py
@@ -1731,7 +1731,7 @@ def test_calls_simpler_if_using_simpler_tracking_number(
 
 
 @mock.patch("uuid.uuid4")
-def test_calls_simpler_if_using_simpler_tracking_number_handles_alternate_request(
+def test_update_application_info_successfully_handles_alternate_request_body(
     mock_uuid,
     db_session,
     client,


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11986  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
- Added method to handle a dict for AssignAgencyTrackingNumber on UpdateApplicationInfo Request Schema
- Added test
- Added method to handle a dict for AssignAgencyNotes

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Errors were getting thrown because the value was being parsed as a dict instead of a string. This handles both cases.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
- [ ] tests passing
after deploy
- [ ] errors not thrown
