### PR TITLE
[Issue #12006] run all tests on util change, run updated specs separately

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -168,7 +168,7 @@ runs:
         TEST_USER_MANAGER_API_KEY: ${{ inputs.test_user_manager_api_key }}
 
       run: |
-        npm run test:e2e -- ${{ env.spec_files }}
+        npm run test:e2e -- ${{ inputs.spec_files }}
       shell: bash
 
     - name: Run all e2e tests (Shard ${{ inputs.current_shard }}/${{ inputs.total_shards }})

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -66,6 +66,9 @@ inputs:
   test_user_manager_api_key:
     description: "manager API key for the new multi-user test system, used to request auth tokens for test users via POST /v1/internal/e2e-token"
     default: ""
+  spec_files:
+    description: "paths to specific spec files to run, will separately, but in addition to any supplied `playwright_tags`"
+    default: ""
 
 outputs:
   artifact-id:
@@ -147,8 +150,29 @@ runs:
           echo "api_url=https://api.grantee2.teams.simpler.grants.gov" >> "$GITHUB_ENV"
         fi
 
+    - name: Run specified e2e tests
+      if: ${{ inputs.spec_files != '' }}
+      working-directory: ./frontend
+      env:
+        CI: true
+        TOTAL_SHARDS: ${{ inputs.total_shards }}
+        CURRENT_SHARD: ${{ inputs.current_shard }}
+        PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
+        PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
+        PLAYWRIGHT_API_URL: ${{ env.api_url }}
+        PLAYWRIGHT_WORKERS: ${{ inputs.workers }}
+        STAGING_TEST_USER_EMAIL: ${{ inputs.staging_test_user_email }}
+        STAGING_TEST_USER_PASSWORD: ${{ inputs.staging_test_user_password }}
+        STAGING_TEST_USER_MFA_KEY: ${{ inputs.staging_test_user_mfa_key }}
+        SESSION_SECRET_OVERRIDE: ${{ inputs.staging_client_session_secret }}
+        TEST_USER_MANAGER_API_KEY: ${{ inputs.test_user_manager_api_key }}
+
+      run: |
+        npm run test:e2e -- ${{ env.spec_files }}
+      shell: bash
+
     - name: Run all e2e tests (Shard ${{ inputs.current_shard }}/${{ inputs.total_shards }})
-      if: ${{ inputs.playwright_tags == '' }}
+      if: ${{ inputs.playwright_tags == '' && inputs.spec_files == '' }}
       working-directory: ./frontend
       env:
         CI: true
@@ -169,7 +193,7 @@ runs:
       shell: bash
 
     - name: Run e2e tests for ${{ inputs.playwright_tags }} (Shard ${{ inputs.current_shard }}/${{ inputs.total_shards }})
-      if: ${{ inputs.playwright_tags != '' }}
+      if: ${{ inputs.playwright_tags != '' && inputs.spec_files == '' }}
       working-directory: ./frontend
       env:
         CI: true

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -233,15 +233,17 @@ runs:
       shell: bash
 
     - name: Verify Blob Report Directory
+      if: ${{ inputs.spec_files == '' }}
       working-directory: ./frontend
       run: |
         echo "Contents of blob-report directory:"
         ls -R blob-report || echo "blob-report directory not found"
       shell: bash
 
+    # skip the test report for specific file based runs
     - name: Upload Blob Report
+      if: ${{ inputs.spec_files == '' && always() || false }}
       id: upload-blob-report
-      if: always()
       uses: actions/upload-artifact@v7
       with:
         name: blob-report-shard-${{ inputs.target }}-${{ inputs.current_shard }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -392,7 +392,7 @@ jobs:
         with:
           files: |
             frontend/tests/playwright.config.ts
-            frontend/tests/e2e/util/**
+            frontend/tests/e2e/utils/**
             frontend/tests/e2e/playwright-env.ts
             frontend/tests/e2e/playwrightUtils.ts
 

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -447,6 +447,8 @@ jobs:
       #             - Run E2E tests for changed spec files
       #           - No
       #             - Run E2E tests
+      #
+      #   Unfortunately Playwright won't let you run both file and grep based filters on which specs to run, within the same invocation
 
       - name: Run All E2E tests (utils updated)
         uses: ./.github/actions/e2e

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -366,7 +366,7 @@ jobs:
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: |
-            frontend/tests/e2e/apply/forms/**/*.spec.ts
+            frontend/tests/e2e/apply/**/*.spec.ts
             frontend/src/components/applyForm/**
             frontend/src/app/**/workspace/applications/*/**/*.tsx
             api/src/form_schema/forms/**

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -391,7 +391,7 @@ jobs:
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: |
-            frontend/tests/utils/**
+            frontend/tests/util/**
             frontend/tests/playwright.config.ts
             frontend/tests/playwright-env.ts
             frontend/tests/playwrightUtils.ts

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -361,16 +361,6 @@ jobs:
       #   CHECKS FOR CHANGED FILES
       #
 
-      - name: Check for updates to core e2e files
-        id: changed-e2e-utils
-        uses: tj-actions/changed-files@v47.0.6
-        with:
-          files: |
-            tests/utils/**
-            tests/playwright.config.ts
-            tests/playwright-env.ts
-            tests/playwrightUtils.ts
-
       - name: Get list of changed apply form files
         id: changed-apply-form-files
         uses: tj-actions/changed-files@v47.0.6
@@ -396,12 +386,22 @@ jobs:
             api/src/api/opportunities_grantor_v1/**
             api/src/services/opportunities_grantor_v1/**
 
+      - name: Check for updates to core e2e files
+        id: changed-e2e-utils
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+            frontend/tests/utils/**
+            frontend/tests/playwright.config.ts
+            frontend/tests/playwright-env.ts
+            frontend/tests/playwrightUtils.ts
+
       - name: Get list of changed e2e spec files
         id: changed-e2e-spec-files
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: |
-            tests/**/*.spec.ts
+            frontend/tests/**/*.spec.ts
 
       - name: Determine test groups to run
         shell: bash

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -357,6 +357,10 @@ jobs:
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
           npm run build
 
+      #
+      #   CHECKS FOR CHANGED FILES
+      #
+
       - name: Check for updates to core e2e files
         id: changed-e2e-utils
         uses: tj-actions/changed-files@v47.0.6
@@ -404,10 +408,15 @@ jobs:
         env:
           APPLY_FORMS_CHANGED: ${{ steps.changed-apply-form-files.outputs.any_changed }}
           OPPORTUNITY_MANAGEMENT_CHANGED: ${{ steps.changed-opportunity-management-files.outputs.any_changed }}
+          E2E_SPECS_CHANGED: ${{ steps.changed-e2e-spec-files.outputs.any_changed }}
+          E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
+
         run: |
           echo "Any apply form files changed? $APPLY_FORMS_CHANGED"
           echo "Any opportunity management files changed? $OPPORTUNITY_MANAGEMENT_CHANGED"
-          echo "Any opportunity management files changed? $OPPORTUNITY_MANAGEMENT_CHANGED"
+          echo "Any e2e spec files changed? $E2E_SPECS_CHANGED"
+          echo "Any e2e util files changed? $E2E_UTILS_CHANGED"
+
           if [[ $GITHUB_EVENT_NAME = "pull_request" ]]; then
             test_group_tags="@smoke"
             if [[ $APPLY_FORMS_CHANGED = "true" ]]; then
@@ -423,7 +432,22 @@ jobs:
             echo "test_group_tags=${{ inputs.playwright_tags }}" >> "$GITHUB_ENV"
           fi
 
-      # run all tests if any e2e utils have changed
+      #
+      #   TEST RUNS
+      #
+      #   Will always run at least one of the following three steps, based on this logic
+      #
+      #   - Any e2e utils have changed?
+      #       - Yes
+      #         - Run All E2E tests (utils updated)
+      #`      - No
+      #         - Any specific spec files to run supplied?
+      #           - Yes
+      #             - Run E2E tests
+      #             - Run E2E tests for changed spec files
+      #           - No
+      #             - Run E2E tests
+
       - name: Run All E2E tests (utils updated)
         uses: ./.github/actions/e2e
         env:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -386,15 +386,15 @@ jobs:
             api/src/api/opportunities_grantor_v1/**
             api/src/services/opportunities_grantor_v1/**
 
-      - name: Check for updates to core e2e files
+      - name: Get list of changed core e2e files
         id: changed-e2e-utils
         uses: tj-actions/changed-files@v47.0.6
         with:
           files: |
-            frontend/tests/util/**
             frontend/tests/playwright.config.ts
-            frontend/tests/playwright-env.ts
-            frontend/tests/playwrightUtils.ts
+            frontend/tests/e2e/util/**
+            frontend/tests/e2e/playwright-env.ts
+            frontend/tests/e2e/playwrightUtils.ts
 
       - name: Get list of changed e2e spec files
         id: changed-e2e-spec-files

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -357,6 +357,16 @@ jobs:
           sed -i 's|^SENDY_API_URL=.*|SENDY_API_URL=http://127.0.0.1:3000|' .env.local
           npm run build
 
+      - name: Check for updates to core e2e files
+        id: changed-e2e-utils
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+            tests/utils/**
+            tests/playwright.config.ts
+            tests/playwright-env.ts
+            tests/playwrightUtils.ts
+
       - name: Get list of changed apply form files
         id: changed-apply-form-files
         uses: tj-actions/changed-files@v47.0.6
@@ -382,6 +392,13 @@ jobs:
             api/src/api/opportunities_grantor_v1/**
             api/src/services/opportunities_grantor_v1/**
 
+      - name: Get list of changed e2e spec files
+        id: changed-e2e-spec-files
+        uses: tj-actions/changed-files@v47.0.6
+        with:
+          files: |
+            tests/**/*.spec.ts
+
       - name: Determine test groups to run
         shell: bash
         env:
@@ -389,6 +406,7 @@ jobs:
           OPPORTUNITY_MANAGEMENT_CHANGED: ${{ steps.changed-opportunity-management-files.outputs.any_changed }}
         run: |
           echo "Any apply form files changed? $APPLY_FORMS_CHANGED"
+          echo "Any opportunity management files changed? $OPPORTUNITY_MANAGEMENT_CHANGED"
           echo "Any opportunity management files changed? $OPPORTUNITY_MANAGEMENT_CHANGED"
           if [[ $GITHUB_EVENT_NAME = "pull_request" ]]; then
             test_group_tags="@smoke"
@@ -405,8 +423,34 @@ jobs:
             echo "test_group_tags=${{ inputs.playwright_tags }}" >> "$GITHUB_ENV"
           fi
 
+      # run all tests if any e2e utils have changed
+      - name: Run All E2E tests (utils updated)
+        uses: ./.github/actions/e2e
+        env:
+          E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
+        if: ${{ env.E2E_UTILS_CHANGED == 'true' }}
+        with:
+          version: ${{ github.ref }}
+          target: "local"
+          needs_node_setup: "false"
+          total_shards: ${{ matrix.total_shards }}
+          current_shard: ${{ matrix.shard }}
+          api_logs: ${{ inputs.api_logs && 'true' || 'false' }}
+          playwright_tags: ""
+          # Not a secret: the local API seeds the test-user manager with the
+          # committed LOCAL_TEST_USER_MANAGER_API_KEY default from api/local.env,
+          # so the frontend must send that same literal value.
+          test_user_manager_api_key: "local-manager-key"
+          # shard 2 is the firefox shard
+          do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
+          # shard 3 is the webkit shard
+          do-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
+
       - name: Run E2E tests
         uses: ./.github/actions/e2e
+        env:
+          E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
+        if: ${{ env.E2E_UTILS_CHANGED != 'true' }}
         with:
           version: ${{ github.ref }}
           target: "local"
@@ -415,6 +459,30 @@ jobs:
           current_shard: ${{ matrix.shard }}
           api_logs: ${{ inputs.api_logs && 'true' || 'false' }}
           playwright_tags: ${{ env.test_group_tags }}
+          # Not a secret: the local API seeds the test-user manager with the
+          # committed LOCAL_TEST_USER_MANAGER_API_KEY default from api/local.env,
+          # so the frontend must send that same literal value.
+          test_user_manager_api_key: "local-manager-key"
+          # shard 2 is the firefox shard
+          do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
+          # shard 3 is the webkit shard
+          do-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
+
+      - name: Run E2E tests for changed spec files
+        uses: ./.github/actions/e2e
+        env:
+          E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
+          E2E_SPECS_CHANGED: ${{ steps.changed-e2e-spec-files.outputs.all_changed_files }}
+        if: ${{ env.E2E_SPECS_CHANGED != '' && env.E2E_UTILS_CHANGED != 'true' }}
+        with:
+          version: ${{ github.ref }}
+          target: "local"
+          needs_node_setup: "false"
+          total_shards: ${{ matrix.total_shards }}
+          current_shard: ${{ matrix.shard }}
+          api_logs: ${{ inputs.api_logs && 'true' || 'false' }}
+          playwright_tags: ""
+          spec_files: ${{ env.E2E_SPECS_CHANGED }}
           # Not a secret: the local API seeds the test-user manager with the
           # committed LOCAL_TEST_USER_MANAGER_API_KEY default from api/local.env,
           # so the frontend must send that same literal value.


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10864

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

This change ensures that any changes to e2e test related files are properly tested in PR prior to merge

* any PRs that include changes to core e2e system files (utilities, config) trigger a full e2e test run of including all tests
* any PRs that include changes to e2e spec files will run tests from those spec files (in addition to any other tests that would normally be run for the PR)

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

1. run `ci-frontend-e2e` actions using this branch as the workflow source and branch `utils-test` as the target. This will simulate a run where a test util has changed. See https://github.com/HHS/simpler-grants-gov/actions/runs/32073220698
2. _VERIFY_: all tests are run
1. run `ci-frontend-e2e` actions using this branch as the workflow source and branch `spec-change` as the target. This will simulate a run where specific, non smoke test spec files are run. See https://github.com/HHS/simpler-grants-gov/actions/runs/32068936680/job/95507913762
2. _VERIFY_: tests for `roadmap` and `vision` are run
3. _VERIFY_: e2e tests for this branch run `@smoke` tag tests as expected