### PR TITLE
[SGP #1069] Grant select privs for new materialized views

### DIFF
--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
@@ -1,10 +1,22 @@
 -- GRANT ... ON ALL TABLES IN SCHEMA and ALTER DEFAULT PRIVILEGES ... ON TABLES
 -- (used elsewhere for these roles) do not cover materialized views in
 -- Postgres. Each materialized view needs its own explicit grant.
-GRANT SELECT ON mv_deliverables_per_quad TO metabaseuser;
-GRANT SELECT ON mv_latest_epic_deliverable_map TO metabaseuser;
-GRANT SELECT ON mv_deliverable_daily_burndown TO metabaseuser;
+--
+-- metabaseuser only exists in environments where Metabase's infra has
+-- provisioned it (not local/CI), so each grant is conditional on the role
+-- actually existing.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app') THEN
+    EXECUTE 'GRANT SELECT ON mv_deliverables_per_quad TO app';
+    EXECUTE 'GRANT SELECT ON mv_latest_epic_deliverable_map TO app';
+    EXECUTE 'GRANT SELECT ON mv_deliverable_daily_burndown TO app';
+  END IF;
 
-GRANT SELECT ON mv_deliverables_per_quad TO app;
-GRANT SELECT ON mv_latest_epic_deliverable_map TO app;
-GRANT SELECT ON mv_deliverable_daily_burndown TO app;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'metabaseuser') THEN
+    EXECUTE 'GRANT SELECT ON mv_deliverables_per_quad TO metabaseuser';
+    EXECUTE 'GRANT SELECT ON mv_latest_epic_deliverable_map TO metabaseuser';
+    EXECUTE 'GRANT SELECT ON mv_deliverable_daily_burndown TO metabaseuser';
+  END IF;
+END
+$$;

--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
@@ -1,0 +1,10 @@
+-- GRANT ... ON ALL TABLES IN SCHEMA and ALTER DEFAULT PRIVILEGES ... ON TABLES
+-- (used elsewhere for these roles) do not cover materialized views in
+-- Postgres. Each materialized view needs its own explicit grant.
+GRANT SELECT ON mv_deliverables_per_quad TO metabaseuser;
+GRANT SELECT ON mv_latest_epic_deliverable_map TO metabaseuser;
+GRANT SELECT ON mv_deliverable_daily_burndown TO metabaseuser;
+
+GRANT SELECT ON mv_deliverables_per_quad TO app;
+GRANT SELECT ON mv_latest_epic_deliverable_map TO app;
+GRANT SELECT ON mv_deliverable_daily_burndown TO app;

--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
@@ -1,6 +1,7 @@
--- GRANT ... ON ALL TABLES IN SCHEMA and ALTER DEFAULT PRIVILEGES ... ON TABLES
--- (used elsewhere for these roles) do not cover materialized views in
--- Postgres. Each materialized view needs its own explicit grant.
+-- metabaseuser's Postgres role isn't provisioned by this repo's
+-- infra/modules/database role-manager pipeline (unlike app/migrator), so
+-- nothing in this codebase keeps its grants in sync with schema changes --
+-- newly created objects need an explicit grant here.
 --
 -- metabaseuser only exists in environments where Metabase's infra has
 -- provisioned it (not local/CI), so each grant is conditional on the role

--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
@@ -1,9 +1,11 @@
 -- app already has SELECT on these materialized views via the
--- ALTER DEFAULT PRIVILEGES set up in migration 0001. metabaseuser's
--- Postgres role isn't provisioned by this repo's infra/modules/database
--- role-manager pipeline (unlike app/migrator), so nothing in this codebase
--- keeps its grants in sync with schema changes -- it needs an explicit
--- grant here.
+-- ALTER DEFAULT PRIVILEGES set up in migration 0001, scoped to objects
+-- migrator creates. metabaseuser's existing access to this schema instead
+-- traces back to a one-time GRANT ON ALL TABLES IN SCHEMA, run against
+-- whatever tables existed at the time -- there's no standing default-acl
+-- rule covering objects migrator creates, so nothing keeps metabaseuser's
+-- grants in sync going forward. Every migration that adds a new relation
+-- needs its own explicit grant here until that's fixed at the infra level.
 --
 -- metabaseuser only exists in environments where Metabase's infra has
 -- provisioned it (not local/CI), so the grant is conditional on the role

--- a/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
+++ b/analytics/src/analytics/integrations/etldb/migrations/versions/0016_grant_materialized_view_privileges.sql
@@ -1,19 +1,15 @@
--- metabaseuser's Postgres role isn't provisioned by this repo's
--- infra/modules/database role-manager pipeline (unlike app/migrator), so
--- nothing in this codebase keeps its grants in sync with schema changes --
--- newly created objects need an explicit grant here.
+-- app already has SELECT on these materialized views via the
+-- ALTER DEFAULT PRIVILEGES set up in migration 0001. metabaseuser's
+-- Postgres role isn't provisioned by this repo's infra/modules/database
+-- role-manager pipeline (unlike app/migrator), so nothing in this codebase
+-- keeps its grants in sync with schema changes -- it needs an explicit
+-- grant here.
 --
 -- metabaseuser only exists in environments where Metabase's infra has
--- provisioned it (not local/CI), so each grant is conditional on the role
+-- provisioned it (not local/CI), so the grant is conditional on the role
 -- actually existing.
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app') THEN
-    EXECUTE 'GRANT SELECT ON mv_deliverables_per_quad TO app';
-    EXECUTE 'GRANT SELECT ON mv_latest_epic_deliverable_map TO app';
-    EXECUTE 'GRANT SELECT ON mv_deliverable_daily_burndown TO app';
-  END IF;
-
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'metabaseuser') THEN
     EXECUTE 'GRANT SELECT ON mv_deliverables_per_quad TO metabaseuser';
     EXECUTE 'GRANT SELECT ON mv_latest_epic_deliverable_map TO metabaseuser';


### PR DESCRIPTION
## Summary

Work for: https://github.com/HHS/simpler-grants-protocol/issues/1069.

## Changes proposed

Adds migration `0016_grant_materialized_view_privileges.sql` to grant
privs for the new materialized views which were added in previous PR https://github.com/HHS/simpler-grants-gov/pull/11819.

The standard mechanisms used to grant privs to new objects (e.g. `ALTER DEFAULT
PRIVILEGES...`) do not extend to materialized views. Since
migration `0015` didn't grant privileges, Metabase queries cannot
read the new views. This PR fixes that. 
