### PR TITLE
[Issue #12311] Align E2E workflow branch/ref propagation and resolve race condition

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -88,7 +88,7 @@ jobs:
   e2e-test-staging:
     name: E2E Staging (post-deploy)
     needs: [deploy]
-    if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     uses: ./.github/workflows/e2e-staging.yml
     secrets: inherit
     with:

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -85,8 +85,20 @@ jobs:
       environment: ${{ matrix.envs }}
       version: ${{ inputs.version || github.ref }}
 
+  e2e-test-staging:
+    name: E2E Staging (post-deploy)
+    needs: [deploy]
+    if: ${{ !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    uses: ./.github/workflows/e2e-staging.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version || github.ref }}
+      target: staging
+      playwright_tags: "@smoke|@core-regression"
+
   send-slack-notification:
     if: failure() && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
-    needs: [frontend-checks, vulnerability-scans, deploy]
+    needs: [frontend-checks, vulnerability-scans, deploy, e2e-test-staging]
     uses: ./.github/workflows/send-slack-notification.yml
     secrets: inherit
+    

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -133,12 +133,11 @@ jobs:
       app_name: "frontend"
       environment: ${{ inputs.environment == 'dev' && 'infra-dev' || inputs.environment == 'staging' && 'infra-staging' || inputs.environment || 'prod' }}
       version: ${{ inputs.version || github.ref }}
-
-  
+      
   e2e-test-staging:
     name: E2E Staging (on Deploy)
     needs: [deploy-frontend]
-    if: ${{ !cancelled() && (inputs.environment == 'prod' || github.event_name == 'release') }}
+    if: ${{ inputs.environment == 'prod' || github.event_name == 'release' }}
     uses: ./.github/workflows/e2e-staging.yml
     secrets: inherit
     with:

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -97,24 +97,13 @@ jobs:
     with:
       app_name: analytics
 
-  # trigger runs of local and staging core regression e2e tests
-  # but do not wait, or block any deployments based on results
+  # Local E2Es can run independently and do not need to wait for deployment.
   e2e-test-local:
     name: E2E Local (on Deploy)
     if: ${{ inputs.environment == 'prod' || github.event_name == 'release' }}
     uses: ./.github/workflows/ci-frontend-e2e.yml
     secrets: inherit
     with:
-      playwright_tags: "@smoke|@core-regression"
-
-  e2e-test-staging:
-    name: E2E Staging (on Deploy)
-    if: ${{ inputs.environment == 'prod' || github.event_name == 'release' }}
-    uses: ./.github/workflows/e2e-staging.yml
-    secrets: inherit
-    with:
-      version: main
-      target: staging
       playwright_tags: "@smoke|@core-regression"
 
   # =====================================================
@@ -144,6 +133,18 @@ jobs:
       app_name: "frontend"
       environment: ${{ inputs.environment == 'dev' && 'infra-dev' || inputs.environment == 'staging' && 'infra-staging' || inputs.environment || 'prod' }}
       version: ${{ inputs.version || github.ref }}
+
+  
+  e2e-test-staging:
+    name: E2E Staging (on Deploy)
+    needs: [deploy-frontend]
+    if: ${{ !cancelled() && (inputs.environment == 'prod' || github.event_name == 'release') }}
+    uses: ./.github/workflows/e2e-staging.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version || github.ref }}
+      target: staging
+      playwright_tags: "@smoke|@core-regression"
 
   # 3. Deploy Analytics after API completes successfully
   deploy-analytics:

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -5,6 +5,10 @@ on:
       - "main"
   workflow_dispatch:
     inputs:
+      version:
+        description: "git reference for testing code to run (e.g., a branch, tag, or commit SHA)"
+        required: false
+        type: string
       api_logs:
         description: "print api logs on failure?"
         default: false
