### PR TITLE
[Issue #10299] Search page - does not recover from error state after applying a valid filter

### DIFF
--- a/frontend/src/app/[locale]/(base)/search/page.tsx
+++ b/frontend/src/app/[locale]/(base)/search/page.tsx
@@ -11,6 +11,7 @@ import { SearchDrawerFilters } from "src/app/[locale]/(base)/search/_components/
 import { SearchDrawerHeading } from "src/app/[locale]/(base)/search/_components/SearchDrawerHeading";
 import SearchResults from "src/app/[locale]/(base)/search/_components/SearchResults";
 import { environment } from "src/constants/environments";
+import { defaultLocale } from "src/i18n/config";
 import { getSession } from "src/services/auth/session";
 import { performAgencySearch } from "src/services/fetch/fetchers/agenciesFetcher";
 import { getSavedOpportunities } from "src/services/fetch/fetchers/savedOpportunityFetcher";
@@ -19,10 +20,15 @@ import QueryProvider from "src/services/search/QueryProvider";
 import { OptionalStringDict } from "src/types/generalTypes";
 import { LocalizedPageProps } from "src/types/intl";
 import { INDIVIDUAL_SAVED_OPPORTUNITIES_SCOPE } from "src/utils/opportunity/savedOpportunitiesUtils";
-import { convertSearchParamsToProperTypes } from "src/utils/search/searchUtils";
+import {
+  convertSearchParamsToProperTypes,
+  paramsToFormattedQuery,
+  sanitizeSearchParams,
+} from "src/utils/search/searchUtils";
 
 import { useTranslations } from "next-intl";
 import { getTranslations, setRequestLocale } from "next-intl/server";
+import { redirect, RedirectType } from "next/navigation";
 import { Suspense, use } from "react";
 
 import { DrawerUnit } from "src/components/core/drawer/DrawerUnit";
@@ -47,6 +53,19 @@ function Search({ searchParams, params }: SearchPageProps) {
   const resolvedSearchParams = use(searchParams);
   setRequestLocale(locale);
   const t = useTranslations("Search");
+
+  // A URL carrying filter values that don't exist would error out the
+  // search and leave behind unlabeled filters the user can't clear.
+  // Drop the bad values and put the URL back in sync before rendering anything.
+  const sanitizedSearchParams = sanitizeSearchParams(resolvedSearchParams);
+  if (sanitizedSearchParams) {
+    const searchPath =
+      locale === defaultLocale ? "/search" : `/${locale}/search`;
+    redirect(
+      `${searchPath}${paramsToFormattedQuery(new URLSearchParams(sanitizedSearchParams))}`,
+      RedirectType.replace,
+    );
+  }
 
   const convertedSearchParams =
     convertSearchParamsToProperTypes(resolvedSearchParams);

--- a/frontend/src/utils/search/searchUtils.test.ts
+++ b/frontend/src/utils/search/searchUtils.test.ts
@@ -59,6 +59,29 @@ describe("paramsToFormattedQuery", () => {
       ),
     ).toEqual("?key=value,anotherValue&big=small&simpler=grants");
   });
