### PR TITLE
[Issue #11359]:  Remove descriptions on cells in SF-424a Section A

### DIFF
--- a/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.test.tsx
+++ b/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.test.tsx
@@ -44,4 +44,30 @@ describe("Budget424aSectionA", () => {
     );
     expect(F1).toHaveValue("32.43");
   });
+
+  // pre-existing summation labels were removed to avoid confusion
+  it("does not render misleading summation labels", () => {
+    render(<Budget424aSectionA {...WidgetProps} />);
+
+    // Column G header
+    expect(screen.queryByText("(sum of C-F)")).not.toBeInTheDocument();
+
+    // Column G, rows 1-4
+    for (let row = 1; row <= 4; row++) {
+      expect(screen.queryByText(`Sum of row ${row}`)).not.toBeInTheDocument();
+    }
+
+    // Row 5, column A
+    expect(screen.queryByText("(sum of 1-4)")).not.toBeInTheDocument();
+
+    // Row 5, columns C-G
+    for (const column of ["C", "D", "E", "F", "G"]) {
+      expect(
+        screen.queryByText(`Sum of column ${column}`),
+      ).not.toBeInTheDocument();
+    }
+
+    // Still renders the plain "Total" labels
+    expect(screen.getAllByText("Total").length).toBeGreaterThan(0);
+  });
 });

--- a/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.tsx
+++ b/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.tsx
@@ -195,9 +195,6 @@ function Budget424aSectionA<
               rowSpan={2}
             >
               Total
-              <div className="text-normal text-no-wrap text-italic">
-                (sum of C-F)
-              </div>
             </td>
           </tr>
           <tr>
@@ -384,9 +381,6 @@ function Budget424aSectionA<
                 <div className="display-flex flex-align-end">
                   <span className="margin-right-1">=</span>
                   <div>
