### PR TITLE
[Issue #11125] Add EKS cluster IaC

### DIFF
--- a/infra/api/eks/infra-dev.s3.tfbackend
+++ b/infra/api/eks/infra-dev.s3.tfbackend
@@ -1,0 +1,4 @@
+bucket         = "simpler-grants-gov-061664787759-us-east-1-tf"
+key            = "infra/api/eks/infra-dev.tfstate"
+region         = "us-east-1"
+use_lockfile   = true

--- a/infra/api/eks/main.tf
+++ b/infra/api/eks/main.tf
@@ -1,0 +1,126 @@
+# EKS cluster layer.
+#
+# Stands up an EKS cluster ALONGSIDE the existing ECS services, not in place of
+# them. Per HHS/simpler-grants-gov#11129 this is an evaluation: run the same
+# workloads on EKS in a lower environment, then decide whether to roll forward
+# or stay on ECS. Nothing here touches the ECS service, database, or search
+# layers, and no existing pipeline deploys to it.
+#
+# Scope is deliberately the cluster and the capacity to bootstrap it. ArgoCD
+# (#11127) and Karpenter (#11128) install on top and are separate tickets; this
+# layer produces the IAM, OIDC, and security group outputs they need.
+#
+# Only infra-dev is configured. The legacy "dev" environment lives in the AWS
+# Beta account (315341936575), which is being decommissioned, so a new layer
+# should not land there.
+
+data "aws_caller_identity" "current" {}
+
+data "aws_vpc" "network" {
+  filter {
+    name   = "tag:Name"
+    values = [local.network_config.vpc_name]
+  }
+}
+
+# Nodes and control plane ENIs go in private subnets. Egress is via the VPC's
+# NAT gateways; nothing in the cluster gets a public IP.
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.network.id]
+  }
+  filter {
+    name   = "tag:subnet_type"
+    values = ["private"]
+  }
+}
+
+locals {
+  prefix = terraform.workspace == "default" ? "" : "${terraform.workspace}-"
+
+  cluster_name = "${local.prefix}${module.app_config.app_name}-${var.environment_name}"
+
+  environment_config = module.app_config.environment_configs[var.environment_name]
+  network_config     = module.project_config.network_configs[local.environment_config.network_name]
+
+  tags = merge(module.project_config.default_tags, {
+    owner       = "navapbc"
+    app         = module.app_config.app_name
+    environment = var.environment_name
+    description = "EKS cluster for the ${var.environment_name} environment"
+  })
+}
+
+terraform {
+  required_version = "1.14.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.27.0, < 7.0.0"
+    }
+    # Reads the OIDC issuer's certificate chain to build the IRSA provider
+    # thumbprint.
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+
+  backend "s3" {
+    encrypt = "true"
+  }
+}
+
+provider "aws" {
+  region = module.project_config.default_region
+  # Refuse to operate against the wrong account (covers plan/apply/destroy).
+  allowed_account_ids = [module.expected_account.account_id]
+  default_tags {
+    tags = local.tags
+  }
+}
+
+module "project_config" {
+  source = "../../project-config"
+}
+
+module "app_config" {
+  source = "../app-config"
+}
+
+module "expected_account" {
+  source       = "../../modules/account-id-by-name"
+  account_name = local.network_config.account_name
+  accounts_dir = "${path.module}/../../accounts"
+}
+
+module "account_guard" {
+  source              = "../../modules/aws-account-guard"
+  expected_account_id = module.expected_account.account_id
+  context             = "the ${var.environment_name} eks cluster"
+}
+
+module "eks" {
+  source = "../../modules/eks"
+
+  cluster_name       = local.cluster_name
+  kubernetes_version = var.kubernetes_version
+
+  vpc_id     = data.aws_vpc.network.id
+  subnet_ids = data.aws_subnets.private.ids
+
+  node_instance_types = var.node_instance_types
+  node_desired_size   = var.node_desired_size
+  node_min_size       = var.node_min_size
+  node_max_size       = var.node_max_size
+
+  # Without at least one entry nobody can reach the cluster:
+  # bootstrap_cluster_creator_admin_permissions is false, so whoever ran the
+  # first apply gets no standing access either.
+  cluster_admin_role_arns = compact([
+    var.sso_admin_role_name != null ? "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-reserved/sso.amazonaws.com/${var.sso_admin_role_name}" : null,
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.project_config.github_actions_role_name}",
+  ])
+}

