### PR TITLE
[unticketed]: update scheduled dev deploy pipeline

### DIFF
--- a/.github/workflows/scheduled-dev-deploy.yml
+++ b/.github/workflows/scheduled-dev-deploy.yml
@@ -78,6 +78,8 @@ jobs:
     name: NOFOs Vulnerability Scans
     needs: [nofos-checks]
     uses: ./.github/workflows/vulnerability-scans-nofos.yml
+    with:
+      fail_on_vulns: false
 
   nofos-deploy:
     name: Deploy NOFOs to Dev

--- a/.github/workflows/scheduled-dev-deploy.yml
+++ b/.github/workflows/scheduled-dev-deploy.yml
@@ -16,6 +16,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: api
+      fail_on_vulns: false
 
   api-deploy:
     name: Deploy API to Dev
@@ -35,6 +36,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: frontend
+      fail_on_vulns: false
 
   frontend-deploy:
     name: Deploy Frontend to Dev
@@ -55,6 +57,7 @@ jobs:
     uses: ./.github/workflows/vulnerability-scans.yml
     with:
       app_name: analytics
+      fail_on_vulns: false
 
   analytics-deploy:
     name: Deploy Analytics to Dev
@@ -85,14 +88,7 @@ jobs:
       version: "main"
 
   send-slack-notification:
-    # Only alert when a deploy itself fails
-    if: |
-      !cancelled()
-      && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
-      && (needs.api-deploy.result == 'failure'
-        || needs.frontend-deploy.result == 'failure'
-        || needs.analytics-deploy.result == 'failure'
-        || needs.nofos-deploy.result == 'failure')
+    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
     needs: [api-deploy, frontend-deploy, analytics-deploy, nofos-deploy]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/scheduled-dev-deploy.yml
+++ b/.github/workflows/scheduled-dev-deploy.yml
@@ -85,7 +85,14 @@ jobs:
       version: "main"
 
   send-slack-notification:
-    if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
+    # Only alert when a deploy itself fails
+    if: |
+      !cancelled()
+      && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release')
+      && (needs.api-deploy.result == 'failure'
+        || needs.frontend-deploy.result == 'failure'
+        || needs.analytics-deploy.result == 'failure'
+        || needs.nofos-deploy.result == 'failure')
     needs: [api-deploy, frontend-deploy, analytics-deploy, nofos-deploy]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit

--- a/.github/workflows/vulnerability-scans-nofos.yml
+++ b/.github/workflows/vulnerability-scans-nofos.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: boolean
         default: false
+      fail_on_vulns:
+        description: "should the job fail if any fixed vulnerabilities above the configured severity are found"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   trivy-scan:
@@ -83,7 +88,7 @@ jobs:
           scan-type: image
           image-ref: nofos:latest
           format: table
-          exit-code: 1
+          exit-code: ${{ inputs.fail_on_vulns && 1 || 0 }}
           ignore-unfixed: true
           vuln-type: os
           scanners: vuln,secret
@@ -130,7 +135,7 @@ jobs:
         with:
           image: nofos:latest
           output-format: json
-          fail-build: true
+          fail-build: ${{ inputs.fail_on_vulns }}
           severity-cutoff: medium
 
       - name: Run Anchore vulnerability scan (table)
@@ -139,7 +144,7 @@ jobs:
         with:
           image: nofos:latest
           output-format: table
-          fail-build: true
+          fail-build: ${{ inputs.fail_on_vulns }}
           severity-cutoff: medium
 
       - name: Print output to workflow summary
@@ -178,13 +183,14 @@ jobs:
         uses: erzz/dockle-action@v1.4.1
         with:
           image: nofos:latest
-          exit-code: "1"
+          exit-code: ${{ inputs.fail_on_vulns && '1' || '0' }}
           failure-threshold: WARN
           accept-filenames: ${{ env.DOCKLE_ACCEPT_FILES }}
 
       - name: Save output to workflow summary
-        if: failure() # Only runs if there is a failure
+        if: always() # Runs even if there is a failure
         run: |
+          [ -f dockle-report.json ] || exit 0
           {
             echo '```json'
             cat dockle-report.json


### PR DESCRIPTION
## Summary

Updated the schedule dev deploy pipeline to only send slack notifications if deploy fails; not when the scans fail.

## Validation steps

Ran the scheduled dev deploy workflow: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/33880776108)