### PR TITLE
[Issue #12088] Undefined field type shaping form data logged as an error for UI-only form inputs

### DIFF
--- a/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityAttachmentUploadInput.tsx
+++ b/frontend/src/app/[locale]/(base)/grantor/opportunity/[id]/edit/_components/OpportunityAttachmentUploadInput.tsx
@@ -18,6 +18,9 @@ interface OpportunityAttachmentUploadInputProps {
   initialAttachments?: OpportunityAttachment[];
 }
 
+// this name, along with the two hidden inputs below, is registered as a non schema form data
+// key (see isNonSchemaFormDataKey) - all three are read by name at save time and none belongs
+// in the opportunity summary body, so renaming one means updating that list too
 const UPLOAD_INPUT_ID = "opportunity-attachment-upload";
 const UPLOAD_LABEL_ID = `${UPLOAD_INPUT_ID}-label`;
 

--- a/frontend/src/components/apply-form/widgets/ApplicationAttachmentWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/ApplicationAttachmentWidget.tsx
@@ -10,6 +10,7 @@ import {
   buildAttachmentDescribedByIds,
   mapAttachmentsToFileMetadata,
 } from "src/utils/applyForm/applicationAttachmentUtils";
+import { VISIBLE_FILE_INPUT_SUFFIX } from "src/utils/formData/formDataUtils";
 
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
@@ -105,7 +106,7 @@ const ApplicationAttachmentWidget = ({
     attachmentsUploadingCounter?.decrementAttachmentsProcessing();
   };
 
-  const visibleInputId = `${id}-visible`;
+  const visibleInputId = `${id}${VISIBLE_FILE_INPUT_SUFFIX}`;
   const error = rawErrors.length ? true : undefined;
   const describedByIds = buildAttachmentDescribedByIds({
     visibleInputId,

--- a/frontend/src/components/apply-form/widgets/ApplicationMultipleAttachmentWidget.tsx
+++ b/frontend/src/components/apply-form/widgets/ApplicationMultipleAttachmentWidget.tsx
@@ -11,6 +11,7 @@ import {
   mapAttachmentsToFileMetadata,
   parseAttachmentIds,
 } from "src/utils/applyForm/applicationAttachmentUtils";
+import { VISIBLE_FILE_INPUT_SUFFIX } from "src/utils/formData/formDataUtils";
 
 import { useTranslations } from "next-intl";
 import { useParams } from "next/navigation";
@@ -179,7 +180,7 @@ const ApplicationMultipleAttachmentWidget = ({
     onChange?.(selectedAttachmentIds);
   }, [selectedAttachmentIds, onChange]);
 
-  const visibleInputId = `${id}-visible`;
+  const visibleInputId = `${id}${VISIBLE_FILE_INPUT_SUFFIX}`;
   const error = rawErrors.length ? true : undefined;
   const describedByIds = buildAttachmentDescribedByIds({
     visibleInputId,

--- a/frontend/src/utils/applyForm/applyFormUtils.ts
+++ b/frontend/src/utils/applyForm/applyFormUtils.ts
@@ -643,12 +643,6 @@ export const shapeFormData = <T extends object>(
   formData: FormData,
   formSchema: RJSFSchema,
 ): T => {
-  formData.delete("$ACTION_REF_1");
-  formData.delete("$ACTION_1:0");
-  formData.delete("$ACTION_1:1");
-  formData.delete("$ACTION_REF_1");
-  formData.delete("$ACTION_KEY");
-  formData.delete("apply-form-button");
 
   const structuredFormData = formDataToObject(
     formData,

--- a/frontend/src/utils/applyForm/applyFormUtils.ts
+++ b/frontend/src/utils/applyForm/applyFormUtils.ts
@@ -643,7 +643,6 @@ export const shapeFormData = <T extends object>(
   formData: FormData,
   formSchema: RJSFSchema,
 ): T => {
-
   const structuredFormData = formDataToObject(
     formData,
     condenseFormSchemaProperties(formSchema),

--- a/frontend/src/utils/formData/formDataToJson.test.ts
+++ b/frontend/src/utils/formData/formDataToJson.test.ts
@@ -166,6 +166,48 @@ describe("formDataToObject", () => {
     // @ts-ignore
     expect(result).toEqual({ whatever: null });
   });
+  it("skips UI only control inputs rather than shaping or reporting them", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {
+      // noop
+    });
+    const formData = new FormData();
+    formData.append("attachments", "an-attachment-id");
+    formData.append("attachments-visible", new File([], ""));
+    formData.append("submitType", "saveAndExit");
+    formData.append("opportunity-attachment-upload", new File([], ""));
+    formData.append("held_pending_file_ids", '["pending-1"]');
+    formData.append("deleted_attachment_ids", "[]");
+    formData.append("$ACTION_KEY", "whatever");
+
+    const formSchema = {
+      attachments: { type: "string" },
+    };
+
+    const result = formDataToObject(formData, formSchema, undefined);
+
+    expect(result).toEqual({ attachments: "an-attachment-id" });
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+  it("reports a schema backed field with no resolvable type", () => {
+    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {
+      // noop
+    });
+    const formData = new FormData();
+    formData.append("typoed_field_name", "a value");
+
+    const formSchema = {
+      correct_field_name: { type: "string" },
+    };
+
+    formDataToObject(formData, formSchema, undefined);
+
+    expect(consoleError).toHaveBeenCalledWith(expect.any(String), {
+      formDataKey: "typoed_field_name",
+      schemaPath: "/typoed_field_name",
+    });
+    consoleError.mockRestore();
+  });
   it("defaults to undefined for empty values when specified", () => {
     const formData = new FormData();
     formData.append("whatever", "");

--- a/frontend/src/utils/formData/formDataToJson.test.ts
+++ b/frontend/src/utils/formData/formDataToJson.test.ts
@@ -166,10 +166,43 @@ describe("formDataToObject", () => {
     // @ts-ignore
     expect(result).toEqual({ whatever: null });
   });
-  it("skips UI only control inputs rather than shaping or reporting them", () => {
-    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {
-      // noop
+  it("defaults to undefined for empty values when specified", () => {
+    const formData = new FormData();
+    formData.append("whatever", "");
+    const formSchema = {
+      something: {
+        items: { whatever: { type: "string" } },
+      },
+    };
+
+    const result = formDataToObject(formData, formSchema, undefined);
+
+    // eslint-disable-next-line
+    // @ts-ignore
+    expect(result).toEqual({ whatever: undefined });
+  });
+});
+
+/*
+  a field whose type cannot be resolved gets its value guessed at, which for submitted
+  application data is worth someone's attention. UI only control inputs are filtered out so they
+  cannot bury it, so these cover both halves: the control inputs stay silent, and every shape of
+  real mismatch still gets a line
+*/
+describe("formDataToObject undefined field type reporting", () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, "error").mockImplementation(() => {
+      // keeps the expected errors out of the test output
     });
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("stays silent for UI only control inputs and leaves them out of the output", () => {
     const formData = new FormData();
     formData.append("attachments", "an-attachment-id");
     formData.append("attachments-visible", new File([], ""));
@@ -187,12 +220,9 @@ describe("formDataToObject", () => {
 
     expect(result).toEqual({ attachments: "an-attachment-id" });
     expect(consoleError).not.toHaveBeenCalled();
-    consoleError.mockRestore();
   });
-  it("reports a schema backed field with no resolvable type", () => {
-    const consoleError = jest.spyOn(console, "error").mockImplementation(() => {
-      // noop
-    });
+
+  it("reports a field with no matching schema definition", () => {
     const formData = new FormData();
     formData.append("typoed_field_name", "a value");
 
@@ -202,25 +232,89 @@ describe("formDataToObject", () => {
 
     formDataToObject(formData, formSchema, undefined);
 
+    // asserted as a prefix rather than expect.any(String) because the e2e check for this
+    // ticket is a grep for this exact wording
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Undefined field type shaping form data"),
+      { formDataKey: "typoed_field_name", schemaPath: "/typoed_field_name" },
+    );
+  });
+
+  // the definition resolves here, so this is the mismatch a missing-pointer check alone misses
+  it("reports a field whose schema definition omits a type", () => {
+    const formData = new FormData();
+    formData.append("status", "a value");
+
+    const formSchema = {
+      status: { enum: ["a value", "another value"] },
+    };
+
+    formDataToObject(formData, formSchema, undefined);
+
+    expect(consoleError).toHaveBeenCalledWith(expect.any(String), {
+      formDataKey: "status",
+      schemaPath: "/status",
+    });
+  });
+
+  it("reports a nested field missing from an otherwise valid parent", () => {
+    const formData = new FormData();
+    formData.append("contact--first_name", "Alice");
+    formData.append("contact--typoed_field_name", "a value");
+
+    const formSchema = {
+      contact: { first_name: { type: "string" } },
+    };
+
+    formDataToObject(formData, formSchema, undefined);
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(expect.any(String), {
+      formDataKey: "contact--typoed_field_name",
+      schemaPath: "/contact/typoed_field_name",
+    });
+  });
+
+  // array keys are rewritten to point at the schema's "items" before the lookup, so the reported
+  // path should name the items definition rather than the submitted index
+  it("reports an array item field missing from the items definition", () => {
+    const formData = new FormData();
+    formData.append("activities[0]--cost", "100");
+    formData.append("activities[0]--typoed_field_name", "a value");
+
+    const formSchema = {
+      activities: { items: { cost: { type: "number" } } },
+    };
+
+    formDataToObject(formData, formSchema, undefined);
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(expect.any(String), {
+      formDataKey: "activities[0]--typoed_field_name",
+      schemaPath: "/activities/items/typoed_field_name",
+    });
+  });
+
+  // the case the ticket is about: 356 control input lines per e2e run used to make a line like
+  // this one indistinguishable from noise
+  it("reports a real mismatch submitted alongside control inputs", () => {
+    const formData = new FormData();
+    formData.append("attachments", "an-attachment-id");
+    formData.append("attachments-visible", new File([], ""));
+    formData.append("att1-visible", new File([], ""));
+    formData.append("submitType", "saveAndExit");
+    formData.append("typoed_field_name", "a value");
+
+    const formSchema = {
+      attachments: { type: "string" },
+    };
+
+    formDataToObject(formData, formSchema, undefined);
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith(expect.any(String), {
       formDataKey: "typoed_field_name",
       schemaPath: "/typoed_field_name",
     });
-    consoleError.mockRestore();
-  });
-  it("defaults to undefined for empty values when specified", () => {
-    const formData = new FormData();
-    formData.append("whatever", "");
-    const formSchema = {
-      something: {
-        items: { whatever: { type: "string" } },
-      },
-    };
-
-    const result = formDataToObject(formData, formSchema, undefined);
-
-    // eslint-disable-next-line
-    // @ts-ignore
-    expect(result).toEqual({ whatever: undefined });
   });
 });

--- a/frontend/src/utils/formData/formDataToJson.ts
+++ b/frontend/src/utils/formData/formDataToJson.ts
@@ -111,12 +111,14 @@ export function formDataToObject<T = NestedObject>(
   const entries = formData.entries();
 
   for (const [key, value] of entries) {
-    const currentKey = parentKey ? `${parentKey}${delimiter}${key}` : key;
     // UI only control inputs carry no schema backed value, so they are skipped rather than
-    // looked up (which would report a type mismatch) and rather than shaped into the output
-    if (isNonSchemaFormDataKey(currentKey)) {
+    // looked up (which would report a type mismatch) and rather than shaped into the output.
+    // Checked against the input's own name rather than the parentKey prefixed path, since
+    // whether something is a control input is a property of the input, not of where it sits
+    if (isNonSchemaFormDataKey(key)) {
       continue;
     }
+    const currentKey = parentKey ? `${parentKey}${delimiter}${key}` : key;
     const chunks = currentKey.split(delimiter);
     const fieldType = getFieldType(
       currentKey,

--- a/frontend/src/utils/formData/formDataToJson.ts
+++ b/frontend/src/utils/formData/formDataToJson.ts
@@ -5,6 +5,7 @@ import {
   FORM_DATA_NESTING_DELIMITER,
   getByPointer,
   getFieldPathFromHtml,
+  isNonSchemaFormDataKey,
 } from "src/utils/formData/formDataUtils";
 
 // like, this is basically anything lol - DWS
@@ -83,7 +84,12 @@ const getFieldType = (
     type?: string;
   };
   if (!formFieldDefinition?.type) {
-    console.error("Undefined field type shaping form data", currentKey);
+    // control inputs are filtered out before we get here, so this is a schema backed field
+    // whose value we are about to guess the type of
+    console.error(
+      "Undefined field type shaping form data - guessing string, submitted value may be the wrong type",
+      { formDataKey: currentKey, schemaPath: fullPath },
+    );
     return "string"; // I mean, like, we may as well take our best guess and cross our fingers
   }
   return formFieldDefinition?.type;
@@ -106,6 +112,11 @@ export function formDataToObject<T = NestedObject>(
 
   for (const [key, value] of entries) {
     const currentKey = parentKey ? `${parentKey}${delimiter}${key}` : key;
+    // UI only control inputs carry no schema backed value, so they are skipped rather than
+    // looked up (which would report a type mismatch) and rather than shaped into the output
+    if (isNonSchemaFormDataKey(currentKey)) {
+      continue;
+    }
     const chunks = currentKey.split(delimiter);
     const fieldType = getFieldType(
       currentKey,

--- a/frontend/src/utils/formData/formDataUtils.test.ts
+++ b/frontend/src/utils/formData/formDataUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   getByPointer,
   getFieldPathFromHtml,
+  isNonSchemaFormDataKey,
 } from "src/utils/formData/formDataUtils";
 
 jest.mock("json-pointer", () => ({
@@ -15,6 +16,34 @@ describe("getFieldPathFromHtml", () => {
   });
   it("honors alternate html side delimiters", () => {
     expect(getFieldPathFromHtml("foo.bar", ".")).toBe("/foo/bar");
+  });
+});
+
+describe("isNonSchemaFormDataKey", () => {
+  it.each([
+    "att1-visible",
+    "attachments-visible",
+    "budget--attachments-visible",
+    "submitType",
+    "apply-form-button",
+    "opportunity-attachment-upload",
+    "held_pending_file_ids",
+    "deleted_attachment_ids",
+    "$ACTION_REF_1",
+    "$ACTION_1:0",
+    "$ACTION_KEY",
+  ])("identifies control input %s", (key) => {
+    expect(isNonSchemaFormDataKey(key)).toBe(true);
+  });
+
+  it.each([
+    "attachments",
+    "att1",
+    "budget--attachments",
+    "opportunity_title",
+    "visible",
+  ])("does not claim schema backed field %s", (key) => {
+    expect(isNonSchemaFormDataKey(key)).toBe(false);
   });
 });
 

--- a/frontend/src/utils/formData/formDataUtils.ts
+++ b/frontend/src/utils/formData/formDataUtils.ts
@@ -10,6 +10,39 @@ export const JSON_SCHEMA_NESTING_DELIMITER = "/";
 // API side validation library delimits nesting with a dot rather than a slash
 export const VALIDATION_ERROR_NESTING_DELIMITER = ".";
 
+/*
+  suffix for the user facing file chooser that attachment widgets render alongside the hidden
+  input holding the schema backed value
+*/
+export const VISIBLE_FILE_INPUT_SUFFIX = "-visible";
+
+const SERVER_ACTION_KEY_PREFIX = "$ACTION";
+
+/*
+  FormData keys belonging to inputs that drive the UI or the submission itself rather than
+  carrying a value defined in a form schema. Each of these is read by name by the code that
+  needs it, so none of them has a schema definition
+*/
+const NON_SCHEMA_FORM_DATA_KEYS = new Set([
+  // which submit button was clicked, read in the opportunity edit and competition actions
+  "submitType",
+  // the apply form's submit button
+  "apply-form-button",
+  // the opportunity attachment chooser, plus the held / marked for deletion ids it carries
+  // through to the next save
+  "opportunity-attachment-upload",
+  "held_pending_file_ids",
+  "deleted_attachment_ids",
+]);
+
+/*
+  Identifies keys that should not be looked up against a form schema
+*/
+export const isNonSchemaFormDataKey = (key: string): boolean =>
+  NON_SCHEMA_FORM_DATA_KEYS.has(key) ||
+  key.endsWith(VISIBLE_FILE_INPUT_SUFFIX) ||
+  key.startsWith(SERVER_ACTION_KEY_PREFIX);
+
 // transform a form data field name / id into a json path that can be used to reference the form schema
 // (assumes that any `/properties` path segments have been removed from schema)
 export const getFieldPathFromHtml = (

--- a/frontend/src/utils/formData/formDataUtils.ts
+++ b/frontend/src/utils/formData/formDataUtils.ts
@@ -24,7 +24,7 @@ const SERVER_ACTION_KEY_PREFIX = "$ACTION";
   needs it, so none of them has a schema definition
 */
 const NON_SCHEMA_FORM_DATA_KEYS = new Set([
-  // which submit button was clicked, read in the opportunity edit and competition actions
+  // which submit button was clicked on the opportunity edit form, read by its action
   "submitType",
   // the apply form's submit button
   "apply-form-button",
@@ -36,7 +36,7 @@ const NON_SCHEMA_FORM_DATA_KEYS = new Set([
 ]);
 
 /*
-  Identifies keys that should not be looked up against a form schema
+  Identifies control input names that should not be looked up against a form schema
 */
 export const isNonSchemaFormDataKey = (key: string): boolean =>
   NON_SCHEMA_FORM_DATA_KEYS.has(key) ||


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #12088 

## Changes proposed

- Updated `formDataUtils.ts` to add `isNonSchemaFormDataKey`, which recognizes the control input names that have no form schema counterpart
- Updated `formDataToJson.ts` to skip those keys at the top of the FormData walk, before the schema type lookup, and to report a real mismatch with what the fallback costs plus the `formDataKey` and resolved `schemaPath`
- Updated `applyFormUtils.ts` to drop the six redundant `formData.delete` calls in `shapeFormData`
- Updated `formDataToJson.test.ts` to add a reporting describe block covering both halves: control inputs stay silent and out of the shaped output, while a missing definition, a definition without a `type`, a nested leaf, an array item path, and a real mismatch submitted alongside control inputs each still produce exactly one line
- Updated `formDataUtils.test.ts` to cover `isNonSchemaFormDataKey` across every control input pattern plus schema-backed names it must not claim
- Updated `ApplicationAttachmentWidget.tsx` to build `visibleInputId` from the shared `VISIBLE_FILE_INPUT_SUFFIX` rather than a local `-visible` literal
- Updated `ApplicationMultipleAttachmentWidget.tsx` to build `visibleInputId` from the same shared suffix
- Updated `OpportunityAttachmentUploadInput.tsx` to note that its upload input name and two hidden inputs are registered as non-schema keys, so a rename has to update that list

## Context for reviewers

The filter is non-mutating on purpose: `edit/actions.ts` reads `submitType` after the save runs, and `processAttachmentChanges` reads the attachment ids from the same FormData, so deleting the keys instead of skipping them would break both. The grantor summary create/update body no longer carries `submitType`, the two attachment id lists, or the upload `File` object (all pre-existing junk in that request), and `held_pending_file_ids` / `deleted_attachment_ids` weren't in the ticket's tally, but they hit the same path so they're covered here.

## Validation steps

Confirm tests pass.

Run the e2e suite in CI (or check the logs for the run on this PR), then search the frontend server log for `Undefined field type shaping form data` - expect zero lines.