### PR TITLE
[unticketed]: update nofos dev deploy

### DIFF
--- a/.github/workflows/scheduled-dev-deploy.yml
+++ b/.github/workflows/scheduled-dev-deploy.yml
@@ -81,7 +81,7 @@ jobs:
     needs: [nofos-checks, nofos-vulnerability-scans]
     uses: ./.github/workflows/deploy-nofos.yml
     with:
-      environment: "dev"
+      environment: "infra-dev"
       version: "main"
 
   send-slack-notification:


### PR DESCRIPTION
## Summary

Updated nofos dev deploy to use the infra-dev environment. 

## Validation steps

Ran the scheduled dev release deploy: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/33403371736)