### PR TITLE
[Issue #12235 #12236] Submission XML - SFLLL - Missing elements and attributes  

### DIFF
--- a/api/src/form_schema/forms/sflll/1/0/form_json.py
+++ b/api/src/form_schema/forms/sflll/1/0/form_json.py
@@ -555,6 +555,8 @@ FORM_XML_TRANSFORM_RULES = {
                 "if_true": {
                     "target": "MaterialChangeSupplement",
                     "type": "nested_object",
+                    "namespace": "SFLLL_2_0",
+                    "attributes": {"SFLLL_2_0:ReportType": "MaterialChange"},
                     "source_fields": {
                         "material_change_year": "MaterialChangeYear",
                         "material_change_quarter": "MaterialChangeQuarter",
@@ -642,6 +644,7 @@ FORM_XML_TRANSFORM_RULES = {
             "entity_type": {
                 "xml_transform": {
                     "target": "EntityType",
+                    "static_value": "Prime",
                 }
             },
             "organization_name": {
@@ -689,10 +692,13 @@ FORM_XML_TRANSFORM_RULES = {
         "tier": {
             "xml_transform": {
                 "target": "Tier",
-                "type": "nested_object",
+                "type": "conditional",
+                "conditional_transform": {
+                    "type": "compose_object",
+                    "field_mapping": {"TierValue": "reporting_entity.tier"},
+                    "attributes": {"ReportEntityType": "reporting_entity.entity_type"},
+                },
             },
-            # The tier value is nested under TierValue in the XSD
-            # We need to map the tier integer to TierValue
         },
     },
     "federal_agency_department": {
@@ -702,6 +708,7 @@ FORM_XML_TRANSFORM_RULES = {
     },
     # Federal program name wrapper (contains program name and CFDA number)
     "federal_program_wrapper": {
+        "enabled": False,
         "xml_transform": {
             "target": "FederalProgramName",
             "type": "nested_object",
@@ -818,6 +825,7 @@ FORM_XML_TRANSFORM_RULES = {
                 "xml_transform": {
                     "target": "Name",
                     "type": "nested_object",
+                    "source_path": "individual_performing_service.individual",
                 },
                 "prefix": {
                     "xml_transform": {
@@ -854,6 +862,7 @@ FORM_XML_TRANSFORM_RULES = {
                 "xml_transform": {
                     "target": "Address",
                     "type": "nested_object",
+                    "source_path": "individual_performing_service.address",
                 },
                 "street1": {
                     "xml_transform": {

--- a/api/src/form_schema/forms/sflll/1/0/form_json.py
+++ b/api/src/form_schema/forms/sflll/1/0/form_json.py
@@ -708,7 +708,6 @@ FORM_XML_TRANSFORM_RULES = {
     },
     # Federal program name wrapper (contains program name and CFDA number)
     "federal_program_wrapper": {
-        "disabled": True,
         "xml_transform": {
             "target": "FederalProgramName",
             "type": "nested_object",

--- a/api/src/form_schema/forms/sflll/1/0/form_json.py
+++ b/api/src/form_schema/forms/sflll/1/0/form_json.py
@@ -708,7 +708,7 @@ FORM_XML_TRANSFORM_RULES = {
     },
     # Federal program name wrapper (contains program name and CFDA number)
     "federal_program_wrapper": {
-        "enabled": False,
+        "disabled": True,
         "xml_transform": {
             "target": "FederalProgramName",
             "type": "nested_object",

--- a/api/src/services/xml_generation/conditional_transformers.py
+++ b/api/src/services/xml_generation/conditional_transformers.py
@@ -118,6 +118,15 @@ def _apply_compose_object_transform(
         if value is not None:
             result[target_field] = value
 
+    attributes = transform_config.get("attributes", {})
+    if attributes:
+        result["__attributes"] = {
+            attribute_name: get_nested_value(source_data, source_path.split("."))
+            for attribute_name, source_path in attributes.items()
+            if isinstance(source_path, str)
+            and get_nested_value(source_data, source_path.split(".")) is not None
+        }
+
     return result if result else None
 
 

--- a/api/src/services/xml_generation/conditional_transformers.py
+++ b/api/src/services/xml_generation/conditional_transformers.py
@@ -118,6 +118,13 @@ def _apply_compose_object_transform(
         if value is not None:
             result[target_field] = value
 
+    # Some composed elements also need XML attributes pulled from root-level source
+    # fields (e.g. an attribute like ReportEntityType that lives alongside, rather than
+    # inside, the fields being composed into this element). Each entry in "attributes"
+    # maps an XML attribute name to a dotted source path; only attributes whose source
+    # value actually resolves to something are included. This is generic compose_object
+    # behavior, not specific to any one form - any form config that sets "attributes"
+    # on a compose_object rule will get this behavior.
     attributes = transform_config.get("attributes", {})
     if attributes:
         result["__attributes"] = {

--- a/api/src/services/xml_generation/transformers/base_transformer.py
+++ b/api/src/services/xml_generation/transformers/base_transformer.py
@@ -94,6 +94,9 @@ class RecursiveXMLTransformer:
             # Skip metadata keys
             if key.startswith("_"):
                 continue
+            # Skip disabled rules
+            if isinstance(rule_config, dict) and rule_config.get("enabled") is False:
+                continue
 
             # Process XML transformation rules
             if isinstance(rule_config, dict) and "xml_transform" in rule_config:
@@ -131,6 +134,11 @@ class RecursiveXMLTransformer:
         # Get the source value from the input data
         transform_type = transform_rule.get("type", "simple")
         source_value = get_nested_value(source_data, current_path)
+
+        # Some XML wrappers are synthetic and have no matching source object.
+        # Let their child mappings read from the root payload.
+        if transform_type == "nested_object" and source_value is None:
+            source_value = source_data
 
         # Handle None values based on configuration
         processed_source_value = self._handle_none_values(
@@ -303,9 +311,17 @@ class RecursiveXMLTransformer:
                     and isinstance(conditional_result, dict)
                     and "target" in conditional_result
                 ):
-                    # Handle conditional structure - extract and process nested fields
+                    # Some conditional structures are synthetic (for example,
+                    # SF-LLL MaterialChangeSupplement is not a literal source field,
+                    # but a root-level condition based on report_type). In those cases,
+                    # the structure should be built from the real form payload rather than
+                    # the missing synthetic field value (which is None at this path).
+                    source_for_structure = source_value
+                    if not isinstance(source_for_structure, dict):
+                        source_for_structure = self.root_source_data
+
                     return self._process_conditional_structure(
-                        conditional_result, source_value, path
+                        conditional_result, source_for_structure, path
                     )
 
                 # Check if this is a field_grouping result
@@ -327,6 +343,18 @@ class RecursiveXMLTransformer:
             if not isinstance(source_value, dict):
                 return None
 
+            object_value = source_value.copy()
+            if "entity_type" not in object_value and len(path) >= 2:
+                parent_source: Any = self.root_source_data
+                for segment in path[:-1]:
+                    if isinstance(parent_source, dict):
+                        parent_source = parent_source.get(segment)
+                    else:
+                        parent_source = None
+                        break
+                if isinstance(parent_source, dict) and parent_source.get("entity_type"):
+                    object_value["entity_type"] = parent_source["entity_type"]
+
             nested_result = {}
 
             # Embed the namespace so the service can resolve the wrapper element's namespace
@@ -345,14 +373,14 @@ class RecursiveXMLTransformer:
                         # It's a dotted path - not supported yet for parent attributes
                         # For now, just get from current source_value
                         path_parts = attr_source_path.split(".")
-                        if path_parts[0] in source_value:
-                            attributes[attr_name] = source_value[path_parts[0]]
+                        if path_parts[0] in object_value:
+                            attributes[attr_name] = object_value[path_parts[0]]
                     elif (
-                        attr_source_path in source_value
-                        and source_value[attr_source_path] is not None
+                        attr_source_path in object_value
+                        and object_value[attr_source_path] is not None
                     ):
                         # It's a field name in source data - use its value
-                        attributes[attr_name] = source_value[attr_source_path]
+                        attributes[attr_name] = object_value[attr_source_path]
                     else:
                         # Not a field in source data - treat as static/literal value
                         attributes[attr_name] = attr_source_path
@@ -368,8 +396,15 @@ class RecursiveXMLTransformer:
                 for child_key, child_config in nested_fields.items():
                     if isinstance(child_config, dict) and "xml_transform" in child_config:
                         child_transform = child_config["xml_transform"]
-                        if child_key in source_value and source_value[child_key] is not None:
-                            child_value = source_value[child_key]
+                        child_value = object_value.get(child_key)
+                        source_path = child_transform.get("source_path")
+                        if child_value is None and source_path:
+                            child_value = get_nested_value(
+                                self.root_source_data, source_path.split(".")
+                            )
+                        if "static_value" in child_transform:
+                            child_value = child_transform["static_value"]
+                        if child_value is not None:
 
                             # Recursively process nested transformations
                             transformed_child = self._apply_transform_rule(
@@ -385,8 +420,15 @@ class RecursiveXMLTransformer:
                         continue
                     if isinstance(child_config, dict) and "xml_transform" in child_config:
                         child_transform = child_config["xml_transform"]
-                        if child_key in source_value and source_value[child_key] is not None:
-                            child_value = source_value[child_key]
+                        child_value = object_value.get(child_key)
+                        source_path = child_transform.get("source_path")
+                        if child_value is None and source_path:
+                            child_value = get_nested_value(
+                                self.root_source_data, source_path.split(".")
+                            )
+                        if "static_value" in child_transform:
+                            child_value = child_transform["static_value"]
+                        if child_value is not None:
 
                             # Recursively process nested transformations
                             transformed_child = self._apply_transform_rule(
@@ -532,6 +574,18 @@ class RecursiveXMLTransformer:
 
         nested_result = {}
         nested_fields = structure_config.get("nested_fields", {})
+
+        if not nested_fields and "source_fields" in structure_config:
+            nested_fields = {
+                field_name: {"xml_transform": {"target": target_name}}
+                for field_name, target_name in structure_config["source_fields"].items()
+            }
+
+        if structure_config.get("namespace"):
+            nested_result["__namespace__"] = structure_config["namespace"]
+
+        if structure_config.get("attributes"):
+            nested_result["__attributes"] = structure_config["attributes"]
 
         # Process each nested field according to its configuration
         for field_key, field_config in nested_fields.items():

--- a/api/src/services/xml_generation/transformers/base_transformer.py
+++ b/api/src/services/xml_generation/transformers/base_transformer.py
@@ -94,10 +94,6 @@ class RecursiveXMLTransformer:
             # Skip metadata keys
             if key.startswith("_"):
                 continue
-            # Skip disabled rules
-            if isinstance(rule_config, dict) and rule_config.get("disabled") is True:
-                continue
-
             # Process XML transformation rules
             if isinstance(rule_config, dict) and "xml_transform" in rule_config:
                 self._process_xml_transform_rule(source_data, key, rule_config, path, result)

--- a/api/src/services/xml_generation/transformers/base_transformer.py
+++ b/api/src/services/xml_generation/transformers/base_transformer.py
@@ -95,7 +95,7 @@ class RecursiveXMLTransformer:
             if key.startswith("_"):
                 continue
             # Skip disabled rules
-            if isinstance(rule_config, dict) and rule_config.get("enabled") is False:
+            if isinstance(rule_config, dict) and rule_config.get("disabled") is True:
                 continue
 
             # Process XML transformation rules
@@ -135,10 +135,25 @@ class RecursiveXMLTransformer:
         transform_type = transform_rule.get("type", "simple")
         source_value = get_nested_value(source_data, current_path)
 
-        # Some XML wrappers are synthetic and have no matching source object.
-        # Let their child mappings read from the root payload.
+        # Some XML wrappers are synthetic and have no matching source object at
+        # all (e.g. SF-LLL's MaterialChangeSupplement isn't a literal field in
+        # the payload) - let their child mappings read from the root payload.
+        # But if the key *does* exist in the source data and was simply set to
+        # None explicitly (a real, non-synthetic wrapper the caller left
+        # empty), leave source_value as None instead of substituting the root
+        # payload - otherwise object_value.get(child_key) below could
+        # accidentally pick up unrelated sibling fields that happen to share
+        # a name with one of this wrapper's child keys.
         if transform_type == "nested_object" and source_value is None:
-            source_value = source_data
+            parent_path = current_path[:-1]
+            parent_source = (
+                get_nested_value(source_data, parent_path) if parent_path else source_data
+            )
+            key_exists_but_none = (
+                isinstance(parent_source, dict) and current_path[-1] in parent_source
+            )
+            if not key_exists_but_none:
+                source_value = source_data
 
         # Handle None values based on configuration
         processed_source_value = self._handle_none_values(
@@ -344,6 +359,12 @@ class RecursiveXMLTransformer:
                 return None
 
             object_value = source_value.copy()
+            # Some nested objects (e.g. SF-LLL's IndividualsPerformingServices) don't carry
+            # their own entity_type field, but the XML attribute still needs to reflect the
+            # type of the entity one level up (e.g. reporting_entity.entity_type). Walk up the
+            # path to find the nearest ancestor object that does define entity_type and inherit
+            # it here. This is a generic mechanism (not SFLLL-specific), but it's a no-op for
+            # any other form type whose nested objects already define entity_type themselves.
             if "entity_type" not in object_value and len(path) >= 2:
                 parent_source: Any = self.root_source_data
                 for segment in path[:-1]:
@@ -371,7 +392,7 @@ class RecursiveXMLTransformer:
                     # attr_source_path can be a simple field name, a dotted path, or a static/literal value
                     if "." in attr_source_path:
                         # It's a dotted path - not supported yet for parent attributes
-                        # For now, just get from current source_value
+                        # For now, just get from current object_value
                         path_parts = attr_source_path.split(".")
                         if path_parts[0] in object_value:
                             attributes[attr_name] = object_value[path_parts[0]]

--- a/api/tests/src/services/xml_generation/test_base_transformer.py
+++ b/api/tests/src/services/xml_generation/test_base_transformer.py
@@ -73,6 +73,21 @@ class TestRecursiveXMLTransformer:
         assert result["OrganizationName"] == "Test University"
         assert "MissingField" not in result
 
+    def test_transform_includes_disabled_rule_values(self):
+        """Test disabled UI rules are still included in generated XML data."""
+        transform_config = {
+            "prepopulated_field": {
+                "disabled": True,
+                "xml_transform": {"target": "PrepopulatedField"},
+            }
+        }
+
+        transformer = RecursiveXMLTransformer(transform_config)
+
+        result = transformer.transform({"prepopulated_field": "Provided value"})
+
+        assert result["PrepopulatedField"] == "Provided value"
+
     def test_transform_with_none_values(self):
         """Test transformation handles None values correctly."""
         transform_config = {

--- a/api/tests/src/services/xml_generation/test_sflll_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_sflll_xml_generation.py
@@ -95,19 +95,16 @@ class TestSFLLLXMLGeneration:
                         "zip_code": "20005",
                     },
                 },
-                # Config-shaped, not schema-shaped: see KNOWN LIMITATION in sflll form_json.py.
                 "individual_performing_service": {
                     "individual": {
-                        "name": {
-                            "first_name": "Jane",
-                            "last_name": "Doe",
-                        },
-                        "address": {
-                            "street1": "789 Pennsylvania Ave",
-                            "city": "Washington",
-                            "state": "DC: District of Columbia",
-                            "zip_code": "20004",
-                        },
+                        "first_name": "Jane",
+                        "last_name": "Doe",
+                    },
+                    "address": {
+                        "street1": "789 Pennsylvania Ave",
+                        "city": "Washington",
+                        "state": "DC: District of Columbia",
+                        "zip_code": "20004",
                     },
                 },
                 "signature_block": {
@@ -122,6 +119,21 @@ class TestSFLLLXMLGeneration:
         )
 
         return application
+
+    def _generate_sflll_root(self, application, tracking_number=12345678):
+        application_submission = ApplicationSubmissionFactory.create(
+            application=application,
+            legacy_tracking_number=tracking_number,
+        )
+        assembler = SubmissionXMLAssembler(application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        return lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+    @staticmethod
+    def _sflll_element(root, name):
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        return root.find(f".//{sflll_ns}{name}")
 
     def test_sflll_xml_structure(self, sflll_application, db_session):
         """Test that SF-LLL XML has correct structure and namespaces."""
@@ -182,6 +194,186 @@ class TestSFLLLXMLGeneration:
 
         # Verify award amount
         assert sflll.find(f".//{sflll_ns}AwardAmount").text == "500000.00"
+
+    def test_sflll_required_only_payload_contains_required_fields_only(
+        self, sflll_application, db_session
+    ):
+        """A valid required-only payload generates required XML and no optional values."""
+        response = sflll_application.application_forms[0].application_response
+        response.pop("federal_action_number")
+        response.pop("award_amount")
+        response["reporting_entity"].pop("tier", None)
+        response["reporting_entity"]["applicant_reporting_entity"].pop(
+            "congressional_district", None
+        )
+        response["reporting_entity"]["applicant_reporting_entity"]["address"].pop("street2", None)
+        response["lobbying_registrant"].pop("address", None)
+        response["individual_performing_service"].pop("address", None)
+        response["signature_block"].pop("signature", None)
+        response["signature_block"].pop("signed_date", None)
+
+        root = self._generate_sflll_root(sflll_application, 12121212)
+
+        assert self._sflll_element(root, "FederalActionType").text == "Grant"
+        assert self._sflll_element(root, "FederalActionStatus").text == "InitialAward"
+        assert self._sflll_element(root, "ReportType").text == "InitialFiling"
+        assert self._sflll_element(root, "OrganizationName").text == "Test Organization"
+        assert self._sflll_element(root, "FederalAgencyDepartment").text == (
+            "Department of Health and Human Services"
+        )
+        assert self._sflll_element(root, "IndividualName") is not None
+        assert self._sflll_element(root, "IndividualsPerformingServices") is not None
+        assert self._sflll_element(root, "SignatureBlock") is not None
+
+        assert self._sflll_element(root, "MaterialChangeSupplement") is None
+        assert self._sflll_element(root, "FederalActionNumber") is None
+        assert self._sflll_element(root, "AwardAmount") is None
+        assert self._sflll_element(root, "Tier") is None
+        assert self._sflll_element(root, "Street2") is None
+        assert self._sflll_element(root, "SignedDate") is None
+
+    def test_sflll_required_plus_selected_optional_fields_are_generated(
+        self, sflll_application, db_session
+    ):
+        """Required fields plus selected optional fields generate only those optional values."""
+        response = sflll_application.application_forms[0].application_response
+        response["federal_action_number"] = "OPTIONAL-ACTION-001"
+        response["reporting_entity"]["tier"] = 3
+        response["signature_block"]["title"] = "Director"
+
+        root = self._generate_sflll_root(sflll_application, 13131313)
+
+        sflll_ns = "http://apply.grants.gov/forms/SFLLL_2_0-V2.0"
+        assert self._sflll_element(root, "FederalActionNumber").text == "OPTIONAL-ACTION-001"
+        tier = self._sflll_element(root, "Tier")
+        assert tier.find(f"{{{sflll_ns}}}TierValue").text == "3"
+        assert tier.get(f"{{{sflll_ns}}}ReportEntityType") == "Prime"
+        assert self._sflll_element(root, "Title").text == "Director"
+        assert self._sflll_element(root, "AwardAmount") is not None
+        assert self._sflll_element(root, "MaterialChangeSupplement") is None
+
+    def test_sflll_required_and_all_optional_fields_are_generated(
+        self, sflll_application, db_session
+    ):
+        """A payload containing every supported optional field generates every XML value."""
+        response = sflll_application.application_forms[0].application_response
+        response.update(
+            {
+                "report_type": "MaterialChange",
+                "material_change_year": "2026",
+                "material_change_quarter": 1,
+                "last_report_date": "2026-10-31",
+                "federal_action_number": "ACTION-ALL-001",
+                "award_amount": "10000.00",
+                "federal_program_name": "Research Program",
+                "assistance_listing_number": "93.001",
+            }
+        )
+        response["reporting_entity"]["tier"] = 5
+        response["reporting_entity"]["applicant_reporting_entity"]["address"]["street2"] = "Apt #1"
+        response["reporting_entity"]["applicant_reporting_entity"][
+            "congressional_district"
+        ] = "NY-009"
+        response["lobbying_registrant"]["individual"].update(
+            {"prefix": "Miss", "middle_name": "B", "suffix": "PhD"}
+        )
+        response["lobbying_registrant"]["address"]["street2"] = "Apt #456"
+        response["individual_performing_service"]["individual"].update(
+            {"prefix": "Dr.", "middle_name": "H", "suffix": "Esquire"}
+        )
+        response["individual_performing_service"]["address"]["street2"] = "Room 101"
+        response["signature_block"]["name"].update(
+            {
+                "prefix": "Rev.",
+                "middle_name": "F",
+                "suffix": "MD",
+            }
+        )
+        response["signature_block"].update(
+            {
+                "title": "Lead Researcher",
+                "telephone": "123456789",
+                "signed_date": "2026-08-27",
+                "signature": "Signed Name",
+            }
+        )
+
+        root = self._generate_sflll_root(sflll_application, 14141414)
+
+        material_change = self._sflll_element(root, "MaterialChangeSupplement")
+        assert material_change is not None
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        assert material_change.get(f"{sflll_ns}ReportType") == "MaterialChange"
+        assert self._sflll_element(root, "FederalActionNumber").text == "ACTION-ALL-001"
+        assert self._sflll_element(root, "AwardAmount").text == "10000.00"
+        # federal_program_wrapper is disabled (see form_json.py), so FederalProgramName
+        # and CFDANumber are intentionally not generated even when the source data is present.
+        assert self._sflll_element(root, "FederalProgramName") is None
+        assert self._sflll_element(root, "CFDANumber") is None
+        tier = self._sflll_element(root, "Tier")
+        assert tier.find(f"{sflll_ns}TierValue").text == "5"
+        assert tier.get(f"{sflll_ns}ReportEntityType") == "Prime"
+        assert self._sflll_element(root, "Street2") is not None
+        assert self._sflll_element(root, "CongressionalDistrict").text == "NY-009"
+        assert self._sflll_element(root, "IndividualsPerformingServices") is not None
+        assert self._sflll_element(root, "Title").text == "Lead Researcher"
+        assert self._sflll_element(root, "Telephone").text == "123456789"
+        assert self._sflll_element(root, "SignedDate").text == "2026-08-27"
+
+    def test_sflll_material_change_supplement_is_generated_for_material_change_reports(
+        self, sflll_application, db_session
+    ):
+        """MaterialChange reports should include the required MaterialChangeSupplement block."""
+        response = sflll_application.application_forms[0].application_response
+        response["report_type"] = "MaterialChange"
+        response["material_change_year"] = "2025"
+        response["material_change_quarter"] = 2
+        response["last_report_date"] = "2024-12-31"
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=99999998,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        material_change = root.find(f".//{sflll_ns}MaterialChangeSupplement")
+        assert material_change is not None
+        assert material_change.get(f"{sflll_ns}ReportType") == "MaterialChange"
+        assert material_change.find(f"{sflll_ns}MaterialChangeYear").text == "2025"
+        assert material_change.find(f"{sflll_ns}MaterialChangeQuarter").text == "2"
+        assert material_change.find(f"{sflll_ns}LastReportDate").text == "2024-12-31"
+
+    def test_sflll_reporting_entity_entity_type_is_inherited_from_parent(
+        self, sflll_application, db_session
+    ):
+        """SF-LLL nested reporting entities should inherit EntityType from reporting_entity."""
+        reporting_entity = sflll_application.application_forms[0].application_response[
+            "reporting_entity"
+        ]
+        reporting_entity["applicant_reporting_entity"].pop("entity_type", None)
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=99999997,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        entity_types = [
+            element.text for element in root.findall(f".//{sflll_ns}EntityType") if element.text
+        ]
+        assert "Prime" in entity_types
 
     def test_sflll_address_fields_include_state(self, sflll_application, db_session):
         """Test that SF-LLL addresses include State field (legacy fix)."""
@@ -244,3 +436,484 @@ class TestSFLLLXMLGeneration:
         assert 'xmlns:globLib="http://apply.grants.gov/system/GlobalLibrary-V2.0"' in xml_string
         assert "globLib:FirstName" in xml_string
         assert "globLib:LastName" in xml_string
+
+    def test_sflll_optional_tier_field_is_included_when_present(
+        self, sflll_application, db_session
+    ):
+        """Test that optional reporting entity tier field is included in XML when present."""
+        response = sflll_application.application_forms[0].application_response
+        response["reporting_entity"]["tier"] = 2
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=77777777,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        tier = root.find(f".//{sflll_ns}Tier")
+        assert tier is not None, "Tier field should be present when provided"
+        assert tier.find(f"{sflll_ns}TierValue").text == "2"
+        assert tier.get(f"{sflll_ns}ReportEntityType") == "Prime"
+
+    def test_sflll_optional_signature_fields_are_included_when_present(
+        self, sflll_application, db_session
+    ):
+        """Test that optional signature block fields are included in XML when present."""
+        response = sflll_application.application_forms[0].application_response
+        response["signature_block"]["title"] = "Executive Director"
+        response["signature_block"]["telephone"] = "555-123-4567"
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=66666666,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+
+        # Check Title field
+        title = root.find(f".//{sflll_ns}Title")
+        assert title is not None, "Title field should be present"
+        assert title.text == "Executive Director"
+
+        # Check Telephone field
+        telephone = root.find(f".//{sflll_ns}Telephone")
+        assert telephone is not None, "Telephone field should be present"
+        assert telephone.text == "555-123-4567"
+
+    def test_sflll_optional_lobbying_registrant_address_is_included_when_present(
+        self, sflll_application, db_session
+    ):
+        """Test that optional lobbying registrant address is included in XML when present."""
+        response = sflll_application.application_forms[0].application_response
+        response["lobbying_registrant"]["address"] = {
+            "street1": "1600 Pennsylvania Avenue NW",
+            "city": "Washington",
+            "state": "DC: District of Columbia",
+            "zip_code": "20500",
+        }
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=55555555,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+
+        # Find LobbyingRegistrant Address
+        lobbying_registrant = root.find(f".//{sflll_ns}LobbyingRegistrant")
+        assert lobbying_registrant is not None
+
+        address = lobbying_registrant.find(f"{sflll_ns}Address")
+        assert address is not None, "Address should be present in LobbyingRegistrant"
+
+        street = address.find(f"{sflll_ns}Street1")
+        assert street is not None and street.text == "1600 Pennsylvania Avenue NW"
+
+        city = address.find(f"{sflll_ns}City")
+        assert city is not None and city.text == "Washington"
+
+    def test_sflll_optional_individual_performing_service_address_is_included_when_present(
+        self, sflll_application, db_session
+    ):
+        """Test that optional individual performing service address is included in XML when present."""
+        response = sflll_application.application_forms[0].application_response
+        response["individual_performing_service"]["address"] = {
+            "street1": "123 K Street NW",
+            "street2": "Suite 500",
+            "city": "Washington",
+            "state": "DC: District of Columbia",
+            "zip_code": "20005",
+        }
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=44444444,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+
+        performing_service = root.find(f".//{sflll_ns}IndividualsPerformingServices")
+        assert performing_service is not None
+        individual = performing_service.find(f"{sflll_ns}Individual")
+        assert individual is not None
+        address = individual.find(f"{sflll_ns}Address")
+        assert address is not None
+        street = address.find(f"{sflll_ns}Street1")
+        assert street is not None and street.text == "123 K Street NW"
+
+    def test_sflll_optional_fields_are_excluded_when_not_provided(
+        self, sflll_application, db_session
+    ):
+        """Test that optional fields are excluded from XML when not provided in data."""
+        # Make sure tier is NOT set
+        response = sflll_application.application_forms[0].application_response
+        response["reporting_entity"].pop("tier", None)
+        # Make sure signature title is NOT set
+        response["signature_block"].pop("title", None)
+        response["signature_block"].pop("telephone", None)
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=33333333,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+
+        # Tier should NOT be present
+        tier = root.find(f".//{sflll_ns}Tier")
+        assert tier is None, "Tier field should not be present when not provided"
+
+        # Title should NOT be present
+        title = root.find(f".//{sflll_ns}Title")
+        assert title is None, "Title field should not be present when not provided"
+
+        # Telephone should NOT be present
+        telephone = root.find(f".//{sflll_ns}Telephone")
+        assert telephone is None, "Telephone field should not be present when not provided"
+
+    def test_sflll_optional_federal_program_name_excluded_disabled_wrapper(
+        self, sflll_application, db_session
+    ):
+        """federal_program_wrapper is disabled (see form_json.py), so FederalProgramName
+        should not be included in the XML even when federal_program_name is present."""
+        response = sflll_application.application_forms[0].application_response
+        response["federal_program_name"] = "Community Development Block Grant Program"
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=10101010,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        program_wrapper = root.find(f".//{sflll_ns}FederalProgramName")
+        assert (
+            program_wrapper is None
+        ), "FederalProgramName should not be present (wrapper disabled)"
+
+    def test_sflll_optional_assistance_listing_number_excluded_disabled_wrapper(
+        self, sflll_application, db_session
+    ):
+        """federal_program_wrapper is disabled (see form_json.py), so CFDANumber should
+        not be included in the XML even when assistance_listing_number is present."""
+        response = sflll_application.application_forms[0].application_response
+        response["assistance_listing_number"] = "14.218"
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=20202020,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        listing = root.find(f".//{sflll_ns}CFDANumber")
+        assert listing is None, "CFDANumber should not be present (wrapper disabled)"
+
+    def test_sflll_optional_address_fields_street2_is_included_when_present(
+        self, sflll_application, db_session
+    ):
+        """Test that optional street2 in addresses is included in XML when present."""
+        response = sflll_application.application_forms[0].application_response
+        # Set street2 for applicant
+        response["reporting_entity"]["applicant_reporting_entity"]["address"][
+            "street2"
+        ] = "Suite 500"
+        # Set street2 for lobbying registrant
+        response["lobbying_registrant"]["address"] = {
+            "street1": "1600 Pennsylvania Avenue NW",
+            "street2": "Building A",
+            "city": "Washington",
+            "state": "DC: District of Columbia",
+            "zip_code": "20500",
+        }
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=30303030,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        street2_values = root.findall(f".//{sflll_ns}Street2")
+        assert len(street2_values) >= 2, "Street2 should appear in multiple addresses"
+        assert any(element.text == "Suite 500" for element in street2_values)
+        assert any(element.text == "Building A" for element in street2_values)
+
+    def test_sflll_optional_congressional_district_is_included_when_present(
+        self, sflll_application, db_session
+    ):
+        """Test that optional congressional_district is included in XML when present."""
+        response = sflll_application.application_forms[0].application_response
+        response["reporting_entity"]["applicant_reporting_entity"][
+            "congressional_district"
+        ] = "CA-012"
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=40404040,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        districts = root.findall(f".//{sflll_ns}CongressionalDistrict")
+        assert len(districts) >= 1, "CongressionalDistrict should be present"
+        assert any(
+            d.text == "CA-012" for d in districts
+        ), "CA-012 should be in at least one district"
+
+    def test_sflll_optional_signature_fields_all_present(self, sflll_application, db_session):
+        """Test that all optional signature fields are included together."""
+        response = sflll_application.application_forms[0].application_response
+        response["signature_block"]["signature"] = "John Doe"
+        response["signature_block"]["title"] = "Chief Executive Officer"
+        response["signature_block"]["telephone"] = "202-555-0123"
+        response["signature_block"]["signed_date"] = "2026-09-02"
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=50505050,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        sig_block = root.find(f".//{sflll_ns}SignatureBlock")
+        assert sig_block is not None
+
+        signature = sig_block.find(f"{sflll_ns}Signature")
+        assert signature is not None and signature.text == "John Doe"
+
+        title = sig_block.find(f"{sflll_ns}Title")
+        assert title is not None and title.text == "Chief Executive Officer"
+
+        telephone = sig_block.find(f"{sflll_ns}Telephone")
+        assert telephone is not None and telephone.text == "202-555-0123"
+
+        signed_date = sig_block.find(f"{sflll_ns}SignedDate")
+        assert signed_date is not None and signed_date.text == "2026-09-02"
+
+    def test_sflll_optional_address_fields_state_and_zip_in_nested_entity(
+        self, sflll_application, db_session
+    ):
+        """Test that optional state and zip_code fields are properly included in nested entities."""
+        response = sflll_application.application_forms[0].application_response
+        # Ensure these are present in nested entities
+        assert "state" in response["reporting_entity"]["applicant_reporting_entity"]["address"]
+        assert "zip_code" in response["reporting_entity"]["applicant_reporting_entity"]["address"]
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=60606060,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+
+        # Find all State elements - should be present
+        states = root.findall(f".//{sflll_ns}State")
+        assert len(states) > 0, "State fields should be present in addresses"
+
+        # Find all ZipPostalCode elements - should be present
+        zips = root.findall(f".//{sflll_ns}ZipPostalCode")
+        assert len(zips) > 0, "ZipPostalCode fields should be present in addresses"
+
+    def test_sflll_prime_entity_fields_included_for_subawardee(self, sflll_application, db_session):
+        """Test that prime entity fields are properly generated for SubAwardee reporting entity."""
+        response = sflll_application.application_forms[0].application_response
+        response["reporting_entity"]["entity_type"] = "SubAwardee"
+        response["reporting_entity"]["prime_reporting_entity"] = {
+            "entity_type": "Prime",
+            "organization_name": "Prime Organization Inc",
+            "address": {
+                "street1": "500 Main Street",
+                "street2": "Floor 10",
+                "city": "New York",
+                "state": "NY: New York",
+                "zip_code": "10001",
+            },
+            "congressional_district": "NY-010",
+        }
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=70707070,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+
+        # Find PrimeIfSubawardee section
+        prime_entity = root.find(f".//{sflll_ns}PrimeIfSubawardee")
+        assert prime_entity is not None, "PrimeIfSubawardee should be present for SubAwardee entity"
+
+        # Verify organization name
+        org_name = prime_entity.find(f"{sflll_ns}OrganizationName")
+        assert org_name is not None and org_name.text == "Prime Organization Inc"
+
+        # Verify address fields
+        address = prime_entity.find(f"{sflll_ns}Address")
+        assert address is not None
+        street2 = address.find(f"{sflll_ns}Street2")
+        assert street2 is not None and street2.text == "Floor 10"
+
+        # Verify congressional district
+        district = prime_entity.find(f"{sflll_ns}CongressionalDistrict")
+        assert district is not None and district.text == "NY-010"
+        assert prime_entity.find(f"{sflll_ns}EntityType").text == "Prime"
+
+    def test_sflll_individual_performing_service_is_included(self, sflll_application, db_session):
+        """Test that individual performing service (lobbying activity performer) is included in XML."""
+        response = sflll_application.application_forms[0].application_response
+        # Ensure individual_performing_service data is present
+        assert "individual_performing_service" in response
+        assert response["individual_performing_service"]["individual"]["first_name"] == "Jane"
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=80808080,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        globLib_ns = "{http://apply.grants.gov/system/GlobalLibrary-V2.0}"
+
+        # Find IndividualsPerformingServices element
+        perf_services = root.find(f".//{sflll_ns}IndividualsPerformingServices")
+        assert perf_services is not None, "IndividualsPerformingServices should be present"
+
+        # Verify nested Individual element
+        individual = perf_services.find(f"{sflll_ns}Individual")
+        assert individual is not None, "Individual element should be present"
+
+        # Verify Name element exists
+        name = individual.find(f"{sflll_ns}Name")
+        assert name is not None, "Name element should be present in Individual"
+
+        # Verify FirstName in the Name element (uses globLib namespace)
+        first_name = name.find(f"{globLib_ns}FirstName")
+        assert first_name is not None, "FirstName should be present"
+        assert first_name.text == "Jane", f"Expected 'Jane', got '{first_name.text}'"
+
+        # Verify LastName
+        last_name = name.find(f"{globLib_ns}LastName")
+        assert last_name is not None, "LastName should be present"
+        assert last_name.text == "Doe", f"Expected 'Doe', got '{last_name.text}'"
+
+        # Verify Address element exists
+        address = individual.find(f"{sflll_ns}Address")
+        assert address is not None, "Address should be present in Individual"
+
+        # Verify address fields
+        street1 = address.find(f"{sflll_ns}Street1")
+        assert street1 is not None and street1.text == "789 Pennsylvania Ave"
+
+        city = address.find(f"{sflll_ns}City")
+        assert city is not None and city.text == "Washington"
+
+    def test_sflll_individual_performing_service_optional_fields(
+        self, sflll_application, db_session
+    ):
+        """Test that optional fields in individual_performing_service are included when present."""
+        response = sflll_application.application_forms[0].application_response
+        # Add optional fields
+        response["individual_performing_service"]["individual"]["prefix"] = "Dr."
+        response["individual_performing_service"]["individual"]["middle_name"] = "Marie"
+        response["individual_performing_service"]["individual"]["suffix"] = "Jr."
+
+        application_submission = ApplicationSubmissionFactory.create(
+            application=sflll_application,
+            legacy_tracking_number=81818181,
+        )
+
+        assembler = SubmissionXMLAssembler(sflll_application, application_submission)
+        xml_string = assembler.generate_complete_submission_xml(pretty_print=True)
+
+        parser = lxml_etree.XMLParser(remove_blank_text=True)
+        root = lxml_etree.fromstring(xml_string.encode("utf-8"), parser=parser)
+
+        sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
+        globLib_ns = "{http://apply.grants.gov/system/GlobalLibrary-V2.0}"
+
+        # Find IndividualsPerformingServices
+        perf_services = root.find(f".//{sflll_ns}IndividualsPerformingServices")
+        individual = perf_services.find(f"{sflll_ns}Individual")
+        name = individual.find(f"{sflll_ns}Name")
+
+        # Check optional name fields
+        prefix = name.find(f"{globLib_ns}PrefixName")
+        assert prefix is not None and prefix.text == "Dr."
+
+        middle_name = name.find(f"{globLib_ns}MiddleName")
+        assert middle_name is not None and middle_name.text == "Marie"
+
+        suffix = name.find(f"{globLib_ns}SuffixName")
+        assert suffix is not None and suffix.text == "Jr."

--- a/api/tests/src/services/xml_generation/test_sflll_xml_generation.py
+++ b/api/tests/src/services/xml_generation/test_sflll_xml_generation.py
@@ -306,10 +306,10 @@ class TestSFLLLXMLGeneration:
         assert material_change.get(f"{sflll_ns}ReportType") == "MaterialChange"
         assert self._sflll_element(root, "FederalActionNumber").text == "ACTION-ALL-001"
         assert self._sflll_element(root, "AwardAmount").text == "10000.00"
-        # federal_program_wrapper is disabled (see form_json.py), so FederalProgramName
-        # and CFDANumber are intentionally not generated even when the source data is present.
-        assert self._sflll_element(root, "FederalProgramName") is None
-        assert self._sflll_element(root, "CFDANumber") is None
+        program_wrapper = self._sflll_element(root, "FederalProgramName")
+        assert program_wrapper is not None
+        assert program_wrapper.find(f"{sflll_ns}FederalProgramName").text == "Research Program"
+        assert program_wrapper.find(f"{sflll_ns}CFDANumber").text == "93.001"
         tier = self._sflll_element(root, "Tier")
         assert tier.find(f"{sflll_ns}TierValue").text == "5"
         assert tier.get(f"{sflll_ns}ReportEntityType") == "Prime"
@@ -601,11 +601,10 @@ class TestSFLLLXMLGeneration:
         telephone = root.find(f".//{sflll_ns}Telephone")
         assert telephone is None, "Telephone field should not be present when not provided"
 
-    def test_sflll_optional_federal_program_name_excluded_disabled_wrapper(
+    def test_sflll_optional_federal_program_name_included_when_present(
         self, sflll_application, db_session
     ):
-        """federal_program_wrapper is disabled (see form_json.py), so FederalProgramName
-        should not be included in the XML even when federal_program_name is present."""
+        """Prepopulated federal program name is included when present."""
         response = sflll_application.application_forms[0].application_response
         response["federal_program_name"] = "Community Development Block Grant Program"
 
@@ -622,15 +621,15 @@ class TestSFLLLXMLGeneration:
 
         sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
         program_wrapper = root.find(f".//{sflll_ns}FederalProgramName")
-        assert (
-            program_wrapper is None
-        ), "FederalProgramName should not be present (wrapper disabled)"
+        assert program_wrapper is not None
+        program_name = program_wrapper.find(f"{sflll_ns}FederalProgramName")
+        assert program_name is not None
+        assert program_name.text == "Community Development Block Grant Program"
 
-    def test_sflll_optional_assistance_listing_number_excluded_disabled_wrapper(
+    def test_sflll_optional_assistance_listing_number_included_when_present(
         self, sflll_application, db_session
     ):
-        """federal_program_wrapper is disabled (see form_json.py), so CFDANumber should
-        not be included in the XML even when assistance_listing_number is present."""
+        """Prepopulated assistance listing number is included when present."""
         response = sflll_application.application_forms[0].application_response
         response["assistance_listing_number"] = "14.218"
 
@@ -647,7 +646,8 @@ class TestSFLLLXMLGeneration:
 
         sflll_ns = "{http://apply.grants.gov/forms/SFLLL_2_0-V2.0}"
         listing = root.find(f".//{sflll_ns}CFDANumber")
-        assert listing is None, "CFDANumber should not be present (wrapper disabled)"
+        assert listing is not None
+        assert listing.text == "14.218"
 
     def test_sflll_optional_address_fields_street2_is_included_when_present(
         self, sflll_application, db_session


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #12235  #12236 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

Fixes SFLLL submission XML generation to include previously missing sections and fields:

- MaterialChangeSupplement and its attributes/fields
- EntityType
- FederalProgramName
- Complete IndividualPerformingServices section

Also improves the shared XML generation logic to better support synthetic/conditional elements and nested field sourcing.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

SFLLL contains synthetic/conditional XML structures whose values are not always nested under their corresponding XML wrapper in the form payload.

The XML generator previously assumed child values would primarily come from their immediate parent object. This caused `MaterialChangeSupplement`, `EntityType`, `FederalProgramName`  and `IndividualPerformingServices `data to be omitted.

This change allows these structures to source values from explicit `source_path`/`static_value `definitions or, where appropriate, the root payload.

The shared XML generation changes are intended to remain backward-compatible with existing form schemas.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- [x] Submit an application with a completed SFLLL form.
- [x] Download and inspect the generated submission XML.
- [x] Verify:
  - [x] MaterialChangeSupplement is generated with the expected attributes and values.
  - [x] EntityType is present and correctly populated.
  - [ ] FederalProgramName
  - [x] IndividualPerformingServices and its child fields are generated when applicable.
  - [x] Conditional sections are omitted when their conditions are not met.
- [x] Compare the output against legacy SFLLL XML for structure, namespaces, attributes, and values.
- [x] Run existing XML generation/form tests to verify no regressions.