@@ -59,13 +63,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha  || github.head_ref || github.ref }}
+          ref: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
           repository: ${{ github.event.repository.full_name }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-api-commit-hash
         env:
-          CLEAN_REF: ${{ github.event.pull_request.head.sha  || github.head_ref || github.ref }}
+          CLEAN_REF: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
         run: |
           cd ..
           COMMIT_HASH=$(git rev-parse "$CLEAN_REF")
@@ -81,13 +85,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha  || github.head_ref || github.ref }}
+          ref: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
           repository: ${{ github.event.repository.full_name }}
           fetch-depth: 1000
       - name: Get commit hash
         id: get-frontend-commit-hash
         env:
-          CLEAN_REF: ${{ github.event.pull_request.head.sha  || github.head_ref || github.ref }}
+          CLEAN_REF: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
         run: |
           cd ..
           COMMIT_HASH=$(git rev-parse "$CLEAN_REF")

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -15,8 +15,13 @@ on:
         type: string
   workflow_call:
     inputs:
+      version:
+        description: "git reference for testing code to run (e.g., a branch, tag, or commit SHA)"
+        required: false
+        type: string
       api_logs:
         description: "print api logs on failure?"
+        required: false
         default: false
         type: boolean
       playwright_tags:
@@ -482,7 +487,7 @@ jobs:
           E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
         if: ${{ env.E2E_UTILS_CHANGED == 'true' }}
         with:
-          version: ${{ github.ref }}
+          version: ${{ inputs.version || github.ref }}
           target: "local"
           needs_node_setup: "false"
           total_shards: ${{ matrix.total_shards }}
@@ -507,7 +512,7 @@ jobs:
           E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
         if: ${{ env.E2E_UTILS_CHANGED != 'true' }}
         with:
-          version: ${{ github.ref }}
+          version: ${{ inputs.version || github.ref }}
           target: "local"
           needs_node_setup: "false"
           total_shards: ${{ matrix.total_shards }}
@@ -533,7 +538,7 @@ jobs:
           E2E_SPECS_CHANGED: ${{ steps.changed-e2e-spec-files.outputs.all_changed_files }}
         if: ${{ env.E2E_SPECS_CHANGED != '' && env.E2E_UTILS_CHANGED != 'true' }}
         with:
-          version: ${{ github.ref }}
+          version: ${{ inputs.version || github.ref }}
           target: "local"
           needs_node_setup: "false"
           total_shards: ${{ matrix.total_shards }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -108,6 +108,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
+          repository: ${{ github.event.repository.full_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -174,6 +177,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
+          repository: ${{ github.event.repository.full_name }}
 
       - name: Restore API Docker image cached
         id: restore-docker-image-cached
@@ -229,6 +235,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
+          repository: ${{ github.event.repository.full_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -491,7 +500,7 @@ jobs:
           E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
         if: ${{ env.E2E_UTILS_CHANGED == 'true' }}
         with:
-          version: ${{ inputs.version || github.ref }}
+          version: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
           target: "local"
           needs_node_setup: "false"
           total_shards: ${{ matrix.total_shards }}
@@ -516,7 +525,7 @@ jobs:
           E2E_UTILS_CHANGED: ${{ steps.changed-e2e-utils.outputs.any_changed }}
         if: ${{ env.E2E_UTILS_CHANGED != 'true' }}
         with:
-          version: ${{ inputs.version || github.ref }}
+          version: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
           target: "local"
           needs_node_setup: "false"
           total_shards: ${{ matrix.total_shards }}
@@ -542,7 +551,7 @@ jobs:
           E2E_SPECS_CHANGED: ${{ steps.changed-e2e-spec-files.outputs.all_changed_files }}
         if: ${{ env.E2E_SPECS_CHANGED != '' && env.E2E_UTILS_CHANGED != 'true' }}
         with:
-          version: ${{ inputs.version || github.ref }}
+          version: ${{ inputs.version || github.event.pull_request.head.sha || github.head_ref || github.ref }}
           target: "local"
           needs_node_setup: "false"
           total_shards: ${{ matrix.total_shards }}

--- a/.github/workflows/ci-frontend-e2e.yml
+++ b/.github/workflows/ci-frontend-e2e.yml
@@ -484,7 +484,7 @@ jobs:
       #   - Any e2e utils have changed?
       #       - Yes
       #         - Run All E2E tests (utils updated)
-      #`      - No
+      #       - No
       #         - Any specific spec files to run supplied?
       #           - Yes
       #             - Run E2E tests

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
     inputs:
+      version:
+        description: "git reference for testing code to run (e.g., a branch, tag, or commit SHA)"
+        required: false
+        type: string
       playwright_tags:
         description: "pipe separated list of @tags denoting groups of tests to run (e.g. @smoke|@core-regression). Leave blank to run all tests"
         required: false
@@ -18,7 +22,7 @@ jobs:
     if: always()
     secrets: inherit
     with:
-      version: main
+      version: ${{ inputs.version || github.ref }}
       target: staging
       playwright_tags: "@smoke|@core-regression|@full-regression"
   daily-e2e-tests-local:
@@ -27,6 +31,7 @@ jobs:
     if: always()
     secrets: inherit
     with:
+      version: ${{ inputs.version || github.ref }}
       playwright_tags: "@smoke|@core-regression|@full-regression"
   send-slack-notification:
     if: failure()

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -1,8 +1,5 @@
 name: E2E Tests (Deployed Target)
 on:
-  push:
-    branches:
-      - "main"
   workflow_dispatch:
     inputs:
       version:
@@ -40,7 +37,7 @@ on:
         required: false
         type: string
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.target || 'staging' }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.target || 'staging' }}-${{ inputs.version || github.ref }}
   cancel-in-progress: true
 jobs:
   e2e-tests-deployed:
@@ -90,14 +87,13 @@ jobs:
           fi
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.version || github.ref }}
       - name: Determine test groups to run
         shell: bash
         run: |
