### PR TITLE
[unticketed]: fix e2e tests failing

### DIFF
--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -332,7 +332,13 @@ jobs:
           cd ../frontend
           # Ensure the API wait script is executable
           chmod +x ../api/bin/wait-for-api.sh
-          ../api/bin/wait-for-api.sh
+          # Dump the API container's own logs on timeout
+          ../api/bin/wait-for-api.sh || {
+            echo "::group::grants-api container logs"
+            docker logs --tail 200 grants-api 2>&1 || true
+            echo "::endgroup::"
+            exit 1
+          }
         shell: bash
 
       # we shouldn't ever need to do this

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -41,10 +41,8 @@ services:
 
   s3mock:
     container_name: s3mock
-    image: adobe/s3mock:5.2.0
+    image: adobe/s3mock:5.1.0
     environment:
-      # 5.2.0+ resolves a relative store root against its own workdir,
-      # which writes inside the container instead of the bind mount below
       - COM_ADOBE_TESTING_S3MOCK_STORE_ROOT=/containers3root
       - COM_ADOBE_TESTING_S3MOCK_STORE_RETAIN_FILES_ON_EXIT=true
       - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=local-mock-public-bucket,local-mock-draft-bucket,local-mock-file-scan-bucket

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -41,9 +41,11 @@ services:
 
   s3mock:
     container_name: s3mock
-    image: adobe/s3mock:latest
+    image: adobe/s3mock:5.2.0
     environment:
-      - COM_ADOBE_TESTING_S3MOCK_STORE_ROOT=containers3root
+      # 5.2.0+ resolves a relative store root against its own workdir,
+      # which writes inside the container instead of the bind mount below
+      - COM_ADOBE_TESTING_S3MOCK_STORE_ROOT=/containers3root
       - COM_ADOBE_TESTING_S3MOCK_STORE_RETAIN_FILES_ON_EXIT=true
       - COM_ADOBE_TESTING_S3MOCK_STORE_INITIAL_BUCKETS=local-mock-public-bucket,local-mock-draft-bucket,local-mock-file-scan-bucket
     ports:


### PR DESCRIPTION
## Summary

E2e tests on github target local where failing due to an update to: adobe/s3mock:latest dependency on August 22nd. 

Pinned the version to a static 5.2.0 and updated the relative path. 

## Validation steps

Ran the e2e pipeline: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/32757441654)