### PR TITLE
[No ticket] Fix flaky validation test for the **Expected Number of Awards** field.

### DIFF
--- a/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-summary.spec.ts
@@ -43,7 +43,7 @@ import { assertNegativeNumberValidationsFromDefinitions } from "tests/e2e/utils/
 import { assertRequiredFieldValidationsFromDefinitions } from "tests/e2e/utils/common/required-field-validation-utils";
 import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
 
-const { SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION} = VALID_TAGS;
+const { SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION } = VALID_TAGS;
 
 async function setupAndNavigateToOpportunitySummary(page: Page) {
   const fillData = buildOpportunityHappyPathFillData(new Date());
@@ -104,7 +104,7 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
 
   test(
     "Negative number validation",
-    { tag: [SMOKE,GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
+    { tag: [SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
     async () => {
       //--------------Test setup start here----------------
       const testPage = authenticatedLifecycle.getPage();

--- a/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-summary.spec.ts
+++ b/frontend/tests/e2e/opportunity/specs/failure-path-opportunity-summary.spec.ts
@@ -43,7 +43,7 @@ import { assertNegativeNumberValidationsFromDefinitions } from "tests/e2e/utils/
 import { assertRequiredFieldValidationsFromDefinitions } from "tests/e2e/utils/common/required-field-validation-utils";
 import { createOpportunity } from "tests/e2e/utils/opportunity/create-opportunity-utils";
 
-const { GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION } = VALID_TAGS;
+const { SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION} = VALID_TAGS;
 
 async function setupAndNavigateToOpportunitySummary(page: Page) {
   const fillData = buildOpportunityHappyPathFillData(new Date());
@@ -79,7 +79,7 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
 
   test(
     "Required-field validation",
-    { tag: [GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
+    { tag: [SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
     async () => {
       //--------------Test setup start here----------------
       const testPage = authenticatedLifecycle.getPage();
@@ -104,7 +104,7 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
 
   test(
     "Negative number validation",
-    { tag: [GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
+    { tag: [SMOKE,GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
     async () => {
       //--------------Test setup start here----------------
       const testPage = authenticatedLifecycle.getPage();
@@ -131,7 +131,7 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
 
   test(
     "Email format validation",
-    { tag: [GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
+    { tag: [SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
     async () => {
       //--------------Test setup start here----------------
       const testPage = authenticatedLifecycle.getPage();
@@ -158,7 +158,7 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
 
   test(
     "Cross-field validation",
-    { tag: [GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
+    { tag: [SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
     async () => {
       //--------------Test setup start here----------------
       const testPage = authenticatedLifecycle.getPage();
@@ -184,7 +184,7 @@ test.describe("Grantor Opportunity Summary Failure Path", () => {
 
   test(
     "Character limits validation",
-    { tag: [GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
+    { tag: [SMOKE, GRANTOR, OPPORTUNITY_MANAGEMENT, CORE_REGRESSION] },
     async () => {
       //--------------Test setup start here----------------
       const testPage = authenticatedLifecycle.getPage();

--- a/frontend/tests/e2e/utils/common/negative-number-validation-utils.ts
+++ b/frontend/tests/e2e/utils/common/negative-number-validation-utils.ts
@@ -15,8 +15,8 @@
  */
 
 import { expect, Page } from "@playwright/test";
-
 import { waitForVisibleAndClick } from "tests/e2e/utils/opportunities/interaction-utils";
+
 import { resolveTextLocator } from "./text-locator-utils";
 
 export type NegativeValidationFieldDefinition = {

--- a/frontend/tests/e2e/utils/common/negative-number-validation-utils.ts
+++ b/frontend/tests/e2e/utils/common/negative-number-validation-utils.ts
@@ -16,6 +16,7 @@
 
 import { expect, Page } from "@playwright/test";
 
+import { waitForVisibleAndClick } from "tests/e2e/utils/opportunities/interaction-utils";
 import { resolveTextLocator } from "./text-locator-utils";
 
 export type NegativeValidationFieldDefinition = {
@@ -70,6 +71,7 @@ export async function assertNegativeNumberValidationsFromDefinitions(
 
   for (const fieldDefinition of negativeValidationFields) {
     const field = page.locator(fieldDefinition.selector);
+    await waitForVisibleAndClick(field);
     await field.fill(negativeValue);
     await field.blur();
 

--- a/frontend/tests/e2e/utils/common/text-locator-utils.ts
+++ b/frontend/tests/e2e/utils/common/text-locator-utils.ts
@@ -25,20 +25,28 @@ type ResolvedTextLocator = {
 const toKebabCase = (value: string): string =>
   value.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 
+const toSnakeCase = (value: string): string =>
+  value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/-+/g, "_")
+    .toLowerCase();
+
 /**
  * Reviewer guide (what logic):
  * 1. Resolve by id with camelCase key first.
  * 2. Resolve by id with kebab-case key second.
- * 3. Resolve by nearest alert within context selector when provided.
- * 4. Resolve by page-level locator when enabled.
- * 5. Resolve by broad alert text match as final fallback.
+ * 3. Resolve by id with snake_case key third.
+ * 4. Resolve by nearest alert within context selector when provided.
+ * 5. Resolve by page-level locator when enabled.
+ * 6. Resolve by broad alert text match as final fallback.
  *
  * Fallback order (most specific to broadest):
  * 1) #{idPrefix}-{camelCaseTargetKey}
  * 2) #{idPrefix}-{kebab-case-target-key}
- * 3) nearest [role='alert'] in the same form group (when contextSelector is provided)
- * 4) page-level fallback locator (only when includePageLevelFallback is true)
- * 5) generic [role='alert'] containing expectedContent
+ * 3) #{idPrefix}-{snake_case_target_key}
+ * 4) nearest [role='alert'] in the same form group (when contextSelector is provided)
+ * 5) page-level fallback locator (only when includePageLevelFallback is true)
+ * 6) generic [role='alert'] containing expectedContent
  *
  * Assertion behavior:
  * - useContainsText=false for id/scoped matches (exact text assertions are expected)
@@ -68,6 +76,13 @@ export async function resolveTextLocator(
   );
   if (await kebabCaseIdLocator.count()) {
     return { locator: kebabCaseIdLocator, useContainsText: false };
+  }
+
+  const snakeCaseIdLocator = options.page.locator(
+    `#${selectorIdPrefix}-${toSnakeCase(options.targetKey)}`,
+  );
+  if (await snakeCaseIdLocator.count()) {
+    return { locator: snakeCaseIdLocator, useContainsText: false };
   }
 
   if (options.contextSelector) {

--- a/frontend/tests/e2e/utils/opportunities/interaction-utils.ts
+++ b/frontend/tests/e2e/utils/opportunities/interaction-utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared interaction helpers for Playwright field actions.
+ *
+ * Reviewer guide:
+ * - Wait for the locator to be visible before clicking.
+ * - Click before filling or selecting whenever possible.
+ * - Keep field interactions stable across tests.
+ */
+import { type Locator } from "@playwright/test";
+
+const DEFAULT_WAIT_TIMEOUT = 5000;
+
+/** Waits for a locator to be visible and clicks it. */
+export async function waitForVisibleAndClick(locator: Locator): Promise<void> {
+  await locator.waitFor({ state: "visible", timeout: DEFAULT_WAIT_TIMEOUT });
+  await locator.click();
+}
+
+/** Clicks the locator and fills it with the provided text. */
+export async function clickAndFill(
+  locator: Locator,
+  text: string,
+): Promise<void> {
+  await waitForVisibleAndClick(locator);
+  await locator.fill(text);
+}
+
+/** Clicks a native select locator and chooses the option label. */
+export async function clickAndSelectOption(
+  locator: Locator,
+  optionLabel: string,
+): Promise<void> {
+  await waitForVisibleAndClick(locator);
+  await locator.selectOption({ label: optionLabel });
+}

--- a/frontend/tests/e2e/utils/opportunities/interaction-utils.ts
+++ b/frontend/tests/e2e/utils/opportunities/interaction-utils.ts
@@ -5,6 +5,18 @@
  * - Wait for the locator to be visible before clicking.
  * - Click before filling or selecting whenever possible.
  * - Keep field interactions stable across tests.
+ *
+ * Using waitForVisibleAndClick() increases test reliability by ensuring that
+ * elements are visible and ready before interaction occurs. This helps make
+ * form interactions more deterministic, particularly for:
+ *
+ * - Frontend validation scenarios
+ * - Validation message rendering
+ * - Field state transitions
+ * - Enable/disable gating behavior
+ *
+ * As a result, tests are less susceptible to timing issues and intermittent
+ * failures caused by UI rendering delays or asynchronous state updates.
  */
 import { type Locator } from "@playwright/test";
 


### PR DESCRIPTION
## Summary

**What Happens?** 
It passed sometimes because the fallback search is not deterministic. The real root cause is the mismatch between the helper’s target-key lookup and the form’s snake_case error IDs.
In other words the test was relying on a loose fallback locator, so timing and DOM details made the result flaky.

Why it failed
The failure is caused by a mismatch between the test helper’s lookup key and the form’s DOM field name.

- Metadata uses valueKey: "expectedNumberOfAwards".
- The actual edit form uses the input id/name expected_number_of_awards.
- resolveTextLocator() tries id-based error locators like:
     +error-for-expectedNumberOfAwards
     +error-for-expected-number-of-awards
- Neither matches the real error id if the page renders errors for expected_number_of_awards.
- So the helper falls back to a generic [role='alert'] search and then cannot find the error text.
<img width="947" height="717" alt="image" src="https://github.com/user-attachments/assets/6219078c-e39a-4cdc-a0a9-b63700686914" />

**Why It Appears Intermittent?**

When the strict lookup fails, the helper falls back to a broader locator:
<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #ISSUE 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Applying the locator fallback fix so the resolver can match snake_case error IDs from form fields.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Updated text-locator-utils.ts so the error locator now also checks for snake_case target keys like expected_number_of_awards.

This should allow the negative-number validation helper to resolve the real form error element instead of falling back to the broad alert lookup.

**Note:**
I also updated negative-number-validation-utils.ts to use waitForVisibleAndClick() from interaction-utils.ts for more stable field interactions.

**What this helps**

Using waitForVisibleAndClick() increases test reliability by ensuring that elements are visible and ready before interaction occurs. This helps make form interactions more deterministic, particularly for:

- Frontend validation scenarios
- Validation message rendering
- Field state transitions
- Enable/disable gating behavior

As a result, tests are less susceptible to timing issues and intermittent failures caused by UI rendering delays or asynchronous state updates.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

[E2E Tests (Deployed Target) #1266](https://github.com/HHS/simpler-grants-gov/actions/runs/32386574770)
[E2E Tests (Local Github Target) #13214](https://github.com/HHS/simpler-grants-gov/actions/runs/32386711496)
[E2E Tests (Local Github Target) #13220](https://github.com/HHS/simpler-grants-gov/actions/runs/32394389918)