-                    <div className="text-normal text-no-wrap text-italic font-sans-2xs">
-                      Sum of row {row + 1}
-                    </div>
                     <CurrencyInput
                       id={`activity_line_items[${row}]--budget_summary--total_amount`}
                       rawErrors={getErrorsA({
@@ -406,17 +400,12 @@ function Budget424aSectionA<
             <td className="padding-05 text-bold" colSpan={2}>
               <div className="display-flex">
                 <span className="margin-right-5">5.</span>
-                <div>
-                  Total
-                  <div className="text-normal text-no-wrap text-italic">
-                    (sum of 1-4)
-                  </div>
-                </div>
+                <div>Total</div>
               </div>
             </td>
 
             <td className="padding-05">
-              <HelperText hasHorizontalLine>Sum of column C</HelperText>
+              <HelperText hasHorizontalLine />
               <CurrencyInput
                 disabled
                 id={
@@ -432,7 +421,7 @@ function Budget424aSectionA<
             </td>
 
             <td className="padding-05">
-              <HelperText hasHorizontalLine>Sum of column D</HelperText>
+              <HelperText hasHorizontalLine />
               <CurrencyInput
                 disabled
                 id={
@@ -448,7 +437,7 @@ function Budget424aSectionA<
             </td>
 
             <td className="padding-05">
-              <HelperText hasHorizontalLine>Sum of column E</HelperText>
+              <HelperText hasHorizontalLine />
               <CurrencyInput
                 disabled
                 id={"total_budget_summary--federal_new_or_revised_amount"}
@@ -462,7 +451,7 @@ function Budget424aSectionA<
             </td>
 
             <td className="padding-05">
-              <HelperText hasHorizontalLine>Sum of column F</HelperText>
+              <HelperText hasHorizontalLine />
               <CurrencyInput
                 disabled
                 id={"total_budget_summary--non_federal_new_or_revised_amount"}
@@ -476,7 +465,7 @@ function Budget424aSectionA<
             </td>
 
             <td className="padding-05">
-              <HelperText hasHorizontalLine>Sum of column G</HelperText>
+              <HelperText hasHorizontalLine />
               <CurrencyInput
                 disabled
                 id={"total_budget_summary--total_amount"}

--- a/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.tsx
+++ b/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.tsx
@@ -1,23 +1,24 @@
 "use client";
 
-import { BaseActivityItem, MoneyString } from "./budgetTypes";
-import { CurrencyInput, DataCell, HelperText } from "./budgetUiComponents";
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 import {
   FormValidationWarning,
   UswdsWidgetProps,
 } from "src/types/applyForm/types";
+
 import React, { JSX } from "react";
+import { Table } from "@trussworks/react-uswds";
+
+import TextWidget from "src/components/apply-form/widgets/TextWidget";
+import { ACTIVITY_ITEMS } from "./budgetConstants";
+import { getErrorsForSection } from "./budgetErrors";
 import {
   activityTitleSchema,
   assistanceListingNumberSchema,
 } from "./budgetSchemas";
+import { BaseActivityItem, MoneyString } from "./budgetTypes";
+import { CurrencyInput, DataCell, HelperText } from "./budgetUiComponents";
 import { asMoney, isRecord } from "./budgetValueGuards";
-
-import { ACTIVITY_ITEMS } from "./budgetConstants";
-import { Table } from "@trussworks/react-uswds";
-import TextWidget from "src/components/apply-form/widgets/TextWidget";
-import { getErrorsForSection } from "./budgetErrors";
 
 interface BudgetSummary {
   federal_estimated_unobligated_amount?: MoneyString;

--- a/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.tsx
+++ b/frontend/src/components/apply-form/widgets/budget/Budget424aSectionA.tsx
@@ -1,24 +1,23 @@
 "use client";
 
+import { BaseActivityItem, MoneyString } from "./budgetTypes";
+import { CurrencyInput, DataCell, HelperText } from "./budgetUiComponents";
 import { FormContextType, RJSFSchema, StrictRJSFSchema } from "@rjsf/utils";
 import {
   FormValidationWarning,
   UswdsWidgetProps,
 } from "src/types/applyForm/types";
-
 import React, { JSX } from "react";
-import { Table } from "@trussworks/react-uswds";
-
-import TextWidget from "src/components/apply-form/widgets/TextWidget";
-import { ACTIVITY_ITEMS } from "./budgetConstants";
-import { getErrorsForSection } from "./budgetErrors";
 import {
   activityTitleSchema,
   assistanceListingNumberSchema,
 } from "./budgetSchemas";
-import { BaseActivityItem, MoneyString } from "./budgetTypes";
-import { CurrencyInput, DataCell, HelperText } from "./budgetUiComponents";
 import { asMoney, isRecord } from "./budgetValueGuards";
+
+import { ACTIVITY_ITEMS } from "./budgetConstants";
+import { Table } from "@trussworks/react-uswds";
+import TextWidget from "src/components/apply-form/widgets/TextWidget";
+import { getErrorsForSection } from "./budgetErrors";
 
 interface BudgetSummary {
   federal_estimated_unobligated_amount?: MoneyString;
@@ -380,7 +379,7 @@ function Budget424aSectionA<
               <DataCell>
                 <div className="display-flex flex-align-end">
                   <span className="margin-right-1">=</span>
-                  <div>
+                  <div className="margin-top-3 padding-top-0">
                     <CurrencyInput
                       id={`activity_line_items[${row}]--budget_summary--total_amount`}
                       rawErrors={getErrorsA({


### PR DESCRIPTION
## Summary

Work for #11359 

## Changes proposed

- Removed misleading sum descriptions 
- Fixed column G input box vertical spacing

## Context for reviewers

Auto-summation was removed from column G rows 1-4.

However, the instructions above the cells are now misleading, as column G is NOT always a summation of the rows. Therefore, the fix here is to remove the label descriptions that indicate summation to avoid user confusion.

## Validation steps

Screenshot of updated Section A
<img width="1970" height="1358" alt="image" src="https://github.com/user-attachments/assets/22b1c177-9811-431f-852d-f822c8f12efb" />

- [x] Approved by Design (Jesica A.)
