### PR TITLE
[Issue #12090] Reduce migration SQL logging in e2e tests

### DIFF
--- a/api/src/db/migrations/run.py
+++ b/api/src/db/migrations/run.py
@@ -3,8 +3,6 @@
 # running on the production docker image from any directory.
 import logging
 import os
-import time
-from typing import Any
 
 import alembic.command as command
 import alembic.script as script
@@ -34,7 +32,7 @@ init_general_logging(logging.root, "migrations", "simpler-grants")
 
 @ecs_background_task(JobType.MIGRATE_UP)
 def up(revision: str = "head") -> None:
-    enable_query_logging()
+    enable_query_error_logging()
     command.upgrade(alembic_cfg, revision)
     # Sync lookup values like enums or other static data
     sync_lookup_values()
@@ -42,48 +40,35 @@ def up(revision: str = "head") -> None:
 
 @ecs_background_task(JobType.MIGRATE_DOWN)
 def down(revision: str = "-1") -> None:
-    enable_query_logging()
+    enable_query_error_logging()
     command.downgrade(alembic_cfg, revision)
 
 
 @ecs_background_task(JobType.MIGRATE_DOWNALL)
 def downall(revision: str = "base") -> None:
-    enable_query_logging()
+    enable_query_error_logging()
     command.downgrade(alembic_cfg, revision)
 
 
-def enable_query_logging() -> None:
-    """Log each migration query as it happens along with timing.
+def collapse_sql(statement: str) -> str:
+    """Collapse a multi-line SQL statement onto a single line."""
+    return " ".join(statement.split())
 
-    Based on the example at https://docs.sqlalchemy.org/en/20/faq/performance.html#query-profiling
-    """
 
-    @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "before_cursor_execute", retval=True)
-    def before_execute(
-        conn: sqlalchemy.Connection,
-        _cursor: Any,
-        statement: str,
-        _parameters: Any,
-        _context: Any,
-        _executemany: bool,
-    ) -> tuple[str, Any]:
-        conn.info.setdefault("query_start_time", []).append(time.monotonic())
-        logger.info("Running migration SQL", extra={"migrate.sql": statement.strip()})
-        return statement, _parameters
+def log_migration_sql_error(exception_context: sqlalchemy.ExceptionContext) -> None:
+    # Errors raised outside of executing a statement (eg. connecting to the DB)
+    # don't have a statement attached to them
+    if exception_context.statement is None:
+        return
 
-    @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, "after_cursor_execute")
-    def after_execute(
-        conn: sqlalchemy.Connection,
-        _cursor: Any,
-        statement: str,
-        _parameters: Any,
-        _context: Any,
-        _executemany: bool,
-    ) -> None:
-        total = int(1000 * (time.monotonic() - conn.info["query_start_time"].pop(-1)))
-        logger.info(
-            "Ran migration SQL", extra={"migrate.sql": statement.strip(), "migrate.time_ms": total}
-        )
+    logger.error(
+        "Migration SQL failed", extra={"migrate.sql": collapse_sql(exception_context.statement)}
+    )
+
+
+def enable_query_error_logging() -> None:
+    """Log the SQL of any migration statement that fails."""
+    sqlalchemy.event.listen(sqlalchemy.engine.Engine, "handle_error", log_migration_sql_error)
 
 
 def have_all_migrations_run(db_engine: sqlalchemy.engine.Engine) -> None:

--- a/api/src/db/migrations/run.py
+++ b/api/src/db/migrations/run.py
@@ -50,9 +50,9 @@ def downall(revision: str = "base") -> None:
     command.downgrade(alembic_cfg, revision)
 
 
-def collapse_sql(statement: str) -> str:
-    """Collapse a multi-line SQL statement onto a single line."""
-    return " ".join(statement.split())
+def escape_sql_newlines(statement: str) -> str:
+    """Escape the newlines in a SQL statement so it logs as a single line."""
+    return "\\n".join(statement.strip().splitlines())
 
 
 def log_migration_sql_error(exception_context: sqlalchemy.ExceptionContext) -> None:
@@ -62,7 +62,8 @@ def log_migration_sql_error(exception_context: sqlalchemy.ExceptionContext) -> N
         return
 
     logger.error(
-        "Migration SQL failed", extra={"migrate.sql": collapse_sql(exception_context.statement)}
+        "Migration SQL failed",
+        extra={"migrate.sql": escape_sql_newlines(exception_context.statement)},
     )
 
 

