### PR TITLE
[Issue #11040] Move full refresh to daily cron

### DIFF
--- a/infra/api/app-config/env-config/scheduled_jobs.tf
+++ b/infra/api/app-config/env-config/scheduled_jobs.tf
@@ -316,9 +316,10 @@ locals {
       )
     }
     load-search-opportunity-data = {
-      task_command = ["flask", "load-search-data", "load-opportunity-data"]
-      # Every hour at the half hour
-      schedule_expression = "cron(30 * * * ? *)"
+      task_command = ["flask", "load-search-data", "load-opportunity-data", "--full-refresh"]
+      # Once a day at 00:30, after the agency data hourly job at 00:00.
+      # Incremental sync now runs every load-transform cycle
+      schedule_expression = "cron(30 0 * * ? *)"
       state               = "ENABLED"
       cpu                 = try(local.scheduled_jobs_config[var.environment].cpu, null)
       mem                 = try(local.scheduled_jobs_config[var.environment].mem, null)


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11040

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Move the `load-search-opportunity-data` scheduled job from hourly `(cron(30 * * * ? *))` to once daily at 00:30 (`cron(30 0 * * ? *)`), scheduled just after the agency data hourly job at 00:00. Adds --full-refresh explicitly to the task command.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Incremental sync now covers opportunity changes every load-transform cycle, so the full index rebuild only needs to run once a day to catch what the trigger doesn't cover (mainly agency changes).

Don't merge until #12282 is done (adds the flag)

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
`terraform fmt -check -diff` passes
