### PR TITLE
[Unticketed] Fixed failing E2E selector for competition application package page

### DIFF
--- a/frontend/tests/e2e/opportunity/fixtures/application-package-field-definitions.ts
+++ b/frontend/tests/e2e/opportunity/fixtures/application-package-field-definitions.ts
@@ -90,7 +90,7 @@ export const APPLICATION_PACKAGE_SUBMISSION_WINDOW_FIELD_DEFINITIONS: Applicatio
       required: true,
     },
     {
-      selector: "#extension_period",
+      selector: "#grace_period",
       label: "Extension period",
       type: "text",
       valueKey: "extensionPeriod",


### PR DESCRIPTION
Updated todo list

## Summary
[unticketed] Fixed a failing E2E field selector for the competition application package page.

## Changes proposed

- Updated `application-package-field-definitions.ts`
- Replaced `selector: "#extension_period"` with `selector: "#grace_period"`

## Context for reviewers
The page now renders the `Extension period` input with `id="grace_period"`, so the existing test metadata was pointing at a stale DOM selector. This resolves the Playwright timeout when filling that field during the happy-path application package spec.

