### PR TITLE
[unticketed]: update grype ignores

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -52,6 +52,27 @@ ignore:
   # Last checked: 07/30/2026
   - vulnerability: CVE-2026-0864
 
+  # stringprep / idna codec: RFC 3454 tables B.2 and B.3 matched against current
+  # Unicode attributes instead of Unicode 3.2.0
+  # Fix only in pre-release Python 3.15 (3.15.0rc2); no fix in any GA 3.14.x yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 09/10/2026
+  - vulnerability: CVE-2026-17084
+
+  # urllib.request.HTTPPasswordMgr: stored credentials matched without regard to
+  # URL scheme, so https:// credentials were reused over http://
+  # Fix only in pre-release Python 3.15 (3.15.0rc2); no fix in any GA 3.14.x yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 09/10/2026
+  - vulnerability: CVE-2026-15806
+
+  # zipfile: bzip2/LZMA/Zstandard members pre-allocate memory from an
+  # attacker-controlled size
+  # Fix only in pre-release Python 3.15 (3.15.0rc2); no fix in any GA 3.14.x yet.
+  # https://github.com/HHS/simpler-grants-gov/issues/8109
+  # Last checked: 09/10/2026
+  - vulnerability: CVE-2026-15310
+
   # dompurify via isomorphic-dompurify
   # Major version upgrade required, will do after 8/12 release
   # Last checked: 08/11/2026


### PR DESCRIPTION
## Summary

Add the below three cve's to grype ignore as they are not released yet in a ga python version. 

```
1. CVE-2026-17084
2. CVE-2026-15806
3. CVE-2026-15310
```

Link to failing anchore scan: [here](https://github.com/HHS/simpler-grants-gov/actions/runs/34475123107/job/102864085064)

## Validation steps

All scans should pass below. 