### PR TITLE
[Issue #11553] voice over removing the filter pills don't mention "filter"  

### DIFF
--- a/frontend/src/app/[locale]/(base)/search/_components/PillList.test.tsx
+++ b/frontend/src/app/[locale]/(base)/search/_components/PillList.test.tsx
@@ -30,7 +30,7 @@ describe("PillList", () => {
     expect(firstLabel).toBeInTheDocument();
 
     const firstButton = screen.getByRole("button", {
-      name: "Remove filter, whatever",
+      name: "Remove filter,whatever",
     });
     expect(firstButton).toBeInTheDocument();
 
@@ -44,7 +44,7 @@ describe("PillList", () => {
     expect(secondLabel).toBeInTheDocument();
 
     const secondButton = screen.getByRole("button", {
-      name: "Remove filter, another",
+      name: "Remove filter,another",
     });
     expect(secondButton).toBeInTheDocument();
 

--- a/frontend/src/app/[locale]/(base)/search/_components/PillList.test.tsx
+++ b/frontend/src/app/[locale]/(base)/search/_components/PillList.test.tsx
@@ -30,7 +30,7 @@ describe("PillList", () => {
     expect(firstLabel).toBeInTheDocument();
 
     const firstButton = screen.getByRole("button", {
-      name: "Remove whatever pill",
+      name: "Remove filter, whatever",
     });
     expect(firstButton).toBeInTheDocument();
 
@@ -44,7 +44,7 @@ describe("PillList", () => {
     expect(secondLabel).toBeInTheDocument();
 
     const secondButton = screen.getByRole("button", {
-      name: "Remove another pill",
+      name: "Remove filter, another",
     });
     expect(secondButton).toBeInTheDocument();
 

--- a/frontend/src/app/[locale]/(base)/search/_components/PillList.tsx
+++ b/frontend/src/app/[locale]/(base)/search/_components/PillList.tsx
@@ -24,6 +24,7 @@ export function PillList({ pills }: { pills: FilterPillLabelData[] }) {
             >
               <Pill
                 label={label}
+                labelPrefix="filter"
                 onClose={() =>
                   removeQueryParamValue(queryParamKey, queryParamValue)
                 }

--- a/frontend/src/components/core/Pill.test.tsx
+++ b/frontend/src/components/core/Pill.test.tsx
@@ -11,8 +11,20 @@ describe("Pill", () => {
   it("calls onClose", async () => {
     const closeSpy = jest.fn();
     render(<Pill label="any sort of label" onClose={closeSpy} />);
-    const closeIcon = screen.getByLabelText("Remove filter, any sort of label");
+    const closeIcon = screen.getByLabelText("Remove any sort of label pill");
     await userEvent.click(closeIcon);
     expect(closeSpy).toHaveBeenCalled();
+  });
+  it("uses labelPrefix in the accessible name when provided", () => {
+    render(
+      <Pill
+        label="Cost sharing: No"
+        labelPrefix="filter"
+        onClose={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByLabelText("Remove filter,Cost sharing: No"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/core/Pill.test.tsx
+++ b/frontend/src/components/core/Pill.test.tsx
@@ -11,7 +11,7 @@ describe("Pill", () => {
   it("calls onClose", async () => {
     const closeSpy = jest.fn();
     render(<Pill label="any sort of label" onClose={closeSpy} />);
-    const closeIcon = screen.getByLabelText("Remove any sort of label pill");
+    const closeIcon = screen.getByLabelText("Remove filter, any sort of label");
     await userEvent.click(closeIcon);
     expect(closeSpy).toHaveBeenCalled();
   });

--- a/frontend/src/components/core/Pill.tsx
+++ b/frontend/src/components/core/Pill.tsx
@@ -16,7 +16,7 @@ export function Pill({
         <Button
           unstyled
           type="button"
-          aria-label={`Remove ${label} pill`}
+          aria-label={`Remove filter, ${label} `}
           className="display-flex flex-align-center margin-left-1"
           onClick={() => {
             onClose();

--- a/frontend/src/components/core/Pill.tsx
+++ b/frontend/src/components/core/Pill.tsx
@@ -5,10 +5,15 @@ import { USWDSIcon } from "./USWDSIcon";
 export function Pill({
   label,
   onClose,
+  labelPrefix,
 }: {
   label: string;
   onClose: () => void;
+  labelPrefix?: string;
 }) {
+  const ariaLabel = labelPrefix
+    ? `Remove ${labelPrefix},${label}`
+    : `Remove ${label} pill`;
   return (
     <div className="border-secondary-darker border-2px radius-pill display-inline-block padding-x-2 padding-y-1 bg-secondary-lightest">
       <div className="display-flex">
@@ -16,7 +21,7 @@ export function Pill({
         <Button
           unstyled
           type="button"
-          aria-label={`Remove filter, ${label} `}
+          aria-label={ariaLabel}
           className="display-flex flex-align-center margin-left-1"
           onClick={() => {
             onClose();


### PR DESCRIPTION
## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes / Work for #11553  

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->

- Update the accessible label for the remove button in the Pill component from Remove [label] to Remove filter, [label].
- Updated `Pill `and `PillList `tests to reflect the new accessible label.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->

Previously, VoiceOver correctly communicated that the button removes something, but it did not identify the item as a search filter. Since keyboard and screen reader focus is on the remove button, users did not have enough context to understand that activating the button removes an applied filter.

Addresses this issue by providing clearer context to screen reader users that the button removes an applied filter.
VoiceOver now reads: "Remove filter, Cost sharing: No, button".

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->

- [x] Apply a filter on the search page.
- [x] Turn on VoiceOver and focus on the filter pill's remove button.
- [x] Verify it announces "Remove filter, [label], button".
- [x] Verify the updated tests pass.