### PR TITLE
[Issue #12100] enable running e2es faster

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -6,6 +6,10 @@ description: Composite action to run Playwright against specified environment
 # based on the do-chrome-install, do-firefox-install, and do-webkit-install inputs.
 # Only the browsers needed for the current test shard are installed, improving CI efficiency.
 # Chrome is cached outside this job, and will be available even if not instructed to install.
+#
+# `playwright_projects` narrows which browsers the run actually exercises (e.g. PR
+# runs pass "Chrome"). Keep it in sync with the do-*-install inputs: requesting a
+# project whose browser was never installed will fail at launch.
 # ---
 
 inputs:
@@ -68,6 +72,9 @@ inputs:
     default: ""
   spec_files:
     description: "paths to specific spec files to run, will separately, but in addition to any supplied `playwright_tags`"
+    default: ""
+  playwright_projects:
+    description: "comma separated list of Playwright project (browser) names to run (e.g. Chrome). Leave blank to run every project defined for the target"
     default: ""
 
 outputs:
@@ -157,6 +164,7 @@ runs:
         CI: true
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
+        PLAYWRIGHT_PROJECTS: ${{ inputs.playwright_projects }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
         PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
         PLAYWRIGHT_API_URL: ${{ env.api_url }}
@@ -178,6 +186,7 @@ runs:
         CI: true
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
+        PLAYWRIGHT_PROJECTS: ${{ inputs.playwright_projects }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
         PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
         PLAYWRIGHT_API_URL: ${{ env.api_url }}
@@ -199,6 +208,7 @@ runs:
         CI: true
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
+        PLAYWRIGHT_PROJECTS: ${{ inputs.playwright_projects }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
         PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
         PLAYWRIGHT_API_URL: ${{ env.api_url }}

--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -76,6 +76,9 @@ inputs:
   playwright_projects:
     description: "comma separated list of Playwright project (browser) names to run (e.g. Chrome). Leave blank to run every project defined for the target"
     default: ""
+  shard_label:
+    description: "unique name for this shard's blob report, used when a run shards more than one project and shard numbers would otherwise collide (e.g. chrome-1). Defaults to current_shard"
+    default: ""
 
 outputs:
   artifact-id:
@@ -157,6 +160,21 @@ runs:
           echo "api_url=https://api.grantee2.teams.simpler.grants.gov" >> "$GITHUB_ENV"
         fi
 
+    # Playwright names its blob report after the shard number alone, so a run that
+    # shards two projects would have both projects write report-1.zip and collide
+    # once the report job merges them into one directory. shard_label
+    # gives each matrix entry its own name for both the file and the artifact.
+    - name: Name this shard's blob report
+      shell: bash
+      env:
+        SHARD_LABEL: ${{ inputs.shard_label }}
+        CURRENT_SHARD: ${{ inputs.current_shard }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        label="${SHARD_LABEL:-$CURRENT_SHARD}"
+        echo "blob_output_name=report-${label}.zip" >> "$GITHUB_ENV"
+        echo "blob_report_name=blob-report-shard-${TARGET}-${label}" >> "$GITHUB_ENV"
+
     - name: Run specified e2e tests
       if: ${{ inputs.spec_files != '' }}
       working-directory: ./frontend
@@ -165,6 +183,7 @@ runs:
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
         PLAYWRIGHT_PROJECTS: ${{ inputs.playwright_projects }}
+        PLAYWRIGHT_BLOB_OUTPUT_NAME: ${{ env.blob_output_name }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
         PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
         PLAYWRIGHT_API_URL: ${{ env.api_url }}
@@ -187,6 +206,7 @@ runs:
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
         PLAYWRIGHT_PROJECTS: ${{ inputs.playwright_projects }}
+        PLAYWRIGHT_BLOB_OUTPUT_NAME: ${{ env.blob_output_name }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
         PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
         PLAYWRIGHT_API_URL: ${{ env.api_url }}
@@ -209,6 +229,7 @@ runs:
         TOTAL_SHARDS: ${{ inputs.total_shards }}
         CURRENT_SHARD: ${{ inputs.current_shard }}
         PLAYWRIGHT_PROJECTS: ${{ inputs.playwright_projects }}
+        PLAYWRIGHT_BLOB_OUTPUT_NAME: ${{ env.blob_output_name }}
         PLAYWRIGHT_TARGET_ENV: ${{ inputs.target }}
         PLAYWRIGHT_BASE_URL: ${{ env.base_url }}
         PLAYWRIGHT_API_URL: ${{ env.api_url }}
@@ -256,6 +277,6 @@ runs:
       id: upload-blob-report
       uses: actions/upload-artifact@v7
       with:
-        name: blob-report-shard-${{ inputs.target }}-${{ inputs.current_shard }}
+        name: ${{ env.blob_report_name }}
         path: /home/runner/work/simpler-grants-gov/simpler-grants-gov/frontend/blob-report
         retention-days: 1

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -446,6 +446,18 @@ jobs:
             echo "test_group_tags=${{ inputs.playwright_tags }}" >> "$GITHUB_ENV"
           fi
 
+      # PRs run Chrome only.
+      # Cross-browser coverage still runs on push to main and in the daily/weekly
+      # scheduled runs, which leave playwright_projects blank to get every project.
+      - name: Determine browsers to run
+        shell: bash
+        run: |
+          if [[ $GITHUB_EVENT_NAME = "pull_request" ]]; then
+            echo "playwright_projects=Chrome" >> "$GITHUB_ENV"
+          else
+            echo "playwright_projects=" >> "$GITHUB_ENV"
+          fi
+
       #
       #   TEST RUNS
       #
@@ -481,10 +493,13 @@ jobs:
           # committed LOCAL_TEST_USER_MANAGER_API_KEY default from api/local.env,
           # so the frontend must send that same literal value.
           test_user_manager_api_key: "local-manager-key"
+          playwright_projects: ${{ env.playwright_projects }}
+          # Only install the non-Chrome browsers when the run isn't narrowed to a
+          # project list (i.e. everything except PRs).
           # shard 2 is the firefox shard
-          do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
+          do-firefox-install: ${{ env.playwright_projects == '' && matrix.shard == 2 && 'true' || 'false' }}
           # shard 3 is the webkit shard
-          do-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
+          do-webkit-install: ${{ env.playwright_projects == '' && matrix.shard == 3 && 'true' || 'false' }}
 
       - name: Run E2E tests
         uses: ./.github/actions/e2e
@@ -503,10 +518,13 @@ jobs:
           # committed LOCAL_TEST_USER_MANAGER_API_KEY default from api/local.env,
           # so the frontend must send that same literal value.
           test_user_manager_api_key: "local-manager-key"
+          playwright_projects: ${{ env.playwright_projects }}
+          # Only install the non-Chrome browsers when the run isn't narrowed to a
+          # project list (i.e. everything except PRs).
           # shard 2 is the firefox shard
-          do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
+          do-firefox-install: ${{ env.playwright_projects == '' && matrix.shard == 2 && 'true' || 'false' }}
           # shard 3 is the webkit shard
-          do-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
+          do-webkit-install: ${{ env.playwright_projects == '' && matrix.shard == 3 && 'true' || 'false' }}
 
       - name: Run E2E tests for changed spec files
         uses: ./.github/actions/e2e
@@ -527,10 +545,13 @@ jobs:
           # committed LOCAL_TEST_USER_MANAGER_API_KEY default from api/local.env,
           # so the frontend must send that same literal value.
           test_user_manager_api_key: "local-manager-key"
+          playwright_projects: ${{ env.playwright_projects }}
+          # Only install the non-Chrome browsers when the run isn't narrowed to a
+          # project list (i.e. everything except PRs).
           # shard 2 is the firefox shard
-          do-firefox-install: ${{ matrix.shard == 2 && 'true' || 'false' }}
+          do-firefox-install: ${{ env.playwright_projects == '' && matrix.shard == 2 && 'true' || 'false' }}
           # shard 3 is the webkit shard
-          do-webkit-install: ${{ matrix.shard == 3 && 'true' || 'false' }}
+          do-webkit-install: ${{ env.playwright_projects == '' && matrix.shard == 3 && 'true' || 'false' }}
 
   create-report:
     name: Create Merged Test Report

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -42,6 +42,16 @@ concurrency:
 jobs:
   e2e-tests-deployed:
     runs-on: ubuntu-22.04
+    # Shard across runners rather than raising the per-runner worker count: the
+    # deployed suite keeps workers at 1 (see the workers input below) because
+    # every test authenticates as one of a handful of static shared test users,
+    # so in-process parallelism is the riskier way to add concurrency.
+    strategy:
+      # A scheduled regression run wants results for every shard, not an early exit.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+        total_shards: [4]
     steps:
       - name: Set target environment
         run: |
@@ -71,8 +81,8 @@ jobs:
         with:
           version: ${{ inputs.version || github.ref }}
           target: ${{ env.defaulted_target }}
-          total_shards: 1
-          current_shard: 1
+          total_shards: ${{ matrix.total_shards }}
+          current_shard: ${{ matrix.shard }}
           workers: 1
           playwright_tags: ${{ env.test_group_tags }}
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -41,17 +41,36 @@ concurrency:
   cancel-in-progress: true
 jobs:
   e2e-tests-deployed:
+    name: E2E ${{ matrix.projects }} ${{ matrix.shard }}/${{ matrix.total_shards }}
     runs-on: ubuntu-22.04
     # Shard across runners rather than raising the per-runner worker count: the
     # deployed suite keeps workers at 1 (see the workers input below) because
     # every test authenticates as one of a handful of static shared test users,
     # so in-process parallelism is the riskier way to add concurrency.
+    #
+    # Each project gets its own shard count instead of sharing one matrix. On a
+    # deployed target, most spec files skip everything but Chrome (see
+    # utils/auth/skip-non-chrome-staging-utils.ts), so most Mobile chrome tests
+    # skip at runtime — but Playwright balances shards by collected test count,
+    # which means a shared matrix hands whole runners work that evaporates in
+    # seconds while the Chrome shards carry everything.
     strategy:
       # A scheduled regression run wants results for every shard, not an early exit.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
-        total_shards: [4]
+        include:
+          - { projects: "Chrome", shard: 1, total_shards: 6, label: chrome-1 }
+          - { projects: "Chrome", shard: 2, total_shards: 6, label: chrome-2 }
+          - { projects: "Chrome", shard: 3, total_shards: 6, label: chrome-3 }
+          - { projects: "Chrome", shard: 4, total_shards: 6, label: chrome-4 }
+          - { projects: "Chrome", shard: 5, total_shards: 6, label: chrome-5 }
+          - { projects: "Chrome", shard: 6, total_shards: 6, label: chrome-6 }
+          - {
+              projects: "Mobile chrome",
+              shard: 1,
+              total_shards: 1,
+              label: mobile-1,
+            }
     steps:
       - name: Set target environment
         run: |
@@ -83,6 +102,8 @@ jobs:
           target: ${{ env.defaulted_target }}
           total_shards: ${{ matrix.total_shards }}
           current_shard: ${{ matrix.shard }}
+          playwright_projects: ${{ matrix.projects }}
+          shard_label: ${{ matrix.label }}
           workers: 1
           playwright_tags: ${{ env.test_group_tags }}
           staging_test_user_email: ${{ secrets.STAGING_TEST_USER_EMAIL }}

--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -89,12 +89,21 @@ In some cases an individual test may be skipped in one or more browsers. This ma
 
 #### How CI parallelizes runs
 
-Both e2e workflows split the suite across a matrix of 4 shards, one runner each, and merge the blob reports afterwards. The two workflows get their concurrency from different places:
+Both e2e workflows split the suite across a matrix of shards, one runner each, and merge the blob reports afterwards. The two workflows get their concurrency from different places:
 
-- **[ci-frontend-e2e.yml](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/ci-frontend-e2e.yml)** (local target) stands up its own API and frontend per shard, so each shard is isolated and runs with the default 10 workers.
-- **[e2e-staging.yml](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/e2e-staging.yml)** (deployed target) points all 4 shards at one shared environment, so it pins `workers: 1`. Every test on a deployed target authenticates as one of a handful of static shared test users, so adding concurrency by sharding across runners — where Playwright keeps same-file tests together — is safer than in-process parallelism. If you see cross-test interference on a deployed run, suspect two shards mutating the same test user's state before you suspect a real regression.
+- **[ci-frontend-e2e.yml](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/ci-frontend-e2e.yml)** (local target) uses 4 shards and stands up its own API and frontend per shard, so each shard is isolated and runs with the default 10 workers.
+- **[e2e-staging.yml](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/e2e-staging.yml)** (deployed target) points every shard at one shared environment, so it pins `workers: 1`. Every test on a deployed target authenticates as one of a handful of static shared test users, so adding concurrency by sharding across runners — where Playwright keeps same-file tests together — is safer than in-process parallelism. If you see cross-test interference on a deployed run, suspect two shards mutating the same test user's state before you suspect a real regression.
 
-Raising the shard count is a matter of editing both `matrix.shard` and `matrix.total_shards` in the workflow; they must agree, since they become Playwright's `--shard=current/total`.
+Raising the shard count means editing both `shard` and `total_shards` in the workflow's matrix; they must agree, since they become Playwright's `--shard=current/total`.
+
+##### Why the deployed target shards each project separately
+
+Playwright balances shards by collected test count, which is a poor proxy for duration in this suite — the `apply/` flows take 60–90s each while most other tests take a few seconds. Two consequences shape the deployed matrix:
+
+1. On a deployed target, most spec files skip everything but Chrome. Those Mobile chrome tests are still collected, so a matrix shared between both projects hands entire runners work that skips in seconds while the Chrome shards carry the whole suite.
+2. `testDir` is walked alphabetically, so `apply/` always sorts first and its slow flows always land on the lowest-numbered shards.
+
+Because Playwright names its blob report after the shard number alone, two projects both running "shard 1" would each write `report-1.zip` and clobber each other when the report job merges them into one directory. The `shard_label` input on the e2e composite action gives each matrix entry a unique name for both the blob file and the artifact; it defaults to the shard number, so single-project runs need not set it.
 
 ## Unit testing
 

--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -73,7 +73,7 @@ The table above shows the default test cadences for each group. Teams may expand
 
 #### Browser test cadences
 
-Locally targeted runs have 4 browser configurations available (Chromium, Mobile Chromium, Webkit, Firefox). Deployed targets only have the two chromium ones, because staging MFA login is rate limited outside of Chrome. Which of the available browsers a given run actually uses depends on the cadence:
+Locally targeted runs have 4 browser configurations available (Chromium, Mobile Chromium, Webkit, Firefox). Deployed targets have only the two chromium ones — they have never defined Firefox or Webkit projects, since the deployed target was split out of the local one. Which of the available browsers a given run actually uses depends on the cadence:
 
 | Cadence        | Browsers                                   |
 | -------------- | ------------------------------------------ |

--- a/documentation/frontend/testing.md
+++ b/documentation/frontend/testing.md
@@ -73,7 +73,28 @@ The table above shows the default test cadences for each group. Teams may expand
 
 #### Browser test cadences
 
-We generally run all of our tests against 4 browser configurations (Chromium, Mobile Chromium, Webkit, Firefox). In some cases a test may be skipped in one or more of these browsers. This may be because the browser's implementation of certain behavior makes it very difficult to test (see Webkit's implementation of pasteboards), because of a need to limit traffic for a certain action (see running login tests only in Chrome), or because usage of the browser is low enough that we do not need to test against it all the time (see Firefox). The posture towards browser based testing can be flexible, though we should strive to test against all four browsers as much as possible.
+Locally targeted runs have 4 browser configurations available (Chromium, Mobile Chromium, Webkit, Firefox). Deployed targets only have the two chromium ones, because staging MFA login is rate limited outside of Chrome. Which of the available browsers a given run actually uses depends on the cadence:
+
+| Cadence        | Browsers                                   |
+| -------------- | ------------------------------------------ |
+| All PRs        | Chromium only                              |
+| Merge to main  | All 4 (local), Chromium + Mobile (staging) |
+| Daily / weekly | All 4 (local), Chromium + Mobile (staging) |
+
+PRs are limited to Chromium so that the smoke suite stays fast — running the same specs across all 4 configurations quadruples the test count for a signal that cross-browser breakage rarely shows up in. Cross-browser coverage still runs on every merge to main and on the daily and weekly schedules, so a Firefox- or Webkit-only regression is caught before release rather than on the PR that introduced it.
+
+A run's browser set is selected with the `playwright_projects` input on the [e2e composite action](https://github.com/HHS/simpler-grants-gov/blob/main/.github/actions/e2e/action.yml), which becomes the `PLAYWRIGHT_PROJECTS` env var that `playwright.config.ts` filters projects on. Leave it blank to run every project defined for the target. When narrowing to a non-Chrome browser, make sure the matching `do-*-install` input is also set, or the run will fail trying to launch a browser that was never installed.
+
+In some cases an individual test may be skipped in one or more browsers. This may be because the browser's implementation of certain behavior makes it very difficult to test (see Webkit's implementation of pasteboards), or because of a need to limit traffic for a certain action (see running login tests only in Chrome). The posture towards browser based testing can be flexible.
+
+#### How CI parallelizes runs
+
+Both e2e workflows split the suite across a matrix of 4 shards, one runner each, and merge the blob reports afterwards. The two workflows get their concurrency from different places:
+
+- **[ci-frontend-e2e.yml](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/ci-frontend-e2e.yml)** (local target) stands up its own API and frontend per shard, so each shard is isolated and runs with the default 10 workers.
+- **[e2e-staging.yml](https://github.com/HHS/simpler-grants-gov/blob/main/.github/workflows/e2e-staging.yml)** (deployed target) points all 4 shards at one shared environment, so it pins `workers: 1`. Every test on a deployed target authenticates as one of a handful of static shared test users, so adding concurrency by sharding across runners — where Playwright keeps same-file tests together — is safer than in-process parallelism. If you see cross-test interference on a deployed run, suspect two shards mutating the same test user's state before you suspect a real regression.
+
+Raising the shard count is a matter of editing both `matrix.shard` and `matrix.total_shards` in the workflow; they must agree, since they become Playwright's `--shard=current/total`.
 
 ## Unit testing
 

--- a/frontend/tests/e2e/playwright-env.ts
+++ b/frontend/tests/e2e/playwright-env.ts
@@ -70,6 +70,9 @@ const playwrightEnv = {
   isCi: process.env.CI,
   totalShards: process.env.TOTAL_SHARDS,
   currentShard: process.env.CURRENT_SHARD,
+  // Comma separated list of Playwright project (browser) names to run, e.g.
+  // "Chrome". Unset means run every project defined for the target env.
+  requestedProjects: process.env.PLAYWRIGHT_PROJECTS,
   clientSessionSecret:
     process.env.SESSION_SECRET_OVERRIDE || process.env.SESSION_SECRET,
   testUserEmail: process.env.STAGING_TEST_USER_EMAIL || "",

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -2,8 +2,83 @@ import { defineConfig, devices } from "@playwright/test";
 
 import playwrightEnv from "./e2e/playwright-env";
 
-const { baseUrl, targetEnv, webServerEnv, isCi, totalShards, currentShard } =
-  playwrightEnv;
+const {
+  baseUrl,
+  targetEnv,
+  webServerEnv,
+  isCi,
+  totalShards,
+  currentShard,
+  requestedProjects,
+} = playwrightEnv;
+
+const chromeProject = {
+  name: "Chrome",
+  use: {
+    ...devices["Desktop Chrome"],
+    permissions: ["clipboard-read", "clipboard-write"],
+  },
+};
+
+const firefoxProject = {
+  name: "Firefox",
+  use: {
+    ...devices["Desktop Firefox"],
+    permissions: [],
+  },
+};
+
+const webkitProject = {
+  name: "Webkit",
+  use: {
+    ...devices["Desktop Safari"],
+    permissions: ["clipboard-read"],
+  },
+};
+
+const mobileChromeProject = {
+  name: "Mobile chrome",
+  use: {
+    ...devices["Pixel 7"],
+    permissions: ["clipboard-read", "clipboard-write"],
+  },
+};
+
+/* Every project available for the current target. Deployed targets are limited to
+   the chromium engine because staging MFA login is rate limited outside of Chrome
+   (see e2e/utils/auth/skip-non-chrome-staging-utils.ts). */
+const availableProjects =
+  targetEnv !== "local"
+    ? [chromeProject, mobileChromeProject]
+    : [chromeProject, firefoxProject, webkitProject, mobileChromeProject];
+
+/* PLAYWRIGHT_PROJECTS narrows the browser matrix without editing this file —
+   PR smoke runs pass "Chrome" so they skip the Firefox / Webkit / mobile
+   variants. We take this as an env var rather than Playwright's --project flag
+   because the e2e composite action already threads every other setting through
+   env, and project names containing spaces are awkward to quote through three
+   duplicated `npm run test:e2e` steps. Unset (the default) runs every project
+   for the target. */
+const projectNames = requestedProjects
+  ? requestedProjects
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean)
+  : [];
+
+const unknownProjectNames = projectNames.filter(
+  (name) => !availableProjects.some((project) => project.name === name),
+);
+
+if (unknownProjectNames.length) {
+  throw new Error(
+    `Unknown PLAYWRIGHT_PROJECTS name(s): ${unknownProjectNames.join(", ")}. Available for target "${targetEnv}": ${availableProjects.map((project) => project.name).join(", ")}`,
+  );
+}
+
+const projects = projectNames.length
+  ? availableProjects.filter((project) => projectNames.includes(project.name))
+  : availableProjects;
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -18,7 +93,10 @@ export default defineConfig({
   /* Retry on CI only */
   retries: isCi ? 3 : 0,
   /* ci-frontend-e2e.yml — no workers passed → defaults to 10, sharding works as normal
-     e2e-staging.yml — passes workers: 1 → PLAYWRIGHT_WORKERS=1, all tests run sequentially */
+     e2e-staging.yml — passes workers: 1 → PLAYWRIGHT_WORKERS=1, so each shard runs
+     its own tests sequentially and concurrency comes from the shard matrix instead.
+     Deployed targets share a handful of static test users (see utils/auth/test-users.ts),
+     so in-process parallelism against one environment is riskier. */
   workers: process.env.PLAYWRIGHT_WORKERS
     ? parseInt(process.env.PLAYWRIGHT_WORKERS)
     : 10,
@@ -46,55 +124,9 @@ export default defineConfig({
     // Specifies which shard this job should execute
     current: parseInt(currentShard || "1"),
   },
-  /* Configure projects for major browsers */
-  projects:
-    targetEnv !== "local"
-      ? [
-          {
-            name: "Chrome",
-            use: {
-              ...devices["Desktop Chrome"],
-              permissions: ["clipboard-read", "clipboard-write"],
-            },
-          },
-          {
-            name: "Mobile chrome",
-            use: {
-              ...devices["Pixel 7"],
-              permissions: ["clipboard-read", "clipboard-write"],
-            },
-          },
-        ]
-      : [
-          {
-            name: "Chrome",
-            use: {
-              ...devices["Desktop Chrome"],
-              permissions: ["clipboard-read", "clipboard-write"],
-            },
-          },
-          {
-            name: "Firefox",
-            use: {
-              ...devices["Desktop Firefox"],
-              permissions: [],
-            },
-          },
-          {
-            name: "Webkit",
-            use: {
-              ...devices["Desktop Safari"],
-              permissions: ["clipboard-read"],
-            },
-          },
-          {
-            name: "Mobile chrome",
-            use: {
-              ...devices["Pixel 7"],
-              permissions: ["clipboard-read", "clipboard-write"],
-            },
-          },
-        ],
+  /* Configure projects for major browsers, optionally narrowed by
+     PLAYWRIGHT_PROJECTS (see above) */
+  projects,
 
   //  Only start the local dev server when running in the local environment.
   webServer:

--- a/frontend/tests/playwright.config.ts
+++ b/frontend/tests/playwright.config.ts
@@ -44,9 +44,11 @@ const mobileChromeProject = {
   },
 };
 
-/* Every project available for the current target. Deployed targets are limited to
-   the chromium engine because staging MFA login is rate limited outside of Chrome
-   (see e2e/utils/auth/skip-non-chrome-staging-utils.ts). */
+/* Every project available for the current target. Deployed targets have only ever
+   defined the two chromium projects — note that most specs additionally gate
+   themselves to Chrome on a deployed target (see
+   e2e/utils/auth/skip-non-chrome-staging-utils.ts), so adding Firefox or Webkit
+   here would not exercise the authenticated flows until that gate is narrowed. */
 const availableProjects =
   targetEnv !== "local"
     ? [chromeProject, mobileChromeProject]


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #12100 

## Changes proposed

- Updated `playwright.config.ts` to put the per-browser project definitions into named consts and filter them by a new `PLAYWRIGHT_PROJECTS` env var, throwing on an unknown project name rather than silently collecting zero tests
- Updated `e2e-staging.yml` to give each project its own shard count via `matrix.include`(Chrome across 6 shards plus Mobile chrome on 1), with `fail-fast: false`- replacing the single unsharded job, and to pass the project and shard label through to the action
- Updated `ci-frontend-e2e.yml` to add a "Determine browsers to run" step that sets `playwright_projects=Chrome` for `pull_request` events (blank everywhere else), pass it to all three e2e run steps, and skip the Firefox/Webkit installs whenever the run is narrowed to a project list
- Updated `action.yml` to accept `playwright_projects` and `shard_label` inputs, export `PLAYWRIGHT_PROJECTS` and `PLAYWRIGHT_BLOB_OUTPUT_NAME` in each test-run step, and name the blob artifact from the shard label
- Updated `testing.md` to replace the stale "we run all tests against 4 browsers" guidance with a per-cadence browser table, and to document how each workflow gets its concurrency and why the deployed target shards each project separately
- Updated `playwright-env.ts` to read `PLAYWRIGHT_PROJECTS` into `requestedProjects`


## Context for reviewers

The deployed target shards each project separately because Playwright balances shards by collected test count, while most Mobile chrome tests skip at runtime on a deployed target. That split is what forces the `shard_label` input: Playwright names its blob report from the shard number alone, so Chrome shard 1 and Mobile shard 1 would both write `report-1.zip` and collide in the merge job. Note staging has never defined Firefox or Webkit projects - that predates this PR and is unchanged here, with 274 collected tests before and after.

## Validation steps

1. Confirm the PR-run browser narrowing from `frontend/`: `PLAYWRIGHT_PROJECTS=Chrome npx playwright test --config ./tests/playwright.config.ts --list --grep "@smoke"` reports 50 tests, versus 200 with the var unset.
2. Confirm a blank value still means "every project" (this is what non-PR events write): `PLAYWRIGHT_PROJECTS= npx playwright test --config ./tests/playwright.config.ts --list` reports 548 tests in the same `Chrome, Firefox, Webkit, Mobile chrome` order as before.
3. Confirm a bad name fails loudly: `PLAYWRIGHT_PROJECTS=Chromium npx playwright test --config ./tests/playwright.config.ts --list` errors with `Unknown PLAYWRIGHT_PROJECTS name(s): Chromium`.
4. In CI on this PR, confirm the four `run-e2e-tests-local` shards each report only `[Chrome]` tests, that shards 2 and 3 skip their "Install Firefox/Webkit and dependencies" steps, and that the blob artifacts are still named `blob-report-shard-local-1..4`.
5. Dispatch E2E Tests (Deployed Target) against staging and confirm 7 jobs run concurrently (`E2E Chrome 1/6`…`6/6` plus `E2E Mobile chrome 1/1`), that seven distinctly-named blob artifacts (`blob-report-shard-staging-chrome-1..6`, `-mobile-1`) all merge into one report, and that the slowest shard lands near ~20-25m rather than the previous ~55m.