### PR TITLE
[Issue #11884] Temporarily removing SF-424 Short

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/page.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/competition/page.tsx
@@ -23,6 +23,10 @@ type PageProps = {
 
 export const dynamic = "force-dynamic";
 
+// We are temporarily removing the SF-424 Short form, pending implementation of form libraries
+// If any other forms need to be blocked, add them to this array
+const blockedForms = ["cf355a4d-d840-43fd-a78f-729edf41ab4c"];
+
 const ButtonSaveAndExit = () => {
   const t = useTranslations("OpportunityCompetition");
   return (
@@ -41,6 +45,9 @@ const ButtonSaveAndExit = () => {
 async function OpportunityCompetitionPage({ params }: PageProps) {
   const { id, locale } = await params;
   const forms = await getForms();
+  forms.data = forms.data.filter((form) => {
+    return !blockedForms.includes(form.form_id);
+  });
   const t = await getTranslations({
     locale,
     namespace: "OpportunityCompetition",


### PR DESCRIPTION
## Summary

Fixes #11884

## Changes proposed

Adds a list of Blocked Forms, which currently only includes SF-424 Short. Removes those forms from the list of forms before it is passed into child components

## Context for reviewers

This is a _temporary_ change pending the addition of form libraries.

## Validation steps

Open the Add Forms modal, and confirm that SF-424 Short is not present. If you click "Select All" and submit, SF-424 Short shouldn't be on the list of added forms.