-          if [[ $GITHUB_EVENT_NAME = "push" ]]; then
-            echo "test_group_tags=@smoke|@core-regression" >> "$GITHUB_ENV"
-          else
-            echo "test_group_tags=${{ inputs.playwright_tags }}" >> "$GITHUB_ENV"
-          fi
+          echo "test_group_tags=${{ inputs.playwright_tags }}" >> "$GITHUB_ENV"
+
       - name: Run E2E tests
         uses: ./.github/actions/e2e
         with:

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -22,6 +22,7 @@ on:
           - grantor2
       playwright_tags:
         description: "pipe separated list of @tags denoting groups of tests to run (e.g. @smoke|@core-regression). Leave blank to run all tests"
+        required: false
         type: string
   workflow_call:
     inputs:
@@ -31,10 +32,12 @@ on:
         type: string
       target:
         description: "application environment to run tests against (dev / prod TK)"
+        required: false
         default: "staging"
         type: string
       playwright_tags:
         description: "pipe separated list of @tags denoting groups of tests to run (e.g. @smoke|@core-regression). Leave blank to run all tests"
+        required: false
         type: string
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.target || 'staging' }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Work for: Task #12311 

## Changes proposed
- Daily workflow: Added an optional version input for manual runs.
  - Daily -> Staging: Previously always used main; now uses the selected version, or github.ref if no version is provided.
  - Daily -> Local: Previously did not explicitly pass a version; now passes the selected version, or github.ref.
  - Manual Daily with a feature branch: Previously Staging used main; now both Staging and Local use the selected feature branch.
  - Scheduled Daily: Previously Staging used main and Local used github.ref; now both use github.ref when no version is provided.
- Corresponding changes:
  - Local workflow: Added an optional version input to workflow_call.
    - Local E2E tests: All three E2E action calls now use inputs.version || github.ref instead of always using github.ref.
    - Local api_logs: Explicitly marked as required: false.
  - Staging workflow: playwright_tags and target: Explicitly marked as required: false.
-   Race condition fix:
    -   e2e-staging.yml - no longer has on.push trigger, so it cannot auto-start on main.
    - cd-frontend.yml - staging E2E only runs after needs: [deploy] completes, with condition if: github.event_name == 'push' && github.ref == 'refs/heads/main'.

## Validation steps
* CI E2E runs as expected and per the above set up without any issues
