### PR TITLE
[Issue #10984] Create daily user table load job

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -273,6 +273,48 @@ locals {
       mem                 = try(local.scheduled_jobs_config[var.environment].mem, null)
       environment_vars    = try(local.scheduled_jobs_config[var.environment].environment_vars, null)
     }
+    load-user-tables = {
+      # The user tables only need daily freshness, so they load here instead of in the
+      # hourly load-transform cycle.
+      #
+      # Load only. Transform, set-current, and store-version are all opportunity steps that
+      # have no bearing on the user tables, and store-version in particular must stay off:
+      # it writes opportunity_version off the opportunity_change_audit queue, and this job
+      # can overlap the hourly cycle (which runs every hour, with the job lock disabled here),
+      # so it would risk versioning opportunities midway through the hourly transform.
+      task_command = [
+        "flask",
+        "data-migration",
+        "load-transform",
+        "--load",
+        "--no-transform",
+        "--no-set-current",
+        "--no-store-version",
+        "-t",
+        "vuser_account",
+        "-t",
+        "tuser_profile"
+      ]
+      # Every day at 3:45am Eastern Time during DST. 2:45am during non-DST.
+      # Minute 45 is the only minute free of the hourly jobs (0, 15, and 30 are all taken),
+      # and hour 7 is free of the daily jobs. Nothing consumes these staging tables yet, so
+      # the slot is chosen purely to stay clear of the rest of the schedule.
+      schedule_expression = "cron(45 7 * * ? *)"
+      state               = local.load-transform-state[var.environment]
+      cpu                 = try(local.scheduled_jobs_config[var.environment].cpu, null)
+      mem                 = try(local.scheduled_jobs_config[var.environment].mem, null)
+      # This job shares the load-transform job type with the hourly job, so the lock is
+      # disabled to keep the two from blocking each other.
+      environment_vars = concat(
+        try(local.scheduled_jobs_config[var.environment].environment_vars, []),
+        [
+          {
+            Name  = "ENABLE_JOB_LOCK"
+            Value = "false"
+          }
+        ]
+      )
+    }
     load-search-opportunity-data = {
       task_command = ["flask", "load-search-data", "load-opportunity-data"]
       # Every hour at the half hour


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10984  

## Changes proposed

- Updated `scheduled_jobs.tf` to add a `load-user-tables` daily scheduled job that loads `vuser_account` and `tuser_profile` from Oracle at 07:45 UTC, with `ENABLE_JOB_LOCK=false` so it does not contend with the hourly `load-transform` job lock.

## Context for reviewers

There are two deliberate deviations from the ticket's acceptance criteria:

1. `--no-store-version` instead of `--store-version`: `StoreOpportunityVersionTask` writes `opportunity_version` off the `opportunity_change_audit` queue. It has nothing to do with the user tables, and it's the final step of a full load → transform → set-current cycle. Running it here, with transform and set-current off and the job lock disabled, would let it snapshot opportunities partway through the hourly transform, which commits per-batch. Those partial versions feed the saved-opportunity change emails.
2. `cron(45 7 * * ? *)` instead of `cron(0 0 * * ? *)`: Nothing consumes these staging tables yet, so "daily freshness" has no deadline and the slot is a choice. Minute 0 is the busiest minute in the schedule (`load-transform` and `load-search-agency-data` both fire there) and `flexible_time_window` is `OFF`, so `0 0` would have guaranteed a nightly overlap with the hourly cycle. Minute 45 is the only minute free of the hourly jobs, hour 7 is free of the daily jobs, and 07:45 UTC lands overnight ET in both DST states. I'm open to changing this if necessary. 

## Validation steps

**AC 3 - verified in dev; blocked in grantee1 by an environment outage.**

Ran the container manually via ECS `Run new task` with the new job's command as a
container override, plus `ENABLE_JOB_LOCK=false`, using the network configuration
copied from each environment's `load-transform` state machine.

dev (task `9cab1650…`, task definition `api-dev:2200`) - Pass:
- No `table load error`.
- `row count` before/after for both tables; e.g. `count.staging.tuser_profile: 12452`.
- `Entering the lock` logged `job_lock_enabled: false` - confirms the container
  environment override works in an environment where the task definition sets
  `ENABLE_JOB_LOCK=true`.
- `Processed records to be updated/inserted/deleted` for both tables.
- `load and transform complete`

grantee1 (task `3ee1fd98…`) - Blocked:
Both tables failed at the first Oracle touch (`log_row_count("before", …)`) with
`ORA-12543: TNS:destination host unreachable`. Pre-existing environment outage,
unrelated to this change - the hourly `load-transform` is failing identically
(task `b89b11c4…` on `topportunity` at 2026-08-21 04:02 UTC, ~11h earlier). RDS in
grantee1 cannot reach the Oracle listener at 10.207.0.0/16; each foreign table
times out after 60s. Raised separately.

**Post-deploy checks:**
1. EventBridge → Scheduler → `api-<env>-load-user-tables`: cron reads
   `cron(45 7 * * ? *)`, timezone `Etc/UTC`, state `ENABLED`.
2. Step Functions → `api-<env>-load-user-tables` → Definition: `Command` is the
   11-element array, and `Environment` is
   `[{"Name": "ENABLE_JOB_LOCK", "Value": "false"}]`.
3. Start that state machine manually and confirm the same five log checks.