--- a/api/tests/src/db/test_migrations.py
+++ b/api/tests/src/db/test_migrations.py
@@ -1,6 +1,5 @@
 import logging
 import uuid
-from unittest.mock import Mock
 
 import alembic.command as command
 import grants_shared.adapters.db as db
@@ -12,8 +11,8 @@ from alembic.util.exc import CommandError
 
 from src.db.migrations.run import (
     alembic_cfg,
-    collapse_sql,
     enable_query_error_logging,
+    escape_sql_newlines,
     log_migration_sql_error,
 )
 from tests.lib import db_testing
@@ -103,12 +102,27 @@ def query_error_logging():
         ("SELECT 1", "SELECT 1"),
         (
             "CREATE TABLE api.example (\n\texample_id UUID NOT NULL, \n\tname TEXT\n)\n\n",
-            "CREATE TABLE api.example ( example_id UUID NOT NULL, name TEXT )",
+            "CREATE TABLE api.example (\\n\texample_id UUID NOT NULL, \\n\tname TEXT\\n)",
+        ),
+        (
+            "CREATE FUNCTION api.f() RETURNS TRIGGER AS $$\n"
+            "BEGIN\n"
+            "    -- Determine the opportunity_id\n"
+            "    RETURN NEW;\n"
+            "END;\n"
+            "$$ LANGUAGE plpgsql;",
+            "CREATE FUNCTION api.f() RETURNS TRIGGER AS $$\\nBEGIN\\n"
+            "    -- Determine the opportunity_id\\n    RETURN NEW;\\nEND;\\n$$ LANGUAGE plpgsql;",
         ),
     ],
 )
