### PR TITLE
[Issue #10773] Migrate tcertificates null-byte workaround to the strip_zeros opt-in

### DIFF
--- a/api/src/data_migration/load/load_oracle_data_task.py
+++ b/api/src/data_migration/load/load_oracle_data_task.py
@@ -69,7 +69,7 @@ class LoadOracleDataTask(src.task.task.Task):
         # Initialize columns_to_exclude if None
         # Note: This does not work on UPDATES and can cause errors because the fields won't be excluded
         # if the column has invalid data
-        self.columns_to_exclude: dict[str, list[str]] = {"tcertificates": ["is_selfsigned"]}
+        self.columns_to_exclude: dict[str, list[str]] = {}
 
         foreign_tables = {k: v for (k, v) in foreign_tables.items() if k in tables_to_load}
         staging_tables = {k: v for (k, v) in staging_tables.items() if k in tables_to_load}

--- a/api/src/db/models/foreign/certificates.py
+++ b/api/src/db/models/foreign/certificates.py
@@ -2,38 +2,6 @@ from src.db.models.legacy_mixin.certificates_mixin import TcertificatesMixin
 
 from . import foreignbase
 
-"""
-This table needs to be manually created in lower environments in order to add the strip_zeros
-option to the is_selfsigned column due to null bytes being present for is_selfsigned. The
-exclude columns option does not work on UPDATES so it causes errors every time an UPDATE is
-attempted when there's a null byte in is_selfsigned. Since null bytes don't seem to be an
-issue in production for that column we can let that be automatically generated.
-
-The command:
-DROP FOREIGN TABLE IF EXISTS legacy.tcertificates;
-CREATE FOREIGN TABLE legacy.tcertificates (
-    currentcertid TEXT OPTIONS (key 'true') NOT NULL,
-    previouscertid TEXT,
-    orgduns TEXT,
-    orgname TEXT,
-    expirationdate DATE,
-    certemail TEXT NOT NULL,
-    agencyid TEXT,
-    requestorlname TEXT,
-    requestorfname TEXT,
-    requestoremail TEXT,
-    requestorphone TEXT,
-    created_date TIMESTAMP WITH TIME ZONE NOT NULL,
-    creator_id TEXT NOT NULL,
-    last_upd_date TIMESTAMP WITH TIME ZONE,
-    last_upd_id TEXT,
-    is_selfsigned TEXT OPTIONS (strip_zeros 'true'),
-    serial_num TEXT,
-    system_name TEXT
-) SERVER grants OPTIONS (schema 'EGRANTSADMIN', table 'TCERTIFICATES', readonly 'true', prefetch '1000');
-
-"""
-
 
 class Tcertificates(foreignbase.ForeignBase, TcertificatesMixin):
     __tablename__ = "tcertificates"

--- a/api/src/db/models/legacy_mixin/certificates_mixin.py
+++ b/api/src/db/models/legacy_mixin/certificates_mixin.py
@@ -9,6 +9,8 @@ from datetime import date, datetime
 
 from sqlalchemy.orm import Mapped, declarative_mixin, mapped_column
 
+from src.db.extension.sqlalchemy_column import StripZerosText
+
 
 @declarative_mixin
 class TcertificatesMixin:
@@ -27,6 +29,8 @@ class TcertificatesMixin:
     creator_id: Mapped[str]
     last_upd_date: Mapped[datetime | None]
     last_upd_id: Mapped[str | None]
-    is_selfsigned: Mapped[str | None]
+    # We've encountered issues where is_selfsigned sometimes includes 0x00
+    # Set the type as StripZerosText to strip those out when generating the create table command.
+    is_selfsigned: Mapped[str | None] = mapped_column(StripZerosText)
     serial_num: Mapped[str | None]
     system_name: Mapped[str | None]

--- a/api/tests/src/data_migration/load/test_load_oracle_data_task.py
+++ b/api/tests/src/data_migration/load/test_load_oracle_data_task.py
@@ -524,21 +524,19 @@ class TestLoadOracleData(BaseTestClass):
         )
         assert task.metrics["count.insert.total"] == 1
 
-    def test_load_data_excludes_tcertificates_column_is_selfsigned_by_default(
+    def test_load_data_copies_tcertificates_column_is_selfsigned(
         self, db_session, foreign_tables, staging_tables, enable_factory_create
     ):
-        """Test that excluded columns are not copied from foreign to staging tables."""
+        """Test that tcertificates.is_selfsigned is copied like any other column now that it
+        relies on the strip_zeros opt-in instead of column exclusion."""
         source_table = foreign_tables["tcertificates"]
         destination_table = staging_tables["tcertificates"]
 
         db_session.execute(sqlalchemy.delete(source_table))
         db_session.execute(sqlalchemy.delete(destination_table))
 
-        # Create a record in the foreign table with specific values
-        # 'is_selfsigned' should be excluded
         source_record = ForeignTcertificatesFactory.create(is_selfsigned="Y")
 
-        # Run the task with column exclusions
         task = load_oracle_data_task.LoadOracleDataTask(
             db_session,
             foreign_tables,
@@ -564,5 +562,5 @@ class TestLoadOracleData(BaseTestClass):
         assert inserted_record.certemail == source_record.certemail
         assert inserted_record.serial_num == source_record.serial_num
 
-        # Verify excluded column was not copied (should be None)
-        assert inserted_record.is_selfsigned is None
+        # Verify is_selfsigned is no longer excluded
+        assert inserted_record.is_selfsigned == source_record.is_selfsigned


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #10773 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
* Flag `is_selfsigned` as `StripZerosText` in `TcertificatesMixin` so the foreign table DDL generator emits `OPTIONS (strip_zeros 'true')` for that column.
* Remove the manual-recreate comment and hand-written `CREATE FOREIGN TABLE` DDL block from `api/src/db/models/foreign/certificates.py`.
* Remove the `tcertificates: ["is_selfsigned"]` entry from `columns_to_exclude` in `load_oracle_data_task.py`, since the column no longer needs to be skipped on load.
* Update the test that asserted `is_selfsigned` was excluded to instead assert it's copied through normally.


## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
`legacy.tcertificates` is created via `CREATE FOREIGN TABLE IF NOT EXISTS`, so this change is a no-op for any environment where the foreign table already exists — the foreign table needs to be manually dropped and recreated in each environment (dev/staging/prod) for the `strip_zeros` option to actually take effect:
```sql
DROP FOREIGN TABLE IF EXISTS legacy.tcertificates;
```
## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
`make test` passes