### PR TITLE
[Issue #11125] Grant SSO admin cluster access on the EKS layer

### DIFF
--- a/infra/api/eks/variables.tf
+++ b/infra/api/eks/variables.tf
@@ -41,8 +41,19 @@ variable "sso_admin_role_name" {
   type        = string
   description = <<EOT
     Name of the AWS IAM Identity Center (SSO) reserved role granted cluster-admin
-    through an EKS access entry. The reserved-SSO role suffix differs per account,
-    so this is set per environment. Null means only the CI/CD role gets access.
+    through an EKS access entry. The reserved-SSO role suffix
+    (AWSReservedSSO_<PermissionSet>_<suffix>) is generated per AWS account, so an
+    environment in a different account must override this with that account's own
+    role — see search_sso_admin_role_name in infra/api/app-config for the same
+    pattern and the per-account values already recorded there.
+
+    Set to null to grant only the CI/CD role, which leaves the cluster reachable
+    by automation but by no human operator.
   EOT
-  default     = null
+
+  # infra-dev's account (061664787759). Matches the value already used for the
+  # same account in infra/api/app-config/infra-dev.tf. Only infra-dev has an EKS
+  # layer today; revisit this default rather than inheriting it blindly if the
+  # layer is extended to an environment in another account.
+  default = "AWSReservedSSO_AdministratorAccess_73856a8074e1d297"
 }

--- a/infra/api/eks/variables.tf
+++ b/infra/api/eks/variables.tf
@@ -51,9 +51,7 @@ variable "sso_admin_role_name" {
     by automation but by no human operator.
   EOT
 
-  # infra-dev's account (061664787759). Matches the value already used for the
-  # same account in infra/api/app-config/infra-dev.tf. Only infra-dev has an EKS
-  # layer today; revisit this default rather than inheriting it blindly if the
-  # layer is extended to an environment in another account.
+  # infra-dev's account (061664787759), matching infra/api/app-config/infra-dev.tf.
+  # Override rather than inherit if this layer reaches another account.
   default = "AWSReservedSSO_AdministratorAccess_73856a8074e1d297"
 }

--- a/infra/api/eks/variables.tf
+++ b/infra/api/eks/variables.tf
@@ -12,10 +12,8 @@ variable "kubernetes_version" {
 variable "node_instance_types" {
   type        = list(string)
   description = <<EOT
-    Instance types for the bootstrap node group. Only has to carry
-    cluster-critical add-ons (CoreDNS, and the Karpenter controller once
-    #11128 lands) — application workloads are expected to run on
-    Karpenter-provisioned nodes.
+    Instance types for the bootstrap node group. Carries only cluster-critical
+    add-ons; application workloads run on Karpenter-provisioned nodes (#11128).
   EOT
   default     = ["t4g.medium"]
 }
@@ -40,15 +38,8 @@ variable "node_max_size" {
 variable "sso_admin_role_name" {
   type        = string
   description = <<EOT
-    Name of the AWS IAM Identity Center (SSO) reserved role granted cluster-admin
-    through an EKS access entry. The reserved-SSO role suffix
-    (AWSReservedSSO_<PermissionSet>_<suffix>) is generated per AWS account, so an
-    environment in a different account must override this with that account's own
-    role — see search_sso_admin_role_name in infra/api/app-config for the same
-    pattern and the per-account values already recorded there.
-
-    Set to null to grant only the CI/CD role, which leaves the cluster reachable
-    by automation but by no human operator.
+    SSO reserved role granted cluster-admin via an EKS access entry. The suffix is
+    per-account; null grants only the CI/CD role, leaving no human access.
   EOT
 
   # infra-dev's account (061664787759), matching infra/api/app-config/infra-dev.tf.


### PR DESCRIPTION
Follow-up to #12352, found while running the first `terraform plan` against infra-dev.

## Problem

`sso_admin_role_name` defaulted to `null`, so a first apply would grant cluster-admin **only to the CI/CD role**. Combined with `endpoint_public_access = false`, that produces a cluster reachable by automation and by no human operator — with no way to inspect the very cluster these tickets exist to evaluate.

The plan confirmed it: 2 `aws_eks_access_entry` resources but only **1** `aws_eks_access_policy_association`, because `compact()` dropped the null SSO entry.

## Change

Defaults the variable to infra-dev's account role. One file, one value, plus documentation.

The value is not a guess — it matches both:
- the account's actual reserved-SSO roles (`aws iam list-roles --path-prefix /aws-reserved/sso.amazonaws.com/`)
- the value already recorded for account `061664787759` at [`infra/api/app-config/infra-dev.tf:60`](https://github.com/HHS/simpler-grants-gov/blob/main/infra/api/app-config/infra-dev.tf#L60) for `search_sso_admin_role_name`

The per-account caveat is documented the same way [`env-config/variables.tf`](https://github.com/HHS/simpler-grants-gov/blob/main/infra/api/app-config/env-config/variables.tf) documents it for the search equivalent: the `AWSReservedSSO_<PermissionSet>_<suffix>` suffix is generated per AWS account, so extending this layer to an environment in another account means overriding rather than inheriting.

## Testing

Planned against **infra-dev** (`061664787759`) with real credentials:

```
Plan: 31 to add, 0 to change, 0 to destroy.
```

Up from 29 — adds an `aws_eks_access_entry` and `aws_eks_access_policy_association` for:

```
arn:aws:iam::061664787759:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_73856a8074e1d297
```

alongside the existing `simpler-grants-gov-github-actions` pair.

- `terraform fmt -check` clean
- Trivy clean, checkov 81 passed / 0 failed

## Note on approach

I first considered a per-environment `.tfvars` file, then a new field threaded through `env-config`. Neither fit: SGG has no `.tfvars` anywhere, and adding an `env-config` field would touch all 13 environments to carry one value used by a single-environment layer. Defaulting the variable matches how the search module already solves the identical per-account problem.

## Still not applied

No apply has run. The plan is clean and this is the last thing I found that would need fixing afterwards rather than before — 31 resources, roughly $120-130/month for the control plane plus two `t4g.medium` nodes. Applying is a separate decision, and there is still no pipeline for this layer (#11129).