+  it("leaves reserved characters within a value encoded", () => {
+    const query = paramsToFormattedQuery(
+      new URLSearchParams([
+        ["query", "R&D grants"],
+        ["status", "posted"],
+      ]),
+    );
+    expect(query).toEqual("?query=R%26D+grants&status=posted");
+    // decoding the whole string would split the query term into a second param
+    expect(Array.from(new URLSearchParams(query.slice(1)))).toEqual([
+      ["query", "R&D grants"],
+      ["status", "posted"],
+    ]);
+  });
+  it("does not let an encoded hash truncate the query string", () => {
+    const query = paramsToFormattedQuery(
+      new URLSearchParams([
+        ["query", "a#b"],
+        ["status", "posted"],
+      ]),
+    );
+    expect(query).toEqual("?query=a%23b&status=posted");
+  });
 });
 
 describe("paramToDateRange", () => {
@@ -121,6 +144,20 @@ describe("removeInvalidParamValues", () => {
     expect(removeInvalidParamValues("sortby", "not_a_sort")).toEqual(undefined);
     expect(removeInvalidParamValues("closeDate", "999")).toEqual(undefined);
   });
+  it("flattens a repeated param, which arrives as an array", () => {
+    expect(removeInvalidParamValues("status", ["posted", "closed"])).toEqual(
+      "posted,closed",
+    );
+    expect(
+      removeInvalidParamValues("status", ["posted", "not_a_status"]),
+    ).toEqual("posted");
+    expect(removeInvalidParamValues("status", ["not_a_status"])).toEqual(
+      undefined,
+    );
+    expect(
+      removeInvalidParamValues("agency", ["CPSC", "NOT-AN-AGENCY"]),
+    ).toEqual("CPSC,NOT-AN-AGENCY");
+  });
 });
 
 describe("sanitizeSearchParams", () => {
@@ -152,6 +189,23 @@ describe("sanitizeSearchParams", () => {
       assistanceListingNumber: "00.000",
       topLevelAgency: "NOPE",
     });
+  });
+  it("does not throw on a repeated param, which arrives as an array", () => {
+    expect(() =>
+      sanitizeSearchParams({ status: ["posted", "closed"] }),
+    ).not.toThrow();
+  });
+  it("does not redirect for a repeated param whose values are all valid", () => {
+    // reshaping an array into the comma separated form is not a reason to bounce the user,
+    // convertSearchParamsToProperTypes normalizes it either way
+    expect(sanitizeSearchParams({ status: ["posted", "closed"] })).toEqual(
+      null,
+    );
+  });
+  it("removes the invalid values from a repeated param", () => {
+    expect(
+      sanitizeSearchParams({ status: ["posted", "not_a_status"] }),
+    ).toEqual({ status: "posted" });
   });
   it("is idempotent, so that sanitizing cannot loop", () => {
     const sanitized = sanitizeSearchParams({
@@ -234,6 +288,18 @@ describe("convertSearchParamsToProperTypes", () => {
     expect(converted.agency).toEqual(new Set(["MADE-UP"]));
     expect(converted.topLevelAgency).toEqual(new Set(["MADE"]));
     expect(converted.assistanceListingNumber).toEqual(new Set(["00.000"]));
+  });
+  it("handles a repeated param arriving as an array", () => {
+    const converted = convertSearchParamsToProperTypes({
+      status: ["posted", "closed"],
+    });
+    expect(converted.status).toEqual(new Set(["posted", "closed"]));
+  });
+  it("drops the invalid values from a repeated param", () => {
+    const converted = convertSearchParamsToProperTypes({
+      status: ["posted", "not_a_status"],
+    });
+    expect(converted.status).toEqual(new Set(["posted"]));
   });
   it("falls back to page 1 for a non numeric page param", () => {
     expect(convertSearchParamsToProperTypes({ page: "not_a_page" }).page).toBe(

--- a/frontend/src/utils/search/searchUtils.test.ts
+++ b/frontend/src/utils/search/searchUtils.test.ts
@@ -11,6 +11,8 @@ import {
   getStatusValueForAgencySearch,
   paramsToFormattedQuery,
   paramToDateRange,
+  removeInvalidParamValues,
+  sanitizeSearchParams,
 } from "src/utils/search/searchUtils";
 import {
   fakeSearchParamDict,
@@ -74,6 +76,95 @@ describe("paramToDateRange", () => {
   });
 });
 
+describe("removeInvalidParamValues", () => {
+  it("passes through params with no known set of valid values", () => {
+    expect(removeInvalidParamValues("agency", "NOT-AN-AGENCY")).toEqual(
+      "NOT-AN-AGENCY",
+    );
+    expect(removeInvalidParamValues("query", "not_a_status")).toEqual(
+      "not_a_status",
+    );
+    expect(removeInvalidParamValues("savedSearch", "anything")).toEqual(
+      "anything",
+    );
+  });
+  it("passes through empty and undefined param values", () => {
+    expect(removeInvalidParamValues("status", undefined)).toEqual(undefined);
+    expect(removeInvalidParamValues("status", "")).toEqual("");
+  });
+  it("passes through valid param values", () => {
+    expect(removeInvalidParamValues("status", "posted,closed")).toEqual(
+      "posted,closed",
+    );
+    expect(removeInvalidParamValues("sortby", "closeDateAsc")).toEqual(
+      "closeDateAsc",
+    );
+    expect(removeInvalidParamValues("andOr", "OR")).toEqual("OR");
+    expect(removeInvalidParamValues("costSharing", "true")).toEqual("true");
+    expect(removeInvalidParamValues("postedDate", "14")).toEqual("14");
+  });
+  it("allows the `none` status sentinel through", () => {
+    expect(removeInvalidParamValues("status", "none")).toEqual("none");
+  });
+  it("removes invalid values and keeps the valid remainder", () => {
+    expect(removeInvalidParamValues("status", "not_a_status,posted")).toEqual(
+      "posted",
+    );
+    expect(removeInvalidParamValues("category", "health,nope,arts")).toEqual(
+      "health,arts",
+    );
+  });
+  it("returns undefined when no valid values are left", () => {
+    expect(removeInvalidParamValues("status", "not_a_status")).toEqual(
+      undefined,
+    );
+    expect(removeInvalidParamValues("sortby", "not_a_sort")).toEqual(undefined);
+    expect(removeInvalidParamValues("closeDate", "999")).toEqual(undefined);
+  });
+});
+
+describe("sanitizeSearchParams", () => {
+  it("returns null when all param values are valid", () => {
+    expect(sanitizeSearchParams(fakeSearchParamDict)).toEqual(null);
+    expect(sanitizeSearchParams({})).toEqual(null);
+  });
+  it("removes params whose values are all invalid", () => {
+    expect(sanitizeSearchParams({ status: "not_a_status" })).toEqual({});
+    expect(
+      sanitizeSearchParams({ query: "simpler", status: "not_a_status" }),
+    ).toEqual({ query: "simpler" });
+  });
+  it("removes only the invalid values from a param", () => {
+    expect(sanitizeSearchParams({ status: "not_a_status,posted" })).toEqual({
+      status: "posted",
+    });
+  });
+  it("leaves params without a known set of valid values alone", () => {
+    expect(
+      sanitizeSearchParams({
+        agency: "NOT-AN-AGENCY",
+        assistanceListingNumber: "00.000",
+        topLevelAgency: "NOPE",
+        status: "not_a_status",
+      }),
+    ).toEqual({
+      agency: "NOT-AN-AGENCY",
+      assistanceListingNumber: "00.000",
+      topLevelAgency: "NOPE",
+    });
+  });
+  it("is idempotent, so that sanitizing cannot loop", () => {
+    const sanitized = sanitizeSearchParams({
+      status: "not_a_status,posted",
+      sortby: "not_a_sort",
+    });
+    expect(sanitized).toEqual({ status: "posted" });
+    expect(
+      sanitizeSearchParams(sanitized as { [key: string]: string }),
+    ).toEqual(null);
+  });
+});
+
 describe("convertSearchParamsToProperTypes", () => {
   it("converts search param strings to proper types", () => {
     expect(
@@ -101,6 +192,56 @@ describe("convertSearchParamsToProperTypes", () => {
       page: 1,
       actionType: SearchFetcherActionType.InitialLoad,
     });
+  });
+  it("falls back to default statuses when every status value is invalid", () => {
+    const converted = convertSearchParamsToProperTypes({
+      status: "not_a_status",
+    });
+    expect(converted.status).toEqual(new Set(["forecasted", "posted"]));
+  });
+  it("keeps only the valid statuses when some are invalid", () => {
+    const converted = convertSearchParamsToProperTypes({
+      status: "not_a_status,closed",
+    });
+    expect(converted.status).toEqual(new Set(["closed"]));
+  });
+  it("drops invalid values across all hardcoded filters", () => {
+    const converted = convertSearchParamsToProperTypes({
+      fundingInstrument: "nope",
+      eligibility: "nope",
+      category: "nope",
+      costSharing: "nope",
+      closeDate: "999",
+      postedDate: "999",
+      sortby: "nope",
+      andOr: "nope",
+    });
+    expect(converted.fundingInstrument).toEqual(new Set());
+    expect(converted.eligibility).toEqual(new Set());
+    expect(converted.category).toEqual(new Set());
+    expect(converted.costSharing).toEqual(new Set());
+    expect(converted.closeDate).toEqual(new Set());
+    expect(converted.postedDate).toEqual(new Set());
+    expect(converted.sortby).toEqual(null);
+    expect(converted.andOr).toEqual("");
+  });
+  it("does not validate agency values, which are not hardcoded", () => {
+    const converted = convertSearchParamsToProperTypes({
+      agency: "MADE-UP",
+      topLevelAgency: "MADE",
+      assistanceListingNumber: "00.000",
+    });
+    expect(converted.agency).toEqual(new Set(["MADE-UP"]));
+    expect(converted.topLevelAgency).toEqual(new Set(["MADE"]));
+    expect(converted.assistanceListingNumber).toEqual(new Set(["00.000"]));
+  });
+  it("falls back to page 1 for a non numeric page param", () => {
+    expect(convertSearchParamsToProperTypes({ page: "not_a_page" }).page).toBe(
+      1,
+    );
+    expect(convertSearchParamsToProperTypes({ page: "0" }).page).toBe(1);
+    expect(convertSearchParamsToProperTypes({ page: "-3" }).page).toBe(1);
+    expect(convertSearchParamsToProperTypes({ page: "3" }).page).toBe(3);
   });
 });
 

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -2,7 +2,12 @@ import {
   SEARCH_NO_STATUS_VALUE,
   STATUS_FILTER_DEFAULT_VALUES,
 } from "src/constants/search";
-import { statusOptions } from "src/constants/searchFilterOptions";
+import {
+  allFilterOptions,
+  andOrOptions,
+  sortOptions,
+  statusOptions,
+} from "src/constants/searchFilterOptions";
 import { OptionalStringDict } from "src/types/generalTypes";
 import { FilterOption } from "src/types/search/searchFilterTypes";
 import { QuerySetParam } from "src/types/search/searchQueryTypes";
@@ -16,6 +21,61 @@ import { SortOptions } from "src/types/search/searchSortTypes";
 export const areSetsEqual = (a: Set<string>, b: Set<string>) =>
   a.size === b.size && [...a].every((value) => b.has(value));
 
+const validParamValues: { [key: string]: Set<string> } = {
+  ...Object.entries(allFilterOptions).reduce(
+    (acc, [filterName, options]) => {
+      acc[filterName] = new Set(options.map(({ value }) => value));
+      return acc;
+    },
+    {} as { [key: string]: Set<string> },
+  ),
+  status: new Set([
+    ...statusOptions.map(({ value }) => value),
+    SEARCH_NO_STATUS_VALUE,
+  ]),
+  sortby: new Set(sortOptions.map(({ value }) => value)),
+  andOr: new Set(andOrOptions.map(({ value }) => value)),
+};
+
+// Strips any values that aren't valid for the given param, returning the comma separated
+// remainder, or undefined if nothing valid is left. Params with no known set of valid
+// values are passed through untouched.
+export const removeInvalidParamValues = (
+  paramKey: string,
+  paramValue: string | undefined,
+): string | undefined => {
+  const validValues = validParamValues[paramKey];
+  if (!paramValue || !validValues) {
+    return paramValue;
+  }
+  const validatedValues = paramValue
+    .split(",")
+    .filter((value) => validValues.has(value));
+  return validatedValues.length ? validatedValues.join(",") : undefined;
+};
+
+// Builds a copy of the incoming search params with all invalid filter values removed.
+// Returns null when there was nothing to remove, so that callers can skip a needless redirect.
+export const sanitizeSearchParams = (
+  params: OptionalStringDict,
+): { [key: string]: string } | null => {
+  let removedAnyValues = false;
+  const sanitizedParams = Object.entries(params).reduce(
+    (acc, [key, value]) => {
+      const validatedValue = removeInvalidParamValues(key, value);
+      if (validatedValue !== value) {
+        removedAnyValues = true;
+      }
+      if (validatedValue !== undefined) {
+        acc[key] = validatedValue;
+      }
+      return acc;
+    },
+    {} as { [key: string]: string },
+  );
+  return removedAnyValues ? sanitizedParams : null;
+};
+
 // Search params (query string) coming from the request URL into the server
 // can be a string, string[], or undefined.
 // Process all of them so they're just a string (or number for page)
@@ -24,24 +84,26 @@ export const areSetsEqual = (a: Set<string>, b: Set<string>) =>
 export function convertSearchParamsToProperTypes(
   params: OptionalStringDict,
 ): QueryParamData {
+  // drop any filter values that don't exist so that a bad URL doesn't propagate
+  const validParams = sanitizeSearchParams(params) || params;
   return {
-    ...params,
-    query: params.query || "", // Convert empty string to null if needed
-    status: paramToSet(params.status, "status"),
-    fundingInstrument: paramToSet(params.fundingInstrument),
-    eligibility: paramToSet(params.eligibility),
-    agency: paramToSet(params.agency),
-    category: paramToSet(params.category),
-    closeDate: paramToDateRange(params.closeDate),
-    postedDate: paramToDateRange(params.postedDate),
-    costSharing: paramToSet(params.costSharing),
-    andOr: (params.andOr as QueryOperator) || "",
-    topLevelAgency: paramToSet(params.topLevelAgency),
-    sortby: (params.sortby as SortOptions) || null, // Convert empty string to null if needed
-    assistanceListingNumber: paramToSet(params.assistanceListingNumber),
+    ...validParams,
+    query: validParams.query || "", // Convert empty string to null if needed
+    status: paramToSet(validParams.status, "status"),
+    fundingInstrument: paramToSet(validParams.fundingInstrument),
+    eligibility: paramToSet(validParams.eligibility),
+    agency: paramToSet(validParams.agency),
+    category: paramToSet(validParams.category),
+    closeDate: paramToDateRange(validParams.closeDate),
+    postedDate: paramToDateRange(validParams.postedDate),
+    costSharing: paramToSet(validParams.costSharing),
+    andOr: (validParams.andOr as QueryOperator) || "",
+    topLevelAgency: paramToSet(validParams.topLevelAgency),
+    sortby: (validParams.sortby as SortOptions) || null, // Convert empty string to null if needed
+    assistanceListingNumber: paramToSet(validParams.assistanceListingNumber),
 
     // Ensure page is at least 1 or default to 1 if undefined
-    page: getSafePage(params.page),
+    page: getSafePage(validParams.page),
     actionType: SearchFetcherActionType.InitialLoad,
   };
 }
@@ -77,10 +139,12 @@ export function paramToDateRange(paramValue?: string): Set<string> {
   return new Set([selectedDates[0], selectedDates[1]]);
 }
 
-// Keeps page >= 1.
+// Keeps page >= 1, and falls back to 1 for a non numeric param value, which would
+// otherwise send NaN through to the API and fail validation.
 // (We can't enforce a max here since this is before the API request)
 function getSafePage(page: string | undefined) {
-  return Math.max(1, parseInt(page || "1"));
+  const parsedPage = parseInt(page || "1");
+  return isNaN(parsedPage) ? 1 : Math.max(1, parsedPage);
 }
 
 // stringifies query params, unencrypts any encrypted commas, and prepends a ?

--- a/frontend/src/utils/search/searchUtils.ts
+++ b/frontend/src/utils/search/searchUtils.ts
@@ -8,7 +8,6 @@ import {
   sortOptions,
   statusOptions,
 } from "src/constants/searchFilterOptions";
-import { OptionalStringDict } from "src/types/generalTypes";
 import { FilterOption } from "src/types/search/searchFilterTypes";
 import { QuerySetParam } from "src/types/search/searchQueryTypes";
 import {
@@ -37,33 +36,38 @@ const validParamValues: { [key: string]: Set<string> } = {
   andOr: new Set(andOrOptions.map(({ value }) => value)),
 };
 
+// A repeated param (?status=posted&status=closed) arrives as a string[] rather than a string,
+// so flatten it to the comma separated form the rest of the search code works with
+const normalizeParamValue = (paramValue: QuerySetParam): string | undefined =>
+  Array.isArray(paramValue) ? paramValue.join(",") : paramValue;
+
 // Strips any values that aren't valid for the given param, returning the comma separated
 // remainder, or undefined if nothing valid is left. Params with no known set of valid
 // values are passed through untouched.
 export const removeInvalidParamValues = (
   paramKey: string,
-  paramValue: string | undefined,
+  paramValue: QuerySetParam,
 ): string | undefined => {
+  const normalizedValue = normalizeParamValue(paramValue);
   const validValues = validParamValues[paramKey];
-  if (!paramValue || !validValues) {
-    return paramValue;
+  if (!normalizedValue || !validValues) {
+    return normalizedValue;
   }
-  const validatedValues = paramValue
+  const validatedValues = normalizedValue
     .split(",")
     .filter((value) => validValues.has(value));
   return validatedValues.length ? validatedValues.join(",") : undefined;
 };
 
-// Builds a copy of the incoming search params with all invalid filter values removed.
-// Returns null when there was nothing to remove, so that callers can skip a needless redirect.
-export const sanitizeSearchParams = (
-  params: OptionalStringDict,
-): { [key: string]: string } | null => {
+// Builds a copy of the incoming search params with every value normalized to a string and all
+// invalid filter values removed, reporting separately whether anything actually had to be removed.
+const validateSearchParams = (params: { [key: string]: QuerySetParam }) => {
   let removedAnyValues = false;
-  const sanitizedParams = Object.entries(params).reduce(
+  const validatedParams = Object.entries(params).reduce(
     (acc, [key, value]) => {
       const validatedValue = removeInvalidParamValues(key, value);
-      if (validatedValue !== value) {
+      // compare against the normalized value so that a repeated param doesn't count as a removal
+      if (validatedValue !== normalizeParamValue(value)) {
         removedAnyValues = true;
       }
       if (validatedValue !== undefined) {
@@ -73,7 +77,16 @@ export const sanitizeSearchParams = (
     },
     {} as { [key: string]: string },
   );
-  return removedAnyValues ? sanitizedParams : null;
+  return { validatedParams, removedAnyValues };
+};
+
+// Returns the search params with all invalid filter values removed, or null when there was
+// nothing to remove, so that callers can skip a needless redirect.
+export const sanitizeSearchParams = (params: {
+  [key: string]: QuerySetParam;
+}): { [key: string]: string } | null => {
+  const { validatedParams, removedAnyValues } = validateSearchParams(params);
+  return removedAnyValues ? validatedParams : null;
 };
 
 // Search params (query string) coming from the request URL into the server
@@ -81,11 +94,12 @@ export const sanitizeSearchParams = (
 // Process all of them so they're just a string (or number for page)
 
 // The above doesn't seem to still be true, should we update? - DWS
-export function convertSearchParamsToProperTypes(
-  params: OptionalStringDict,
-): QueryParamData {
-  // drop any filter values that don't exist so that a bad URL doesn't propagate
-  const validParams = sanitizeSearchParams(params) || params;
+export function convertSearchParamsToProperTypes(params: {
+  [key: string]: QuerySetParam;
+}): QueryParamData {
+  // drop any filter values that don't exist so that a bad URL doesn't propagate, and take the
+  // validated params unconditionally so that repeated params are always flattened to a string
+  const { validatedParams: validParams } = validateSearchParams(params);
   return {
     ...validParams,
     query: validParams.query || "", // Convert empty string to null if needed
@@ -148,12 +162,14 @@ function getSafePage(page: string | undefined) {
 }
 
 // stringifies query params, unencrypts any encrypted commas, and prepends a ?
+// note that only commas are decoded - decoding the whole string would turn an encoded
+// reserved character inside a value (e.g. `&` or `#` in a search term) back into a
+// delimiter, splitting one param into two
 export const paramsToFormattedQuery = (params: URLSearchParams): string => {
   if (!params.size) {
     return "";
   }
-  // return `?${params.toString().replaceAll("%2C", ",")}`;
-  return `?${decodeURIComponent(params.toString())}`;
+  return `?${params.toString().replaceAll("%2C", ",")}`;
 };
 
 export const getAgencyParent = (agencyCode: string) => agencyCode.split("-")[0];

--- a/frontend/tests/e2e/search/search-state/features/search-error-recovery.feature
+++ b/frontend/tests/e2e/search/search-state/features/search-error-recovery.feature
@@ -1,29 +1,39 @@
 # @featureArea Search
 # @feature Search State Error Handling and Recovery
 # @specFile tests/e2e/search/search-state/specs/search-error-recovery.spec.ts
-# @debugNote Covers invalid query error state and recovery path
+# @debugNote Covers invalid filter values in the URL and the recovery path
 
-Feature: Search Error state and Recovery
+Feature: Search State Error Handling and Recovery
   As a user on Search
-  I want the system to handle invalid query states clearly
-  And recover when I apply a valid filter
+  I want invalid filter values in the URL to be discarded
+  And the URL to reflect the filters that were actually applied
   So that I can continue searching without restarting
 
 /* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
-  Scenario: Invalid status query shows error state
+  Scenario: Invalid filter value is dropped from the URL
     Given I navigate to "/search?<param>=<invalid_value>"
-    Then I should see an error alert
+    Then the "<param>" param should be removed from the URL
+    And I should not see an error alert
+    And I should see search results
 
-/* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
-  Scenario: Recover from error state when applying a valid filter
-    Given I navigate to "/search?<param>=<invalid_value>"
-    And I should see an error alert
-
-    When I open the filter drawer
-    And I select the "Closed" opportunity status filter
-    Then the URL should update to include "status=closed"
-    
     Examples:
     | param     | invalid_value |
     | status    | not_a_status  |
     | category  | invalid_value |
+
+/* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+  Scenario: Valid filter values survive alongside an invalid one
+    Given I navigate to "/search?status=not_a_status,closed"
+    Then the URL should update to "status=closed"
+    And I should not see an error alert
+
+/* @tags GRANTEE, OPPORTUNITY_SEARCH, FULL_REGRESSION */
+  Scenario: Applying a filter after an invalid one does not re-append the invalid value
+    Given I navigate to "/search?status=not_a_status"
+
+    When I open the filter drawer
+    And I select the "Closed" opportunity status filter
+    Then the URL should update to "status=closed"
+    And the URL should not contain "not_a_status"
+    And I should not see an error alert
+    And I should not see an unlabeled filter pill

--- a/frontend/tests/e2e/search/search-state/specs/search-error-recovery.spec.ts
+++ b/frontend/tests/e2e/search/search-state/specs/search-error-recovery.spec.ts
@@ -1,7 +1,7 @@
 /**
  * @feature Search Error Handling and Recovery
  * @featureFile tests/e2e/search/search-state/features/search-error-recovery.feature
- * @scenario Show an error state for invalid search params and recover by running a valid search
+ * @scenario Drop invalid filter values from the URL and keep the page usable
  */
 
 import { expect, test } from "@playwright/test";
@@ -10,31 +10,63 @@ import { VALID_TAGS } from "tests/e2e/tags";
 import {
   toggleCheckbox,
   toggleFilterDrawer,
+  waitForSearchResultsInitialLoad,
 } from "tests/e2e/utils/search/searchSpecUtil";
 
 const { GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION } = VALID_TAGS;
 
 const SEARCH_TIMEOUT = playwrightEnv.targetEnv !== "local" ? 15000 : 5000;
 
-test.describe("Search error page", () => {
+// a filter value that is not in the hardcoded option list has no label, so it renders a pill
+// with an empty label - and an empty aria-label - if it makes it as far as the pill list
+const UNLABELED_PILL = '[aria-label="Remove  pill"]';
+
+test.describe("Search invalid filter values", () => {
   test(
-    "should return an error page when expected",
+    "should drop an invalid filter value from the URL rather than erroring",
     { tag: [GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION] },
     async ({ page }) => {
       // Given I navigate to "/search?status=not_a_status"
       await page.goto("/search?status=not_a_status");
 
-      // Then I should see an error alert on the page
-      expect(page.locator(".usa-alert--error")).toBeTruthy();
+      // Then the invalid status should be removed from the URL
+      await page.waitForURL((url) => !url.search.includes("not_a_status"), {
+        timeout: SEARCH_TIMEOUT,
+      });
+
+      // And I should see search results rather than an error alert
+      await waitForSearchResultsInitialLoad(page);
+      await expect(page.locator(".usa-alert--error")).toHaveCount(0);
+
+      // And no unlabeled filter pill should be left behind
+      await expect(page.locator(UNLABELED_PILL)).toHaveCount(0);
     },
   );
 
   test(
-    "should allow for performing a new search from error state",
+    "should keep the valid values when only some are invalid",
+    { tag: [GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION] },
+    async ({ page }) => {
+      // Given I navigate to "/search?status=not_a_status,closed"
+      await page.goto("/search?status=not_a_status,closed");
+
+      // Then only the valid status should remain in the URL
+      await page.waitForURL((url) => url.search.includes("status=closed"), {
+        timeout: SEARCH_TIMEOUT,
+      });
+      expect(page.url()).not.toContain("not_a_status");
+
+      await expect(page.locator(".usa-alert--error")).toHaveCount(0);
+    },
+  );
+
+  test(
+    "should not re-append an invalid value when a valid filter is applied",
     { tag: [GRANTEE, OPPORTUNITY_SEARCH, CORE_REGRESSION] },
     async ({ page }) => {
       // Given I navigate to "/search?status=not_a_status"
       await page.goto("/search?status=not_a_status");
+      await waitForSearchResultsInitialLoad(page);
 
       // When I open the filters
       await toggleFilterDrawer(page);
@@ -42,10 +74,15 @@ test.describe("Search error page", () => {
       // And I select the "Closed" opportunity status filter
       await toggleCheckbox(page, "status-closed");
 
-      // Then the URL should include "status=closed"
-      await page.waitForURL(/closed/, {
-        timeout: SEARCH_TIMEOUT,
-      });
+      // Then the URL should include the closed status without the invalid value.
+      // Note that the default statuses come along with it, since the invalid value was
+      // dropped on load and the status filter fell back to its defaults.
+      await page.waitForURL(/status=[^&]*closed/, { timeout: SEARCH_TIMEOUT });
+      expect(page.url()).not.toContain("not_a_status");
+
+      // And the page should still be usable
+      await expect(page.locator(".usa-alert--error")).toHaveCount(0);
+      await expect(page.locator(UNLABELED_PILL)).toHaveCount(0);
     },
   );
 });


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #10299 

## Changes proposed

- Updated `searchUtils.ts` to validate filter params against their hardcoded option lists. Added a `validParamValues` lookup, `removeInvalidParamValues`, `normalizeParamValue`, and `validateSearchParams` / `sanitizeSearchParams`; fixed `paramsToFormattedQuery` to decode only commas rather than the whole query string, and guarded `getSafePage` against a non-numeric `page` param returning `NaN`
- Updated `page.tsx` to redirect to the sanitized query string when the URL carries filter values that don't exist, before any search request is issued
- Updated `searchUtils.test.ts` with cases covering value stripping, the `status=none` sentinel, sanitize idempotency, repeated params arriving as arrays, reserved characters surviving a redirect, per-filter fallbacks, and the `page` guard
- Updated `search-error-recovery.spec.ts` to assert the invalid value is dropped from the URL, no error alert renders, and no unlabeled pill is left behind
- Updated `search-error-recovery.feature` to describe the new drop-and-redirect behavior instead of the old error state

## Context for reviewers

One bad URL value produced three separate symptoms because it fanned out to three consumers: the API request (422 → error page), the checkbox toggle's seed set (`new Set(query)`, which is why applying a valid filter appended to the invalid one), and the pill label lookup (no match → empty pill), so sanitizing at parse time fixes all three at once. `agency` / `topLevelAgency` / `assistanceListingNumber` are deliberately excluded from validation since their values are dynamic and can't be checked without a network call. Two fixes here go slightly wider than the reported bug: `paramsToFormattedQuery` was running `decodeURIComponent` over the entire query string, which turned an encoded reserved character inside a value back into a delimiter (`?query=R%26D+grants` reparsed as `query=R` plus a second param, and an encoded `#` truncated everything after it) - that is pre-existing and affected every client-side filter interaction through `useSearchParamUpdater`, not just the new redirect; and `validateSearchParams` normalizes repeated params (`?status=posted&status=closed`, which arrive as `string[]`) before anything calls `.split`, which also closes a latent crash in `paramToDateRange`. Note that a repeated param whose values are all valid deliberately does not redirect.

## Validation steps

Confirm tests pass.

Testing locally:
Start the API (`make init && make start` in `api/`) and the frontend (`cd frontend && npm run dev`), then confirm the redirects:
   - `/search?status=not_a_status` → `/search`, results render, no error alert, no empty pill
   - `/search?status=not_a_status,closed` → `/search?status=closed`
   - `/search?query=simpler&status=nope&sortby=bogus` → `/search?query=simpler`
   - `/es/search?status=not_a_status` → `/es/search` (locale prefix preserved)
   - `/search?status=closed`, `/search?status=none`, `/search?agency=MADE-UP` → 200 with no redirect
   - `/search?status=posted&status=closed` and `/search?closeDate=7&closeDate=30` → 200, no server error
   - `/search?status=posted&status=not_a_status` → `/search?status=posted`
   - `/search?status=not_a_status&query=R%26D+grants` → `/search?query=R%26D+grants` with the encoding intact, and the search term still reads `R&D grants` in the search box