### PR TITLE
[Issue #11048] Fix "Show full description" leaving a space and not removing ellipsis

### DIFF
--- a/frontend/src/components/core/ContentDisplayToggle.tsx
+++ b/frontend/src/components/core/ContentDisplayToggle.tsx
@@ -9,16 +9,6 @@ import { USWDSIcon } from "src/components/core/USWDSIcon";
 
 type ContentDisplayToggleTypes = "default" | "centered";
 
-/*
- * ContentDisplayToggle
- *
- * Toggles display of child content
- *
- * @param {string} breakpoint - used to:
- *  - add a class to toggled content to always display it at viewport sizes above the specified breakpoint
- *  - add a class to toggled button to hide it at viewport sizes above the specified breakpoint
- *  @param {boolean} positionButtonBelowContent - defines whether toggle button will appear below or above child content
- */
 export default function ContentDisplayToggle({
   hideCallToAction,
   showCallToAction,
@@ -26,6 +16,7 @@ export default function ContentDisplayToggle({
   showContentByDefault = false,
   positionButtonBelowContent = true,
   type = "default",
+  onToggle,
   children,
 }: {
   hideCallToAction: string;
@@ -34,10 +25,17 @@ export default function ContentDisplayToggle({
   showContentByDefault?: boolean;
   type?: ContentDisplayToggleTypes;
   positionButtonBelowContent?: boolean;
+  onToggle?: (visible: boolean) => void;
   children: React.ReactNode;
 }) {
   const [toggledContentVisible, setToggledContentVisible] =
     useState<boolean>(showContentByDefault);
+
+  const handleToggle = () => {
+    const next = !toggledContentVisible;
+    setToggledContentVisible(next);
+    onToggle?.(next);
+  };
 
   const iconName = toggledContentVisible ? "arrow_drop_up" : "arrow_drop_down";
 
@@ -67,9 +65,7 @@ export default function ContentDisplayToggle({
       >
         <button
           type="button"
-          onClick={() => {
-            setToggledContentVisible(!toggledContentVisible);
-          }}
+          onClick={handleToggle}
           aria-pressed={toggledContentVisible}
           className="usa-button usa-button--unstyled text-no-underline"
         >

--- a/frontend/src/components/core/ContentDisplayToggle.tsx
+++ b/frontend/src/components/core/ContentDisplayToggle.tsx
@@ -9,6 +9,16 @@ import { USWDSIcon } from "src/components/core/USWDSIcon";
 
 type ContentDisplayToggleTypes = "default" | "centered";
 
+/*
+ * ContentDisplayToggle
+ *
+ * Toggles display of child content
+ *
+ * @param {string} breakpoint - used to:
+ *  - add a class to toggled content to always display it at viewport sizes above the specified breakpoint
+ *  - add a class to toggled button to hide it at viewport sizes above the specified breakpoint
+ *  @param {boolean} positionButtonBelowContent - defines whether toggle button will appear below or above child content
+ */
 export default function ContentDisplayToggle({
   hideCallToAction,
   showCallToAction,

--- a/frontend/src/components/core/ExpandableTextContent.tsx
+++ b/frontend/src/components/core/ExpandableTextContent.tsx
@@ -1,5 +1,9 @@
+"use client";
+
 import DOMPurify from "isomorphic-dompurify";
 import { splitMarkup } from "src/utils/generalUtils";
+
+import { useState } from "react";
 
 import ContentDisplayToggle from "src/components/core/ContentDisplayToggle";
 
@@ -16,6 +20,8 @@ export const ExpandableTextContent = ({
   splitAt?: number;
   splitIfLongerThan?: number;
 }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   if (textContent?.length < splitIfLongerThan) {
     return (
       <div
@@ -39,23 +45,21 @@ export const ExpandableTextContent = ({
       />
     );
   }
+
   return (
     <>
       <div
         dangerouslySetInnerHTML={{
-          __html: preSplit + "...",
+          __html: isExpanded ? purifiedSummary : preSplit + "…",
         }}
       />
       <ContentDisplayToggle
         showCallToAction={showCallToAction}
         hideCallToAction={hideCallToAction}
         positionButtonBelowContent={false}
+        onToggle={setIsExpanded}
       >
-        <div
-          dangerouslySetInnerHTML={{
-            __html: postSplit,
-          }}
-        />
+        {null}
       </ContentDisplayToggle>
     </>
   );

--- a/frontend/src/components/core/ExpandableTextContent.tsx
+++ b/frontend/src/components/core/ExpandableTextContent.tsx
@@ -50,7 +50,7 @@ export const ExpandableTextContent = ({
     <>
       <div
         dangerouslySetInnerHTML={{
-          __html: isExpanded ? purifiedSummary : preSplit + "…",
+          __html: isExpanded ? purifiedSummary : preSplit + "...",
         }}
       />
       <ContentDisplayToggle


### PR DESCRIPTION
(edit: 9/14/2026 Looked through some other issues and found a Confluence file regarding the opportunity detail page, seems like a proper plan/fix for this issue is being addressed already, and I think this PR would've introduced/not fixed issues regarding a11y and machine-readability. Oops!)

## Summary

<!-- Use "Fixes" to automatically close issue upon PR merge. Use "Work for" when UAT is required. -->
Fixes #11048 and Work for #12056 

## Changes proposed

<!-- What was added, updated, or removed in this PR. -->
Adds an optional onToggle callback function to `/frontend/src/components/core/ContentDisplayToggle.tsx`.

Adds conditional rendering to `/frontend/src/components/core/ExpandableTextContent.tsx` based on `isExpanded` value derived from the child `ContentDisplayToggle` component via the callback. 
When a split is necessary and the child `ContentDisplayToggle` is not expanded, the existing `preSplit` value is shown with the ellipsis added, and when `ContentDisplayToggle` is expanded, the full `purifiedSummary` is shown.

## Context for reviewers

<!-- Technical or background context, more in-depth details of the implementation, and anything else you'd like reviewers to know about that will help them understand the changes in the PR. -->
I don't think it is possible to keep the `postSplit` content within the ContentDisplayToggle and to have the postSplit text gracefully continue from where the `preSplit` is cut off. 

I'm not sure about the accessibility considerations of this solution. ContentDisplayToggle is now being used to change a different, non-child component. If that is a problem, I'm not sure how to rectify this with the conclusion directly above. 

Only partially addresses #12056 by removing the ellipsis once the full description is shown and by removing the unnatural line break.

## Validation steps

<!-- Manual testing instructions, as well as any helpful references (screenshots, GIF demos, code examples or output). -->
**Before:**
<img width="835" height="669" alt="11048before" src="https://github.com/user-attachments/assets/9eae0911-1966-4529-b6c2-01df22eae00e" />

**After:**
<img width="835" height="669" alt="11048after" src="https://github.com/user-attachments/assets/7f8a2687-f5d6-4348-bd64-6633bc18c024" />
