### PR TITLE
[Issue 11641] Preserve native close-date description in CommonGrants output

### DIFF
--- a/api/src/services/common_grants/transformation.py
+++ b/api/src/services/common_grants/transformation.py
@@ -335,6 +335,9 @@ def transform_opportunity_to_cg(v1_opportunity: Opportunity) -> OpportunityBase 
             "summary_description": v1_opportunity.summary.summary_description,
             "post_date": v1_opportunity.summary.post_date,
             "close_date": v1_opportunity.summary.close_date,
+            "close_date_description": getattr(
+                v1_opportunity.summary, "close_date_description", None
+            ),
             "estimated_total_program_funding": v1_opportunity.summary.estimated_total_program_funding,
             "award_ceiling": v1_opportunity.summary.award_ceiling,
             "award_floor": v1_opportunity.summary.award_floor,
@@ -390,6 +393,11 @@ def transform_search_result_to_cg(opp_data: dict) -> OpportunityBase | None:
         post_date = summary.get("post_date") if isinstance(summary, dict) else summary.post_date
         close_date = summary.get("close_date") if isinstance(summary, dict) else summary.close_date
         # TODO: summary.close_date is not the correct value! deadlines are stored in competitions
+        close_date_description = (
+            summary.get("close_date_description")
+            if isinstance(summary, dict)
+            else getattr(summary, "close_date_description", None)
+        )
         timeline = OppTimeline(
             postDate=(
                 SingleDateEvent(
@@ -404,7 +412,7 @@ def transform_search_result_to_cg(opp_data: dict) -> OpportunityBase | None:
                 SingleDateEvent(
                     name="Application Deadline",
                     date=_transform_date_to_cg(close_date),
-                    description="Deadline for submitting applications",
+                    description=close_date_description or "Deadline for submitting applications",
                 )
                 if close_date
                 else None

--- a/api/tests/src/services/common_grants/test_transformation.py
+++ b/api/tests/src/services/common_grants/test_transformation.py
@@ -1580,3 +1580,33 @@ def test_build_custom_filters_applies_valid_filter_when_other_key_invalid():
     )
     assert applied == {"agency": {"one_of": ["USAID"]}}
     assert errors == ["customFilters.bogus: unsupported filter"]
+
+
+class TestPreserveDroppedSummaryFields:
+    """RED tests for HHS/simpler-grants-gov#11641: close-date description
+    dropped by the CommonGrants transformation."""
+
+    def _opp_data(self, **summary_extra) -> dict:
+        payload = _opp_data_with_info_url("https://example.com/info", "More info")
+        payload["summary"].update(summary_extra)
+        return payload
+
+    def test_close_date_description_preserved(self):
+        """#11641: native close-date description wins over the generic text."""
+        from src.services.common_grants.transformation import transform_search_result_to_cg
+
+        result = transform_search_result_to_cg(
+            self._opp_data(close_date_description="Portal closes at 5pm ET, apply early")
+        )
+        assert result is not None
+        assert result.key_dates.close_date is not None
+        assert result.key_dates.close_date.description == "Portal closes at 5pm ET, apply early"
+
+    def test_close_date_description_falls_back_to_generic(self):
+        """#11641: generic description remains when no native one exists."""
+        from src.services.common_grants.transformation import transform_search_result_to_cg
+
+        result = transform_search_result_to_cg(self._opp_data())
+        assert result is not None
+        assert result.key_dates.close_date is not None
+        assert result.key_dates.close_date.description == "Deadline for submitting applications"


### PR DESCRIPTION
Fixes #11641

Use the native `summary.close_date_description` for `keyDates.closeDate.description` when it is present, keeping the existing generic text as the fallback. The field already exists in the DB model and the V1 search schema (so it is in the search index too) — it just never reached the CommonGrants output. Covers both search and detail responses.

## Validation steps

- 2 new tests (native description wins, generic fallback stays): `pytest -q tests/src/services/common_grants/test_transformation.py` — 67 passed
- `ruff check` and `mypy` clean on the touched source file