### PR TITLE
[Issue #1099] Metabase full production backup (initial content)

### DIFF
--- a/analytics/metabase-backup-v2/CHANGELOG.txt
+++ b/analytics/metabase-backup-v2/CHANGELOG.txt
@@ -1,0 +1,77 @@
+
+=== Backup completed at 2026-08-18 01:33:57 ===
+Collections processed: 9
+Questions processed: 88
+Questions skipped: 8
+Dashboards processed: 4
+Dashboards skipped: 2
+Files added: 0
+Files modified: 64
+Files removed: 0
+================================
+
+=== Backup completed at 2026-08-18 01:01:26 ===
+Collections processed: 9
+Questions processed: 88
+Questions skipped: 8
+Dashboards processed: 4
+Dashboards skipped: 2
+Files added: 0
+Files modified: 64
+Files removed: 0
+================================
+
+=== Backup completed at 2026-08-18 00:45:08 ===
+Collections processed: 9
+Questions processed: 88
+Questions skipped: 8
+Dashboards processed: 4
+Dashboards skipped: 2
+Files added: 0
+Files modified: 60
+Files removed: 0
+================================
+
+=== Backup completed at 2026-08-18 00:41:55 ===
+Collections processed: 9
+Questions processed: 88
+Questions skipped: 8
+Dashboards processed: 4
+Dashboards skipped: 2
+Files added: 0
+Files modified: 60
+Files removed: 2
+================================
+
+=== Backup completed at 2026-08-18 00:32:39 ===
+Collections processed: 9
+Questions processed: 88
+Questions skipped: 8
+Dashboards processed: 6
+Dashboards skipped: 0
+Files added: 0
+Files modified: 60
+Files removed: 0
+================================
+
+=== Backup completed at 2026-08-18 00:26:03 ===
+Collections processed: 9
+Questions processed: 88
+Questions skipped: 8
+Dashboards processed: 6
+Dashboards skipped: 0
+Files added: 176
+Files modified: 0
+Files removed: 0
+================================
+
+=== Backup completed at 2026-08-18 00:11:42 ===
+Collections processed: 9
+Questions processed: 0
+Questions skipped: 96
+Dashboards processed: 6
+Dashboards skipped: 0
+Files added: 6
+Files modified: 0
+Files removed: 0
+================================

--- a/analytics/metabase-backup-v2/README.md
+++ b/analytics/metabase-backup-v2/README.md
@@ -1,8 +1,7 @@
 # metabase-backup-v2/
 
-This directory is intentionally empty until a `backup-v2` run populates it.
-Run `make mb-backup-v2` to back up the target Metabase instance's questions
-*and* dashboards here, in the format described in
+A full backup of the production Metabase instance's questions *and*
+dashboards, in the format described in
 [`../src/analytics/integrations/metabase/BACKUP_V2_AND_RESTORE_FORMAT.md`](../src/analytics/integrations/metabase/BACKUP_V2_AND_RESTORE_FORMAT.md).
 
 This is a separate, more capable sibling of
@@ -10,17 +9,17 @@ This is a separate, more capable sibling of
 question SQL only) -- see that module's own README for how the two differ,
 and for the disaster-recovery purpose both directories serve.
 
