### PR TITLE
Update Read Opportunity Endpoint for Tagline and Purpose Statement

### DIFF
--- a/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
+++ b/api/src/api/opportunities_grantor_v1/opportunity_grantor_schemas.py
@@ -239,6 +239,8 @@ class OpportunityGetResponseSchema(AbstractResponseSchema):
       "data": {
         "opportunity_number": "ABC-2026-001",
         "opportunity_title": "Research Grant for Climate Innovation",
+        "tagline": "Accelerating climate innovation",
+        "purpose_statement": "Support research that advances innovative climate technologies.",
         "agency_id": "550e8400-e29b-41d4-a716-446655440000",
         "category": "discretionary",
         "category_explanation": "Competitive research grant",

--- a/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_get.py
+++ b/api/tests/src/api/opportunities_grantors_v1/test_opportunity_route_get.py
@@ -25,6 +25,8 @@ def opportunity(
     grantor_auth_data,
     opportunity_number="TEST-2026-123",
     opportunity_title="Test Opportunity for GET",
+    tagline="Test tagline for GET",
+    purpose_statement="Test purpose statement for GET",
 ):
     """Create a test opportunity"""
     user, agency, _, _ = grantor_auth_data
@@ -34,6 +36,8 @@ def opportunity(
         agency_code=agency.agency_code,
         opportunity_number=opportunity_number,
         opportunity_title=opportunity_title,
+        tagline=tagline,
+        purpose_statement=purpose_statement,
     )
 
     opportunity.agency_record = agency
@@ -72,6 +76,8 @@ def test_get_opportunity_success(client, db_session, grantor_auth_data, opportun
     assert response_data["opportunity_id"] == str(opportunity.opportunity_id)
     assert response_data["opportunity_number"] == opportunity.opportunity_number
     assert response_data["opportunity_title"] == opportunity.opportunity_title
+    assert response_data["tagline"] == opportunity.tagline
+    assert response_data["purpose_statement"] == opportunity.purpose_statement
     assert response_data["agency_code"] == opportunity.agency_code
     assert response_data["category"] == opportunity.category.value
 


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11311 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Update the `GET /v1/grantors/opportunities/{opportunity_id}` endpoint to return tagline and purpose statement in the data object.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Tagline and Purpose Statement are already present in the schema, this simply adds it to the response data.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- [x] New fields are present in the response
- [x] Unit test updated