### PR TITLE
[12174] E2E Zip File download POC

### DIFF
--- a/frontend/tests/e2e/apply/fixtures/sf424b-data.ts
+++ b/frontend/tests/e2e/apply/fixtures/sf424b-data.ts
@@ -45,3 +45,15 @@ export const SF424B_OPPORTUNITY_DATA: PrintViewFormData = {
   expectedPrepopulatedFields: {},
   buildTestData: buildSF424BHappyPathTestData,
 };
+
+/**
+ * Fixed test data used specifically for submission ZIP/XML verification.
+ * These values are intentionally stable so the generated GrantApplication.xml
+ * can be verified against known values.
+ */
+export const SF424B_ZIP_EXPECTED_DATA = {
+  representative_name: "simpler-grants-e2e-tester@navapbc.com",
+  title: "ZIP TEST 001",
+  applicant_organization: "ZIP TEST ORG 001",
+  SubmittedDate: "2026-09-09",
+} as const;

--- a/frontend/tests/e2e/apply/submission/specs/submission-zip-verification-sf424b.spec.ts
+++ b/frontend/tests/e2e/apply/submission/specs/submission-zip-verification-sf424b.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * @feature Apply - Submission zip content verification
+ * @scenario Open a pre-submitted SF-424B application, check for the submission zip
+ * to become available, then verify the zip contains a valid SF424B.pdf and a
+ * GrantApplication.xml whose content matches the data that was filled in.
+ */
+
+import {
+  test,
+  type BrowserContext,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+import { SF424B_ZIP_EXPECTED_DATA } from "tests/e2e/apply/fixtures/sf424b-data";
+import { VALID_TAGS } from "tests/e2e/tags";
+import { authenticateE2eUser } from "tests/e2e/utils/auth/authenticate-e2e-user-utils";
+import { skipNonChromeOnStaging } from "tests/e2e/utils/auth/skip-non-chrome-staging-utils";
+import {
+  assertXmlContains,
+  downloadAndUnzipSubmission,
+  waitForSubmissionZipReady,
+} from "tests/e2e/utils/submission/submission-zip-utils";
+
+const { APPLY, CORE_REGRESSION, GRANTEE } = VALID_TAGS;
+
+const APPLICATION_URL =
+  "https://staging.simpler.grants.gov/workspace/applications/aa9da806-3764-4e98-8dd7-8e5a72b20bd8";
+
+test.beforeEach(({ page: _ }, testInfo) => {
+  test.skip(
+    process.env.PLAYWRIGHT_TARGET_ENV === "local",
+    "Submission ZIP verification runs only against staging",
+  );
+  skipNonChromeOnStaging(testInfo);
+});
+
+test(
+  "Submission zip contains SF424B PDF and XML with correct form data",
+  { tag: [APPLY, GRANTEE, CORE_REGRESSION] },
+  async (
+    { page, context }: { page: Page; context: BrowserContext },
+    testInfo: TestInfo,
+  ) => {
+    const isMobile = testInfo.project.name.match(/[Mm]obile/);
+    await authenticateE2eUser(page, context, !!isMobile);
+
+    // --- Open the pre-submitted application ---
+    await page.goto(APPLICATION_URL);
+    await page.waitForLoadState("domcontentloaded");
+
+    // --- Check if the zip is downloadable, then download and unzip it ---
+    await waitForSubmissionZipReady(page, APPLICATION_URL);
+    const contents = await downloadAndUnzipSubmission(page);
+
+    // --- Verify GrantApplication.xml contains the entered field values ---
+    // Element names AND prefix confirmed against SF-424B's own _xml_config in
+    // api/src/form_schema/forms/sf424b/1/0/form_json.py, which explicitly sets
+    // "root_namespace_prefix": "SF424B" - every element in this form's body carries
+    // that prefix, e.g. <SF424B:ApplicantOrganizationName>...</SF424B:ApplicantOrganizationName>.
+    // (Cross-checked against a real generated SF-424 GrantApplication.xml sample, which
+    // confirmed the same convention: prefix = the form's short_form_name/root_namespace_prefix.)
+    //   title                  -> SF424B:RepresentativeTitle (via authorized_representative_wrapper)
+    //   applicant_organization -> SF424B:ApplicantOrganizationName
+    assertXmlContains(contents, [
+      `<SF424B:RepresentativeName>${SF424B_ZIP_EXPECTED_DATA.representative_name}</SF424B:RepresentativeName>`,
+      `<SF424B:RepresentativeTitle>${SF424B_ZIP_EXPECTED_DATA.title}</SF424B:RepresentativeTitle>`,
+      `<SF424B:ApplicantOrganizationName>${SF424B_ZIP_EXPECTED_DATA.applicant_organization}</SF424B:ApplicantOrganizationName>`,
+      `<SF424B:SubmittedDate>${SF424B_ZIP_EXPECTED_DATA.SubmittedDate}</SF424B:SubmittedDate>`,
+    ]);
+  },
+);

--- a/frontend/tests/e2e/utils/submission/submission-zip-utils.ts
+++ b/frontend/tests/e2e/utils/submission/submission-zip-utils.ts
@@ -1,0 +1,169 @@
+/**
+ * Utilities for downloading, unzipping, and verifying the contents of an
+ * application submission zip file in Playwright e2e tests.
+ *
+ * The submission zip produced by CreateApplicationSubmissionTask contains:
+ *   - <ShortFormName>.pdf  - one per included form (e.g. "SF424B.pdf")
+ *   - GrantApplication.xml - full submission XML (if XML generation is enabled)
+ *   - manifest.txt         - human-readable manifest listing every file
+ *
+ * Uses @zip.js/zip.js (an existing project dependency, already used for zip
+ * handling in src/utils/opportunity/zipUtils.ts) rather than adding a new
+ * zip library. Verification here is XML-only: GrantApplication.xml is plain
+ * text and needs no extra dependency to check that entered form data made it
+ * into the submission. PDF entries are left unzipped along with everything
+ * else in ZipContents.files if a caller wants to look at them, but this
+ * module doesn't parse or assert on PDF content.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { expect, type Page } from "@playwright/test";
+import * as zip from "@zip.js/zip.js";
+
+// zip.js defaults to Web Workers, which aren't available in a plain Node
+// (Playwright test) process - run inline instead.
+zip.configure({ useWebWorkers: false });
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ZipContents {
+  /** Raw bytes keyed by file name (e.g. "SF424B.pdf", "GrantApplication.xml") */
+  files: Map<string, Uint8Array>;
+}
+
+// ---------------------------------------------------------------------------
+// Waiting for the zip to become available
+// ---------------------------------------------------------------------------
+
+/**
+ * Waits for the application submission zip to become downloadable.
+ *
+ * The download button only renders once `application_status` reaches
+ * ACCEPTED (see InformationCard.tsx's ApplicationSubmissionDownload). Right
+ * after submitting, status is SUBMITTED and a different element renders
+ * instead (`application-submission-download-message`, a "preparing your
+ * download" message) - there is no button to wait on yet. That transition
+ * happens via an async backend job with no client-side polling, so this
+ * reloads the page on an interval rather than relying on Playwright's
+ * default auto-retry, which only re-checks the already-loaded DOM.
+ *
+ * @param page Playwright Page object, already on the application page
+ * @param applicationUrl The application page URL to reload while polling
+ * @param options.timeoutMs Overall time budget before giving up (default 3 min)
+ * @param options.pollIntervalMs Time between reloads (default 10s)
+ */
+export async function waitForSubmissionZipReady(
+  page: Page,
+  applicationUrl: string,
+  options: { timeoutMs?: number; pollIntervalMs?: number } = {},
+): Promise<void> {
+  const { timeoutMs = 180_000, pollIntervalMs = 10_000 } = options;
+  const downloadButton = page.getByTestId("application-submission-download");
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await downloadButton.isVisible().catch(() => false)) {
+      await expect(downloadButton).toBeEnabled({ timeout: 10_000 });
+      return;
+    }
+    await page.waitForTimeout(pollIntervalMs);
+    await page.goto(applicationUrl, { waitUntil: "domcontentloaded" });
+  }
+
+  throw new Error(
+    `Submission zip was not ready (application-submission-download button never appeared) ` +
+      `within ${timeoutMs}ms. The application may still be SUBMITTED rather than ACCEPTED.`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Download & unzip
+// ---------------------------------------------------------------------------
+
+/**
+ * Clicks the (already-visible, already-enabled) submission download button,
+ * waits for the browser download event, saves the file to a temp path,
+ * unzips it in memory via @zip.js/zip.js, and returns a map of
+ * file name → bytes for every entry in the zip.
+ *
+ * Call `waitForSubmissionZipReady` first - this does not wait for the
+ * button to appear, only for the download it triggers.
+ *
+ * @param page Playwright Page object
+ */
+export async function downloadAndUnzipSubmission(
+  page: Page,
+): Promise<ZipContents> {
+  const downloadButton = page.getByTestId("application-submission-download");
+
+  const downloadPromise = page.waitForEvent("download");
+  await downloadButton.click();
+  const download = await downloadPromise;
+
+  const tmpPath = path.join(os.tmpdir(), `submission-${Date.now()}.zip`);
+  await download.saveAs(tmpPath);
+
+  const zipBytes = new Uint8Array(fs.readFileSync(tmpPath));
+  const files = new Map<string, Uint8Array>();
+
+  const zipReader = new zip.ZipReader(new zip.Uint8ArrayReader(zipBytes));
+  try {
+    const entries = await zipReader.getEntries();
+    for (const entry of entries) {
+      // Skip directory entries
+      if (entry.directory || !entry.getData) continue;
+      const fileName = path.basename(entry.filename);
+      const data = await entry.getData(new zip.Uint8ArrayWriter());
+      files.set(fileName, data);
+    }
+  } finally {
+    await zipReader.close();
+  }
+
+  // Clean up tmp file
+  try {
+    fs.unlinkSync(tmpPath);
+  } catch {
+    // non-fatal
+  }
+
+  return { files };
+}
+
+// ---------------------------------------------------------------------------
+// XML helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Asserts that GrantApplication.xml exists in the zip and that its raw text
+ * contains each of the provided expected strings (simple text search - no
+ * full XML parsing needed for field value assertions).
+ *
+ * @param contents ZipContents returned by downloadAndUnzipSubmission
+ * @param expectedStrings Strings that must appear in the XML text
+ */
+export function assertXmlContains(
+  contents: ZipContents,
+  expectedStrings: string[],
+): void {
+  const xmlBytes = contents.files.get("GrantApplication.xml");
+  if (!xmlBytes) {
+    const available = [...contents.files.keys()].join(", ");
+    throw new Error(
+      `GrantApplication.xml not found in zip. Available files: ${available}`,
+    );
+  }
+
+  const xmlText = Buffer.from(xmlBytes).toString("utf-8");
+
+  for (const expected of expectedStrings) {
+    expect(
+      xmlText,
+      `Expected GrantApplication.xml to contain: "${expected}"`,
+    ).toContain(expected);
+  }
+}

--- a/frontend/tests/e2e/utils/submission/submission-zip-utils.ts
+++ b/frontend/tests/e2e/utils/submission/submission-zip-utils.ts
@@ -9,7 +9,7 @@
  *
  * Uses @zip.js/zip.js (an existing project dependency, already used for zip
  * handling in src/utils/opportunity/zipUtils.ts) rather than adding a new
- * zip library. Verification here is XML-only: GrantApplication.xml. 
+ * zip library. Verification here is XML-only: GrantApplication.xml.
  * PDF entries are left unzipped along with everything
  * else in ZipContents.files if a caller wants to look at them, but this
  * module doesn't parse or assert on PDF content.

--- a/frontend/tests/e2e/utils/submission/submission-zip-utils.ts
+++ b/frontend/tests/e2e/utils/submission/submission-zip-utils.ts
@@ -9,9 +9,8 @@
  *
  * Uses @zip.js/zip.js (an existing project dependency, already used for zip
  * handling in src/utils/opportunity/zipUtils.ts) rather than adding a new
- * zip library. Verification here is XML-only: GrantApplication.xml is plain
- * text and needs no extra dependency to check that entered form data made it
- * into the submission. PDF entries are left unzipped along with everything
+ * zip library. Verification here is XML-only: GrantApplication.xml. 
+ * PDF entries are left unzipped along with everything
  * else in ZipContents.files if a caller wants to look at them, but this
  * module doesn't parse or assert on PDF content.
  */


### PR DESCRIPTION
## Summary
Work for: Task #12174 

## Changes proposed
- Create a new staging-only E2E test that uses a pre-submitted application with SF424B for this POC. 
  - The test is staging-only because submission ZIPs for newly submitted applications are generated asynchronously on the 15th minute of each hour. Using a pre-submitted application with an already-generated ZIP avoids waiting for that scheduled processing, so local runs are skipped.
- Update existing frontend/tests/e2e/apply/fixtures/sf424b-data.ts - Add fixed SF-424B test data for validating the expected values in XML
- Create new reusable submission ZIP utilities to wait for ZIP availability, download and unzip the submission, and provide utilities for verifying the contents of XML.
  - Verify that the downloaded submission ZIP contains GrantApplication.xml with the expected form data

## Context for reviewers
- Test spec: 
  - frontend/tests/e2e/apply/submission/specs/submission-zip-verification-sf424b.spec.ts
- Fixture update: 
  - frontend/tests/e2e/apply/fixtures/sf424b-data.ts
- New helper: 
  - frontend/tests/e2e/utils/submission/submission-zip-utils.ts

## Validation steps
Run the standalone Playwright test and it should complete the workflow per requirement in #12174 