-A fresh backup here can be fed directly to `make mb-restore` (via
+This directory can be fed directly to `make mb-restore` (via
 `MB_RESTORE_DIR=metabase-backup-v2`) to publish everything it contains into
 a new, timestamped Metabase collection.
 
-## Populating or refreshing this backup
+## Refreshing this backup
 
 1. Get an API key with schema-metadata access (see the format doc's
    cross-instance field id section for why) and set `MB_API_URL`/`MB_API_KEY`
    for the target instance.
 2. From `simpler-grants-gov/analytics`, run `make mb-backup-v2` and confirm
-   it completes without errors -- a `CHANGELOG.txt` gets written to this
-   directory with the run's stats.
-3. Create a branch, add the `.sql`/`.json`/`CHANGELOG.txt` files, and open a
-   PR.
+   it completes without errors -- the `CHANGELOG.txt` in this directory gets
+   a new entry with the run's stats.
+3. Create a branch, add the changed `.sql`/`.json`/`CHANGELOG.txt` files, and
+   open a PR.

--- a/analytics/metabase-backup-v2/dashboards/Delivery_Metrics/Delivery_Metrics.json
+++ b/analytics/metabase-backup-v2/dashboards/Delivery_Metrics/Delivery_Metrics.json
@@ -1,0 +1,2058 @@
+{
+  "name": "Delivery Metrics",
+  "description": null,
+  "width": "full",
+  "auto_apply_filters": false,
+  "parameters": [
+    {
+      "id": "830da802",
+      "slug": "deliverable",
+      "name": "Deliverable",
+      "type": "string/=",
+      "sectionId": "string",
+      "isMultiSelect": false,
+      "required": true,
+      "default": [
+        "Grant protocol specification *"
+      ],
+      "values_source_type": "card",
+      "values_source_config": {
+        "card": "All_Deliverables_Titles_Including_Done",
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      }
+    },
+    {
+      "id": "e73edea",
+      "slug": "quad",
+      "name": "Quad",
+      "type": "string/=",
+      "sectionId": "string",
+      "isMultiSelect": false,
+      "required": true,
+      "default": [
+        "Quad 3"
+      ],
+      "values_source_type": "card",
+      "values_source_config": {
+        "card": "All_Quads",
+        "value_field": [
+          "field",
+          "name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      }
+    }
+  ],
+  "tabs": [
+    "Deliverables Pct Done",
+    "Acceptance",
+    "Burndown Issues",
+    "Burndown Points",
+    "Deliverable Details",
+    "Links"
+  ],
+  "dashcards": [
+    {
+      "tab": "Acceptance",
+      "col": 0,
+      "row": 0,
+      "size_x": 24,
+      "size_y": 10,
+      "card": "All_Deliverables_Acceptance_Criteria_Metrics_Done",
+      "visualization_settings": {
+        "graph.show_goal": false,
+        "graph.y_axis.title_text": "total",
+        "graph.show_values": true,
+        "table.cell_column": "total_issues",
+        "graph.goal_label": "100%",
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "deliverable",
+        "graph.goal_value": 100,
+        "card.title": "Acceptance Criteria+Metrics Done",
+        "graph.metrics": [
+          "done_indicators",
+          "open_indicators"
+        ],
+        "graph.label_value_formatting": "compact",
+        "graph.series_order": null,
+        "table.pivot_column": "issues_with_points",
+        "column_settings": {},
+        "series_settings": {
+          "done_indicators": {
+            "title": "done ",
+            "color": "#69C8C8"
+          },
+          "open_indicators": {
+            "title": "not done",
+            "color": "#C7EAEA"
+          }
+        },
+        "graph.y_axis.auto_range": true,
+        "graph.dimensions": [
+          "deliverable_title"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Acceptance",
+      "col": 0,
+      "row": 10,
+      "size_x": 24,
+      "size_y": 10,
+      "card": "All_Deliverables_Acceptance_Criteria_Done",
+      "visualization_settings": {
+        "graph.show_goal": false,
+        "graph.y_axis.title_text": "total",
+        "graph.show_values": true,
+        "table.cell_column": "total_issues",
+        "graph.goal_label": "100%",
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "deliverable",
+        "graph.goal_value": 100,
+        "card.title": "Acceptance Criteria Done",
+        "graph.metrics": [
+          "criteria_done",
+          "criteria_open"
+        ],
+        "graph.label_value_formatting": "compact",
+        "graph.series_order": null,
+        "table.pivot_column": "issues_with_points",
+        "column_settings": {
+          "[\"name\",\"criteria_pct_complete\"]": {
+            "suffix": "%"
+          },
+          "[\"name\",\"metrics_pct_complete\"]": {
+            "suffix": "%"
+          }
+        },
+        "series_settings": {
+          "criteria_done": {
+            "title": "criteria done",
+            "color": "#69C8C8"
+          },
+          "criteria_open": {
+            "title": "criteria open",
+            "color": "#C7EAEA"
+          }
+        },
+        "graph.y_axis.auto_range": true,
+        "graph.dimensions": [
+          "deliverable_title"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Acceptance",
+      "col": 0,
+      "row": 20,
+      "size_x": 24,
+      "size_y": 10,
+      "card": "All_Deliverables_Acceptance_Metrics_Done",
+      "visualization_settings": {
+        "graph.show_goal": false,
+        "graph.y_axis.title_text": "total",
+        "graph.show_values": true,
+        "table.cell_column": "total_issues",
+        "graph.goal_label": "100%",
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "deliverable",
+        "graph.goal_value": 100,
+        "card.title": "Acceptance Metrics Done",
+        "graph.metrics": [
+          "metrics_done",
+          "metrics_open"
+        ],
+        "graph.label_value_formatting": "compact",
+        "graph.series_order": null,
+        "table.pivot_column": "issues_with_points",
+        "column_settings": {
+          "[\"name\",\"criteria_pct_complete\"]": {
+            "suffix": "%"
+          },
+          "[\"name\",\"metrics_pct_complete\"]": {
+            "suffix": "%"
+          }
+        },
+        "series_settings": {
+          "metrics_done": {
+            "title": "metrics done",
+            "color": "#69C8C8"
+          },
+          "metrics_open": {
+            "title": "metrics open",
+            "color": "#C7EAEA"
+          }
+        },
+        "graph.y_axis.auto_range": true,
+        "graph.dimensions": [
+          "deliverable_title"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 0,
+      "row": 0,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_01",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Authenticate via Login.gov": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 12,
+      "row": 0,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_02",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Co-Design Quad 2": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 0,
+      "row": 6,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_03",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Delivery Metrics 2.0": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 12,
+      "row": 6,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_04",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Full Support for Opportunity Attachments (NOFOs) *": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 0,
+      "row": 12,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_05",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Communications Content Strategy": {
+            "color": "#87BCEC",
+            "line.marker_enabled": false
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 12,
+      "row": 12,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_06",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Open Source Community Growth": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 0,
+      "row": 18,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_07",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Opportunity Email Notifications": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 12,
+      "row": 18,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_08",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Public Product Analytics": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 0,
+      "row": 24,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_09",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Search/Opportunity Listing v2 *": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 12,
+      "row": 24,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_10",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Simpler Application Workflow *": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 0,
+      "row": 30,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_11",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Simpler SOAP Proxy/Router": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Issues",
+      "col": 12,
+      "row": 30,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Issue_with_Deliverable_Ranked_Order_12",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "graph.y_axis.max": 30,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Burndown by Issue with Deliverable Ranked Order 12": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 0,
+      "row": 0,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_01",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Authenticate via Login.gov": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 12,
+      "row": 0,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_02",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Co-Design Quad 2": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 0,
+      "row": 6,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_03",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Delivery Metrics 2.0": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 12,
+      "row": 6,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_04",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Full Support for Opportunity Attachments (NOFOs) *": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 0,
+      "row": 12,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_05",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Communications Content Strategy": {
+            "color": "#87BCEC",
+            "line.marker_enabled": false
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 12,
+      "row": 12,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_06",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Open Source Community Growth": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 0,
+      "row": 18,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_07",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Opportunity Email Notifications": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 12,
+      "row": 18,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_08",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Public Product Analytics": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 0,
+      "row": 24,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_09",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Search/Opportunity Listing v2 *": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 12,
+      "row": 24,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_10",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Simpler Application Workflow *": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 0,
+      "row": 30,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_11",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "Simpler SOAP Proxy/Router": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Burndown Points",
+      "col": 12,
+      "row": 30,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Burndown_by_Points_with_Deliverable_Ranked_Order_12",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "graph.y_axis.max": 40,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "day",
+        "card.title": "",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "graph.series_order": null,
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "undefined": {
+            "color": "#87BCEC",
+            "line.marker_enabled": false
+          },
+          "Burndown by Points with Deliverable Ranked Order 12": {
+            "color": "#87BCEC"
+          }
+        },
+        "graph.y_axis.auto_range": false,
+        "graph.dimensions": [
+          "issue_day",
+          "deliverable_title"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 0,
+      "size_x": 24,
+      "size_y": 1,
+      "text": "# {{deliverable_title}}",
+      "visualization_settings": {
+        "text.align_horizontal": "left",
+        "text.align_vertical": "middle"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 1,
+      "size_x": 12,
+      "size_y": 5,
+      "card": "Deliverable_Status_History",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "d_effective",
+            "enabled": true
+          }
+        ],
+        "table.pivot_column": "d_effective",
+        "table.cell_column": "status",
+        "table.column_formatting": [
+          {
+            "columns": [
+              "status"
+            ],
+            "type": "single",
+            "operator": "=",
+            "value": "In Progress",
+            "color": "#C7EAEA",
+            "highlight_row": true,
+            "id": 0
+          },
+          {
+            "columns": [
+              "status"
+            ],
+            "type": "single",
+            "operator": "=",
+            "value": "Done",
+            "color": "#98D9D9",
+            "highlight_row": true,
+            "id": 1
+          }
+        ],
+        "column_settings": {
+          "[\"name\",\"d_effective\"]": {
+            "column_title": "Effective Date",
+            "date_abbreviate": true
+          },
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 12,
+      "row": 1,
+      "size_x": 12,
+      "size_y": 5,
+      "card": "Deliverable_Percent_Pointed_includes_only_open_issues",
+      "visualization_settings": {
+        "graph.show_goal": true,
+        "graph.y_axis.title_text": "% of issues with story points",
+        "graph.show_values": true,
+        "pie.slice_threshold": 1,
+        "pie.percent_visibility": "both",
+        "table.cell_column": "total_issues",
+        "graph.goal_label": "100%",
+        "graph.series_order_dimension": null,
+        "pie.show_labels": false,
+        "graph.x_axis.title_text": "deliverable",
+        "graph.goal_value": 100,
+        "card.title": "Pointed vs Unpointed Open Issues",
+        "pie.sort_rows": false,
+        "pie.rows": [
+          {
+            "key": "pointed",
+            "name": "Pointed",
+            "originalName": "pointed",
+            "color": "#509EE3",
+            "defaultColor": false,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          },
+          {
+            "key": "unpointed",
+            "name": "Not Pointed",
+            "originalName": "unpointed",
+            "color": "#EF8C8C",
+            "defaultColor": false,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          }
+        ],
+        "graph.metrics": [],
+        "graph.label_value_formatting": "compact",
+        "graph.series_order": null,
+        "pie.show_legend": true,
+        "pie.decimal_places": 0,
+        "table.pivot_column": "issues_with_points",
+        "pie.show_total": true,
+        "column_settings": {},
+        "version": 2,
+        "series_settings": {
+          "percent_pointed": {
+            "color": "#509EE3",
+            "title": "Pointed"
+          },
+          "percent_non_pointed": {
+            "color": "#F7C4C4",
+            "title": "Not Pointed"
+          }
+        },
+        "graph.dimensions": [
+          "deliverable_title"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 6,
+      "size_x": 12,
+      "size_y": 3,
+      "card": "Deliverable_Percent_Done_by_Issue_Count",
+      "visualization_settings": {
+        "scalar.field": "percent_complete",
+        "card.title": "Issues Done"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 12,
+      "row": 6,
+      "size_x": 12,
+      "size_y": 3,
+      "card": "Deliverable_Percent_Done_by_Points",
+      "visualization_settings": {
+        "scalar.field": "percent_complete",
+        "card.title": "Story Points Done"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 9,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Deliverable_Burnup_Issue_Count",
+      "visualization_settings": {
+        "graph.dimensions": [
+          "issue_day"
+        ],
+        "series_settings": {
+          "total_closed": {
+            "color": "#69C8C8",
+            "line.marker_enabled": false,
+            "title": "total closed"
+          },
+          "total_remaining": {
+            "line.marker_enabled": false,
+            "color": "#C7EAEA",
+            "title": "total remaining"
+          }
+        },
+        "card.title": "Burnup (issues)",
+        "graph.x_axis.title_text": "day",
+        "graph.y_axis.title_text": "issues",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "graph.metrics": [
+          "total_closed",
+          "total_remaining"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 12,
+      "row": 9,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Deliverable_Burnup_Points",
+      "visualization_settings": {
+        "graph.dimensions": [
+          "issue_day"
+        ],
+        "series_settings": {
+          "total_closed": {
+            "color": "#69C8C8",
+            "line.marker_enabled": false,
+            "title": "total closed"
+          },
+          "total_remaining": {
+            "line.marker_enabled": false,
+            "color": "#C7EAEA",
+            "title": "total remaining"
+          }
+        },
+        "card.title": "Burnup (points)",
+        "graph.x_axis.title_text": "day",
+        "graph.y_axis.title_text": "points",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "graph.metrics": [
+          "total_closed",
+          "total_remaining"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 15,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Deliverable_Burndown_Issue_Count",
+      "visualization_settings": {
+        "graph.dimensions": [
+          "issue_day"
+        ],
+        "series_settings": {
+          "total_remaining": {
+            "color": "#69C8C8",
+            "line.marker_enabled": false
+          }
+        },
+        "card.title": "Burndown (issues)",
+        "graph.x_axis.title_text": "day",
+        "graph.y_axis.title_text": "issues",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "graph.metrics": [
+          "total_remaining"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 12,
+      "row": 15,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Deliverable_Burndown_Points",
+      "visualization_settings": {
+        "graph.dimensions": [
+          "issue_day"
+        ],
+        "series_settings": {
+          "total_remaining": {
+            "color": "#69C8C8",
+            "line.marker_enabled": false
+          }
+        },
+        "card.title": "Burndown (points)",
+        "graph.x_axis.title_text": "day",
+        "graph.y_axis.title_text": "points",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "graph.metrics": [
+          "total_remaining"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 21,
+      "size_x": 24,
+      "size_y": 3,
+      "card": "Deliverable_GitHub_Link_NEW",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "title",
+            "enabled": true
+          },
+          {
+            "name": "ghid",
+            "enabled": false
+          },
+          {
+            "name": "url",
+            "enabled": true
+          }
+        ],
+        "table.pivot_column": "title",
+        "table.cell_column": "url",
+        "card.title": "Deliverable",
+        "column_settings": {
+          "[\"name\",\"title\"]": {
+            "column_title": "Title"
+          },
+          "[\"name\",\"url\"]": {
+            "view_as": "link",
+            "column_title": "Link",
+            "link_text": "{{ghid}}",
+            "link_url": "{{url}}"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 24,
+      "size_x": 24,
+      "size_y": 10,
+      "card": "Epics_in_Deliverable",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "epic_title",
+            "enabled": true
+          },
+          {
+            "name": "url",
+            "enabled": true
+          },
+          {
+            "name": "deliverable_id",
+            "enabled": false
+          },
+          {
+            "name": "epic_id",
+            "enabled": false
+          },
+          {
+            "name": "epic_ghid",
+            "enabled": false
+          }
+        ],
+        "table.pivot_column": "deliverable_id",
+        "table.cell_column": "url",
+        "card.title": "Epics",
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"deliverable_id\"]": {},
+          "[\"name\",\"epic_id\"]": {},
+          "[\"name\",\"epic_title\"]": {
+            "view_as": "link",
+            "link_text": "{{epic_title}}",
+            "link_url": "{{url}}",
+            "column_title": "Title"
+          },
+          "[\"name\",\"epic_ghid\"]": {},
+          "[\"name\",\"url\"]": {
+            "column_title": "Link",
+            "view_as": "link",
+            "link_text": "{{epic_ghid}}",
+            "link_url": "{{url}}"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 34,
+      "size_x": 24,
+      "size_y": 9,
+      "card": "Deliverable_Issues_Open",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "issue_title",
+            "enabled": true
+          },
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "issue_ghid",
+            "enabled": false
+          },
+          {
+            "name": "issue_url",
+            "enabled": false
+          },
+          {
+            "name": "pointed",
+            "enabled": true
+          },
+          {
+            "name": "points",
+            "enabled": true
+          },
+          {
+            "name": "d_effective",
+            "enabled": false
+          },
+          {
+            "name": "issue_id",
+            "enabled": false
+          }
+        ],
+        "table.pivot_column": "issue_title",
+        "table.cell_column": "points",
+        "card.title": " Open  Issues",
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"issue_title\"]": {
+            "view_as": "link",
+            "link_text": "{{issue_title}}",
+            "link_url": "{{issue_url}}",
+            "column_title": "Title"
+          },
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          },
+          "[\"name\",\"pointed\"]": {
+            "column_title": "Pointed"
+          },
+          "[\"name\",\"points\"]": {
+            "column_title": "Points"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverable Details",
+      "col": 0,
+      "row": 43,
+      "size_x": 24,
+      "size_y": 9,
+      "card": "Deliverable_Issues_Done",
+      "visualization_settings": {
+        "table.pivot_column": "issue_title",
+        "table.cell_column": "points",
+        "table.columns": [
+          {
+            "name": "issue_url",
+            "enabled": true
+          },
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "pointed",
+            "enabled": true
+          },
+          {
+            "name": "points",
+            "enabled": true
+          },
+          {
+            "name": "issue_title",
+            "enabled": false
+          },
+          {
+            "name": "issue_ghid",
+            "enabled": false
+          },
+          {
+            "name": "issue_id",
+            "enabled": false
+          },
+          {
+            "name": "d_effective",
+            "enabled": false
+          }
+        ],
+        "card.title": "Done Issues",
+        "card.hide_empty": true,
+        "column_settings": {
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          },
+          "[\"name\",\"issue_url\"]": {
+            "view_as": "link",
+            "column_title": "Title",
+            "link_text": "{{issue_title}}",
+            "link_url": "{{issue_url}}"
+          },
+          "[\"name\",\"pointed\"]": {
+            "column_title": "Pointed"
+          },
+          "[\"name\",\"points\"]": {
+            "column_title": "Points"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "830da802",
+          "target_tag": "deliverable_title"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverables Pct Done",
+      "col": 0,
+      "row": 0,
+      "size_x": 24,
+      "size_y": 10,
+      "card": "All_Deliverables_Percent_Done_by_Issue_Count",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issue count",
+        "graph.show_values": true,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "deliverable",
+        "card.title": "Deliverable % Done by Issue Count",
+        "graph.metrics": [
+          "issues_closed",
+          "issues_open"
+        ],
+        "graph.series_order": null,
+        "series_settings": {
+          "issues_closed": {
+            "title": "issues closed",
+            "color": "#69C8C8"
+          },
+          "issues_open": {
+            "title": "issues open",
+            "color": "#C7EAEA"
+          }
+        },
+        "graph.dimensions": [
+          "deliverable_title"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverables Pct Done",
+      "col": 0,
+      "row": 10,
+      "size_x": 24,
+      "size_y": 10,
+      "card": "All_Deliverables_Percent_Done_by_Points",
+      "visualization_settings": {
+        "graph.show_values": true,
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "deliverable",
+        "card.title": "Deliverable % Done by Story Points",
+        "graph.metrics": [
+          "points_closed",
+          "points_open"
+        ],
+        "graph.series_order": null,
+        "series_settings": {
+          "points_closed": {
+            "title": "points closed"
+          },
+          "points_open": {
+            "title": "points open"
+          }
+        },
+        "graph.dimensions": [
+          "deliverable_title"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Deliverables Pct Done",
+      "col": 0,
+      "row": 20,
+      "size_x": 24,
+      "size_y": 10,
+      "card": "All_Deliverables_Percent_Pointed",
+      "visualization_settings": {
+        "graph.show_goal": true,
+        "graph.y_axis.title_text": "% of issues with story points",
+        "graph.show_values": true,
+        "table.cell_column": "total_issues",
+        "graph.goal_label": "100%",
+        "graph.series_order_dimension": null,
+        "graph.x_axis.title_text": "deliverable",
+        "graph.goal_value": 100,
+        "card.title": "Deliverable % of Issues Pointed",
+        "graph.metrics": [
+          "percent_pointed"
+        ],
+        "graph.label_value_formatting": "compact",
+        "graph.series_order": null,
+        "table.pivot_column": "issues_with_points",
+        "column_settings": {
+          "[\"name\",\"percent_pointed\"]": {
+            "suffix": "%",
+            "number_style": "decimal"
+          }
+        },
+        "series_settings": {
+          "percent_pointed": {
+            "color": "#509EE3",
+            "title": "Pointed"
+          },
+          "percent_non_pointed": {
+            "color": "#F7C4C4",
+            "title": "Not Pointed"
+          }
+        },
+        "graph.dimensions": [
+          "deliverable_title"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "e73edea",
+          "target_tag": "quad"
+        }
+      ]
+    },
+    {
+      "tab": "Links",
+      "col": 0,
+      "row": 0,
+      "size_x": 24,
+      "size_y": 15,
+      "card": "All_Deliverables_Titles_Excluding_Done",
+      "visualization_settings": {
+        "table.pivot_column": "deliverable_id",
+        "table.cell_column": "d_effective",
+        "table.columns": [
+          {
+            "name": "deliverable_id",
+            "enabled": false
+          },
+          {
+            "name": "url",
+            "enabled": true
+          },
+          {
+            "name": "title",
+            "enabled": false
+          },
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "quad_name",
+            "enabled": true
+          },
+          {
+            "name": "d_effective",
+            "enabled": false
+          },
+          {
+            "name": "ghid",
+            "enabled": true
+          }
+        ],
+        "card.title": "Open Deliverables",
+        "column_settings": {
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          },
+          "[\"name\",\"ghid\"]": {
+            "view_as": "link",
+            "link_text": "{{ghid}}",
+            "link_url": "{{url}}",
+            "column_title": "Link"
+          },
+          "[\"name\",\"quad_name\"]": {
+            "column_title": "Quad"
+          },
+          "[\"name\",\"url\"]": {
+            "view_as": "link",
+            "link_text": "{{title}}",
+            "link_url": "{{url}}",
+            "column_title": "Title"
+          }
+        }
+      }
+    },
+    {
+      "tab": "Links",
+      "col": 0,
+      "row": 15,
+      "size_x": 24,
+      "size_y": 15,
+      "card": "All_Deliverables_Titles_Including_Done_Only",
+      "visualization_settings": {
+        "table.pivot_column": "deliverable_id",
+        "table.cell_column": "d_effective",
+        "table.columns": [
+          {
+            "name": "url",
+            "enabled": true
+          },
+          {
+            "name": "deliverable_id",
+            "enabled": false
+          },
+          {
+            "name": "title",
+            "enabled": false
+          },
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "d_effective",
+            "enabled": false
+          },
+          {
+            "name": "quad_name",
+            "enabled": true
+          },
+          {
+            "name": "ghid",
+            "enabled": true
+          }
+        ],
+        "card.title": "DONE Deliverables",
+        "column_settings": {
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          },
+          "[\"name\",\"ghid\"]": {
+            "view_as": "link",
+            "link_text": "{{ghid}}",
+            "link_url": "{{url}}",
+            "column_title": "Link"
+          },
+          "[\"name\",\"quad_name\"]": {
+            "column_title": "Quad"
+          },
+          "[\"name\",\"url\"]": {
+            "view_as": "link",
+            "link_text": "{{title}}",
+            "link_url": "{{url}}",
+            "column_title": "Title"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/dashboards/Quad_Data/ETL_Metrics.json
+++ b/analytics/metabase-backup-v2/dashboards/Quad_Data/ETL_Metrics.json
@@ -1,0 +1,488 @@
+{
+  "name": "ETL Metrics",
+  "description": null,
+  "width": "fixed",
+  "auto_apply_filters": true,
+  "parameters": [],
+  "tabs": [],
+  "dashcards": [
+    {
+      "tab": null,
+      "col": 0,
+      "row": 0,
+      "size_x": 12,
+      "size_y": 4,
+      "card": "ETL_Data_Quality_Monitor",
+      "visualization_settings": {
+        "table.pivot_column": "etl_health_status",
+        "card.title": "Data Quality",
+        "column_settings": {
+          "[\"name\",\"etl_health_status\"]": {
+            "column_title": "Health status of most recent dataset"
+          }
+        }
+      }
+    },
+    {
+      "tab": null,
+      "col": 12,
+      "row": 0,
+      "size_x": 12,
+      "size_y": 4,
+      "card": "Data_Availability_Age_of_Current_Snapshot",
+      "visualization_settings": {
+        "scalar.field": "formatted_time_difference",
+        "table.columns": [
+          {
+            "name": "current_datetime",
+            "enabled": false
+          },
+          {
+            "name": "max_t_created",
+            "enabled": false
+          },
+          {
+            "name": "formatted_time_difference",
+            "enabled": true
+          }
+        ],
+        "card.title": "Data Age",
+        "column_settings": {
+          "[\"name\",\"current_datetime\"]": {},
+          "[\"name\",\"max_t_created\"]": {},
+          "[\"name\",\"formatted_time_difference\"]": {
+            "column_title": "Time elapsed since most recent data refresh"
+          }
+        }
+      }
+    },
+    {
+      "tab": null,
+      "col": 0,
+      "row": 4,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Deliverable_Count_All",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "deliverable count",
+        "graph.x_axis.title_text": "ETL date",
+        "card.title": "Deliverable Count",
+        "graph.metrics": [
+          "deliverable_count"
+        ],
+        "graph.y_axis.axis_enabled": true,
+        "card.description": "# of deliverables in data warehouse",
+        "column_settings": {
+          "[\"name\",\"deliverable_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "deliverable_count": {
+            "color": "#227FD2",
+            "line.marker_enabled": false,
+            "line.missing": "zero"
+          }
+        },
+        "graph.dimensions": [
+          "deliverable_day"
+        ]
+      }
+    },
+    {
+      "tab": null,
+      "col": 12,
+      "row": 4,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Deliverable_Status_Distribution",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "deliverable  count",
+        "graph.show_values": false,
+        "graph.x_axis.title_text": "ETL date",
+        "card.title": "Deliverable Status",
+        "graph.metrics": [
+          "done_count",
+          "in_progress_count",
+          "planning_count",
+          "backlog_count"
+        ],
+        "graph.y_axis.axis_enabled": true,
+        "graph.label_value_formatting": "auto",
+        "column_settings": {},
+        "series_settings": {
+          "done_count": {
+            "title": "Done",
+            "color": "#227FD2",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "in_progress_count": {
+            "title": "In Progress",
+            "color": "#689636",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "planning_count": {
+            "color": "#8A5EB0",
+            "title": "Planning",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "backlog_count": {
+            "title": "Backlog",
+            "color": "#E75454",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          }
+        },
+        "graph.dimensions": [
+          "deliverable_day"
+        ],
+        "stackable.stack_type": null
+      }
+    },
+    {
+      "tab": null,
+      "col": 0,
+      "row": 10,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Issue_Count_All",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issue count",
+        "graph.show_values": false,
+        "graph.x_axis.title_text": "ETL date",
+        "card.title": "Issue Count",
+        "graph.metrics": [
+          "issue_count"
+        ],
+        "graph.y_axis.axis_enabled": true,
+        "graph.label_value_formatting": "auto",
+        "card.description": "# of issues in data warehouse",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "issue_count": {
+            "line.marker_enabled": false,
+            "color": "#227FD2",
+            "line.missing": "zero"
+          }
+        },
+        "graph.dimensions": [
+          "issue_day"
+        ]
+      }
+    },
+    {
+      "tab": null,
+      "col": 12,
+      "row": 10,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Issue_Status_Distribution",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issue count",
+        "graph.show_values": false,
+        "graph.x_axis.title_text": "ETL date",
+        "card.title": "Issue Status",
+        "graph.metrics": [
+          "done_count",
+          "in_review_count",
+          "in_progress_count",
+          "todo_count",
+          "planning_count",
+          "prioritized_count",
+          "backlog_count",
+          "blocked_count",
+          "icebox_count"
+        ],
+        "graph.y_axis.axis_enabled": true,
+        "graph.label_value_formatting": "auto",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "in_review_count": {
+            "title": "In Review",
+            "color": "#509EE3",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "prioritized_count": {
+            "color": "#A989C5",
+            "title": "Prioritized",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "todo_count": {
+            "title": "To Do",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "blocked_count": {
+            "title": "Blocked",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "backlog_count": {
+            "title": "Backlog",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "in_progress_count": {
+            "title": "In Progress",
+            "color": "#689636",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "done_count": {
+            "title": "Done",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "planning_count": {
+            "title": "Planning",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          },
+          "icebox_count": {
+            "color": "#98D9D9",
+            "title": "Icebox",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          }
+        },
+        "graph.dimensions": [
+          "issue_day"
+        ],
+        "stackable.stack_type": null
+      }
+    },
+    {
+      "tab": null,
+      "col": 0,
+      "row": 16,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Issue_Count_Pointed_vs_Unpointed_Total",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issue count",
+        "graph.show_values": false,
+        "graph.x_axis.title_text": "ETL date",
+        "card.title": "Pointed vs Unpointed",
+        "graph.metrics": [
+          "nonzero_points_count",
+          "zero_points_count"
+        ],
+        "graph.y_axis.axis_enabled": true,
+        "graph.label_value_formatting": "auto",
+        "card.description": "issues with or without points in data warehouse",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "zero_points_count": {
+            "line.marker_enabled": false,
+            "line.missing": "zero",
+            "title": "Not Pointed",
+            "color": "#EF8C8C",
+            "axis": null
+          },
+          "nonzero_points_count": {
+            "color": "#227FD2",
+            "title": "Pointed",
+            "line.missing": "zero",
+            "line.marker_enabled": false
+          }
+        },
+        "graph.dimensions": [
+          "issue_day"
+        ],
+        "stackable.stack_type": null
+      }
+    },
+    {
+      "tab": null,
+      "col": 12,
+      "row": 16,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Issue_Sum_of_Pointed",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points sum",
+        "graph.show_values": false,
+        "graph.x_axis.title_text": "ETL date",
+        "card.title": "Sum of Points",
+        "graph.metrics": [
+          "total_points"
+        ],
+        "graph.y_axis.axis_enabled": true,
+        "graph.label_value_formatting": "auto",
+        "card.description": "sum of points in data warehouse",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "total_points": {
+            "color": "#509EE3",
+            "line.marker_enabled": false,
+            "line.missing": "zero"
+          }
+        },
+        "graph.dimensions": [
+          "issue_day"
+        ]
+      }
+    },
+    {
+      "tab": null,
+      "col": 0,
+      "row": 22,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Issue_Count_Pointed_vs_Unpointed",
+      "visualization_settings": {
+        "pie.slice_threshold": 1,
+        "pie.percent_visibility": "both",
+        "pie.dimension": [
+          "pointed_count"
+        ],
+        "pie.show_labels": false,
+        "card.title": "Pointed vs Unpointed",
+        "pie.rows": [
+          {
+            "key": "pointed",
+            "name": "Pointed",
+            "originalName": "pointed",
+            "color": "#509EE3",
+            "defaultColor": false,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          },
+          {
+            "key": "unpointed",
+            "name": "Not Pointed ",
+            "originalName": "unpointed",
+            "color": "#EF8C8C",
+            "defaultColor": false,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          }
+        ],
+        "pie.metric": "pointed_count",
+        "pie.decimal_places": 0,
+        "pie.show_total": true
+      }
+    },
+    {
+      "tab": null,
+      "col": 12,
+      "row": 22,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Issue_Count_Issue_Type",
+      "visualization_settings": {
+        "pie.slice_threshold": 1,
+        "pie.percent_visibility": "both",
+        "pie.dimension": [
+          "issue_type"
+        ],
+        "pie.show_labels": false,
+        "card.title": "Issue Type",
+        "pie.rows": [
+          {
+            "key": "Task",
+            "name": "Task",
+            "originalName": "Task",
+            "color": "#509EE3",
+            "defaultColor": false,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          },
+          {
+            "key": "None",
+            "name": "None",
+            "originalName": "None",
+            "color": "#EF8C8C",
+            "defaultColor": false,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          },
+          {
+            "key": "Bug",
+            "name": "Bug",
+            "originalName": "Bug",
+            "color": "#F9D45C",
+            "defaultColor": true,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          },
+          {
+            "key": "Enhancement",
+            "name": "Enhancement",
+            "originalName": "Enhancement",
+            "color": "#98D9D9",
+            "defaultColor": false,
+            "enabled": true,
+            "hidden": false,
+            "isOther": false
+          }
+        ],
+        "pie.metric": "issue_percentage",
+        "pie.show_legend": true,
+        "pie.decimal_places": 0,
+        "pie.show_total": true,
+        "version": 2
+      }
+    },
+    {
+      "tab": null,
+      "col": 0,
+      "row": 28,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "ETL_Sprint_Count_All",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "sprint count",
+        "graph.show_values": false,
+        "graph.x_axis.title_text": "ETL date",
+        "card.title": "Sprint Count",
+        "graph.metrics": [
+          "distinct_sprint_count"
+        ],
+        "card.description": "count all sprints in warehouse",
+        "column_settings": {
+          "[\"name\",\"issue_day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "distinct_sprint_count": {
+            "color": "#509EE3",
+            "title": "sprint count",
+            "line.marker_enabled": false,
+            "line.missing": "zero"
+          }
+        },
+        "graph.dimensions": [
+          "issue_day"
+        ]
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/dashboards/Sprint_Metrics/Issue_History.json
+++ b/analytics/metabase-backup-v2/dashboards/Sprint_Metrics/Issue_History.json
@@ -1,0 +1,277 @@
+{
+  "name": "Issue History",
+  "description": null,
+  "width": "fixed",
+  "auto_apply_filters": true,
+  "parameters": [
+    {
+      "id": "363e9677",
+      "slug": "github_issue_path",
+      "name": "GitHub Issue Path",
+      "type": "string/=",
+      "sectionId": "string",
+      "isMultiSelect": false,
+      "required": false
+    }
+  ],
+  "tabs": [],
+  "dashcards": [
+    {
+      "tab": null,
+      "col": 0,
+      "row": 0,
+      "size_x": 24,
+      "size_y": 3,
+      "card": "Issue_Title",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "title",
+            "enabled": true
+          },
+          {
+            "name": "ghid",
+            "enabled": false
+          },
+          {
+            "name": "url",
+            "enabled": true
+          }
+        ],
+        "table.pivot_column": "issue_id",
+        "table.cell_column": "is_closed",
+        "card.title": "Summary",
+        "column_settings": {
+          "[\"name\",\"title\"]": {
+            "column_title": "Title"
+          },
+          "[\"name\",\"url\"]": {
+            "view_as": "link",
+            "column_title": "Link",
+            "link_text": "{{ghid}}",
+            "link_url": "{{url}}"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "363e9677",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": null,
+      "col": 0,
+      "row": 3,
+      "size_x": 12,
+      "size_y": 7,
+      "card": "Issue_Status_History",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "d_effective",
+            "enabled": true
+          }
+        ],
+        "table.pivot_column": "d_effective",
+        "table.cell_column": "status",
+        "card.title": "Status History",
+        "table.column_formatting": [
+          {
+            "columns": [
+              "status"
+            ],
+            "type": "single",
+            "operator": "not-null",
+            "value": "In Progress",
+            "color": "#C7EAEA",
+            "highlight_row": false,
+            "id": 2
+          }
+        ],
+        "column_settings": {
+          "[\"name\",\"d_effective\"]": {
+            "column_title": "Effective Date",
+            "date_abbreviate": true
+          },
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "363e9677",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": null,
+      "col": 12,
+      "row": 3,
+      "size_x": 12,
+      "size_y": 7,
+      "card": "Issue_Sprint_History",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "sprint_name",
+            "enabled": true
+          },
+          {
+            "name": "d_effective",
+            "enabled": true
+          },
+          {
+            "name": "sprint_id",
+            "enabled": false
+          },
+          {
+            "name": "start_date",
+            "enabled": false
+          },
+          {
+            "name": "end_date",
+            "enabled": false
+          }
+        ],
+        "table.pivot_column": "d_effective",
+        "table.cell_column": "status",
+        "card.title": "Sprint History",
+        "table.column_formatting": [
+          {
+            "columns": [
+              "name",
+              "sprint_name"
+            ],
+            "type": "single",
+            "operator": "not-null",
+            "value": "",
+            "color": "#C7EAEA",
+            "highlight_row": false,
+            "id": 0
+          }
+        ],
+        "column_settings": {
+          "[\"name\",\"d_effective\"]": {
+            "column_title": "Effective Date",
+            "date_abbreviate": true
+          },
+          "[\"name\",\"sprint_name\"]": {
+            "column_title": "Sprint"
+          },
+          "[\"name\",\"start_date\"]": {
+            "column_title": "Sprint Start",
+            "date_abbreviate": true
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "363e9677",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": null,
+      "col": 0,
+      "row": 10,
+      "size_x": 24,
+      "size_y": 19,
+      "card": "Issue_History",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "id",
+            "enabled": false
+          },
+          {
+            "name": "issue_id",
+            "enabled": false
+          },
+          {
+            "name": "title",
+            "enabled": true
+          },
+          {
+            "name": "name",
+            "enabled": true
+          },
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "is_closed",
+            "enabled": false
+          },
+          {
+            "name": "points",
+            "enabled": true
+          },
+          {
+            "name": "d_effective",
+            "enabled": false
+          },
+          {
+            "name": "t_created",
+            "enabled": false
+          },
+          {
+            "name": "sprint_id",
+            "enabled": false
+          },
+          {
+            "name": "project_id",
+            "enabled": false
+          },
+          {
+            "name": "type",
+            "enabled": false
+          },
+          {
+            "name": "t_modified",
+            "enabled": true
+          }
+        ],
+        "table.pivot_column": "issue_id",
+        "table.cell_column": "is_closed",
+        "card.title": "Full History",
+        "column_settings": {
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          },
+          "[\"name\",\"is_closed\"]": {
+            "column_title": "Closed?"
+          },
+          "[\"name\",\"points\"]": {
+            "column_title": "Points"
+          },
+          "[\"name\",\"t_modified\"]": {
+            "column_title": "Timestamp",
+            "date_abbreviate": true
+          },
+          "[\"name\",\"name\"]": {
+            "column_title": "Sprint"
+          },
+          "[\"name\",\"title\"]": {
+            "column_title": "Title"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "363e9677",
+          "target_tag": "ghid"
+        }
+      ]
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/dashboards/Sprint_Metrics/Sprint_Metrics.json
+++ b/analytics/metabase-backup-v2/dashboards/Sprint_Metrics/Sprint_Metrics.json
@@ -1,0 +1,601 @@
+{
+  "name": "Sprint Metrics",
+  "description": null,
+  "width": "full",
+  "auto_apply_filters": true,
+  "parameters": [
+    {
+      "id": "c208d96a",
+      "slug": "sprint",
+      "name": "Sprint",
+      "type": "string/=",
+      "sectionId": "string",
+      "isMultiSelect": false,
+      "required": true,
+      "default": [
+        "Sprint 6.7"
+      ],
+      "values_source_type": "card",
+      "values_source_config": {
+        "card": "Sprints_with_SCD_data",
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      }
+    },
+    {
+      "id": "59f4a426",
+      "slug": "project",
+      "name": "Project",
+      "type": "string/=",
+      "sectionId": "string",
+      "isMultiSelect": false,
+      "required": true,
+      "default": [
+        "13"
+      ]
+    }
+  ],
+  "tabs": [
+    "NEW"
+  ],
+  "dashcards": [
+    {
+      "tab": "NEW",
+      "col": 0,
+      "row": 0,
+      "size_x": 8,
+      "size_y": 3,
+      "card": "Sprint_Name",
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 8,
+      "row": 0,
+      "size_x": 4,
+      "size_y": 3,
+      "card": "Sprint_Issues_Pointed",
+      "parameter_mappings": [
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        },
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 12,
+      "row": 0,
+      "size_x": 4,
+      "size_y": 3,
+      "card": "Sprint_Days_Left_in_Sprint",
+      "parameter_mappings": [
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        },
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 16,
+      "row": 0,
+      "size_x": 8,
+      "size_y": 3,
+      "card": "Sprint_End_Date",
+      "visualization_settings": {
+        "graph.dimensions": [
+          "day"
+        ],
+        "table.cell_column": "total_closed",
+        "table.pivot_column": "total_opened",
+        "series_settings": {
+          "total_remaining": {
+            "color": "#509EE3"
+          }
+        },
+        "scalar.field": "days_remaining",
+        "column_settings": {
+          "[\"name\",\"end_date\"]": {
+            "date_abbreviate": true,
+            "date_style": "MMMM D, YYYY"
+          }
+        },
+        "graph.metrics": [
+          "total_remaining"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        },
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 0,
+      "row": 3,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Sprint_Burnup_by_issues",
+      "visualization_settings": {
+        "series_settings": {
+          "total_closed": {
+            "color": "#A989C5",
+            "line.marker_enabled": false,
+            "title": "total closed"
+          },
+          "total_remaining": {
+            "color": "#88BF4D",
+            "line.marker_enabled": false,
+            "title": "total remaining"
+          }
+        },
+        "graph.dimensions": [
+          "day"
+        ],
+        "card.title": "Burnup (issues)",
+        "graph.y_axis.title_text": "issues",
+        "graph.x_axis.axis_enabled": "compact",
+        "column_settings": {
+          "[\"name\",\"day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "graph.metrics": [
+          "total_closed",
+          "total_remaining"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        },
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 12,
+      "row": 3,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Sprint_Burnup_by_points",
+      "visualization_settings": {
+        "series_settings": {
+          "total_closed": {
+            "color": "#A989C5",
+            "line.marker_enabled": false,
+            "title": "total closed"
+          },
+          "total_remaining": {
+            "color": "#88BF4D",
+            "line.marker_enabled": false,
+            "title": "total remaining"
+          }
+        },
+        "graph.dimensions": [
+          "day"
+        ],
+        "card.title": "Burnup (points)",
+        "graph.x_axis.axis_enabled": "compact",
+        "graph.y_axis.title_text": "points",
+        "column_settings": {
+          "[\"name\",\"day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "graph.metrics": [
+          "total_closed",
+          "total_remaining"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        },
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 0,
+      "row": 9,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Sprint_Burndown_by_issues",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "issues",
+        "table.cell_column": "total_closed",
+        "graph.x_axis.axis_enabled": "compact",
+        "card.title": "Burndown (issues)",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "table.pivot_column": "total_opened",
+        "column_settings": {
+          "[\"name\",\"day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "total_remaining": {
+            "color": "#509EE3",
+            "line.marker_enabled": false
+          }
+        },
+        "graph.dimensions": [
+          "day"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        },
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 12,
+      "row": 9,
+      "size_x": 12,
+      "size_y": 6,
+      "card": "Sprint_Burndown_by_points",
+      "visualization_settings": {
+        "graph.y_axis.title_text": "points",
+        "table.cell_column": "total_closed",
+        "graph.x_axis.axis_enabled": "compact",
+        "card.title": "Burndown (points)",
+        "graph.metrics": [
+          "total_remaining"
+        ],
+        "table.pivot_column": "total_opened",
+        "column_settings": {
+          "[\"name\",\"day\"]": {
+            "date_abbreviate": true
+          }
+        },
+        "series_settings": {
+          "total_remaining": {
+            "color": "#509EE3",
+            "line.marker_enabled": false
+          }
+        },
+        "graph.dimensions": [
+          "day"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        },
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 0,
+      "row": 15,
+      "size_x": 24,
+      "size_y": 6,
+      "card": "Sprint_Velocity_Trend",
+      "visualization_settings": {
+        "graph.dimensions": [
+          "sprint_name"
+        ],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.x_axis.title_text": "sprint",
+        "graph.x_axis.axis_enabled": "compact",
+        "graph.y_axis.title_text": "points closed",
+        "graph.show_values": true,
+        "graph.metrics": [
+          "points_closed"
+        ]
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "59f4a426",
+          "target_tag": "ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 0,
+      "row": 21,
+      "size_x": 24,
+      "size_y": 9,
+      "card": "Sprint_Issues_Open",
+      "visualization_settings": {
+        "table.pivot_column": "type",
+        "table.cell_column": "ghid",
+        "table.columns": [
+          {
+            "name": "issue_url",
+            "enabled": true
+          },
+          {
+            "name": "pointed",
+            "enabled": true
+          },
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "points",
+            "enabled": false
+          },
+          {
+            "name": "d_effective",
+            "enabled": true
+          },
+          {
+            "name": "issue_id",
+            "enabled": false
+          },
+          {
+            "name": "issue_title",
+            "enabled": false
+          },
+          {
+            "name": "issue_ghid",
+            "enabled": false
+          },
+          {
+            "name": "sprint_end_date",
+            "enabled": false
+          }
+        ],
+        "card.title": "Open Issues",
+        "column_settings": {
+          "[\"name\",\"issue_title\"]": {},
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          },
+          "[\"name\",\"points\"]": {
+            "column_title": "Points"
+          },
+          "[\"name\",\"sprint_end_date\"]": {},
+          "[\"name\",\"issue_url\"]": {
+            "column_title": "Link ",
+            "view_as": "link",
+            "link_text": "{{issue_title}}",
+            "link_url": "{{issue_url}}"
+          },
+          "[\"name\",\"issue_ghid\"]": {},
+          "[\"name\",\"d_effective\"]": {
+            "column_title": "Effective Date",
+            "date_abbreviate": true
+          },
+          "[\"name\",\"pointed\"]": {
+            "column_title": "Pointed"
+          },
+          "[\"name\",\"issue_id\"]": {}
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        },
+        {
+          "parameter": "59f4a426",
+          "target_tag": "project_ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 0,
+      "row": 30,
+      "size_x": 24,
+      "size_y": 9,
+      "card": "Sprint_Issues_Done",
+      "visualization_settings": {
+        "table.pivot_column": "type",
+        "table.cell_column": "ghid",
+        "table.columns": [
+          {
+            "name": "issue_url",
+            "enabled": true
+          },
+          {
+            "name": "pointed",
+            "enabled": true
+          },
+          {
+            "name": "lead_time_days",
+            "enabled": true
+          },
+          {
+            "name": "status",
+            "enabled": true
+          },
+          {
+            "name": "points",
+            "enabled": false
+          },
+          {
+            "name": "d_effective",
+            "enabled": true
+          },
+          {
+            "name": "issue_id",
+            "enabled": false
+          },
+          {
+            "name": "issue_title",
+            "enabled": false
+          },
+          {
+            "name": "issue_ghid",
+            "enabled": false
+          },
+          {
+            "name": "in_progress_date",
+            "enabled": false
+          },
+          {
+            "name": "done_date",
+            "enabled": false
+          }
+        ],
+        "card.title": "Done Issues",
+        "column_settings": {
+          "[\"name\",\"issue_title\"]": {
+            "column_title": "Link",
+            "view_as": "link",
+            "link_text": "{{issue_title}}",
+            "link_url": "{{issue_url}}"
+          },
+          "[\"name\",\"pointed\"]": {
+            "column_title": "Pointed",
+            "view_as": "auto"
+          },
+          "[\"name\",\"status\"]": {
+            "column_title": "Status"
+          },
+          "[\"name\",\"d_effective\"]": {
+            "column_title": "Effective Date",
+            "date_abbreviate": true
+          },
+          "[\"name\",\"lead_time_days\"]": {
+            "column_title": "Lead Time"
+          },
+          "[\"name\",\"issue_url\"]": {
+            "column_title": "Link ",
+            "view_as": "link",
+            "link_text": "{{issue_title}}",
+            "link_url": "{{issue_url}}"
+          },
+          "[\"name\",\"points\"]": {
+            "column_title": "Points"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        },
+        {
+          "parameter": "59f4a426",
+          "target_tag": "project_ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 0,
+      "row": 39,
+      "size_x": 8,
+      "size_y": 3,
+      "card": "Sprint_Issues_Lead_Time_Avg",
+      "visualization_settings": {
+        "card.title": "Avg Lead Time for Done Issues",
+        "column_settings": {
+          "[\"name\",\"average_lead_time_days\"]": {
+            "suffix": " days"
+          }
+        }
+      },
+      "parameter_mappings": [
+        {
+          "parameter": "c208d96a",
+          "target_tag": "sprint_name"
+        },
+        {
+          "parameter": "59f4a426",
+          "target_tag": "project_ghid"
+        }
+      ]
+    },
+    {
+      "tab": "NEW",
+      "col": 8,
+      "row": 39,
+      "size_x": 8,
+      "size_y": 3,
+      "card": "Data_Availability_Oldest",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "minimum_date",
+            "enabled": true
+          }
+        ],
+        "column_settings": {
+          "[\"name\",\"minimum_date\"]": {
+            "date_abbreviate": true,
+            "date_style": "MMMM D, YYYY"
+          }
+        }
+      }
+    },
+    {
+      "tab": "NEW",
+      "col": 16,
+      "row": 39,
+      "size_x": 8,
+      "size_y": 3,
+      "card": "Data_Availability_Newest",
+      "visualization_settings": {
+        "table.columns": [
+          {
+            "name": "maximum_date",
+            "enabled": true
+          }
+        ],
+        "column_settings": {
+          "[\"name\",\"maximum_date\"]": {
+            "column_title": "Newest Dateset:",
+            "date_abbreviate": true,
+            "date_style": "MMMM D, YYYY"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Newest.json
+++ b/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Newest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Data Availability - Newest",
+  "display": "object",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "maximum_date",
+        "enabled": true
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"maximum_date\"]": {
+        "column_title": "Newest Dateset:",
+        "date_abbreviate": true,
+        "date_style": "MMMM D, YYYY"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Newest.sql
+++ b/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Newest.sql
@@ -1,0 +1,2 @@
+SELECT max(gh_issue_history.d_effective) AS maximum_date
+FROM gh_issue_history

--- a/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Oldest.json
+++ b/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Oldest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Data Availability - Oldest",
+  "display": "object",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "minimum_date",
+        "enabled": true
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"minimum_date\"]": {
+        "date_abbreviate": true,
+        "date_style": "MMMM D, YYYY",
+        "column_title": "Oldest  Dataset:"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Oldest.sql
+++ b/analytics/metabase-backup-v2/level_0/Data_Availability/Data_Availability_Oldest.sql
@@ -1,0 +1,2 @@
+SELECT min(gh_issue_history.d_effective) AS minimum_date
+FROM gh_issue_history

--- a/analytics/metabase-backup-v2/level_0/Data_Availability/Default_Reporting_Period.json
+++ b/analytics/metabase-backup-v2/level_0/Data_Availability/Default_Reporting_Period.json
@@ -1,0 +1,5 @@
+{
+  "name": "Default Reporting Period",
+  "display": "object",
+  "visualization_settings": {}
+}

--- a/analytics/metabase-backup-v2/level_0/Data_Availability/Default_Reporting_Period.sql
+++ b/analytics/metabase-backup-v2/level_0/Data_Availability/Default_Reporting_Period.sql
@@ -1,0 +1,5 @@
+WITH reporting_period AS
+  (SELECT CURRENT_DATE - INTERVAL '60 days' AS start_date,
+          CURRENT_DATE AS end_date)
+SELECT *
+FROM reporting_period;

--- a/analytics/metabase-backup-v2/level_0/ETL_Metrics/ETL_Data_Quality_Anomaly_Detector.json
+++ b/analytics/metabase-backup-v2/level_0/ETL_Metrics/ETL_Data_Quality_Anomaly_Detector.json
@@ -1,0 +1,80 @@
+{
+  "name": "ETL Data Quality - Anomaly Detector",
+  "display": "object",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "etl_health_status",
+        "enabled": true
+      },
+      {
+        "name": "current_day_issue_count",
+        "enabled": true
+      },
+      {
+        "name": "previous_day_issue_count",
+        "enabled": true
+      },
+      {
+        "name": "current_day_deliverable_count",
+        "enabled": true
+      },
+      {
+        "name": "previous_day_deliverable_count",
+        "enabled": true
+      },
+      {
+        "name": "current_day_point_sum",
+        "enabled": true
+      },
+      {
+        "name": "previous_day_point_sum",
+        "enabled": true
+      },
+      {
+        "name": "current_day_sprint_count",
+        "enabled": true
+      },
+      {
+        "name": "current_day_pointed_issue_pct",
+        "enabled": true
+      },
+      {
+        "name": "failure_reason",
+        "enabled": true
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"previous_day_deliverable_count\"]": {
+        "column_title": "deliverables (previous)"
+      },
+      "[\"name\",\"current_day_point_sum\"]": {
+        "column_title": "total points"
+      },
+      "[\"name\",\"current_day_sprint_count\"]": {
+        "column_title": "sprint count"
+      },
+      "[\"name\",\"current_day_pointed_issue_pct\"]": {
+        "column_title": "pct of issues with points>0 "
+      },
+      "[\"name\",\"etl_health_status\"]": {
+        "column_title": "data validation result"
+      },
+      "[\"name\",\"current_day_task_issue_pct\"]": {
+        "column_title": "pct of issues with type=task"
+      },
+      "[\"name\",\"previous_day_issue_count\"]": {
+        "column_title": "issues (previous)"
+      },
+      "[\"name\",\"previous_day_point_sum\"]": {
+        "column_title": "total points (previous)"
+      },
+      "[\"name\",\"current_day_deliverable_count\"]": {
+        "column_title": "deliverables"
+      },
+      "[\"name\",\"current_day_issue_count\"]": {
+        "column_title": "issues"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_0/ETL_Metrics/ETL_Data_Quality_Anomaly_Detector.sql
+++ b/analytics/metabase-backup-v2/level_0/ETL_Metrics/ETL_Data_Quality_Anomaly_Detector.sql
@@ -1,0 +1,219 @@
+WITH -- Centralized Constants
+constants AS
+  (SELECT 2000 AS min_issue_count, -- Minimum issue count for the latest day
+ 20 AS min_deliverable_count, -- Minimum deliverable count for the latest day
+ 3500 AS min_point_sum, -- Minimum total point sum for the latest day
+ 40 AS min_sprint_count, -- Minimum number of distinct sprints
+ 50.0 AS min_pointed_issue_pct, -- Minimum % of pointed issues
+ 70.0 AS min_task_issue_pct, -- Minimum % of task-type issues
+ INTERVAL '24 hours' AS max_data_age -- Max allowed age for the latest data
+), -- Get max available dates from both tables
+max_dates AS
+  (SELECT
+     (SELECT MAX(d_effective)
+      FROM gh_issue_history) AS max_issue_date,
+
+     (SELECT MAX(d_effective)
+      FROM gh_deliverable_history) AS max_deliverable_date), -- Count issues for the most recent two days
+issue_counts AS
+  (SELECT d_effective,
+          COUNT(id) AS issue_count
+   FROM gh_issue_history
+   WHERE d_effective >=
+       (SELECT max_issue_date
+        FROM max_dates) - INTERVAL '1 day'
+   GROUP BY d_effective), -- Get issue counts for current and previous day
+issue_comparison AS
+  (SELECT MAX(CASE
+                  WHEN d_effective =
+                         (SELECT max_issue_date
+                          FROM max_dates) THEN issue_count
+              END) AS current_day_issue_count,
+          MAX(CASE
+                  WHEN d_effective =
+                         (SELECT max_issue_date
+                          FROM max_dates) - INTERVAL '1 day' THEN issue_count
+              END) AS previous_day_issue_count
+   FROM issue_counts), -- Count deliverables for the most recent two days
+deliverable_counts AS
+  (SELECT d_effective,
+          COUNT(id) AS deliverable_count
+   FROM gh_deliverable_history
+   WHERE d_effective >=
+       (SELECT max_deliverable_date
+        FROM max_dates) - INTERVAL '1 day'
+   GROUP BY d_effective), -- Get deliverable counts for current and previous day
+deliverable_comparison AS
+  (SELECT MAX(CASE
+                  WHEN d_effective =
+                         (SELECT max_deliverable_date
+                          FROM max_dates) THEN deliverable_count
+              END) AS current_day_deliverable_count,
+          MAX(CASE
+                  WHEN d_effective =
+                         (SELECT max_deliverable_date
+                          FROM max_dates) - INTERVAL '1 day' THEN deliverable_count
+              END) AS previous_day_deliverable_count
+   FROM deliverable_counts), -- Calculate point sums for the most recent two days
+point_sums AS
+  (SELECT d_effective,
+          COALESCE(SUM(points), 0) AS total_points
+   FROM gh_issue_history
+   WHERE d_effective >=
+       (SELECT max_issue_date
+        FROM max_dates) - INTERVAL '1 day'
+   GROUP BY d_effective), -- Get point sums for current and previous day
+point_comparison AS
+  (SELECT MAX(CASE
+                  WHEN d_effective =
+                         (SELECT max_issue_date
+                          FROM max_dates) THEN total_points
+              END) AS current_day_point_sum,
+          MAX(CASE
+                  WHEN d_effective =
+                         (SELECT max_issue_date
+                          FROM max_dates) - INTERVAL '1 day' THEN total_points
+              END) AS previous_day_point_sum
+   FROM point_sums), -- Count distinct sprint IDs for the latest day
+sprint_count AS
+  (SELECT COUNT(DISTINCT sprint_id) AS current_day_sprint_count
+   FROM gh_issue_history
+   WHERE d_effective =
+       (SELECT max_issue_date
+        FROM max_dates)), -- Calculate percentage of pointed issues
+pointed_issues AS
+  (SELECT COUNT(*) FILTER (
+                           WHERE points > 0) * 100.0 / NULLIF(COUNT(*), 0) AS pointed_issue_pct
+   FROM gh_issue_history
+   WHERE d_effective =
+       (SELECT max_issue_date
+        FROM max_dates)), -- Calculate percentage of task-type issues
+task_issues AS
+  (SELECT COUNT(*) FILTER (
+                           WHERE TYPE = 'Task') * 100.0 / NULLIF(COUNT(*), 0) AS task_issue_pct
+   FROM gh_issue), -- Check last update timestamps for both tables
+last_update_check AS
+  (SELECT
+     (SELECT NOW() - MAX(t_created)
+      FROM gh_issue_history
+      WHERE d_effective =
+          (SELECT max_issue_date
+           FROM max_dates)) AS issue_time_since_last_update,
+
+     (SELECT NOW() - MAX(t_created)
+      FROM gh_deliverable_history
+      WHERE d_effective =
+          (SELECT max_deliverable_date
+           FROM max_dates)) AS deliverable_time_since_last_update), -- Ensure minimum thresholds are met
+min_threshold_check AS
+  (SELECT -- Data freshness checks
+ CASE
+     WHEN
+            (SELECT issue_time_since_last_update
+             FROM last_update_check) >
+            (SELECT max_data_age
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_issue_data_fresh,
+ CASE
+     WHEN
+            (SELECT deliverable_time_since_last_update
+             FROM last_update_check) >
+            (SELECT max_data_age
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_deliverable_data_fresh, -- Record count and other checks
+ CASE
+     WHEN
+            (SELECT current_day_issue_count
+             FROM issue_comparison) <
+            (SELECT min_issue_count
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_issue_count_above_min,
+ CASE
+     WHEN
+            (SELECT current_day_deliverable_count
+             FROM deliverable_comparison) <
+            (SELECT min_deliverable_count
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_deliverable_count_above_min,
+ CASE
+     WHEN
+            (SELECT current_day_point_sum
+             FROM point_comparison) <
+            (SELECT min_point_sum
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_point_sum_above_min,
+ CASE
+     WHEN
+            (SELECT current_day_sprint_count
+             FROM sprint_count) <
+            (SELECT min_sprint_count
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_sprint_count_above_min,
+ CASE
+     WHEN
+            (SELECT pointed_issue_pct
+             FROM pointed_issues) <
+            (SELECT min_pointed_issue_pct
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_pointed_issue_pct_above_min,
+ CASE
+     WHEN
+            (SELECT task_issue_pct
+             FROM task_issues) <
+            (SELECT min_task_issue_pct
+             FROM constants) THEN FALSE
+     ELSE TRUE
+ END AS is_task_issue_pct_above_min) -- Return a row only if unhealthy
+
+SELECT '🚨 Data quality validation FAILED' AS etl_health_status,
+       ic.previous_day_issue_count,
+       ic.current_day_issue_count,
+       dc.previous_day_deliverable_count,
+       dc.current_day_deliverable_count,
+       pc.previous_day_point_sum,
+       pc.current_day_point_sum,
+       sc.current_day_sprint_count,
+       pi.pointed_issue_pct AS current_day_pointed_issue_pct,
+       ti.task_issue_pct AS current_day_task_issue_pct,
+       fr.failure_reason
+FROM issue_comparison AS ic
+JOIN deliverable_comparison AS dc ON TRUE
+JOIN point_comparison AS pc ON TRUE
+JOIN sprint_count AS sc ON TRUE
+JOIN pointed_issues AS pi ON TRUE
+JOIN task_issues AS ti ON TRUE
+JOIN min_threshold_check AS mtc ON TRUE
+CROSS JOIN LATERAL
+  (SELECT STRING_AGG(reason, ', ') AS failure_reason
+   FROM
+     (SELECT 'issue data age max breached' AS reason
+      WHERE mtc.is_issue_data_fresh = FALSE
+      UNION ALL SELECT 'deliverable data age max breached'
+      WHERE mtc.is_deliverable_data_fresh = FALSE
+      UNION ALL SELECT 'issue count min breached'
+      WHERE mtc.is_issue_count_above_min = FALSE
+      UNION ALL SELECT 'deliverable count min breached'
+      WHERE mtc.is_deliverable_count_above_min = FALSE
+      UNION ALL SELECT 'point sum min breached'
+      WHERE mtc.is_point_sum_above_min = FALSE
+      UNION ALL SELECT 'sprint count min breached'
+      WHERE mtc.is_sprint_count_above_min = FALSE
+      UNION ALL SELECT 'pointed issue pct min breached'
+      WHERE mtc.is_pointed_issue_pct_above_min = FALSE
+      UNION ALL SELECT 'task issue pct min breached'
+      WHERE mtc.is_task_issue_pct_above_min = FALSE) AS reasons) AS fr
+WHERE mtc.is_issue_data_fresh = FALSE
+  OR mtc.is_deliverable_data_fresh = FALSE
+  OR mtc.is_issue_count_above_min = FALSE
+  OR mtc.is_deliverable_count_above_min = FALSE
+  OR mtc.is_point_sum_above_min = FALSE
+  OR mtc.is_sprint_count_above_min = FALSE
+  OR mtc.is_pointed_issue_pct_above_min = FALSE
+  OR mtc.is_task_issue_pct_above_min = FALSE;

--- a/analytics/metabase-backup-v2/level_0/Sprint_Metrics/Project_Data.json
+++ b/analytics/metabase-backup-v2/level_0/Sprint_Metrics/Project_Data.json
@@ -1,0 +1,8 @@
+{
+  "name": "Project Data",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "name",
+    "table.cell_column": "ghid"
+  }
+}

--- a/analytics/metabase-backup-v2/level_0/Sprint_Metrics/Project_Data.sql
+++ b/analytics/metabase-backup-v2/level_0/Sprint_Metrics/Project_Data.sql
@@ -1,0 +1,8 @@
+SELECT *,
+       CASE
+           WHEN ghid = 13 THEN 'Nava'
+           WHEN ghid = 17 THEN 'Agile Six'
+       END AS scrum_board
+FROM gh_project
+WHERE ghid IN (13,
+               17)

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_01.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_01.json
@@ -1,0 +1,74 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 01",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Automated API Key Management for External Users": {
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_01.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_01.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 1 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_02.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_02.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 02",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Co-Design Quad 3": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_02.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_02.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 2 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_03.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_03.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 03",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "CommonGrants - Apply workflow *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_03.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_03.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 3 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_04.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_04.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 04",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "CommonGrants - Developer tools": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_04.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_04.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 4 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_05.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_05.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 05",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Content Strategy & Comms": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_05.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_05.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 5 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_06.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_06.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 06",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Open Source Community Growth Quad 3": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_06.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_06.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 6 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_07.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_07.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 07",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Participatory budgeting tools": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_07.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_07.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 7 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_08.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_08.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 08",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Promote Simpler Search *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_08.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_08.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 8 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_09.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_09.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 09",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Simpler Application Workflow Pilot *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_09.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_09.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 9 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_10.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_10.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 10",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "SOAP Proxy/Router for Apply APIs *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_10.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_10.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 10 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_11.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_11.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 11",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Tech Scaling": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_11.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_11.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 11 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_12.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_12.json
@@ -1,0 +1,74 @@
+{
+  "name": "Burndown by Issue with Deliverable Ranked Order 12",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issues",
+    "graph.y_axis.max": 30,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "undefined": {
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "237ae113-f608-4884-a6d1-7d8256e4e53f",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_12.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Issue_with_Deliverable_Ranked_Order_12.sql
@@ -1,0 +1,121 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 12 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate issues opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate issues closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_01.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_01.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 01",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Automated API Key Management for External Users": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_01.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_01.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 1 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_02.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_02.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 02",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Co-Design Quad 3": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_02.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_02.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 2 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_03.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_03.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 03",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "CommonGrants - Apply workflow *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_03.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_03.sql
@@ -1,0 +1,160 @@
+WITH RECURSIVE -- Constants
+ constants AS
+  (SELECT 3 AS deliverable_ranked_order), -- Get reporting period dynamically
+ reporting_period AS ({{#restore:Default_Reporting_Period}}), -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have NOT converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Join sources to generate final collection of deliverables in the given quad
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective,
+          ROW_NUMBER() OVER (PARTITION BY q.quad_id
+                             ORDER BY d.deliverable_title) AS ranked_order
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY d.deliverable_title), -- Resolve the selected deliverable using the constant deliverable_ghid
+ selected_deliverable AS
+  (SELECT deliverable_id,
+          deliverable_ghid,
+          deliverable_title
+   FROM deliverables
+   WHERE ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+ epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+ epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+ raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+ direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+ combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+ opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+ closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_04.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_04.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 04",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "CommonGrants - Developer tools": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_04.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_04.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 4 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_05.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_05.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 05",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Content Strategy & Comms": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_05.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_05.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 5 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_06.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_06.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 06",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Open Source Community Growth Quad 3": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_06.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_06.sql
@@ -1,0 +1,160 @@
+WITH RECURSIVE -- Constants
+ constants AS
+  (SELECT 6 AS deliverable_ranked_order), -- Get reporting period dynamically
+ reporting_period AS ({{#restore:Default_Reporting_Period}}), -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have NOT converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Join sources to generate final collection of deliverables in the given quad
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective,
+          ROW_NUMBER() OVER (PARTITION BY q.quad_id
+                             ORDER BY d.deliverable_title) AS ranked_order
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY d.deliverable_title), -- Resolve the selected deliverable using the constant deliverable_ghid
+ selected_deliverable AS
+  (SELECT deliverable_id,
+          deliverable_ghid,
+          deliverable_title
+   FROM deliverables
+   WHERE ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+ epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+ epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+ raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+ direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+ combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+ opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+ closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_07.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_07.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 07",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Participatory budgeting tools": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_07.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_07.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 7 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_08.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_08.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 08",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Promote Simpler Search *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_08.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_08.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 8 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_09.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_09.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 09",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Simpler Application Workflow Pilot *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_09.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_09.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 9 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_10.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_10.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 10",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "SOAP Proxy/Router for Apply APIs *": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_10.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_10.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 10 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_11.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_11.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 11",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "Tech Scaling": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_11.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_11.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 11 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_12.json
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_12.json
@@ -1,0 +1,75 @@
+{
+  "name": "Burndown by Points with Deliverable Ranked Order 12",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "points",
+    "graph.y_axis.max": 40,
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "day",
+    "graph.metrics": [
+      "total_remaining"
+    ],
+    "graph.series_order": null,
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "undefined": {
+        "color": "#87BCEC",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.y_axis.auto_range": false,
+    "graph.dimensions": [
+      "issue_day",
+      "deliverable_title"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5ce6adc5-b49f-4d7d-9161-30908d7b2387",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_12.sql
+++ b/analytics/metabase-backup-v2/level_1/Burndowns/Burndown_by_Points_with_Deliverable_Ranked_Order_12.sql
@@ -1,0 +1,123 @@
+WITH RECURSIVE -- Constants
+constants AS
+  (SELECT 12 AS deliverable_ranked_order), -- Reporting period
+reporting_period AS ({{#restore:Default_Reporting_Period}}), -- All deliverables grouped by quad
+all_deliverables AS {{#850-model-quad-deliverables}}, -- Get quad id from selected quad name
+quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}
+   ORDER BY name
+   LIMIT 1), -- Get deliverable via quad_id and ranked_order
+selected_deliverable AS
+  (SELECT *
+   FROM all_deliverables
+   WHERE quad_id =
+       (SELECT quad_id
+        FROM quad)
+     AND ranked_order =
+       (SELECT deliverable_ranked_order
+        FROM constants)), -- Get latest epic-to-deliverable mappings
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Get epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.deliverable_id), -- Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Filter out issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.deliverable_ghid), -- Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Calculate points opened in the given time period
+opened AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Calculate points closed in the given time period
+closed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- Aggregate points opened and closed by day
+totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day)
+SELECT sd.deliverable_id,
+       sd.deliverable_ghid,
+       sd.deliverable_title,
+
+  (SELECT CONCAT('https://github.com/', sd.deliverable_ghid)
+   FROM constants) AS deliverable_url,
+       t.issue_day,
+       t.total_opened,
+       t.total_closed,
+       t.total_remaining
+FROM totals t
+CROSS JOIN selected_deliverable sd;

--- a/analytics/metabase-backup-v2/level_1/Data_Availability/Data_Availability_Age_of_Current_Snapshot.json
+++ b/analytics/metabase-backup-v2/level_1/Data_Availability/Data_Availability_Age_of_Current_Snapshot.json
@@ -1,0 +1,26 @@
+{
+  "name": "Data Availability - Age of Current Snapshot",
+  "display": "object",
+  "visualization_settings": {
+    "scalar.field": "formatted_time_difference",
+    "table.columns": [
+      {
+        "name": "current_datetime",
+        "enabled": false
+      },
+      {
+        "name": "max_t_created",
+        "enabled": false
+      },
+      {
+        "name": "formatted_time_difference",
+        "enabled": true
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"formatted_time_difference\"]": {
+        "column_title": "Age of current snapshot:"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/Data_Availability/Data_Availability_Age_of_Current_Snapshot.sql
+++ b/analytics/metabase-backup-v2/level_1/Data_Availability/Data_Availability_Age_of_Current_Snapshot.sql
@@ -1,0 +1,9 @@
+SELECT NOW() AS current_datetime,
+       MAX(t_created) AS max_t_created,
+       CONCAT(FLOOR(EXTRACT(EPOCH
+                            FROM (NOW() - MAX(t_created))) / 3600), ' hours, ', FLOOR(MOD(EXTRACT(EPOCH
+                                                                                                  FROM (NOW() - MAX(t_created))), 3600) / 60), ' minutes') AS formatted_time_difference
+FROM gh_issue_history
+WHERE d_effective =
+    (SELECT MAX(d_effective)
+     FROM gh_issue_history);

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Done.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Done.json
@@ -1,0 +1,82 @@
+{
+  "name": "All Deliverables - Acceptance Criteria Done",
+  "display": "row",
+  "visualization_settings": {
+    "graph.show_goal": false,
+    "graph.y_axis.title_text": "total",
+    "graph.show_values": true,
+    "table.cell_column": "total_issues",
+    "graph.goal_label": "100%",
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "deliverable",
+    "graph.goal_value": 100,
+    "graph.metrics": [
+      "criteria_done",
+      "criteria_open"
+    ],
+    "graph.label_value_formatting": "compact",
+    "graph.series_order": null,
+    "table.pivot_column": "issues_with_points",
+    "column_settings": {},
+    "series_settings": {
+      "criteria_done": {
+        "title": "criteria done",
+        "color": "#69C8C8"
+      },
+      "criteria_open": {
+        "title": "criteria open",
+        "color": "#C7EAEA"
+      }
+    },
+    "graph.y_axis.auto_range": true,
+    "graph.dimensions": [
+      "deliverable_title"
+    ],
+    "stackable.stack_type": "stacked"
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "e1b8b8fd-db00-4ab8-bfc0-a54059d3669a",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "e1b8b8fd-db00-4ab8-bfc0-a54059d3669a",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Done.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Done.sql
@@ -1,0 +1,75 @@
+WITH -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have not converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get deliverables for our given quad id
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY qdm.d_effective DESC), -- Get latest state snapshot for each deliverable
+ deliverable_state AS
+  (SELECT *
+   FROM
+     (SELECT h.deliverable_id,
+             h.status,
+             h.accept_criteria_done,
+             h.accept_criteria_total,
+             h.accept_metrics_done,
+             h.accept_metrics_total,
+             h.d_effective,
+             ROW_NUMBER() OVER (PARTITION BY h.deliverable_id
+                                ORDER BY h.d_effective DESC) AS ranked_order
+      FROM gh_deliverable_history h) history
+   WHERE history.ranked_order = 1)
+SELECT d.deliverable_title,
+       h.status,
+       h.accept_criteria_done AS criteria_done,
+       h.accept_criteria_total AS criteria_total,
+       (h.accept_criteria_total - h.accept_criteria_done) AS criteria_open,
+       h.accept_metrics_done AS metrics_done,
+       h.accept_metrics_total AS metrics_total,
+       (h.accept_metrics_total - h.accept_metrics_done) AS metrics_open,
+       h.d_effective
+FROM deliverables d
+JOIN deliverable_state h ON d.deliverable_id = h.deliverable_id
+ORDER BY d.deliverable_title ASC,
+         h.d_effective DESC;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Metrics_Done.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Metrics_Done.json
@@ -1,0 +1,82 @@
+{
+  "name": "All Deliverables - Acceptance Criteria+Metrics Done",
+  "display": "row",
+  "visualization_settings": {
+    "graph.show_goal": false,
+    "graph.y_axis.title_text": "total",
+    "graph.show_values": true,
+    "table.cell_column": "total_issues",
+    "graph.goal_label": "100%",
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "deliverable",
+    "graph.goal_value": 100,
+    "graph.metrics": [
+      "done_indicators",
+      "open_indicators"
+    ],
+    "graph.label_value_formatting": "compact",
+    "graph.series_order": null,
+    "table.pivot_column": "issues_with_points",
+    "column_settings": {},
+    "series_settings": {
+      "done_indicators": {
+        "title": "done ",
+        "color": "#69C8C8"
+      },
+      "open_indicators": {
+        "title": "not done",
+        "color": "#C7EAEA"
+      }
+    },
+    "graph.y_axis.auto_range": true,
+    "graph.dimensions": [
+      "deliverable_title"
+    ],
+    "stackable.stack_type": "stacked"
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "ad4b53aa-9fe3-44c6-bb29-eb0a41b4b32c",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "ad4b53aa-9fe3-44c6-bb29-eb0a41b4b32c",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Metrics_Done.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Criteria_Metrics_Done.sql
@@ -1,0 +1,70 @@
+WITH -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have not converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get deliverables for our given quad id
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY qdm.d_effective DESC), -- Get latest state snapshot for each deliverable
+ deliverable_state AS
+  (SELECT *
+   FROM
+     (SELECT h.deliverable_id,
+             h.status,
+             (h.accept_criteria_done + h.accept_metrics_done) AS done_indicators,
+             (h.accept_criteria_total + h.accept_metrics_total) AS total_indicators,
+             h.d_effective,
+             ROW_NUMBER() OVER (PARTITION BY h.deliverable_id
+                                ORDER BY h.d_effective DESC) AS ranked_order
+      FROM gh_deliverable_history h) history
+   WHERE history.ranked_order = 1)
+SELECT d.deliverable_title,
+       h.status,
+       h.done_indicators,
+       h.total_indicators,
+       (h.total_indicators - h.done_indicators) AS open_indicators,
+       h.d_effective
+FROM deliverables d
+JOIN deliverable_state h ON d.deliverable_id = h.deliverable_id
+ORDER BY d.deliverable_title ASC,
+         h.d_effective DESC;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Metrics_Done.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Metrics_Done.json
@@ -1,0 +1,82 @@
+{
+  "name": "All Deliverables - Acceptance Metrics Done",
+  "display": "row",
+  "visualization_settings": {
+    "graph.show_goal": false,
+    "graph.y_axis.title_text": "total",
+    "graph.show_values": true,
+    "table.cell_column": "total_issues",
+    "graph.goal_label": "100%",
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "deliverable",
+    "graph.goal_value": 100,
+    "graph.metrics": [
+      "metrics_done",
+      "metrics_open"
+    ],
+    "graph.label_value_formatting": "compact",
+    "graph.series_order": null,
+    "table.pivot_column": "issues_with_points",
+    "column_settings": {},
+    "series_settings": {
+      "metrics_done": {
+        "title": "metrics done",
+        "color": "#69C8C8"
+      },
+      "metrics_open": {
+        "title": "metrics open",
+        "color": "#C7EAEA"
+      }
+    },
+    "graph.y_axis.auto_range": true,
+    "graph.dimensions": [
+      "deliverable_title"
+    ],
+    "stackable.stack_type": "stacked"
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "964aea1f-3525-4e22-b60e-96a37fdda676",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "964aea1f-3525-4e22-b60e-96a37fdda676",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Metrics_Done.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Acceptance_Metrics_Done.sql
@@ -1,0 +1,75 @@
+WITH -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have not converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get deliverables for our given quad id
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY qdm.d_effective DESC), -- Get latest state snapshot for each deliverable
+ deliverable_state AS
+  (SELECT *
+   FROM
+     (SELECT h.deliverable_id,
+             h.status,
+             h.accept_criteria_done,
+             h.accept_criteria_total,
+             h.accept_metrics_done,
+             h.accept_metrics_total,
+             h.d_effective,
+             ROW_NUMBER() OVER (PARTITION BY h.deliverable_id
+                                ORDER BY h.d_effective DESC) AS ranked_order
+      FROM gh_deliverable_history h) history
+   WHERE history.ranked_order = 1)
+SELECT d.deliverable_title,
+       h.status,
+       h.accept_criteria_done AS criteria_done,
+       h.accept_criteria_total AS criteria_total,
+       (h.accept_criteria_total - h.accept_criteria_done) AS criteria_open,
+       h.accept_metrics_done AS metrics_done,
+       h.accept_metrics_total AS metrics_total,
+       (h.accept_metrics_total - h.accept_metrics_done) AS metrics_open,
+       h.d_effective
+FROM deliverables d
+JOIN deliverable_state h ON d.deliverable_id = h.deliverable_id
+ORDER BY d.deliverable_title ASC,
+         h.d_effective DESC;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Issue_Count.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Issue_Count.json
@@ -1,0 +1,73 @@
+{
+  "name": "All Deliverables - Percent Done by Issue Count",
+  "display": "row",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "deliverable_title"
+    ],
+    "graph.series_order_dimension": null,
+    "graph.series_order": null,
+    "stackable.stack_type": "stacked",
+    "graph.x_axis.title_text": "deliverable",
+    "series_settings": {
+      "issues_closed": {
+        "title": "issues closed",
+        "color": "#69C8C8"
+      },
+      "issues_open": {
+        "title": "issues open",
+        "color": "#C7EAEA"
+      }
+    },
+    "graph.y_axis.title_text": "issue count",
+    "graph.metrics": [
+      "issues_closed",
+      "issues_open"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "6e290e5b-ab14-42f8-93fa-54c6ce8c4d6c",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "6e290e5b-ab14-42f8-93fa-54c6ce8c4d6c",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Issue_Count.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Issue_Count.sql
@@ -1,0 +1,184 @@
+WITH RECURSIVE -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have not converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get deliverables for our given quad id
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY qdm.d_effective DESC), -- Get latest epic-to-deliverable mappings only
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (m.epic_id) m.epic_id,
+                      e.ghid AS epic_ghid,
+                      m.deliverable_id,
+                      m.d_effective
+   FROM gh_epic_deliverable_map m
+   JOIN gh_epic e ON m.epic_id = e.id
+   ORDER BY m.epic_id,
+            m.d_effective DESC), -- Get epics currently mapped to each deliverable
+ epics_in_deliverable AS
+  (SELECT ds.deliverable_id,
+          ds.deliverable_title,
+          lem.epic_id,
+          lem.epic_ghid,
+          e.title AS epic_title
+   FROM deliverables ds
+   JOIN latest_epic_mappings lem ON lem.deliverable_id = ds.deliverable_id
+   JOIN gh_epic e ON e.id = lem.epic_id), --  Build the recursive issue hierarchy, including direct-to-deliverable issues
+ issue_hierarchy AS
+  (-- Issues that are direct children of an epic
+ SELECT e.deliverable_id,
+        e.deliverable_title,
+        e.epic_id,
+        e.epic_ghid AS root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic,
+               EXISTS
+     (SELECT 1
+      FROM gh_deliverable
+      WHERE ghid = i.ghid) AS is_deliverable
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL -- Issues that are direct children of the deliverable
+ SELECT ds.deliverable_id,
+        ds.deliverable_title,
+        NULL AS epic_id,
+        NULL AS root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic,
+               EXISTS
+     (SELECT 1
+      FROM gh_deliverable
+      WHERE ghid = i.ghid) AS is_deliverable
+   FROM deliverables ds
+   JOIN gh_issue i ON i.parent_issue_ghid = ds.deliverable_ghid
+   UNION ALL -- Recursively find children of each issue
+ SELECT ih.deliverable_id,
+        ih.deliverable_title,
+        ih.epic_id,
+        ih.root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic,
+               EXISTS
+     (SELECT 1
+      FROM gh_deliverable
+      WHERE ghid = i.ghid) AS is_deliverable
+   FROM gh_issue i
+   JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid), -- For each issue, find the latest effective date from gh_issue_history
+ latest_issue_date AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS max_d_effective
+   FROM gh_issue_history h
+   JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+   GROUP BY h.issue_id), -- Determine each issue’s current closed state (exclude issues that are epics or deliverables)
+ issue_state AS
+  (SELECT ih.deliverable_id,
+          ih.deliverable_title,
+          h.issue_id,
+          h.d_effective,
+          MAX(CASE
+                  WHEN h.is_closed::BOOLEAN = TRUE THEN 1
+                  ELSE 0
+              END) AS is_closed
+   FROM gh_issue_history h
+   JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+   JOIN latest_issue_date lid ON h.issue_id = lid.issue_id
+   AND h.d_effective = lid.max_d_effective
+   WHERE NOT ih.is_epic
+     AND NOT ih.is_deliverable
+   GROUP BY ih.deliverable_id,
+            ih.deliverable_title,
+            h.issue_id,
+            h.d_effective), -- Count open and closed issues per deliverable
+ subtotals AS
+  (SELECT deliverable_id,
+          deliverable_title,
+          SUM(CASE
+                  WHEN is_closed = 0 THEN 1
+                  ELSE 0
+              END) AS issues_open,
+          SUM(CASE
+                  WHEN is_closed = 1 THEN 1
+                  ELSE 0
+              END) AS issues_closed,
+          COUNT(*) AS total_issues
+   FROM issue_state
+   GROUP BY deliverable_id,
+            deliverable_title), -- Calculate percent complete per deliverable
+ total AS
+  (SELECT deliverable_id,
+          deliverable_title,
+          CASE
+              WHEN SUM(total_issues) = 0 THEN '0%'
+              ELSE CONCAT(CEIL(100 * (SUM(issues_closed)::DECIMAL / NULLIF(SUM(total_issues)::DECIMAL, 0))), '%')
+          END AS percent_complete
+   FROM subtotals
+   GROUP BY deliverable_id,
+            deliverable_title) -- Final output: Percent complete for each deliverable
+
+SELECT s.deliverable_id,
+       s.deliverable_title,
+       s.issues_open,
+       s.issues_closed,
+       s.total_issues,
+       t.percent_complete
+FROM subtotals s
+JOIN total t ON s.deliverable_id = t.deliverable_id
+ORDER BY s.deliverable_title;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Points.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Points.json
@@ -1,0 +1,73 @@
+{
+  "name": "All Deliverables - Percent Done by Points",
+  "display": "row",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "deliverable_title"
+    ],
+    "graph.series_order_dimension": null,
+    "graph.series_order": null,
+    "stackable.stack_type": "stacked",
+    "graph.x_axis.title_text": "deliverable",
+    "series_settings": {
+      "points_closed": {
+        "title": "points closed",
+        "color": "#69C8C8"
+      },
+      "points_open": {
+        "title": "points open",
+        "color": "#C7EAEA"
+      }
+    },
+    "graph.y_axis.title_text": "sum of points",
+    "graph.metrics": [
+      "points_closed",
+      "points_open"
+    ]
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "3fe0858b-b11d-4ab9-9c15-4a7f8f92736c",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "3fe0858b-b11d-4ab9-9c15-4a7f8f92736c",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Points.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Done_by_Points.sql
@@ -1,0 +1,176 @@
+WITH RECURSIVE -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have not converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get deliverables for our given quad id
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY qdm.d_effective DESC), -- Get latest epic-to-deliverable mappings only
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (m.epic_id) m.epic_id,
+                      m.deliverable_id,
+                      e.ghid AS epic_ghid,
+                      m.d_effective
+   FROM gh_epic_deliverable_map m
+   JOIN gh_epic e ON m.epic_id = e.id
+   ORDER BY m.epic_id,
+            m.d_effective DESC), -- Get epics currently mapped to each deliverable
+ epics_in_deliverable AS
+  (SELECT ds.deliverable_id,
+          ds.deliverable_title,
+          lem.epic_id,
+          lem.epic_ghid,
+          e.title AS epic_title
+   FROM deliverables ds
+   JOIN latest_epic_mappings lem ON lem.deliverable_id = ds.deliverable_id
+   JOIN gh_epic e ON e.id = lem.epic_id), -- Build the recursive issue hierarchy, including issues directly linked to a deliverable
+ issue_hierarchy AS
+  (-- Issues that are direct children of an epic
+ SELECT e.deliverable_id,
+        e.deliverable_title,
+        e.epic_id,
+        e.epic_ghid AS root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic,
+               EXISTS
+     (SELECT 1
+      FROM gh_deliverable
+      WHERE ghid = i.ghid) AS is_deliverable
+   FROM epics_in_deliverable e
+   INNER JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL -- Issues that are direct children of the deliverable
+ SELECT ds.deliverable_id,
+        ds.deliverable_title,
+        NULL AS epic_id,
+        NULL AS root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic,
+               EXISTS
+     (SELECT 1
+      FROM gh_deliverable
+      WHERE ghid = i.ghid) AS is_deliverable
+   FROM deliverables ds
+   INNER JOIN gh_issue i ON i.parent_issue_ghid = ds.deliverable_ghid
+   UNION ALL -- Recursively find the children of each issue
+ SELECT ih.deliverable_id,
+        ih.deliverable_title,
+        ih.epic_id,
+        ih.root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic,
+               EXISTS
+     (SELECT 1
+      FROM gh_deliverable
+      WHERE ghid = i.ghid) AS is_deliverable
+   FROM gh_issue i
+   INNER JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid), -- For each issue, get the maximum d_effective from gh_issue_history
+ latest_issue_date AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS max_d_effective
+   FROM gh_issue_history h
+   JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+   GROUP BY h.issue_id), -- Aggregate points and determine closed state for each issue based on its latest snapshot
+ issue_state AS
+  (SELECT ih.deliverable_id,
+          ih.deliverable_title,
+          h.issue_id,
+          h.d_effective,
+          SUM(h.points) AS total_points,
+          MAX(CASE
+                  WHEN h.is_closed::BOOLEAN = TRUE THEN 1
+                  ELSE 0
+              END) AS is_closed
+   FROM gh_issue_history h
+   INNER JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+   INNER JOIN latest_issue_date lid ON h.issue_id = lid.issue_id
+   AND h.d_effective = lid.max_d_effective
+   WHERE NOT ih.is_epic -- Exclude issues that are epics
+
+     AND NOT ih.is_deliverable -- Exclude issues that are deliverables
+
+   GROUP BY ih.deliverable_id,
+            ih.deliverable_title,
+            h.issue_id,
+            h.d_effective) -- Count open and closed points per deliverable and calculate percent complete
+
+SELECT deliverable_id,
+       deliverable_title,
+       SUM(CASE
+               WHEN is_closed = 0 THEN total_points
+               ELSE 0
+           END) AS points_open,
+       SUM(CASE
+               WHEN is_closed = 1 THEN total_points
+               ELSE 0
+           END) AS points_closed,
+       SUM(total_points) AS total_points,
+       CASE
+           WHEN SUM(total_points) = 0 THEN '0%'
+           ELSE CONCAT(CEIL(100 * (SUM(CASE
+                                           WHEN is_closed = 1 THEN total_points
+                                           ELSE 0
+                                       END)::DECIMAL / NULLIF(SUM(total_points)::DECIMAL, 0))), '%')
+       END AS percent_complete,
+       COUNT(*) AS total_issues
+FROM issue_state
+GROUP BY deliverable_id,
+         deliverable_title
+ORDER BY deliverable_title;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Pointed.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Pointed.json
@@ -1,0 +1,85 @@
+{
+  "name": "All Deliverables - Percent Pointed",
+  "display": "row",
+  "visualization_settings": {
+    "graph.show_goal": true,
+    "graph.y_axis.title_text": "% of issues with story points",
+    "graph.show_values": true,
+    "table.cell_column": "total_issues",
+    "graph.goal_label": "100%",
+    "graph.series_order_dimension": null,
+    "graph.x_axis.title_text": "deliverable",
+    "graph.goal_value": 100,
+    "graph.metrics": [
+      "percent_pointed"
+    ],
+    "graph.label_value_formatting": "compact",
+    "graph.series_order": null,
+    "table.pivot_column": "issues_with_points",
+    "column_settings": {
+      "[\"name\",\"percent_pointed\"]": {
+        "suffix": "%",
+        "number_style": "decimal"
+      }
+    },
+    "series_settings": {
+      "percent_pointed": {
+        "color": "#227FD2",
+        "title": "Pointed"
+      },
+      "percent_non_pointed": {
+        "color": "#F7C4C4",
+        "title": "Not Pointed"
+      }
+    },
+    "graph.dimensions": [
+      "deliverable_title"
+    ],
+    "stackable.stack_type": "stacked"
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "bd31d27c-471b-4b04-b637-95ef91751418",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "bd31d27c-471b-4b04-b637-95ef91751418",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Pointed.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Percent_Pointed.sql
@@ -1,0 +1,147 @@
+WITH RECURSIVE -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have not converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get deliverables for our given quad id
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY qdm.d_effective DESC), -- Get latest epic-to-deliverable mappings
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (m.epic_id) m.epic_id,
+                      m.deliverable_id,
+                      e.ghid AS epic_ghid,
+                      m.d_effective
+   FROM gh_epic_deliverable_map m
+   JOIN gh_epic e ON m.epic_id = e.id
+   ORDER BY m.epic_id,
+            m.d_effective DESC), -- Get epics currently mapped to each deliverable
+ epics_in_deliverable AS
+  (SELECT ds.deliverable_id,
+          ds.deliverable_title,
+          lem.epic_id,
+          lem.epic_ghid,
+          e.title AS epic_title
+   FROM deliverables ds
+   JOIN latest_epic_mappings lem ON lem.deliverable_id = ds.deliverable_id
+   JOIN gh_epic e ON e.id = lem.epic_id), -- Build recursive issue hierarchy, including direct-to-deliverable issues
+ issue_hierarchy AS
+  (-- Issues that are direct children of an epic
+ SELECT e.deliverable_id,
+        e.deliverable_title,
+        e.epic_id,
+        e.epic_ghid AS root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL -- Issues that are direct children of the deliverable
+ SELECT ds.deliverable_id,
+        ds.deliverable_title,
+        NULL AS epic_id,
+        NULL AS root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic
+   FROM deliverables ds
+   JOIN gh_issue i ON i.parent_issue_ghid = ds.deliverable_ghid
+   UNION ALL -- Recursively find children of each issue
+ SELECT ih.deliverable_id,
+        ih.deliverable_title,
+        ih.epic_id,
+        ih.root_epic_ghid,
+        i.id AS issue_id,
+        i.ghid AS issue_ghid,
+        i.title AS issue_title,
+        i.parent_issue_ghid,
+        EXISTS
+     (SELECT 1
+      FROM gh_epic
+      WHERE ghid = i.ghid) AS is_epic
+   FROM gh_issue i
+   JOIN issue_hierarchy ih ON i.parent_issue_ghid = ih.issue_ghid), -- Find the latest d_effective per issue
+ latest_issue_date AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS max_d_effective
+   FROM gh_issue_history h
+   JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+   GROUP BY h.issue_id), -- Determine if an issue has points on its most recent history record
+ issue_state AS
+  (SELECT ih.deliverable_id,
+          ih.deliverable_title,
+          h.issue_id,
+          CASE
+              WHEN MAX(h.points) > 0 THEN 1
+              ELSE 0
+          END AS has_points
+   FROM gh_issue_history h
+   JOIN issue_hierarchy ih ON h.issue_id = ih.issue_id
+   JOIN latest_issue_date lid ON h.issue_id = lid.issue_id
+   AND h.d_effective = lid.max_d_effective
+   WHERE NOT ih.is_epic
+   GROUP BY ih.deliverable_id,
+            ih.deliverable_title,
+            h.issue_id) -- Calculate percent pointed and percent non-pointed per deliverable
+
+SELECT deliverable_id,
+       deliverable_title,
+       ROUND(100.0 * COUNT(CASE
+                               WHEN has_points = 1 THEN 1
+                           END) / NULLIF(COUNT(*), 0), 1) AS percent_pointed,
+       ROUND(100.0 * COUNT(CASE
+                               WHEN has_points = 0 THEN 1
+                           END) / NULLIF(COUNT(*), 0), 1) AS percent_non_pointed
+FROM issue_state
+GROUP BY deliverable_id,
+         deliverable_title
+ORDER BY deliverable_title;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Excluding_Done.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Excluding_Done.json
@@ -1,0 +1,58 @@
+{
+  "name": "All Deliverables - Titles Excluding Done",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "deliverable_id",
+    "table.cell_column": "d_effective",
+    "table.columns": [
+      {
+        "name": "deliverable_id",
+        "enabled": false
+      },
+      {
+        "name": "url",
+        "enabled": true
+      },
+      {
+        "name": "title",
+        "enabled": false
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "quad_name",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      },
+      {
+        "name": "ghid",
+        "enabled": true
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      },
+      "[\"name\",\"ghid\"]": {
+        "view_as": "link",
+        "link_text": "{{ghid}}",
+        "link_url": "{{url}}",
+        "column_title": "Link"
+      },
+      "[\"name\",\"quad_name\"]": {
+        "column_title": "Quad"
+      },
+      "[\"name\",\"url\"]": {
+        "view_as": "link",
+        "link_text": "{{title}}",
+        "link_url": "{{url}}",
+        "column_title": "Deliverable"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Excluding_Done.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Excluding_Done.sql
@@ -1,0 +1,57 @@
+WITH -- Get deliverables
+ deliverable AS
+  (SELECT d.id AS deliverable_id,
+          d.title,
+          d.ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get latest state snapshot for each deliverable
+ deliverable_state AS
+  (SELECT *
+   FROM
+     (SELECT h.deliverable_id,
+             h.status,
+             h.d_effective,
+             ROW_NUMBER() OVER (PARTITION BY h.deliverable_id
+                                ORDER BY h.d_effective DESC) AS ranked_order,
+             d.title,
+             d.ghid
+      FROM gh_deliverable_history h
+      JOIN deliverable d ON h.deliverable_id = d.deliverable_id) history
+   WHERE history.ranked_order = 1), -- Get latest quad mapping per deliverable
+ latest_deliverable_quad AS
+  (SELECT *
+   FROM
+     (SELECT dm.deliverable_id,
+             dm.quad_id,
+             dm.d_effective,
+             ROW_NUMBER() OVER (PARTITION BY dm.deliverable_id
+                                ORDER BY dm.d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map dm) quad_history
+   WHERE quad_history.ranked_order = 1), -- Get quad names for each deliverable using latest mapping
+ deliverable_quad AS
+  (SELECT lq.deliverable_id,
+          q.name AS quad_name
+   FROM latest_deliverable_quad lq
+   JOIN gh_quad q ON lq.quad_id = q.id)
+SELECT ds.deliverable_id,
+       ds.title,
+       ds.status,
+       ds.d_effective,
+       ds.ghid,
+       dq.quad_name,
+       CONCAT('https://github.com/', ds.ghid) AS url
+FROM deliverable_state ds
+LEFT JOIN deliverable_quad dq ON ds.deliverable_id = dq.deliverable_id
+WHERE ds.status != 'Done'
+ORDER BY ds.title ASC;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done.json
@@ -1,0 +1,40 @@
+{
+  "name": "All Deliverables - Titles Including Done",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "deliverable_id",
+    "table.cell_column": "d_effective",
+    "table.columns": [
+      {
+        "name": "deliverable_id",
+        "enabled": false
+      },
+      {
+        "name": "title",
+        "enabled": true
+      },
+      {
+        "name": "ghid",
+        "enabled": false
+      },
+      {
+        "name": "url",
+        "enabled": true
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"title\"]": {
+        "column_title": "Deliverable",
+        "view_as": "link",
+        "link_text": "{{title}}",
+        "link_url": "{{url}}"
+      },
+      "[\"name\",\"url\"]": {
+        "view_as": "link",
+        "column_title": "Link",
+        "link_text": "{{ghid}}",
+        "link_url": "{{url}}"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done.sql
@@ -1,0 +1,18 @@
+SELECT id AS deliverable_id,
+       title,
+       ghid,
+       concat('https://github.com/', ghid) AS url
+FROM gh_deliverable d
+WHERE NOT EXISTS
+    (SELECT 1
+     FROM gh_epic e
+     WHERE e.ghid = d.ghid
+       AND e.t_modified > d.t_modified
+       AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+  AND NOT EXISTS
+    (SELECT 1
+     FROM gh_issue i
+     WHERE i.ghid = d.ghid
+       AND i.t_modified > d.t_modified
+       AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')
+ORDER BY title

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done_Only.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done_Only.json
@@ -1,0 +1,58 @@
+{
+  "name": "All Deliverables - Titles Including Done Only",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "deliverable_id",
+    "table.cell_column": "d_effective",
+    "table.columns": [
+      {
+        "name": "deliverable_id",
+        "enabled": false
+      },
+      {
+        "name": "url",
+        "enabled": true
+      },
+      {
+        "name": "title",
+        "enabled": false
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      },
+      {
+        "name": "quad_name",
+        "enabled": true
+      },
+      {
+        "name": "ghid",
+        "enabled": true
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      },
+      "[\"name\",\"ghid\"]": {
+        "view_as": "link",
+        "link_text": "{{ghid}}",
+        "link_url": "{{url}}",
+        "column_title": "Link"
+      },
+      "[\"name\",\"quad_name\"]": {
+        "column_title": "Quad"
+      },
+      "[\"name\",\"url\"]": {
+        "view_as": "link",
+        "link_text": "{{title}}",
+        "link_url": "{{url}}",
+        "column_title": "Deliverable"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done_Only.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/All_Deliverables_Titles_Including_Done_Only.sql
@@ -1,0 +1,57 @@
+WITH -- Get deliverables
+ deliverable AS
+  (SELECT id AS deliverable_id,
+          title,
+          ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get latest state snapshot for each deliverable
+ deliverable_state AS
+  (SELECT *
+   FROM
+     (SELECT h.deliverable_id,
+             h.status,
+             h.d_effective,
+             ROW_NUMBER() OVER (PARTITION BY h.deliverable_id
+                                ORDER BY h.d_effective DESC) AS ranked_order,
+             d.title,
+             d.ghid
+      FROM gh_deliverable_history h
+      JOIN deliverable d ON h.deliverable_id = d.deliverable_id) history
+   WHERE history.ranked_order = 1), -- Get latest quad mapping per deliverable
+ latest_deliverable_quad AS
+  (SELECT *
+   FROM
+     (SELECT dm.deliverable_id,
+             dm.quad_id,
+             dm.d_effective,
+             ROW_NUMBER() OVER (PARTITION BY dm.deliverable_id
+                                ORDER BY dm.d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map dm) quad_history
+   WHERE quad_history.ranked_order = 1), -- Get quad names for each deliverable using latest mapping
+ deliverable_quad AS
+  (SELECT lq.deliverable_id,
+          q.name AS quad_name
+   FROM latest_deliverable_quad lq
+   JOIN gh_quad q ON lq.quad_id = q.id)
+SELECT ds.deliverable_id,
+       ds.title,
+       ds.status,
+       ds.d_effective,
+       ds.ghid,
+       dq.quad_name,
+       CONCAT('https://github.com/', ds.ghid) AS url
+FROM deliverable_state ds
+LEFT JOIN deliverable_quad dq ON ds.deliverable_id = dq.deliverable_id
+WHERE ds.status = 'Done'
+ORDER BY ds.title ASC;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Issue_Count.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Issue_Count.json
@@ -1,0 +1,74 @@
+{
+  "name": "Deliverable - Burndown Issue Count",
+  "display": "area",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "issue_day"
+    ],
+    "series_settings": {
+      "total_remaining": {
+        "color": "#509EE3",
+        "line.marker_enabled": false
+      }
+    },
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_remaining"
+    ]
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "deliverable_title",
+      "id": "dbcb297e-e7e8-4b8c-bcb4-4f2d0f2126c2",
+      "display-name": "Deliverable Title",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "values_query_type": "list",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "dbcb297e-e7e8-4b8c-bcb4-4f2d0f2126c2",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Issue_Count.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Issue_Count.sql
@@ -1,0 +1,100 @@
+WITH RECURSIVE -- 1. Get reporting period dynamically
+ reporting_period AS ({{#restore:Default_Reporting_Period}}), -- 2. Resolve the selected deliverable
+ selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- 3. Latest epic-to-deliverable mappings only
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- 4. Epics currently mapped to the selected deliverable
+ epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- 5. Recursively walk the issue tree from epics
+ epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- 6. Pre-filter issues that are direct children of the deliverable
+ raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- 7. Filter out issues that are actually epics mapped elsewhere
+ direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- 8. Combine both sources
+ combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- 9. Calculate issues opened in the given time period
+ opened AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_opened
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- 10. Calculate issues closed in the given time period
+ closed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_closed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- 11. Aggregate issues opened and closed by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day) -- Final output
+
+SELECT issue_day,
+       total_opened,
+       total_closed,
+       total_remaining
+FROM totals;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Points.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Points.json
@@ -1,0 +1,75 @@
+{
+  "name": "Deliverable - Burndown Points",
+  "display": "area",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "issue_day"
+    ],
+    "series_settings": {
+      "total_remaining": {
+        "color": "#509EE3",
+        "line.marker_enabled": false
+      }
+    },
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_remaining"
+    ]
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "079d0b26-afbb-4c85-936c-160cb11dd0b9",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "079d0b26-afbb-4c85-936c-160cb11dd0b9",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Points.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burndown_Points.sql
@@ -1,0 +1,105 @@
+WITH RECURSIVE -- 1. Get reporting period dynamically
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- 2. Select the deliverable using the dynamic filter
+ selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- 3. Get the latest epic-to-deliverable mappings (most recent d_effective per epic)
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- 4. Retrieve epics currently mapped to the selected deliverable
+ epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- 5. Recursively traverse issues starting from epics
+ epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- 6. Get raw issues that are direct children of the deliverable
+ raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- 7. Filter out any direct issues that are actually epics mapped elsewhere
+ direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- 8. Combine epic-based issues and direct deliverable issues
+ combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- 9. Deduplicate history entries: for each issue and day, only include the latest record
+ latest_history AS
+  (SELECT *
+   FROM
+     (SELECT h.*,
+             ROW_NUMBER() OVER (PARTITION BY h.issue_id, h.d_effective
+                                ORDER BY h.t_modified DESC) AS rn
+      FROM gh_issue_history h
+      JOIN combined_issues ci ON h.issue_id = ci.issue_id
+      WHERE h.d_effective BETWEEN
+          (SELECT start_date
+           FROM reporting_period) AND
+          (SELECT end_date
+           FROM reporting_period)) sub
+   WHERE rn = 1), -- 10. Aggregate total points opened per day
+ opened AS
+  (SELECT d_effective AS issue_day,
+          SUM(points) AS total_opened
+   FROM latest_history
+   GROUP BY d_effective
+   ORDER BY d_effective), -- 11. Aggregate total points closed per day
+ closed AS
+  (SELECT d_effective AS issue_day,
+          SUM(points) AS total_closed
+   FROM latest_history
+   WHERE is_closed::BOOLEAN = TRUE
+   GROUP BY d_effective
+   ORDER BY d_effective), -- 12. Combine opened and closed totals by day
+ totals AS
+  (SELECT COALESCE(o.issue_day, c.issue_day) AS issue_day,
+          COALESCE(o.total_opened, 0) AS total_opened,
+          COALESCE(c.total_closed, 0) AS total_closed,
+          COALESCE(o.total_opened, 0) - COALESCE(c.total_closed, 0) AS total_remaining
+   FROM opened o
+   FULL OUTER JOIN closed c ON o.issue_day = c.issue_day
+   ORDER BY issue_day)
+SELECT *
+FROM totals;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Issue_Count.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Issue_Count.json
@@ -1,0 +1,87 @@
+{
+  "name": "Deliverable - Burnup Issue Count",
+  "display": "area",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "issue_day"
+    ],
+    "series_settings": {
+      "total_scope": {
+        "color": "#88BF4D"
+      },
+      "total_closed": {
+        "color": "#A989C5",
+        "line.marker_enabled": false
+      },
+      "total_remaining": {
+        "line.marker_enabled": false,
+        "color": "#88BF4D"
+      },
+      "total_completed": {
+        "color": "#A989C5"
+      }
+    },
+    "graph.x_axis.scale": "timeseries",
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_scope",
+      "total_completed"
+    ]
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "type": "dimension",
+      "name": "deliverable_title",
+      "id": "dbcb297e-e7e8-4b8c-bcb4-4f2d0f2126c2",
+      "display-name": "Deliverable Title",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "widget-type": "string/=",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "values_query_type": "list",
+      "name": "Deliverable Title",
+      "isMultiSelect": true,
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "dbcb297e-e7e8-4b8c-bcb4-4f2d0f2126c2",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Issue_Count.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Issue_Count.sql
@@ -1,0 +1,96 @@
+WITH RECURSIVE -- 1. Get reporting period dynamically
+ reporting_period AS ({{#restore:Default_Reporting_Period}}), -- 2. Resolve the selected deliverable
+ selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- 3. Latest epic-to-deliverable mappings only
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- 4. Epics currently mapped to the selected deliverable
+ epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- 5. Recursively traverse the issue tree starting from epics
+ epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- 6. Pre-filter issues that are direct children of the deliverable
+ raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- 7. Filter out issues that are actually epics mapped elsewhere
+ direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- 8. Combine both epic-based issues and direct deliverable issues
+ combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- 9. Calculate total issue scope (issues tracked) in the given time period
+ SCOPE AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_scope
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- 10. Calculate issues completed in the given time period
+ completed AS
+  (SELECT h.d_effective AS issue_day,
+          COUNT(DISTINCT h.issue_id) AS total_completed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- 11. Aggregate scope and completed work by day (both climb toward total scope)
+ totals AS
+  (SELECT COALESCE(s.issue_day, c.issue_day) AS issue_day,
+          COALESCE(s.total_scope, 0) AS total_scope,
+          COALESCE(c.total_completed, 0) AS total_completed
+   FROM SCOPE s
+   FULL OUTER JOIN completed c ON s.issue_day = c.issue_day
+   ORDER BY issue_day)
+SELECT *
+FROM totals;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Points.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Points.json
@@ -1,0 +1,87 @@
+{
+  "name": "Deliverable - Burnup Points",
+  "display": "area",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "issue_day"
+    ],
+    "series_settings": {
+      "total_scope": {
+        "color": "#88BF4D"
+      },
+      "total_closed": {
+        "color": "#A989C5",
+        "line.marker_enabled": false
+      },
+      "total_remaining": {
+        "line.marker_enabled": false,
+        "color": "#88BF4D"
+      },
+      "total_completed": {
+        "color": "#A989C5"
+      }
+    },
+    "graph.x_axis.scale": "timeseries",
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_scope",
+      "total_completed"
+    ]
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "id": "dbcb297e-e7e8-4b8c-bcb4-4f2d0f2126c2",
+      "display-name": "Deliverable Title",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "deliverable_title",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "values_query_type": "list",
+      "name": "Deliverable Title",
+      "isMultiSelect": true,
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "dbcb297e-e7e8-4b8c-bcb4-4f2d0f2126c2",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Points.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Burnup_Points.sql
@@ -1,0 +1,96 @@
+WITH RECURSIVE -- 1. Get reporting period dynamically
+ reporting_period AS ({{#restore:Default_Reporting_Period}}), -- 2. Resolve the selected deliverable
+ selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- 3. Latest epic-to-deliverable mappings only
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- 4. Epics currently mapped to the selected deliverable
+ epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- 5. Recursively traverse the issue tree from epics
+ epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- 6. Pre-filter issues that are direct children of the deliverable
+ raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- 7. Filter out issues that are actually epics mapped elsewhere
+ direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- 8. Combine epic-based and direct deliverable issues
+ combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- 9. Calculate total points scope (points tracked) in the given time period
+ SCOPE AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_scope
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- 10. Calculate points completed in the given time period
+ completed AS
+  (SELECT h.d_effective AS issue_day,
+          SUM(h.points) AS total_completed
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   CROSS JOIN reporting_period
+   WHERE h.is_closed::BOOLEAN = TRUE
+     AND h.d_effective BETWEEN reporting_period.start_date AND reporting_period.end_date
+   GROUP BY h.d_effective
+   ORDER BY h.d_effective), -- 11. Aggregate scope and completed work by day (both climb toward total scope)
+ totals AS
+  (SELECT COALESCE(s.issue_day, c.issue_day) AS issue_day,
+          COALESCE(s.total_scope, 0) AS total_scope,
+          COALESCE(c.total_completed, 0) AS total_completed
+   FROM SCOPE s
+   FULL OUTER JOIN completed c ON s.issue_day = c.issue_day
+   ORDER BY issue_day)
+SELECT *
+FROM totals;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_GitHub_Link_NEW.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_GitHub_Link_NEW.json
@@ -1,0 +1,82 @@
+{
+  "name": "Deliverable GitHub Link (NEW)",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "title",
+        "enabled": true
+      },
+      {
+        "name": "ghid",
+        "enabled": false
+      },
+      {
+        "name": "url",
+        "enabled": true
+      }
+    ],
+    "table.pivot_column": "title",
+    "table.cell_column": "url",
+    "column_settings": {
+      "[\"name\",\"url\"]": {
+        "view_as": "link",
+        "column_title": "View on GitHub",
+        "link_text": "{{ghid}}",
+        "link_url": "{{url}}"
+      }
+    }
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "8e4f1d84-83d9-4d15-9d2e-23be63cb985d",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "8e4f1d84-83d9-4d15-9d2e-23be63cb985d",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_GitHub_Link_NEW.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_GitHub_Link_NEW.sql
@@ -1,0 +1,5 @@
+SELECT title,
+       ghid,
+       concat('https://github.com/', ghid) AS url
+FROM gh_deliverable
+WHERE {{deliverable_title}}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Done.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Done.json
@@ -1,0 +1,108 @@
+{
+  "name": "Deliverable - Issues Done",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "issue_title",
+    "table.cell_column": "points",
+    "table.columns": [
+      {
+        "name": "issue_url",
+        "enabled": true
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "pointed",
+        "enabled": true
+      },
+      {
+        "name": "points",
+        "enabled": true
+      },
+      {
+        "name": "issue_title",
+        "enabled": false
+      },
+      {
+        "name": "issue_ghid",
+        "enabled": false
+      },
+      {
+        "name": "issue_id",
+        "enabled": false
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      },
+      "[\"name\",\"issue_url\"]": {
+        "view_as": "link",
+        "column_title": "Link",
+        "link_text": "{{issue_title}}",
+        "link_url": "{{issue_url}}"
+      },
+      "[\"name\",\"pointed\"]": {
+        "column_title": "Pointed"
+      }
+    }
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "a6f2de2c-070a-4afe-9dec-638774c3c065",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "a6f2de2c-070a-4afe-9dec-638774c3c065",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Done.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Done.sql
@@ -1,0 +1,138 @@
+WITH RECURSIVE -- Step 1: Resolve the selected deliverable
+selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Step 7: Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Step 8: Assign numerical priorities to statuses
+ranked_statuses AS
+  (SELECT 'Icebox' AS status,
+          1 AS status_priority
+   UNION ALL SELECT 'Backlog',
+                    2
+   UNION ALL SELECT 'Prioritized',
+                    3
+   UNION ALL SELECT 'Planning',
+                    4
+   UNION ALL SELECT 'Todo',
+                    5
+   UNION ALL SELECT 'Blocked',
+                    6
+   UNION ALL SELECT 'In Progress',
+                    7
+   UNION ALL SELECT 'In Review',
+                    8
+   UNION ALL SELECT 'Done',
+                    9), -- Step 9: Latest state per issue
+latest_history AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS latest_d_effective
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   GROUP BY h.issue_id), -- Step 10: Points from most recent record
+latest_points AS
+  (SELECT h.issue_id,
+          SUM(h.points) AS total_points
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective
+   GROUP BY h.issue_id), -- Step 11: Mark pointed state
+issue_pointed_state AS
+  (SELECT h.issue_id,
+          CASE
+              WHEN SUM(h.points) > 0 THEN '√'
+              ELSE NULL
+          END AS pointed
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective
+   GROUP BY h.issue_id), -- Step 12: Rank current issue status
+ranked_issues AS
+  (SELECT h.issue_id,
+          ci.issue_ghid,
+          ci.issue_title,
+          h.d_effective,
+          h.status,
+          rs.status_priority,
+          ROW_NUMBER() OVER (PARTITION BY h.issue_id
+                             ORDER BY rs.status_priority DESC) AS rn
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   JOIN ranked_statuses rs ON h.status = rs.status) -- Final output
+
+SELECT ri.issue_title,
+       ri.status,
+       ri.issue_ghid,
+       CONCAT('http://github.com/', ri.issue_ghid) AS issue_url,
+       ips.pointed,
+       lp.total_points AS points,
+       ri.d_effective,
+       ri.issue_id
+FROM ranked_issues ri
+JOIN issue_pointed_state ips ON ri.issue_id = ips.issue_id
+JOIN latest_points lp ON ri.issue_id = lp.issue_id
+WHERE ri.rn = 1
+  AND ri.status = 'Done'
+ORDER BY ri.issue_title;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Open.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Open.json
@@ -1,0 +1,102 @@
+{
+  "name": "Deliverable - Issues Open",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "issue_title",
+        "enabled": true
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "issue_ghid",
+        "enabled": false
+      },
+      {
+        "name": "issue_url",
+        "enabled": false
+      },
+      {
+        "name": "pointed",
+        "enabled": true
+      },
+      {
+        "name": "points",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      },
+      {
+        "name": "issue_id",
+        "enabled": false
+      }
+    ],
+    "table.pivot_column": "issue_title",
+    "table.cell_column": "points",
+    "column_settings": {
+      "[\"name\",\"issue_title\"]": {
+        "view_as": "link",
+        "link_text": "{{issue_title}}",
+        "link_url": "{{issue_url}}",
+        "column_title": "title"
+      }
+    }
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "23fc8571-b571-496e-a8b7-2eaf02a116ad",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "23fc8571-b571-496e-a8b7-2eaf02a116ad",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Open.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Issues_Open.sql
@@ -1,0 +1,138 @@
+WITH RECURSIVE -- Step 1: Resolve the selected deliverable
+selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Step 7: Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Step 8: Assign numerical priorities to statuses
+ranked_statuses AS
+  (SELECT 'Icebox' AS status,
+          1 AS status_priority
+   UNION ALL SELECT 'Backlog',
+                    2
+   UNION ALL SELECT 'Prioritized',
+                    3
+   UNION ALL SELECT 'Planning',
+                    4
+   UNION ALL SELECT 'Todo',
+                    5
+   UNION ALL SELECT 'Blocked',
+                    6
+   UNION ALL SELECT 'In Progress',
+                    7
+   UNION ALL SELECT 'In Review',
+                    8
+   UNION ALL SELECT 'Done',
+                    9), -- Step 9: Latest state per issue
+latest_history AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS latest_d_effective
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   GROUP BY h.issue_id), -- Step 10: Points from most recent record
+latest_points AS
+  (SELECT h.issue_id,
+          SUM(h.points) AS total_points
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective
+   GROUP BY h.issue_id), -- Step 11: Mark pointed state
+issue_pointed_state AS
+  (SELECT h.issue_id,
+          CASE
+              WHEN SUM(h.points) > 0 THEN '√'
+              ELSE NULL
+          END AS pointed
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective
+   GROUP BY h.issue_id), -- Step 12: Rank current issue status
+ranked_issues AS
+  (SELECT h.issue_id,
+          ci.issue_ghid,
+          ci.issue_title,
+          h.d_effective,
+          h.status,
+          rs.status_priority,
+          ROW_NUMBER() OVER (PARTITION BY h.issue_id
+                             ORDER BY rs.status_priority DESC) AS rn
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   JOIN ranked_statuses rs ON h.status = rs.status) -- Final output
+
+SELECT ri.issue_title,
+       ri.status,
+       ri.issue_ghid,
+       CONCAT('http://github.com/', ri.issue_ghid) AS issue_url,
+       ips.pointed,
+       lp.total_points AS points,
+       ri.d_effective,
+       ri.issue_id
+FROM ranked_issues ri
+JOIN issue_pointed_state ips ON ri.issue_id = ips.issue_id
+JOIN latest_points lp ON ri.issue_id = lp.issue_id
+WHERE ri.rn = 1
+  AND ri.status != 'Done'
+ORDER BY ri.issue_title;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Issue_Count.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Issue_Count.json
@@ -1,0 +1,57 @@
+{
+  "name": "Deliverable Percent Done by Issue Count",
+  "display": "scalar",
+  "visualization_settings": {
+    "scalar.field": "percent_complete"
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "deliverable_title",
+      "id": "562cdd4d-d09b-4453-87b9-7ee0c7cdcd14",
+      "display-name": "Deliverable Title",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "562cdd4d-d09b-4453-87b9-7ee0c7cdcd14",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "name": "Deliverable Title",
+      "slug": "deliverable_title",
+      "required": true,
+      "values_source_type": "card",
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Issue_Count.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Issue_Count.sql
@@ -1,0 +1,94 @@
+WITH RECURSIVE -- Step 1: Resolve the selected deliverable
+selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Step 7: Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Step 8: Latest snapshot per issue (deduped by issue_id + max d_effective)
+latest_history AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS latest_d_effective
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   GROUP BY h.issue_id), -- Step 9: Pull latest is_closed values
+issue_statuses AS
+  (SELECT h.issue_id,
+          h.is_closed::BOOLEAN AS is_closed
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective) -- Step 10: Compute final result
+
+SELECT SUM(CASE
+               WHEN is_closed THEN 1
+               ELSE 0
+           END) AS issues_closed,
+       SUM(CASE
+               WHEN is_closed THEN 0
+               ELSE 1
+           END) AS issues_open,
+       COUNT(*) AS total_issues,
+       CONCAT(CEIL(100 * (SUM(CASE
+                                  WHEN is_closed THEN 1
+                                  ELSE 0
+                              END)::DECIMAL / NULLIF(COUNT(*), 0))), '%') AS percent_complete
+FROM issue_statuses;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Points.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Points.json
@@ -1,0 +1,59 @@
+{
+  "name": "Deliverable Percent Done by Points",
+  "display": "scalar",
+  "visualization_settings": {
+    "scalar.field": "percent_complete"
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "562cdd4d-d09b-4453-87b9-7ee0c7cdcd14",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "562cdd4d-d09b-4453-87b9-7ee0c7cdcd14",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Points.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Done_by_Points.sql
@@ -1,0 +1,97 @@
+WITH RECURSIVE -- Step 1: Resolve the selected deliverable
+selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Step 7: Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Step 8: Latest snapshot per issue
+latest_history AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS latest_d_effective
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   GROUP BY h.issue_id), -- Step 9: Pull point data from latest state
+issue_points AS
+  (SELECT h.issue_id,
+          h.points,
+          CASE
+              WHEN h.is_closed = 1 THEN h.points
+              ELSE 0
+          END AS points_closed,
+          CASE
+              WHEN h.is_closed = 0 THEN h.points
+              ELSE 0
+          END AS points_open
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective) -- Final calculation
+
+SELECT SUM(points_open) AS points_open,
+       SUM(points_closed) AS points_closed,
+       SUM(points) AS total_points,
+       CASE
+           WHEN SUM(points) = 0 THEN '0%'
+           ELSE CONCAT(CEIL(100 * (SUM(points_closed)::DECIMAL / NULLIF(SUM(points), 0))), '%')
+       END AS percent_complete,
+       COUNT(*) AS total_issues
+FROM issue_points;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Pointed_includes_only_open_issues.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Pointed_includes_only_open_issues.json
@@ -1,0 +1,111 @@
+{
+  "name": "Deliverable Percent Pointed (includes only open issues)",
+  "display": "pie",
+  "visualization_settings": {
+    "graph.show_goal": true,
+    "graph.y_axis.title_text": "% of issues with story points",
+    "graph.show_values": true,
+    "pie.slice_threshold": 1,
+    "pie.percent_visibility": "both",
+    "table.cell_column": "total_issues",
+    "graph.goal_label": "100%",
+    "graph.series_order_dimension": null,
+    "pie.show_labels": false,
+    "graph.x_axis.title_text": "deliverable",
+    "graph.goal_value": 100,
+    "pie.sort_rows": false,
+    "pie.rows": [
+      {
+        "key": "pointed",
+        "name": "Pointed",
+        "originalName": "pointed",
+        "color": "#509EE3",
+        "defaultColor": false,
+        "enabled": true,
+        "hidden": false,
+        "isOther": false
+      },
+      {
+        "key": "unpointed",
+        "name": "Not Pointed",
+        "originalName": "unpointed",
+        "color": "#EF8C8C",
+        "defaultColor": false,
+        "enabled": true,
+        "hidden": false,
+        "isOther": false
+      }
+    ],
+    "graph.metrics": [],
+    "graph.label_value_formatting": "compact",
+    "graph.series_order": null,
+    "pie.decimal_places": 0,
+    "table.pivot_column": "issues_with_points",
+    "pie.show_total": true,
+    "column_settings": {},
+    "series_settings": {
+      "percent_pointed": {
+        "color": "#509EE3",
+        "title": "Pointed"
+      },
+      "percent_non_pointed": {
+        "color": "#F7C4C4",
+        "title": "Not Pointed"
+      }
+    },
+    "graph.dimensions": [
+      "deliverable_title"
+    ],
+    "stackable.stack_type": "stacked"
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "deliverable_title",
+      "id": "dbc59a9f-7315-471a-8a9b-149a97ef85ce",
+      "display-name": "Deliverable Title",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "dbc59a9f-7315-471a-8a9b-149a97ef85ce",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "name": "Deliverable Title",
+      "slug": "deliverable_title",
+      "required": true,
+      "values_source_type": "card",
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Pointed_includes_only_open_issues.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Percent_Pointed_includes_only_open_issues.sql
@@ -1,0 +1,113 @@
+WITH RECURSIVE -- Step 1: Resolve the selected deliverable
+selected_deliverable AS
+  (SELECT id,
+          ghid
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- Step 2: Latest epic-to-deliverable mappings only
+latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- Step 3: Epics currently mapped to the selected deliverable
+epics_in_deliverable AS
+  (SELECT lem.epic_id,
+          lem.epic_ghid,
+          lem.deliverable_id
+   FROM latest_epic_mappings lem
+   JOIN selected_deliverable sd ON lem.deliverable_id = sd.id), -- Step 4: Recursively walk the issue tree from epics
+epic_issue_tree AS
+  (SELECT e.deliverable_id,
+          e.epic_id,
+          e.epic_ghid,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM epics_in_deliverable e
+   JOIN gh_issue i ON i.parent_issue_ghid = e.epic_ghid
+   UNION ALL SELECT eit.deliverable_id,
+                    eit.epic_id,
+                    eit.epic_ghid,
+                    i.id AS issue_id,
+                    i.ghid AS issue_ghid,
+                    i.title AS issue_title,
+                    i.parent_issue_ghid
+   FROM gh_issue i
+   JOIN epic_issue_tree eit ON i.parent_issue_ghid = eit.issue_ghid), -- Step 5: Pre-filter issues that are direct children of the deliverable
+raw_direct_issues AS
+  (SELECT sd.id AS deliverable_id,
+          i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM selected_deliverable sd
+   JOIN gh_issue i ON i.parent_issue_ghid = sd.ghid), -- Step 6: Filter out issues that are actually epics mapped elsewhere
+direct_issues AS
+  (SELECT rdi.deliverable_id,
+          NULL::integer AS epic_id,
+          NULL::text AS epic_ghid,
+          rdi.issue_id,
+          rdi.issue_ghid,
+          rdi.issue_title,
+          rdi.parent_issue_ghid
+   FROM raw_direct_issues rdi
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM latest_epic_mappings lem
+        JOIN gh_epic ep ON lem.epic_id = ep.id
+        WHERE ep.ghid = rdi.issue_ghid)), -- Step 7: Combine both sources
+combined_issues AS
+  (SELECT *
+   FROM epic_issue_tree
+   UNION ALL SELECT *
+   FROM direct_issues), -- Step 8: Ranked statuses
+ranked_statuses AS
+  (SELECT 'Icebox' AS status,
+          1 AS status_priority
+   UNION ALL SELECT 'Backlog',
+                    2
+   UNION ALL SELECT 'Prioritized',
+                    3
+   UNION ALL SELECT 'Planning',
+                    4
+   UNION ALL SELECT 'Todo',
+                    5
+   UNION ALL SELECT 'Blocked',
+                    6
+   UNION ALL SELECT 'In Progress',
+                    7
+   UNION ALL SELECT 'In Review',
+                    8
+   UNION ALL SELECT 'Done',
+                    9), -- Step 9: Latest state per issue
+latest_history AS
+  (SELECT h.issue_id,
+          MAX(h.d_effective) AS latest_d_effective
+   FROM gh_issue_history h
+   JOIN combined_issues ci ON h.issue_id = ci.issue_id
+   GROUP BY h.issue_id), -- Step 10: Issues with latest status not Done, de-duped by issue_id
+open_issues AS
+  (SELECT h.issue_id,
+          SUM(h.points) AS total_points
+   FROM gh_issue_history h
+   JOIN latest_history lh ON h.issue_id = lh.issue_id
+   AND h.d_effective = lh.latest_d_effective
+   WHERE h.status != 'Done'
+   GROUP BY h.issue_id), -- Step 11: Categorize issues by pointing state
+issue_pointing_state AS
+  (SELECT issue_id,
+          CASE
+              WHEN total_points > 0 THEN 'pointed'
+              ELSE 'unpointed'
+          END AS issue_state
+   FROM open_issues) -- Step 12: Count and return
+
+SELECT issue_state,
+       COUNT(*) AS issue_count
+FROM issue_pointing_state
+GROUP BY issue_state
+ORDER BY issue_state;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_Current_NEW.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_Current_NEW.json
@@ -1,0 +1,59 @@
+{
+  "name": "Deliverable Status Current (NEW)",
+  "display": "scalar",
+  "visualization_settings": {
+    "scalar.field": "status"
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "a4660bd6-4adb-4ec4-8f6f-e41e2b1d9b5b",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "a4660bd6-4adb-4ec4-8f6f-e41e2b1d9b5b",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_Current_NEW.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_Current_NEW.sql
@@ -1,0 +1,13 @@
+WITH deliverable AS
+  (SELECT id AS deliverable_id,
+          title
+   FROM gh_deliverable
+   WHERE {{deliverable_title}})
+SELECT d.title,
+       h.status,
+       h.d_effective
+FROM deliverable AS d,
+     gh_deliverable_history AS h
+WHERE h.deliverable_id = d.deliverable_id
+ORDER BY d_effective DESC
+LIMIT 1

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_History.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_History.json
@@ -1,0 +1,79 @@
+{
+  "name": "Deliverable Status History",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": true
+      }
+    ],
+    "table.pivot_column": "d_effective",
+    "table.cell_column": "status",
+    "column_settings": {
+      "[\"name\",\"d_effective\"]": {
+        "column_title": "Effective Date",
+        "date_abbreviate": true
+      },
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      }
+    }
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "84c8b906-b99c-4c5d-9f71-53e813f38345",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "84c8b906-b99c-4c5d-9f71-53e813f38345",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_History.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Deliverable_Status_History.sql
@@ -1,0 +1,33 @@
+WITH deliverable_history AS
+  (SELECT h.d_effective,
+          h.status,
+          h.deliverable_id
+   FROM gh_deliverable_history AS h
+   INNER JOIN gh_deliverable ON gh_deliverable.id = h.deliverable_id
+   WHERE {{deliverable_title}}
+   ORDER BY h.deliverable_id,
+            h.d_effective ASC), -- Add previous status using LAG() to detect transitions
+-- LAG() gets the status from the previous row (ordered by date) for the same deliverable
+history_with_previous AS
+  (SELECT d_effective,
+          status,
+          deliverable_id,
+          LAG(status) OVER (PARTITION BY deliverable_id
+                            ORDER BY d_effective ASC) AS previous_status
+   FROM deliverable_history), -- Filter to only rows where status changed (or is the first row for a deliverable)
+-- IS DISTINCT FROM handles NULL comparisons correctly
+transition_dates AS
+  (SELECT d_effective,
+          status,
+          deliverable_id
+   FROM history_with_previous
+   WHERE previous_status IS NULL -- Include first occurrence (no previous status)
+
+     OR status IS DISTINCT -- Include when status actually changed
+
+     FROM previous_status) -- Return transition dates with status
+
+SELECT t.d_effective,
+       t.status
+FROM transition_dates t
+ORDER BY t.d_effective ASC

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Epics_in_Deliverable.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Epics_in_Deliverable.json
@@ -1,0 +1,90 @@
+{
+  "name": "Epics in Deliverable",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "deliverable_id",
+        "enabled": false
+      },
+      {
+        "name": "epic_id",
+        "enabled": false
+      },
+      {
+        "name": "epic_title",
+        "enabled": false
+      },
+      {
+        "name": "epic_ghid",
+        "enabled": false
+      },
+      {
+        "name": "url",
+        "enabled": true
+      }
+    ],
+    "table.pivot_column": "deliverable_id",
+    "table.cell_column": "url",
+    "column_settings": {
+      "[\"name\",\"url\"]": {
+        "column_title": "GitHub Link",
+        "view_as": "link",
+        "link_text": "{{epic_title}}",
+        "link_url": "{{url}}"
+      }
+    }
+  },
+  "template_tags": {
+    "deliverable_title": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "deliverable_title",
+      "type": "dimension",
+      "id": "829330c2-c7b7-441f-be2b-e9d97982f347",
+      "dimension": [
+        "field",
+        246,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Deliverable Title",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_deliverable",
+        "column": "title"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "deliverable_title",
+      "name": "Deliverable Title",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "829330c2-c7b7-441f-be2b-e9d97982f347",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "deliverable_title"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 205,
+        "value_field": [
+          "field",
+          "title",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Epics_in_Deliverable.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Epics_in_Deliverable.sql
@@ -1,0 +1,28 @@
+WITH -- 1. Resolve the selected deliverable
+ selected_deliverable AS
+  (SELECT id,
+          ghid,
+          title
+   FROM gh_deliverable
+   WHERE {{deliverable_title}}), -- 2. Latest epic-to-deliverable mappings only (current mapping)
+ latest_epic_mappings AS
+  (SELECT DISTINCT ON (edm.epic_id) edm.epic_id,
+                      e.ghid AS epic_ghid,
+                      edm.deliverable_id,
+                      edm.d_effective
+   FROM gh_epic_deliverable_map edm
+   JOIN gh_epic e ON edm.epic_id = e.id
+   ORDER BY edm.epic_id,
+            edm.d_effective DESC), -- 3. Epics currently mapped to the selected deliverable (using latest mapping)
+ epics_in_deliverable AS
+  (SELECT sd.id AS deliverable_id,
+          lem.epic_id,
+          e.title AS epic_title,
+          lem.epic_ghid,
+          CONCAT('https://github.com/', lem.epic_ghid) AS url
+   FROM selected_deliverable sd
+   JOIN latest_epic_mappings lem ON lem.deliverable_id = sd.id
+   JOIN gh_epic e ON e.id = lem.epic_id)
+SELECT *
+FROM epics_in_deliverable
+ORDER BY epic_title;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Orphan_Issues_with_No_Deliverable.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Orphan_Issues_with_No_Deliverable.json
@@ -1,0 +1,54 @@
+{
+  "name": "Orphan Issues with No Deliverable",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "issue_url",
+        "enabled": true
+      },
+      {
+        "name": "issue_title",
+        "enabled": false
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "pointed",
+        "enabled": true
+      },
+      {
+        "name": "points",
+        "enabled": true
+      },
+      {
+        "name": "issue_ghid",
+        "enabled": false
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      },
+      {
+        "name": "issue_id",
+        "enabled": false
+      },
+      {
+        "name": "parent_issue_ghid",
+        "enabled": true
+      }
+    ],
+    "table.pivot_column": "pointed",
+    "table.cell_column": "points",
+    "column_settings": {
+      "[\"name\",\"issue_url\"]": {
+        "view_as": "link",
+        "column_title": "issue",
+        "link_text": "{{issue_title}}",
+        "link_url": "{{issue_url}}"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Orphan_Issues_with_No_Deliverable.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Orphan_Issues_with_No_Deliverable.sql
@@ -1,0 +1,90 @@
+WITH -- Step 1: Find all orphan issues (those with NULL parent_issue_ghid and are NOT epics or deliverables)
+ orphan_issues AS
+  (SELECT i.id AS issue_id,
+          i.ghid AS issue_ghid,
+          i.title AS issue_title,
+          i.parent_issue_ghid
+   FROM gh_issue i
+   LEFT JOIN gh_epic e ON i.ghid = e.ghid -- Exclude epics
+
+   LEFT JOIN gh_deliverable d ON i.ghid = d.ghid -- Exclude deliverables
+
+   WHERE i.parent_issue_ghid IS NULL
+     AND e.ghid IS NULL -- Ensure issue is NOT an epic
+
+     AND d.ghid IS NULL -- Ensure issue is NOT a deliverable
+), -- Step 2: Assign a numerical priority to statuses (lower value = higher priority)
+ ranked_statuses AS
+  (SELECT 'Icebox' AS status,
+          1 AS status_priority
+   UNION ALL SELECT 'Backlog',
+                    2
+   UNION ALL SELECT 'Prioritized',
+                    3
+   UNION ALL SELECT 'Planning',
+                    4
+   UNION ALL SELECT 'Todo',
+                    5
+   UNION ALL SELECT 'Blocked',
+                    6
+   UNION ALL SELECT 'In Progress',
+                    7
+   UNION ALL SELECT 'In Review',
+                    8
+   UNION ALL SELECT 'Done',
+                    9), -- Step 3: Find the most recent history snapshot per issue
+ latest_history AS
+  (SELECT gh_issue_history.issue_id,
+          MAX(gh_issue_history.d_effective) AS latest_d_effective
+   FROM gh_issue_history
+   INNER JOIN orphan_issues ON gh_issue_history.issue_id = orphan_issues.issue_id
+   GROUP BY gh_issue_history.issue_id), -- Step 4: Sum points only for the most recent `d_effective`
+ latest_points AS
+  (SELECT gh_issue_history.issue_id,
+          SUM(gh_issue_history.points) AS total_points
+   FROM gh_issue_history
+   INNER JOIN latest_history ON gh_issue_history.issue_id = latest_history.issue_id
+   AND gh_issue_history.d_effective = latest_history.latest_d_effective
+   GROUP BY gh_issue_history.issue_id), -- Step 5: Determine if an issue is pointed or not
+ issue_pointed_state AS
+  (SELECT gh_issue_history.issue_id,
+          CASE
+              WHEN SUM(gh_issue_history.points) > 0 THEN '√'
+              ELSE NULL
+          END AS pointed
+   FROM gh_issue_history
+   INNER JOIN latest_history ON gh_issue_history.issue_id = latest_history.issue_id
+   AND gh_issue_history.d_effective = latest_history.latest_d_effective
+   GROUP BY gh_issue_history.issue_id), -- Step 6: Determine the highest-priority status per issue
+ ranked_issues AS
+  (SELECT gh_issue_history.issue_id,
+          orphan_issues.issue_ghid,
+          orphan_issues.issue_title,
+          orphan_issues.parent_issue_ghid,
+          gh_issue_history.d_effective,
+          gh_issue_history.status,
+          ranked_statuses.status_priority,
+          ROW_NUMBER() OVER (PARTITION BY gh_issue_history.issue_id
+                             ORDER BY ranked_statuses.status_priority DESC) AS rn
+   FROM gh_issue_history
+   INNER JOIN orphan_issues ON gh_issue_history.issue_id = orphan_issues.issue_id
+   INNER JOIN ranked_statuses ON gh_issue_history.status = ranked_statuses.status
+   INNER JOIN latest_history ON gh_issue_history.issue_id = latest_history.issue_id
+   AND gh_issue_history.d_effective = latest_history.latest_d_effective) -- Step 7: Final selection with parent issue GHID for debugging
+
+SELECT DISTINCT ri.issue_title,
+                ri.status,
+                ri.issue_ghid,
+                ri.parent_issue_ghid,
+                CONCAT('http://github.com/', ri.issue_ghid) AS issue_url,
+                COALESCE(ips.pointed, '') AS pointed,
+                COALESCE(lp.total_points, 0) AS points,
+                ri.d_effective,
+                ri.issue_id
+FROM ranked_issues ri
+LEFT JOIN issue_pointed_state ips ON ri.issue_id = ips.issue_id
+LEFT JOIN latest_points lp ON ri.issue_id = lp.issue_id
+WHERE ri.rn = 1 -- Keep only the highest-priority status per issue
+
+  AND ri.status != 'Done' -- Exclude completed issues
+ORDER BY ri.issue_title;

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Quad_Deliverables.json
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Quad_Deliverables.json
@@ -1,0 +1,53 @@
+{
+  "name": "Quad Deliverables",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "quad_id",
+    "table.cell_column": "d_effective"
+  },
+  "template_tags": {
+    "quad": {
+      "widget-type": "string/=",
+      "default": [
+        "Quad 3"
+      ],
+      "name": "quad",
+      "type": "dimension",
+      "id": "62e5d725-f378-498f-90a0-5afba9eee4f3",
+      "dimension": [
+        "field",
+        310,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Quad",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_quad",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "62e5d725-f378-498f-90a0-5afba9eee4f3",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "quad"
+        ]
+      ],
+      "name": "Quad",
+      "slug": "quad",
+      "default": [
+        "Quad 3"
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Quad_Deliverables.sql
+++ b/analytics/metabase-backup-v2/level_1/Delivery_Metrics/Quad_Deliverables.sql
@@ -1,0 +1,51 @@
+WITH -- Get quad id from quad name
+ quad AS
+  (SELECT id AS quad_id,
+          name AS quad_name,
+          ghid AS quad_ghid,
+          start_date,
+          end_date
+   FROM gh_quad
+   WHERE {{quad}}), -- Get latest quad-deliverable relationships
+ quad_deliverable_map AS
+  (SELECT *
+   FROM
+     (SELECT quad_id,
+             deliverable_id,
+             d_effective,
+             ROW_NUMBER() OVER (PARTITION BY deliverable_id
+                                ORDER BY d_effective DESC) AS ranked_order
+      FROM gh_deliverable_quad_map) history
+   WHERE history.ranked_order = 1), -- Get deliverables that have not converted to epics or issues
+ all_deliverables AS
+  (SELECT d.id AS deliverable_id,
+          d.title AS deliverable_title,
+          d.ghid AS deliverable_ghid
+   FROM gh_deliverable d
+   WHERE NOT EXISTS
+       (SELECT 1
+        FROM gh_epic e
+        WHERE e.ghid = d.ghid
+          AND e.t_modified > d.t_modified
+          AND CAST(e.t_modified AS DATE) != DATE '2025-02-04')
+     AND NOT EXISTS
+       (SELECT 1
+        FROM gh_issue i
+        WHERE i.ghid = d.ghid
+          AND i.t_modified > d.t_modified
+          AND CAST(i.t_modified AS DATE) != DATE '2025-02-04')), -- Get deliverables for our given quad id
+ deliverables AS
+  (SELECT q.quad_id,
+          q.quad_name,
+          q.quad_ghid,
+          d.deliverable_id,
+          d.deliverable_title,
+          d.deliverable_ghid,
+          qdm.d_effective
+   FROM quad q
+   JOIN quad_deliverable_map qdm ON q.quad_id = qdm.quad_id
+   JOIN all_deliverables d ON qdm.deliverable_id = d.deliverable_id
+   ORDER BY qdm.d_effective DESC)
+SELECT *
+FROM deliverables
+ORDER BY deliverable_title ASC

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Deliverable_History_Age.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Deliverable_History_Age.json
@@ -1,0 +1,5 @@
+{
+  "name": "ETL Data Quality - Deliverable History Age",
+  "display": "object",
+  "visualization_settings": {}
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Deliverable_History_Age.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Deliverable_History_Age.sql
@@ -1,0 +1,5 @@
+SELECT NOW() - MAX(t_created) AS deliverable_time_since_last_update
+FROM gh_deliverable_history
+WHERE d_effective =
+    (SELECT MAX(d_effective)
+     FROM gh_deliverable_history)

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Monitor.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Monitor.json
@@ -1,0 +1,12 @@
+{
+  "name": "ETL Data Quality - Monitor",
+  "display": "object",
+  "visualization_settings": {
+    "table.pivot_column": "etl_health_status",
+    "column_settings": {
+      "[\"name\",\"etl_health_status\"]": {
+        "column_title": "data validation result"
+      }
+    }
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Monitor.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Data_Quality_Monitor.sql
@@ -1,0 +1,8 @@
+WITH anomaly_detector AS {{#restore:ETL_Data_Quality_Anomaly_Detector}}
+SELECT etl_health_status
+FROM anomaly_detector
+UNION ALL
+SELECT '✅ Data quality validated' AS etl_health_status
+WHERE NOT EXISTS
+    (SELECT 1
+     FROM anomaly_detector);

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Count_All.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Count_All.json
@@ -1,0 +1,27 @@
+{
+  "name": "ETL Deliverable - Count All",
+  "display": "area",
+  "visualization_settings": {
+    "series_settings": {
+      "deliverable_count": {
+        "color": "#227FD2",
+        "line.marker_enabled": false,
+        "line.missing": "zero"
+      }
+    },
+    "graph.x_axis.title_text": "ETL date",
+    "graph.y_axis.title_text": "deliverable count",
+    "graph.dimensions": [
+      "deliverable_day"
+    ],
+    "graph.y_axis.axis_enabled": true,
+    "column_settings": {
+      "[\"name\",\"deliverable_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "deliverable_count"
+    ]
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Count_All.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Count_All.sql
@@ -1,0 +1,20 @@
+WITH -- Get reporting period dates
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- Get the max available date from `gh_deliverable_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_deliverable_history), -- Generate a list of all dates in the reporting period, but stop at the last available history date
+ date_series AS
+  (SELECT generate_series(
+                            (SELECT start_date
+                             FROM reporting_period), LEAST(
+                                                             (SELECT end_date
+                                                              FROM reporting_period),
+                                                             (SELECT max_date
+                                                              FROM max_history_date)), INTERVAL '1 day')::DATE AS deliverable_day) -- Count deliverables for each day in the valid reporting period
+
+SELECT ds.deliverable_day,
+       COUNT(dh.id) AS deliverable_count
+FROM date_series ds
+LEFT JOIN gh_deliverable_history dh ON ds.deliverable_day = dh.d_effective
+GROUP BY ds.deliverable_day
+ORDER BY ds.deliverable_day;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Status_Distribution.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Status_Distribution.json
@@ -1,0 +1,52 @@
+{
+  "name": "ETL Deliverable - Status Distribution",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "deliverable count",
+    "graph.show_values": false,
+    "graph.x_axis.title_text": "ETL date",
+    "graph.metrics": [
+      "done_count",
+      "in_progress_count",
+      "planning_count",
+      "backlog_count"
+    ],
+    "graph.y_axis.axis_enabled": true,
+    "graph.label_value_formatting": "auto",
+    "column_settings": {
+      "[\"name\",\"deliverable_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "backlog_count": {
+        "line.marker_enabled": false,
+        "line.missing": "zero",
+        "color": "#EF8C8C",
+        "title": "Backlog"
+      },
+      "planning_count": {
+        "color": "#8A5EB0",
+        "title": "Planning",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "in_progress_count": {
+        "title": "In Progress",
+        "color": "#689636",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "done_count": {
+        "title": "Done",
+        "color": "#227FD2",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.dimensions": [
+      "deliverable_day"
+    ],
+    "stackable.stack_type": null
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Status_Distribution.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Deliverable_Status_Distribution.sql
@@ -1,0 +1,42 @@
+WITH -- Get reporting period dates
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- Get the max available date from `gh_deliverable_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_deliverable_history), -- Generate a list of all dates in the reporting period, but stop at the last available history date
+ date_series AS
+  (SELECT generate_series(
+                            (SELECT start_date
+                             FROM reporting_period), LEAST(
+                                                             (SELECT end_date
+                                                              FROM reporting_period),
+                                                             (SELECT max_date
+                                                              FROM max_history_date)), INTERVAL '1 day')::DATE AS deliverable_day), -- Count deliverables for each status per day (filtering only specific statuses)
+ daily_status_counts AS
+  (SELECT ds.deliverable_day,
+          dh.status,
+          COUNT(dh.id) AS deliverable_count
+   FROM date_series ds
+   LEFT JOIN gh_deliverable_history dh ON ds.deliverable_day = dh.d_effective
+   WHERE dh.status IN ('Backlog',
+                       'Done',
+                       'In Progress',
+                       'Planning')
+   GROUP BY ds.deliverable_day,
+            dh.status) -- Pivot the status values into separate columns
+
+SELECT dsc.deliverable_day,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Backlog' THEN dsc.deliverable_count
+                    END), 0) AS backlog_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Done' THEN dsc.deliverable_count
+                    END), 0) AS done_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'In Progress' THEN dsc.deliverable_count
+                    END), 0) AS in_progress_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Planning' THEN dsc.deliverable_count
+                    END), 0) AS planning_count
+FROM daily_status_counts dsc
+GROUP BY dsc.deliverable_day
+ORDER BY dsc.deliverable_day;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_All.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_All.json
@@ -1,0 +1,29 @@
+{
+  "name": "ETL Issue - Count All",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issue count",
+    "graph.show_values": false,
+    "graph.x_axis.title_text": "ETL date",
+    "graph.metrics": [
+      "issue_count"
+    ],
+    "graph.y_axis.axis_enabled": true,
+    "graph.label_value_formatting": "auto",
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "issue_count": {
+        "line.marker_enabled": false,
+        "color": "#227FD2",
+        "line.missing": "zero"
+      }
+    },
+    "graph.dimensions": [
+      "issue_day"
+    ]
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_All.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_All.sql
@@ -1,0 +1,26 @@
+WITH -- Get reporting period dates
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- Get the max available date from `gh_issue_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_issue_history), -- Generate a list of all dates in the reporting period, but stop at the last available history date
+ date_series AS
+  (SELECT generate_series(
+                            (SELECT start_date
+                             FROM reporting_period), LEAST(
+                                                             (SELECT end_date
+                                                              FROM reporting_period),
+                                                             (SELECT max_date
+                                                              FROM max_history_date)), INTERVAL '1 day')::DATE AS issue_day), -- Deduplicate issue records per day by counting each issue only once
+ daily_unique_issues AS
+  (SELECT h.d_effective AS issue_day,
+          h.issue_id
+   FROM gh_issue_history h
+   GROUP BY h.d_effective,
+            h.issue_id) -- Count unique issues per day in the valid reporting period
+
+SELECT ds.issue_day,
+       COUNT(dis.issue_id) AS issue_count
+FROM date_series ds
+LEFT JOIN daily_unique_issues dis ON ds.issue_day = dis.issue_day
+GROUP BY ds.issue_day
+ORDER BY ds.issue_day;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Issue_Type.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Issue_Type.json
@@ -1,0 +1,59 @@
+{
+  "name": "ETL Issue - Count Issue Type %",
+  "display": "pie",
+  "visualization_settings": {
+    "pie.slice_threshold": 1,
+    "pie.percent_visibility": "both",
+    "pie.dimension": [
+      "issue_type"
+    ],
+    "pie.show_labels": false,
+    "pie.rows": [
+      {
+        "key": "Task",
+        "name": "Task",
+        "originalName": "Task",
+        "color": "#509EE3",
+        "defaultColor": false,
+        "enabled": true,
+        "hidden": false,
+        "isOther": false
+      },
+      {
+        "key": "None",
+        "name": "None",
+        "originalName": "None",
+        "color": "#EF8C8C",
+        "defaultColor": false,
+        "enabled": true,
+        "hidden": false,
+        "isOther": false
+      },
+      {
+        "key": "Bug",
+        "name": "Bug",
+        "originalName": "Bug",
+        "color": "#F9D45C",
+        "defaultColor": true,
+        "enabled": true,
+        "hidden": false,
+        "isOther": true
+      },
+      {
+        "key": "Enhancement",
+        "name": "Enhancement",
+        "originalName": "Enhancement",
+        "color": "#98D9D9",
+        "defaultColor": true,
+        "enabled": true,
+        "hidden": false,
+        "isOther": true
+      }
+    ],
+    "pie.metric": "issue_percentage",
+    "pie.show_legend": true,
+    "pie.decimal_places": 0,
+    "pie.show_total": true,
+    "version": 2
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Issue_Type.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Issue_Type.sql
@@ -1,0 +1,22 @@
+WITH -- Get the most recent available date from `gh_issue_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_issue_history), -- Get the latest issue records from `gh_issue_history`
+ latest_issues AS
+  (SELECT DISTINCT issue_id
+   FROM gh_issue_history
+   WHERE d_effective =
+       (SELECT max_date
+        FROM max_history_date)), -- Count total issues grouped by type, ensuring only recent issues are included
+ issue_counts AS
+  (SELECT COALESCE(i.type, 'Unknown') AS issue_type, -- Handle NULL types
+ COUNT(*) AS issue_count
+   FROM latest_issues li
+   LEFT JOIN gh_issue i ON li.issue_id = i.id -- Use LEFT JOIN to ensure all issues are included
+
+   GROUP BY COALESCE(i.type, 'Unknown')) -- Return only the total counts per issue type
+
+SELECT ic.issue_type,
+       ic.issue_count
+FROM issue_counts ic
+ORDER BY ic.issue_count DESC;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed.json
@@ -1,0 +1,36 @@
+{
+  "name": "ETL Issue - Count Pointed vs Unpointed %",
+  "display": "pie",
+  "visualization_settings": {
+    "pie.metric": "pointed_count",
+    "pie.dimension": [
+      "pointed_count"
+    ],
+    "pie.rows": [
+      {
+        "key": "pointed",
+        "name": "Pointed",
+        "originalName": "pointed",
+        "color": "#509EE3",
+        "defaultColor": false,
+        "enabled": true,
+        "hidden": false,
+        "isOther": false
+      },
+      {
+        "key": "unpointed",
+        "name": "Not Pointed",
+        "originalName": "unpointed",
+        "color": "#EF8C8C",
+        "defaultColor": false,
+        "enabled": true,
+        "hidden": false,
+        "isOther": false
+      }
+    ],
+    "pie.show_labels": false,
+    "pie.decimal_places": 0,
+    "pie.slice_threshold": 1,
+    "pie.percent_visibility": "both"
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed.sql
@@ -1,0 +1,27 @@
+WITH -- Get the most recent available date from `gh_issue_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_issue_history), -- Determine pointed vs. unpointed status for each issue_id
+ latest_issues AS
+  (SELECT issue_id,
+          CASE
+              WHEN SUM(CASE
+                           WHEN points > 0 THEN 1
+                           ELSE 0
+                       END) > 0 THEN 'pointed'
+              ELSE 'unpointed'
+          END AS issue_state
+   FROM gh_issue_history
+   WHERE d_effective =
+       (SELECT max_date
+        FROM max_history_date)
+   GROUP BY issue_id), -- Count the number of pointed and unpointed issues
+ issue_counts AS
+  (SELECT issue_state,
+          COUNT(*) AS issue_count
+   FROM latest_issues
+   GROUP BY issue_state) -- Return the final issue count breakdown
+
+SELECT *
+FROM issue_counts
+ORDER BY issue_state;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed_Total.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed_Total.json
@@ -1,0 +1,38 @@
+{
+  "name": "ETL Issue - Count Pointed vs Unpointed Total",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issue count",
+    "graph.show_values": false,
+    "graph.x_axis.title_text": "ETL date",
+    "graph.metrics": [
+      "nonzero_points_count",
+      "zero_points_count"
+    ],
+    "graph.y_axis.axis_enabled": true,
+    "graph.label_value_formatting": "auto",
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "nonzero_points_count": {
+        "color": "#227FD2",
+        "title": "Pointed",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "zero_points_count": {
+        "line.marker_enabled": false,
+        "line.missing": "zero",
+        "title": "Not Pointed",
+        "color": "#EF8C8C"
+      }
+    },
+    "graph.dimensions": [
+      "issue_day"
+    ],
+    "stackable.stack_type": null
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed_Total.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Count_Pointed_vs_Unpointed_Total.sql
@@ -1,0 +1,38 @@
+WITH -- Get reporting period dates
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- Get the max available date from `gh_issue_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_issue_history), -- Generate a list of all dates in the reporting period, but stop at the last available history date
+ date_series AS
+  (SELECT generate_series(
+                            (SELECT start_date
+                             FROM reporting_period), LEAST(
+                                                             (SELECT end_date
+                                                              FROM reporting_period),
+                                                             (SELECT max_date
+                                                              FROM max_history_date)), INTERVAL '1 day')::DATE AS issue_day), -- Determine pointed vs. unpointed status for each issue_id per day
+ daily_issue_states AS
+  (SELECT h.d_effective AS issue_day,
+          h.issue_id,
+          CASE
+              WHEN SUM(CASE
+                           WHEN h.points > 0 THEN 1
+                           ELSE 0
+                       END) > 0 THEN 'pointed'
+              ELSE 'unpointed'
+          END AS issue_state
+   FROM gh_issue_history h
+   GROUP BY h.d_effective,
+            h.issue_id) -- Calculate daily sum of pointed and unpointed issues
+
+SELECT ds.issue_day,
+       COUNT(CASE
+                 WHEN dis.issue_state = 'unpointed' THEN 1
+             END) AS zero_points_count,
+       COUNT(CASE
+                 WHEN dis.issue_state = 'pointed' THEN 1
+             END) AS nonzero_points_count
+FROM date_series ds
+LEFT JOIN daily_issue_states dis ON ds.issue_day = dis.issue_day
+GROUP BY ds.issue_day
+ORDER BY ds.issue_day;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Status_Distribution.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Status_Distribution.json
@@ -1,0 +1,82 @@
+{
+  "name": "ETL Issue - Status Distribution",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "issue count",
+    "graph.show_values": false,
+    "graph.x_axis.title_text": "ETL date",
+    "graph.metrics": [
+      "done_count",
+      "in_review_count",
+      "in_progress_count",
+      "todo_count",
+      "planning_count",
+      "prioritized_count",
+      "backlog_count",
+      "blocked_count",
+      "icebox_count"
+    ],
+    "graph.y_axis.axis_enabled": true,
+    "graph.label_value_formatting": "auto",
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "in_review_count": {
+        "title": "In Review",
+        "color": "#509EE3",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "prioritized_count": {
+        "color": "#A989C5",
+        "title": "Prioritized",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "todo_count": {
+        "title": "To Do",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "blocked_count": {
+        "title": "Blocked",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "backlog_count": {
+        "title": "Backlog",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "in_progress_count": {
+        "title": "In Progress",
+        "color": "#689636",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "done_count": {
+        "title": "Done",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "planning_count": {
+        "title": "Planning",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      },
+      "icebox_count": {
+        "color": "#98D9D9",
+        "title": "Icebox",
+        "line.missing": "zero",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.dimensions": [
+      "issue_day"
+    ],
+    "stackable.stack_type": null
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Status_Distribution.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Status_Distribution.sql
@@ -1,0 +1,60 @@
+WITH -- Get reporting period dates
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- Get the max available date from `gh_issue_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_issue_history), -- Generate a list of all dates in the reporting period, but stop at the last available history date
+ date_series AS
+  (SELECT generate_series(
+                            (SELECT start_date
+                             FROM reporting_period), LEAST(
+                                                             (SELECT end_date
+                                                              FROM reporting_period),
+                                                             (SELECT max_date
+                                                              FROM max_history_date)), INTERVAL '1 day')::DATE AS issue_day), -- Deduplicate issue records per day, ensuring each issue_id is counted once per day based on its latest status
+ daily_unique_status AS
+  (SELECT h.d_effective AS issue_day,
+          h.issue_id,
+          h.status
+   FROM gh_issue_history h
+   GROUP BY h.d_effective,
+            h.issue_id,
+            h.status), -- Count issues for each status per day
+ daily_status_counts AS
+  (SELECT dus.issue_day,
+          dus.status,
+          COUNT(dus.issue_id) AS issue_count
+   FROM daily_unique_status dus
+   GROUP BY dus.issue_day,
+            dus.status) -- Pivot the status values into separate columns
+
+SELECT dsc.issue_day,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Backlog' THEN dsc.issue_count
+                    END), 0) AS backlog_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Blocked' THEN dsc.issue_count
+                    END), 0) AS blocked_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Done' THEN dsc.issue_count
+                    END), 0) AS done_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Icebox' THEN dsc.issue_count
+                    END), 0) AS icebox_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'In Progress' THEN dsc.issue_count
+                    END), 0) AS in_progress_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'In Review' THEN dsc.issue_count
+                    END), 0) AS in_review_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Planning' THEN dsc.issue_count
+                    END), 0) AS planning_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Prioritized' THEN dsc.issue_count
+                    END), 0) AS prioritized_count,
+       COALESCE(SUM(CASE
+                        WHEN dsc.status = 'Todo' THEN dsc.issue_count
+                    END), 0) AS todo_count
+FROM daily_status_counts dsc
+GROUP BY dsc.issue_day
+ORDER BY dsc.issue_day;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Sum_of_Pointed.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Sum_of_Pointed.json
@@ -1,0 +1,29 @@
+{
+  "name": "ETL Issue - Sum of Pointed",
+  "display": "area",
+  "visualization_settings": {
+    "graph.y_axis.title_text": "total story points",
+    "graph.show_values": false,
+    "graph.x_axis.title_text": "ETL date",
+    "graph.metrics": [
+      "total_points"
+    ],
+    "graph.y_axis.axis_enabled": true,
+    "graph.label_value_formatting": "auto",
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "series_settings": {
+      "total_points": {
+        "color": "#509EE3",
+        "line.marker_enabled": false,
+        "line.missing": "zero"
+      }
+    },
+    "graph.dimensions": [
+      "issue_day"
+    ]
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Sum_of_Pointed.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Issue_Sum_of_Pointed.sql
@@ -1,0 +1,20 @@
+WITH -- Get reporting period dates
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- Get the max available date from `gh_issue_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_issue_history), -- Generate a list of all dates in the reporting period, but stop at the last available history date
+ date_series AS
+  (SELECT generate_series(
+                            (SELECT start_date
+                             FROM reporting_period), LEAST(
+                                                             (SELECT end_date
+                                                              FROM reporting_period),
+                                                             (SELECT max_date
+                                                              FROM max_history_date)), INTERVAL '1 day')::DATE AS issue_day) -- Calculate daily sum of points and count of records with points = 0 and > 0
+
+SELECT ds.issue_day,
+       COALESCE(SUM(h.points), 0) AS total_points
+FROM date_series ds
+LEFT JOIN gh_issue_history h ON ds.issue_day = h.d_effective
+GROUP BY ds.issue_day
+ORDER BY ds.issue_day;

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Sprint_Count_All.json
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Sprint_Count_All.json
@@ -1,0 +1,28 @@
+{
+  "name": "ETL Sprint - Count All",
+  "display": "area",
+  "visualization_settings": {
+    "series_settings": {
+      "distinct_sprint_count": {
+        "color": "#509EE3",
+        "title": "sprint count",
+        "line.marker_enabled": false,
+        "line.missing": "zero"
+      }
+    },
+    "graph.x_axis.title_text": "ETL date",
+    "graph.y_axis.title_text": "sprint count",
+    "graph.dimensions": [
+      "issue_day"
+    ],
+    "column_settings": {
+      "[\"name\",\"issue_day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "distinct_sprint_count"
+    ]
+  },
+  "description": "count all sprints in data warehouse"
+}

--- a/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Sprint_Count_All.sql
+++ b/analytics/metabase-backup-v2/level_1/ETL_Metrics/ETL_Sprint_Count_All.sql
@@ -1,0 +1,20 @@
+WITH -- Get reporting period dates
+ reporting_period AS {{#restore:Default_Reporting_Period}}, -- Get the max available date from `gh_issue_history`
+ max_history_date AS
+  (SELECT MAX(d_effective) AS max_date
+   FROM gh_issue_history), -- Generate a list of all dates in the reporting period, but stop at the last available history date
+ date_series AS
+  (SELECT generate_series(
+                            (SELECT start_date
+                             FROM reporting_period), LEAST(
+                                                             (SELECT end_date
+                                                              FROM reporting_period),
+                                                             (SELECT max_date
+                                                              FROM max_history_date)), INTERVAL '1 day')::DATE AS issue_day) -- Count distinct sprint_id values for each day
+
+SELECT ds.issue_day,
+       COUNT(DISTINCT h.sprint_id) AS distinct_sprint_count
+FROM date_series ds
+LEFT JOIN gh_issue_history h ON ds.issue_day = h.d_effective
+GROUP BY ds.issue_day
+ORDER BY ds.issue_day;

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_History.json
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_History.json
@@ -1,0 +1,128 @@
+{
+  "name": "Issue History",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "id",
+        "enabled": false
+      },
+      {
+        "name": "issue_id",
+        "enabled": false
+      },
+      {
+        "name": "t_modified",
+        "enabled": true
+      },
+      {
+        "name": "title",
+        "enabled": true
+      },
+      {
+        "name": "name",
+        "enabled": true
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "is_closed",
+        "enabled": false
+      },
+      {
+        "name": "points",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      },
+      {
+        "name": "t_created",
+        "enabled": false
+      },
+      {
+        "name": "sprint_id",
+        "enabled": false
+      },
+      {
+        "name": "project_id",
+        "enabled": false
+      },
+      {
+        "name": "type",
+        "enabled": false
+      }
+    ],
+    "table.pivot_column": "issue_id",
+    "table.cell_column": "is_closed",
+    "column_settings": {
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      },
+      "[\"name\",\"is_closed\"]": {
+        "column_title": "Closed?"
+      },
+      "[\"name\",\"points\"]": {
+        "column_title": "Points"
+      },
+      "[\"name\",\"t_modified\"]": {
+        "column_title": "Datetime",
+        "date_abbreviate": true
+      },
+      "[\"name\",\"name\"]": {
+        "column_title": "Sprint"
+      },
+      "[\"name\",\"title\"]": {
+        "column_title": "Issue"
+      }
+    }
+  },
+  "template_tags": {
+    "ghid": {
+      "widget-type": "string/contains",
+      "name": "ghid",
+      "type": "dimension",
+      "id": "5f3963e4-0603-4072-91b9-276052a882da",
+      "dimension": [
+        "field",
+        282,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Ghid",
+      "options": {
+        "case-sensitive": false
+      },
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_issue",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5f3963e4-0603-4072-91b9-276052a882da",
+      "type": "string/contains",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "name": "Ghid",
+      "slug": "ghid",
+      "required": true,
+      "options": {
+        "case-sensitive": false
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_History.sql
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_History.sql
@@ -1,0 +1,18 @@
+WITH issue_data AS
+  (SELECT id AS issue_id,
+          title,
+          TYPE
+   FROM gh_issue
+   WHERE {{ghid}}),
+     sprint_data AS
+  (SELECT id,
+          name
+   FROM gh_sprint)
+SELECT h.*,
+       sprint_data.name,
+       issue_data.title,
+       issue_data.type
+FROM gh_issue_history h
+JOIN issue_data ON issue_data.issue_id = h.issue_id
+JOIN sprint_data ON sprint_data.id = h.sprint_id
+ORDER BY d_effective DESC

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Sprint_History.json
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Sprint_History.json
@@ -1,0 +1,85 @@
+{
+  "name": "Issue Sprint History",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "d_effective",
+        "enabled": true
+      },
+      {
+        "name": "sprint_id",
+        "enabled": false
+      },
+      {
+        "name": "start_date",
+        "enabled": false
+      },
+      {
+        "name": "end_date",
+        "enabled": false
+      },
+      {
+        "name": "sprint_name",
+        "enabled": true
+      }
+    ],
+    "table.pivot_column": "d_effective",
+    "table.cell_column": "status",
+    "column_settings": {
+      "[\"name\",\"d_effective\"]": {
+        "column_title": "Effective Date",
+        "date_abbreviate": true
+      },
+      "[\"name\",\"start_date\"]": {
+        "column_title": "Sprint Start",
+        "date_abbreviate": true
+      }
+    }
+  },
+  "template_tags": {
+    "ghid": {
+      "widget-type": "string/contains",
+      "name": "ghid",
+      "type": "dimension",
+      "id": "f4bd9bdf-0407-4f8f-8102-a2b56122450d",
+      "dimension": [
+        "field",
+        282,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Ghid",
+      "options": {
+        "case-sensitive": false
+      },
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_issue",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "f4bd9bdf-0407-4f8f-8102-a2b56122450d",
+      "type": "string/contains",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "name": "Ghid",
+      "slug": "ghid",
+      "required": true,
+      "options": {
+        "case-sensitive": false
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Sprint_History.sql
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Sprint_History.sql
@@ -1,0 +1,37 @@
+WITH issue_history AS
+  (SELECT h.d_effective,
+          h.sprint_id,
+          h.issue_id
+   FROM gh_issue_history AS h
+   INNER JOIN gh_issue ON gh_issue.id = h.issue_id
+   WHERE {{ghid}}
+   ORDER BY h.issue_id,
+            h.d_effective ASC), -- Add previous sprint_id using LAG() to detect transitions
+-- LAG() gets the sprint_id from the previous row (ordered by date) for the same issue
+history_with_previous AS
+  (SELECT d_effective,
+          sprint_id,
+          issue_id,
+          LAG(sprint_id) OVER (PARTITION BY issue_id
+                               ORDER BY d_effective ASC) AS previous_sprint_id
+   FROM issue_history), -- Filter to only rows where sprint_id changed (or is the first row for an issue)
+-- IS DISTINCT FROM handles NULL comparisons correctly
+transition_dates AS
+  (SELECT d_effective,
+          sprint_id,
+          issue_id
+   FROM history_with_previous
+   WHERE -- Include first occurrence (no previous sprint_id)
+ previous_sprint_id IS NULL -- OR include when sprint_id actually changed
+
+     OR sprint_id IS DISTINCT
+     FROM previous_sprint_id) -- Join with sprint details and return results
+
+SELECT t.d_effective,
+       t.sprint_id,
+       gh_sprint.name AS sprint_name,
+       gh_sprint.start_date,
+       gh_sprint.end_date
+FROM transition_dates t
+INNER JOIN gh_sprint ON gh_sprint.id = t.sprint_id
+ORDER BY t.d_effective DESC

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Status_History.json
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Status_History.json
@@ -1,0 +1,72 @@
+{
+  "name": "Issue Status History",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": true
+      }
+    ],
+    "table.pivot_column": "d_effective",
+    "table.cell_column": "status",
+    "column_settings": {
+      "[\"name\",\"d_effective\"]": {
+        "column_title": "Effective Date",
+        "date_abbreviate": true
+      },
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      }
+    }
+  },
+  "template_tags": {
+    "ghid": {
+      "widget-type": "string/contains",
+      "name": "ghid",
+      "type": "dimension",
+      "id": "f4bd9bdf-0407-4f8f-8102-a2b56122450d",
+      "dimension": [
+        "field",
+        282,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Ghid",
+      "options": {
+        "case-sensitive": false
+      },
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_issue",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "f4bd9bdf-0407-4f8f-8102-a2b56122450d",
+      "type": "string/contains",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "name": "Ghid",
+      "slug": "ghid",
+      "required": true,
+      "options": {
+        "case-sensitive": false
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Status_History.sql
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Status_History.sql
@@ -1,0 +1,33 @@
+WITH issue_history AS
+  (SELECT h.d_effective,
+          h.status,
+          h.issue_id
+   FROM gh_issue_history AS h
+   INNER JOIN gh_issue ON gh_issue.id = h.issue_id
+   WHERE {{ghid}}
+   ORDER BY h.issue_id,
+            h.d_effective ASC), -- Add previous status using LAG() to detect transitions
+-- LAG() gets the status from the previous row (ordered by date) for the same issue
+history_with_previous AS
+  (SELECT d_effective,
+          status,
+          issue_id,
+          LAG(status) OVER (PARTITION BY issue_id
+                            ORDER BY d_effective ASC) AS previous_status
+   FROM issue_history), -- Filter to only rows where status changed (or is the first row for an issue)
+-- IS DISTINCT FROM handles NULL comparisons correctly
+transition_dates AS
+  (SELECT d_effective,
+          status,
+          issue_id
+   FROM history_with_previous
+   WHERE previous_status IS NULL -- Include first occurrence (no previous status)
+
+     OR status IS DISTINCT -- Include when status actually changed
+
+     FROM previous_status) -- Return transition dates with status
+
+SELECT t.d_effective,
+       t.status
+FROM transition_dates t
+ORDER BY t.d_effective DESC

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Title.json
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Title.json
@@ -1,0 +1,85 @@
+{
+  "name": "Issue Title",
+  "display": "table",
+  "visualization_settings": {
+    "table.columns": [
+      {
+        "name": "title",
+        "enabled": true
+      },
+      {
+        "name": "ghid",
+        "enabled": false
+      },
+      {
+        "name": "url",
+        "enabled": true
+      },
+      {
+        "name": "id",
+        "enabled": true
+      }
+    ],
+    "table.pivot_column": "issue_id",
+    "table.cell_column": "is_closed",
+    "column_settings": {
+      "[\"name\",\"title\"]": {
+        "column_title": "Title"
+      },
+      "[\"name\",\"url\"]": {
+        "view_as": "link",
+        "column_title": "Link",
+        "link_text": "{{ghid}}",
+        "link_url": "{{url}}"
+      },
+      "[\"name\",\"id\"]": {
+        "column_title": "Internal ID"
+      }
+    }
+  },
+  "template_tags": {
+    "ghid": {
+      "widget-type": "string/contains",
+      "name": "ghid",
+      "type": "dimension",
+      "id": "5f3963e4-0603-4072-91b9-276052a882da",
+      "dimension": [
+        "field",
+        282,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Ghid",
+      "options": {
+        "case-sensitive": false
+      },
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_issue",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "5f3963e4-0603-4072-91b9-276052a882da",
+      "type": "string/contains",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "name": "Ghid",
+      "slug": "ghid",
+      "required": true,
+      "options": {
+        "case-sensitive": false
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Title.sql
+++ b/analytics/metabase-backup-v2/level_1/Issue_Data/Issue_Title.sql
@@ -1,0 +1,7 @@
+SELECT title,
+       ghid,
+       concat('https://github.com/', ghid) AS url,
+       id
+FROM gh_issue
+WHERE {{ghid}}
+LIMIT 1

--- a/analytics/metabase-backup-v2/level_1/Quad_Data/All_Quads.json
+++ b/analytics/metabase-backup-v2/level_1/Quad_Data/All_Quads.json
@@ -1,0 +1,8 @@
+{
+  "name": "All Quads",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "id",
+    "table.cell_column": "duration"
+  }
+}

--- a/analytics/metabase-backup-v2/level_1/Quad_Data/All_Quads.sql
+++ b/analytics/metabase-backup-v2/level_1/Quad_Data/All_Quads.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM gh_quad
+ORDER BY start_date DESC

--- a/analytics/metabase-backup-v2/level_1/Quad_Data/Current_Quad.json
+++ b/analytics/metabase-backup-v2/level_1/Quad_Data/Current_Quad.json
@@ -1,0 +1,5 @@
+{
+  "name": "Current Quad",
+  "display": "scalar",
+  "visualization_settings": {}
+}

--- a/analytics/metabase-backup-v2/level_1/Quad_Data/Current_Quad.sql
+++ b/analytics/metabase-backup-v2/level_1/Quad_Data/Current_Quad.sql
@@ -1,0 +1,7 @@
+WITH current_quad AS
+  (SELECT name
+   FROM app.gh_quad
+   WHERE CURRENT_DATE - 1 BETWEEN start_date AND end_date
+   LIMIT 1)
+SELECT name
+FROM current_quad

--- a/analytics/metabase-backup-v2/level_1/Quad_Data/Days_left_in_Quad.json
+++ b/analytics/metabase-backup-v2/level_1/Quad_Data/Days_left_in_Quad.json
@@ -1,0 +1,33 @@
+{
+  "name": "Days left in Quad",
+  "display": "scalar",
+  "visualization_settings": {},
+  "template_tags": {
+    "date": {
+      "widget-type": null,
+      "type": "date",
+      "name": "date",
+      "id": "03b3bcdc-3547-4337-a3d0-7def62f85930",
+      "display-name": "Date",
+      "default": "2024-12-18",
+      "required": true
+    }
+  },
+  "parameters": [
+    {
+      "id": "03b3bcdc-3547-4337-a3d0-7def62f85930",
+      "type": "date/single",
+      "target": [
+        "variable",
+        [
+          "template-tag",
+          "date"
+        ]
+      ],
+      "name": "Date",
+      "slug": "date",
+      "default": "2024-12-18",
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Quad_Data/Days_left_in_Quad.sql
+++ b/analytics/metabase-backup-v2/level_1/Quad_Data/Days_left_in_Quad.sql
@@ -1,0 +1,8 @@
+WITH current_sprint AS
+  (SELECT start_date,
+          end_date
+   FROM app.gh_quad
+   WHERE {{ date }} - 1 BETWEEN start_date AND end_date
+   LIMIT 1)
+SELECT end_date - {{ date }}
+FROM current_sprint

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Project_Name.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Project_Name.json
@@ -1,0 +1,44 @@
+{
+  "name": "Project Name",
+  "display": "scalar",
+  "visualization_settings": {},
+  "template_tags": {
+    "ghid": {
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "ghid",
+      "id": "a53f6553-171b-47c7-befb-7201bb2cb063",
+      "display-name": "Ghid",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "a53f6553-171b-47c7-befb-7201bb2cb063",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "name": "Ghid",
+      "slug": "ghid",
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Project_Name.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Project_Name.sql
@@ -1,0 +1,6 @@
+SELECT CASE
+           WHEN ghid = 13 THEN 'Simpler.Grants.gov'
+           WHEN ghid = 17 THEN 'Product & Delivery'
+       END AS scrum_board
+FROM gh_project
+WHERE {{ghid}}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_issues.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_issues.json
@@ -1,0 +1,128 @@
+{
+  "name": "Sprint Burndown by issues",
+  "display": "area",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "day"
+    ],
+    "table.cell_column": "total_closed",
+    "table.pivot_column": "total_opened",
+    "series_settings": {
+      "total_remaining": {
+        "color": "#509EE3",
+        "line.marker_enabled": false
+      }
+    },
+    "column_settings": {
+      "[\"name\",\"day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_remaining"
+    ]
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "Project",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint Name",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "ghid",
+      "values_query_type": "list",
+      "name": "Project",
+      "type": "string/=",
+      "values_source_type": "static-list",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_issues.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_issues.sql
@@ -1,0 +1,45 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}}), -- get sprint_id for project_id/sprint_name
+ sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.start_date AS sprint_start_date,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM project_data,
+        gh_sprint
+   WHERE gh_sprint.project_id = project_data.project_id
+     AND {{sprint_name}}), -- calculate issues opened in the sprint identified by sprint_id
+ opened AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          count(*) AS total_opened
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- calculate issues closed in the sprint
+ closed AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          count(*) AS total_closed
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND gh_issue_history.is_closed = 1
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- aggregate issues opened and closed by day
+ totals AS
+  (SELECT opened.day AS DAY,
+          opened.total_opened,
+          closed.total_closed,
+          opened.total_opened - closed.total_closed AS total_remaining
+   FROM opened,
+        closed
+   WHERE opened.day = closed.day
+   ORDER BY DAY)
+SELECT *
+FROM totals

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_points.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_points.json
@@ -1,0 +1,127 @@
+{
+  "name": "Sprint Burndown by points",
+  "display": "area",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "day"
+    ],
+    "table.cell_column": "total_closed",
+    "table.pivot_column": "total_opened",
+    "series_settings": {
+      "total_remaining": {
+        "color": "#509EE3",
+        "line.marker_enabled": false
+      }
+    },
+    "column_settings": {
+      "[\"name\",\"day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_remaining"
+    ]
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "Project",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint Name",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "ghid",
+      "name": "Project",
+      "type": "string/=",
+      "values_source_type": "static-list",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_points.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burndown_by_points.sql
@@ -1,0 +1,45 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}}), -- get sprint_id for project_id/sprint_name
+ sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.start_date AS sprint_start_date,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM project_data,
+        gh_sprint
+   WHERE gh_sprint.project_id = project_data.project_id
+     AND {{sprint_name}}), -- calculate points opened in the sprint
+ opened AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          sum(gh_issue_history.points) AS total_opened
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- calculate points closed in the sprint
+ closed AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          sum(gh_issue_history.points) AS total_closed
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND gh_issue_history.is_closed = 1
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- aggregate points opened and closed by day
+ totals AS
+  (SELECT opened.day AS DAY,
+          opened.total_opened,
+          closed.total_closed,
+          opened.total_opened - closed.total_closed AS total_remaining
+   FROM opened,
+        closed
+   WHERE opened.day = closed.day
+   ORDER BY DAY)
+SELECT *
+FROM totals

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_issues.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_issues.json
@@ -1,0 +1,139 @@
+{
+  "name": "Sprint Burnup by issues",
+  "display": "area",
+  "visualization_settings": {
+    "series_settings": {
+      "total_scope": {
+        "color": "#88BF4D",
+        "line.marker_enabled": false
+      },
+      "total_completed": {
+        "color": "#A989C5",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.dimensions": [
+      "day"
+    ],
+    "graph.x_axis.scale": "timeseries",
+    "stackable.stack_type": null,
+    "graph.y_axis.auto_split": false,
+    "column_settings": {
+      "[\"name\",\"day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_completed",
+      "total_scope"
+    ]
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "9392efee-5590-430c-9031-3aaed414641a",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "cc52d7aa-8456-4f68-88c1-a677621f668d",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "Project",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "default": null,
+      "name": "Sprint Name",
+      "isMultiSelect": true,
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "9392efee-5590-430c-9031-3aaed414641a",
+      "options": null,
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "ghid",
+      "default": null,
+      "name": "Project",
+      "isMultiSelect": true,
+      "type": "string/=",
+      "values_source_type": "static-list",
+      "id": "cc52d7aa-8456-4f68-88c1-a677621f668d",
+      "options": null,
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_issues.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_issues.sql
@@ -1,0 +1,44 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}}), -- get sprint_id for project_id/sprint_name
+ sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.start_date AS sprint_start_date,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM project_data,
+        gh_sprint
+   WHERE gh_sprint.project_id = project_data.project_id
+     AND {{sprint_name}}), -- calculate total sprint scope (issues tracked) by day
+ SCOPE AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          count(*) AS total_scope
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- calculate issues completed in the sprint by day
+ completed AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          count(*) AS total_completed
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND gh_issue_history.is_closed = 1
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- aggregate scope and completed work by day (both climb toward total scope)
+ totals AS
+  (SELECT scope.day AS DAY,
+          scope.total_scope,
+          completed.total_completed
+   FROM SCOPE,
+        completed
+   WHERE scope.day = completed.day
+   ORDER BY DAY)
+SELECT *
+FROM totals

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_points.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_points.json
@@ -1,0 +1,139 @@
+{
+  "name": "Sprint Burnup by points",
+  "display": "area",
+  "visualization_settings": {
+    "series_settings": {
+      "total_scope": {
+        "color": "#88BF4D",
+        "line.marker_enabled": false
+      },
+      "total_completed": {
+        "color": "#A989C5",
+        "line.marker_enabled": false
+      }
+    },
+    "graph.dimensions": [
+      "day"
+    ],
+    "graph.x_axis.scale": "timeseries",
+    "stackable.stack_type": null,
+    "graph.y_axis.auto_split": false,
+    "column_settings": {
+      "[\"name\",\"day\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_completed",
+      "total_scope"
+    ]
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "9392efee-5590-430c-9031-3aaed414641a",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "cc52d7aa-8456-4f68-88c1-a677621f668d",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "Project",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "default": null,
+      "name": "Sprint Name",
+      "isMultiSelect": true,
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "9392efee-5590-430c-9031-3aaed414641a",
+      "options": null,
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "ghid",
+      "default": null,
+      "name": "Project",
+      "isMultiSelect": true,
+      "type": "string/=",
+      "values_source_type": "static-list",
+      "id": "cc52d7aa-8456-4f68-88c1-a677621f668d",
+      "options": null,
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_points.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Burnup_by_points.sql
@@ -1,0 +1,44 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}}), -- get sprint_id for project_id/sprint_name
+ sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.start_date AS sprint_start_date,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM project_data,
+        gh_sprint
+   WHERE gh_sprint.project_id = project_data.project_id
+     AND {{sprint_name}}), -- calculate total sprint scope (points tracked) by day
+ SCOPE AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          sum(gh_issue_history.points) AS total_scope
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- calculate points completed in the sprint by day
+ completed AS
+  (SELECT gh_issue_history.d_effective AS DAY,
+          sum(gh_issue_history.points) AS total_completed
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND gh_issue_history.is_closed = 1
+     AND (gh_issue_history.d_effective >= sprint_data.sprint_start_date
+          AND gh_issue_history.d_effective <= sprint_data.sprint_end_date)
+   GROUP BY DAY
+   ORDER BY DAY), -- aggregate scope and completed work by day (both climb toward total scope)
+ totals AS
+  (SELECT scope.day AS DAY,
+          scope.total_scope,
+          completed.total_completed
+   FROM SCOPE,
+        completed
+   WHERE scope.day = completed.day
+   ORDER BY DAY)
+SELECT *
+FROM totals

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Days_Left_in_Sprint.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Days_Left_in_Sprint.json
@@ -1,0 +1,115 @@
+{
+  "name": "Sprint Days Left in Sprint",
+  "display": "scalar",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "day"
+    ],
+    "table.cell_column": "total_closed",
+    "table.pivot_column": "total_opened",
+    "series_settings": {
+      "total_remaining": {
+        "color": "#509EE3"
+      }
+    },
+    "scalar.field": "days_remaining",
+    "column_settings": {
+      "[\"name\",\"days_remaining\"]": {
+        "decimals": 0
+      }
+    },
+    "graph.metrics": [
+      "total_remaining"
+    ]
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "GitHub Project #",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint Name",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "ghid",
+      "values_query_type": "list",
+      "name": "GitHub Project #",
+      "type": "string/=",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Days_Left_in_Sprint.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Days_Left_in_Sprint.sql
@@ -1,0 +1,14 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}})
+SELECT CASE
+           WHEN gh_sprint.end_date - CURRENT_DATE < 0 THEN 0
+           WHEN gh_sprint.end_date - CURRENT_DATE > 14 THEN 14
+           ELSE gh_sprint.end_date - CURRENT_DATE
+       END AS days_remaining
+FROM project_data,
+     gh_sprint
+WHERE {{sprint_name}}
+  AND gh_sprint.project_id = project_data.project_id

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_End_Date.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_End_Date.json
@@ -1,0 +1,115 @@
+{
+  "name": "Sprint End Date ",
+  "display": "scalar",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "day"
+    ],
+    "table.cell_column": "total_closed",
+    "table.pivot_column": "total_opened",
+    "series_settings": {
+      "total_remaining": {
+        "color": "#509EE3"
+      }
+    },
+    "scalar.field": "days_remaining",
+    "column_settings": {
+      "[\"name\",\"end_date\"]": {
+        "date_abbreviate": true
+      }
+    },
+    "graph.metrics": [
+      "total_remaining"
+    ]
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "GitHub Project #",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint Name",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "ghid",
+      "values_query_type": "list",
+      "name": "GitHub Project #",
+      "type": "string/=",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_End_Date.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_End_Date.sql
@@ -1,0 +1,10 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}})
+SELECT gh_sprint.end_date-1 AS end_date
+FROM project_data,
+     gh_sprint
+WHERE {{sprint_name}}
+  AND gh_sprint.project_id = project_data.project_id

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_All.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_All.json
@@ -1,0 +1,163 @@
+{
+  "name": "Sprint Issues All",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "type",
+    "table.cell_column": "ghid",
+    "table.columns": [
+      {
+        "name": "issue_url",
+        "enabled": true
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "points",
+        "enabled": true
+      },
+      {
+        "name": "pointed",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      },
+      {
+        "name": "issue_id",
+        "enabled": false
+      },
+      {
+        "name": "issue_title",
+        "enabled": false
+      },
+      {
+        "name": "issue_ghid",
+        "enabled": false
+      },
+      {
+        "name": "sprint_end_date",
+        "enabled": false
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"issue_url\"]": {
+        "column_title": "Link ",
+        "view_as": "link",
+        "link_text": "{{issue_title}}",
+        "link_url": "{{issue_url}}"
+      },
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      },
+      "[\"name\",\"points\"]": {
+        "column_title": "Points"
+      },
+      "[\"name\",\"pointed\"]": {
+        "column_title": "Pointed"
+      }
+    }
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "project_ghid": {
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "project_ghid",
+      "id": "736607dc-8c29-46b5-aa60-b6e1acb1955e",
+      "display-name": "Project",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "id": "736607dc-8c29-46b5-aa60-b6e1acb1955e",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "project_ghid"
+        ]
+      ],
+      "name": "Project",
+      "slug": "project_ghid",
+      "required": true,
+      "values_source_type": "static-list",
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_All.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_All.sql
@@ -1,0 +1,51 @@
+WITH -- get sprint_id
+sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.project_id,
+          gh_sprint.name AS sprint_name,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM gh_sprint
+   INNER JOIN gh_project ON gh_project.id = gh_sprint.project_id
+   WHERE {{sprint_name}}
+     AND {{project_ghid}}), -- get each issue_id in sprint
+issue_id_list AS
+  (SELECT DISTINCT issue_id AS issue_id,
+                   s.sprint_end_date
+   FROM gh_issue_sprint_map m
+   INNER JOIN sprint_data s ON s.sprint_id = m.sprint_id), -- get metadata for each issue
+issue_data AS
+  (SELECT i.id AS issue_id,
+          i.title AS issue_title,
+          i.ghid AS issue_ghid,
+          issue_id_list.sprint_end_date
+   FROM gh_issue i
+   INNER JOIN issue_id_list ON issue_id_list.issue_id = i.id
+   ORDER BY issue_title), -- get partition of issue history
+history_partition AS
+  (SELECT *
+   FROM gh_issue_history h
+   INNER JOIN gh_project ON gh_project.id = h.project_id
+   WHERE {{project_ghid}}), -- get state of issue at end of sprint
+issue_state AS
+  (SELECT h.d_effective,
+          h.issue_id,
+          i.issue_title,
+          i.issue_ghid,
+          concat('https://github.com/', i.issue_ghid) AS issue_url,
+          h.status,
+          h.points,
+          i.sprint_end_date,
+          CASE
+              WHEN h.points > 0 THEN '√'
+              ELSE NULL
+          END AS pointed
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE (i.sprint_end_date < CURRENT_DATE
+          AND h.d_effective = i.sprint_end_date)
+     OR (i.sprint_end_date >= CURRENT_DATE
+         AND h.d_effective = CURRENT_DATE - 1)
+   ORDER BY h.issue_id)
+SELECT *
+FROM issue_state
+ORDER BY issue_title

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Done.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Done.json
@@ -1,0 +1,175 @@
+{
+  "name": "Sprint Issues Done",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "type",
+    "table.cell_column": "ghid",
+    "table.columns": [
+      {
+        "name": "issue_id",
+        "enabled": false
+      },
+      {
+        "name": "issue_title",
+        "enabled": true
+      },
+      {
+        "name": "pointed",
+        "enabled": true
+      },
+      {
+        "name": "lead_time_days",
+        "enabled": true
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": true
+      },
+      {
+        "name": "issue_ghid",
+        "enabled": false
+      },
+      {
+        "name": "issue_url",
+        "enabled": false
+      },
+      {
+        "name": "points",
+        "enabled": false
+      },
+      {
+        "name": "in_progress_date",
+        "enabled": false
+      },
+      {
+        "name": "done_date",
+        "enabled": false
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"issue_title\"]": {
+        "column_title": "Link",
+        "view_as": "link",
+        "link_text": "{{issue_title}}",
+        "link_url": "{{issue_url}}"
+      },
+      "[\"name\",\"pointed\"]": {
+        "column_title": "Pointed",
+        "view_as": "auto"
+      },
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      },
+      "[\"name\",\"d_effective\"]": {
+        "column_title": "Effective Date"
+      },
+      "[\"name\",\"lead_time_days\"]": {
+        "column_title": "Lead Time"
+      }
+    }
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "project_ghid": {
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "project_ghid",
+      "id": "736607dc-8c29-46b5-aa60-b6e1acb1955e",
+      "display-name": "Project",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "id": "736607dc-8c29-46b5-aa60-b6e1acb1955e",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "project_ghid"
+        ]
+      ],
+      "name": "Project",
+      "slug": "project_ghid",
+      "required": true,
+      "values_source_type": "static-list",
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Done.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Done.sql
@@ -1,0 +1,93 @@
+WITH -- get sprint_id
+sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.project_id,
+          gh_sprint.name AS sprint_name,
+          gh_sprint.start_date AS sprint_start_date,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM gh_sprint
+   INNER JOIN gh_project ON gh_project.id = gh_sprint.project_id
+   WHERE {{sprint_name}}
+     AND {{project_ghid}}), -- get each issue_id in sprint
+issue_id_list AS
+  (SELECT DISTINCT issue_id AS issue_id,
+                   s.sprint_start_date,
+                   s.sprint_end_date
+   FROM gh_issue_sprint_map m
+   INNER JOIN sprint_data s ON s.sprint_id = m.sprint_id), -- get metadata for each issue
+issue_data AS
+  (SELECT i.id AS issue_id,
+          i.title AS issue_title,
+          i.ghid AS issue_ghid,
+          issue_id_list.sprint_start_date,
+          issue_id_list.sprint_end_date
+   FROM gh_issue i
+   INNER JOIN issue_id_list ON issue_id_list.issue_id = i.id
+   ORDER BY issue_title), -- get partition of issue history
+history_partition AS
+  (SELECT *
+   FROM gh_issue_history h
+   INNER JOIN gh_project ON gh_project.id = h.project_id
+   WHERE {{project_ghid}}), -- get state of issue at end of sprint to identify DONE issues
+issue_state AS
+  (SELECT h.d_effective,
+          h.issue_id,
+          i.issue_title,
+          i.issue_ghid,
+          concat('https://github.com/', i.issue_ghid) AS issue_url,
+          h.status,
+          h.points,
+          i.sprint_start_date,
+          i.sprint_end_date,
+          CASE
+              WHEN h.points > 0 THEN '√'
+              ELSE NULL
+          END AS pointed
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE (i.sprint_end_date < CURRENT_DATE
+          AND h.d_effective = i.sprint_end_date)
+     OR (i.sprint_end_date >= CURRENT_DATE
+         AND h.d_effective = CURRENT_DATE - 1)
+   ORDER BY h.issue_id), -- get first occurrence of "In Progress" status for each issue
+in_progress_dates AS
+  (SELECT h.issue_id,
+          MIN(h.d_effective) AS in_progress_date
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE h.status = 'In Progress'
+   GROUP BY h.issue_id), -- get first occurrence of "Done" status for each issue
+done_dates AS
+  (SELECT h.issue_id,
+          MIN(h.d_effective) AS done_date
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE h.status = 'Done'
+   GROUP BY h.issue_id), -- calculate lead time for all DONE issues
+lead_time_calculation AS
+  (SELECT i.issue_id,
+          i.issue_title,
+          i.issue_ghid,
+          i.issue_url,
+          i.points,
+          i.pointed,
+          i.status,
+          i.d_effective,
+          ipd.in_progress_date,
+          dd.done_date,
+          CASE
+              WHEN ipd.in_progress_date IS NOT NULL
+                   AND dd.done_date IS NOT NULL
+                   AND dd.done_date >= ipd.in_progress_date THEN GREATEST(1, dd.done_date - ipd.in_progress_date)
+              WHEN dd.done_date IS NOT NULL THEN 1
+              ELSE 1
+          END AS lead_time_days
+   FROM issue_state i
+   LEFT JOIN in_progress_dates ipd ON i.issue_id = ipd.issue_id
+   LEFT JOIN done_dates dd ON i.issue_id = dd.issue_id
+   WHERE i.status = 'Done'
+     AND (dd.done_date IS NULL
+          OR dd.done_date >= i.sprint_start_date))
+SELECT *
+FROM lead_time_calculation
+ORDER BY issue_title

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Lead_Time_Avg.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Lead_Time_Avg.json
@@ -1,0 +1,119 @@
+{
+  "name": "Sprint Issues Lead Time Avg",
+  "display": "scalar",
+  "visualization_settings": {
+    "column_settings": {
+      "[\"name\",\"average_lead_time_days\"]": {
+        "suffix": " days"
+      }
+    }
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/contains",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "eec84556-0c51-4204-a5d9-6b309de3e68f",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": {
+        "case-sensitive": false
+      },
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "project_ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "project_ghid",
+      "type": "dimension",
+      "id": "d392fb0d-3031-46b8-910b-68acfd68a5e9",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "Project",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "values_query_type": "list",
+      "name": "Sprint Name",
+      "type": "string/contains",
+      "values_source_type": "card",
+      "id": "eec84556-0c51-4204-a5d9-6b309de3e68f",
+      "options": {
+        "case-sensitive": false
+      },
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "project_ghid",
+      "name": "Project",
+      "type": "string/=",
+      "values_source_type": "static-list",
+      "id": "d392fb0d-3031-46b8-910b-68acfd68a5e9",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "project_ghid"
+        ]
+      ],
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Lead_Time_Avg.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Lead_Time_Avg.sql
@@ -1,0 +1,83 @@
+WITH -- get sprint_id
+sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.project_id,
+          gh_sprint.name AS sprint_name,
+          gh_sprint.start_date AS sprint_start_date,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM gh_sprint
+   INNER JOIN gh_project ON gh_project.id = gh_sprint.project_id
+   WHERE {{sprint_name}}
+     AND {{project_ghid}}), -- get each issue_id in sprint
+issue_id_list AS
+  (SELECT DISTINCT issue_id AS issue_id,
+                   s.sprint_start_date,
+                   s.sprint_end_date
+   FROM gh_issue_sprint_map m
+   INNER JOIN sprint_data s ON s.sprint_id = m.sprint_id), -- get metadata for each issue
+issue_data AS
+  (SELECT i.id AS issue_id,
+          i.title AS issue_title,
+          i.ghid AS issue_ghid,
+          issue_id_list.sprint_start_date,
+          issue_id_list.sprint_end_date
+   FROM gh_issue i
+   INNER JOIN issue_id_list ON issue_id_list.issue_id = i.id
+   ORDER BY issue_title), -- get partition of issue history
+history_partition AS
+  (SELECT *
+   FROM gh_issue_history h
+   INNER JOIN gh_project ON gh_project.id = h.project_id
+   WHERE {{project_ghid}}), -- get state of issue at end of sprint to identify DONE issues
+issue_state AS
+  (SELECT h.d_effective,
+          h.issue_id,
+          i.issue_title,
+          i.issue_ghid,
+          h.status,
+          h.points,
+          i.sprint_start_date,
+          i.sprint_end_date
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE (i.sprint_end_date < CURRENT_DATE
+          AND h.d_effective = i.sprint_end_date)
+     OR (i.sprint_end_date >= CURRENT_DATE
+         AND h.d_effective = CURRENT_DATE - 1)
+   ORDER BY h.issue_id), -- get first occurrence of "In Progress" status for each issue
+in_progress_dates AS
+  (SELECT h.issue_id,
+          MIN(h.d_effective) AS in_progress_date
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE h.status = 'In Progress'
+   GROUP BY h.issue_id), -- get first occurrence of "Done" status for each issue
+done_dates AS
+  (SELECT h.issue_id,
+          MIN(h.d_effective) AS done_date
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE h.status = 'Done'
+   GROUP BY h.issue_id), -- calculate lead time for all DONE issues, with minimum lead time of 1 day
+all_lead_times AS
+  (SELECT i.issue_id,
+          CASE
+              WHEN ipd.in_progress_date IS NOT NULL
+                   AND dd.done_date IS NOT NULL
+                   AND dd.done_date >= ipd.in_progress_date THEN GREATEST(1, dd.done_date - ipd.in_progress_date)
+              WHEN dd.done_date IS NOT NULL THEN 1
+              ELSE 1
+          END AS lead_time_days
+   FROM issue_state i
+   LEFT JOIN in_progress_dates ipd ON i.issue_id = ipd.issue_id
+   LEFT JOIN done_dates dd ON i.issue_id = dd.issue_id
+   WHERE i.status = 'Done'
+     AND (dd.done_date IS NULL
+          OR dd.done_date >= i.sprint_start_date)), -- calculate average lead time
+average_lead_time AS
+  (SELECT AVG(lead_time_days) AS avg_lead_time_days,
+          COUNT(*) AS issues_with_lead_time
+   FROM all_lead_times)
+SELECT ROUND(avg_lead_time_days, 1) AS average_lead_time_days,
+       issues_with_lead_time
+FROM average_lead_time

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Open.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Open.json
@@ -1,0 +1,167 @@
+{
+  "name": "Sprint Issues Open",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "type",
+    "table.cell_column": "ghid",
+    "table.columns": [
+      {
+        "name": "issue_url",
+        "enabled": true
+      },
+      {
+        "name": "status",
+        "enabled": true
+      },
+      {
+        "name": "points",
+        "enabled": true
+      },
+      {
+        "name": "pointed",
+        "enabled": true
+      },
+      {
+        "name": "d_effective",
+        "enabled": false
+      },
+      {
+        "name": "issue_id",
+        "enabled": false
+      },
+      {
+        "name": "issue_title",
+        "enabled": false
+      },
+      {
+        "name": "issue_ghid",
+        "enabled": false
+      },
+      {
+        "name": "sprint_end_date",
+        "enabled": false
+      },
+      {
+        "name": "sprint_start_date",
+        "enabled": false
+      }
+    ],
+    "column_settings": {
+      "[\"name\",\"issue_url\"]": {
+        "column_title": "Link ",
+        "view_as": "link",
+        "link_text": "{{issue_title}}",
+        "link_url": "{{issue_url}}"
+      },
+      "[\"name\",\"status\"]": {
+        "column_title": "Status"
+      },
+      "[\"name\",\"points\"]": {
+        "column_title": "Points"
+      },
+      "[\"name\",\"pointed\"]": {
+        "column_title": "Pointed"
+      }
+    }
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "project_ghid": {
+      "widget-type": "string/=",
+      "type": "dimension",
+      "name": "project_ghid",
+      "id": "736607dc-8c29-46b5-aa60-b6e1acb1955e",
+      "display-name": "Project",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "id": "736607dc-8c29-46b5-aa60-b6e1acb1955e",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "project_ghid"
+        ]
+      ],
+      "name": "Project",
+      "slug": "project_ghid",
+      "required": true,
+      "values_source_type": "static-list",
+      "values_source_config": {
+        "values": [
+          [
+            "17",
+            "Product & Delivery"
+          ],
+          [
+            "13",
+            "Simpler.Grants.gov"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Open.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Open.sql
@@ -1,0 +1,69 @@
+WITH -- get sprint_id
+sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.project_id,
+          gh_sprint.name AS sprint_name,
+          gh_sprint.start_date AS sprint_start_date,
+          gh_sprint.end_date-1 AS sprint_end_date
+   FROM gh_sprint
+   INNER JOIN gh_project ON gh_project.id = gh_sprint.project_id
+   WHERE {{sprint_name}}
+     AND {{project_ghid}}), -- get sprint mapping as of sprint end date
+sprint_mapping_at_end AS
+  (SELECT m.issue_id,
+          m.sprint_id,
+          m.d_effective,
+          ROW_NUMBER() OVER (PARTITION BY m.issue_id
+                             ORDER BY m.d_effective DESC) AS rn
+   FROM gh_issue_sprint_map m
+   CROSS JOIN sprint_data s
+   WHERE m.d_effective <= CASE
+                              WHEN s.sprint_end_date < CURRENT_DATE THEN s.sprint_end_date
+                              ELSE CURRENT_DATE - 1
+                          END), -- get each issue_id in sprint (only if mapped to this sprint on sprint end date)
+issue_id_list AS
+  (SELECT DISTINCT sm.issue_id AS issue_id,
+                   s.sprint_start_date,
+                   s.sprint_end_date
+   FROM sprint_mapping_at_end sm
+   INNER JOIN sprint_data s ON s.sprint_id = sm.sprint_id
+   WHERE sm.rn = 1), -- get metadata for each issue
+issue_data AS
+  (SELECT i.id AS issue_id,
+          i.title AS issue_title,
+          i.ghid AS issue_ghid,
+          issue_id_list.sprint_start_date,
+          issue_id_list.sprint_end_date
+   FROM gh_issue i
+   INNER JOIN issue_id_list ON issue_id_list.issue_id = i.id
+   ORDER BY issue_title), -- get partition of issue history
+history_partition AS
+  (SELECT *
+   FROM gh_issue_history h
+   INNER JOIN gh_project ON gh_project.id = h.project_id
+   WHERE {{project_ghid}}), -- get state of issue at end of sprint
+issue_state AS
+  (SELECT h.d_effective,
+          h.issue_id,
+          i.issue_title,
+          i.issue_ghid,
+          concat('https://github.com/', i.issue_ghid) AS issue_url,
+          h.status,
+          h.points,
+          i.sprint_start_date,
+          i.sprint_end_date,
+          CASE
+              WHEN h.points > 0 THEN '√'
+              ELSE NULL
+          END AS pointed
+   FROM history_partition h
+   INNER JOIN issue_data i ON i.issue_id = h.issue_id
+   WHERE (i.sprint_end_date < CURRENT_DATE
+          AND h.d_effective = i.sprint_end_date)
+     OR (i.sprint_end_date >= CURRENT_DATE
+         AND h.d_effective = CURRENT_DATE - 1)
+   ORDER BY h.issue_id)
+SELECT *
+FROM issue_state
+WHERE status != 'Done'
+ORDER BY issue_title

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Pointed.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Pointed.json
@@ -1,0 +1,133 @@
+{
+  "name": "Sprint Issues Pointed",
+  "display": "scalar",
+  "visualization_settings": {
+    "table.pivot_column": "type",
+    "table.cell_column": "ghid",
+    "table.columns": [
+      {
+        "name": "title",
+        "enabled": true
+      },
+      {
+        "name": "points",
+        "enabled": true
+      },
+      {
+        "name": "pointed_total",
+        "enabled": true
+      },
+      {
+        "name": "unpointed_total",
+        "enabled": true
+      },
+      {
+        "name": "issue_count",
+        "enabled": true
+      },
+      {
+        "name": "percent_pointed",
+        "enabled": true
+      },
+      {
+        "name": "percent_unpointed",
+        "enabled": true
+      }
+    ],
+    "scalar.field": "percent_pointed",
+    "column_settings": {
+      "[\"name\",\"percent_pointed\"]": {
+        "suffix": "%"
+      }
+    }
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "cb376770-017b-4121-917e-ba8eb7e5fb1b",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "GitHub Project #",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint Name",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "c98bb509-537c-4795-a011-6c6aca4563f8",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "id": "cb376770-017b-4121-917e-ba8eb7e5fb1b",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "name": "GitHub Project #",
+      "slug": "ghid",
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Pointed.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Issues_Pointed.sql
@@ -1,0 +1,50 @@
+WITH data_availability AS {{#restore:Data_Availability_Newest}}, -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}}), -- get sprint_id
+ sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.start_date,
+          gh_sprint.end_date-1 AS end_date
+   FROM project_data,
+        gh_sprint
+   WHERE gh_sprint.project_id = project_data.project_id
+     AND {{sprint_name}}), -- get list of issue_ids in sprint
+ issue_id_list AS
+  (SELECT DISTINCT (issue_id)
+   FROM app.gh_issue_sprint_map AS ism,
+        sprint_data
+   WHERE ism.sprint_id = sprint_data.sprint_id), -- get state of each issue on last day of sprint
+ issue_state AS
+  (SELECT h.issue_id,
+          h.points,
+          CASE
+              WHEN h.points > 0 THEN TRUE
+              ELSE FALSE
+          END AS has_points
+   FROM app.gh_issue_history AS h,
+        sprint_data,
+        data_availability
+   WHERE h.sprint_id = sprint_data.sprint_id
+     AND ((-- use last day of sprint as effective date IF it is in the past...
+ h.d_effective = sprint_data.end_date
+           AND sprint_data.end_date < CURRENT_DATE)
+          OR (-- ...otherwise use yesterday
+ h.d_effective = data_availability.maximum_date
+              AND sprint_data.end_date >= CURRENT_DATE))), -- get pointed count
+ pointed AS
+  (SELECT count(*) AS total
+   FROM issue_state AS i
+   WHERE i.has_points = TRUE), -- get unpointed count
+ unpointed AS
+  (SELECT count(*) AS total
+   FROM issue_state AS i
+   WHERE i.has_points = FALSE)
+SELECT pointed.total AS pointed_total,
+       unpointed.total AS unpointed_total,
+       pointed.total + unpointed.total AS issue_count,
+       pointed.total * 100 / (pointed.total + unpointed.total) AS percent_pointed,
+       unpointed.total * 100 / (pointed.total + unpointed.total) AS percent_unpointed
+FROM pointed,
+     unpointed

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Name.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Name.json
@@ -1,0 +1,56 @@
+{
+  "name": "Sprint Name",
+  "display": "scalar",
+  "visualization_settings": {},
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "cf4981ac-f15b-4f83-8154-8dbe8b44696a",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint Name",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "cf4981ac-f15b-4f83-8154-8dbe8b44696a",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Name.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Name.sql
@@ -1,0 +1,4 @@
+SELECT name
+FROM gh_sprint
+WHERE {{sprint_name}}
+LIMIT 1

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Start_Date.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Start_Date.json
@@ -1,0 +1,116 @@
+{
+  "name": "Sprint Start Date",
+  "display": "scalar",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "day"
+    ],
+    "table.cell_column": "total_closed",
+    "table.pivot_column": "total_opened",
+    "series_settings": {
+      "total_remaining": {
+        "color": "#509EE3"
+      }
+    },
+    "scalar.field": "days_remaining",
+    "column_settings": {
+      "[\"name\",\"start_date\"]": {
+        "date_abbreviate": true,
+        "date_style": "M/D/YYYY"
+      }
+    },
+    "graph.metrics": [
+      "total_remaining"
+    ]
+  },
+  "template_tags": {
+    "sprint_name": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "sprint_name",
+      "type": "dimension",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "dimension": [
+        "field",
+        318,
+        {
+          "base-type": "type/Text",
+          "effective-type": "type/Text"
+        }
+      ],
+      "display-name": "Sprint Name",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "name"
+      }
+    },
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "GitHub Project #",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "slug": "sprint_name",
+      "name": "Sprint Name",
+      "type": "string/=",
+      "values_source_type": "card",
+      "id": "3a63ce6a-96bf-417a-b165-f81ee11dd13e",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "sprint_name"
+        ]
+      ],
+      "values_source_config": {
+        "card_id": 152,
+        "value_field": [
+          "field",
+          "sprint_name",
+          {
+            "base-type": "type/Text"
+          }
+        ]
+      },
+      "required": true
+    },
+    {
+      "slug": "ghid",
+      "values_query_type": "list",
+      "name": "GitHub Project #",
+      "type": "string/=",
+      "id": "a1ceb784-2804-456b-96cd-1d6b81f79b81",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Start_Date.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Start_Date.sql
@@ -1,0 +1,10 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}})
+SELECT gh_sprint.start_date
+FROM project_data,
+     gh_sprint
+WHERE {{sprint_name}}
+  AND gh_sprint.project_id = project_data.project_id

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Velocity_Trend.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Velocity_Trend.json
@@ -1,0 +1,56 @@
+{
+  "name": "Sprint Velocity Trend",
+  "display": "bar",
+  "visualization_settings": {
+    "graph.dimensions": [
+      "sprint_name"
+    ],
+    "graph.series_order_dimension": null,
+    "graph.series_order": null,
+    "graph.show_values": true,
+    "graph.metrics": [
+      "points_closed"
+    ]
+  },
+  "template_tags": {
+    "ghid": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "ghid",
+      "type": "dimension",
+      "id": "8ce0585b-db90-4a39-ba35-b9d07c56727b",
+      "dimension": [
+        "field",
+        302,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "GitHub Project #",
+      "options": null,
+      "required": true,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_project",
+        "column": "ghid"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "8ce0585b-db90-4a39-ba35-b9d07c56727b",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "ghid"
+        ]
+      ],
+      "name": "GitHub Project #",
+      "slug": "ghid",
+      "required": true
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Velocity_Trend.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprint_Velocity_Trend.sql
@@ -1,0 +1,43 @@
+WITH -- get project_id
+ project_data AS
+  (SELECT gh_project.id AS project_id
+   FROM gh_project
+   WHERE {{ghid}}), -- get sprint_id for past N sprints
+ sprint_data AS
+  (SELECT gh_sprint.id AS sprint_id,
+          gh_sprint.name AS sprint_name,
+          gh_sprint.end_date-1 AS sprint_last_day
+   FROM project_data,
+        gh_sprint
+   WHERE gh_sprint.project_id = project_data.project_id
+     AND gh_sprint.start_date <= CURRENT_DATE
+   ORDER BY gh_sprint.start_date DESC
+   LIMIT 5), -- get last day of each sprint
+ sprint_end AS
+  (SELECT max(gh_issue_history.d_effective) AS sprint_last_day,
+          sprint_data.sprint_name,
+          sprint_data.sprint_id
+   FROM gh_issue_history,
+        sprint_data
+   WHERE gh_issue_history.sprint_id = sprint_data.sprint_id
+     AND gh_issue_history.d_effective <= sprint_data.sprint_last_day
+   GROUP BY sprint_data.sprint_id,
+            sprint_data.sprint_name
+   ORDER BY sprint_data.sprint_id,
+            sprint_data.sprint_name), -- get total closed points as of the last day of the sprint
+ velocity_per_sprint AS
+  (SELECT sprint_end.sprint_id,
+          sprint_end.sprint_name,
+          sum(gh_issue_history.points) AS points_closed,
+          sprint_end.sprint_last_day
+   FROM gh_issue_history,
+        sprint_end
+   WHERE gh_issue_history.sprint_id = sprint_end.sprint_id
+     AND gh_issue_history.d_effective = sprint_end.sprint_last_day
+     AND gh_issue_history.is_closed = 1
+   GROUP BY sprint_end.sprint_id,
+            sprint_end.sprint_name,
+            sprint_end.sprint_last_day
+   ORDER BY sprint_end.sprint_name)
+SELECT *
+FROM velocity_per_sprint

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprints_with_SCD_data.json
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprints_with_SCD_data.json
@@ -1,0 +1,47 @@
+{
+  "name": "Sprints with SCD data",
+  "display": "table",
+  "visualization_settings": {
+    "table.pivot_column": "sprint_name",
+    "table.cell_column": "sprint_id"
+  },
+  "template_tags": {
+    "project_id": {
+      "widget-type": "string/=",
+      "default": null,
+      "name": "project_id",
+      "type": "dimension",
+      "id": "a9d1c5a2-f1e2-46c3-b46c-3a3cfc3f949b",
+      "dimension": [
+        "field",
+        314,
+        {
+          "base-type": "type/Integer",
+          "effective-type": "type/Integer"
+        }
+      ],
+      "display-name": "Project ID",
+      "options": null,
+      "field_ref": {
+        "schema": "app",
+        "table": "gh_sprint",
+        "column": "project_id"
+      }
+    }
+  },
+  "parameters": [
+    {
+      "id": "a9d1c5a2-f1e2-46c3-b46c-3a3cfc3f949b",
+      "type": "string/=",
+      "target": [
+        "dimension",
+        [
+          "template-tag",
+          "project_id"
+        ]
+      ],
+      "name": "Project ID",
+      "slug": "project_id"
+    }
+  ]
+}

--- a/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprints_with_SCD_data.sql
+++ b/analytics/metabase-backup-v2/level_1/Sprint_Metrics/Sprints_with_SCD_data.sql
@@ -1,0 +1,17 @@
+WITH project_data AS {{#restore:Project_Data}},
+     oldest_data AS {{#restore:Data_Availability_Oldest}},
+     newest_data AS {{#restore:Data_Availability_Newest}},
+     sprint_data AS
+  (SELECT gh_sprint.name AS sprint_name,
+          gh_sprint.start_date,
+          gh_sprint.id AS sprint_id
+   FROM gh_sprint,
+        oldest_data,
+        newest_data
+   WHERE {{project_id}}
+     AND gh_sprint.start_date >= oldest_data.minimum_date
+     AND gh_sprint.start_date <= newest_data.maximum_date
+   ORDER BY sprint_name DESC)
+SELECT *
+FROM sprint_data
+LIMIT 16


### PR DESCRIPTION
## Summary

Work for HHS/simpler-grants-protocol#1099

Stacked on #12034 -- base this PR against that branch, not `main`.

## Changes proposed

- `metabase-backup-v2/`: a full backup of the production instance's questions and dashboards, captured with the `backup-v2` tooling added in #12034. Mirrors how the existing `sql/` backup directory is already tracked in source control.

## Context for reviewers

Split out of #12034 to keep that PR reviewable as just the functionality -- 183 files of captured question/dashboard content made the diff unwieldy on top of the actual code changes. This PR is close to a pure data diff: every `.sql`/`.json` file here was produced by `make mb-backup-v2` against the production Metabase instance, not hand-authored.

## Validation steps

- `make mb-backup-v2` completed without errors: 88 questions captured (with sidecar metadata and `field_ref` cross-instance data for every `dimension`-type filter), 8 correctly skipped (GUI-built, non-SQL questions), 4 dashboards captured, 2 correctly skipped (they reference the excluded non-SQL cards).
- Content verified restorable: `make mb-restore --restore-dir metabase-backup-v2` against a separate Dev Metabase instance created every question and dashboard successfully in a new collection.
