### PR TITLE
[Issue #11710] Default filters retained when using a saved search

### DIFF
--- a/frontend/src/app/[locale]/(base)/workspace/saved-search-queries/_components/SavedSearchesList.test.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/saved-search-queries/_components/SavedSearchesList.test.tsx
@@ -174,6 +174,30 @@ describe("SavedSearchesList", () => {
     expect(definitionTwo).toHaveTextContent("category: Arts");
   });
 
+  it("does not display a status value for a search with no statuses selected", () => {
+    render(
+      <SavedSearchesList
+        agencyOptions={fakeAgencyOptions}
+        savedSearches={[
+          makeSavedSearchResult({
+            searchParams: {
+              query: "another search term",
+              status: "none",
+            },
+          }),
+        ]}
+        editText={"edit"}
+        deleteText={"delete"}
+        paramDisplayMapping={fakeParamDisplayMapping}
+      />,
+    );
+
+    const definition = screen.getByTestId("saved-search-definition");
+
+    expect(definition).toHaveTextContent("query: another search term");
+    expect(definition).not.toHaveTextContent("status:");
+  });
+
   it("renders edit and delete modal button items for each list item", async () => {
     render(
       <SavedSearchesList

--- a/frontend/src/app/[locale]/(base)/workspace/saved-search-queries/_components/SavedSearchesList.tsx
+++ b/frontend/src/app/[locale]/(base)/workspace/saved-search-queries/_components/SavedSearchesList.tsx
@@ -1,3 +1,4 @@
+import { SEARCH_NO_STATUS_VALUE } from "src/constants/search";
 import {
   FilterOption,
   HardcodedFrontendFilterNames,
@@ -29,6 +30,10 @@ const toSavedSearchFilterDisplayValues = (
     (acc, [key, paramDisplay]) => {
       const value = backendFilterValues[key as ValidSearchQueryParam];
       if (!value || key === "page") {
+        return acc;
+      }
+      // "no status" means the user deselected every status, which has no display value
+      if (key === "status" && value === SEARCH_NO_STATUS_VALUE) {
         return acc;
       }
       let displayValue = "";

--- a/frontend/src/utils/search/searchFormatUtils.test.ts
+++ b/frontend/src/utils/search/searchFormatUtils.test.ts
@@ -241,7 +241,23 @@ describe("searchToQueryParams", () => {
     expect(queryParams.query).toEqual("something to search for");
 
     const emptyQueryParams = searchToQueryParams({} as SavedSearchQuery);
-    expect(emptyQueryParams).toEqual({ query: "" });
+    expect(emptyQueryParams).toEqual({ query: "", status: "none" });
+  });
+  it("sets the no status param if the saved search has no status filter", () => {
+    const queryParams = searchToQueryParams({
+      ...fakeSavedSearch,
+      filters: { funding_instrument: { one_of: ["grant"] } },
+    });
+
+    expect(queryParams.status).toEqual("none");
+  });
+  it("sets the no status param if the saved search has an empty status filter", () => {
+    const queryParams = searchToQueryParams({
+      ...fakeSavedSearch,
+      filters: { opportunity_status: { one_of: [] } },
+    });
+
+    expect(queryParams.status).toEqual("none");
   });
   it("correctly handles close date ranges", () => {
     const queryParams = searchToQueryParams({

--- a/frontend/src/utils/search/searchFormatUtils.test.ts
+++ b/frontend/src/utils/search/searchFormatUtils.test.ts
@@ -1,3 +1,4 @@
+import { OptionalStringDict } from "src/types/generalTypes";
 import {
   SavedSearchQuery,
   SearchFetcherActionType,
@@ -9,6 +10,7 @@ import {
   paginationToSortby,
   searchToQueryParams,
 } from "src/utils/search/searchFormatUtils";
+import { convertSearchParamsToProperTypes } from "src/utils/search/searchUtils";
 import {
   fakeSavedSearch,
   searchFetcherParams,
@@ -317,5 +319,59 @@ describe("paginationToSortBy", () => {
         { order_by: "agency_name", sort_direction: "ascending" },
       ]),
     ).toEqual({ sortby: "agencyAsc" });
+  });
+});
+
+// exercises the full saved search seam: search page query params are converted and stored on save,
+// then converted back to query params and re-read by the search page when the search is reopened
+describe("saved search round trip", () => {
+  const saveAndReopen = (searchPageParams: OptionalStringDict) => {
+    const stored = formatSearchRequestBody(
+      convertSearchParamsToProperTypes(searchPageParams),
+    );
+    const reopenedParams = searchToQueryParams(stored as SavedSearchQuery);
+    return convertSearchParamsToProperTypes(reopenedParams);
+  };
+
+  it("does not reapply default statuses to a search saved with all statuses deselected", () => {
+    const stored = formatSearchRequestBody(
+      convertSearchParamsToProperTypes({ status: "none", query: "research" }),
+    );
+    // the deselected state is stored as the absence of a status filter
+    expect(stored.filters?.opportunity_status).toBeUndefined();
+
+    const reopened = saveAndReopen({ status: "none", query: "research" });
+    expect(reopened.status).toEqual(new Set());
+    expect(reopened.query).toEqual("research");
+  });
+
+  it("retains default statuses for a search saved without touching the status filter", () => {
+    const reopened = saveAndReopen({ query: "research" });
+    expect(reopened.status).toEqual(new Set(["forecasted", "posted"]));
+  });
+
+  it("retains an explicitly selected subset of statuses", () => {
+    const reopened = saveAndReopen({ status: "closed" });
+    expect(reopened.status).toEqual(new Set(["closed"]));
+  });
+
+  it("retains non status filters and sort order", () => {
+    const reopened = saveAndReopen({
+      status: "none",
+      fundingInstrument: "grant,cooperative_agreement",
+      agency: "DOC-EDA",
+      closeDate: "30",
+      costSharing: "true",
+      sortby: "opportunityTitleAsc",
+    });
+
+    expect(reopened.status).toEqual(new Set());
+    expect(reopened.fundingInstrument).toEqual(
+      new Set(["grant", "cooperative_agreement"]),
+    );
+    expect(reopened.agency).toEqual(new Set(["DOC-EDA"]));
+    expect(reopened.closeDate).toEqual(new Set(["30"]));
+    expect(reopened.costSharing).toEqual(new Set(["true"]));
+    expect(reopened.sortby).toEqual("opportunityTitleAsc");
   });
 });

--- a/frontend/src/utils/search/searchFormatUtils.ts
+++ b/frontend/src/utils/search/searchFormatUtils.ts
@@ -1,4 +1,5 @@
 import { pickBy } from "lodash";
+import { SEARCH_NO_STATUS_VALUE } from "src/constants/search";
 import { OptionalStringDict } from "src/types/generalTypes";
 import {
   ValidSearchQueryParamData,
@@ -263,9 +264,16 @@ export const searchToQueryParams = (
         )
       : {};
 
+  // default status values are written into a saved search when it's created, so a saved search
+  // without a status filter means the user deselected every status. Set the "no status" param
+  // explicitly, otherwise the search page would apply the status defaults on load
+  const filtersWithStatus = filters.status
+    ? filters
+    : { ...filters, status: SEARCH_NO_STATUS_VALUE };
+
   const sortby = paginationToSortby(searchRecord?.pagination?.sort_order || []);
   const withQueryAndSort = {
-    ...filters,
+    ...filtersWithStatus,
     query: searchRecord.query || "",
     ...sortby,
   };

--- a/frontend/tests/e2e/search/search-results/features/searchresults-v2-save-search.feature
+++ b/frontend/tests/e2e/search/search-results/features/searchresults-v2-save-search.feature
@@ -155,6 +155,16 @@ Scenario: Saved search dropdown consistently reflects the applied selection
   When I reselect "<secondSavedSearch>"
   Then the dropdown should show "<secondSavedSearch>" as selected
 
+# --- reported as issue 11710 ---
+Scenario: Saved search with all statuses deselected does not reapply the default statuses
+  Given I am logged in
+  And I have deselected the "Open" and "Forecasted" status filters
+  When I save the search
+  And I reopen the saved search
+  Then the "Open" and "Forecasted" filter pills should not be displayed
+  And no status filter checkboxes should be selected
+  And the results should match the search that was saved
+
 # --- reported and awaiting confirmation on expected behavior ---
 # --- Per reviewer comment this may belong in Search feature instead of Save Search --- 
 # --- Commented out for future discussion ---


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Work for #11710 

## Changes proposed

- Updated `searchFormatUtils.ts` to set the `status=none` param when a saved search has no status filter, so the search page no longer reapplies the default `forecasted,posted` statuses on load
- Updated `SavedSearchesList.tsx` to skip the `none` status sentinel when rendering a saved search's filter summary, instead of printing an empty `Status:` row
- Updated `searchFormatUtils.test.ts` to cover the missing and empty status filter cases, and to expect the `none` status on an empty saved search
- Updated `SavedSearchesList.test.tsx` to assert no status row renders for a saved search with every status deselected
- Updated `searchresults-v2-save-search.feature` to document the reported scenario

## Context for reviewers

The "no statuses selected" state is represented in the URL by the `status=none` sentinel, but it was being erased on the saved-search round trip: `buildFilters` drops empty sets, so the stored `search_query` had no `opportunity_status` key, and on reload `paramToSet` treated the missing param as "apply the defaults." Reading an absent status filter as "user cleared them all" is safe because default statuses are materialized at save time. A default search saves `opportunity_status: {one_of: ["forecasted", "posted"]}` - so the two states are distinguishable in stored records. One behavior change: any saved search already persisted without `opportunity_status` will now resolve to all statuses rather than the defaults, which will visibly change its results on first reopen.

## Validation steps

Confirm test pass. 

To test manually:
1. Go to `localhost:3000/search` and sign in.
2. Uncheck Open and Forecasted in the Status filter (or click the X on both pills). URL should become `?status=none`. Note the result count.
3. Save → name it → save.
4. Reload `/search` fresh, then pick that saved search from the dropdown.
    Before the fix: the Open/Forecasted pills come back and the count changes.
    After: no status pills, no status checkboxes selected, same count as step 2.
5. Also check the other entry point: `/workspace/saved-search-queries` - the saved query should show no `Status:` row, and clicking its link should land on `/search` with statuses still cleared.
6. Regression check: save a normal search with only Open checked, reopen it - only Open should be selected, not Open + Forecasted.