### PR TITLE
[Issue #12180] Align local 'orgMember' E2E seed user with staging and add a dedicated no agency test user

### DIFF
--- a/api/tests/lib/seed_e2e.py
+++ b/api/tests/lib/seed_e2e.py
@@ -57,6 +57,8 @@ E2E_ORGANIZATION_ID = uuid.UUID("e5f6a7b8-c9d0-4e5f-8a0b-1c2d3e4f5061")
 # Static id for the secondary E2E test user, a member of the E2E test organization.
 E2E_ORG_MEMBER_USER_ID = uuid.UUID("a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d")
 # Static id for the local no-agency E2E test user.
+# This user is seeded ahead of the no-agency branch tests that need a
+# fully authenticated user with no agency memberships.
 E2E_NO_AGENCY_USER_ID = uuid.UUID("c0ffee00-1234-4e56-89ab-cdef01234567")
 
 

--- a/api/tests/lib/seed_e2e.py
+++ b/api/tests/lib/seed_e2e.py
@@ -56,6 +56,8 @@ E2E_ORGANIZATION_ID = uuid.UUID("e5f6a7b8-c9d0-4e5f-8a0b-1c2d3e4f5061")
 
 # Static id for the secondary E2E test user, a member of the E2E test organization.
 E2E_ORG_MEMBER_USER_ID = uuid.UUID("a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d")
+# Static id for the local no-agency E2E test user.
+E2E_NO_AGENCY_USER_ID = uuid.UUID("c0ffee00-1234-4e56-89ab-cdef01234567")
 
 
 class _SeedE2EConfig(PydanticBaseEnvConfig):
@@ -113,10 +115,20 @@ def _build_users_and_tokens(db_session: db.Session) -> None:
     _write_token_to_file(primary_user.jwt_token)
 
     # Secondary test user with organization membership, mirroring the staging test user.
+    # Add agency membership so local invalid-agency failure path can be exercised.
     (
         UserBuilder(E2E_ORG_MEMBER_USER_ID, db_session, "e2e org member test user")
         .with_e2e_test_user()
         .with_organization(e2e_organization, roles=[ORG_MEMBER])
+        .with_agency(e2e_agency, roles=[OPPORTUNITY_PUBLISHER])
+        .build()
+    )
+
+    # Dedicated local user with no agency membership, used to verify the no-agency
+    # failure path on the grantor opportunities page.
+    (
+        UserBuilder(E2E_NO_AGENCY_USER_ID, db_session, "e2e no-agency test user")
+        .with_e2e_test_user()
         .build()
     )
 

--- a/frontend/tests/e2e/utils/auth/test-users.ts
+++ b/frontend/tests/e2e/utils/auth/test-users.ts
@@ -11,7 +11,8 @@ import playwrightEnv, { SupportedEnvs } from "tests/e2e/playwright-env";
   api/tests/lib/seed_e2e.py, then add a matching entry here.
 */
 
-export type TestUserKey = "primaryOrgAdmin" | "orgMember";
+export type TestUserKey =
+  "primaryOrgAdmin" | "orgMember" | "orgMemberWithAgency" | "noAgencyUser";
 // Organization ids used to build org-scoped URLs (e.g. the org detail page).
 export type TestOrgKey = "e2eTestOrg";
 
@@ -27,6 +28,10 @@ const LOCAL_TEST_USER_IDS: Record<TestUserKey, string> = {
   // but NOT MANAGE_ORG_MEMBERS. Used to assert a non-default (org-member) user
   // can log in and view their organization's detail page.
   orgMember: "a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d",
+  // Local alias for the same seeded org member with agency access.
+  orgMemberWithAgency: "a7b8c9d0-e1f2-4a3b-8c4d-5e6f7a8b9c0d",
+  // Authenticated user with no agency associations for the no-agency branch.
+  noAgencyUser: "c0ffee00-1234-4e56-89ab-cdef01234567",
 };
 
 // Staging ids reference users provisioned directly in staging (not by the repo
@@ -38,6 +43,10 @@ const STAGING_TEST_USER_IDS: Record<TestUserKey, string> = {
   primaryOrgAdmin: "c850d239-43bb-4ccd-9746-977ac7978b79",
   // Member of "E2E Test Organization" (see STAGING_TEST_ORG_IDS.e2eTestOrg).
   orgMember: "ba856cd5-e047-436e-9b6b-f53b4cc534cc",
+  // Staging alias for the same seeded org member with agency access.
+  orgMemberWithAgency: "ba856cd5-e047-436e-9b6b-f53b4cc534cc",
+  // Staging user with no agency membership for the no-agency branch.
+  noAgencyUser: "deadbeef-4321-4e56-89ab-cdef01234567",
 };
 
 const LOCAL_TEST_ORG_IDS: Record<TestOrgKey, string> = {

--- a/frontend/tests/e2e/utils/auth/test-users.ts
+++ b/frontend/tests/e2e/utils/auth/test-users.ts
@@ -7,8 +7,10 @@ import playwrightEnv, { SupportedEnvs } from "tests/e2e/playwright-env";
 
   Each seeded user is flagged in the API seed (with_e2e_test_user grants the
   READ_TEST_USER_TOKEN privilege) so its session token can be fetched via
-  POST /v1/internal/e2e-token. To add a test user: seed it with a static id in
-  api/tests/lib/seed_e2e.py, then add a matching entry here.
+  POST /v1/internal/e2e-token. This file exposes the logical test-user keys
+  that correspond to seeded identities prepared before the E2E tests run.
+  To add a test user: seed it with a static id in api/tests/lib/seed_e2e.py,
+  then add a matching entry here.
 */
 
 export type TestUserKey =


### PR DESCRIPTION
## Summary
Prepare E2E seed data for new local test scenarios and expose matching frontend test user keys.
support this test: [Issue #11779] Create failure-path-opportunities-list.spec.ts- #12143 
<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #12180 

## Changes proposed

- Added `E2E_NO_AGENCY_USER_ID` to `seed_e2e.py`
- Seeded a dedicated local no-agency E2E user for no-agency branch coverage
- Added agency membership to the existing org-member test user so local invalid-agency and grantor scenarios can be exercised
- Extended `test-users.ts` with new `TestUserKey` values:
  - `orgMemberWithAgency`
  - `noAgencyUser`
- Added matching local and staging ID mappings for the new test user keys

## Context for reviewers

This branch is setting up preseeded E2E identities before tests use them. The frontend mapping file now reflects the intended seeded local/staging users, and the backend seed script creates the required user state for:
- an org member with agency access
- an authenticated user with no agency memberships

That prepares the app for future tests that validate both grantor and no-agency flows.

## Validation steps


