### PR TITLE
[unticketed] Add file size bytes to logs in stream endpoint

### DIFF
--- a/api/src/services/files/stream_file_scan_results.py
+++ b/api/src/services/files/stream_file_scan_results.py
@@ -256,6 +256,10 @@ def stream_file_scan_results(
                         "user_id": user_id,
                         "file_scan_status": status,
                         "stream_duration_seconds": elapsed,
+                        # infected files will log file_size_bytes of null
+                        "file_size_bytes": (
+                            file_metadata.file_size_bytes if file_metadata else None
+                        ),
                     },
                 )
                 return


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #unticketed 

## Changes proposed

This pr adds the file size in bytes to the logs in the file stream endpoint

## Context for reviewers

This additional log data will provide insights into relations between file size and file scanning duration

## Validation steps

- Run the api locally
- Send request through the api or run the frontend to upload a file
- Verify that the following logs appear locally
`grants-api  | 16:23:56.392  src.services.files.stream_file_scan_results generate                     INFO     File scan results stream reached terminal status
...
file_scan_status=complete stream_duration_seconds=3.564735 file_size_bytes=62631 app.name=src.app app_name=api app_domain=simpler-grants run_mode=service environment=local
...`
