### PR TITLE
[Issue #12087] Reduce logging of Parent agency not found: undefined in e2e tests

### DIFF
--- a/frontend/src/utils/search/filterUtils.test.ts
+++ b/frontend/src/utils/search/filterUtils.test.ts
@@ -319,6 +319,82 @@ describe("agenciesToNestedFilterOptions", () => {
       },
     ]);
   });
+
+  it("surfaces an agency with a dashed code but no parent as a top level option", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const result = agenciesToNestedFilterOptions([
+      {
+        agency_code: "DOCNIST",
+        agency_name: "National Institute of Standards and Technology",
+        top_level_agency: null,
+        agency_id: 1,
+      },
+      {
+        agency_code: "AR-TEST",
+        agency_name: "Award Recommendation Test Agency",
+        top_level_agency: null,
+        agency_id: 2,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: "DOCNIST",
+        label: "National Institute of Standards and Technology",
+        value: "DOCNIST",
+      },
+      {
+        id: "AR-TEST",
+        label: "Award Recommendation Test Agency",
+        value: "AR-TEST",
+      },
+    ]);
+    expect(consoleError).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  it("skips and logs an agency whose referenced parent is missing from the list", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const result = agenciesToNestedFilterOptions([
+      {
+        agency_code: "DOCNIST",
+        agency_name: "National Institute of Standards and Technology",
+        top_level_agency: null,
+        agency_id: 1,
+      },
+      {
+        agency_code: "NOPE-SUB",
+        agency_name: "Orphaned by a missing parent",
+        top_level_agency: {
+          agency_code: "NOPE",
+          agency_name: "Never added to the list",
+          top_level_agency: null,
+          agency_id: 3,
+        },
+        agency_id: 2,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: "DOCNIST",
+        label: "National Institute of Standards and Technology",
+        value: "DOCNIST",
+      },
+    ]);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Parent agency NOPE referenced by NOPE-SUB not found in filter options",
+    );
+
+    consoleError.mockRestore();
+  });
 });
 
 describe("flattenAgencies", () => {

--- a/frontend/src/utils/search/filterUtils.test.ts
+++ b/frontend/src/utils/search/filterUtils.test.ts
@@ -2,6 +2,7 @@ import { BaseOpportunity } from "src/types/opportunity/opportunityResponseTypes"
 import { RelevantAgencyRecord } from "src/types/search/searchFilterTypes";
 import {
   agenciesToNestedFilterOptions,
+  agenciesToSortedAndNestedFilterOptions,
   agencyToFilterOption,
   flattenAgencies,
   floatTopLevelAgencies,
@@ -191,6 +192,10 @@ describe("getAgencyDisplayName", () => {
 });
 
 describe("agenciesToNestedFilterOptions", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("converts a simple list of top level agencies to filter options", () => {
     expect(agenciesToNestedFilterOptions(fakeAgencyResponseData)).toEqual([
       {
@@ -353,8 +358,6 @@ describe("agenciesToNestedFilterOptions", () => {
       },
     ]);
     expect(consoleError).not.toHaveBeenCalled();
-
-    consoleError.mockRestore();
   });
 
   it("skips and logs an agency whose referenced parent is missing from the list", () => {
@@ -392,8 +395,67 @@ describe("agenciesToNestedFilterOptions", () => {
     expect(consoleError).toHaveBeenCalledWith(
       "Parent agency NOPE referenced by NOPE-SUB not found in filter options",
     );
+  });
+});
 
-    consoleError.mockRestore();
+describe("agenciesToSortedAndNestedFilterOptions", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("floats, nests and sorts a list containing a parentless dashed agency", () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    // deliberately ordered with the sub agency ahead of its parent so that the
+    // float step has something to do
+    const result = agenciesToSortedAndNestedFilterOptions([
+      {
+        agency_code: "MOCKTRASH-TRASH",
+        agency_name: "More TRASH",
+        top_level_agency: {
+          agency_code: "MOCKTRASH",
+          agency_name: "Mational TRASH",
+          top_level_agency: null,
+          agency_id: 2,
+        },
+        agency_id: 1,
+      },
+      {
+        agency_code: "AR-TEST",
+        agency_name: "Award Recommendation Test Agency",
+        top_level_agency: null,
+        agency_id: 3,
+      },
+      {
+        agency_code: "MOCKTRASH",
+        agency_name: "Mational TRASH",
+        top_level_agency: null,
+        agency_id: 2,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: "AR-TEST",
+        label: "Award Recommendation Test Agency",
+        value: "AR-TEST",
+      },
+      {
+        id: "MOCKTRASH",
+        label: "Mational TRASH",
+        value: "MOCKTRASH",
+        children: [
+          {
+            id: "MOCKTRASH-TRASH",
+            label: "More TRASH",
+            value: "MOCKTRASH-TRASH",
+          },
+        ],
+      },
+    ]);
+    expect(consoleError).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/utils/search/filterUtils.ts
+++ b/frontend/src/utils/search/filterUtils.ts
@@ -105,14 +105,21 @@ export const agenciesToNestedFilterOptions = (
     if (isTopLevelAgency(rawAgency)) {
       return [...acc, agencyOption];
     }
-    const parent = acc.find(
-      (agency: FilterOption) =>
-        agency.id === rawAgency.top_level_agency?.agency_code,
-    );
-    // parent should always already exist in the list because of the pre-sort, if it doesn't just skip the agency
+    const parentCode = rawAgency.top_level_agency?.agency_code;
+    // A dash in the agency code makes an agency look like a sub agency, but the API only
+    // populates top_level_agency when the code's prefix is a real agency, so a dashed code
+    // can legitimately have no parent at all (the API tracks these as orphaned child
+    // agencies). Surface them at the top level so they stay selectable in the filter
+    // rather than being dropped.
+    if (!parentCode) {
+      return [...acc, agencyOption];
+    }
+    const parent = acc.find((agency: FilterOption) => agency.id === parentCode);
+    // a referenced parent should already be in the list because of the pre-sort, if it
+    // isn't there is nothing to nest the agency under, so skip it
     if (!parent) {
       console.error(
-        `Parent agency not found: ${rawAgency.top_level_agency?.agency_code || "undefined"}`,
+        `Parent agency ${parentCode} referenced by ${rawAgency.agency_code} not found in filter options`,
       );
       return acc;
     }


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #12087 

## Changes proposed

- Updated `filterUtils.ts` to split `agenciesToNestedFilterOptions`' single "no parent" branch into two cases: an agency with no `top_level_agency` reference is now surfaced as a top-level filter option instead of being dropped and logged, while an agency referencing a parent genuinely absent from the list is still skipped but logged with both the parent and child agency codes.
- Updated `filterUtils.test.ts` to add coverage for each branch: a dashed code with no parent appears as a top-level option and logs nothing, and a dashed code whose referenced parent is missing is skipped with the new message.

## Context for reviewers

The `undefined` in the log was a real classification mismatch, not a missing-data bug: the API only populates `top_level_agency` when the code's dash prefix is an actual agency row and deliberately leaves it `null` otherwise, while the frontend inferred "sub-agency" from `agency_code.includes("-")` alone, so a parentless dashed code could never match a parent and was silently dropped from the filter entirely. In the local/e2e seed the single offender is `AR-TEST`, which has 14 opportunities and isn't flagged as a test agency, so it was returned by the search and dropped on every render.

Promoting these to top-level options is safe because childless options render as a plain checkbox writing the `agency` query param, which is the correct `agency_code` filter semantics; and an orphan can never itself become a parent, since the API only ever derives dash-free parent codes.

Two things left out deliberately: `AR-TEST` is not renamed (it's referenced only in the seed, so renaming is safe, but keeping it means local/e2e data continues to exercise the parentless path - the e2e run is clean either way), and the two classification rules are not unified. The frontend still infers hierarchy from the code string, which is the root of the mismatch.

## Validation steps

Confirm tests pass. 

Verify against real data with the local stack up and seeded:
Load the search page and open the Agency filter: "Award Recommendation Test Agency" now appears as its own top-level option, and the frontend server console logs no `Parent agency not found` lines.