-def test_collapse_sql(statement, expected):
-    assert collapse_sql(statement) == expected
+def test_escape_sql_newlines(statement, expected):
+    escaped = escape_sql_newlines(statement)
+
+    assert escaped == expected
+    assert "\n" not in escaped
+    # The escaped form has to survive a round trip back into runnable SQL
+    assert escaped.replace("\\n", "\n") == statement.strip()
 
 
 def test_successful_migration_sql_not_logged(
@@ -135,14 +149,21 @@ def test_failing_migration_sql_logged_at_error(
 
     error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
     assert [getattr(record, "migrate.sql") for record in error_records] == [
-        "CREATE TABLE example ( bad_column NOT_A_TYPE )"
+        "CREATE TABLE example (\\n\tbad_column NOT_A_TYPE\\n)"
     ]
 
 
-def test_failing_connection_without_statement_not_logged(caplog: pytest.LogCaptureFixture):
+def test_failing_connection_without_statement_not_logged(
+    query_error_logging, caplog: pytest.LogCaptureFixture
+):
     """Errors that aren't tied to a statement (eg. failing to connect) have nothing to log."""
     caplog.set_level(logging.INFO)
 
-    log_migration_sql_error(Mock(spec=sqlalchemy.ExceptionContext, statement=None))
+    # Nothing listens on port 1, so this fails to connect without ever sending a statement
+    engine = sqlalchemy.create_engine(
+        "postgresql+psycopg://app@localhost:1/nope", connect_args={"connect_timeout": 2}
+    )
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        engine.connect()
 
-    assert not caplog.records
+    assert not [record for record in caplog.records if hasattr(record, "migrate.sql")]

--- a/api/tests/src/db/test_migrations.py
+++ b/api/tests/src/db/test_migrations.py
@@ -1,14 +1,21 @@
 import logging
 import uuid
+from unittest.mock import Mock
 
 import alembic.command as command
 import grants_shared.adapters.db as db
 import pytest
+import sqlalchemy
 from alembic.script import ScriptDirectory
 from alembic.script.revision import MultipleHeads
 from alembic.util.exc import CommandError
 
-from src.db.migrations.run import alembic_cfg
+from src.db.migrations.run import (
+    alembic_cfg,
+    collapse_sql,
+    enable_query_error_logging,
+    log_migration_sql_error,
+)
 from tests.lib import db_testing
 
 
@@ -76,3 +83,66 @@ def test_db_init_with_migrations(empty_schema):
     # Verify the DB session works after initializing the migrations
     db_session = empty_schema.get_session()
     db_session.close()
+
+
+@pytest.fixture
+def query_error_logging():
+    """Register the migration error logging listener, and clean it up afterwards.
+
+    The listener attaches to the Engine class itself, so it'd otherwise
+    stay registered for every test that runs after this one.
+    """
+    enable_query_error_logging()
+    yield
+    sqlalchemy.event.remove(sqlalchemy.engine.Engine, "handle_error", log_migration_sql_error)
+
+
+@pytest.mark.parametrize(
+    "statement,expected",
+    [
+        ("SELECT 1", "SELECT 1"),
+        (
+            "CREATE TABLE api.example (\n\texample_id UUID NOT NULL, \n\tname TEXT\n)\n\n",
+            "CREATE TABLE api.example ( example_id UUID NOT NULL, name TEXT )",
+        ),
+    ],
+)
+def test_collapse_sql(statement, expected):
+    assert collapse_sql(statement) == expected
+
+
+def test_successful_migration_sql_not_logged(
+    empty_schema, query_error_logging, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.DEBUG)
+
+    db_session = empty_schema.get_session()
+    db_session.execute(sqlalchemy.text("CREATE TABLE example (\n\texample_id INT\n)"))
+    db_session.close()
+
+    assert not [record for record in caplog.records if hasattr(record, "migrate.sql")]
+
+
+def test_failing_migration_sql_logged_at_error(
+    empty_schema, query_error_logging, caplog: pytest.LogCaptureFixture
+):
+    caplog.set_level(logging.INFO)
+
+    db_session = empty_schema.get_session()
+    with pytest.raises(sqlalchemy.exc.ProgrammingError):
+        db_session.execute(sqlalchemy.text("CREATE TABLE example (\n\tbad_column NOT_A_TYPE\n)"))
+    db_session.close()
+
+    error_records = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert [getattr(record, "migrate.sql") for record in error_records] == [
+        "CREATE TABLE example ( bad_column NOT_A_TYPE )"
+    ]
+
+
+def test_failing_connection_without_statement_not_logged(caplog: pytest.LogCaptureFixture):
+    """Errors that aren't tied to a statement (eg. failing to connect) have nothing to log."""
+    caplog.set_level(logging.INFO)
+
+    log_migration_sql_error(Mock(spec=sqlalchemy.ExceptionContext, statement=None))
+
+    assert not caplog.records


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #12090 

## Changes proposed

- Updated `run.py` to stop logging every migration statement. Removed the `before_cursor_execute` and `after_cursor_execute` listeners (and the `migrate.time_ms` timing they carried), replacing them with a single `handle_error` listener that logs only the statement that failed, newline-escaped to one line by the new `escape_sql_newlines` helper. `enable_query_logging` is renamed `enable_query_error_logging` at its three call sites.
- Updated `test_migrations.py` to cover the new behavior: `collapse_sql` whitespace collapsing, successful statements emitting no `migrate.sql` record even at DEBUG, a failing statement logging once at ERROR with the collapsed SQL, and the no-statement guard for connect-time errors.

## Context for reviewers

`handle_error` also fires for errors with no statement attached (connection failures, pool pre-ping), which is what the `statement is None` guard covers.

As a note, there is no longer any way to recover the executed SQL by raising the log level. Alembic's own per-revision INFO logs and the migration files themselves are the remaining record.

## Validation steps

Confirm tests pass. 

In addition to the logs of the CI runs (including the ones run in this PR), the log reduction can be verified against a scratch database:
   ```
   docker exec grants-db psql -U app -d app -c "CREATE DATABASE migrate_log_check;"
   docker compose run --rm -e DB_NAME=migrate_log_check -e LOG_FORMAT=human-readable grants-api setup-postgres-db
   docker compose run --rm -e DB_NAME=migrate_log_check -e LOG_FORMAT=human-readable grants-api db-migrate | wc -l
   ```
Expect ~545 lines, against ~10,475 on `main`.

Verify a failing migration still surfaces the statement by forcing a collision on the first table the migrations create, then re-run:
   ```
   docker exec grants-db psql -U app -d app -c "DROP DATABASE migrate_log_check;" -c "CREATE DATABASE migrate_log_check;"
   docker compose run --rm -e DB_NAME=migrate_log_check -e LOG_FORMAT=human-readable grants-api setup-postgres-db
   docker exec grants-db psql -U app -d migrate_log_check -c "CREATE TABLE api.topportunity (blocker int);"
   docker compose run --rm -e DB_NAME=migrate_log_check -e LOG_FORMAT=human-readable grants-api db-migrate
   ```
Expect exit code 1 and exactly one `Migration SQL failed` ERROR line carrying the full `CREATE TABLE api.topportunity (...)` on a single line.

Clean up: `docker exec grants-db psql -U app -d app -c "DROP DATABASE migrate_log_check;"`.