--- a/infra/api/eks/outputs.tf
+++ b/infra/api/eks/outputs.tf
@@ -1,0 +1,30 @@
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  value = module.eks.cluster_certificate_authority_data
+}
+
+# Consumed by ArgoCD (#11127) and Karpenter (#11128) when building the IAM
+# trust policies for their service accounts.
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider_url" {
+  value = module.eks.oidc_provider_url
+}
+
+# Karpenter reuses the bootstrap node role for the nodes it provisions.
+output "node_role_arn" {
+  value = module.eks.node_role_arn
+}
+
+output "node_security_group_id" {
+  value = module.eks.node_security_group_id
+}

--- a/infra/api/eks/variables.tf
+++ b/infra/api/eks/variables.tf
@@ -1,0 +1,48 @@
+variable "environment_name" {
+  type        = string
+  description = "name of the application environment"
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes control plane version. See https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html"
+  default     = "1.33"
+}
+
+variable "node_instance_types" {
+  type        = list(string)
+  description = <<EOT
+    Instance types for the bootstrap node group. Only has to carry
+    cluster-critical add-ons (CoreDNS, and the Karpenter controller once
+    #11128 lands) — application workloads are expected to run on
+    Karpenter-provisioned nodes.
+  EOT
+  default     = ["t4g.medium"]
+}
+
+variable "node_desired_size" {
+  type        = number
+  description = "Desired size of the bootstrap node group. Two nodes so the add-ons survive losing one."
+  default     = 2
+}
+
+variable "node_min_size" {
+  type    = number
+  default = 2
+}
+
+variable "node_max_size" {
+  type        = number
+  description = "Ceiling for the bootstrap group. Kept low on purpose: scaling is Karpenter's job, not this group's."
+  default     = 4
+}
+
+variable "sso_admin_role_name" {
+  type        = string
+  description = <<EOT
+    Name of the AWS IAM Identity Center (SSO) reserved role granted cluster-admin
+    through an EKS access entry. The reserved-SSO role suffix differs per account,
+    so this is set per environment. Null means only the CI/CD role gets access.
+  EOT
+  default     = null
+}

--- a/infra/modules/eks/addons.tf
+++ b/infra/modules/eks/addons.tf
@@ -1,56 +1,51 @@
 # Core add-ons.
 #
 # Managed as EKS add-ons rather than left to the versions EKS bootstraps with,
-# so upgrades are explicit and visible in a plan. Versions are resolved to the
-# default for the cluster's Kubernetes version rather than pinned, so a
+# so upgrades are explicit and visible in a plan. Versions resolve to the
+# default for the cluster's Kubernetes version rather than being pinned, so a
 # kubernetes_version bump carries them along.
+#
+# eks-pod-identity-agent is the current alternative to IRSA for granting pods
+# IAM roles. The OIDC provider in main.tf covers IRSA; installing both leaves
+# either path open, since ArgoCD (#11127) and Karpenter (#11128) differ in
+# which they expect.
+locals {
+  # CoreDNS is separated from the rest because it is the only add-on that
+  # schedules onto nodes: installed before the node group exists it has nowhere
+  # to run and reports degraded. The other three are node agents that EKS rolls
+  # out to instances as they join, so they must NOT wait for the node group —
+  # nodes need vpc-cni and kube-proxy to reach Ready in the first place.
+  node_agent_addons = toset(["vpc-cni", "kube-proxy", "eks-pod-identity-agent"])
+  scheduled_addons  = toset(["coredns"])
+
+  all_addons = setunion(local.node_agent_addons, local.scheduled_addons)
+}
 
 data "aws_eks_addon_version" "this" {
-  for_each = toset(["vpc-cni", "coredns", "kube-proxy", "eks-pod-identity-agent"])
+  for_each = local.all_addons
 
   addon_name         = each.value
   kubernetes_version = aws_eks_cluster.main.version
   most_recent        = true
 }
 
-# vpc-cni and kube-proxy run on every node, so they must be in place before the
-# node group's instances can become Ready.
-resource "aws_eks_addon" "vpc_cni" {
+resource "aws_eks_addon" "node_agent" {
+  for_each = local.node_agent_addons
+
   cluster_name  = aws_eks_cluster.main.name
-  addon_name    = "vpc-cni"
-  addon_version = data.aws_eks_addon_version.this["vpc-cni"].version
+  addon_name    = each.value
+  addon_version = data.aws_eks_addon_version.this[each.value].version
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"
 }
 
-resource "aws_eks_addon" "kube_proxy" {
+resource "aws_eks_addon" "scheduled" {
+  for_each = local.scheduled_addons
+
   cluster_name  = aws_eks_cluster.main.name
-  addon_name    = "kube-proxy"
-  addon_version = data.aws_eks_addon_version.this["kube-proxy"].version
-
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "PRESERVE"
-}
-
-# Pod Identity is the current alternative to IRSA for granting pods IAM roles.
-# The OIDC provider in main.tf covers IRSA; this add-on leaves both paths open,
-# since ArgoCD (#11127) and Karpenter (#11128) differ in which they expect.
-resource "aws_eks_addon" "pod_identity" {
-  cluster_name  = aws_eks_cluster.main.name
-  addon_name    = "eks-pod-identity-agent"
-  addon_version = data.aws_eks_addon_version.this["eks-pod-identity-agent"].version
-
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "PRESERVE"
-}
-
-# CoreDNS schedules onto nodes, so it waits for the node group. Without this
-# the add-on installs into a cluster with nowhere to run and reports degraded.
-resource "aws_eks_addon" "coredns" {
-  cluster_name  = aws_eks_cluster.main.name
-  addon_name    = "coredns"
-  addon_version = data.aws_eks_addon_version.this["coredns"].version
+  addon_name    = each.value
+  addon_version = data.aws_eks_addon_version.this[each.value].version
 
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "PRESERVE"

--- a/infra/modules/eks/addons.tf
+++ b/infra/modules/eks/addons.tf
@@ -1,0 +1,59 @@
+# Core add-ons.
+#
+# Managed as EKS add-ons rather than left to the versions EKS bootstraps with,
+# so upgrades are explicit and visible in a plan. Versions are resolved to the
+# default for the cluster's Kubernetes version rather than pinned, so a
+# kubernetes_version bump carries them along.
+
+data "aws_eks_addon_version" "this" {
+  for_each = toset(["vpc-cni", "coredns", "kube-proxy", "eks-pod-identity-agent"])
+
+  addon_name         = each.value
+  kubernetes_version = aws_eks_cluster.main.version
+  most_recent        = true
+}
+
+# vpc-cni and kube-proxy run on every node, so they must be in place before the
+# node group's instances can become Ready.
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name  = aws_eks_cluster.main.name
+  addon_name    = "vpc-cni"
+  addon_version = data.aws_eks_addon_version.this["vpc-cni"].version
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+}
+
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name  = aws_eks_cluster.main.name
+  addon_name    = "kube-proxy"
+  addon_version = data.aws_eks_addon_version.this["kube-proxy"].version
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+}
+
+# Pod Identity is the current alternative to IRSA for granting pods IAM roles.
+# The OIDC provider in main.tf covers IRSA; this add-on leaves both paths open,
+# since ArgoCD (#11127) and Karpenter (#11128) differ in which they expect.
+resource "aws_eks_addon" "pod_identity" {
+  cluster_name  = aws_eks_cluster.main.name
+  addon_name    = "eks-pod-identity-agent"
+  addon_version = data.aws_eks_addon_version.this["eks-pod-identity-agent"].version
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+}
+
+# CoreDNS schedules onto nodes, so it waits for the node group. Without this
+# the add-on installs into a cluster with nowhere to run and reports degraded.
+resource "aws_eks_addon" "coredns" {
+  cluster_name  = aws_eks_cluster.main.name
+  addon_name    = "coredns"
+  addon_version = data.aws_eks_addon_version.this["coredns"].version
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "PRESERVE"
+
+  depends_on = [aws_eks_node_group.bootstrap]
+}

--- a/infra/modules/eks/iam.tf
+++ b/infra/modules/eks/iam.tf
@@ -1,0 +1,64 @@
+data "aws_iam_policy_document" "cluster_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "cluster" {
+  name               = "${var.cluster_name}-cluster"
+  assume_role_policy = data.aws_iam_policy_document.cluster_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "cluster" {
+  role       = aws_iam_role.cluster.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+# --- Node role ---------------------------------------------------------------
+
+data "aws_iam_policy_document" "node_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "node" {
+  name               = "${var.cluster_name}-node"
+  assume_role_policy = data.aws_iam_policy_document.node_assume_role.json
+}
+
+# The three policies every EKS node needs: join the cluster, run the VPC CNI,
+# and pull images from ECR.
+resource "aws_iam_role_policy_attachment" "node" {
+  for_each = toset([
+    "AmazonEKSWorkerNodePolicy",
+    "AmazonEKS_CNI_Policy",
+    "AmazonEC2ContainerRegistryReadOnly",
+  ])
+
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/${each.value}"
+}
+
+# Lets Systems Manager Session Manager reach the nodes for debugging without
+# opening SSH or assigning public IPs.
+resource "aws_iam_role_policy_attachment" "node_ssm" {
+  role       = aws_iam_role.node.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+# Nodes authenticate to the cluster through an access entry rather than the
+# aws-auth ConfigMap.
+resource "aws_eks_access_entry" "node" {
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = aws_iam_role.node.arn
+  type          = "EC2_LINUX"
+}

--- a/infra/modules/eks/main.tf
+++ b/infra/modules/eks/main.tf
@@ -1,0 +1,128 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+# Control plane logs. Encrypted with the same customer-managed key as the
+# cluster's Kubernetes secrets, matching how modules/search encrypts its
+# OpenSearch log group.
+resource "aws_cloudwatch_log_group" "cluster" {
+  # EKS writes to this exact path; it is not configurable. Creating it here
+  # rather than letting EKS create it implicitly is what lets us set retention
+  # and a KMS key.
+  name              = "/aws/eks/${var.cluster_name}/cluster"
+  retention_in_days = var.log_retention_in_days
+  kms_key_id        = aws_kms_key.eks.arn
+}
+
+resource "aws_kms_key" "eks" {
+  description         = "Key for EKS cluster ${var.cluster_name}"
+  enable_key_rotation = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowCloudWatchLogs"
+        Effect    = "Allow"
+        Principal = { Service = "logs.${data.aws_region.current.name}.amazonaws.com" }
+        Action    = ["kms:Encrypt*", "kms:Decrypt*", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:Describe*"]
+        Resource  = "*"
+        Condition = {
+          ArnLike = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/eks/${var.cluster_name}/cluster"
+          }
+        }
+      },
+    ]
+  })
+
+  # checkov:skip=CKV2_AWS_64:Key policy is defined inline above
+}
+
+resource "aws_kms_alias" "eks" {
+  name          = "alias/eks/${var.cluster_name}"
+  target_key_id = aws_kms_key.eks.key_id
+}
+
+resource "aws_eks_cluster" "main" {
+  name     = var.cluster_name
+  version  = var.kubernetes_version
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids              = var.subnet_ids
+    security_group_ids      = [aws_security_group.cluster.id]
+    endpoint_private_access = true
+    endpoint_public_access  = var.endpoint_public_access
+  }
+
+  # API_AND_CONFIG_MAP rather than API so that access entries manage
+  # authentication while the aws-auth ConfigMap still resolves — Karpenter's
+  # node role is registered through the ConfigMap path by some install methods.
+  access_config {
+    authentication_mode                         = "API_AND_CONFIG_MAP"
+    bootstrap_cluster_creator_admin_permissions = false
+  }
+
+  # Encrypt Kubernetes secrets at rest with our own key rather than the
+  # AWS-owned default.
+  encryption_config {
+    provider {
+      key_arn = aws_kms_key.eks.arn
+    }
+    resources = ["secrets"]
+  }
+
+  enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster,
+    aws_cloudwatch_log_group.cluster,
+  ]
+}
+
+# IRSA. Lets in-cluster service accounts assume IAM roles without node-level
+# credentials — required by Karpenter (#11128) and ArgoCD (#11127).
+data "tls_certificate" "cluster" {
+  url = aws_eks_cluster.main.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "cluster" {
+  url             = aws_eks_cluster.main.identity[0].oidc[0].issuer
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.cluster.certificates[0].sha1_fingerprint]
+}
+
+# Cluster-admin for the roles named by the caller (SSO admin, CI/CD deploy).
+# bootstrap_cluster_creator_admin_permissions is false above, so without at
+# least one entry here nobody can reach the cluster.
+resource "aws_eks_access_entry" "admin" {
+  for_each = toset(var.cluster_admin_role_arns)
+
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = each.value
+  type          = "STANDARD"
+}
+
+resource "aws_eks_access_policy_association" "admin" {
+  for_each = toset(var.cluster_admin_role_arns)
+
+  cluster_name  = aws_eks_cluster.main.name
+  principal_arn = each.value
+  policy_arn    = "arn:${data.aws_partition.current.partition}:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.admin]
+}

