### PR TITLE
[Issue #12229] Fix SF-424a fields incorrectly showing as required

### DIFF
--- a/api/src/form_schema/forms/sf424a/1/0/form_json.py
+++ b/api/src/form_schema/forms/sf424a/1/0/form_json.py
@@ -4,6 +4,47 @@ from src.constants.lookup_constants import FormType
 from src.db.models.competition_models import Form
 from src.form_schema.shared import COMMON_SHARED_V1
 
+# Section B (budget_categories) fields that a user can enter directly. The two
+# totals (total_direct_charge_amount, total_amount) are auto-calculated and always
+# pre-populated as "0.00", so they can't be used to tell whether a row has data.
+SECTION_B_USER_ENTERED_FIELDS = [
+    "personnel_amount",
+    "fringe_benefits_amount",
+    "travel_amount",
+    "equipment_amount",
+    "supplies_amount",
+    "contractual_amount",
+    "construction_amount",
+    "other_amount",
+    "total_indirect_charge_amount",
+    "program_income_amount",
+]
+
+# Section A, Column A (activity_title) is only required on rows 2-4 when the row
+# has data entered in Section A (budget_summary) or Section B (budget_categories).
+# Row 1 is always required, which is enforced separately via prefixItems below.
+ACTIVITY_TITLE_REQUIRED_WHEN_ROW_HAS_DATA = {
+    "if": {
+        "anyOf": [
+            # Section A - budget_summary is never auto-populated, so any value present
+            # means the user entered data in this row.
+            {
+                "required": ["budget_summary"],
+                "properties": {"budget_summary": {"type": "object", "minProperties": 1}},
+            },
+            # Section B - only user-entered fields count as data for this row.
+            *[
+                {
+                    "required": ["budget_categories"],
+                    "properties": {"budget_categories": {"required": [field]}},
+                }
+                for field in SECTION_B_USER_ENTERED_FIELDS
+            ],
+        ]
+    },
+    "then": {"required": ["activity_title"]},
+}
+
 FORM_JSON_SCHEMA = {
     "type": "object",
     "required": [
@@ -15,9 +56,15 @@ FORM_JSON_SCHEMA = {
             "type": "array",
             "minItems": 1,
             "maxItems": 4,
+            # Row 1 (the first line item) always requires activity_title. This lives in
+            # its own allOf subschema so it does not disable the "items" schema for index 0
+            # (prefixItems and items only interact within the same schema object).
+            "allOf": [{"prefixItems": [{"required": ["activity_title"]}]}],
             "items": {
                 "type": "object",
-                "required": ["activity_title"],
+                # activity_title is conditionally required on rows 2-4 (see the conditional).
+                # Row 1's unconditional requirement is handled by prefixItems above.
+                "allOf": [ACTIVITY_TITLE_REQUIRED_WHEN_ROW_HAS_DATA],
                 "properties": {
                     "activity_title": {
                         # Activity title appears in multiple places on the form

--- a/api/tests/src/form_schema/forms/test_sf424a.py
+++ b/api/tests/src/form_schema/forms/test_sf424a.py
@@ -307,6 +307,90 @@ def test_sf424a_v1_0_empty_line_item(full_valid_json_v1_0, sf424a_v1_0):
         assert validation_issue.field in EXPECTED_REQUIRED_FIELDS
 
 
+def test_sf424a_v1_0_row_1_always_required(sf424a_v1_0):
+    """Row 1 activity_title is required even when only later rows hold data."""
+    data = {
+        "activity_line_items": [
+            {},
+            {"activity_title": "Line2", "budget_summary": {"total_amount": "5.00"}},
+        ],
+        "confirmation": True,
+    }
+    validation_issues = validate_json_schema_for_form(data, sf424a_v1_0)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "required"
+    assert validation_issues[0].field == "$.activity_line_items[0].activity_title"
+
+
+def test_sf424a_v1_0_empty_rows_2_4_not_required(sf424a_v1_0):
+    """Rows 2-4 without any data do not require activity_title."""
+    data = {
+        "activity_line_items": [{"activity_title": "Line1"}, {}, {}, {}],
+        "confirmation": True,
+    }
+    validation_issues = validate_json_schema_for_form(data, sf424a_v1_0)
+    assert len(validation_issues) == 0
+
+
+def test_sf424a_v1_0_row_required_when_section_a_data_entered(sf424a_v1_0):
+    """Row 3 Section A data with an empty Column A errors as required (ticket example)."""
+    data = {
+        "activity_line_items": [
+            {"activity_title": "Line1"},
+            {},
+            {"budget_summary": {"federal_new_or_revised_amount": "10.00"}},
+        ],
+        "confirmation": True,
+    }
+    validation_issues = validate_json_schema_for_form(data, sf424a_v1_0)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "required"
+    assert validation_issues[0].field == "$.activity_line_items[2].activity_title"
+
+    # Providing the title clears the error
+    data["activity_line_items"][2]["activity_title"] = "Line3"
+    assert len(validate_json_schema_for_form(data, sf424a_v1_0)) == 0
+
+
+def test_sf424a_v1_0_row_required_when_section_b_data_entered(sf424a_v1_0):
+    """Row 3 Section B user-entered data with an empty Column A errors as required."""
+    data = {
+        "activity_line_items": [
+            {"activity_title": "Line1"},
+            {},
+            {
+                "budget_categories": {
+                    "personnel_amount": "5.00",
+                    "total_direct_charge_amount": "5.00",
+                    "total_amount": "5.00",
+                }
+            },
+        ],
+        "confirmation": True,
+    }
+    validation_issues = validate_json_schema_for_form(data, sf424a_v1_0)
+
+    assert len(validation_issues) == 1
+    assert validation_issues[0].type == "required"
+    assert validation_issues[0].field == "$.activity_line_items[2].activity_title"
+
+
+def test_sf424a_v1_0_row_not_required_with_only_autopopulated_totals(sf424a_v1_0):
+    """Auto-populated Section B totals alone do not make activity_title required."""
+    data = {
+        "activity_line_items": [
+            {"activity_title": "Line1"},
+            {"budget_categories": {"total_direct_charge_amount": "0.00", "total_amount": "0.00"}},
+            {"budget_categories": {"total_direct_charge_amount": "0.00", "total_amount": "0.00"}},
+        ],
+        "confirmation": True,
+    }
+    validation_issues = validate_json_schema_for_form(data, sf424a_v1_0)
+    assert len(validation_issues) == 0
+
+
 def test_sf424a_v1_0_no_line_items(full_valid_json_v1_0, sf424a_v1_0):
     data = full_valid_json_v1_0
     data["activity_line_items"] = []
@@ -582,6 +666,32 @@ def test_sf424a_v_1_0_auto_summation_full_data(
         },
         "confirmation": True,
     }
+
+
+def test_sf424a_v_1_0_conditional_required_end_to_end(enable_factory_create, sf424a_v1_0):
+    """Through pre-population, empty rows stay optional and Section A data forces Column A."""
+    data = {
+        "activity_line_items": [
+            {"activity_title": "Line1"},
+            {},
+            {"budget_summary": {"federal_new_or_revised_amount": "10.00"}},
+            {},
+        ],
+        "confirmation": True,
+    }
+    app = setup_application_for_form_validation(
+        data,
+        json_schema=sf424a_v1_0.form_json_schema,
+        rule_schema=sf424a_v1_0.form_rule_schema,
+    )
+
+    validation_issues = validate_application_form(app, ApplicationAction.MODIFY)
+
+    # Pre-population injects budget_categories totals into every row, but only row 3
+    # (which has Section A data and no Column A value) is flagged as required.
+    required_issues = [i for i in validation_issues if i.type == "required"]
+    assert len(required_issues) == 1
+    assert required_issues[0].field == "$.activity_line_items[2].activity_title"
 
 
 def test_sf424a_v_1_0_total_budget_summary_sums_column_g(enable_factory_create, sf424a_v1_0):

--- a/frontend/tests/e2e/apply/fixtures/sf424a-field-definitions.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424a-field-definitions.ts
@@ -398,21 +398,11 @@ export const SF424A_FORM_CONFIG: FillFormConfig = {
 };
 
 // Top alert validation errors for SF-424A blank-save behavior.
+// Only row 1 (index 0) Column A is always required. Rows 2-4 are conditionally
+// required and stay optional when their row has no Section A or B data.
 export const SF424A_ALERT_ERRORS: FieldError[] = [
   {
     fieldId: "activity_line_items[0]--activity_title",
-    message: "'activity_title' is a required property",
-  },
-  {
-    fieldId: "activity_line_items[1]--activity_title",
-    message: "'activity_title' is a required property",
-  },
-  {
-    fieldId: "activity_line_items[2]--activity_title",
-    message: "'activity_title' is a required property",
-  },
-  {
-    fieldId: "activity_line_items[3]--activity_title",
     message: "'activity_title' is a required property",
   },
   {


### PR DESCRIPTION
# Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #12229 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Recommit the SF-424A conditional-required fix from #11287, which was reverted in #11398 pending UAT that never happened. Row 1 of Section A always requires `activity_title`; rows 2-4 only require it when that row has data in Section A or Section B.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
Reapplied via `git revert` of the revert commit (b580d21d4) on top of latest main. This time it should go through UAT before merge.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
make test args="tests/src/form_schema/forms/test_sf424a.py"