### PR TITLE
[Issue #10996] Adding range validation to expected awards

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
@@ -152,6 +152,9 @@ export default function OpportunityEditForm({
     const form = event.currentTarget.form;
     if (!form) return;
     const formData = new FormData(form);
+    const expectedNumberOfAwards = getNumericAmountFromString(
+      formData.get("expected_number_of_awards") as string | null,
+    );
     const estTotalFunding = getNumericAmountFromString(
       formData.get("estimated_total_program_funding") as string | null,
     );
@@ -162,12 +165,13 @@ export default function OpportunityEditForm({
       formData.get("award_ceiling") as string | null,
     );
     // clear old error messages
+    setSingleFrontendError("expected_number_of_awards", null);
     setSingleFrontendError("award_floor", null);
     setSingleFrontendError("award_ceiling", null);
     setSingleFrontendError("estimated_total_program_funding", null);
     const maxLimit = 1000000000000000;
 
-    //--- min & max values for Award Minimum, Award Minimum and Total Program Funding ---
+    //--- min & max values for Award Minimum, Award Minimum, Total Program Funding, and Expected Number of Awards ---
     if (awardMin < 0 || awardMin >= maxLimit) {
       const errMsg = t("validationErrors.awardMinCurrencyInput");
       setSingleFrontendError("award_floor", errMsg);
@@ -179,6 +183,12 @@ export default function OpportunityEditForm({
     if (estTotalFunding < 0 || estTotalFunding >= maxLimit) {
       const errMsg = t("validationErrors.totalFundingCurrencyInput");
       setSingleFrontendError("estimated_total_program_funding", errMsg);
+    }
+    if (expectedNumberOfAwards < 0 || expectedNumberOfAwards >= maxLimit) {
+      setSingleFrontendError(
+        "expected_number_of_awards",
+        t("validationErrors.expectedNumberOfAwaredsInput"),
+      );
     }
   };
 
@@ -436,6 +446,7 @@ export default function OpportunityEditForm({
                   name="expected_number_of_awards"
                   type="text"
                   defaultValue={initialValues.expected_number_of_awards}
+                  onBlur={singleFieldValidation}
                   className="width-full"
                 />
               </FormGroup>

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityEditForm.tsx
@@ -171,7 +171,7 @@ export default function OpportunityEditForm({
     setSingleFrontendError("estimated_total_program_funding", null);
     const maxLimit = 1000000000000000;
 
-    //--- min & max values for Award Minimum, Award Minimum, Total Program Funding, and Expected Number of Awards ---
+    //--- min & max values for Award Minimum, Award Maximum, Total Program Funding, and Expected Number of Awards ---
     if (awardMin < 0 || awardMin >= maxLimit) {
       const errMsg = t("validationErrors.awardMinCurrencyInput");
       setSingleFrontendError("award_floor", errMsg);
@@ -187,7 +187,7 @@ export default function OpportunityEditForm({
     if (expectedNumberOfAwards < 0 || expectedNumberOfAwards >= maxLimit) {
       setSingleFrontendError(
         "expected_number_of_awards",
-        t("validationErrors.expectedNumberOfAwaredsInput"),
+        t("validationErrors.expectedNumberOfAwardsInput"),
       );
     }
   };

--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/actions.ts
@@ -77,6 +77,7 @@ const CURRENCY_FIELD_NAMES = [
   "award_floor",
   "award_ceiling",
   "estimated_total_program_funding",
+  "expected_number_of_awards",
 ] as const;
 
 function stripCurrencyFormatting(formData: FormData) {

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -398,8 +398,8 @@ export const messages = {
       additionalInfoUrl: "Enter an additional information URL.",
       additionalInfoUrlText: "Enter additional information URL text.",
       grantorContactDetails: "Enter grantor contact details.",
-      expectedNumberOfAwaredsInput:
-        "Expected number of awards must be greater than or equal to zero.",
+      expectedNumberOfAwardsInput:
+        "Expected number of awards must be greater than or equal to zero and less than 1,000,000,000,000,000.",
       awardMinCurrencyInput:
         "Award minimum must be greater than or equal to zero and less than $1,000,000,000,000,000.",
       awardMaxCurrencyInput:

--- a/frontend/src/i18n/messages/en/index.ts
+++ b/frontend/src/i18n/messages/en/index.ts
@@ -398,6 +398,8 @@ export const messages = {
       additionalInfoUrl: "Enter an additional information URL.",
       additionalInfoUrlText: "Enter additional information URL text.",
       grantorContactDetails: "Enter grantor contact details.",
+      expectedNumberOfAwaredsInput:
+        "Expected number of awards must be greater than or equal to zero.",
       awardMinCurrencyInput:
         "Award minimum must be greater than or equal to zero and less than $1,000,000,000,000,000.",
       awardMaxCurrencyInput:

--- a/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
+++ b/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
@@ -161,9 +161,8 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       valueKey: "expectedNumberOfAwards",
       selector: "#expected_number_of_awards",
       required: false,
-      // Un-comment after bug fixed
-      // negativeNumberValidationMessage:
-      //   "Expected number of awards must be greater than or equal to zero.",
+      negativeNumberValidationMessage:
+        "Expected number of awards must be greater than or equal to zero.",
     },
     {
       label: "Estimated total program funding",

--- a/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
+++ b/frontend/tests/e2e/opportunity/fixtures/opportunity-pages-field-definitions.ts
@@ -162,7 +162,7 @@ export const FUNDING_DETAILS_FIELD_DEFINITIONS: OpportunityPageFieldDefinition[]
       selector: "#expected_number_of_awards",
       required: false,
       negativeNumberValidationMessage:
-        "Expected number of awards must be greater than or equal to zero.",
+        "Expected number of awards must be greater than or equal to zero and less than 1,000,000,000,000,000.",
     },
     {
       label: "Estimated total program funding",


### PR DESCRIPTION
## Summary

Fixes for #10996 

## Changes proposed

Adds negative number validation to the expected awards field

## Validation steps

Create an opportunity
Navigate to the Opportunity Summary page
Enter a negative number for expected number of awards
There should be an error message
If you attempt to save, it will fail
If you change to a positive value, it will succeed