--- a/infra/modules/eks/networking.tf
+++ b/infra/modules/eks/networking.tf
@@ -65,6 +65,7 @@ resource "aws_vpc_security_group_ingress_rule" "node_from_node" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "node_from_cluster" {
+  # checkov:skip=CKV_AWS_25:Source is the control plane security group, not 0.0.0.0/0. The check fires only because the ephemeral port range needed for kubelet and webhooks (1025-65535) happens to contain 3389.
   security_group_id            = aws_security_group.node.id
   description                  = "Kubelet and webhooks from the control plane"
   referenced_security_group_id = aws_security_group.cluster.id
@@ -91,6 +92,7 @@ resource "aws_vpc_security_group_egress_rule" "node_to_cluster" {
 # VPC endpoints. Nodes run arbitrary workloads whose destinations are not known
 # in advance, so tightening this means enumerating what the workloads need —
 # worth revisiting once the evaluation settles what actually runs here.
+# trivy:ignore:AVD-AWS-0104
 resource "aws_vpc_security_group_egress_rule" "node_to_internet" {
   security_group_id = aws_security_group.node.id
   description       = "Outbound internet for image pulls and AWS APIs"

--- a/infra/modules/eks/networking.tf
+++ b/infra/modules/eks/networking.tf
@@ -1,0 +1,99 @@
+data "aws_vpc" "cluster" {
+  id = var.vpc_id
+}
+
+# Control plane security group. EKS also creates its own managed cluster
+# security group and attaches it alongside this one; this group is what we
+# control directly.
+resource "aws_security_group" "cluster" {
+  name_prefix = "${var.cluster_name}-cluster-"
+  description = "EKS control plane for ${var.cluster_name}"
+  vpc_id      = var.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Nodes reach the Kubernetes API. Scoped to the node security group rather than
+# a CIDR so it stays correct if the VPC is re-addressed.
+resource "aws_vpc_security_group_ingress_rule" "cluster_from_nodes" {
+  security_group_id            = aws_security_group.cluster.id
+  description                  = "Kubernetes API from nodes"
+  referenced_security_group_id = aws_security_group.node.id
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+}
+
+# The control plane calls back into the nodes — webhooks, kubectl exec/logs, and
+# the metrics server all rely on this.
+resource "aws_vpc_security_group_egress_rule" "cluster_to_nodes" {
+  security_group_id            = aws_security_group.cluster.id
+  description                  = "Control plane to node kubelet and webhooks"
+  referenced_security_group_id = aws_security_group.node.id
+  from_port                    = 1025
+  to_port                      = 65535
+  ip_protocol                  = "tcp"
+}
+
+# --- Nodes -------------------------------------------------------------------
+
+resource "aws_security_group" "node" {
+  name_prefix = "${var.cluster_name}-node-"
+  description = "EKS nodes for ${var.cluster_name}"
+  vpc_id      = var.vpc_id
+
+  # Required so Karpenter (#11128) can discover this group by tag when it
+  # builds launch templates for the nodes it provisions.
+  tags = {
+    "karpenter.sh/discovery" = var.cluster_name
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Pod-to-pod traffic across nodes. Kubernetes assumes a flat network between
+# nodes, so this is deliberately wide within the group.
+resource "aws_vpc_security_group_ingress_rule" "node_from_node" {
+  security_group_id            = aws_security_group.node.id
+  description                  = "Node to node, all ports"
+  referenced_security_group_id = aws_security_group.node.id
+  ip_protocol                  = "-1"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "node_from_cluster" {
+  security_group_id            = aws_security_group.node.id
+  description                  = "Kubelet and webhooks from the control plane"
+  referenced_security_group_id = aws_security_group.cluster.id
+  from_port                    = 1025
+  to_port                      = 65535
+  ip_protocol                  = "tcp"
+}
+
+# Nodes must reach the Kubernetes API to join the cluster and stay registered.
+resource "aws_vpc_security_group_egress_rule" "node_to_cluster" {
+  security_group_id            = aws_security_group.node.id
+  description                  = "Kubernetes API"
+  referenced_security_group_id = aws_security_group.cluster.id
+  from_port                    = 443
+  to_port                      = 443
+  ip_protocol                  = "tcp"
+}
+
+# Egress to the internet, via the VPC's NAT gateways. Needed to pull container
+# images from registries outside our ECR and to reach AWS API endpoints that
+# have no interface endpoint in this VPC.
+#
+# Wider than the ECS services in this project, which scope egress to specific
+# VPC endpoints. Nodes run arbitrary workloads whose destinations are not known
+# in advance, so tightening this means enumerating what the workloads need —
+# worth revisiting once the evaluation settles what actually runs here.
+resource "aws_vpc_security_group_egress_rule" "node_to_internet" {
+  security_group_id = aws_security_group.node.id
+  description       = "Outbound internet for image pulls and AWS APIs"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}

--- a/infra/modules/eks/node_group.tf
+++ b/infra/modules/eks/node_group.tf
@@ -1,0 +1,78 @@
+# Bootstrap managed node group.
+#
+# Deliberately small. Karpenter (#11128) is intended to provision the real
+# capacity, but Karpenter itself has to run somewhere — a cluster with no nodes
+# cannot schedule the Karpenter controller. This group exists to host the
+# controller and other cluster-critical add-ons; application workloads should
+# land on Karpenter-provisioned nodes.
+resource "aws_launch_template" "node" {
+  name_prefix = "${var.cluster_name}-node-"
+
+  vpc_security_group_ids = [aws_security_group.node.id]
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size = var.node_disk_size
+      volume_type = "gp3"
+      encrypted   = true
+    }
+  }
+
+  # IMDSv2 required, and a hop limit of 2 so pods using the node's role can
+  # still reach the metadata service through the container network.
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
+
+  monitoring {
+    enabled = true
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "${var.cluster_name}-node"
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_eks_node_group" "bootstrap" {
+  cluster_name    = aws_eks_cluster.main.name
+  node_group_name = "${var.cluster_name}-bootstrap"
+  node_role_arn   = aws_iam_role.node.arn
+  subnet_ids      = var.subnet_ids
+  instance_types  = var.node_instance_types
+
+  scaling_config {
+    desired_size = var.node_desired_size
+    min_size     = var.node_min_size
+    max_size     = var.node_max_size
+  }
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
+
+  update_config {
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    # Whatever is running the cluster autoscaling — Karpenter, or manual
+    # scaling during the evaluation — owns desired_size after creation.
+    ignore_changes = [scaling_config[0].desired_size]
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node,
+    aws_eks_access_entry.node,
+  ]
+}

--- a/infra/modules/eks/node_group.tf
+++ b/infra/modules/eks/node_group.tf
@@ -6,6 +6,7 @@
 # controller and other cluster-critical add-ons; application workloads should
 # land on Karpenter-provisioned nodes.
 resource "aws_launch_template" "node" {
+  # checkov:skip=CKV_AWS_341:A hop limit of 2 is required on EKS nodes. Pods reach IMDS through the container network, which costs an extra hop, so a limit of 1 breaks IRSA — the mechanism ArgoCD (#11127) and Karpenter (#11128) authenticate with. IMDSv2 is still enforced below.
   name_prefix = "${var.cluster_name}-node-"
 
   vpc_security_group_ids = [aws_security_group.node.id]

--- a/infra/modules/eks/outputs.tf
+++ b/infra/modules/eks/outputs.tf
@@ -1,0 +1,60 @@
+output "cluster_name" {
+  value = aws_eks_cluster.main.name
+}
+
+output "cluster_arn" {
+  value = aws_eks_cluster.main.arn
+}
+
+output "cluster_endpoint" {
+  description = "Kubernetes API endpoint. Private unless endpoint_public_access is set."
+  value       = aws_eks_cluster.main.endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64 CA bundle for the API server, for building a kubeconfig."
+  value       = aws_eks_cluster.main.certificate_authority[0].data
+}
+
+output "cluster_security_group_id" {
+  description = "Security group this module manages for the control plane."
+  value       = aws_security_group.cluster.id
+}
+
+output "cluster_managed_security_group_id" {
+  description = "The security group EKS creates and attaches itself. Add-ons that need to reach the control plane often expect this one."
+  value       = aws_eks_cluster.main.vpc_config[0].cluster_security_group_id
+}
+
+output "node_security_group_id" {
+  description = "Security group for the nodes. Tagged for Karpenter discovery."
+  value       = aws_security_group.node.id
+}
+
+output "node_role_arn" {
+  description = "IAM role the nodes assume. Karpenter reuses this for the nodes it provisions."
+  value       = aws_iam_role.node.arn
+}
+
+output "node_role_name" {
+  value = aws_iam_role.node.name
+}
+
+output "oidc_provider_arn" {
+  description = "IRSA provider ARN, for the trust policies of roles assumed by service accounts."
+  value       = aws_iam_openid_connect_provider.cluster.arn
+}
+
+output "oidc_provider_url" {
+  description = "IRSA issuer URL, without the https:// prefix, as trust policy conditions expect it."
+  value       = replace(aws_iam_openid_connect_provider.cluster.url, "https://", "")
+}
+
+output "kms_key_arn" {
+  description = "Key encrypting Kubernetes secrets and the control plane log group."
+  value       = aws_kms_key.eks.arn
+}
+
+output "kubernetes_version" {
+  value = aws_eks_cluster.main.version
+}

--- a/infra/modules/eks/variables.tf
+++ b/infra/modules/eks/variables.tf
@@ -1,0 +1,63 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the control plane. See https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC the cluster runs in"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Private subnet IDs for the control plane ENIs and the node group"
+  type        = list(string)
+}
+
+variable "endpoint_public_access" {
+  description = "Whether the Kubernetes API server is reachable from the public internet. Kept false so access stays in-VPC."
+  type        = bool
+  default     = false
+}
+
+variable "node_instance_types" {
+  description = "Instance types for the bootstrap managed node group"
+  type        = list(string)
+}
+
+variable "node_desired_size" {
+  description = "Desired node count for the bootstrap managed node group"
+  type        = number
+}
+
+variable "node_min_size" {
+  description = "Minimum node count for the bootstrap managed node group"
+  type        = number
+}
+
+variable "node_max_size" {
+  description = "Maximum node count for the bootstrap managed node group"
+  type        = number
+}
+
+variable "node_disk_size" {
+  description = "EBS volume size in GB for each node in the bootstrap managed node group"
+  type        = number
+  default     = 20
+}
+
+variable "log_retention_in_days" {
+  description = "Retention for the control plane log group. Matches the 1827-day (5 year) retention used by the other service log groups."
+  type        = number
+  default     = 1827
+}
+
+variable "cluster_admin_role_arns" {
+  description = "IAM role ARNs granted cluster-admin via EKS access entries. Typically the SSO administrator role and the CI/CD deploy role."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Fixes HHS/simpler-grants-gov#11125

Adds `infra/modules/eks` and an `infra/api/eks` root layer for **infra-dev**.

## Approach

The cluster stands up **alongside** the existing ECS services, not in place of them. HHS/simpler-grants-gov#11129 frames this set of tickets as an evaluation — "we don't want to modify our existing pipelines, but create new ones so we can test, and make the decision to roll forward with them or keep our existing ecs infra." So nothing here touches the ECS service, database, or search layers, and no existing pipeline deploys to it.

Scope is the cluster and enough capacity to bootstrap it. ArgoCD (#11127) and Karpenter (#11128) install on top and are separate tickets — this layer exports the OIDC provider ARN, node role, and security group IDs they need.

## Contents

| File | Purpose |
|---|---|
| `main.tf` | Control plane, customer-managed KMS key, IRSA OIDC provider, access entries |
| `iam.tf` | Cluster and node roles |
| `networking.tf` | Control plane and node security groups |
| `node_group.tf` | Bootstrap managed node group behind a launch template |
| `addons.tf` | `vpc-cni`, `kube-proxy`, `coredns`, `eks-pod-identity-agent` |

## Security posture

Matches the surrounding layers:

- Private API endpoint only (`endpoint_public_access = false`)
- Nodes in private subnets, no public IPs
- IMDSv2 required, hop limit 2
- Encrypted gp3 volumes
- Kubernetes secrets encrypted with a customer-managed key rather than the AWS-owned default
- All five control plane log types to CloudWatch at the project's 1827-day retention, log group encrypted with the same key
- SSM Session Manager for node access instead of SSH

Access uses EKS access entries with `bootstrap_cluster_creator_admin_permissions = false`, so nobody holds standing admin merely from having run the first apply. `authentication_mode` is `API_AND_CONFIG_MAP` rather than `API` because some Karpenter install paths still register the node role through the aws-auth ConfigMap.

## Why infra-dev and not dev

The legacy `dev` environment lives in the AWS Beta account (`315341936575`), which is being decommissioned. `infra-dev` is in `061664787759`. Adding a new layer to an account on its way out did not seem right.

## Bootstrap node group

Deliberately small — `t4g.medium` × 2, max 4. Karpenter is meant to provision the real capacity, but the Karpenter controller has to run somewhere, and a cluster with no nodes cannot schedule it. This group hosts cluster-critical add-ons; application workloads should land on Karpenter-provisioned nodes once HHS/simpler-grants-gov#11128 is in. `desired_size` is in `ignore_changes` so whatever owns autoscaling can move it without fighting Terraform.

The node security group carries `karpenter.sh/discovery = <cluster_name>` so HHS/simpler-grants-gov#11128 can find it by tag.

## Testing

- `terraform fmt -check -recursive` clean
- `terraform validate` passes on both the module and the root layer
- `make infra-validate-module-eks` passes — the CI target picks the module up automatically via the `MODULES` wildcard, so no Makefile change is needed

There is one `Deprecated attribute` warning for `data.aws_region.current.name` under AWS provider v6. It is **pre-existing repo-wide** — `modules/search/authentication.tf` and `modules/service/access_control.tf` use the same form — so this follows the surrounding convention rather than diverging. Worth a separate sweep.

**Not applied anywhere.** No `terraform plan` has been run against infra-dev, so this is unverified against real AWS state.

## Reviewer notes

- **Node egress is `0.0.0.0/0`**, which is wider than the ECS services in this project (they scope egress to specific VPC endpoints). Nodes run arbitrary workloads whose destinations are not known ahead of time. Flagging it explicitly rather than burying it — worth tightening once the evaluation settles what actually runs here. There is a comment in `networking.tf` saying so.
- **Kubernetes version is `1.33`**, defaulted in `variables.tf`. Worth confirming that is the version you want to evaluate on.
- **Cost:** two `t4g.medium` nodes plus the EKS control plane (~$0.10/hr) run continuously once applied.
- **`sso_admin_role_name` defaults to null**, so on a first apply only the CI/CD role gets cluster-admin. Set it per environment if you want SSO console access.