### PR TITLE
[Issue #10986] Remove user tables from hourly cycle

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -48,8 +48,6 @@ TABLES_TO_LOAD = [
     "tcompetition",
     "tinstructions",
     "tcertificates",
-    "vuser_account",
-    "tuser_profile",
 ]
 
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10986  

## Changes proposed

- Updated `load_oracle_data_task.py` to remove `vuser_account` and `tuser_profile` from `TABLES_TO_LOAD`

## Context for reviewers

Follow-up to #10984, which added the daily `load-user-tables` scheduled job. That job passes `-t vuser_account -t tuser_profile` explicitly, and `LoadOracleDataTask` only falls back to `TABLES_TO_LOAD` when `tables_to_load` is empty, so the daily job is unaffected by this removal.

## Validation steps

Confirm tests still pass.